### PR TITLE
Adapt FxA ETL for merging backfill data at the raw MAU stage

### DIFF
--- a/sql/firefox_accounts_exact_mau28_raw_v1.sql
+++ b/sql/firefox_accounts_exact_mau28_raw_v1.sql
@@ -1,11 +1,36 @@
 WITH
+  -- We have a one-time backfill of FxA data extracted from Amplitude that
+  -- runs through EOD 2019-03-27.
+  backfill AS (
+    SELECT
+      *
+    FROM
+      static.fxa_amplitude_export_users_last_seen
+    WHERE
+      submission_date < DATE '2019-03-28'
+  ),
+  -- "Live" FxA data gets to BigQuery via a Stackdriver pipeline that had its
+  -- first stable day on 2019-03-01, so first valid day for MAU is 2019-03-28.
+  live AS (
+    SELECT
+      *
+    FROM
+      fxa_users_last_seen_v1
+    WHERE
+      submission_date >= DATE '2019-03-28'
+  ),
+  unioned AS (
+    SELECT * FROM backfill
+    UNION ALL
+    SELECT * FROM live
+  ),
   inactive_days AS (
     SELECT
       *,
       DATE_DIFF(submission_date, date_last_seen, DAY) AS _inactive_days,
       DATE_DIFF(submission_date, date_last_seen_in_tier1_country, DAY) AS _inactive_days_tier1
     FROM
-      fxa_users_last_seen_v1
+      unioned
   )
 
 SELECT

--- a/sql/fxa_all_events_v1.sql
+++ b/sql/fxa_all_events_v1.sql
@@ -1,0 +1,42 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-derived-datasets.telemetry.fxa_all_events_v1`
+AS
+
+WITH
+  fxa_auth_events AS (
+    SELECT
+      timestamp AS submission_timestamp,
+      jsonPayload.fields.user_id AS user_id,
+      jsonPayload.fields.country AS country,
+      jsonPayload.fields.event_type AS event_type
+    FROM
+      `moz-fx-data-derived-datasets.telemetry.fxa_auth_events_v1`
+  ),
+
+  -- This table doesn't include any user events that are considered "active",
+  -- but should always be included for a complete raw event log.
+  fxa_auth_bounce_events AS (
+    SELECT
+      timestamp AS submission_timestamp,
+      jsonPayload.fields.user_id AS user_id,
+      CAST(NULL AS STRING) AS country,  -- No country field in auth_bounces
+      jsonPayload.fields.event_type AS event_type
+    FROM
+      `moz-fx-data-derived-datasets.telemetry.fxa_auth_bounce_events_v1`
+  ),
+
+  fxa_content_events AS (
+    SELECT
+      timestamp AS submission_timestamp,
+      jsonPayload.fields.user_id AS user_id,
+      jsonPayload.fields.country AS country,
+      jsonPayload.fields.event_type AS event_type
+    FROM
+      `moz-fx-data-derived-datasets.telemetry.fxa_content_events_v1`
+  )
+
+SELECT * FROM fxa_auth_events
+UNION ALL
+SELECT * FROM fxa_auth_bounce_events
+UNION ALL
+SELECT * FROM fxa_content_events

--- a/sql/fxa_users_last_seen_v1.init.sql
+++ b/sql/fxa_users_last_seen_v1.init.sql
@@ -5,9 +5,9 @@ SELECT
   IF(country IN ('United States', 'France', 'Germany', 'United Kingdom', 'Canada'),
     submission_date,
     NULL) AS date_last_seen_in_tier1_country,
-  * EXCEPT (submission_date, generated_time)
+  * EXCEPT (submission_date, generated_time, seen_in_tier1_country)
 FROM
   fxa_users_daily_v1
 WHERE
-  -- 2017-10-01 is the first date in the Amplitude FxA project.
-  submission_date = DATE '2017-10-01'
+  -- Choose an arbitrary date that contains no records.
+  submission_date = DATE_FROM_UNIX_DATE(0)

--- a/sql/static/README.md
+++ b/sql/static/README.md
@@ -1,0 +1,4 @@
+This directory contains definitions for derived tables in the `static` dataset.
+
+In particular, we have two tables based on a one-time export of Firefox Accounts
+extracted from Amplitude and imported to BigQuery.

--- a/sql/static/fxa_amplitude_export_users_daily.sql
+++ b/sql/static/fxa_amplitude_export_users_daily.sql
@@ -46,7 +46,7 @@ WITH
     udf_mode_last(ARRAY_AGG(country) OVER w1) AS country,
     udf_contains_tier1_country(ARRAY_AGG(country) OVER w1) AS seen_in_tier1_country
   FROM
-    fxa_all_events_v1
+    fxa_amplitude_export_event_date
   WHERE
     user_id IS NOT NULL
     AND event_type NOT IN (
@@ -55,20 +55,20 @@ WITH
       'fxa_reg - password_missing','fxa_sms - sent', 'mktg - email_click',
       'mktg - email_open','mktg - email_sent','sync - repair_success',
       'sync - repair_triggered')
-    AND EXTRACT(DATE FROM submission_timestamp) = @submission_date
+    AND event_date = @submission_date
   WINDOW
     w1 AS (
       PARTITION BY
       user_id
     ORDER BY
-      submission_timestamp DESC
+      event_time DESC
     ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
     -- We must provide a modified window for ROW_NUMBER which cannot accept a frame clause.
     w1_unframed AS (
     PARTITION BY
       user_id
     ORDER BY
-      submission_timestamp DESC) )
+      event_time DESC) )
 SELECT
   * EXCEPT (_n)
 FROM

--- a/sql/static/fxa_amplitude_export_users_last_seen.sql
+++ b/sql/static/fxa_amplitude_export_users_last_seen.sql
@@ -1,0 +1,50 @@
+WITH
+  current_sample AS (
+  SELECT
+    -- Record the last day on which we received any FxA event at all from this user.
+    @submission_date AS date_last_seen,
+    -- Record the last day on which the user was in a "Tier 1" country;
+    -- this allows a variant of country-segmented MAU where we can still count
+    -- a user that appeared in one of the target countries in the previous
+    -- 28 days even if the most recent "country" value is not in this set.
+    IF(seen_in_tier1_country,
+      @submission_date,
+      NULL) AS date_last_seen_in_tier1_country,
+    * EXCEPT (submission_date,
+      generated_time,
+      seen_in_tier1_country)
+  FROM
+    fxa_amplitude_export_users_daily
+  WHERE
+    submission_date = @submission_date ),
+  previous AS (
+  SELECT
+    * EXCEPT (submission_date,
+      generated_time)
+      -- We use REPLACE to null out any last_seen observations older than 28 days;
+      -- this ensures data never bleeds in from outside the target 28 day window.
+      REPLACE (IF(date_last_seen_in_tier1_country > DATE_SUB(@submission_date, INTERVAL 28 DAY),
+          date_last_seen_in_tier1_country,
+          NULL) AS date_last_seen_in_tier1_country)
+  FROM
+    fxa_amplitude_export_users_last_seen
+  WHERE
+    submission_date = DATE_SUB(@submission_date, INTERVAL 1 DAY)
+    AND date_last_seen > DATE_SUB(@submission_date, INTERVAL 28 DAY) )
+SELECT
+  @submission_date AS submission_date,
+  CURRENT_DATETIME() AS generated_time,
+  COALESCE(current_sample.date_last_seen,
+    previous.date_last_seen) AS date_last_seen,
+  COALESCE(current_sample.date_last_seen_in_tier1_country,
+    previous.date_last_seen_in_tier1_country) AS date_last_seen_in_tier1_country,
+  IF(current_sample.user_id IS NOT NULL,
+    current_sample,
+    previous).* EXCEPT (date_last_seen,
+    date_last_seen_in_tier1_country)
+FROM
+  current_sample
+FULL JOIN
+  previous
+USING
+  (user_id)


### PR DESCRIPTION
We learned today that backfilled data contains hashed user_id
while the live Stackdriver pipeline for FxA contains unhashed ids.
Running the relevant HMAC hash would be complex, so we are instead
defining an overlap period of 28 days where we calculate intermediate
MAU tables for backfill and for stackdriver data separately,
then we union the two together.

We'll coordinate to do a final one-time import of backfill data
tomorrow morning, then use Stackdriver data from 3/28 and forward.