### PR TITLE
Use earliest row with document_id by timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Recommended practices
 - Should use `_` prefix in generated column names not meant for output
 - Should not use `DATETIME` type, due to incompatiblity with
   [spark-bigquery-connector](https://github.com/GoogleCloudPlatform/spark-bigquery-connector/issues/5)
+- Should use the earliest row for each `document_id` by `submission_timestamp`
+  if filtering duplicates
 
 ### UDFs
 

--- a/sql/core_clients_daily_v1.sql
+++ b/sql/core_clients_daily_v1.sql
@@ -53,7 +53,7 @@ WITH
   numbered_duplicates AS (
   SELECT
     * REPLACE(LOWER(client_id) AS client_id),
-    ROW_NUMBER() OVER (PARTITION BY client_id, submission_date_s3, metadata.document_id ORDER BY metadata.timestamp DESC) AS _n
+    ROW_NUMBER() OVER (PARTITION BY client_id, submission_date_s3, metadata.document_id ORDER BY metadata.timestamp) AS _n
   FROM
     telemetry_core_parquet_v3
   WHERE

--- a/sql/static/fxa_amplitude_export_users_daily.sql
+++ b/sql/static/fxa_amplitude_export_users_daily.sql
@@ -1,22 +1,20 @@
-CREATE TEMP FUNCTION udf_mode_last(x ANY TYPE) AS ((
-  SELECT
-    val
-  FROM (
+CREATE TEMP FUNCTION
+  udf_mode_last(list ANY TYPE) AS ((
     SELECT
-      val,
-      COUNT(val) AS n,
-      MAX(offset) AS max_offset
+      _value
     FROM
-      UNNEST(x) AS val
-    WITH OFFSET AS offset
+      UNNEST(list) AS _value
+    WITH
+    OFFSET
+      AS
+    _offset
     GROUP BY
-      val
+      _value
     ORDER BY
-      n DESC,
-      max_offset DESC
-  )
-  LIMIT 1
-));
+      COUNT(_value) DESC,
+      MAX(_offset) DESC
+    LIMIT
+      1 ));
 
 -- This UDF is only applicable in the context of this query;
 -- telemetry data accepts countries as two-digit codes, but FxA
@@ -60,14 +58,14 @@ WITH
       PARTITION BY
       user_id
     ORDER BY
-      event_time DESC
+      event_time
     ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
     -- We must provide a modified window for ROW_NUMBER which cannot accept a frame clause.
     w1_unframed AS (
     PARTITION BY
       user_id
     ORDER BY
-      event_time DESC) )
+      event_time) )
 SELECT
   * EXCEPT (_n)
 FROM


### PR DESCRIPTION
core_clients_daily_v1 was selecting latest row

extra:
- add recommendation to use earliest to readme
- fix mode_last in `static/fxa_amplitude_export_users_daily.sql`, not sure if I should remove this change, because it's too late because it's static.

not included:
- clients_daily_v7 already uses earliest
- fxa_users_daily_v1 doesn't deduplicate