### PR TITLE
Add bucket_id to nondesktop tables

### DIFF
--- a/sql/firefox_nondesktop_exact_mau28_raw_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_raw_v1.sql
@@ -14,6 +14,10 @@ SELECT
   COUNTIF(_inactive_days < 28) AS mau,
   COUNTIF(_inactive_days < 7) AS wau,
   COUNTIF(_inactive_days < 1) AS dau,
+  -- We hash client_ids into 20 buckets to aid in computing
+  -- confidence intervals for mau/wau/dau sums; the particular hash
+  -- function and number of buckets is subject to change in the future.
+  MOD(ABS(FARM_FINGERPRINT(client_id)), 20) AS id_bucket,
   -- Instead of app_name and os, we provide a single clean "product" name
   -- that includes OS where necessary to disambiguate.
   CASE app_name
@@ -47,6 +51,7 @@ WHERE
   AND submission_date = @submission_date
 GROUP BY
   submission_date,
+  id_bucket,
   product,
   normalized_channel,
   campaign,


### PR DESCRIPTION
As discussed in the [Smoot Growth Dashboard Engineering Requirements](https://docs.google.com/document/d/1L8tWDUjccutGGAldhpypRtPCaw3kkXboPUTtTZb02OA/edit?usp=sharing):

> In order to support statistical inference (confidence intervals and hypothesis tests), we require the concept of a ID Bucket.  We divide the space of user IDs (probably client_id in most cases) into 20 buckets with equal probability of assignment into each bucket.  It is very important that this assignment is orthogonal to anything else that we care about - for example, it would be a problem if newer profiles were more likely to be assigned to particular buckets, or if profiles in certain experiment arms always ended up in particular buckets.