### PR TITLE
Refactor nondesktop exact_mau28 tables into live views

### DIFF
--- a/sql/firefox_nondesktop_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_dimensions_v1.sql
@@ -1,0 +1,9 @@
+SELECT
+  -- 2019 goals define MAU for a given observation date based on a window of the
+  -- previous 28 days, not including the observation date. To be consistent with goals,
+  -- users should plot based on observation_date rather than submission_date.
+  DATE_ADD(submission_date, INTERVAL 1 DAY) AS observation_date,
+  submission_date AS last_submission_date_in_window,
+  * EXCEPT (submission_date, generated_time, normalized_channel)
+FROM
+  firefox_nondesktop_exact_mau28_raw_v1

--- a/sql/firefox_nondesktop_exact_mau28_by_product_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_product_v1.sql
@@ -1,6 +1,6 @@
 SELECT
-  submission_date,
-  CURRENT_DATETIME() AS generated_time,
+  observation_date,
+  last_submission_date_in_window,
   product,
   SUM(mau) AS mau,
   SUM(wau) AS wau,
@@ -9,9 +9,8 @@ SELECT
   SUM(IF(country IN ('US', 'FR', 'DE', 'UK', 'CA'), wau, 0)) AS tier1_wau,
   SUM(IF(country IN ('US', 'FR', 'DE', 'UK', 'CA'), dau, 0)) AS tier1_dau
 FROM
-  firefox_nondesktop_exact_mau28_by_product_by_dimensions_v1
-WHERE
-  submission_date = @submission_date
+  firefox_nondesktop_exact_mau28_by_dimensions_v1
 GROUP BY
-  submission_date,
+  observation_date,
+  last_submission_date_in_window,
   product

--- a/sql/firefox_nondesktop_exact_mau28_raw_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_raw_v1.sql
@@ -29,7 +29,10 @@ SELECT
 FROM
   inactive_days
 WHERE
-  -- This list corresponds to the products considered for 2019 nondesktop KPIs.
+  -- This list corresponds to the products considered for 2019 nondesktop KPIs;
+  -- we apply this filter here rather than in the live view because this field
+  -- is not normalized and there are many single pings that come in with unique
+  -- nonsensical app_name values.
   app_name IN (
     'Fennec', -- Firefox for Android and Firefox for iOS
     'Focus',
@@ -37,10 +40,11 @@ WHERE
     'FirefoxForFireTV', -- Amazon Fire TV
     'FirefoxConnect' -- Amazon Echo Show
     )
+  -- There are also many strange nonsensical entries for os, so we filter here.
   AND os IN ('Android', 'iOS')
   -- 2017-01-01 is the first populated day of telemetry_core_parquet, so start 28 days later.
-  AND @submission_date >= '2017-01-28'
-  AND @submission_date = submission_date
+  AND submission_date >= DATE('2017-01-28')
+  AND submission_date = @submission_date
 GROUP BY
   submission_date,
   product,


### PR DESCRIPTION
This is an alternative to #13 that separates ETL to a single
dimensional `_raw_v1` table and then delays details for the presentation
layer to live views where possible.