### PR TITLE
Add last_date struct for specific usage criteria

### DIFF
--- a/sql/clients_last_seen_v1.sql
+++ b/sql/clients_last_seen_v1.sql
@@ -19,9 +19,26 @@ WITH current_sample AS (
 SELECT
   @submission_date AS submission_date,
   CURRENT_DATETIME() AS generated_time,
+
+  -- This last_date struct is used to record the last date that a particular
+  -- client met various criteria; we record a null date if the client does
+  -- not meet a given criterion.
+  STRUCT (
+    IF(
+      country IN ('US', 'FR', 'DE', 'UK', 'CA'),
+      current_sample.submission_date,
+      previous.last_date.seen_in_tier1_country
+    ) AS seen_in_tier1_country,
+    IF(
+      scalar_parent_browser_engagement_total_uri_count_sum >= 5
+      current_sample.submission_date,
+      previous.last_date.visited_5_uri
+    ) AS visited_5_uri
+  ) AS last_date,
+
   IF(current_sample.client_id IS NOT NULL,
     current_sample,
-    previous).*
+    previous).* EXCEPT (last_date)
 FROM
   current_sample
 FULL JOIN


### PR DESCRIPTION
For usage criteria that can't be determined solely from the values associated with our most recent observation of a user, it's necessary to track a separate "last seen date" specific to that criterion. This PR proposes a `last_date` struct to hold such additional criteria.

I'm not at all certain right now that the SQL syntax here works as written, but looking for concerns with the approach sooner than later.