### PR TITLE
don't depend on PATH for invoking subprocess in test

### DIFF
--- a/tests/test_longitudinal.py
+++ b/tests/test_longitudinal.py
@@ -1,12 +1,20 @@
 import textwrap
 import subprocess
+import sys
 
 import pytest
 
 
 def test_basic():
     results = subprocess.check_output(
-        ["sql/longitudinal.sql.py", "--tablename", "foo", "--to", "20190401"]
+        [
+            sys.executable,
+            "sql/longitudinal.sql.py",
+            "--tablename",
+            "foo",
+            "--to",
+            "20190401",
+        ]
     ).decode("ascii")
     assert results == textwrap.dedent(
         """
@@ -35,6 +43,7 @@ def test_everything():
 
     results = subprocess.check_output(
         [
+            sys.executable,
             "sql/longitudinal.sql.py",
             "--tablename",
             "foo",
@@ -82,6 +91,7 @@ def test_column_conflict():
     with pytest.raises(subprocess.CalledProcessError) as e:
         subprocess.check_output(
             [
+                sys.executable,
                 "sql/longitudinal.sql.py",
                 "--tablename",
                 "foo",


### PR DESCRIPTION
this makes tests runnable in virtualenvs, etc