### PR TITLE
Add seen_in_tier1_country for fxa tables

### DIFF
--- a/sql/firefox_accounts_exact_mau28_raw_v1.sql
+++ b/sql/firefox_accounts_exact_mau28_raw_v1.sql
@@ -32,7 +32,7 @@ FROM
 WHERE
   -- First data is on 2017-10-01, so we start 28 days later for first complete MAU value.
   submission_date >= DATE '2017-10-28'
-  --AND submission_date = @submission_date
+  AND submission_date = @submission_date
 GROUP BY
   submission_date,
   id_bucket,

--- a/sql/fxa_users_daily_v1.sql
+++ b/sql/fxa_users_daily_v1.sql
@@ -22,7 +22,7 @@ CREATE TEMP FUNCTION udf_mode_last(x ANY TYPE) AS ((
 -- telemetry data accepts countries as two-digit codes, but FxA
 -- data includes long-form country names. The logic here is specific
 -- to the FxA data.
-CREATE TEMP FUNCTION udf_contains_tier1_country(x ANY TYPE) AS ((
+CREATE TEMP FUNCTION udf_contains_tier1_country(x ANY TYPE) AS (
   EXISTS(
     SELECT
       country
@@ -33,8 +33,8 @@ CREATE TEMP FUNCTION udf_contains_tier1_country(x ANY TYPE) AS ((
       'France',
       'Germany',
       'United Kingdom',
-      'Canada')
-    )));
+      'Canada'))
+);
 
 WITH
   windowed AS (

--- a/sql/fxa_users_daily_v1.sql
+++ b/sql/fxa_users_daily_v1.sql
@@ -18,6 +18,10 @@ CREATE TEMP FUNCTION udf_mode_last(x ANY TYPE) AS ((
   LIMIT 1
 ));
 
+-- This UDF is only applicable in the context of this query;
+-- telemetry data accepts countries as two-digit codes, but FxA
+-- data includes long-form country names. The logic here is specific
+-- to the FxA data.
 CREATE TEMP FUNCTION udf_contains_tier1_country(x ANY TYPE) AS ((
   EXISTS(
     SELECT

--- a/sql/fxa_users_last_seen_v1.sql
+++ b/sql/fxa_users_last_seen_v1.sql
@@ -7,16 +7,12 @@ WITH
     -- this allows a variant of country-segmented MAU where we can still count
     -- a user that appeared in one of the target countries in the previous
     -- 28 days even if the most recent "country" value is not in this set.
-    IF(country IN (
-      'United States',
-      'France',
-      'Germany',
-      'United Kingdom',
-      'Canada'),
+    IF(seen_in_tier1_country,
       @submission_date,
       NULL) AS date_last_seen_in_tier1_country,
     * EXCEPT (submission_date,
-      generated_time)
+      generated_time,
+      seen_in_tier1_country)
   FROM
     fxa_users_daily_v1
   WHERE


### PR DESCRIPTION
This allows for a true "inclusive tier 1" calculation that matches exactly with what you get from the self-join method of calculating MAU from raw events. In particular, it allows us to reproduce exactly the calculation that has been used to define the relationships goal for 2019.