### PR TITLE
Update live views to use fully qualified table names

### DIFF
--- a/sql/firefox_nondesktop_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_dimensions_v1.sql
@@ -1,9 +1,7 @@
 SELECT
-  -- 2019 goals define MAU for a given observation date based on a window of the
-  -- previous 28 days, not including the observation date. To be consistent with goals,
-  -- users should plot based on observation_date rather than submission_date.
-  DATE_ADD(submission_date, INTERVAL 1 DAY) AS observation_date,
-  submission_date AS last_submission_date_in_window,
-  * EXCEPT (submission_date, generated_time, normalized_channel)
+  * EXCEPT (generated_time)
 FROM
-  firefox_nondesktop_exact_mau28_raw_v1
+  `moz-fx-data-derived-datasets.analysis.firefox_nondesktop_exact_mau28_raw_v1`
+
+-- This is a "live view" and can be updated via bq:
+-- bq update --project moz-fx-data-derived-datasets --use_legacy_sql=false --view "$(cat sql/firefox_nondesktop_exact_mau28_by_dimensions_v1.sql)" analysis.firefox_nondesktop_exact_mau28_by_dimensions_v1

--- a/sql/firefox_nondesktop_exact_mau28_by_product_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_product_v1.sql
@@ -1,6 +1,5 @@
 SELECT
-  observation_date,
-  last_submission_date_in_window,
+  submission_date,
   product,
   SUM(mau) AS mau,
   SUM(wau) AS wau,
@@ -9,8 +8,10 @@ SELECT
   SUM(IF(country IN ('US', 'FR', 'DE', 'UK', 'CA'), wau, 0)) AS tier1_wau,
   SUM(IF(country IN ('US', 'FR', 'DE', 'UK', 'CA'), dau, 0)) AS tier1_dau
 FROM
-  firefox_nondesktop_exact_mau28_by_dimensions_v1
+  `moz-fx-data-derived-datasets.analysis.firefox_nondesktop_exact_mau28_by_dimensions_v1`
 GROUP BY
-  observation_date,
-  last_submission_date_in_window,
+  submission_date,
   product
+
+-- This is a "live view" and can be updated via bq:
+-- bq mk --project moz-fx-data-derived-datasets --use_legacy_sql=false --view "$(cat sql/firefox_nondesktop_exact_mau28_by_product_v1.sql)" analysis.firefox_nondesktop_exact_mau28_by_product_v1


### PR DESCRIPTION
Per [BQ docs on creating views](https://cloud.google.com/bigquery/docs/views#creating_a_view):

> For standard SQL views, the query must include the project ID in table and view references in the form `[PROJECT_ID].[DATASET].[TABLE]`.

We also remove the `observation_date` column. After further discussion with
the growth dashboard group, we're comfortable using the established definition
of the MAU window including the date of report; the concern is to make sure
we never include a partial day, which is already guaranteed by batch processing
only after a day is closed.