### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @relud @jklukas


### PR DESCRIPTION
Per discussion in Data Platform team meeting, we are not adopting CODEOWNERS as a team for now and will reevaluate in the future.