### PR TITLE
Add min_profile_subsession_counter to clients_daily

### DIFF
--- a/sql/telemetry_derived/clients_daily_v7/query.sql
+++ b/sql/telemetry_derived/clients_daily_v7/query.sql
@@ -232,6 +232,7 @@ SELECT
   udf_mode_last(ARRAY_AGG(is_wow64)) AS is_wow64,
   udf_mode_last(ARRAY_AGG(locale)) AS locale,
   udf_mode_last(ARRAY_AGG(memory_mb)) AS memory_mb,
+  MIN(profile_subsession_counter) AS min_profile_subsession_counter,
   udf_mode_last(ARRAY_AGG(normalized_channel)) AS normalized_channel,
   udf_mode_last(ARRAY_AGG(normalized_os_version)) AS normalized_os_version,
   udf_mode_last(ARRAY_AGG(os)) AS os,

--- a/templates/telemetry_derived/clients_daily_v7/query.sql
+++ b/templates/telemetry_derived/clients_daily_v7/query.sql
@@ -117,6 +117,7 @@ SELECT
   udf_mode_last(ARRAY_AGG(is_wow64)) AS is_wow64,
   udf_mode_last(ARRAY_AGG(locale)) AS locale,
   udf_mode_last(ARRAY_AGG(memory_mb)) AS memory_mb,
+  MIN(profile_subsession_counter) AS min_profile_subsession_counter,
   udf_mode_last(ARRAY_AGG(normalized_channel)) AS normalized_channel,
   udf_mode_last(ARRAY_AGG(normalized_os_version)) AS normalized_os_version,
   udf_mode_last(ARRAY_AGG(os)) AS os,


### PR DESCRIPTION
Being able to identify rows in clients_daily that correspond to a profile's first-ever ping is useful.

Will this automatically propagate to clients_last_seen once it starts being populated here?