### PR TITLE
Add normalized_channel to nondesktop dimensions

### DIFF
--- a/sql/firefox_nondesktop_exact_mau28_by_product_by_dimensions_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_product_by_dimensions_v1.sql
@@ -22,6 +22,7 @@ SELECT
     WHEN 'Zerda' THEN 'Firefox Lite'
     ELSE app_name
   END AS product,
+  normalized_channel,
   campaign,
   country,
   distribution_id
@@ -37,13 +38,13 @@ WHERE
     'FirefoxConnect' -- Amazon Echo Show
     )
   AND os IN ('Android', 'iOS')
-  AND normalized_channel = 'release'
   -- 2017-01-01 is the first populated day of telemetry_core_parquet, so start 28 days later.
   AND @submission_date >= '2017-01-28'
   AND @submission_date = submission_date
 GROUP BY
   submission_date,
   product,
+  normalized_channel,
   campaign,
   country,
   distribution_id


### PR DESCRIPTION
For a time, we thought we were going to use release only for KPI
calculations, but this is likely going to revert to the historical
stance of including prerelease in MAU calculations.

This PR removes the filter we had on channel, and retains normalized_channel
as a dimension so we can filter by channel if needed at the analysis level.