### PR TITLE
Add WAU and id_bucket to desktop mau datasets

### DIFF
--- a/sql/firefox_desktop_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_desktop_exact_mau28_by_dimensions_v1.sql
@@ -27,7 +27,8 @@ SELECT
 FROM
   inactive_days
 WHERE
-  submission_date = @submission_date
+  client_id IS NOT NULL
+  AND submission_date = @submission_date
 GROUP BY
   submission_date,
   id_bucket,

--- a/sql/firefox_desktop_exact_mau28_v1.sql
+++ b/sql/firefox_desktop_exact_mau28_v1.sql
@@ -2,6 +2,7 @@ SELECT
   submission_date,
   CURRENT_DATETIME() AS generated_time,
   SUM(mau) AS mau,
+  SUM(wau) AS wau,
   SUM(dau) AS dau
 FROM
   firefox_desktop_exact_mau28_by_dimensions_v1


### PR DESCRIPTION
Mirrors what we've done for nondesktop.

Actually rolling this out will involve getting the change merged
to `spark-parquet-to-bigquery`, then doing a manual recreation of the table
and downstream. Because there's no windowing or joining involved, though,
those recreations can each be done efficiently in a single query that takes
perhaps a few minutes to run.

This change will allow us to move the Growth Dashboard off of Spark-based
analysis of Parquet datasets and onto BQ (via Redash)!