### PR TITLE
Add --dataset_id and --project_id to script/run_multipart_query

### DIFF
--- a/script/run_multipart_query
+++ b/script/run_multipart_query
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Writes multiple queries to temporary tables and then joins the results.
@@ -39,6 +39,13 @@ parser.add_argument(
     help="Maximum number of queries to execute concurrently",
 )
 parser.add_argument(
+    "--dataset_id",
+    help="Default dataset, if not specified all tables must be qualified with dataset",
+)
+parser.add_argument(
+    "--project_id", help="Default project, if not specified the sdk will determine one"
+)
+parser.add_argument(
     "--destination_table", help="table where combined results will be written"
 )
 parser.add_argument(
@@ -48,7 +55,6 @@ parser.add_argument(
 )
 parser.add_argument(
     "--clustering_fields",
-    default=[],
     type=lambda f: f.split(","),
     help="comma separated list of clustering fields on the destination table",
 )
@@ -106,6 +112,7 @@ def run_part(client, part, args):
         query = sql_file.read()
     job_config = bigquery.QueryJobConfig(
         destination=get_temporary_dataset(client).table(f"anon{uuid4().hex}"),
+        default_dataset=args.dataset_id,
         use_legacy_sql=False,
         dry_run=args.dry_run,
         query_parameters=args.parameters,
@@ -123,7 +130,11 @@ def run_part(client, part, args):
 
 def main():
     args = parser.parse_args()
-    client = bigquery.Client()
+    if "." not in args.dataset_id and args.project_id is not None:
+        args.dataset_id = f"{args.project_id}.{args.dataset_id}"
+    if "." not in args.destination_table and args.dataset_id is not None:
+        args.destination_table = f"{args.dataset_id}.{args.destination_table}"
+    client = bigquery.Client(args.project_id)
     with ThreadPool(args.parallelism) as pool:
         parts = pool.starmap(
             run_part,
@@ -144,24 +155,26 @@ def main():
                 for _, job in parts[1:]
             )
         )
-        job = client.query(
-            query=query,
-            job_config=bigquery.QueryJobConfig(
-                destination=args.destination_table,
-                time_partitioning=args.time_partitioning_field,
-                clustering_fields=args.clustering_fields,
-                write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
-                use_legacy_sql=False,
-                priority=args.priority,
-            ),
-        )
-        job.result()
-        print(f"Processed {job.total_bytes_processed:,d} bytes to combine results")
-        total_bytes += job.total_bytes_processed
-        print(f"Processed {total_bytes:,d} bytes in total")
-        for _, job in parts:
-            client.delete_table(sql_table_id(job.destination).split("$")[0])
-        print(f"Deleted {len(parts)} temporary tables")
+        try:
+            job = client.query(
+                query=query,
+                job_config=bigquery.QueryJobConfig(
+                    destination=args.destination_table,
+                    time_partitioning=args.time_partitioning_field,
+                    clustering_fields=args.clustering_fields,
+                    write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+                    use_legacy_sql=False,
+                    priority=args.priority,
+                ),
+            )
+            job.result()
+            print(f"Processed {job.total_bytes_processed:,d} bytes to combine results")
+            total_bytes += job.total_bytes_processed
+            print(f"Processed {total_bytes:,d} bytes in total")
+        finally:
+            for _, job in parts:
+                client.delete_table(sql_table_id(job.destination).split("$")[0])
+            print(f"Deleted {len(parts)} temporary tables")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
and attempt to clean up temp tables on failure, and specify python3 in the `#!`, and make `clustering_fields=None` when it's not specified.

this should fix the `sql_main_summary` airflow task