### PR TITLE
Specify new fxa_configured field in clients_last_seen

### DIFF
--- a/sql/clients_last_seen_v1.sql
+++ b/sql/clients_last_seen_v1.sql
@@ -1,14 +1,15 @@
 WITH
   _current AS (
   SELECT
-    * EXCEPT (submission_date_s3),
+    * EXCEPT (submission_date_s3, fxa_configured),
     0 AS days_since_seen,
     -- For measuring Active MAU, where this is the days since this
     -- client_id was an Active User as defined by
     -- https://docs.telemetry.mozilla.org/cookbooks/active_dau.html
     IF(scalar_parent_browser_engagement_total_uri_count_sum >= 5,
       0,
-      NULL) AS days_since_visited_5_uri
+      NULL) AS days_since_visited_5_uri,
+    fxa_configured
   FROM
     clients_daily_v6
   WHERE

--- a/tests/clients_last_seen_v1/test_single_day/clients_daily_v6.schema.json
+++ b/tests/clients_last_seen_v1/test_single_day/clients_daily_v6.schema.json
@@ -31,5 +31,10 @@
     "name": "scalar_parent_browser_engagement_total_uri_count_sum",
     "type": "INT64",
     "mode": "NULLABLE"
+  },
+  {
+    "name": "fxa_configured",
+    "type": "BOOLEAN",
+    "mode": "NULLABLE"
   }
 ]

--- a/tests/clients_last_seen_v1/test_single_day/clients_last_seen_v1.schema.json
+++ b/tests/clients_last_seen_v1/test_single_day/clients_last_seen_v1.schema.json
@@ -40,5 +40,10 @@
     "name": "days_since_visited_5_uri",
     "type": "INT64",
     "mode": "NULLABLE"
+  },
+  {
+    "name": "fxa_configured",
+    "type": "BOOLEAN",
+    "mode": "NULLABLE"
   }
 ]


### PR DESCRIPTION
Discussing with Google in case 19367621; this seems like a bug in BQ since this commit should give the same logical result, but we're currently seeing the job fail due to a struct schema mismatch error.

This workaround gets the query passing the parser.