### PR TITLE
Use imputed values for desktop KPIs after Armag-add-on

### DIFF
--- a/sql/firefox_desktop_exact_mau28_v1.sql
+++ b/sql/firefox_desktop_exact_mau28_v1.sql
@@ -45,13 +45,13 @@ SELECT
     base.tier1_mau) AS tier1_mau)
 FROM
   base
-LEFT JOIN
+FULL JOIN
   imputed_global
 USING
   (submission_date)
-LEFT JOIN
+FULL JOIN
   imputed_tier1
 USING
   (submission_date)
 ORDER BY
-  1
+  submission_date

--- a/sql/firefox_desktop_exact_mau28_v1.sql
+++ b/sql/firefox_desktop_exact_mau28_v1.sql
@@ -1,3 +1,5 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-derived-datasets.telemetry.firefox_desktop_exact_mau28_v1` AS
 WITH
   base AS (
   SELECT
@@ -5,6 +7,9 @@ WITH
     SUM(mau) AS mau,
     SUM(wau) AS wau,
     SUM(dau) AS dau,
+    sum(IF(country IN ('US', 'GB', 'FR', 'DE', 'CA'), mau, 0)) AS tier1_mau,
+    sum(IF(country IN ('US', 'GB', 'FR', 'DE', 'CA'), wau, 0)) AS tier1_wau,
+    sum(IF(country IN ('US', 'GB', 'FR', 'DE', 'CA'), dau, 0)) AS tier1_dau,
     SUM(visited_5_uri_mau) AS visited_5_uri_mau,
     SUM(visited_5_uri_wau) AS visited_5_uri_wau,
     SUM(visited_5_uri_dau) AS visited_5_uri_dau
@@ -14,24 +19,38 @@ WITH
     submission_date ),
   -- We use imputed values for the period after the Armag-add-on deletion event;
   -- see https://bugzilla.mozilla.org/show_bug.cgi?id=1552558
-  imputed AS (
+  imputed_global AS (
   SELECT
     `date` AS submission_date,
     mau
   FROM
-    static.firefox_desktop_imputed_mau28_v1
+    `moz-fx-data-derived-datasets.static.firefox_desktop_imputed_mau28_v1`
   WHERE
-    datasource = 'desktop_global')
+    datasource = 'desktop_global'),
+    --
+      imputed_tier1 AS (
+  SELECT
+    `date` AS submission_date,
+    mau
+  FROM
+    `moz-fx-data-derived-datasets.static.firefox_desktop_imputed_mau28_v1`
+  WHERE
+    datasource = 'desktop_tier1')
+
 SELECT
-  submission_date,
-  coalesce(imputed.mau,
+  base.* REPLACE (
+  COALESCE(imputed_global.mau,
     base.mau) AS mau,
-  base.* EXCEPT (submission_date,
-    mau)
+  COALESCE(imputed_tier1.mau,
+    base.tier1_mau) AS tier1_mau)
 FROM
   base
 LEFT JOIN
-  imputed
+  imputed_global
+USING
+  (submission_date)
+LEFT JOIN
+  imputed_tier1
 USING
   (submission_date)
 ORDER BY

--- a/sql/firefox_desktop_exact_mau28_v1.sql
+++ b/sql/firefox_desktop_exact_mau28_v1.sql
@@ -1,14 +1,38 @@
-CREATE OR REPLACE VIEW
-  firefox_desktop_exact_mau28_v1 AS
+WITH
+  base AS (
+  SELECT
+    submission_date,
+    SUM(mau) AS mau,
+    SUM(wau) AS wau,
+    SUM(dau) AS dau,
+    SUM(visited_5_uri_mau) AS visited_5_uri_mau,
+    SUM(visited_5_uri_wau) AS visited_5_uri_wau,
+    SUM(visited_5_uri_dau) AS visited_5_uri_dau
+  FROM
+    `moz-fx-data-derived-datasets.telemetry.firefox_desktop_exact_mau28_by_dimensions_v1`
+  GROUP BY
+    submission_date ),
+  -- We use imputed values for the period after the Armag-add-on deletion event;
+  -- see https://bugzilla.mozilla.org/show_bug.cgi?id=1552558
+  imputed AS (
+  SELECT
+    `date` AS submission_date,
+    mau
+  FROM
+    static.firefox_desktop_imputed_mau28_v1
+  WHERE
+    datasource = 'desktop_global')
 SELECT
   submission_date,
-  SUM(mau) AS mau,
-  SUM(wau) AS wau,
-  SUM(dau) AS dau,
-  SUM(visited_5_uri_mau) AS visited_5_uri_mau,
-  SUM(visited_5_uri_wau) AS visited_5_uri_wau,
-  SUM(visited_5_uri_dau) AS visited_5_uri_dau
+  coalesce(imputed.mau,
+    base.mau) AS mau,
+  base.* EXCEPT (submission_date,
+    mau)
 FROM
-  `moz-fx-data-derived-datasets.telemetry.firefox_desktop_exact_mau28_by_dimensions_v1`
-GROUP BY
-  submission_date
+  base
+LEFT JOIN
+  imputed
+USING
+  (submission_date)
+ORDER BY
+  1

--- a/sql/firefox_kpi_dashboard_v1.sql
+++ b/sql/firefox_kpi_dashboard_v1.sql
@@ -251,11 +251,11 @@ WITH
     'actual' AS type,
     `date`,
     mau,
-    -- The confidence interval is chosen here somewhat arbitrarily as 1% of the
-    -- value; in any case, we should show a larger interval than we do for
+    -- The confidence interval is chosen here somewhat arbitrarily as 0.5% of
+    -- the value; in any case, we should show a larger interval than we do for
     -- non-imputed actuals.
-    mau - mau * 0.01 AS mau_low,
-    mau + mau * 0.01 AS mau_high
+    mau - mau * 0.005 AS mau_low,
+    mau + mau * 0.005 AS mau_high
   FROM
     static.firefox_desktop_imputed_mau28_v1 )
   --


### PR DESCRIPTION
A prototype of the KPI dashboard using these imputed values can be seen in https://dbc-caf9527b-e073.cloud.databricks.com/#notebook/131180/dashboard/131209/present