### PR TITLE
Have unversioned views hit versioned views for parquet unnesting

### DIFF
--- a/sql/org_mozilla_samples_glean/baseline.sql
+++ b/sql/org_mozilla_samples_glean/baseline.sql
@@ -1,4 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean.baseline`
-AS SELECT * FROM
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.baseline_v1`

--- a/sql/org_mozilla_samples_glean/events.sql
+++ b/sql/org_mozilla_samples_glean/events.sql
@@ -1,4 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean.events`
-AS SELECT * FROM
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.events_v1`

--- a/sql/org_mozilla_samples_glean/metrics.sql
+++ b/sql/org_mozilla_samples_glean/metrics.sql
@@ -1,4 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean.metrics`
-AS SELECT * FROM
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.metrics_v1`

--- a/sql/telemetry/clients_daily.sql
+++ b/sql/telemetry/clients_daily.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.clients_daily`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.clients_daily_v6`
+  `moz-fx-data-derived-datasets.telemetry.clients_daily_v6`

--- a/sql/telemetry/crash_aggregates.sql
+++ b/sql/telemetry/crash_aggregates.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.crash_aggregates`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.crash_aggregates_v1`
+  `moz-fx-data-derived-datasets.telemetry.crash_aggregates_v1`

--- a/sql/telemetry/crash_summary.sql
+++ b/sql/telemetry/crash_summary.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.crash_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.crash_summary_v2`
+  `moz-fx-data-derived-datasets.telemetry.crash_summary_v2`

--- a/sql/telemetry/eng_workflow_build_parquet.sql
+++ b/sql/telemetry/eng_workflow_build_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.eng_workflow_build_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.eng_workflow_build_parquet_v1`
+  `moz-fx-data-derived-datasets.telemetry.eng_workflow_build_parquet_v1`

--- a/sql/telemetry/events.sql
+++ b/sql/telemetry/events.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.events`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.events_v1`
+  `moz-fx-data-derived-datasets.telemetry.events_v1`

--- a/sql/telemetry/experiments.sql
+++ b/sql/telemetry/experiments.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.experiments`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.experiments_v1`
+  `moz-fx-data-derived-datasets.telemetry.experiments_v1`

--- a/sql/telemetry/experiments_aggregates.sql
+++ b/sql/telemetry/experiments_aggregates.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.experiments_aggregates`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.experiments_aggregates_v1`
+  `moz-fx-data-derived-datasets.telemetry.experiments_aggregates_v1`

--- a/sql/telemetry/first_shutdown_summary.sql
+++ b/sql/telemetry/first_shutdown_summary.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.first_shutdown_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.first_shutdown_summary_v4`
+  `moz-fx-data-derived-datasets.telemetry.first_shutdown_summary_v4`

--- a/sql/telemetry/main_summary.sql
+++ b/sql/telemetry/main_summary.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.main_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.main_summary_v4`
+  `moz-fx-data-derived-datasets.telemetry.main_summary_v4`

--- a/sql/telemetry/socorro_crash.sql
+++ b/sql/telemetry/socorro_crash.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.socorro_crash`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.socorro_crash_v2`
+  `moz-fx-data-derived-datasets.telemetry.socorro_crash_v2`

--- a/sql/telemetry/sync_events.sql
+++ b/sql/telemetry/sync_events.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.sync_events`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.sync_events_v1`
+  `moz-fx-data-derived-datasets.telemetry.sync_events_v1`

--- a/sql/telemetry/sync_flat_summary.sql
+++ b/sql/telemetry/sync_flat_summary.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.sync_flat_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.sync_flat_summary_v1`
+  `moz-fx-data-derived-datasets.telemetry.sync_flat_summary_v1`

--- a/sql/telemetry/sync_summary.sql
+++ b/sql/telemetry/sync_summary.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.sync_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.sync_summary_v2`
+  `moz-fx-data-derived-datasets.telemetry.sync_summary_v2`

--- a/sql/telemetry/telemetry_core_parquet.sql
+++ b/sql/telemetry/telemetry_core_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.telemetry_core_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.telemetry_core_parquet_v3`
+  `moz-fx-data-derived-datasets.telemetry.telemetry_core_parquet_v3`

--- a/sql/telemetry/telemetry_focus_event_parquet.sql
+++ b/sql/telemetry/telemetry_focus_event_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.telemetry_focus_event_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.telemetry_focus_event_parquet_v1`
+  `moz-fx-data-derived-datasets.telemetry.telemetry_focus_event_parquet_v1`

--- a/sql/telemetry/telemetry_mobile_event_parquet.sql
+++ b/sql/telemetry/telemetry_mobile_event_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.telemetry_mobile_event_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.telemetry_mobile_event_parquet_v2`
+  `moz-fx-data-derived-datasets.telemetry.telemetry_mobile_event_parquet_v2`

--- a/sql/telemetry/telemetry_new_profile_parquet.sql
+++ b/sql/telemetry/telemetry_new_profile_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.telemetry_new_profile_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.telemetry_new_profile_parquet_v2`
+  `moz-fx-data-derived-datasets.telemetry.telemetry_new_profile_parquet_v2`

--- a/sql/telemetry/telemetry_shield_study_parquet.sql
+++ b/sql/telemetry/telemetry_shield_study_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.telemetry_shield_study_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.telemetry_shield_study_parquet_v1`
+  `moz-fx-data-derived-datasets.telemetry.telemetry_shield_study_parquet_v1`

--- a/templates/org_mozilla_samples_glean/baseline.sql
+++ b/templates/org_mozilla_samples_glean/baseline.sql
@@ -1,4 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean.baseline`
-AS SELECT * FROM
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.baseline_v1`

--- a/templates/org_mozilla_samples_glean/events.sql
+++ b/templates/org_mozilla_samples_glean/events.sql
@@ -1,4 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean.events`
-AS SELECT * FROM
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.events_v1`

--- a/templates/org_mozilla_samples_glean/metrics.sql
+++ b/templates/org_mozilla_samples_glean/metrics.sql
@@ -1,4 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean.metrics`
-AS SELECT * FROM
-  `moz-fx-data-shared-prod.org_mozilla_samples_glean_stable.metrics_v1`

--- a/templates/telemetry/clients_daily.sql
+++ b/templates/telemetry/clients_daily.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.clients_daily`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.clients_daily_v6`
+  `moz-fx-data-derived-datasets.telemetry.clients_daily_v6`

--- a/templates/telemetry/crash_aggregates.sql
+++ b/templates/telemetry/crash_aggregates.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.crash_aggregates`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.crash_aggregates_v1`
+  `moz-fx-data-derived-datasets.telemetry.crash_aggregates_v1`

--- a/templates/telemetry/crash_summary.sql
+++ b/templates/telemetry/crash_summary.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.crash_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.crash_summary_v2`
+  `moz-fx-data-derived-datasets.telemetry.crash_summary_v2`

--- a/templates/telemetry/eng_workflow_build_parquet.sql
+++ b/templates/telemetry/eng_workflow_build_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.eng_workflow_build_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.eng_workflow_build_parquet_v1`
+  `moz-fx-data-derived-datasets.telemetry.eng_workflow_build_parquet_v1`

--- a/templates/telemetry/events.sql
+++ b/templates/telemetry/events.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.events`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.events_v1`
+  `moz-fx-data-derived-datasets.telemetry.events_v1`

--- a/templates/telemetry/experiments.sql
+++ b/templates/telemetry/experiments.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.experiments`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.experiments_v1`
+  `moz-fx-data-derived-datasets.telemetry.experiments_v1`

--- a/templates/telemetry/experiments_aggregates.sql
+++ b/templates/telemetry/experiments_aggregates.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.experiments_aggregates`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.experiments_aggregates_v1`
+  `moz-fx-data-derived-datasets.telemetry.experiments_aggregates_v1`

--- a/templates/telemetry/first_shutdown_summary.sql
+++ b/templates/telemetry/first_shutdown_summary.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.first_shutdown_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.first_shutdown_summary_v4`
+  `moz-fx-data-derived-datasets.telemetry.first_shutdown_summary_v4`

--- a/templates/telemetry/main_summary.sql
+++ b/templates/telemetry/main_summary.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.main_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.main_summary_v4`
+  `moz-fx-data-derived-datasets.telemetry.main_summary_v4`

--- a/templates/telemetry/socorro_crash.sql
+++ b/templates/telemetry/socorro_crash.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.socorro_crash`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.socorro_crash_v2`
+  `moz-fx-data-derived-datasets.telemetry.socorro_crash_v2`

--- a/templates/telemetry/sync_events.sql
+++ b/templates/telemetry/sync_events.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.sync_events`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.sync_events_v1`
+  `moz-fx-data-derived-datasets.telemetry.sync_events_v1`

--- a/templates/telemetry/sync_flat_summary.sql
+++ b/templates/telemetry/sync_flat_summary.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.sync_flat_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.sync_flat_summary_v1`
+  `moz-fx-data-derived-datasets.telemetry.sync_flat_summary_v1`

--- a/templates/telemetry/sync_summary.sql
+++ b/templates/telemetry/sync_summary.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.sync_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.sync_summary_v2`
+  `moz-fx-data-derived-datasets.telemetry.sync_summary_v2`

--- a/templates/telemetry/telemetry_core_parquet.sql
+++ b/templates/telemetry/telemetry_core_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.telemetry_core_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.telemetry_core_parquet_v3`
+  `moz-fx-data-derived-datasets.telemetry.telemetry_core_parquet_v3`

--- a/templates/telemetry/telemetry_focus_event_parquet.sql
+++ b/templates/telemetry/telemetry_focus_event_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.telemetry_focus_event_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.telemetry_focus_event_parquet_v1`
+  `moz-fx-data-derived-datasets.telemetry.telemetry_focus_event_parquet_v1`

--- a/templates/telemetry/telemetry_mobile_event_parquet.sql
+++ b/templates/telemetry/telemetry_mobile_event_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.telemetry_mobile_event_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.telemetry_mobile_event_parquet_v2`
+  `moz-fx-data-derived-datasets.telemetry.telemetry_mobile_event_parquet_v2`

--- a/templates/telemetry/telemetry_new_profile_parquet.sql
+++ b/templates/telemetry/telemetry_new_profile_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.telemetry_new_profile_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.telemetry_new_profile_parquet_v2`
+  `moz-fx-data-derived-datasets.telemetry.telemetry_new_profile_parquet_v2`

--- a/templates/telemetry/telemetry_shield_study_parquet.sql
+++ b/templates/telemetry/telemetry_shield_study_parquet.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.telemetry_shield_study_parquet`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.telemetry_shield_study_parquet_v1`
+  `moz-fx-data-derived-datasets.telemetry.telemetry_shield_study_parquet_v1`


### PR DESCRIPTION
flod reported in `#fx-metrics` that submission_date_s3 was missing
for the clients_daily view. That view and other unversioned views
were directly referencing telemetry_derived tables and missing out
on transformations such as parquet unnesting.