### PR TITLE
Use fully qualified table names again in smoot queries

### DIFF
--- a/sql/telemetry_derived/smoot_usage_new_profiles_v2/query.sql
+++ b/sql/telemetry_derived/smoot_usage_new_profiles_v2/query.sql
@@ -1,10 +1,10 @@
 WITH
   base AS (
-  SELECT * FROM smoot_usage_desktop_v2
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_derived.smoot_usage_desktop_v2`
   UNION ALL
-  SELECT * FROM smoot_usage_nondesktop_v2
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_derived.smoot_usage_nondesktop_v2`
   UNION ALL
-  SELECT * FROM smoot_usage_fxa_v2
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_derived.smoot_usage_fxa_v2`
   )
   --
 SELECT

--- a/templates/telemetry_derived/smoot_usage_new_profiles_v2/query.sql
+++ b/templates/telemetry_derived/smoot_usage_new_profiles_v2/query.sql
@@ -1,10 +1,10 @@
 WITH
   base AS (
-  SELECT * FROM smoot_usage_desktop_v2
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_derived.smoot_usage_desktop_v2`
   UNION ALL
-  SELECT * FROM smoot_usage_nondesktop_v2
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_derived.smoot_usage_nondesktop_v2`
   UNION ALL
-  SELECT * FROM smoot_usage_fxa_v2
+  SELECT * FROM `moz-fx-data-shared-prod.telemetry_derived.smoot_usage_fxa_v2`
   )
   --
 SELECT


### PR DESCRIPTION
Reverts a premature change in https://github.com/mozilla/bigquery-etl/pull/409

Airflow is not yet ready to run queries in shared-prod, which blocks us simplifying the paths here.