### PR TITLE
Bug 1539385 Add smoot_usage_v1 view on clients_daily

### DIFF
--- a/sql/smoot_usage_v1.sql
+++ b/sql/smoot_usage_v1.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-derived-datasets.telemetry.smoot_usage_v1`
+AS
+WITH
+  clients_daily_with_usage_array AS (
+  SELECT
+    *,
+    ['Any Firefox Desktop Activity',
+    IF(devtools_toolbox_opened_count_sum > 0,
+      'Firefox Desktop Dev Tools Opened',
+      NULL) ] AS usage_ids
+  FROM
+    `moz-fx-data-derived-datasets.telemetry.clients_daily_v6` )
+SELECT
+  submission_date_s3 AS date,
+  client_id AS profile_id,
+  usage_id,
+  country
+FROM
+  clients_daily_with_usage_array,
+  UNNEST(usage_ids) AS usage_id
+WHERE
+  usage_id IS NOT NULL


### PR DESCRIPTION
Implements the usage table described in [Jesse's Google Doc](https://docs.google.com/document/d/1wbcMGEw4b7GkFsNV74n-h9OK_OLRRgPdFyxdjjHDmiY/edit)
as a live view on top of `clients_daily`. This version excludes
the new profile creation usage_id which requires looking at a window of
history. 
That will wait for a subsequent change as it is more involved, likely needing a materialized table that could be unioned into this view.

This view already exists and can be queried like:

```
SELECT *
FROM `moz-fx-data-derived-datasets.telemetry.smoot_usage_v1`
WHERE date = '2019-03-01'
LIMIT 1000
```