### PR TITLE
Add observation_date to firefox_nondesktop_mau28_*

### DIFF
--- a/sql/firefox_nondesktop_exact_mau28_by_product_by_dimensions_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_product_by_dimensions_v1.sql
@@ -9,10 +9,11 @@ WITH
   )
 
 SELECT
+  submission_date,
   -- 2019 goals define MAU for a given observation date based on a window of the
-  -- previous 28 days, not including the observation date.
+  -- previous 28 days, not including the observation date. To be consistent with goals,
+  -- users should plot based on observation_date rather than submission_date.
   DATE_ADD(submission_date, INTERVAL 1 DAY) AS observation_date,
-  submission_date AS last_submission_date_in_window,
   CURRENT_DATETIME() AS generated_time,
   COUNTIF(_inactive_days < 28) AS mau,
   COUNTIF(_inactive_days < 7) AS wau,
@@ -42,7 +43,7 @@ WHERE
   AND os IN ('Android', 'iOS')
   AND normalized_channel = 'release'
   -- 2017-01-01 is the first populated day of telemetry_core_parquet, so start 28 days later.
-  AND @submission_date >= '2017-01-28'
+  AND @submission_date >= DATE('2017-01-28')
   AND @submission_date = submission_date
 GROUP BY
   submission_date,

--- a/sql/firefox_nondesktop_exact_mau28_by_product_by_dimensions_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_product_by_dimensions_v1.sql
@@ -9,7 +9,10 @@ WITH
   )
 
 SELECT
-  submission_date,
+  -- 2019 goals define MAU for a given observation date based on a window of the
+  -- previous 28 days, not including the observation date.
+  DATE_ADD(submission_date, INTERVAL 1 DAY) AS observation_date,
+  submission_date AS last_submission_date_in_window,
   CURRENT_DATETIME() AS generated_time,
   COUNTIF(_inactive_days < 28) AS mau,
   COUNTIF(_inactive_days < 7) AS wau,

--- a/sql/firefox_nondesktop_exact_mau28_by_product_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_product_v1.sql
@@ -1,5 +1,6 @@
 SELECT
-  submission_date,
+  observation_date,
+  last_submission_date_in_window,
   CURRENT_DATETIME() AS generated_time,
   product,
   SUM(mau) AS mau,
@@ -13,5 +14,6 @@ FROM
 WHERE
   submission_date = @submission_date
 GROUP BY
-  submission_date,
+  observation_date,
+  last_submission_date_in_window,
   product

--- a/sql/firefox_nondesktop_exact_mau28_by_product_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_product_v1.sql
@@ -1,6 +1,6 @@
 SELECT
+  submission_date,
   observation_date,
-  last_submission_date_in_window,
   CURRENT_DATETIME() AS generated_time,
   product,
   SUM(mau) AS mau,
@@ -14,6 +14,6 @@ FROM
 WHERE
   submission_date = @submission_date
 GROUP BY
+  submission_date,
   observation_date,
-  last_submission_date_in_window,
   product


### PR DESCRIPTION
The 2019 goal definition of mau has defined an offset such that MAU for
2019-01-29 should consider the previous 28 days not including the current day,
so 2019-01-01 through 2019-01-28.

This PR changes our nondesktop MAU tables to call this field `observation_date`
~~and puts `submission_date` into a `last_submission_date_in_window` field to
hopefully make this self-explanatory without needing to look up documentation~~ (I've updated the PR to change last_submission_date_in_window back to submission_date; we'll continue to use that as the time partitioning field and I think keeping the name consistent with other tables makes it easier to reason through the ETL chain).

If we make this change, I'll follow up with similar changes for the desktop
tables.