### PR TITLE
Fix --submission-date for export_to_parquet.py

### DIFF
--- a/script/pyspark/export_to_parquet.py
+++ b/script/pyspark/export_to_parquet.py
@@ -81,8 +81,8 @@ parser.add_argument(
     "--submission-date",
     dest="submission_date",
     help="Short for: --filter \"submission_date = DATE 'SUBMISSION_DATE'\""
-    ' --static-partitions submission_date=SUBMISSION_DATE --where "submission_date IS'
-    ' NOT NULL"',
+    " --where \"submission_date = DATE 'SUBMISSION_DATE'\""
+    " --static-partitions submission_date=SUBMISSION_DATE",
 )
 parser.add_argument(
     "--where",
@@ -104,11 +104,15 @@ args = parser.parse_args()
 # handle --submission-date
 if args.submission_date is not None:
     # --filter "submission_date = DATE 'SUBMISSION_DATE'"
-    args.filter.append("submission_date = DATE '" + args.submission_date + "'")
+    condition = "submission_date = DATE '" + args.submission_date + "'"
+    args.filter.append(condition)
     # --static-partitions submission_date=SUBMISSION_DATE
     args.static_partitions.append("submission_date=" + args.submission_date)
     # --where "submission_date IS NOT NULL"
-    args.where += " AND submission_date IS NOT NULL"
+    if args.where == "TRUE":
+        args.where = condition
+    else:
+        args.where = "(" + args.where + ") AND " + condition
 
 # append table and --static-partitions to destination
 args.destination = "/".join(


### PR DESCRIPTION
`submission_date IS NOT NULL` isn't a sufficient where clause to prevent pushdown of `drop('submission_date')` through to the storage api request.

testing shows `submission_date = DATE 'SUBMISSION_DATE'` does what we need.