### PR TITLE
Optimize clients_last_seen_v1.init.sql

### DIFF
--- a/sql/clients_last_seen_v1.init.sql
+++ b/sql/clients_last_seen_v1.init.sql
@@ -1,17 +1,20 @@
+WITH input AS (
+  SELECT
+    ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY submission_date_s3 DESC) AS _row,
+    *
+  FROM
+    clients_daily_v6
+  WHERE
+    submission_date_s3 <= @submission_date
+    AND submission_date_s3 > DATE_SUB(@submission_date, INTERVAL 28 DAY)
+)
 SELECT
   @submission_date AS submission_date,
   CURRENT_DATETIME() AS generated_time,
-  MAX(submission_date_s3) AS last_seen_date,
-  -- approximate LAST_VALUE(input).*
-  ARRAY_AGG(input
-    ORDER BY submission_date_s3
-    DESC LIMIT 1
-  )[OFFSET(0)].* EXCEPT (submission_date_s3)
+  submission_date_s3 AS last_seen_date,
+  * EXCEPT (_row,
+    submission_date_s3)
 FROM
-  clients_daily_v6 AS input
+  input
 WHERE
-  submission_date_s3 <= @submission_date
-  AND
-  submission_date_s3 > DATE_SUB(@submission_date, INTERVAL 28 DAY)
-GROUP BY
-  input.client_id
+  _row = 1

--- a/sql/clients_last_seen_v1.init.sql
+++ b/sql/clients_last_seen_v1.init.sql
@@ -1,6 +1,6 @@
 WITH input AS (
   SELECT
-    ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY submission_date_s3 DESC) AS _row,
+    ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY submission_date_s3 DESC) AS n,
     *
   FROM
     clients_daily_v6
@@ -12,9 +12,9 @@ SELECT
   @submission_date AS submission_date,
   CURRENT_DATETIME() AS generated_time,
   submission_date_s3 AS last_seen_date,
-  * EXCEPT (_row,
+  * EXCEPT (n,
     submission_date_s3)
 FROM
   input
 WHERE
-  _row = 1
+  n = 1


### PR DESCRIPTION
same output, but it uses a window to avoid doing `group by` which in turn makes it much faster

when limiting the input to 2019-02-25 and 2019-02-26 I observed ~8.5x less compute usage and ~6x less time

(I also checked on making a similar change to the non-init version, but the `full outer join` used there instead of a `group by` was more efficient)