### PR TITLE
Fixup: reference the shared-prod main_summary_v4 view

### DIFF
--- a/sql/telemetry/main_summary/view.sql
+++ b/sql/telemetry/main_summary/view.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.main_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry.main_summary_v4`
+  `moz-fx-data-shared-prod.telemetry.main_summary_v4`

--- a/templates/telemetry/main_summary/view.sql
+++ b/templates/telemetry/main_summary/view.sql
@@ -1,4 +1,4 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.main_summary`
 AS SELECT * FROM
-  `moz-fx-data-derived-datasets.telemetry.main_summary_v4`
+  `moz-fx-data-shared-prod.telemetry.main_summary_v4`


### PR DESCRIPTION
This should have no functional change, but is future-proofing for the day when derived-datasets is torn down.