### PR TITLE
Use partition elimination with fenix_events

### DIFF
--- a/sql/fenix_events_amplitude_v1.sql
+++ b/sql/fenix_events_amplitude_v1.sql
@@ -5,5 +5,4 @@ SELECT
 FROM
   fenix_events_v1
 WHERE
-  submission_date = @submission_date
-  AND submission_timestamp > TIMESTAMP(@submission_date)
+  DATE(submission_timestamp) = @submission_date

--- a/sql/fenix_events_amplitude_v1.sql
+++ b/sql/fenix_events_amplitude_v1.sql
@@ -6,3 +6,4 @@ FROM
   fenix_events_v1
 WHERE
   submission_date = @submission_date
+  AND submission_timestamp > TIMESTAMP(@submission_date)

--- a/sql/fenix_events_v1.sql
+++ b/sql/fenix_events_v1.sql
@@ -4,7 +4,6 @@ CREATE OR REPLACE VIEW
     `moz-fx-data-derived-datasets.telemetry.fenix_events_v1` AS
 SELECT
     submission_timestamp,
-    DATE(submission_timestamp) AS submission_date,
     client_info.client_id AS device_id,
     CONCAT(document_id, CAST(event.timestamp AS STRING)) AS insert_id,
     CONCAT(event.category, '.', event.name) AS event_type,

--- a/sql/fenix_events_v1.sql
+++ b/sql/fenix_events_v1.sql
@@ -3,6 +3,7 @@
 CREATE OR REPLACE VIEW
     `moz-fx-data-derived-datasets.telemetry.fenix_events_v1` AS
 SELECT
+    submission_timestamp,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id AS device_id,
     CONCAT(document_id, CAST(event.timestamp AS STRING)) AS insert_id,

--- a/templates/fenix_events_amplitude_v1.sql
+++ b/templates/fenix_events_amplitude_v1.sql
@@ -4,3 +4,4 @@ FROM
   fenix_events_v1
 WHERE
   submission_date = @submission_date
+  AND submission_timestamp > TIMESTAMP(@submission_date)

--- a/templates/fenix_events_amplitude_v1.sql
+++ b/templates/fenix_events_amplitude_v1.sql
@@ -3,5 +3,4 @@ SELECT
 FROM
   fenix_events_v1
 WHERE
-  submission_date = @submission_date
-  AND submission_timestamp > TIMESTAMP(@submission_date)
+  DATE(submission_timestamp) = @submission_date

--- a/templates/fenix_events_v1.sql
+++ b/templates/fenix_events_v1.sql
@@ -2,7 +2,6 @@ CREATE OR REPLACE VIEW
     `moz-fx-data-derived-datasets.telemetry.fenix_events_v1` AS
 SELECT
     submission_timestamp,
-    DATE(submission_timestamp) AS submission_date,
     client_info.client_id AS device_id,
     CONCAT(document_id, CAST(event.timestamp AS STRING)) AS insert_id,
     CONCAT(event.category, '.', event.name) AS event_type,

--- a/templates/fenix_events_v1.sql
+++ b/templates/fenix_events_v1.sql
@@ -1,6 +1,7 @@
 CREATE OR REPLACE VIEW
     `moz-fx-data-derived-datasets.telemetry.fenix_events_v1` AS
 SELECT
+    submission_timestamp,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id AS device_id,
     CONCAT(document_id, CAST(event.timestamp AS STRING)) AS insert_id,


### PR DESCRIPTION
Previously, the fenix_events_amplitude_v1 query
failed because there was no partition elimination.