### PR TITLE
Add udf_json_extract_keyed_histogram_js

### DIFF
--- a/udf/udf_json_extract_keyed_histogram_js.sql
+++ b/udf/udf_json_extract_keyed_histogram_js.sql
@@ -1,0 +1,58 @@
+/*
+
+Returns an array of parsed structs from a JSON string representing a keyed histogram.
+
+*/
+
+CREATE TEMP FUNCTION
+  udf_json_extract_keyed_histogram_js (input STRING)
+  RETURNS ARRAY<STRUCT<key STRING,
+  bucket_count INT64,
+  histogram_type INT64,
+  `sum` INT64,
+  `range` ARRAY<INT64>,
+  `values` ARRAY<STRUCT<key INT64,
+  value INT64>> > >
+  LANGUAGE js AS """
+    if (input == null) {
+      return null;
+    }
+    var result = [];
+    var parsed = JSON.parse(input);
+    for (var histoKey in parsed) {
+      var histogram = parsed[histoKey]
+      var valuesMap = histogram.values;
+      var valuesArray = [];
+      for (var key in valuesMap) {
+        valuesArray.push({"key": parseInt(key), "value": valuesMap[key]})
+      }
+      histogram.values = valuesArray;
+      histogram.key = histoKey
+      result.push(histogram)
+    }
+    result.values = valuesArray;
+    return result;
+""";
+
+-- Tests
+
+WITH
+  keyed_histogram AS (
+    SELECT AS VALUE
+      '{"audio/mp4a-latm":{"bucket_count":3,"histogram_type":4,"sum":3,"range":[1,2],"values":{"0":3,"1":0}}}' ),
+  --
+  extracted AS (
+    SELECT
+      histogram.*
+    FROM
+      keyed_histogram,
+      UNNEST(udf_json_extract_keyed_histogram_js(keyed_histogram)) AS histogram )
+  --
+SELECT
+  assert_equals('audio/mp4a-latm', `key`),
+  assert_equals(3, bucket_count),
+  assert_equals(4, histogram_type),
+  assert_equals(3, `sum`),
+  assert_array_equals([1, 2], `range`)
+FROM
+  extracted

--- a/udf/udf_json_extract_keyed_histogram_js.sql
+++ b/udf/udf_json_extract_keyed_histogram_js.sql
@@ -30,7 +30,6 @@ CREATE TEMP FUNCTION
       histogram.key = histoKey
       result.push(histogram)
     }
-    result.values = valuesArray;
     return result;
 """;
 
@@ -53,6 +52,9 @@ SELECT
   assert_equals(3, bucket_count),
   assert_equals(4, histogram_type),
   assert_equals(3, `sum`),
-  assert_array_equals([1, 2], `range`)
+  assert_array_equals([1, 2], `range`),
+  assert_array_equals([STRUCT(0 AS key, 3 AS value),
+                       STRUCT(1 AS key, 0 AS value)],
+                      `values`)
 FROM
   extracted


### PR DESCRIPTION
I suspect we won't use this other than in tests since performance tests suggest we will probably want to represent keyed histograms as map types where the values are json strings representing individual histograms, rather than representing a keyed histogram as a single json string.

But I will use this in performance testing to confirm and document what interacting with keyed histograms as single json strings looks like.