### PR TITLE
Refined fxa table wildcards

### DIFF
--- a/sql/fxa_auth_bounce_events_v1.sql
+++ b/sql/fxa_auth_bounce_events_v1.sql
@@ -7,10 +7,10 @@ SELECT
             user_id),
           TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id) AS fields )) AS jsonPayload )
 FROM
-  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_bounces_*`
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_bounces_20*`
 WHERE
   jsonPayload.type = 'amplitudeEvent'
   AND jsonPayload.fields.event_type IS NOT NULL
   AND jsonPayload.fields.user_id IS NOT NULL
-  AND _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d',
+  AND _TABLE_SUFFIX = FORMAT_DATE('%g%m%d',
     @submission_date)

--- a/sql/fxa_auth_events_v1.sql
+++ b/sql/fxa_auth_events_v1.sql
@@ -7,10 +7,10 @@ SELECT
             user_id),
           TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id) AS fields )) AS jsonPayload )
 FROM
-  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_*`
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_20*`
 WHERE
   jsonPayload.type = 'amplitudeEvent'
   AND jsonPayload.fields.event_type IS NOT NULL
   AND jsonPayload.fields.user_id IS NOT NULL
-  AND _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d',
+  AND _TABLE_SUFFIX = FORMAT_DATE('%g%m%d',
     @submission_date)

--- a/sql/fxa_content_events_v1.sql
+++ b/sql/fxa_content_events_v1.sql
@@ -7,10 +7,10 @@ SELECT
             user_id),
           TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id) AS fields )) AS jsonPayload )
 FROM
-  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_content_*`
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_content_20*`
 WHERE
   jsonPayload.type = 'amplitudeEvent'
   AND jsonPayload.fields.event_type IS NOT NULL
   AND jsonPayload.fields.user_id IS NOT NULL
-  AND _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d',
+  AND _TABLE_SUFFIX = FORMAT_DATE('%g%m%d',
     @submission_date)


### PR DESCRIPTION
Fixes error:

> Error in query string: Error processing job 'moz-fx-data-derived-datasets:bqjob_r246b8e9136dc0b7f_0000016a8ec82840_1': Field name event_type does not exist in STRUCT<uid STRING, op STRING, action STRING, ...> at [13:26]

It looks like BigQuery was getting confused and including `auth_bounces` tables
as part of resolving schema for the `auth_*` wildcard. Adding an explicit
`20` for the century before the wildcard avoids the confusion.