### PR TITLE
Add script to format sql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,17 @@ jobs:
         command: |
           echo "${DOCKER_PASS:?}" | docker login -u "${DOCKER_USER:?}" --password-stdin
           docker push "$IMAGE"
+  lint:
+    docker:
+    - image: node:12
+    steps:
+    - checkout
+    - run:
+        name: Install dependencies
+        command: npm install
+    - run:
+        name: Lint js code
+        command: npm run lint:js
 
 workflows:
   version: 2
@@ -80,6 +91,7 @@ workflows:
         context: data-eng-circleci-tests
     - verify-generated-sql
     - dry-run-sql
+    - lint
     - deploy:
         context: data-eng-bigquery-etl-dockerhub
         requires:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,12 @@
+env:
+  browser: true
+  commonjs: true
+  es6: true
+extends: airbnb-base
+globals:
+  Atomics: readonly
+  SharedArrayBuffer: readonly
+parserOptions:
+  ecmaVersion: 2018
+rules:
+  no-console: off

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 *.swo
 .DS_Store
 .mypy_cache/
+node_modules/
+package-lock.json
 venv/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,37 @@ BigQuery ETL
 
 Bigquery UDFs and SQL queries for building derived datasets.
 
+Formatting SQL
+---
+
+SQL should be formatted using `script/format-sql`. This script requires `node`,
+with dependencies installed via `npm install`.
+
+On OSX you can install `node` (and `npm` with it) from homebew with the command
+`brew install node`, or from nodesource as explained in
+[this guide](https://nodesource.com/blog/installing-nodejs-tutorial-mac-os-x/).
+
+Paths to directories or files can be passed as arguments to `script/format-sql`,
+or if none are specified it will read `.` and ignore `.git` and `node_modules`
+directories.
+
+SQL can be formatted without modifying files by piping sql to the script and
+output will automatically go to stdout, e.g.:
+
+```bash
+echo 'SELECT 1,2,3' | script/format-sql
+```
+
+To turn off sql formatting for a block of SQL, wrap it in `format:off` and
+`format:on` comments, like this:
+
+```sql
+SELECT
+  -- format:off
+  submission_date, sample_id, client_id
+  -- format:on
+```
+
 Recommended practices
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "bigquery-etl",
+  "description": "Mozilla BigQuery ETL",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mozilla/bigquery-etl"
+  },
+  "scripts": {
+    "format-sql": "node script/format-sql",
+    "lint": "npm run lint:js && npm run lint:sql",
+    "lint:js": "eslint script/format-sql",
+    "lint:sql": "node script/format-sql"
+  },
+  "license": "MPL-2.0",
+  "dependencies": {
+    "sql-formatter": "2.3.2",
+    "klaw-sync": "6.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^5.16.0",
+    "eslint-config-airbnb-base": "13.1.0",
+    "eslint-plugin-import": "2.17.3"
+  }
+}

--- a/script/format-sql
+++ b/script/format-sql
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+try {
+  require('klaw-sync'); // eslint-disable-line global-require
+  require('sql-formatter'); // eslint-disable-line global-require
+} catch (err) {
+  console.log('Missing dependencies. This probably means `npm install` should be run.');
+  process.exit(1);
+}
+
+const fs = require('fs');
+const klawSync = require('klaw-sync');
+const Formatter = require('sql-formatter/lib/core/Formatter');
+const Tokenizer = require('sql-formatter/lib/core/Tokenizer');
+
+const tokenizerCfg = {
+  // Define keywords for BigQuery Standard SQL
+  // These words get capitalized
+  reservedWords: [
+    'ASSERT_ROWS_MODIFIED', 'ALL', 'AND', 'ANY', 'ARRAY', 'AS', 'ASC', 'AT',
+    'BETWEEN', 'BY', 'CASE', 'CAST', 'COLLATE', 'CONTAINS', 'CREATE', 'CROSS',
+    'CUBE', 'CURRENT', 'DEFAULT', 'DEFINE', 'DESC', 'DISTINCT', 'ELSE', 'END',
+    'ENUM', 'ESCAPE', 'EXCEPT', 'EXCLUDE', 'EXISTS', 'EXTRACT', 'FALSE', 'FETCH',
+    'FOLLOWING', 'FOR', 'FROM', 'FULL', 'FUNCTION', 'GROUP', 'GROUPING',
+    'GROUPS', 'HASH', 'HAVING', 'IF', 'IGNORE', 'IN', 'INNER', 'INTERSECT',
+    'INTERVAL', 'INTO', 'IS', 'JOIN', 'LATERAL', 'LEFT', 'LIKE', 'LIMIT',
+    'LOOKUP', 'MERGE', 'NATURAL', 'NEW', 'NO', 'NOT', 'NULL', 'NULLS', 'OF',
+    'OFFSET', 'ON', 'OR', 'ORDER', 'ORDINAL', 'OUTER', 'OVER', 'PARTITION',
+    'PRECEDING', 'PROTO', 'RANGE', 'RECURSIVE', 'REPLACE', 'RESPECT', 'RIGHT',
+    'ROLLUP', 'ROWS', 'SELECT', 'SET', 'SOME', 'STRUCT', 'TABLESAMPLE', 'TEMP',
+    'TEMPORARY', 'THEN', 'TO', 'TREAT', 'TRUE', 'UNBOUNDED', 'UNION', 'UNNEST',
+    'USING', 'WHEN', 'WHERE', 'WINDOW', 'WITH', 'WITHIN',
+  ],
+  // These words get their own line followed by increased indent
+  reservedToplevelWords: [
+    // DDL
+    'ALTER TABLE IF EXISTS', 'ALTER TABLE', 'CREATE OR REPLACE TABLE',
+    'CREATE TABLE IF NOT EXISTS', 'CREATE TABLE', 'DROP TABLE', 'DROP VIEW',
+    // DML
+    'DELETE FROM', 'DELETE', 'INSERT INTO', 'INSERT', 'MERGE INTO', 'MERGE',
+    'UPDATE',
+    // SQL
+    'CROSS JOIN', 'FROM', 'FULL JOIN', 'FULL OUTER JOIN', 'GROUP BY', 'HAVING',
+    'INNER JOIN', 'INTERSECT', 'JOIN', 'LEFT JOIN', 'LEFT OUTER JOIN', 'LIMIT',
+    'ORDER BY', 'OUTER JOIN', 'PARTITION BY', 'RIGHT JOIN', 'RIGHT OUTER JOIN',
+    'ROWS BETWEEN', 'ROWS', 'SELECT AS STRUCT', 'SELECT AS VALUE', 'SELECT',
+    'SET', 'UNION ALL', 'UNION', 'USING', 'VALUES', 'WHERE',
+  ],
+  // These words start a new line at the current indent
+  reservedNewlineWords: ['AND', 'BETWEEN', 'ELSE', 'OR', 'WHEN', 'XOR'],
+  // eslint-disable-next-line quotes
+  stringTypes: [`''`, '""', '``'],
+  openParens: ['(', 'CASE', '['],
+  closeParens: [')', 'END', ']'],
+  indexedPlaceholderTypes: ['?'],
+  namedPlaceholderTypes: ['@'],
+  lineCommentTypes: ['#', '--'],
+};
+// add support for byte strings like b"" and b''
+const STRING_REGEX = new RegExp(`^([bB]?(?:${Tokenizer.prototype.createStringPattern(tokenizerCfg.stringTypes)}))`);
+// add >> and << to OPERATOR_REGEX to prevent spaces being added in the middle
+const OPERATOR_REGEX = /^(<<|>>|!=|<>|==|<=|>=|!<|!>|\|\||::|->>|->|~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|.)/;
+
+// BigQuery Standard SQL and capitalizing keywords aren't directly supported
+// by the sql-formatter library, so we implement support for those here
+function format(query) {
+  const tokenizer = new Tokenizer(tokenizerCfg);
+  tokenizer.STRING_REGEX = STRING_REGEX;
+  tokenizer.OPERATOR_REGEX = OPERATOR_REGEX;
+  const formatter = new Formatter({}, tokenizer);
+  let unformatted;
+  formatter.tokens = tokenizer.tokenize(query).flatMap((token) => {
+    // rewrite 'format off' comment through 'format on' comment as a single multiline comment token
+    if (unformatted !== undefined) {
+      // append to unformatted
+      unformatted.value += token.value;
+      if (token.type.endsWith('comment') && token.value.match(/\s*format\s*[:\s]\s*on\s*/)) {
+        // end unformatted block
+        unformatted = undefined;
+      }
+      // drop token, now that value as been appended to unformatted
+      return [];
+    }
+    if (token.type.endsWith('comment') && token.value.match(/\s*format\s*[:\s]\s*off\s*/)) {
+      // begin unformatted block
+      unformatted = token;
+      return [token];
+    }
+    if (token.type.startsWith('reserved')) {
+      // capitalize keywords
+      return [{ type: token.type, value: token.value.toUpperCase() }];
+    }
+    return [token];
+  });
+  // format whitespace
+  // force newline after every semicolon
+  // trim unwanted whitespace from end of statement
+  // end with newline
+  return `${formatter.getFormattedQueryFromTokens().replace(/;\n?/g, ';\n').trim()}\n`;
+}
+
+// Accept files or directories to format as command line arguments
+const args = process.argv.slice(2);
+// Default to formatting stdin
+if (!args.length) {
+  if (process.stdin.isTTY) {
+    console.log('Error: must pipe to stdin or provide a list of files and directories as arguments');
+    process.exit(1);
+  }
+  process.stdout.write(format(fs.readFileSync(0, 'utf-8')));
+} else {
+  // Get number of formatted files
+  const modified = args.flatMap((arg) => {
+    try {
+      // try to walk directory
+      return klawSync(arg).flatMap(item => (item.path.endsWith('.sql') ? item.path : []));
+    } catch (ignore) {
+      // must not be a directory, treat it like a file
+      return [arg];
+    }
+  }).filter((file) => {
+    const query = fs.readFileSync(file, 'utf-8');
+    const formatted = format(query);
+    const changed = query !== formatted;
+    // log change and overwrite file
+    if (changed) {
+      console.log(`modified ${file}`);
+      fs.writeFileSync(file, formatted);
+    }
+    return changed;
+  }).length;
+  // Summarize changes unless we only formatted stdin
+  console.log(`${modified} file(s) modified`);
+  // Exit non-zero on changes to make CI fail
+  if (modified) {
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
This is written for node because [sql-formatter](https://github.com/zeroturnaround/sql-formatter) is the first library I found that outputs SQL compatible with [our style guide](https://docs.telemetry.mozilla.org/concepts/sql_style.html), and my attempts at writing something to do this in python have proven fruitless.

cc @mythmon because we were talking about this yesterday and I'm not familiar with node, so the more eyes checking this work the better