### PR TITLE
Support options with underscores and fix incorrect variable

### DIFF
--- a/script/copy_deduplicate
+++ b/script/copy_deduplicate
@@ -38,6 +38,7 @@ WHERE
 
 parser = ArgumentParser(description=__doc__)
 parser.add_argument(
+    "--project_id",
     "--project-id",
     default="moz-fx-data-shar-nonprod-efed",
     help="ID of the project in which to run query jobs",
@@ -55,6 +56,7 @@ parser.add_argument(
     help="Maximum number of queries to execute concurrently",
 )
 parser.add_argument(
+    "--dry_run",
     "--dry-run",
     action="store_true",
     help=(
@@ -111,7 +113,7 @@ def run_deduplication_query(client, live_table, stable_table, date, dry_run):
         query_job.result()
         print(
             "Processed {} bytes to populate {}".format(
-                query_job.total_bytes_processed, destination_table_spec
+                query_job.total_bytes_processed, destination
             )
         )
 


### PR DESCRIPTION
This job failed in Airflow with `NameError: name 'destination_table_spec' is not defined`, motivating this PR.
