### PR TITLE
Add UDFs for parsing histogram JSON

### DIFF
--- a/udf/udf_js_json_extract_histogram.sql
+++ b/udf/udf_js_json_extract_histogram.sql
@@ -2,7 +2,7 @@
 
 Returns a parsed struct from a JSON string representing a histogram.
 
-This implementation uses Javascript and is provided for performance comparison;
+This implementation uses JavaScript and is provided for performance comparison;
 see udf_json_extract_histogram for a pure SQL implementation that will likely
 be more usable in practice.
 
@@ -17,6 +17,9 @@ CREATE TEMP FUNCTION
   `values` ARRAY<STRUCT<key INT64,
   value INT64>> >
   LANGUAGE js AS """
+    if (input == null) {
+      return null;
+    }
     var result = JSON.parse(input);
     var valuesMap = result.values;
     var valuesArray = [];

--- a/udf/udf_js_json_extract_histogram.sql
+++ b/udf/udf_js_json_extract_histogram.sql
@@ -1,0 +1,53 @@
+/*
+
+Returns a parsed struct from a JSON string representing a histogram.
+
+This implementation uses Javascript and is provided for performance comparison;
+see udf_json_extract_histogram for a pure SQL implementation that will likely
+be more usable in practice.
+
+*/
+
+CREATE TEMP FUNCTION
+  udf_js_json_extract_histogram (input STRING)
+  RETURNS STRUCT<bucket_count INT64,
+  histogram_type INT64,
+  `sum` INT64,
+  `range` ARRAY<INT64>,
+  `values` ARRAY<STRUCT<key INT64,
+  value INT64>> >
+  LANGUAGE js AS """
+    var result = JSON.parse(input);
+    var valuesMap = result.values;
+    var valuesArray = [];
+    for (var key in valuesMap) {
+      valuesArray.push({"key": parseInt(key), "value": valuesMap[key]})
+    }
+    result.values = valuesArray;
+    return result;
+""";
+
+-- Tests
+
+WITH
+  histogram AS (
+    SELECT AS VALUE
+      '{"bucket_count":10,"histogram_type":1,"sum":2628,"range":[1,100],"values":{"0":12434,"1":297,"13":8}}' ),
+  --
+  extracted AS (
+    SELECT
+      udf_js_json_extract_histogram(histogram).*
+    FROM
+      histogram )
+  --
+  SELECT
+    assert_equals(10, bucket_count),
+    assert_equals(1, histogram_type),
+    assert_equals(2628, `sum`),
+    assert_array_equals([1, 100], `range`),
+    assert_array_equals([STRUCT(0 AS key, 12434 AS value),
+                         STRUCT(1 AS key, 297 AS value),
+                         STRUCT(13 AS key, 8 AS value)],
+                        `values`)
+  FROM
+    extracted

--- a/udf/udf_json_extract_histogram.sql
+++ b/udf/udf_json_extract_histogram.sql
@@ -1,0 +1,53 @@
+/*
+
+Returns a parsed struct from a JSON string representing a histogram.
+
+The built-in BigQuery JSON parsing functions are not powerful enough to handle
+all the logic here, so we resort to some string processing. This function could
+behave unexpectedly on poorly-formatted histogram JSON, but we expect that
+payload validation in the data pipeline should ensure that histograms are well
+formed, which gives us some flexibility here.
+
+The only "correct" way to fully parse JSON strings in BigQuery is via JS UDFs;
+we provide a JS implementation udf_js_json_extract_histogram for comparison,
+but we expect that the overhead of the JS sandbox means that the pure SQL
+implementation here will have better performance.
+
+*/
+
+CREATE TEMP FUNCTION
+  udf_json_extract_histogram (input STRING) AS (STRUCT(
+    CAST(JSON_EXTRACT_SCALAR(input, '$.bucket_count') AS INT64) AS bucket_count,
+    CAST(JSON_EXTRACT_SCALAR(input, '$.histogram_type') AS INT64) AS histogram_type,
+    CAST(JSON_EXTRACT_SCALAR(input, '$.sum') AS INT64) AS `sum`,
+    ARRAY(
+      SELECT
+        CAST(bound AS INT64)
+      FROM
+        UNNEST(SPLIT(TRIM(JSON_EXTRACT(input, '$.range'), '[]'), ',')) AS bound) AS `range`,
+    udf_json_extract_int_map(JSON_EXTRACT(input, '$.values')) AS `values` ));
+
+-- Tests
+
+WITH
+  histogram AS (
+    SELECT AS VALUE
+      '{"bucket_count":10,"histogram_type":1,"sum":2628,"range":[1,100],"values":{"0":12434,"1":297,"13":8}}' ),
+  --
+  extracted AS (
+     SELECT
+       udf_json_extract_histogram(histogram).*
+     FROM
+       histogram )
+  --
+SELECT
+  assert_equals(10, bucket_count),
+  assert_equals(1, histogram_type),
+  assert_equals(2628, `sum`),
+  assert_array_equals([1, 100], `range`),
+  assert_array_equals([STRUCT(0 AS key, 12434 AS value),
+                       STRUCT(1 AS key, 297 AS value),
+                       STRUCT(13 AS key, 8 AS value)],
+                      `values`)
+FROM
+  extracted

--- a/udf/udf_json_extract_int_map.sql
+++ b/udf/udf_json_extract_int_map.sql
@@ -1,0 +1,23 @@
+/*
+
+Returns an array of key/value structs from a string representing a JSON map.
+
+Used by udf_json_extract_histogram.
+
+*/
+
+CREATE TEMP FUNCTION
+  udf_json_extract_int_map (input STRING) AS (ARRAY(
+    SELECT
+      STRUCT(CAST(SPLIT(entry, ':')[OFFSET(0)] AS INT64) AS key,
+             CAST(SPLIT(entry, ':')[OFFSET(1)] AS INT64) AS value)
+    FROM
+      UNNEST(SPLIT(REPLACE(TRIM(input, '{}'), '"', ''), ',')) AS entry ));
+
+-- Tests
+
+SELECT
+  assert_array_equals([STRUCT(0 AS key, 12434 AS value),
+                       STRUCT(1 AS key, 297 AS value),
+                       STRUCT(13 AS key, 8 AS value)],
+                      udf_json_extract_int_map('{"0":12434,"1":297,"13":8}'));

--- a/udf/udf_json_extract_int_map.sql
+++ b/udf/udf_json_extract_int_map.sql
@@ -12,7 +12,9 @@ CREATE TEMP FUNCTION
       STRUCT(CAST(SPLIT(entry, ':')[OFFSET(0)] AS INT64) AS key,
              CAST(SPLIT(entry, ':')[OFFSET(1)] AS INT64) AS value)
     FROM
-      UNNEST(SPLIT(REPLACE(TRIM(input, '{}'), '"', ''), ',')) AS entry ));
+      UNNEST(SPLIT(REPLACE(TRIM(input, '{}'), '"', ''), ',')) AS entry
+    WHERE
+      LENGTH(entry) > 0 ));
 
 -- Tests
 
@@ -20,4 +22,5 @@ SELECT
   assert_array_equals([STRUCT(0 AS key, 12434 AS value),
                        STRUCT(1 AS key, 297 AS value),
                        STRUCT(13 AS key, 8 AS value)],
-                      udf_json_extract_int_map('{"0":12434,"1":297,"13":8}'));
+                      udf_json_extract_int_map('{"0":12434,"1":297,"13":8}')),
+  assert_equals(0, ARRAY_LENGTH(udf_json_extract_int_map('{}')));


### PR DESCRIPTION
These will be used in performance testing of the proposed main ping representation where we leave histograms as JSON strings.