### PR TITLE
Use v4 of Sync pings

### DIFF
--- a/sql/telemetry/sync/view.sql
+++ b/sql/telemetry/sync/view.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.sync`
 AS SELECT * FROM
-  `moz-fx-data-shared-prod.telemetry_stable.sync_v5`
+  `moz-fx-data-shared-prod.telemetry_stable.sync_v4`

--- a/templates/telemetry/sync/view.sql
+++ b/templates/telemetry/sync/view.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.sync`
 AS SELECT * FROM
-  `moz-fx-data-shared-prod.telemetry_stable.sync_v5`
+  `moz-fx-data-shared-prod.telemetry_stable.sync_v4`


### PR DESCRIPTION
Per [this pr](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/422) and [Bug 1572744](https://bugzilla.mozilla.org/show_bug.cgi?id=1572744), we should be using version `4` of the sync ping table for the unqualified table (rather than `v5`).