### PR TITLE
Add udf_enforce_date_param

### DIFF
--- a/sql/fxa_users_daily_v1.sql
+++ b/sql/fxa_users_daily_v1.sql
@@ -1,4 +1,10 @@
 CREATE TEMP FUNCTION
+  udf_enforce_date_param(p1 DATE,
+    p2 DATE)
+  RETURNS BOOLEAN AS ( (p1 = p2)
+    OR (p1 = DATE('1111-11-11'))
+    OR (p2 = DATE('1111-11-11')) );
+CREATE TEMP FUNCTION
   udf_mode_last(list ANY TYPE) AS ((
     SELECT
       _value
@@ -74,7 +80,7 @@ WITH
       'mktg - email_sent',
       'sync - repair_success',
       'sync - repair_triggered')
-    AND DATE(submission_timestamp) = @submission_date
+    AND udf_enforce_date_param(DATE(submission_timestamp), @submission_date)
   WINDOW
     w1 AS (
     PARTITION BY

--- a/templates/fxa_users_daily_v1.sql
+++ b/templates/fxa_users_daily_v1.sql
@@ -56,7 +56,7 @@ WITH
       'mktg - email_sent',
       'sync - repair_success',
       'sync - repair_triggered')
-    AND DATE(submission_timestamp) = @submission_date
+    AND udf_enforce_date_param(DATE(submission_timestamp), @submission_date)
   WINDOW
     w1 AS (
     PARTITION BY

--- a/udf/udf_enforce_date_param.sql
+++ b/udf/udf_enforce_date_param.sql
@@ -1,0 +1,39 @@
+/*
+
+Returns true if the two passed dates are identical or if either of them is
+equal to the special flag date 0001-01-01.
+
+This is useful for queries that have a @submission_date parameter and are
+generally executed incrementally, but occasionally need to be run over all
+time to recreate the table. A query can be written with a WHERE clause like:
+
+    WHERE udf_enforce_date_param(submission_date, @submission_date)
+
+Under normal operation, this clause is equivalent to:
+
+    WHERE submission_date = @submission_date
+
+But if you execute the query with `--parameter submission_date:DATE:1111-11-11`,
+this essentially removes the WHERE clause.
+
+Proper use of this function requires that your query not reference the
+`@submission_date` parameter anywhere other than in the call to this function.
+It also requires that each day is independent, enforced by having your query
+group by submission_date or partition by submission_date in window functions
+(such as in clients_daily).
+
+*/
+
+CREATE TEMP FUNCTION
+  udf_enforce_date_param(p1 DATE,
+    p2 DATE)
+  RETURNS BOOLEAN AS ( (p1 = p2)
+    OR (p1 = DATE('1111-11-11'))
+    OR (p2 = DATE('1111-11-11')) );
+--
+SELECT
+  assert_true(udf_enforce_date_param(DATE('1111-11-11'), DATE('2019-06-02'))),
+  assert_true(udf_enforce_date_param(DATE('2019-06-02'), DATE('1111-11-11'))),
+  assert_true(udf_enforce_date_param(DATE('1111-11-11'), DATE('1111-11-11'))),
+  assert_true(udf_enforce_date_param(DATE('2019-06-02'), DATE('2019-06-02'))),
+  assert_false(udf_enforce_date_param(DATE('2019-06-02'), DATE('2019-06-03')))


### PR DESCRIPTION
This is an idea that may be more complex than it's worth.
But I was running quite a few queries today where I needed
to recreate a whole table and that process involved frequently modifying
the generated query to comment out the submission_date filter.

If this existed, I would have been able to use an unmodified query and call:

```
bq query --project moz-fx-data-derived-datasets 
  \ --nouse_legacy_sql 
  \ --dataset_id telemetry 
  \ --destination_table 'firefox_accounts_exact_mau28_raw_v1' 
  \ -n0 -q 
  \ --replace 
  \ --parameter submission_date:DATE:1111-11-11
```

As a future improvement, we could wrap support for this into the script runner wrappers so that you wouldn't have to pass the magic date explicitly.