### PR TITLE
Add setting gcloud authentication credentials to test documentation

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,7 @@ venv/bin/pytest --black --docstyle --flake8 --mypy-ignore-missing-imports -n 4
 ```
 
 To provide [authentication credentials for the Google Cloud API](https://cloud.google.com/docs/authentication/getting-started) the `GOOGLE_APPLICATION_CREDENTIALS` environment variable must be set to the file path of the JSON file that contains the service account key.
+See [Mozilla BigQuery API Access instructions](https://docs.telemetry.mozilla.org/cookbooks/bigquery.html#gcp-bigquery-api-access) to request credentials if you don't already have them.
 
 How to Configure a Generated Test
 ===

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,8 @@ venv/bin/pip install -r requirements.txt
 venv/bin/pytest --black --docstyle --flake8 --mypy-ignore-missing-imports -n 4
 ```
 
+To provide [authentication credentials for the Google Cloud API](https://cloud.google.com/docs/authentication/getting-started) the `GOOGLE_APPLICATION_CREDENTIALS` environment variable must be set to the file path of the JSON file that contains the service account key.
+
 How to Configure a Generated Test
 ===
 


### PR DESCRIPTION
The test documentation did not mention that the `GOOGLE_APPLICATION_CREDENTIALS` environment variable needs to be set otherwise almost all tests will fail locally. So I added that to the docs.