### PR TITLE
Reuse bigquery client and set default project_id

### DIFF
--- a/script/publish_persistent_udfs
+++ b/script/publish_persistent_udfs
@@ -47,6 +47,7 @@ def main():
 
     raw_udfs = {x.name: x for x in read_udf_dir(args.udf_dir)}
     published_udfs = []
+    client = bigquery.Client(args.project_id)
 
     for raw_udf in raw_udfs:
         # get all dependencies for UDF and publish as persistent UDF
@@ -54,13 +55,11 @@ def main():
         udfs_to_publish.append(raw_udf)
         for dep in udfs_to_publish:
             if dep not in published_udfs:
-                publish_persistent_udf(raw_udfs[dep], args.dataset, args.project_id)
+                publish_persistent_udf(raw_udfs[dep], client, args.dataset, args.project_id)
                 published_udfs.append(dep)
 
 
-def publish_persistent_udf(raw_udf, dataset, project_id):
-    client = bigquery.Client()
-
+def publish_persistent_udf(raw_udf, client, dataset, project_id):
     # transforms temporary UDF to persistent UDFs and publishes them
     for definition in raw_udf.definitions:
         # Within a standard SQL function, references to other entities require explicit project IDs


### PR DESCRIPTION
if we don't set the default project id, then the bigquery logs for updating the udfs may show up in the wrong project, which is inconvenient when tracking down errors.