### PR TITLE
Add static country_code and country_name tables

### DIFF
--- a/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_accounts_exact_mau28_by_dimensions_v1.sql
@@ -3,9 +3,13 @@ CREATE OR REPLACE VIEW
 AS
 SELECT
   raw.* EXCEPT (mau_tier1_inclusive),
-    -- We rename this column here to match the new standard of prefixing _mau
-    -- with the usage criterion; we can refactor to have the correct name in
-    -- the raw table the next time we need to make a change and backfill.
-    mau_tier1_inclusive AS seen_in_tier1_country_mau
+  -- We rename this column here to match the new standard of prefixing _mau
+  -- with the usage criterion; we can refactor to have the correct name in
+  -- the raw table the next time we need to make a change and backfill.
+  mau_tier1_inclusive AS seen_in_tier1_country_mau,
+  COALESCE(cn.code, raw.country) AS country_code
 FROM
   `moz-fx-data-derived-datasets.telemetry.firefox_accounts_exact_mau28_raw_v1` AS raw
+LEFT JOIN
+  `moz-fx-data-derived-datasets.static.country_names_v1` cn
+  ON (raw.country = cn.name)

--- a/sql/firefox_desktop_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_desktop_exact_mau28_by_dimensions_v1.sql
@@ -20,9 +20,13 @@ SELECT
   attribution.campaign,
   attribution.content,
   country,
+  COALESCE(cc.name, cls.country) AS country_name,
   distribution_id
 FROM
-  clients_last_seen_v1
+  clients_last_seen_v1 cls
+LEFT JOIN
+  static.country_codes_v1 cc
+  ON (cls.country = cc.code)
 WHERE
   client_id IS NOT NULL
   AND submission_date = @submission_date
@@ -34,4 +38,5 @@ GROUP BY
   campaign,
   content,
   country,
+  country_name,
   distribution_id

--- a/sql/firefox_nondesktop_exact_mau28_by_dimensions_v1.sql
+++ b/sql/firefox_nondesktop_exact_mau28_by_dimensions_v1.sql
@@ -2,6 +2,10 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-derived-datasets.telemetry.firefox_nondesktop_exact_mau28_by_dimensions_v1`
 AS
 SELECT
-  raw.*
+  raw.*,
+  COALESCE(cc.name, raw.country) AS country_name
 FROM
   `moz-fx-data-derived-datasets.telemetry.firefox_nondesktop_exact_mau28_raw_v1` AS raw
+LEFT JOIN
+  `moz-fx-data-derived-datasets.static.country_codes_v1` cc
+  ON (raw.country = cc.code)

--- a/sql/static/.gitignore
+++ b/sql/static/.gitignore
@@ -1,0 +1,1 @@
+country_names_full.csv

--- a/sql/static/country_codes.csv
+++ b/sql/static/country_codes.csv
@@ -1,0 +1,250 @@
+Name,Code
+Afghanistan,AF
+Åland Islands,AX
+Albania,AL
+Algeria,DZ
+American Samoa,AS
+Andorra,AD
+Angola,AO
+Anguilla,AI
+Antarctica,AQ
+Antigua and Barbuda,AG
+Argentina,AR
+Armenia,AM
+Aruba,AW
+Australia,AU
+Austria,AT
+Azerbaijan,AZ
+Bahamas,BS
+Bahrain,BH
+Bangladesh,BD
+Barbados,BB
+Belarus,BY
+Belgium,BE
+Belize,BZ
+Benin,BJ
+Bermuda,BM
+Bhutan,BT
+"Bolivia, Plurinational State of",BO
+"Bonaire, Sint Eustatius and Saba",BQ
+Bosnia and Herzegovina,BA
+Botswana,BW
+Bouvet Island,BV
+Brazil,BR
+British Indian Ocean Territory,IO
+Brunei Darussalam,BN
+Bulgaria,BG
+Burkina Faso,BF
+Burundi,BI
+Cambodia,KH
+Cameroon,CM
+Canada,CA
+Cape Verde,CV
+Cayman Islands,KY
+Central African Republic,CF
+Chad,TD
+Chile,CL
+China,CN
+Christmas Island,CX
+Cocos (Keeling) Islands,CC
+Colombia,CO
+Comoros,KM
+Congo,CG
+"Congo, the Democratic Republic of the",CD
+Cook Islands,CK
+Costa Rica,CR
+Côte d'Ivoire,CI
+Croatia,HR
+Cuba,CU
+Curaçao,CW
+Cyprus,CY
+Czech Republic,CZ
+Denmark,DK
+Djibouti,DJ
+Dominica,DM
+Dominican Republic,DO
+Ecuador,EC
+Egypt,EG
+El Salvador,SV
+Equatorial Guinea,GQ
+Eritrea,ER
+Estonia,EE
+Ethiopia,ET
+Falkland Islands (Malvinas),FK
+Faroe Islands,FO
+Fiji,FJ
+Finland,FI
+France,FR
+French Guiana,GF
+French Polynesia,PF
+French Southern Territories,TF
+Gabon,GA
+Gambia,GM
+Georgia,GE
+Germany,DE
+Ghana,GH
+Gibraltar,GI
+Greece,GR
+Greenland,GL
+Grenada,GD
+Guadeloupe,GP
+Guam,GU
+Guatemala,GT
+Guernsey,GG
+Guinea,GN
+Guinea-Bissau,GW
+Guyana,GY
+Haiti,HT
+Heard Island and McDonald Islands,HM
+Holy See (Vatican City State),VA
+Honduras,HN
+Hong Kong,HK
+Hungary,HU
+Iceland,IS
+India,IN
+Indonesia,ID
+"Iran, Islamic Republic of",IR
+Iraq,IQ
+Ireland,IE
+Isle of Man,IM
+Israel,IL
+Italy,IT
+Jamaica,JM
+Japan,JP
+Jersey,JE
+Jordan,JO
+Kazakhstan,KZ
+Kenya,KE
+Kiribati,KI
+"Korea, Democratic People's Republic of",KP
+"Korea, Republic of",KR
+Kuwait,KW
+Kyrgyzstan,KG
+Lao People's Democratic Republic,LA
+Latvia,LV
+Lebanon,LB
+Lesotho,LS
+Liberia,LR
+Libya,LY
+Liechtenstein,LI
+Lithuania,LT
+Luxembourg,LU
+Macao,MO
+"Macedonia, the Former Yugoslav Republic of",MK
+Madagascar,MG
+Malawi,MW
+Malaysia,MY
+Maldives,MV
+Mali,ML
+Malta,MT
+Marshall Islands,MH
+Martinique,MQ
+Mauritania,MR
+Mauritius,MU
+Mayotte,YT
+Mexico,MX
+"Micronesia, Federated States of",FM
+"Moldova, Republic of",MD
+Monaco,MC
+Mongolia,MN
+Montenegro,ME
+Montserrat,MS
+Morocco,MA
+Mozambique,MZ
+Myanmar,MM
+Namibia,NA
+Nauru,NR
+Nepal,NP
+Netherlands,NL
+New Caledonia,NC
+New Zealand,NZ
+Nicaragua,NI
+Niger,NE
+Nigeria,NG
+Niue,NU
+Norfolk Island,NF
+Northern Mariana Islands,MP
+Norway,NO
+Oman,OM
+Pakistan,PK
+Palau,PW
+"Palestine, State of",PS
+Panama,PA
+Papua New Guinea,PG
+Paraguay,PY
+Peru,PE
+Philippines,PH
+Pitcairn,PN
+Poland,PL
+Portugal,PT
+Puerto Rico,PR
+Qatar,QA
+Réunion,RE
+Romania,RO
+Russian Federation,RU
+Rwanda,RW
+Saint Barthélemy,BL
+"Saint Helena, Ascension and Tristan da Cunha",SH
+Saint Kitts and Nevis,KN
+Saint Lucia,LC
+Saint Martin (French part),MF
+Saint Pierre and Miquelon,PM
+Saint Vincent and the Grenadines,VC
+Samoa,WS
+San Marino,SM
+Sao Tome and Principe,ST
+Saudi Arabia,SA
+Senegal,SN
+Serbia,RS
+Seychelles,SC
+Sierra Leone,SL
+Singapore,SG
+Sint Maarten (Dutch part),SX
+Slovakia,SK
+Slovenia,SI
+Solomon Islands,SB
+Somalia,SO
+South Africa,ZA
+South Georgia and the South Sandwich Islands,GS
+South Sudan,SS
+Spain,ES
+Sri Lanka,LK
+Sudan,SD
+Suriname,SR
+Svalbard and Jan Mayen,SJ
+Swaziland,SZ
+Sweden,SE
+Switzerland,CH
+Syrian Arab Republic,SY
+"Taiwan, Province of China",TW
+Tajikistan,TJ
+"Tanzania, United Republic of",TZ
+Thailand,TH
+Timor-Leste,TL
+Togo,TG
+Tokelau,TK
+Tonga,TO
+Trinidad and Tobago,TT
+Tunisia,TN
+Turkey,TR
+Turkmenistan,TM
+Turks and Caicos Islands,TC
+Tuvalu,TV
+Uganda,UG
+Ukraine,UA
+United Arab Emirates,AE
+United Kingdom,GB
+United States,US
+United States Minor Outlying Islands,UM
+Uruguay,UY
+Uzbekistan,UZ
+Vanuatu,VU
+"Venezuela, Bolivarian Republic of",VE
+Viet Nam,VN
+"Virgin Islands, British",VG
+"Virgin Islands, U.S.",VI
+Wallis and Futuna,WF
+Western Sahara,EH
+Yemen,YE
+Zambia,ZM
+Zimbabwe,ZW

--- a/sql/static/country_codes.sh
+++ b/sql/static/country_codes.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Creates static tables for mapping between country codes and country names
+# by loading data from CSV files.
+
+cd "$(dirname "$0")"
+
+# List of ISO 3166 alpha-2 country codes and names generated via:
+# curl -sL https://datahub.io/core/country-list/r/data.csv > country_codes.csv
+# See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+
+
+## Load country_codes_v1
+
+COUNTRY_CODES_SCHEMA='
+[
+  {
+    "name": "name",
+    "description": "Official country name per ISO 3166",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "code",
+    "description": "ISO 3166 alpha-2 country code",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  }
+]
+'
+
+bq load \
+   --ignore_unknown_values \
+   --skip_leading_rows=1 \
+   --source_format=CSV \
+   --schema=<(echo "$COUNTRY_CODES_SCHEMA") \
+   --replace \
+   moz-fx-data-derived-datasets:static.country_codes_v1 \
+   country_codes.csv
+
+bq update \
+   --description "Mapping of ISO 3166 alpha-2 country codes to country names; country codes are unique" \
+   moz-fx-data-derived-datasets:static.country_codes_v1
+
+## Load country_names_v1
+
+COUNTRY_NAMES_SCHEMA='
+[
+  {
+    "name": "name",
+    "description": "An official or common country name; a single country may appear with multiple names",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "code",
+    "description": "ISO 3166 alpha-2 country code",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  }
+]
+'
+
+(cat country_codes.csv && sed 1d country_names_alternate.csv) > country_names_full.csv
+
+bq load \
+   --ignore_unknown_values \
+   --skip_leading_rows=1 \
+   --source_format=CSV \
+   --schema=<(echo "$COUNTRY_NAMES_SCHEMA") \
+   --replace \
+   moz-fx-data-derived-datasets:static.country_names_v1 \
+   country_names_full.csv
+
+bq update \
+   --description="Mapping of country names to ISO 3166 alpha-2 country codes; the same code may appear under multiple names" \
+   moz-fx-data-derived-datasets:static.country_names_v1

--- a/sql/static/country_names_alternate.csv
+++ b/sql/static/country_names_alternate.csv
@@ -1,0 +1,38 @@
+Name,Code
+Russia,RU
+Czechia,CZ
+Taiwan,TW
+Iran,IR
+South Korea,KR
+Vietnam,VN
+Venezuela,VE
+Republic of Lithuania,LT
+Bolivia,CO
+Ivory Coast,CI
+Republic of Moldova,MD
+Tanzania,TZ
+Hashemite Kingdom of Jordan,JO
+Macedonia,MK
+Syria,SY
+Palestine,PS
+Brunei,BN
+Laos,LA
+Republic of the Congo,CG
+U.S. Virgin Islands,VI
+Cabo Verde,CV
+Eswatini,SZ
+Åland,AX
+Sint Maarten,SX
+Democratic Republic of Timor-Leste,TL
+St Kitts and Nevis,KN
+Kosovo,XK
+"Bonaire, Sint Eustatius, and Saba",BQ
+British Virgin Islands,VG
+Federated States of Micronesia,FM
+Saint Martin,MF
+São Tomé and Príncipe,ST
+Vatican City,VA
+Falkland Islands,FK
+North Korea,KP
+Cocos [Keeling] Islands,CC
+Saint Helena,SH


### PR DESCRIPTION
This is exploring a potential new pattern of generating a static table based on a bash script that runs `bq mk` and `bq load` commands to load CSVs to BQ.

I am putting these in the `static` dataset, but we don't have the same permissions there for redash, etc. to be able to reach them. We could simply put them in `telemetry` for now, or we could use this as an excuse to question how we want to lay out datasets again.