### PR TITLE
Revert join to US census data for country codes

### DIFF
--- a/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
@@ -2,22 +2,10 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-derived-datasets.telemetry.firefox_accounts_exact_mau28_by_dimensions_v1`
 AS
 SELECT
-  raw.* EXCEPT (generated_time, country, mau_tier1_inclusive),
+  raw.* EXCEPT (generated_time, mau_tier1_inclusive),
     -- We rename this column here to match the new standard of prefixing _mau
     -- with the usage criterion; we can refactor to have the correct name in
     -- the raw table the next time we need to make a change and backfill.
-    mau_tier1_inclusive AS seen_in_tier1_country_mau,
-  -- Telemetry data includes a "country" field that is the 2-letter ISO 3166-1
-  -- country code while FxA data contains long-form country names;
-  -- we join with a public dataset to retrieve the country code here to have
-  -- a consistent interface with desktop and nondesktop exact_mau28 views;
-  -- this value will be null for some countries with multiple names
-  -- (for example, FxA data contains "South Korea" vs. "Republic of Korea").
-  census_data.country_code AS country,
-  raw.country AS country_name
+    mau_tier1_inclusive AS seen_in_tier1_country_mau
 FROM
   `moz-fx-data-derived-datasets.telemetry.firefox_accounts_exact_mau28_raw_v1` AS raw
-LEFT JOIN
-  `bigquery-public-data.census_bureau_international.country_names_area` AS census_data
-ON
-  raw.country = census_data.country_name

--- a/sql/firefox_nondesktop_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_dimensions_v1.sql
@@ -2,11 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-derived-datasets.telemetry.firefox_nondesktop_exact_mau28_by_dimensions_v1`
 AS
 SELECT
-  raw.* EXCEPT (generated_time),
-  census_data.country_name
+  raw.* EXCEPT (generated_time)
 FROM
   `moz-fx-data-derived-datasets.telemetry.firefox_nondesktop_exact_mau28_raw_v1` AS raw
-LEFT JOIN
-  `bigquery-public-data.census_bureau_international.country_names_area` AS census_data
-ON
-  raw.country = census_data.country_code


### PR DESCRIPTION
It turns out that the country codes in the US Census Bureau
public dataset are not the same as ISO 3166 codes.

They use "UK" for United Kingdom and "GB" for Gabon whereas
ISO 3166 specifies United Kingdom as "GB".

Reverts https://github.com/mozilla/bigquery-etl/pull/72