### PR TITLE
Join with public dataset for country code lookup

### DIFF
--- a/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
@@ -2,21 +2,22 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-derived-datasets.telemetry.firefox_accounts_exact_mau28_by_dimensions_v1`
 AS
 SELECT
-  * EXCEPT (generated_time, country, mau_tier1_inclusive),
+  raw.* EXCEPT (generated_time, country, mau_tier1_inclusive),
     -- We rename this column here to match the new standard of prefixing _mau
     -- with the usage criterion; we can refactor to have the correct name in
     -- the raw table the next time we need to make a change and backfill.
     mau_tier1_inclusive AS seen_in_tier1_country_mau,
-  -- We normalize country to match the two-digit country codes that appear in
-  -- telemetry data, so that this view is compatible with the exact_mau28 views
-  -- for desktop and nondesktop.
-  CASE country
-    WHEN 'United States' THEN 'US'
-    WHEN 'France' THEN 'FR'
-    WHEN 'Germany' THEN 'DE'
-    WHEN 'United Kingdom' THEN 'UK'
-    WHEN 'Canada' THEN 'CA'
-    ELSE 'Other'
-  END AS country
+  -- Telemetry data includes a "country" field that is the 2-letter ISO 3166-1
+  -- country code while FxA data contains long-form country names;
+  -- we join with a public dataset to retrieve the country code here to have
+  -- a consistent interface with desktop and nondesktop exact_mau28 views;
+  -- this value will be null for some countries with multiple names
+  -- (for example, FxA data contains "South Korea" vs. "Republic of Korea").
+  census_data.country_code AS country,
+  raw.country AS country_name
 FROM
-  `moz-fx-data-derived-datasets.telemetry.firefox_accounts_exact_mau28_raw_v1`
+  `moz-fx-data-derived-datasets.telemetry.firefox_accounts_exact_mau28_raw_v1` AS raw
+LEFT JOIN
+  `bigquery-public-data.census_bureau_international.country_names_area` AS census_data
+ON
+  raw.country = census_data.country_name

--- a/sql/firefox_nondesktop_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_dimensions_v1.sql
@@ -2,6 +2,11 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-derived-datasets.telemetry.firefox_nondesktop_exact_mau28_by_dimensions_v1`
 AS
 SELECT
-  * EXCEPT (generated_time)
+  raw.* EXCEPT (generated_time),
+  census_data.country_name
 FROM
-  `moz-fx-data-derived-datasets.telemetry.firefox_nondesktop_exact_mau28_raw_v1`
+  `moz-fx-data-derived-datasets.telemetry.firefox_nondesktop_exact_mau28_raw_v1` AS raw
+LEFT JOIN
+  `bigquery-public-data.census_bureau_international.country_names_area` AS census_data
+ON
+  raw.country = census_data.country_code


### PR DESCRIPTION
This PR replaces a CASE statement we were using to partially convert
country names to country codes. Rather than maintain our own static
dataset of country data, we join with one of the public datasets
that Google maintains.

This could be a useful pattern for some other common lookups in the future, but I'm interested in thoughts on whether adding a dependency on public datasets could be problematic.