### PR TITLE
change fxa_users_services_first_seen_v1 to account for service being null for most sync events

### DIFF
--- a/sql/telemetry_derived/fxa_users_services_first_seen_v1/init.sql
+++ b/sql/telemetry_derived/fxa_users_services_first_seen_v1/init.sql
@@ -48,7 +48,7 @@ WITH
     w1_reversed AS (
       PARTITION BY
         user_id,
-        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service) AS service
+        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service)
       ORDER BY
         `timestamp` DESC
       ROWS BETWEEN
@@ -58,7 +58,7 @@ WITH
     w1_unframed AS (
       PARTITION BY
         user_id,
-        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service) AS service
+        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service)
       ORDER BY
         `timestamp`)),
   -- we need this next section because `did_register` will be BOTH true and false within the flows that the user registered on.

--- a/sql/telemetry_derived/fxa_users_services_first_seen_v1/init.sql
+++ b/sql/telemetry_derived/fxa_users_services_first_seen_v1/init.sql
@@ -39,7 +39,7 @@ WITH
   FROM
     `moz-fx-data-derived-datasets.telemetry.fxa_content_auth_oauth_events_v1`
   WHERE
-    ((event_type IN ('fxa_login - complete', 'fxa_reg - complete'))
+    ((event_type IN ('fxa_login - complete', 'fxa_reg - complete') AND service IS NOT NULL)
       OR (event_type LIKE 'fxa_activity%'))
     AND DATE(`timestamp`) >= '2019-03-01'
     AND user_id IS NOT NULL

--- a/sql/telemetry_derived/fxa_users_services_first_seen_v1/init.sql
+++ b/sql/telemetry_derived/fxa_users_services_first_seen_v1/init.sql
@@ -27,7 +27,7 @@ WITH
   SELECT
     ROW_NUMBER() OVER w1_unframed AS _n,
     user_id,
-    service,
+    IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service) AS service,
     -- using mode_last with w1_reversed to get mode_first
     udf_mode_last(ARRAY_AGG(`timestamp`) OVER w1_reversed) AS first_service_timestamp,
     udf_mode_last(ARRAY_AGG(os_name) OVER w1_reversed) AS first_service_os,
@@ -42,14 +42,13 @@ WITH
     ((event_type IN ('fxa_login - complete', 'fxa_reg - complete'))
       OR (event_type LIKE 'fxa_activity%'))
     AND DATE(`timestamp`) >= '2019-03-01'
-    AND service IS NOT NULL
     AND user_id IS NOT NULL
   WINDOW
     -- We must provide a window with `ORDER BY timestamp DESC` so that udf_mode_last actually aggregates mode first.
     w1_reversed AS (
       PARTITION BY
         user_id,
-        service
+        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service) AS service
       ORDER BY
         `timestamp` DESC
       ROWS BETWEEN
@@ -59,7 +58,7 @@ WITH
     w1_unframed AS (
       PARTITION BY
         user_id,
-        service
+        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service) AS service
       ORDER BY
         `timestamp`)),
   -- we need this next section because `did_register` will be BOTH true and false within the flows that the user registered on.

--- a/sql/telemetry_derived/fxa_users_services_first_seen_v1/init.sql
+++ b/sql/telemetry_derived/fxa_users_services_first_seen_v1/init.sql
@@ -21,13 +21,19 @@ CREATE OR REPLACE TABLE
 PARTITION BY DATE(first_service_timestamp)
 CLUSTER BY service, user_id AS
 WITH
+  base AS (
+  SELECT
+    * REPLACE(IF(service IS NULL AND event_type = 'fxa_activity - cert_signed',
+                 'sync', service) AS service)
+  FROM
+    `moz-fx-data-derived-datasets.telemetry.fxa_content_auth_oauth_events_v1` ),
   -- use a window function to look within each USER and SERVICE for the first value of service, os, and country.
   -- also, get the first value of flow_id for later use and create a boolean column that is true if the first instance of a service usage includes a registration.
   first_services AS (
   SELECT
     ROW_NUMBER() OVER w1_unframed AS _n,
     user_id,
-    IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service) AS service,
+    service,
     -- using mode_last with w1_reversed to get mode_first
     udf_mode_last(ARRAY_AGG(`timestamp`) OVER w1_reversed) AS first_service_timestamp,
     udf_mode_last(ARRAY_AGG(os_name) OVER w1_reversed) AS first_service_os,
@@ -37,7 +43,7 @@ WITH
       IFNULL(event_type = 'fxa_reg - complete', FALSE)
       ) OVER w1_reversed AS did_register
   FROM
-    `moz-fx-data-derived-datasets.telemetry.fxa_content_auth_oauth_events_v1`
+    base
   WHERE
     ((event_type IN ('fxa_login - complete', 'fxa_reg - complete') AND service IS NOT NULL)
       OR (event_type LIKE 'fxa_activity%'))
@@ -48,7 +54,7 @@ WITH
     w1_reversed AS (
       PARTITION BY
         user_id,
-        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service)
+        service
       ORDER BY
         `timestamp` DESC
       ROWS BETWEEN
@@ -58,7 +64,7 @@ WITH
     w1_unframed AS (
       PARTITION BY
         user_id,
-        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service)
+        service
       ORDER BY
         `timestamp`)),
   -- we need this next section because `did_register` will be BOTH true and false within the flows that the user registered on.

--- a/templates/telemetry_derived/fxa_users_services_first_seen_v1/init.sql
+++ b/templates/telemetry_derived/fxa_users_services_first_seen_v1/init.sql
@@ -30,7 +30,7 @@ WITH
     w1_reversed AS (
       PARTITION BY
         user_id,
-        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service) AS service
+        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service)
       ORDER BY
         `timestamp` DESC
       ROWS BETWEEN
@@ -40,7 +40,7 @@ WITH
     w1_unframed AS (
       PARTITION BY
         user_id,
-        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service) AS service
+        IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service)
       ORDER BY
         `timestamp`)),
   -- we need this next section because `did_register` will be BOTH true and false within the flows that the user registered on.


### PR DESCRIPTION
should have caught this before Jeff merged his PR, sorry :(. I think this means will will have to run the backfill again :(

this is similar to problem jeff addressed as part of https://github.com/mozilla/bigquery-etl/pull/396 that adds 'sync' for cert_signed events. I should have realized that we would have to do it for this table too. 

I'm not sure about the scope of the window clause but I hazarded a guess that I needed to repeat the `IF(` clause there. there may be a better way of doing it. 

we shouldn't have to worry about nulls creeping into service here because all the other `fxa_activity - *` events will have a non-null value for service. 

cc @ksiegler1