### PR TITLE
Hit _live tables for fenix data

### DIFF
--- a/sql/glean_clients_daily_v1.sql
+++ b/sql/glean_clients_daily_v1.sql
@@ -73,7 +73,7 @@ WITH
     metrics AS baseline_metrics,
     NULL AS metrics
   FROM
-    `moz-fx-data-shared-prod.org_mozilla_fenix.baseline_v1`
+    `moz-fx-data-shared-prod.org_mozilla_fenix_live.baseline_v1`
   UNION ALL
   SELECT
     submission_timestamp,
@@ -85,7 +85,7 @@ WITH
     NULL AS baseline_metrics,
     metrics
   FROM
-    `moz-fx-data-shared-prod.org_mozilla_fenix.metrics_v1`
+    `moz-fx-data-shared-prod.org_mozilla_fenix_live.metrics_v1`
   ),
   --
   base AS (

--- a/templates/glean_clients_daily_v1.sql
+++ b/templates/glean_clients_daily_v1.sql
@@ -10,7 +10,7 @@ WITH
     metrics AS baseline_metrics,
     NULL AS metrics
   FROM
-    `moz-fx-data-shared-prod.org_mozilla_fenix.baseline_v1`
+    `moz-fx-data-shared-prod.org_mozilla_fenix_live.baseline_v1`
   UNION ALL
   SELECT
     submission_timestamp,
@@ -22,7 +22,7 @@ WITH
     NULL AS baseline_metrics,
     metrics
   FROM
-    `moz-fx-data-shared-prod.org_mozilla_fenix.metrics_v1`
+    `moz-fx-data-shared-prod.org_mozilla_fenix_live.metrics_v1`
   ),
   --
   base AS (


### PR DESCRIPTION
We've had 0 dau for fenix the last 7 days due to switching which tables
are fed by the pipeline. I've backfilled from the _live tables, and this
will allow further days to get the right data.