### PR TITLE
Tweaks to exact_mau views for consistency

### DIFF
--- a/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
@@ -2,11 +2,11 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-derived-datasets.telemetry.firefox_accounts_exact_mau28_by_dimensions_v1`
 AS
 SELECT
-  * EXCEPT (generated_time, country)
+  * EXCEPT (generated_time, country, mau_tier1_inclusive),
     -- We rename this column here to match the new standard of prefixing _mau
     -- with the usage criterion; we can refactor to have the correct name in
     -- the raw table the next time we need to make a change and backfill.
-    REPLACE (mau_tier1_inclusive AS seen_in_tier1_country_mau),
+    mau_tier1_inclusive AS seen_in_tier1_country_mau,
   -- We normalize country to match the two-digit country codes that appear in
   -- telemetry data, so that this view is compatible with the exact_mau28 views
   -- for desktop and nondesktop.

--- a/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
@@ -3,6 +3,9 @@ CREATE OR REPLACE VIEW
 AS
 SELECT
   * EXCEPT (generated_time, country)
+    -- We rename this column here to match the new standard of prefixing _mau
+    -- with the usage criterion; we can refactor to have the correct name in
+    -- the raw table the next time we need to make a change and backfill.
     REPLACE (mau_tier1_inclusive AS seen_in_tier1_country_mau),
   -- We normalize country to match the two-digit country codes that appear in
   -- telemetry data, so that this view is compatible with the exact_mau28 views

--- a/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
@@ -2,7 +2,8 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-derived-datasets.telemetry.firefox_accounts_exact_mau28_by_dimensions_v1`
 AS
 SELECT
-  * EXCEPT (generated_time, country),
+  * EXCEPT (generated_time, country)
+    REPLACE (mau_tier1_inclusive AS seen_in_tier1_country_mau),
   -- We normalize country to match the two-digit country codes that appear in
   -- telemetry data, so that this view is compatible with the exact_mau28 views
   -- for desktop and nondesktop.

--- a/sql/firefox_accounts_exact_mau28_v1.sql
+++ b/sql/firefox_accounts_exact_mau28_v1.sql
@@ -6,10 +6,8 @@ SELECT
   SUM(mau) AS mau,
   SUM(wau) AS wau,
   SUM(dau) AS dau,
-  SUM(seen_in_tier1_country_mau) AS tier1_mau,
-  SUM(seen_in_tier1_country_wau) AS tier1_wau,
-  SUM(seen_in_tier1_country_dau) AS tier1_dau
+  SUM(seen_in_tier1_country_mau) AS tier1_mau
 FROM
-  `moz-fx-data-derived-datasets.analysis.firefox_accounts_exact_mau28_by_dimensions_v1`
+  `moz-fx-data-derived-datasets.telemetry.firefox_accounts_exact_mau28_by_dimensions_v1`
 GROUP BY
   submission_date

--- a/sql/firefox_accounts_exact_mau28_v1.sql
+++ b/sql/firefox_accounts_exact_mau28_v1.sql
@@ -6,9 +6,9 @@ SELECT
   SUM(mau) AS mau,
   SUM(wau) AS wau,
   SUM(dau) AS dau,
-  SUM(IF(country IN ('US', 'FR', 'DE', 'UK', 'CA'), mau, 0)) AS tier1_mau,
-  SUM(IF(country IN ('US', 'FR', 'DE', 'UK', 'CA'), wau, 0)) AS tier1_wau,
-  SUM(IF(country IN ('US', 'FR', 'DE', 'UK', 'CA'), dau, 0)) AS tier1_dau
+  SUM(seen_in_tier1_country_mau) AS tier1_mau,
+  SUM(seen_in_tier1_country_wau) AS tier1_wau,
+  SUM(seen_in_tier1_country_dau) AS tier1_dau
 FROM
   `moz-fx-data-derived-datasets.analysis.firefox_accounts_exact_mau28_by_dimensions_v1`
 GROUP BY

--- a/sql/firefox_nondesktop_exact_mau28_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_v1.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-derived-datasets.telemetry.firefox_nondesktop_exact_mau28_v1`
+AS
+SELECT
+  submission_date,
+  SUM(mau) AS mau,
+  SUM(wau) AS wau,
+  SUM(dau) AS dau,
+  SUM(IF(country IN ('US', 'FR', 'DE', 'UK', 'CA'), mau, 0)) AS tier1_mau,
+  SUM(IF(country IN ('US', 'FR', 'DE', 'UK', 'CA'), wau, 0)) AS tier1_wau,
+  SUM(IF(country IN ('US', 'FR', 'DE', 'UK', 'CA'), dau, 0)) AS tier1_dau
+FROM
+  `moz-fx-data-derived-datasets.telemetry.firefox_nondesktop_exact_mau28_by_dimensions_v1`
+GROUP BY
+  submission_date


### PR DESCRIPTION
As discussed in mozilla/firefox-data-docs#258
the current column name for tier 1 mau in firefox accounts tables
uses a suffix rather than a prefix.

This renames the column in the by_dimensions view rather than in
the raw table so that we avoid having to backfill and update the
Airflow DAG.

In the exact_mau_v1 view, we continue to use the simple "tier1_mau" column
so that we have consistently named columns across the final views
for desktop, nondesktop, and fxa. And these columns are exactly
match exactly with what is presented in the growth dashboard
(we show tier 1 plots for all 3, but only FxA is using the
"seen in tier 1 country" usage criterion).

---

Also, we add a final nondesktop view that aggregates across products so that we can make the statement in the docs that these final views match exactly with the data presented in the growth dashboard.