### PR TITLE
Latest version views and publishing script

### DIFF
--- a/script/dryrun
+++ b/script/dryrun
@@ -2,13 +2,15 @@
 
 import glob
 import json
+from multiprocessing.pool import ThreadPool
 import os.path
 import sys
 from urllib.request import urlopen, Request
 
-DRY_RUN_URL = 'https://us-central1-moz-fx-data-derived-datasets.cloudfunctions.net/bigquery-etl-dryrun'
-exitcode = 0
-skip={
+
+DRY_RUN_URL = "https://us-central1-moz-fx-data-derived-datasets.cloudfunctions.net/bigquery-etl-dryrun"
+
+SKIP = {
     # Access Denied
     "sql/telemetry/fxa_content_events_v1.sql",
     "sql/telemetry/fenix_events_v1.sql",
@@ -35,33 +37,60 @@ skip={
     "sql/telemetry_derived/addons_v3.sql",
     "sql/telemetry_derived/addons_aggregates_v3.sql",
 }
-for sql in glob.glob('sql/*/*.sql'):
-    if sql in skip:
-        continue
-    pad = ' ' * (60 - len(sql))
+
+
+def worker_entrypoint(sqlfile):
+    sql = open(sqlfile).read()
     try:
-        print(sql, end=pad)
         r = urlopen(
             Request(
                 DRY_RUN_URL,
-                headers = {
-                    'Content-Type': 'application/json'
-                },
-                data=json.dumps({
-                    'dataset': os.path.basename(os.path.dirname(sql)),
-                    'query': open(sql).read(),
-                }).encode('utf8'),
-                method='POST'
-            ))
+                headers={"Content-Type": "application/json"},
+                data=json.dumps(
+                    {
+                        "dataset": os.path.basename(os.path.dirname(sqlfile)),
+                        "query": sql,
+                    }
+                ).encode("utf8"),
+                method="POST",
+            )
+        )
     except Exception as e:
-        print('ERROR\n', e)
-        exitcode = 1
+        print(f"{sqlfile:59} ERROR\n", e)
+        return False
+    response = json.load(r)
+    if "errors" in response and len(response["errors"]) == 1:
+        error = response["errors"][0]
     else:
-        response = json.load(r)
-        if response['valid']:
-            print('OK')
-        else:
-            print('ERROR\n', response['errors'])
-            exitcode = 1
+        error = None
+    if response["valid"]:
+        print(f"{sqlfile:59} OK")
+    elif (
+        error
+        and error["code"] == 403
+        and "does not have bigquery.tables.create permission for dataset"
+        in error["message"]
+    ):
+        # We want the dryrun service to only have read permissions, so
+        # we expect CREATE VIEW and CREATE TABLE to throw specific
+        # exceptions.
+        print(f"{sqlfile:59} OK, but with insufficient access to create table/view")
+    else:
+        print(f"{sqlfile:59} ERROR\n", response["errors"])
+        return False
+    return True
 
-sys.exit(exitcode)
+
+def main():
+    sqlfiles = [f for f in glob.glob("sql/*/*.sql") if f not in SKIP]
+    with ThreadPool(8) as p:
+        result = p.map(worker_entrypoint, sqlfiles, chunksize=1)
+    if all(result):
+        exitcode = 0
+    else:
+        exitcode = 1
+    sys.exit(exitcode)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/generate_missing_latest_version_views
+++ b/script/generate_missing_latest_version_views
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 
-"""Create and update views of the latest versions of tables."""
+"""Generate one view definition file per document type in '_stable' tables.
+
+Run as:
+  ./script/generate_missing_latest_version_views 'moz-fx-data-shared-prod:*_stable.*'
+"""
 
 from argparse import ArgumentParser
 from google.cloud import bigquery
-from multidict import MultiDict
 from typing import Callable, Iterable, Tuple
 from fnmatch import fnmatchcase
 import logging
+import os
 import re
 import sys
 
@@ -41,22 +45,14 @@ parser.add_argument(
     f" defaults to: {DEFAULT_EXCLUDE}",
 )
 parser.add_argument(
-    "--dry-run",
-    action="store_true",
-    help="Don't apply changes and set log level to DEBUG",
-)
-parser.add_argument(
     "--log-level",
     default="INFO",
     help="Defaults to INFO",
 )
 
 args = parser.parse_args()
-exit(0)
 
 # set log level
-if args.dry_run:
-    args.log_level = "DEBUG"
 try:
     logging.basicConfig(level=args.log_level, format="%(levelname)s %(message)s")
 except ValueError as e:
@@ -84,16 +80,16 @@ for pattern in args.patterns:
     table = table or "*"
     if uses_wildcards(project):
         if all_projects is None:
-            all_projects = {p.project_id for p in client.list_projects()}
+            all_projects = [p.project_id for p in client.list_projects()]
         projects = [p for p in all_projects if fnmatchcase(project, p)]
     for project in projects:
         datasets = [dataset]
         if uses_wildcards(dataset):
             if project not in all_datasets:
-                all_datasets[project] = {
+                all_datasets[project] = [
                     d.dataset_id for d in client.list_datasets(project)
-                }
-            datasets = [d.dataset_id for d in all_datasets if fnmatchcase(dataset, d)]
+                ]
+            datasets = [d for d in all_datasets[project] if fnmatchcase(d, dataset)]
         for dataset in datasets:
             dataset = f"{project}.{dataset}"
             tables = [(f"{dataset}.{table}", None)]
@@ -102,45 +98,34 @@ for pattern in args.patterns:
                     all_tables[dataset] = list(client.list_tables(dataset))
                 tables = [
                     (f"{dataset}.{t.table_id}", t.table_type)
-                    for t in all_tables if fnmatchcase(table, t.table_id)
+                    for t in all_tables[dataset] if fnmatchcase(t.table_id, table)
                 ]
             for full_table_id, table_type in tables:
-                if fnmatchcase(table, t.table_id):
-                    view = VERSION_RE.sub("", full_table_id)
-                    if view not in views:
-                        views[view] = {}
-                    views[view][full_table_id] = table_type
+                view = VERSION_RE.sub("", full_table_id)
+                if view not in views:
+                    views[view] = {}
+                views[view][full_table_id] = table_type
 
 for view, tables in views.items():
     if any(fnmatchcase(pattern, view) for pattern in args.exclude):
         log.info("skipping table: matched by exclude pattern: {view}")
         continue
     version = max(
-        int(match.group())
+        int(match.group()[2:])
         for table in tables
         for match in (VERSION_RE.search(table),)
         if match is not None
     )
+    project, dataset, viewname = view.split(".")
     target = f"{view}_v{version}"
-    view_query = f"SELECT * FROM `{target}`"
-    try:
-        table = client.get_table(view)
-    except NotFound:
-        logging.info("creating view of: {latest_version}")
-        if not args.dry_run:
-            client.create_table(view, view_query=view_query)
-    else:
-        if table.table_type != "VIEW":
-            log.warning(f"skipping table: exists and is not view: {view}")
-            continue
-        actual_query = WHITESPACE_RE.sub(" ", table.view_query.replace("`", "").strip()))
-        if VERSION_RE.sub("", actual_query) != VERSION_RE.sub("", view_query.replace("`", "")):
-            log.warning(f"skipping table: not a version view: {view}")
-            continue
-        if normalized_actual_query == normalized_view_query:
-            log.warning(f"skipping table: already up to date: {view}")
-            continue
-        table.view_query = view_query
-        logging.info("updating view to: {latest_version}")
-        if not args.dry_run:
-            client.update_table(table, ["view_query"])
+    view_query = f"SELECT * FROM\n  `{target}`"
+    view_dataset = dataset.rsplit("_", 1)[-1]
+    full_view_id = '.'.join([project, view_dataset, viewname])
+    target_file = f"templates/{view_dataset}/{viewname}.sql"
+    full_sql = f"CREATE OR REPLACE VIEW\n  `{full_view_id}`\nAS {view_query}\n"
+    if not os.path.exists(target_file):
+        print("Creating " + target_file)
+        if not os.path.exists(os.path.dirname(target_file)):
+            os.makedirs(os.path.dirname(target_file))
+        with open(target_file, 'w') as f:
+            f.write(full_sql)

--- a/script/generate_missing_latest_version_views
+++ b/script/generate_missing_latest_version_views
@@ -122,7 +122,7 @@ for view, tables in views.items():
     project, dataset, viewname = view.split(".")
     target = f"{view}_v{version}"
     view_query = f"SELECT * FROM\n  `{target}`"
-    view_dataset = dataset.rsplit("_", 1)[-1]
+    view_dataset = dataset.rsplit("_", 1)[0]
     full_view_id = ".".join([project, view_dataset, viewname])
     target_file = f"templates/{view_dataset}/{viewname}.sql"
     full_sql = f"CREATE OR REPLACE VIEW\n  `{full_view_id}`\nAS {view_query}\n"

--- a/script/generate_missing_latest_version_views
+++ b/script/generate_missing_latest_version_views
@@ -23,9 +23,6 @@ WILDCARD_RE = re.compile(r"[*?[]")
 DEFAULT_PATTERN = "telemetry.*"
 DEFAULT_EXCLUDE = r"*_raw"
 
-client = bigquery.Client()
-
-
 def pattern(value: str) -> Tuple[str, str, str]:
     PATTERN_RE.fullmatch(value).groups(client.project)
 
@@ -58,6 +55,8 @@ except ValueError as e:
     parser.error(f"argument --log-level: {e}")
 
 wildcards = set("*?[]")
+
+client = bigquery.Client()
 
 
 def uses_wildcards(pattern: str) -> bool:

--- a/script/generate_missing_latest_version_views
+++ b/script/generate_missing_latest_version_views
@@ -24,8 +24,10 @@ DEFAULT_EXCLUDE = r"*_raw"
 
 client = bigquery.Client()
 
+
 def pattern(value: str) -> Tuple[str, str, str]:
     PATTERN_RE.fullmatch(value).groups(client.project)
+
 
 parser = ArgumentParser(description=__doc__)
 parser.add_argument(
@@ -44,11 +46,7 @@ parser.add_argument(
     help="Latest-version views that should be ignored, may use shell-style wildcards,"
     f" defaults to: {DEFAULT_EXCLUDE}",
 )
-parser.add_argument(
-    "--log-level",
-    default="INFO",
-    help="Defaults to INFO",
-)
+parser.add_argument("--log-level", default="INFO", help="Defaults to INFO")
 
 args = parser.parse_args()
 
@@ -59,8 +57,11 @@ except ValueError as e:
     parser.error(f"argument --log-level: {e}")
 
 wildcards = set("*?[]")
+
+
 def uses_wildcards(pattern: str) -> bool:
     return bool(set("*?[]") & set(pattern))
+
 
 patterns = [
     (project, dataset, table)
@@ -98,7 +99,8 @@ for pattern in args.patterns:
                     all_tables[dataset] = list(client.list_tables(dataset))
                 tables = [
                     (f"{dataset}.{t.table_id}", t.table_type)
-                    for t in all_tables[dataset] if fnmatchcase(t.table_id, table)
+                    for t in all_tables[dataset]
+                    if fnmatchcase(t.table_id, table)
                 ]
             for full_table_id, table_type in tables:
                 view = VERSION_RE.sub("", full_table_id)
@@ -120,12 +122,12 @@ for view, tables in views.items():
     target = f"{view}_v{version}"
     view_query = f"SELECT * FROM\n  `{target}`"
     view_dataset = dataset.rsplit("_", 1)[-1]
-    full_view_id = '.'.join([project, view_dataset, viewname])
+    full_view_id = ".".join([project, view_dataset, viewname])
     target_file = f"templates/{view_dataset}/{viewname}.sql"
     full_sql = f"CREATE OR REPLACE VIEW\n  `{full_view_id}`\nAS {view_query}\n"
     if not os.path.exists(target_file):
         print("Creating " + target_file)
         if not os.path.exists(os.path.dirname(target_file)):
             os.makedirs(os.path.dirname(target_file))
-        with open(target_file, 'w') as f:
+        with open(target_file, "w") as f:
             f.write(full_sql)

--- a/script/generate_missing_latest_version_views
+++ b/script/generate_missing_latest_version_views
@@ -7,13 +7,14 @@ Run as:
 """
 
 from argparse import ArgumentParser
-from google.cloud import bigquery
-from typing import Callable, Iterable, Tuple
 from fnmatch import fnmatchcase
 import logging
 import os
 import re
 import sys
+from typing import Callable, Iterable, Tuple
+
+from google.cloud import bigquery
 
 VERSION_RE = re.compile(r"_v([0-9]+)$")
 WHITESPACE_RE = re.compile(r"\s+")

--- a/script/publish_views
+++ b/script/publish_views
@@ -3,10 +3,10 @@
 """Find view definition files and execute them."""
 
 from argparse import ArgumentParser
-from google.cloud import bigquery
 import logging
 import os
 
+from google.cloud import bigquery
 import sqlparse
 
 

--- a/script/publish_views
+++ b/script/publish_views
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+"""Find view definition files and execute them."""
+
+from argparse import ArgumentParser
+from google.cloud import bigquery
+import logging
+import os
+
+import sqlparse
+
+
+def process_file(client, args, filepath):
+    with open(filepath) as f:
+        sql = f.read()
+    parsed = sqlparse.parse(sql)[0]
+    tokens = [t for t in parsed.tokens if not t.is_whitespace]
+    if tokens[0].normalized == "CREATE OR REPLACE" and tokens[1].normalized == "VIEW":
+        target_view = str(tokens[2])
+        target_project = target_view.strip("`").split(".")[0]
+        if args.target_project is None or target_project == args.target_project:
+            job_config = bigquery.QueryJobConfig(
+                use_legacy_sql=False, dry_run=args.dry_run
+            )
+            query_job = client.query(sql, job_config)
+            if args.dry_run:
+                print(f"Validated definition of {target_view} in {filepath}")
+            else:
+                query_job.result()
+                print(f"Published view {target_view}")
+
+
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "target",
+        nargs="+",
+        help="File or directory containing view definitions to execute",
+    )
+    parser.add_argument(
+        "--target-project",
+        help="If specified, only execute views defined under the given project ID",
+    )
+    parser.add_argument("--log-level", default="INFO", help="Defaults to INFO")
+    parser.add_argument(
+        "--dry_run",
+        "--dry-run",
+        action="store_true",
+        help="Validate view definitions, but do not publish them.",
+    )
+
+    args = parser.parse_args()
+    client = bigquery.Client()
+
+    # set log level
+    try:
+        logging.basicConfig(level=args.log_level, format="%(levelname)s %(message)s")
+    except ValueError as e:
+        parser.error(f"argument --log-level: {e}")
+
+    for target in args.target:
+        if os.path.isdir(target):
+            for root, dirs, files in os.walk(target):
+                sql_files = [
+                    filename for filename in files if filename.endswith(".sql")
+                ]
+                for sql_file in sql_files:
+                    process_file(client, args, os.path.join(root, sql_file))
+        else:
+            process_file(client, args, target)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/update-latest-version-views
+++ b/script/update-latest-version-views
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+"""Create and update views of the latest versions of tables."""
+
+from argparse import ArgumentParser
+from google.cloud import bigquery
+from multidict import MultiDict
+from typing import Callable, Iterable, Tuple
+from fnmatch import fnmatchcase
+import logging
+import re
+import sys
+
+VERSION_RE = re.compile(r"_v([0-9]+)$")
+WHITESPACE_RE = re.compile(r"\s+")
+WILDCARD_RE = re.compile(r"[*?[]")
+
+DEFAULT_PATTERN = "telemetry.*"
+DEFAULT_EXCLUDE = r"*_raw"
+
+client = bigquery.Client()
+
+def pattern(value: str) -> Tuple[str, str, str]:
+    PATTERN_RE.fullmatch(value).groups(client.project)
+
+parser = ArgumentParser(description=__doc__)
+parser.add_argument(
+    "patterns",
+    metavar="[project:]dataset[.table]",
+    default=[DEFAULT_PATTERN],
+    nargs="*",
+    help="Table that should have a latest-version view, may use shell-style wildcards,"
+    f" defaults to: {DEFAULT_PATTERN}",
+)
+parser.add_argument(
+    "--exclude",
+    action="append",
+    default=[DEFAULT_EXCLUDE],
+    metavar="project:dataset.table",
+    help="Latest-version views that should be ignored, may use shell-style wildcards,"
+    f" defaults to: {DEFAULT_EXCLUDE}",
+)
+parser.add_argument(
+    "--dry-run",
+    action="store_true",
+    help="Don't apply changes and set log level to DEBUG",
+)
+parser.add_argument(
+    "--log-level",
+    default="INFO",
+    help="Defaults to INFO",
+)
+
+args = parser.parse_args()
+exit(0)
+
+# set log level
+if args.dry_run:
+    args.log_level = "DEBUG"
+try:
+    logging.basicConfig(level=args.log_level, format="%(levelname)s %(message)s")
+except ValueError as e:
+    parser.error(f"argument --log-level: {e}")
+
+wildcards = set("*?[]")
+def uses_wildcards(pattern: str) -> bool:
+    return bool(set("*?[]") & set(pattern))
+
+patterns = [
+    (project, dataset, table)
+    for pattern in args.patterns
+    for project, _, dataset_table in (pattern.partition(":"),)
+    for dataset, _, table in (dataset_table.partition("."),)
+]
+all_projects = None
+all_datasets = {}
+all_tables = {}
+views = {}
+for pattern in args.patterns:
+    project, _, dataset_table = pattern.partition(":")
+    dataset, _, table = dataset_table.partition(".")
+    projects = [project or client.project]
+    dataset = dataset or "*"
+    table = table or "*"
+    if uses_wildcards(project):
+        if all_projects is None:
+            all_projects = {p.project_id for p in client.list_projects()}
+        projects = [p for p in all_projects if fnmatchcase(project, p)]
+    for project in projects:
+        datasets = [dataset]
+        if uses_wildcards(dataset):
+            if project not in all_datasets:
+                all_datasets[project] = {
+                    d.dataset_id for d in client.list_datasets(project)
+                }
+            datasets = [d.dataset_id for d in all_datasets if fnmatchcase(dataset, d)]
+        for dataset in datasets:
+            dataset = f"{project}.{dataset}"
+            tables = [(f"{dataset}.{table}", None)]
+            if uses_wildcards(table):
+                if dataset not in all_tables:
+                    all_tables[dataset] = list(client.list_tables(dataset))
+                tables = [
+                    (f"{dataset}.{t.table_id}", t.table_type)
+                    for t in all_tables if fnmatchcase(table, t.table_id)
+                ]
+            for full_table_id, table_type in tables:
+                if fnmatchcase(table, t.table_id):
+                    view = VERSION_RE.sub("", full_table_id)
+                    if view not in views:
+                        views[view] = {}
+                    views[view][full_table_id] = table_type
+
+for view, tables in views.items():
+    if any(fnmatchcase(pattern, view) for pattern in args.exclude):
+        log.info("skipping table: matched by exclude pattern: {view}")
+        continue
+    version = max(
+        int(match.group())
+        for table in tables
+        for match in (VERSION_RE.search(table),)
+        if match is not None
+    )
+    target = f"{view}_v{version}"
+    view_query = f"SELECT * FROM `{target}`"
+    try:
+        table = client.get_table(view)
+    except NotFound:
+        logging.info("creating view of: {latest_version}")
+        if not args.dry_run:
+            client.create_table(view, view_query=view_query)
+    else:
+        if table.table_type != "VIEW":
+            log.warning(f"skipping table: exists and is not view: {view}")
+            continue
+        actual_query = WHITESPACE_RE.sub(" ", table.view_query.replace("`", "").strip()))
+        if VERSION_RE.sub("", actual_query) != VERSION_RE.sub("", view_query.replace("`", "")):
+            log.warning(f"skipping table: not a version view: {view}")
+            continue
+        if normalized_actual_query == normalized_view_query:
+            log.warning(f"skipping table: already up to date: {view}")
+            continue
+        table.view_query = view_query
+        logging.info("updating view to: {latest_version}")
+        if not args.dry_run:
+            client.update_table(table, ["view_query"])

--- a/sql/activity_stream/impression_stats.sql
+++ b/sql/activity_stream/impression_stats.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.activity_stream.impression_stats`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.activity_stream_stable.impression_stats_v1`

--- a/sql/activity_stream/spoc_fills.sql
+++ b/sql/activity_stream/spoc_fills.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.activity_stream.spoc_fills`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.activity_stream_stable.spoc_fills_v1`

--- a/sql/coverage/coverage.sql
+++ b/sql/coverage/coverage.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.coverage.coverage`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.coverage_stable.coverage_v1`

--- a/sql/edge_validator/error_report.sql
+++ b/sql/edge_validator/error_report.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.edge_validator.error_report`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.edge_validator_stable.error_report_v1`

--- a/sql/eng_workflow/bmobugs.sql
+++ b/sql/eng_workflow/bmobugs.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.eng_workflow.bmobugs`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.eng_workflow_stable.bmobugs_v1`

--- a/sql/eng_workflow/build.sql
+++ b/sql/eng_workflow/build.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.eng_workflow.build`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.eng_workflow_stable.build_v1`

--- a/sql/eng_workflow/hgpush.sql
+++ b/sql/eng_workflow/hgpush.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.eng_workflow.hgpush`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.eng_workflow_stable.hgpush_v1`

--- a/sql/firefox_installer/install.sql
+++ b/sql/firefox_installer/install.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_installer.install`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.firefox_installer_stable.install_v1`

--- a/sql/firefox_launcher_process/launcher_process_failure.sql
+++ b/sql/firefox_launcher_process/launcher_process_failure.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_launcher_process.launcher_process_failure`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.firefox_launcher_process_stable.launcher_process_failure_v1`

--- a/sql/mobile/activation.sql
+++ b/sql/mobile/activation.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mobile.activation`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.mobile_stable.activation_v1`

--- a/sql/mozdata/event.sql
+++ b/sql/mozdata/event.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mozdata.event`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.mozdata_stable.event_v1`

--- a/sql/mozza/event.sql
+++ b/sql/mozza/event.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mozza.event`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.mozza_stable.event_v1`

--- a/sql/org_mozilla_fenix/activation.sql
+++ b/sql/org_mozilla_fenix/activation.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.activation`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.activation_v1`

--- a/sql/org_mozilla_fenix/baseline.sql
+++ b/sql/org_mozilla_fenix/baseline.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.baseline`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.baseline_v1`

--- a/sql/org_mozilla_fenix/bookmarks_sync.sql
+++ b/sql/org_mozilla_fenix/bookmarks_sync.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.bookmarks_sync`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.bookmarks_sync_v1`

--- a/sql/org_mozilla_fenix/events.sql
+++ b/sql/org_mozilla_fenix/events.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.events`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.events_v1`

--- a/sql/org_mozilla_fenix/history_sync.sql
+++ b/sql/org_mozilla_fenix/history_sync.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.history_sync`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.history_sync_v1`

--- a/sql/org_mozilla_fenix/metrics.sql
+++ b/sql/org_mozilla_fenix/metrics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.metrics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.metrics_v1`

--- a/sql/org_mozilla_reference_browser/baseline.sql
+++ b/sql/org_mozilla_reference_browser/baseline.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser.baseline`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser_stable.baseline_v1`

--- a/sql/org_mozilla_reference_browser/events.sql
+++ b/sql/org_mozilla_reference_browser/events.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser.events`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser_stable.events_v1`

--- a/sql/org_mozilla_reference_browser/metrics.sql
+++ b/sql/org_mozilla_reference_browser/metrics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser.metrics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser_stable.metrics_v1`

--- a/sql/org_mozilla_samples_glean/baseline.sql
+++ b/sql/org_mozilla_samples_glean/baseline.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean.baseline`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.baseline_v1`

--- a/sql/org_mozilla_samples_glean/events.sql
+++ b/sql/org_mozilla_samples_glean/events.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean.events`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.events_v1`

--- a/sql/org_mozilla_samples_glean/metrics.sql
+++ b/sql/org_mozilla_samples_glean/metrics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean.metrics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.metrics_v1`

--- a/sql/org_mozilla_tv_firefox/baseline.sql
+++ b/sql/org_mozilla_tv_firefox/baseline.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox.baseline`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox_stable.baseline_v1`

--- a/sql/org_mozilla_tv_firefox/events.sql
+++ b/sql/org_mozilla_tv_firefox/events.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox.events`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox_stable.events_v1`

--- a/sql/org_mozilla_tv_firefox/metrics.sql
+++ b/sql/org_mozilla_tv_firefox/metrics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox.metrics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox_stable.metrics_v1`

--- a/sql/pocket/fire_tv_events.sql
+++ b/sql/pocket/fire_tv_events.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.pocket.fire_tv_events`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.pocket_stable.fire_tv_events_v1`

--- a/sql/telemetry/addon_install_blocked.sql
+++ b/sql/telemetry/addon_install_blocked.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.addon_install_blocked`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.addon_install_blocked_v4`

--- a/sql/telemetry/advancedtelemetry.sql
+++ b/sql/telemetry/advancedtelemetry.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.advancedtelemetry`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.advancedtelemetry_v4`

--- a/sql/telemetry/android_anr_report.sql
+++ b/sql/telemetry/android_anr_report.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.android_anr_report`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.android_anr_report_v10`

--- a/sql/telemetry/anonymous.sql
+++ b/sql/telemetry/anonymous.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.anonymous`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.anonymous_v4`

--- a/sql/telemetry/bhr.sql
+++ b/sql/telemetry/bhr.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.bhr`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.bhr_v4`

--- a/sql/telemetry/block_autoplay.sql
+++ b/sql/telemetry/block_autoplay.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.block_autoplay`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.block_autoplay_v4`

--- a/sql/telemetry/certificate_checker.sql
+++ b/sql/telemetry/certificate_checker.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.certificate_checker`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.certificate_checker_v4`

--- a/sql/telemetry/core.sql
+++ b/sql/telemetry/core.sql
@@ -1,4 +1,27 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.core`
-AS SELECT * FROM
-  `moz-fx-data-shared-prod.telemetry_stable.core_v10`
+AS
+WITH unioned AS (
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v2`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v3`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v4`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v5`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v6`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v7`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v8`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v9`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v10`)
+  --
+SELECT
+  *
+FROM
+  unioned
+

--- a/sql/telemetry/core.sql
+++ b/sql/telemetry/core.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.core`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.core_v10`

--- a/sql/telemetry/crash.sql
+++ b/sql/telemetry/crash.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.crash`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.crash_v4`

--- a/sql/telemetry/deletion.sql
+++ b/sql/telemetry/deletion.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.deletion`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.deletion_v4`

--- a/sql/telemetry/deployment_checker.sql
+++ b/sql/telemetry/deployment_checker.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.deployment_checker`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.deployment_checker_v4`

--- a/sql/telemetry/disable_sha1rollout.sql
+++ b/sql/telemetry/disable_sha1rollout.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.disable_sha1rollout`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.disable_sha1rollout_v4`

--- a/sql/telemetry/downgrade.sql
+++ b/sql/telemetry/downgrade.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.downgrade`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.downgrade_v4`

--- a/sql/telemetry/event.sql
+++ b/sql/telemetry/event.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.event`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.event_v4`

--- a/sql/telemetry/first_shutdown.sql
+++ b/sql/telemetry/first_shutdown.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.first_shutdown`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_v4`

--- a/sql/telemetry/flash_shield_study.sql
+++ b/sql/telemetry/flash_shield_study.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.flash_shield_study`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.flash_shield_study_v4`

--- a/sql/telemetry/focus_event.sql
+++ b/sql/telemetry/focus_event.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.focus_event`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.focus_event_v1`

--- a/sql/telemetry/frecency_update.sql
+++ b/sql/telemetry/frecency_update.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.frecency_update`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.frecency_update_v4`

--- a/sql/telemetry/ftu.sql
+++ b/sql/telemetry/ftu.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.ftu`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.ftu_v3`

--- a/sql/telemetry/health.sql
+++ b/sql/telemetry/health.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.health`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.health_v9`

--- a/sql/telemetry/heartbeat.sql
+++ b/sql/telemetry/heartbeat.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.heartbeat`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.heartbeat_v4`

--- a/sql/telemetry/main.sql
+++ b/sql/telemetry/main.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.main`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.main_v4`

--- a/sql/telemetry/malware_addon_states.sql
+++ b/sql/telemetry/malware_addon_states.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.malware_addon_states`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.malware_addon_states_v4`

--- a/sql/telemetry/mobile_event.sql
+++ b/sql/telemetry/mobile_event.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.mobile_event`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.mobile_event_v1`

--- a/sql/telemetry/mobile_metrics.sql
+++ b/sql/telemetry/mobile_metrics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.mobile_metrics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.mobile_metrics_v1`

--- a/sql/telemetry/modules.sql
+++ b/sql/telemetry/modules.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.modules`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.modules_v4`

--- a/sql/telemetry/new_profile.sql
+++ b/sql/telemetry/new_profile.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.new_profile`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.new_profile_v4`

--- a/sql/telemetry/optout.sql
+++ b/sql/telemetry/optout.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.optout`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.optout_v4`

--- a/sql/telemetry/outofdate_notifications_system_addon.sql
+++ b/sql/telemetry/outofdate_notifications_system_addon.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.outofdate_notifications_system_addon`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.outofdate_notifications_system_addon_v4`

--- a/sql/telemetry/pioneer_study.sql
+++ b/sql/telemetry/pioneer_study.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.pioneer_study`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.pioneer_study_v4`

--- a/sql/telemetry/pre_account.sql
+++ b/sql/telemetry/pre_account.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.pre_account`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.pre_account_v4`

--- a/sql/telemetry/prio.sql
+++ b/sql/telemetry/prio.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.prio`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.prio_v4`

--- a/sql/telemetry/saved_session.sql
+++ b/sql/telemetry/saved_session.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.saved_session`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.saved_session_v4`

--- a/sql/telemetry/searchvol.sql
+++ b/sql/telemetry/searchvol.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.searchvol`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.searchvol_v4`

--- a/sql/telemetry/searchvolextra.sql
+++ b/sql/telemetry/searchvolextra.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.searchvolextra`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.searchvolextra_v4`

--- a/sql/telemetry/shield_icq_v1.sql
+++ b/sql/telemetry/shield_icq_v1.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.shield_icq_v1`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.shield_icq_v1_v4`

--- a/sql/telemetry/shield_study.sql
+++ b/sql/telemetry/shield_study.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.shield_study`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.shield_study_v4`

--- a/sql/telemetry/shield_study_addon.sql
+++ b/sql/telemetry/shield_study_addon.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.shield_study_addon`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.shield_study_addon_v4`

--- a/sql/telemetry/shield_study_error.sql
+++ b/sql/telemetry/shield_study_error.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.shield_study_error`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.shield_study_error_v4`

--- a/sql/telemetry/sync.sql
+++ b/sql/telemetry/sync.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.sync`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.sync_v5`

--- a/sql/telemetry/system_addon_deployment_diagnostics.sql
+++ b/sql/telemetry/system_addon_deployment_diagnostics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.system_addon_deployment_diagnostics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.system_addon_deployment_diagnostics_v4`

--- a/sql/telemetry/testpilot.sql
+++ b/sql/telemetry/testpilot.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.testpilot`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.testpilot_v4`

--- a/sql/telemetry/testpilottest.sql
+++ b/sql/telemetry/testpilottest.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.testpilottest`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.testpilottest_v4`

--- a/sql/telemetry/tls13_middlebox_alt_server_hello_1.sql
+++ b/sql/telemetry/tls13_middlebox_alt_server_hello_1.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_alt_server_hello_1`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_alt_server_hello_1_v4`

--- a/sql/telemetry/tls13_middlebox_beta.sql
+++ b/sql/telemetry/tls13_middlebox_beta.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_beta`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_beta_v4`

--- a/sql/telemetry/tls13_middlebox_draft22.sql
+++ b/sql/telemetry/tls13_middlebox_draft22.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_draft22`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_draft22_v4`

--- a/sql/telemetry/tls13_middlebox_ghack.sql
+++ b/sql/telemetry/tls13_middlebox_ghack.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_ghack`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_ghack_v4`

--- a/sql/telemetry/tls13_middlebox_repetition.sql
+++ b/sql/telemetry/tls13_middlebox_repetition.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_repetition`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_repetition_v4`

--- a/sql/telemetry/tls13_middlebox_testing.sql
+++ b/sql/telemetry/tls13_middlebox_testing.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_testing`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_testing_v4`

--- a/sql/telemetry/tls_13_study.sql
+++ b/sql/telemetry/tls_13_study.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls_13_study`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls_13_study_v4`

--- a/sql/telemetry/tls_13_study_v1.sql
+++ b/sql/telemetry/tls_13_study_v1.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls_13_study_v1`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls_13_study_v1_v4`

--- a/sql/telemetry/tls_13_study_v2.sql
+++ b/sql/telemetry/tls_13_study_v2.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls_13_study_v2`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls_13_study_v2_v4`

--- a/sql/telemetry/tls_13_study_v3.sql
+++ b/sql/telemetry/tls_13_study_v3.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls_13_study_v3`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls_13_study_v3_v4`

--- a/sql/telemetry/tls_13_study_v4.sql
+++ b/sql/telemetry/tls_13_study_v4.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls_13_study_v4`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls_13_study_v4_v4`

--- a/sql/telemetry/uitour_tag.sql
+++ b/sql/telemetry/uitour_tag.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uitour_tag`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.uitour_tag_v4`

--- a/sql/telemetry/untrusted_modules.sql
+++ b/sql/telemetry/untrusted_modules.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.untrusted_modules`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.untrusted_modules_v4`

--- a/sql/telemetry/update.sql
+++ b/sql/telemetry/update.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.update`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.update_v4`

--- a/sql/telemetry/x_contextual_feature_recommendation.sql
+++ b/sql/telemetry/x_contextual_feature_recommendation.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.x_contextual_feature_recommendation`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.x_contextual_feature_recommendation_v4`

--- a/sql/webpagetest/webpagetest_run.sql
+++ b/sql/webpagetest/webpagetest_run.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.webpagetest.webpagetest_run`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.webpagetest_stable.webpagetest_run_v1`

--- a/templates/activity_stream/impression_stats.sql
+++ b/templates/activity_stream/impression_stats.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.activity_stream.impression_stats`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.activity_stream_stable.impression_stats_v1`

--- a/templates/activity_stream/spoc_fills.sql
+++ b/templates/activity_stream/spoc_fills.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.activity_stream.spoc_fills`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.activity_stream_stable.spoc_fills_v1`

--- a/templates/coverage/coverage.sql
+++ b/templates/coverage/coverage.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.coverage.coverage`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.coverage_stable.coverage_v1`

--- a/templates/edge_validator/error_report.sql
+++ b/templates/edge_validator/error_report.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.edge_validator.error_report`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.edge_validator_stable.error_report_v1`

--- a/templates/eng_workflow/bmobugs.sql
+++ b/templates/eng_workflow/bmobugs.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.eng_workflow.bmobugs`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.eng_workflow_stable.bmobugs_v1`

--- a/templates/eng_workflow/build.sql
+++ b/templates/eng_workflow/build.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.eng_workflow.build`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.eng_workflow_stable.build_v1`

--- a/templates/eng_workflow/hgpush.sql
+++ b/templates/eng_workflow/hgpush.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.eng_workflow.hgpush`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.eng_workflow_stable.hgpush_v1`

--- a/templates/firefox_installer/install.sql
+++ b/templates/firefox_installer/install.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_installer.install`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.firefox_installer_stable.install_v1`

--- a/templates/firefox_launcher_process/launcher_process_failure.sql
+++ b/templates/firefox_launcher_process/launcher_process_failure.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_launcher_process.launcher_process_failure`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.firefox_launcher_process_stable.launcher_process_failure_v1`

--- a/templates/mobile/activation.sql
+++ b/templates/mobile/activation.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mobile.activation`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.mobile_stable.activation_v1`

--- a/templates/mozdata/event.sql
+++ b/templates/mozdata/event.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mozdata.event`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.mozdata_stable.event_v1`

--- a/templates/mozza/event.sql
+++ b/templates/mozza/event.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mozza.event`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.mozza_stable.event_v1`

--- a/templates/org_mozilla_fenix/activation.sql
+++ b/templates/org_mozilla_fenix/activation.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.activation`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.activation_v1`

--- a/templates/org_mozilla_fenix/baseline.sql
+++ b/templates/org_mozilla_fenix/baseline.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.baseline`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.baseline_v1`

--- a/templates/org_mozilla_fenix/bookmarks_sync.sql
+++ b/templates/org_mozilla_fenix/bookmarks_sync.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.bookmarks_sync`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.bookmarks_sync_v1`

--- a/templates/org_mozilla_fenix/events.sql
+++ b/templates/org_mozilla_fenix/events.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.events`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.events_v1`

--- a/templates/org_mozilla_fenix/history_sync.sql
+++ b/templates/org_mozilla_fenix/history_sync.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.history_sync`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.history_sync_v1`

--- a/templates/org_mozilla_fenix/metrics.sql
+++ b/templates/org_mozilla_fenix/metrics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.metrics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_stable.metrics_v1`

--- a/templates/org_mozilla_reference_browser/baseline.sql
+++ b/templates/org_mozilla_reference_browser/baseline.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser.baseline`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser_stable.baseline_v1`

--- a/templates/org_mozilla_reference_browser/events.sql
+++ b/templates/org_mozilla_reference_browser/events.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser.events`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser_stable.events_v1`

--- a/templates/org_mozilla_reference_browser/metrics.sql
+++ b/templates/org_mozilla_reference_browser/metrics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser.metrics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_reference_browser_stable.metrics_v1`

--- a/templates/org_mozilla_samples_glean/baseline.sql
+++ b/templates/org_mozilla_samples_glean/baseline.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean.baseline`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.baseline_v1`

--- a/templates/org_mozilla_samples_glean/events.sql
+++ b/templates/org_mozilla_samples_glean/events.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean.events`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.events_v1`

--- a/templates/org_mozilla_samples_glean/metrics.sql
+++ b/templates/org_mozilla_samples_glean/metrics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean.metrics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.metrics_v1`

--- a/templates/org_mozilla_tv_firefox/baseline.sql
+++ b/templates/org_mozilla_tv_firefox/baseline.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox.baseline`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox_stable.baseline_v1`

--- a/templates/org_mozilla_tv_firefox/events.sql
+++ b/templates/org_mozilla_tv_firefox/events.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox.events`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox_stable.events_v1`

--- a/templates/org_mozilla_tv_firefox/metrics.sql
+++ b/templates/org_mozilla_tv_firefox/metrics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox.metrics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.org_mozilla_tv_firefox_stable.metrics_v1`

--- a/templates/pocket/fire_tv_events.sql
+++ b/templates/pocket/fire_tv_events.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.pocket.fire_tv_events`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.pocket_stable.fire_tv_events_v1`

--- a/templates/telemetry/addon_install_blocked.sql
+++ b/templates/telemetry/addon_install_blocked.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.addon_install_blocked`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.addon_install_blocked_v4`

--- a/templates/telemetry/advancedtelemetry.sql
+++ b/templates/telemetry/advancedtelemetry.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.advancedtelemetry`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.advancedtelemetry_v4`

--- a/templates/telemetry/android_anr_report.sql
+++ b/templates/telemetry/android_anr_report.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.android_anr_report`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.android_anr_report_v10`

--- a/templates/telemetry/anonymous.sql
+++ b/templates/telemetry/anonymous.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.anonymous`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.anonymous_v4`

--- a/templates/telemetry/bhr.sql
+++ b/templates/telemetry/bhr.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.bhr`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.bhr_v4`

--- a/templates/telemetry/block_autoplay.sql
+++ b/templates/telemetry/block_autoplay.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.block_autoplay`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.block_autoplay_v4`

--- a/templates/telemetry/certificate_checker.sql
+++ b/templates/telemetry/certificate_checker.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.certificate_checker`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.certificate_checker_v4`

--- a/templates/telemetry/core.sql
+++ b/templates/telemetry/core.sql
@@ -1,4 +1,27 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.core`
-AS SELECT * FROM
-  `moz-fx-data-shared-prod.telemetry_stable.core_v10`
+AS
+WITH unioned AS (
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v2`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v3`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v4`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v5`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v6`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v7`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v8`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v9`
+  UNION ALL
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v10`)
+  --
+SELECT
+  *
+FROM
+  unioned
+

--- a/templates/telemetry/core.sql
+++ b/templates/telemetry/core.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.core`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.core_v10`

--- a/templates/telemetry/crash.sql
+++ b/templates/telemetry/crash.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.crash`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.crash_v4`

--- a/templates/telemetry/deletion.sql
+++ b/templates/telemetry/deletion.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.deletion`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.deletion_v4`

--- a/templates/telemetry/deployment_checker.sql
+++ b/templates/telemetry/deployment_checker.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.deployment_checker`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.deployment_checker_v4`

--- a/templates/telemetry/disable_sha1rollout.sql
+++ b/templates/telemetry/disable_sha1rollout.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.disable_sha1rollout`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.disable_sha1rollout_v4`

--- a/templates/telemetry/downgrade.sql
+++ b/templates/telemetry/downgrade.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.downgrade`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.downgrade_v4`

--- a/templates/telemetry/event.sql
+++ b/templates/telemetry/event.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.event`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.event_v4`

--- a/templates/telemetry/first_shutdown.sql
+++ b/templates/telemetry/first_shutdown.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.first_shutdown`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_v4`

--- a/templates/telemetry/flash_shield_study.sql
+++ b/templates/telemetry/flash_shield_study.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.flash_shield_study`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.flash_shield_study_v4`

--- a/templates/telemetry/focus_event.sql
+++ b/templates/telemetry/focus_event.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.focus_event`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.focus_event_v1`

--- a/templates/telemetry/frecency_update.sql
+++ b/templates/telemetry/frecency_update.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.frecency_update`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.frecency_update_v4`

--- a/templates/telemetry/ftu.sql
+++ b/templates/telemetry/ftu.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.ftu`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.ftu_v3`

--- a/templates/telemetry/health.sql
+++ b/templates/telemetry/health.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.health`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.health_v9`

--- a/templates/telemetry/heartbeat.sql
+++ b/templates/telemetry/heartbeat.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.heartbeat`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.heartbeat_v4`

--- a/templates/telemetry/main.sql
+++ b/templates/telemetry/main.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.main`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.main_v4`

--- a/templates/telemetry/malware_addon_states.sql
+++ b/templates/telemetry/malware_addon_states.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.malware_addon_states`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.malware_addon_states_v4`

--- a/templates/telemetry/mobile_event.sql
+++ b/templates/telemetry/mobile_event.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.mobile_event`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.mobile_event_v1`

--- a/templates/telemetry/mobile_metrics.sql
+++ b/templates/telemetry/mobile_metrics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.mobile_metrics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.mobile_metrics_v1`

--- a/templates/telemetry/modules.sql
+++ b/templates/telemetry/modules.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.modules`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.modules_v4`

--- a/templates/telemetry/new_profile.sql
+++ b/templates/telemetry/new_profile.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.new_profile`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.new_profile_v4`

--- a/templates/telemetry/optout.sql
+++ b/templates/telemetry/optout.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.optout`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.optout_v4`

--- a/templates/telemetry/outofdate_notifications_system_addon.sql
+++ b/templates/telemetry/outofdate_notifications_system_addon.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.outofdate_notifications_system_addon`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.outofdate_notifications_system_addon_v4`

--- a/templates/telemetry/pioneer_study.sql
+++ b/templates/telemetry/pioneer_study.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.pioneer_study`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.pioneer_study_v4`

--- a/templates/telemetry/pre_account.sql
+++ b/templates/telemetry/pre_account.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.pre_account`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.pre_account_v4`

--- a/templates/telemetry/prio.sql
+++ b/templates/telemetry/prio.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.prio`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.prio_v4`

--- a/templates/telemetry/saved_session.sql
+++ b/templates/telemetry/saved_session.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.saved_session`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.saved_session_v4`

--- a/templates/telemetry/searchvol.sql
+++ b/templates/telemetry/searchvol.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.searchvol`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.searchvol_v4`

--- a/templates/telemetry/searchvolextra.sql
+++ b/templates/telemetry/searchvolextra.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.searchvolextra`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.searchvolextra_v4`

--- a/templates/telemetry/shield_icq_v1.sql
+++ b/templates/telemetry/shield_icq_v1.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.shield_icq_v1`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.shield_icq_v1_v4`

--- a/templates/telemetry/shield_study.sql
+++ b/templates/telemetry/shield_study.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.shield_study`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.shield_study_v4`

--- a/templates/telemetry/shield_study_addon.sql
+++ b/templates/telemetry/shield_study_addon.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.shield_study_addon`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.shield_study_addon_v4`

--- a/templates/telemetry/shield_study_error.sql
+++ b/templates/telemetry/shield_study_error.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.shield_study_error`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.shield_study_error_v4`

--- a/templates/telemetry/sync.sql
+++ b/templates/telemetry/sync.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.sync`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.sync_v5`

--- a/templates/telemetry/system_addon_deployment_diagnostics.sql
+++ b/templates/telemetry/system_addon_deployment_diagnostics.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.system_addon_deployment_diagnostics`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.system_addon_deployment_diagnostics_v4`

--- a/templates/telemetry/testpilot.sql
+++ b/templates/telemetry/testpilot.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.testpilot`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.testpilot_v4`

--- a/templates/telemetry/testpilottest.sql
+++ b/templates/telemetry/testpilottest.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.testpilottest`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.testpilottest_v4`

--- a/templates/telemetry/tls13_middlebox_alt_server_hello_1.sql
+++ b/templates/telemetry/tls13_middlebox_alt_server_hello_1.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_alt_server_hello_1`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_alt_server_hello_1_v4`

--- a/templates/telemetry/tls13_middlebox_beta.sql
+++ b/templates/telemetry/tls13_middlebox_beta.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_beta`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_beta_v4`

--- a/templates/telemetry/tls13_middlebox_draft22.sql
+++ b/templates/telemetry/tls13_middlebox_draft22.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_draft22`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_draft22_v4`

--- a/templates/telemetry/tls13_middlebox_ghack.sql
+++ b/templates/telemetry/tls13_middlebox_ghack.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_ghack`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_ghack_v4`

--- a/templates/telemetry/tls13_middlebox_repetition.sql
+++ b/templates/telemetry/tls13_middlebox_repetition.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_repetition`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_repetition_v4`

--- a/templates/telemetry/tls13_middlebox_testing.sql
+++ b/templates/telemetry/tls13_middlebox_testing.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls13_middlebox_testing`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls13_middlebox_testing_v4`

--- a/templates/telemetry/tls_13_study.sql
+++ b/templates/telemetry/tls_13_study.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls_13_study`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls_13_study_v4`

--- a/templates/telemetry/tls_13_study_v1.sql
+++ b/templates/telemetry/tls_13_study_v1.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls_13_study_v1`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls_13_study_v1_v4`

--- a/templates/telemetry/tls_13_study_v2.sql
+++ b/templates/telemetry/tls_13_study_v2.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls_13_study_v2`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls_13_study_v2_v4`

--- a/templates/telemetry/tls_13_study_v3.sql
+++ b/templates/telemetry/tls_13_study_v3.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls_13_study_v3`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls_13_study_v3_v4`

--- a/templates/telemetry/tls_13_study_v4.sql
+++ b/templates/telemetry/tls_13_study_v4.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.tls_13_study_v4`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.tls_13_study_v4_v4`

--- a/templates/telemetry/uitour_tag.sql
+++ b/templates/telemetry/uitour_tag.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uitour_tag`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.uitour_tag_v4`

--- a/templates/telemetry/untrusted_modules.sql
+++ b/templates/telemetry/untrusted_modules.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.untrusted_modules`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.untrusted_modules_v4`

--- a/templates/telemetry/update.sql
+++ b/templates/telemetry/update.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.update`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.update_v4`

--- a/templates/telemetry/x_contextual_feature_recommendation.sql
+++ b/templates/telemetry/x_contextual_feature_recommendation.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.x_contextual_feature_recommendation`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.telemetry_stable.x_contextual_feature_recommendation_v4`

--- a/templates/webpagetest/webpagetest_run.sql
+++ b/templates/webpagetest/webpagetest_run.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.webpagetest.webpagetest_run`
+AS SELECT * FROM
+  `moz-fx-data-shared-prod.webpagetest_stable.webpagetest_run_v1`


### PR DESCRIPTION
Closes #218 and #221 

This starts from @relud's draft script in #226 and adapts it to generate view definition files instead of creating views directly.

This PR is broken into several commits:

- Adapt @relud's script
- Run the script and generate basic views for all doctypes
- manually modify views for e.g. core ping as a union of v2 through v10
- Add a script for running all views in a directory
