### PR TITLE
Set temp table expiration in copy_deduplicate

### DIFF
--- a/script/copy_deduplicate
+++ b/script/copy_deduplicate
@@ -191,12 +191,13 @@ def get_temporary_dataset(client):
     return temporary_dataset
 
 
-def get_temporary_table(client, date):
-    """Generate a random writable temporary table reference.
+def get_temporary_table(client, schema, clustering_fields, time_partitioning, date):
+    """Generate a temporary table and return the specified date partition.
 
-    This function generates a table reference that looks similar to, but won't
-    collide with, a server-assinged table and the web console will consider
-    temporary, for writing query results with time partitioning and clustering.
+    Generates a table name that looks similar to, but won't collide with, a
+    server-assigned table and that the web console will consider temporary.
+    Table expiration can't be set from a query job, so the table is created
+    here.
 
     In order for query results to use time partitioning, and by extension
     clustering, destination table must be explicitly set. Destination must be
@@ -213,11 +214,17 @@ def get_temporary_table(client, date):
     "_" and table_id starts with "anon" and is followed by at least one
     character.
     """
-    return get_temporary_dataset(client).table(f"anon{uuid4().hex}${date:%Y%m%d}")
+    dataset = get_temporary_dataset(client)
+    table = bigquery.Table(dataset.table(f"anon{uuid4().hex}"), schema)
+    table.expires = datetime.now() + timedelta(days=1)
+    table.clustering_fields = clustering_fields
+    table.time_partitioning = time_partitioning
+    table = client.create_table(table, exists_ok=False)
+    return f"{sql_full_table_id(table)}${date:%Y%m%d}"
 
 
 def sql_full_table_id(table):
-    return table.full_table_id.replace(":", ".")
+    return f"{table.project}.{table.dataset_id}.{table.table_id}"
 
 
 def get_deduplication_query(live_table, hourly):
@@ -233,9 +240,13 @@ def get_query_job_configs(client, stable_table, date, dry_run, hourly, priority)
         for hour in range(24):
             value = (date + timedelta(hours=hour)).isoformat()
             yield bigquery.QueryJobConfig(
-                destination=get_temporary_table(client, date),
-                clustering_fields=stable_table.clustering_fields,
-                time_partitioning=stable_table.time_partitioning,
+                destination=get_temporary_table(
+                    client=client,
+                    schema=stable_table.schema,
+                    clustering_fields=stable_table.clustering_fields,
+                    time_partitioning=stable_table.time_partitioning,
+                    date=date,
+                ),
                 query_parameters=[
                     bigquery.ScalarQueryParameter("submission_hour", "TIMESTAMP", value)
                 ],
@@ -271,13 +282,16 @@ def copy_join_parts(client, stable_table, query_jobs):
     else:
         print(f"Processed {total_bytes} bytes to populate {stable_table}")
         if len(query_jobs) > 1:
-            print(f"Copying {len(query_jobs)} results to populate {stable_table}")
             sources = [job.destination for job in query_jobs]
             job_config = bigquery.CopyJobConfig(
                 write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE
             )
             copy_job = client.copy_table(sources, stable_table, job_config=job_config)
             copy_job.result()
+            print(f"Copied {len(query_jobs)} results to populate {stable_table}")
+            for source in sources:
+                client.delete_table(sql_full_table_id(source).split("$")[0])
+            print(f"Deleted {len(query_jobs)} temporary tables")
 
 
 def main():


### PR DESCRIPTION
and delete temp tables when finished, because there's no need to leave them around for a full day.