### PR TITLE
Build docker on python-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 ARG PYTHON_VERSION=3.7
 
 # build typed-ast in separate stage because it requires gcc and libc-dev
-FROM python:${PYTHON_VERSION}-alpine
+FROM python:${PYTHON_VERSION}-slim
 COPY requirements.txt constraints.txt ./
-RUN apk add --no-cache gcc libc-dev && \
+RUN apt-get update -qqy && apt-get install -qqy gcc libc-dev && \
     pip install -r requirements.txt
 
-FROM python:${PYTHON_VERSION}-alpine
+FROM python:${PYTHON_VERSION}-slim
 # add bash for entrypoing and python2 for google-cloud-sdk
-RUN apk add --no-cache bash python2
+RUN apt-get update -qqy && apt-get install -qqy bash python
 COPY --from=google/cloud-sdk:alpine /google-cloud-sdk /google-cloud-sdk
 ENV PATH /google-cloud-sdk/bin:$PATH
 COPY --from=0 /usr/local /usr/local


### PR DESCRIPTION
this fixes CI `deploy` builds on master.

the problem is that alpine isn't compatible with python manylinux wheels (due to using a different compiler) and there's no tarball available on pypi to build protobuf 3.9.1