### PR TITLE
Update deploy circleci workflow job to use restricted context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ workflows:
     - verify-generated-sql
     - dry-run-sql
     - deploy:
+        context: data-eng-bigquery-etl-dockerhub
         requires:
         # can't run in parallel because CIRCLE_BUILD_NUM is same
         - build


### PR DESCRIPTION
As part of the comments in https://github.com/mozilla/bigquery-etl/pull/338 I've created a new circleci restricted context `data-eng-bigquery-etl-dockerhub` and groups `dataops` and `telemetry` have access to this context. 

I've also removed all environment variables configured `bigquery-etl` in CircleCI UI and enabled `Pass secrets to builds from forked pull requests`.

