### PR TITLE
Use `#!/usr/bin/env python3` consistently

### DIFF
--- a/script/dryrun
+++ b/script/dryrun
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Passes all queries defined under sql/ to a Cloud Function that will run the

--- a/script/generate_incremental_table
+++ b/script/generate_incremental_table
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from argparse import ArgumentParser
 from datetime import datetime, timedelta

--- a/script/generate_views
+++ b/script/generate_views
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Generate one view definition file per document type in '_stable' tables.

--- a/script/publish_views
+++ b/script/publish_views
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Find view definition files and execute them."""
 


### PR DESCRIPTION
This uses python3 consistently in the script shebang headers. If I run `script/dryrun` via shell, it points to my default python installation which is python2.