### PR TITLE
Address glam dag timeouts

### DIFF
--- a/script/dryrun
+++ b/script/dryrun
@@ -53,8 +53,7 @@ SKIP = {
     # Syntax error
     "sql/telemetry_derived/clients_last_seen_v1/init.sql",
     # HTTP Error 408: Request Time-out
-    "sql/telemetry_derived/clients_histogram_aggregates_v1/query.sql",
-    "sql/telemetry_derived/clients_scalar_aggregates_v1/query.sql",
+    "sql/telemetry_derived/latest_versions/query.sql",
 }
 
 USE_DERIVED_DATASETS = {

--- a/sql/telemetry_derived/clients_histogram_aggregates_v1/init.sql
+++ b/sql/telemetry_derived/clients_histogram_aggregates_v1/init.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.telemetry_derived.clients_histogram_aggregates_v1` (
+    client_id STRING,
+    os STRING,
+    app_version INT64,
+    app_build_id STRING,
+    channel STRING,
+    histogram_aggregates ARRAY <STRUCT<
+      first_bucket INT64,
+      last_bucket INT64,
+      num_buckets INT64,
+      latest_version INT64,
+      metric STRING,
+      metric_type STRING,
+      key STRING,
+      agg_type STRING,
+      aggregates STRUCT<key_val ARRAY<STRUCT<key STRING, value INT64>>>
+    >>
+)
+PARTITION BY RANGE_BUCKET(app_version, GENERATE_ARRAY(30, 200, 1))
+CLUSTER BY app_version, channel, client_id

--- a/sql/telemetry_derived/clients_histogram_aggregates_v1/query.sql
+++ b/sql/telemetry_derived/clients_histogram_aggregates_v1/query.sql
@@ -10,66 +10,67 @@ CREATE TEMP FUNCTION udf_map_sum(entries ANY TYPE) AS (
   )
 );
 --
-CREATE TEMP FUNCTION udf_normalized_sum (arrs ARRAY<STRUCT<key STRING, value INT64>>)
-RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
-  -- Returns the normalized sum of the input maps.
-  -- It returns the total_count[k] / SUM(total_count)
-  -- for each key k.
+CREATE TEMP FUNCTION udf_merged_user_data(old_aggs ANY TYPE, new_aggs ANY TYPE)
+  RETURNS ARRAY<STRUCT<
+    first_bucket INT64,
+    last_bucket INT64,
+    num_buckets INT64,
+    latest_version INT64,
+    metric STRING,
+    metric_type STRING,
+    key STRING,
+    agg_type STRING,
+    aggregates ARRAY<STRUCT<key STRING, value INT64>>>> AS (
   (
-    WITH total_counts AS (
-      SELECT
-        sum(a.value) AS total_count
-      FROM
-        UNNEST(arrs) AS a
-    ),
+    WITH unnested AS
+      (SELECT *
+      FROM UNNEST(old_aggs)
 
-    summed_counts AS (
-      SELECT
-        a.key AS k,
-        SUM(a.value) AS v
-      FROM
-        UNNEST(arrs) AS a
+      UNION ALL
+
+      SELECT *
+      FROM UNNEST(new_aggs)),
+
+    aggregated_data AS
+      (SELECT AS STRUCT
+        first_bucket,
+        last_bucket,
+        num_buckets,
+        latest_version,
+        metric,
+        metric_type,
+        key,
+        agg_type,
+        udf_map_sum(ARRAY_CONCAT_AGG(aggregates)) AS histogram_aggregates
+      FROM unnested
       GROUP BY
-        a.key
-    ),
+        first_bucket,
+        last_bucket,
+        num_buckets,
+        latest_version,
+        metric,
+        metric_type,
+        key,
+        agg_type)
 
-    final_values AS (
-      SELECT
-        STRUCT<key STRING, value FLOAT64>(k, 1.0 * v / total_count) AS record
-      FROM
-        summed_counts
-      CROSS JOIN
-        total_counts
-    )
-
-    SELECT
-        ARRAY_AGG(record)
-    FROM
-      final_values
+      SELECT ARRAY_AGG((
+        first_bucket,
+        last_bucket,
+        num_buckets,
+        latest_version,
+        metric,
+        metric_type,
+        key,
+        agg_type,
+        histogram_aggregates))
+      FROM aggregated_data
   )
 );
 
-WITH latest_versions AS (
-  SELECT channel, MAX(CAST(app_version AS INT64)) AS latest_version
-  FROM
-    (SELECT
-      normalized_channel AS channel,
-      SPLIT(application.version, '.')[OFFSET(0)] AS app_version,
-      COUNT(*)
-    FROM `moz-fx-data-shared-prod.telemetry_stable.main_v4`
-    WHERE DATE(submission_timestamp) > DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
-      AND normalized_channel IN ("nightly", "beta", "release")
-    GROUP BY 1, 2
-    HAVING COUNT(DISTINCT client_id) > 2000
-    ORDER BY 1, 2 DESC)
-  GROUP BY 1),
-
-filtered_date_channel AS (
+WITH filtered_date_channel AS (
   SELECT *
   FROM clients_daily_histogram_aggregates_v1
-  WHERE submission_date > DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
-    AND channel IN ('release', 'beta', 'nightly')
-),
+  WHERE submission_date = @submission_date),
 
 filtered_aggregates AS (
   SELECT
@@ -89,10 +90,13 @@ filtered_aggregates AS (
   CROSS JOIN
     UNNEST(histogram_aggregates)
   WHERE value IS NOT NULL
+    AND ARRAY_LENGTH(value) > 0
+    AND bucket_range.num_buckets > 0
 ),
 
-version_filtered AS
+version_filtered_new AS
   (SELECT
+      submission_date,
       client_id,
       os,
       app_version,
@@ -112,7 +116,7 @@ version_filtered AS
   ON latest_versions.channel = hist_aggs.channel
   WHERE CAST(app_version AS INT64) >= (latest_version - 2)),
 
-normalized_histograms AS
+aggregated_histograms AS
   (SELECT
       client_id,
       os,
@@ -122,14 +126,14 @@ normalized_histograms AS
       first_bucket,
       last_bucket,
       num_buckets,
+      latest_version,
       metric,
       metric_type,
       key,
       agg_type,
-      latest_version,
-      udf_normalized_sum(udf_map_sum(ARRAY_CONCAT_AGG(value))) AS aggregates
+      udf_map_sum(ARRAY_CONCAT_AGG(value)) AS aggregates
   FROM
-      version_filtered
+      version_filtered_new
   GROUP BY
       client_id,
       os,
@@ -143,23 +147,93 @@ normalized_histograms AS
       metric_type,
       key,
       agg_type,
-      latest_version)
+      latest_version),
 
-SELECT
+clients_histogram_aggregates_new AS
+  (SELECT
     client_id,
     os,
     app_version,
     app_build_id,
     channel,
-    first_bucket,
-    last_bucket,
-    num_buckets,
-    metric,
-    metric_type,
-    normalized_histograms.key AS key,
-    agg_type,
-    agg.key AS bucket,
-    agg.value AS value
-FROM normalized_histograms
-CROSS JOIN UNNEST(aggregates) AS agg
-WHERE num_buckets > 0
+    ARRAY_AGG(STRUCT<
+      first_bucket INT64,
+      last_bucket INT64,
+      num_buckets INT64,
+      latest_version INT64,
+      metric STRING,
+      metric_type STRING,
+      key STRING,
+      agg_type STRING,
+      aggregates ARRAY<STRUCT<key STRING, value INT64>>>(
+        first_bucket,
+        last_bucket,
+        num_buckets,
+        latest_version,
+        metric,
+        metric_type,
+        key,
+        agg_type,
+        aggregates
+  )) AS histogram_aggregates
+  FROM aggregated_histograms
+  GROUP BY
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel),
+
+clients_histogram_aggregates_old AS
+  (SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    histogram_aggs.channel AS channel,
+    histogram_aggregates
+  FROM clients_histogram_aggregates_v1 AS histogram_aggs
+  LEFT JOIN latest_versions
+  ON latest_versions.channel = histogram_aggs.channel
+  WHERE app_version >= (latest_version - 2)),
+
+joined_new_old AS (
+  SELECT
+    CASE
+      WHEN old_data.client_id IS NOT NULL THEN old_data.client_id
+      ELSE new_data.client_id
+    END AS client_id,
+    CASE
+      WHEN old_data.os IS NOT NULL THEN old_data.os
+      ELSE new_data.os
+    END AS os,
+    CASE
+      WHEN old_data.app_version IS NOT NULL THEN old_data.app_version
+      ELSE CAST(new_data.app_version AS INT64)
+    END AS app_version,
+    CASE
+      WHEN old_data.app_build_id IS NOT NULL THEN old_data.app_build_id
+      ELSE new_data.app_build_id
+    END AS app_build_id,
+    CASE
+      WHEN old_data.channel IS NOT NULL THEN old_data.channel
+      ELSE new_data.channel
+    END AS channel,
+    old_data.histogram_aggregates AS old_aggs,
+    new_data.histogram_aggregates AS new_aggs
+  FROM clients_histogram_aggregates_new AS new_data
+  FULL OUTER JOIN clients_histogram_aggregates_old AS old_data
+    ON new_data.client_id = old_data.client_id
+    AND new_data.os = old_data.os
+    AND CAST(new_data.app_version AS INT64) = old_data.app_version
+    AND new_data.app_build_id = old_data.app_build_id
+    AND new_data.channel = old_data.channel)
+
+SELECT
+  client_id,
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  udf_merged_user_data(old_aggs, new_aggs) AS histogram_aggregates
+FROM joined_new_old

--- a/sql/telemetry_derived/clients_histogram_aggregates_v1/query.sql
+++ b/sql/telemetry_derived/clients_histogram_aggregates_v1/query.sql
@@ -199,26 +199,11 @@ clients_histogram_aggregates_old AS
 
 joined_new_old AS (
   SELECT
-    CASE
-      WHEN old_data.client_id IS NOT NULL THEN old_data.client_id
-      ELSE new_data.client_id
-    END AS client_id,
-    CASE
-      WHEN old_data.os IS NOT NULL THEN old_data.os
-      ELSE new_data.os
-    END AS os,
-    CASE
-      WHEN old_data.app_version IS NOT NULL THEN old_data.app_version
-      ELSE CAST(new_data.app_version AS INT64)
-    END AS app_version,
-    CASE
-      WHEN old_data.app_build_id IS NOT NULL THEN old_data.app_build_id
-      ELSE new_data.app_build_id
-    END AS app_build_id,
-    CASE
-      WHEN old_data.channel IS NOT NULL THEN old_data.channel
-      ELSE new_data.channel
-    END AS channel,
+    COALESCE(old_data.client_id, new_data.client_id) AS client_id,
+    COALESCE(old_data.os, new_data.os) AS os,
+    COALESCE(old_data.app_version, CAST(new_data.app_version AS INT64)) AS app_version,
+    COALESCE(old_data.app_build_id, new_data.app_build_id) AS app_build_id,
+    COALESCE(old_data.channel, new_data.channel) AS channel,
     old_data.histogram_aggregates AS old_aggs,
     new_data.histogram_aggregates AS new_aggs
   FROM clients_histogram_aggregates_new AS new_data

--- a/sql/telemetry_derived/clients_scalar_aggregates_v1/init.sql
+++ b/sql/telemetry_derived/clients_scalar_aggregates_v1/init.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.telemetry_derived.clients_scalar_aggregates_v1` (
+    client_id STRING,
+    os STRING,
+    app_version INT64,
+    app_build_id STRING,
+    channel STRING,
+    scalar_aggregates ARRAY <STRUCT<metric STRING,
+    metric_type STRING,
+    key STRING,
+    agg_type STRING,
+    value FLOAT64>>)
+PARTITION BY RANGE_BUCKET(app_version, GENERATE_ARRAY(30, 200, 1))
+CLUSTER BY app_version, channel, client_id

--- a/sql/telemetry_derived/clients_scalar_aggregates_v1/query.sql
+++ b/sql/telemetry_derived/clients_scalar_aggregates_v1/query.sql
@@ -185,26 +185,11 @@ filtered_old AS (
 
 joined_new_old AS (
   SELECT
-    CASE
-      WHEN old_data.client_id IS NOT NULL THEN old_data.client_id
-      ELSE new_data.client_id
-    END AS client_id,
-    CASE
-      WHEN old_data.os IS NOT NULL THEN old_data.os
-      ELSE new_data.os
-    END AS os,
-    CASE
-      WHEN old_data.app_version IS NOT NULL THEN old_data.app_version
-      ELSE CAST(new_data.app_version AS INT64)
-    END AS app_version,
-    CASE
-      WHEN old_data.app_build_id IS NOT NULL THEN old_data.app_build_id
-      ELSE new_data.app_build_id
-    END AS app_build_id,
-    CASE
-      WHEN old_data.channel IS NOT NULL THEN old_data.channel
-      ELSE new_data.channel
-    END AS channel,
+    COALESCE(old_data.client_id, new_data.client_id) AS client_id,
+    COALESCE(old_data.os, new_data.os) AS os,
+    COALESCE(old_data.app_version, CAST(new_data.app_version AS INT64)) AS app_version,
+    COALESCE(old_data.app_build_id, new_data.app_build_id) AS app_build_id,
+    COALESCE(old_data.channel, new_data.channel) AS channel,
     old_data.scalar_aggregates AS old_aggs,
     new_data.scalar_aggregates AS new_aggs
   FROM filtered_new AS new_data

--- a/sql/telemetry_derived/clients_scalar_bucket_counts_v1/query.sql
+++ b/sql/telemetry_derived/clients_scalar_bucket_counts_v1/query.sql
@@ -1,0 +1,127 @@
+CREATE TEMP FUNCTION udf_bucket (
+  val FLOAT64
+)
+RETURNS FLOAT64 AS (
+  -- Bucket `value` into a histogram with min_bucket, max_bucket and num_buckets
+  (
+    SELECT max(CAST(bucket AS INT64))
+    FROM UNNEST([0, 1.0, 41.0, 81.0, 121.0, 162.0, 202.0, 242.0, 283.0, 323.0, 363.0, 404.0, 444.0, 484.0, 525.0, 565.0, 605.0, 646.0, 686.0, 726.0, 767.0, 807.0, 847.0, 888.0, 928.0, 968.0, 1008.0, 1049.0, 1089.0, 1129.0, 1170.0, 1210.0, 1250.0, 1291.0, 1331.0, 1371.0, 1412.0, 1452.0, 1492.0, 1533.0, 1573.0, 1613.0, 1654.0, 1694.0, 1734.0, 1775.0, 1815.0, 1855.0, 1895.0, 1936.0, 1976.0, 2016.0, 2057.0, 2097.0, 2137.0, 2178.0, 2218.0, 2258.0, 2299.0, 2339.0, 2379.0, 2420.0, 2460.0, 2500.0, 2541.0, 2581.0, 2621.0, 2662.0, 2702.0, 2742.0, 2782.0, 2823.0, 2863.0, 2903.0, 2944.0, 2984.0, 3024.0, 3065.0, 3105.0, 3145.0, 3186.0, 3226.0, 3266.0, 3307.0, 3347.0, 3387.0, 3428.0, 3468.0, 3508.0, 3549.0, 3589.0, 3629.0, 3669.0, 3710.0, 3750.0, 3790.0, 3831.0, 3871.0, 3911.0, 3952.0, 3992.0, 4032.0, 4073.0, 4113.0, 4153.0, 4194.0, 4234.0, 4274.0, 4315.0, 4355.0, 4395.0, 4436.0, 4476.0, 4516.0, 4556.0, 4597.0, 4637.0, 4677.0, 4718.0, 4758.0, 4798.0, 4839.0, 4879.0, 4919.0, 4960.0, 5000.0, 5040.0, 5081.0, 5121.0, 5161.0, 5202.0, 5242.0, 5282.0, 5323.0, 5363.0, 5403.0, 5444.0, 5484.0, 5524.0, 5564.0, 5605.0, 5645.0, 5685.0, 5726.0, 5766.0, 5806.0, 5847.0, 5887.0, 5927.0, 5968.0, 6008.0, 6048.0, 6089.0, 6129.0, 6169.0, 6210.0, 6250.0, 6290.0, 6331.0, 6371.0, 6411.0, 6451.0, 6492.0, 6532.0, 6572.0, 6613.0, 6653.0, 6693.0, 6734.0, 6774.0, 6814.0, 6855.0, 6895.0, 6935.0, 6976.0, 7016.0, 7056.0, 7097.0, 7137.0, 7177.0, 7218.0, 7258.0, 7298.0, 7338.0, 7379.0, 7419.0, 7459.0, 7500.0, 7540.0, 7580.0, 7621.0, 7661.0, 7701.0, 7742.0, 7782.0, 7822.0, 7863.0, 7903.0, 7943.0, 7984.0, 8024.0, 8064.0, 8105.0, 8145.0, 8185.0, 8225.0, 8266.0, 8306.0, 8346.0, 8387.0, 8427.0, 8467.0, 8508.0, 8548.0, 8588.0, 8629.0, 8669.0, 8709.0, 8750.0, 8790.0, 8830.0, 8871.0, 8911.0, 8951.0, 8992.0, 9032.0, 9072.0, 9112.0, 9153.0, 9193.0, 9233.0, 9274.0, 9314.0, 9354.0, 9395.0, 9435.0, 9475.0, 9516.0, 9556.0, 9596.0, 9637.0, 9677.0, 9717.0, 9758.0, 9798.0, 9838.0, 9879.0, 9919.0, 9959.0, 10000.0]) AS bucket
+    WHERE val >= CAST(bucket AS INT64)
+  )
+);
+
+CREATE TEMP FUNCTION udf_boolean_buckets(
+  scalar_aggs ARRAY<STRUCT<metric STRING, metric_type STRING, key STRING, agg_type STRING, value FLOAT64>>)
+  RETURNS ARRAY<STRUCT<metric STRING,
+    metric_type STRING,
+    key STRING,
+    agg_type STRING,
+    bucket STRING>> AS (
+    (
+      WITH boolean_columns AS
+        (SELECT
+          metric,
+          metric_type,
+          key,
+          agg_type,
+          CASE agg_type
+            WHEN 'true' THEN value ELSE 0
+          END AS bool_true,
+          CASE agg_type
+            WHEN 'false' THEN value ELSE 0
+          END AS bool_false
+        FROM UNNEST(scalar_aggs)
+        WHERE metric_type in ("boolean", "keyed-scalar-boolean")),
+
+      summed_bools AS
+        (SELECT
+          metric,
+          metric_type,
+          key,
+          '' AS agg_type,
+          SUM(bool_true) AS bool_true,
+          SUM(bool_false) AS bool_false
+        FROM boolean_columns
+        GROUP BY 1,2,3,4),
+
+      booleans AS
+        (SELECT * EXCEPT(bool_true, bool_false),
+        CASE
+          WHEN bool_true > 0 AND bool_false > 0
+          THEN "sometimes"
+          WHEN bool_true > 0 AND bool_false = 0
+          THEN "always"
+          WHEN bool_true = 0 AND bool_false > 0
+          THEN "never"
+        END AS bucket
+        FROM summed_bools
+        WHERE bool_true > 0 OR bool_false > 0)
+
+      SELECT ARRAY_AGG((metric, metric_type, key, agg_type, bucket))
+      FROM booleans
+    )
+);
+
+WITH bucketed_booleans AS (
+  SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    udf_boolean_buckets(scalar_aggregates) AS scalar_aggregates
+  FROM
+    clients_scalar_aggregates_v1),
+
+bucketed_scalars AS (
+  SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    metric,
+    metric_type,
+    key,
+    agg_type,
+    SAFE_CAST(udf_bucket(SAFE_CAST(value AS FLOAT64)) AS STRING) AS bucket
+  FROM
+    clients_scalar_aggregates_v1
+  CROSS JOIN UNNEST(scalar_aggregates)
+  WHERE
+    metric_type = 'scalar' OR metric_type = 'keyed-scalar'),
+
+booleans_and_scalars AS (
+  SELECT * EXCEPT(scalar_aggregates)
+  FROM bucketed_booleans
+  CROSS JOIN UNNEST(scalar_aggregates)
+
+  UNION ALL
+
+  SELECT *
+  FROM bucketed_scalars)
+
+SELECT
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  metric,
+  metric_type,
+  key,
+  agg_type AS client_agg_type,
+  'histogram' AS agg_type,
+  bucket,
+  COUNT(*) AS count
+FROM
+  booleans_and_scalars
+GROUP BY
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  metric,
+  metric_type,
+  key,
+  client_agg_type,
+  bucket

--- a/sql/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
+++ b/sql/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
@@ -1,59 +1,8 @@
-CREATE TEMP FUNCTION udf_exponential_buckets(min FLOAT64, max FLOAT64, nBuckets FLOAT64)
-RETURNS ARRAY<FLOAT64>
-LANGUAGE js AS
-'''
-  let logMax = Math.log(max);
-  let current = min;
-  if (current === 0) {
-    current = 1;
-  } // If starting from 0, the second bucket should be 1 rather than 0
-  let retArray = [0, current];
-  for (let bucketIndex = 2; bucketIndex < nBuckets; bucketIndex++) {
-    let logCurrent = Math.log(current);
-    let logRatio = (logMax - logCurrent) / (nBuckets - bucketIndex);
-    let logNext = logCurrent + logRatio;
-    let nextValue =  Math.round(Math.exp(logNext));
-    current = nextValue > current ? nextValue : current + 1;
-    retArray[bucketIndex] = current;
-  }
-  return retArray
-''';
-
-CREATE TEMP FUNCTION udf_linear_buckets(min FLOAT64, max FLOAT64, nBuckets FLOAT64)
-RETURNS ARRAY<FLOAT64>
-LANGUAGE js AS
-'''
-  let result = [0];
-  for (let i = 1; i < nBuckets; i++) {
-    let linearRange = (min * (nBuckets - 1 - i) + max * (i - 1)) / (nBuckets - 2);
-    result.push(Math.round(linearRange));
-  }
-  return result;
-''';
-
-CREATE TEMP FUNCTION udf_to_string_arr(buckets ARRAY<INT64>)
+CREATE TEMP FUNCTION udf_get_buckets()
 RETURNS ARRAY<STRING> AS (
   (
     SELECT ARRAY_AGG(CAST(bucket AS STRING))
-    FROM UNNEST(buckets) AS bucket
-  )
-);
-
-CREATE TEMP FUNCTION udf_get_buckets(min INT64, max INT64, num INT64, metric_type STRING)
-RETURNS ARRAY<INT64> AS (
-  (
-    WITH buckets AS (
-      SELECT
-        CASE
-          WHEN metric_type = 'histogram-exponential'
-          THEN udf_exponential_buckets(min, max, num)
-          ELSE udf_linear_buckets(min, max, num)
-       END AS arr
-    )
-
-    SELECT ARRAY_AGG(CAST(item AS INT64))
-    FROM buckets
-    CROSS JOIN UNNEST(arr) AS item
+    FROM UNNEST([0, 1.0, 41.0, 81.0, 121.0, 162.0, 202.0, 242.0, 283.0, 323.0, 363.0, 404.0, 444.0, 484.0, 525.0, 565.0, 605.0, 646.0, 686.0, 726.0, 767.0, 807.0, 847.0, 888.0, 928.0, 968.0, 1008.0, 1049.0, 1089.0, 1129.0, 1170.0, 1210.0, 1250.0, 1291.0, 1331.0, 1371.0, 1412.0, 1452.0, 1492.0, 1533.0, 1573.0, 1613.0, 1654.0, 1694.0, 1734.0, 1775.0, 1815.0, 1855.0, 1895.0, 1936.0, 1976.0, 2016.0, 2057.0, 2097.0, 2137.0, 2178.0, 2218.0, 2258.0, 2299.0, 2339.0, 2379.0, 2420.0, 2460.0, 2500.0, 2541.0, 2581.0, 2621.0, 2662.0, 2702.0, 2742.0, 2782.0, 2823.0, 2863.0, 2903.0, 2944.0, 2984.0, 3024.0, 3065.0, 3105.0, 3145.0, 3186.0, 3226.0, 3266.0, 3307.0, 3347.0, 3387.0, 3428.0, 3468.0, 3508.0, 3549.0, 3589.0, 3629.0, 3669.0, 3710.0, 3750.0, 3790.0, 3831.0, 3871.0, 3911.0, 3952.0, 3992.0, 4032.0, 4073.0, 4113.0, 4153.0, 4194.0, 4234.0, 4274.0, 4315.0, 4355.0, 4395.0, 4436.0, 4476.0, 4516.0, 4556.0, 4597.0, 4637.0, 4677.0, 4718.0, 4758.0, 4798.0, 4839.0, 4879.0, 4919.0, 4960.0, 5000.0, 5040.0, 5081.0, 5121.0, 5161.0, 5202.0, 5242.0, 5282.0, 5323.0, 5363.0, 5403.0, 5444.0, 5484.0, 5524.0, 5564.0, 5605.0, 5645.0, 5685.0, 5726.0, 5766.0, 5806.0, 5847.0, 5887.0, 5927.0, 5968.0, 6008.0, 6048.0, 6089.0, 6129.0, 6169.0, 6210.0, 6250.0, 6290.0, 6331.0, 6371.0, 6411.0, 6451.0, 6492.0, 6532.0, 6572.0, 6613.0, 6653.0, 6693.0, 6734.0, 6774.0, 6814.0, 6855.0, 6895.0, 6935.0, 6976.0, 7016.0, 7056.0, 7097.0, 7137.0, 7177.0, 7218.0, 7258.0, 7298.0, 7338.0, 7379.0, 7419.0, 7459.0, 7500.0, 7540.0, 7580.0, 7621.0, 7661.0, 7701.0, 7742.0, 7782.0, 7822.0, 7863.0, 7903.0, 7943.0, 7984.0, 8024.0, 8064.0, 8105.0, 8145.0, 8185.0, 8225.0, 8266.0, 8306.0, 8346.0, 8387.0, 8427.0, 8467.0, 8508.0, 8548.0, 8588.0, 8629.0, 8669.0, 8709.0, 8750.0, 8790.0, 8830.0, 8871.0, 8911.0, 8951.0, 8992.0, 9032.0, 9072.0, 9112.0, 9153.0, 9193.0, 9233.0, 9274.0, 9314.0, 9354.0, 9395.0, 9435.0, 9475.0, 9516.0, 9556.0, 9596.0, 9637.0, 9677.0, 9717.0, 9758.0, 9798.0, 9838.0, 9879.0, 9919.0, 9959.0, 10000.0]) AS bucket
   )
 );
 
@@ -74,22 +23,6 @@ RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
        ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(record.key, record.value))
     FROM
       summed_counts
-  )
-);
-
-CREATE TEMP FUNCTION udf_bucket (
-  val FLOAT64,
-  min_bucket INT64,
-  max_bucket INT64,
-  num_buckets INT64,
-  metric_type STRING
-)
-RETURNS FLOAT64 AS (
-  -- Bucket `value` into a histogram with min_bucket, max_bucket and num_buckets
-  (
-    SELECT max(CAST(bucket AS INT64))
-    FROM UNNEST(udf_get_buckets(min_bucket, max_bucket, num_buckets, metric_type)) AS bucket
-    WHERE val >= CAST(bucket AS INT64)
   )
 );
 
@@ -114,52 +47,6 @@ RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
   )
 );
 
-WITH bucketed_scalars AS (
-  SELECT
-    client_id,
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    metric,
-    metric_type,
-    key,
-    agg_type,
-    CASE
-      WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
-        THEN SAFE_CAST(udf_bucket(SAFE_CAST(agg_value AS FLOAT64), 1, 1000, 50, 'scalar') AS STRING)
-      WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
-        THEN agg_value
-    END AS bucket
-  FROM
-    clients_scalar_aggregates_v1),
-
-bucket_counts AS (
-  SELECT
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    metric,
-    metric_type,
-    key,
-    agg_type AS client_agg_type,
-    'histogram' AS agg_type,
-    bucket,
-    COUNT(*) AS count
-  FROM
-    bucketed_scalars
-  GROUP BY
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    metric,
-    metric_type,
-    key,
-    client_agg_type,
-    bucket)
-
 SELECT
   os,
   app_version,
@@ -174,7 +61,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -182,7 +69,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   os,
   app_version,
@@ -210,7 +97,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -218,7 +105,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   app_version,
   app_build_id,
@@ -233,7 +120,7 @@ UNION ALL
 
 SELECT
   os,
-  CAST(NULL AS STRING) AS app_version,
+  CAST(NULL AS INT64) AS app_version,
   app_build_id,
   channel,
   metric,
@@ -245,7 +132,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -253,7 +140,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   os,
   app_build_id,
@@ -280,7 +167,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -288,7 +175,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   os,
   app_version,
@@ -303,7 +190,7 @@ UNION ALL
 
 SELECT
   os,
-  CAST(NULL AS STRING) AS app_version,
+  CAST(NULL AS INT64) AS app_version,
   CAST(NULL AS STRING) AS app_build_id,
   channel,
   metric,
@@ -315,7 +202,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -323,7 +210,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   os,
   channel,
@@ -349,7 +236,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -357,7 +244,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   app_version,
   channel,
@@ -383,7 +270,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -391,7 +278,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   app_version,
   metric,
@@ -404,7 +291,7 @@ UNION ALL
 
 SELECT
   os,
-  CAST(NULL AS STRING) AS app_version,
+  CAST(NULL AS INT64) AS app_version,
   CAST(NULL AS STRING) AS app_build_id,
   CAST(NULL AS STRING) AS channel,
   metric,
@@ -416,7 +303,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -424,7 +311,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   os,
   metric,
@@ -437,7 +324,7 @@ UNION ALL
 
 SELECT
   CAST(NULL AS STRING) AS os,
-  CAST(NULL AS STRING) AS app_version,
+  CAST(NULL AS INT64) AS app_version,
   CAST(NULL AS STRING) AS app_build_id,
   channel,
   metric,
@@ -449,7 +336,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -457,7 +344,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   channel,
   metric,
@@ -470,7 +357,7 @@ UNION ALL
 
 SELECT
   CAST(NULL AS STRING) AS os,
-  CAST(NULL AS STRING) AS app_version,
+  CAST(NULL AS INT64) AS app_version,
   CAST(NULL AS STRING) AS app_build_id,
   CAST(NULL AS STRING) AS channel,
   metric,
@@ -482,7 +369,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -490,7 +377,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   metric,
   metric_type,

--- a/sql/telemetry_derived/latest_versions/query.sql
+++ b/sql/telemetry_derived/latest_versions/query.sql
@@ -1,0 +1,13 @@
+SELECT channel, MAX(CAST(app_version AS INT64)) AS latest_version
+  FROM
+    (SELECT
+      normalized_channel AS channel,
+      SPLIT(application.version, '.')[OFFSET(0)] AS app_version,
+      COUNT(*)
+    FROM `moz-fx-data-shared-prod.telemetry_stable.main_v4`
+    WHERE DATE(submission_timestamp) > DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+      AND normalized_channel IN ("nightly", "beta", "release")
+    GROUP BY 1, 2
+    HAVING COUNT(DISTINCT client_id) > 2000
+    ORDER BY 1, 2 DESC)
+GROUP BY 1

--- a/templates/telemetry_derived/clients_histogram_aggregates_v1/init.sql
+++ b/templates/telemetry_derived/clients_histogram_aggregates_v1/init.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.telemetry_derived.clients_histogram_aggregates_v1` (
+    client_id STRING,
+    os STRING,
+    app_version INT64,
+    app_build_id STRING,
+    channel STRING,
+    histogram_aggregates ARRAY <STRUCT<
+      first_bucket INT64,
+      last_bucket INT64,
+      num_buckets INT64,
+      latest_version INT64,
+      metric STRING,
+      metric_type STRING,
+      key STRING,
+      agg_type STRING,
+      aggregates STRUCT<key_val ARRAY<STRUCT<key STRING, value INT64>>>
+    >>
+)
+PARTITION BY RANGE_BUCKET(app_version, GENERATE_ARRAY(30, 200, 1))
+CLUSTER BY app_version, channel, client_id

--- a/templates/telemetry_derived/clients_histogram_aggregates_v1/query.sql
+++ b/templates/telemetry_derived/clients_histogram_aggregates_v1/query.sql
@@ -187,26 +187,11 @@ clients_histogram_aggregates_old AS
 
 joined_new_old AS (
   SELECT
-    CASE
-      WHEN old_data.client_id IS NOT NULL THEN old_data.client_id
-      ELSE new_data.client_id
-    END AS client_id,
-    CASE
-      WHEN old_data.os IS NOT NULL THEN old_data.os
-      ELSE new_data.os
-    END AS os,
-    CASE
-      WHEN old_data.app_version IS NOT NULL THEN old_data.app_version
-      ELSE CAST(new_data.app_version AS INT64)
-    END AS app_version,
-    CASE
-      WHEN old_data.app_build_id IS NOT NULL THEN old_data.app_build_id
-      ELSE new_data.app_build_id
-    END AS app_build_id,
-    CASE
-      WHEN old_data.channel IS NOT NULL THEN old_data.channel
-      ELSE new_data.channel
-    END AS channel,
+    COALESCE(old_data.client_id, new_data.client_id) AS client_id,
+    COALESCE(old_data.os, new_data.os) AS os,
+    COALESCE(old_data.app_version, CAST(new_data.app_version AS INT64)) AS app_version,
+    COALESCE(old_data.app_build_id, new_data.app_build_id) AS app_build_id,
+    COALESCE(old_data.channel, new_data.channel) AS channel,
     old_data.histogram_aggregates AS old_aggs,
     new_data.histogram_aggregates AS new_aggs
   FROM clients_histogram_aggregates_new AS new_data

--- a/templates/telemetry_derived/clients_histogram_aggregates_v1/query.sql
+++ b/templates/telemetry_derived/clients_histogram_aggregates_v1/query.sql
@@ -1,63 +1,64 @@
-CREATE TEMP FUNCTION udf_normalized_sum (arrs ARRAY<STRUCT<key STRING, value INT64>>)
-RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
-  -- Returns the normalized sum of the input maps.
-  -- It returns the total_count[k] / SUM(total_count)
-  -- for each key k.
+CREATE TEMP FUNCTION udf_merged_user_data(old_aggs ANY TYPE, new_aggs ANY TYPE)
+  RETURNS ARRAY<STRUCT<
+    first_bucket INT64,
+    last_bucket INT64,
+    num_buckets INT64,
+    latest_version INT64,
+    metric STRING,
+    metric_type STRING,
+    key STRING,
+    agg_type STRING,
+    aggregates ARRAY<STRUCT<key STRING, value INT64>>>> AS (
   (
-    WITH total_counts AS (
-      SELECT
-        sum(a.value) AS total_count
-      FROM
-        UNNEST(arrs) AS a
-    ),
+    WITH unnested AS
+      (SELECT *
+      FROM UNNEST(old_aggs)
 
-    summed_counts AS (
-      SELECT
-        a.key AS k,
-        SUM(a.value) AS v
-      FROM
-        UNNEST(arrs) AS a
+      UNION ALL
+
+      SELECT *
+      FROM UNNEST(new_aggs)),
+
+    aggregated_data AS
+      (SELECT AS STRUCT
+        first_bucket,
+        last_bucket,
+        num_buckets,
+        latest_version,
+        metric,
+        metric_type,
+        key,
+        agg_type,
+        udf_map_sum(ARRAY_CONCAT_AGG(aggregates)) AS histogram_aggregates
+      FROM unnested
       GROUP BY
-        a.key
-    ),
+        first_bucket,
+        last_bucket,
+        num_buckets,
+        latest_version,
+        metric,
+        metric_type,
+        key,
+        agg_type)
 
-    final_values AS (
-      SELECT
-        STRUCT<key STRING, value FLOAT64>(k, 1.0 * v / total_count) AS record
-      FROM
-        summed_counts
-      CROSS JOIN
-        total_counts
-    )
-
-    SELECT
-        ARRAY_AGG(record)
-    FROM
-      final_values
+      SELECT ARRAY_AGG((
+        first_bucket,
+        last_bucket,
+        num_buckets,
+        latest_version,
+        metric,
+        metric_type,
+        key,
+        agg_type,
+        histogram_aggregates))
+      FROM aggregated_data
   )
 );
 
-WITH latest_versions AS (
-  SELECT channel, MAX(CAST(app_version AS INT64)) AS latest_version
-  FROM
-    (SELECT
-      normalized_channel AS channel,
-      SPLIT(application.version, '.')[OFFSET(0)] AS app_version,
-      COUNT(*)
-    FROM `moz-fx-data-shared-prod.telemetry_stable.main_v4`
-    WHERE DATE(submission_timestamp) > DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
-      AND normalized_channel IN ("nightly", "beta", "release")
-    GROUP BY 1, 2
-    HAVING COUNT(DISTINCT client_id) > 2000
-    ORDER BY 1, 2 DESC)
-  GROUP BY 1),
-
-filtered_date_channel AS (
+WITH filtered_date_channel AS (
   SELECT *
   FROM clients_daily_histogram_aggregates_v1
-  WHERE submission_date > DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
-    AND channel IN ('release', 'beta', 'nightly')
-),
+  WHERE submission_date = @submission_date),
 
 filtered_aggregates AS (
   SELECT
@@ -77,10 +78,13 @@ filtered_aggregates AS (
   CROSS JOIN
     UNNEST(histogram_aggregates)
   WHERE value IS NOT NULL
+    AND ARRAY_LENGTH(value) > 0
+    AND bucket_range.num_buckets > 0
 ),
 
-version_filtered AS
+version_filtered_new AS
   (SELECT
+      submission_date,
       client_id,
       os,
       app_version,
@@ -100,7 +104,7 @@ version_filtered AS
   ON latest_versions.channel = hist_aggs.channel
   WHERE CAST(app_version AS INT64) >= (latest_version - 2)),
 
-normalized_histograms AS
+aggregated_histograms AS
   (SELECT
       client_id,
       os,
@@ -110,14 +114,14 @@ normalized_histograms AS
       first_bucket,
       last_bucket,
       num_buckets,
+      latest_version,
       metric,
       metric_type,
       key,
       agg_type,
-      latest_version,
-      udf_normalized_sum(udf_map_sum(ARRAY_CONCAT_AGG(value))) AS aggregates
+      udf_map_sum(ARRAY_CONCAT_AGG(value)) AS aggregates
   FROM
-      version_filtered
+      version_filtered_new
   GROUP BY
       client_id,
       os,
@@ -131,23 +135,93 @@ normalized_histograms AS
       metric_type,
       key,
       agg_type,
-      latest_version)
+      latest_version),
 
-SELECT
+clients_histogram_aggregates_new AS
+  (SELECT
     client_id,
     os,
     app_version,
     app_build_id,
     channel,
-    first_bucket,
-    last_bucket,
-    num_buckets,
-    metric,
-    metric_type,
-    normalized_histograms.key AS key,
-    agg_type,
-    agg.key AS bucket,
-    agg.value AS value
-FROM normalized_histograms
-CROSS JOIN UNNEST(aggregates) AS agg
-WHERE num_buckets > 0
+    ARRAY_AGG(STRUCT<
+      first_bucket INT64,
+      last_bucket INT64,
+      num_buckets INT64,
+      latest_version INT64,
+      metric STRING,
+      metric_type STRING,
+      key STRING,
+      agg_type STRING,
+      aggregates ARRAY<STRUCT<key STRING, value INT64>>>(
+        first_bucket,
+        last_bucket,
+        num_buckets,
+        latest_version,
+        metric,
+        metric_type,
+        key,
+        agg_type,
+        aggregates
+  )) AS histogram_aggregates
+  FROM aggregated_histograms
+  GROUP BY
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel),
+
+clients_histogram_aggregates_old AS
+  (SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    histogram_aggs.channel AS channel,
+    histogram_aggregates
+  FROM clients_histogram_aggregates_v1 AS histogram_aggs
+  LEFT JOIN latest_versions
+  ON latest_versions.channel = histogram_aggs.channel
+  WHERE app_version >= (latest_version - 2)),
+
+joined_new_old AS (
+  SELECT
+    CASE
+      WHEN old_data.client_id IS NOT NULL THEN old_data.client_id
+      ELSE new_data.client_id
+    END AS client_id,
+    CASE
+      WHEN old_data.os IS NOT NULL THEN old_data.os
+      ELSE new_data.os
+    END AS os,
+    CASE
+      WHEN old_data.app_version IS NOT NULL THEN old_data.app_version
+      ELSE CAST(new_data.app_version AS INT64)
+    END AS app_version,
+    CASE
+      WHEN old_data.app_build_id IS NOT NULL THEN old_data.app_build_id
+      ELSE new_data.app_build_id
+    END AS app_build_id,
+    CASE
+      WHEN old_data.channel IS NOT NULL THEN old_data.channel
+      ELSE new_data.channel
+    END AS channel,
+    old_data.histogram_aggregates AS old_aggs,
+    new_data.histogram_aggregates AS new_aggs
+  FROM clients_histogram_aggregates_new AS new_data
+  FULL OUTER JOIN clients_histogram_aggregates_old AS old_data
+    ON new_data.client_id = old_data.client_id
+    AND new_data.os = old_data.os
+    AND CAST(new_data.app_version AS INT64) = old_data.app_version
+    AND new_data.app_build_id = old_data.app_build_id
+    AND new_data.channel = old_data.channel)
+
+SELECT
+  client_id,
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  udf_merged_user_data(old_aggs, new_aggs) AS histogram_aggregates
+FROM joined_new_old

--- a/templates/telemetry_derived/clients_scalar_aggregates_v1/init.sql
+++ b/templates/telemetry_derived/clients_scalar_aggregates_v1/init.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.telemetry_derived.clients_scalar_aggregates_v1` (
+    client_id STRING,
+    os STRING,
+    app_version INT64,
+    app_build_id STRING,
+    channel STRING,
+    scalar_aggregates ARRAY <STRUCT<metric STRING,
+    metric_type STRING,
+    key STRING,
+    agg_type STRING,
+    value FLOAT64>>)
+PARTITION BY RANGE_BUCKET(app_version, GENERATE_ARRAY(30, 200, 1))
+CLUSTER BY app_version, channel, client_id

--- a/templates/telemetry_derived/clients_scalar_aggregates_v1/query.sql
+++ b/templates/telemetry_derived/clients_scalar_aggregates_v1/query.sql
@@ -185,26 +185,11 @@ filtered_old AS (
 
 joined_new_old AS (
   SELECT
-    CASE
-      WHEN old_data.client_id IS NOT NULL THEN old_data.client_id
-      ELSE new_data.client_id
-    END AS client_id,
-    CASE
-      WHEN old_data.os IS NOT NULL THEN old_data.os
-      ELSE new_data.os
-    END AS os,
-    CASE
-      WHEN old_data.app_version IS NOT NULL THEN old_data.app_version
-      ELSE CAST(new_data.app_version AS INT64)
-    END AS app_version,
-    CASE
-      WHEN old_data.app_build_id IS NOT NULL THEN old_data.app_build_id
-      ELSE new_data.app_build_id
-    END AS app_build_id,
-    CASE
-      WHEN old_data.channel IS NOT NULL THEN old_data.channel
-      ELSE new_data.channel
-    END AS channel,
+    COALESCE(old_data.client_id, new_data.client_id) AS client_id,
+    COALESCE(old_data.os, new_data.os) AS os,
+    COALESCE(old_data.app_version, CAST(new_data.app_version AS INT64)) AS app_version,
+    COALESCE(old_data.app_build_id, new_data.app_build_id) AS app_build_id,
+    COALESCE(old_data.channel, new_data.channel) AS channel,
     old_data.scalar_aggregates AS old_aggs,
     new_data.scalar_aggregates AS new_aggs
   FROM filtered_new AS new_data

--- a/templates/telemetry_derived/clients_scalar_bucket_counts_v1/query.sql
+++ b/templates/telemetry_derived/clients_scalar_bucket_counts_v1/query.sql
@@ -1,0 +1,127 @@
+CREATE TEMP FUNCTION udf_bucket (
+  val FLOAT64
+)
+RETURNS FLOAT64 AS (
+  -- Bucket `value` into a histogram with min_bucket, max_bucket and num_buckets
+  (
+    SELECT max(CAST(bucket AS INT64))
+    FROM UNNEST([0, 1.0, 41.0, 81.0, 121.0, 162.0, 202.0, 242.0, 283.0, 323.0, 363.0, 404.0, 444.0, 484.0, 525.0, 565.0, 605.0, 646.0, 686.0, 726.0, 767.0, 807.0, 847.0, 888.0, 928.0, 968.0, 1008.0, 1049.0, 1089.0, 1129.0, 1170.0, 1210.0, 1250.0, 1291.0, 1331.0, 1371.0, 1412.0, 1452.0, 1492.0, 1533.0, 1573.0, 1613.0, 1654.0, 1694.0, 1734.0, 1775.0, 1815.0, 1855.0, 1895.0, 1936.0, 1976.0, 2016.0, 2057.0, 2097.0, 2137.0, 2178.0, 2218.0, 2258.0, 2299.0, 2339.0, 2379.0, 2420.0, 2460.0, 2500.0, 2541.0, 2581.0, 2621.0, 2662.0, 2702.0, 2742.0, 2782.0, 2823.0, 2863.0, 2903.0, 2944.0, 2984.0, 3024.0, 3065.0, 3105.0, 3145.0, 3186.0, 3226.0, 3266.0, 3307.0, 3347.0, 3387.0, 3428.0, 3468.0, 3508.0, 3549.0, 3589.0, 3629.0, 3669.0, 3710.0, 3750.0, 3790.0, 3831.0, 3871.0, 3911.0, 3952.0, 3992.0, 4032.0, 4073.0, 4113.0, 4153.0, 4194.0, 4234.0, 4274.0, 4315.0, 4355.0, 4395.0, 4436.0, 4476.0, 4516.0, 4556.0, 4597.0, 4637.0, 4677.0, 4718.0, 4758.0, 4798.0, 4839.0, 4879.0, 4919.0, 4960.0, 5000.0, 5040.0, 5081.0, 5121.0, 5161.0, 5202.0, 5242.0, 5282.0, 5323.0, 5363.0, 5403.0, 5444.0, 5484.0, 5524.0, 5564.0, 5605.0, 5645.0, 5685.0, 5726.0, 5766.0, 5806.0, 5847.0, 5887.0, 5927.0, 5968.0, 6008.0, 6048.0, 6089.0, 6129.0, 6169.0, 6210.0, 6250.0, 6290.0, 6331.0, 6371.0, 6411.0, 6451.0, 6492.0, 6532.0, 6572.0, 6613.0, 6653.0, 6693.0, 6734.0, 6774.0, 6814.0, 6855.0, 6895.0, 6935.0, 6976.0, 7016.0, 7056.0, 7097.0, 7137.0, 7177.0, 7218.0, 7258.0, 7298.0, 7338.0, 7379.0, 7419.0, 7459.0, 7500.0, 7540.0, 7580.0, 7621.0, 7661.0, 7701.0, 7742.0, 7782.0, 7822.0, 7863.0, 7903.0, 7943.0, 7984.0, 8024.0, 8064.0, 8105.0, 8145.0, 8185.0, 8225.0, 8266.0, 8306.0, 8346.0, 8387.0, 8427.0, 8467.0, 8508.0, 8548.0, 8588.0, 8629.0, 8669.0, 8709.0, 8750.0, 8790.0, 8830.0, 8871.0, 8911.0, 8951.0, 8992.0, 9032.0, 9072.0, 9112.0, 9153.0, 9193.0, 9233.0, 9274.0, 9314.0, 9354.0, 9395.0, 9435.0, 9475.0, 9516.0, 9556.0, 9596.0, 9637.0, 9677.0, 9717.0, 9758.0, 9798.0, 9838.0, 9879.0, 9919.0, 9959.0, 10000.0]) AS bucket
+    WHERE val >= CAST(bucket AS INT64)
+  )
+);
+
+CREATE TEMP FUNCTION udf_boolean_buckets(
+  scalar_aggs ARRAY<STRUCT<metric STRING, metric_type STRING, key STRING, agg_type STRING, value FLOAT64>>)
+  RETURNS ARRAY<STRUCT<metric STRING,
+    metric_type STRING,
+    key STRING,
+    agg_type STRING,
+    bucket STRING>> AS (
+    (
+      WITH boolean_columns AS
+        (SELECT
+          metric,
+          metric_type,
+          key,
+          agg_type,
+          CASE agg_type
+            WHEN 'true' THEN value ELSE 0
+          END AS bool_true,
+          CASE agg_type
+            WHEN 'false' THEN value ELSE 0
+          END AS bool_false
+        FROM UNNEST(scalar_aggs)
+        WHERE metric_type in ("boolean", "keyed-scalar-boolean")),
+
+      summed_bools AS
+        (SELECT
+          metric,
+          metric_type,
+          key,
+          '' AS agg_type,
+          SUM(bool_true) AS bool_true,
+          SUM(bool_false) AS bool_false
+        FROM boolean_columns
+        GROUP BY 1,2,3,4),
+
+      booleans AS
+        (SELECT * EXCEPT(bool_true, bool_false),
+        CASE
+          WHEN bool_true > 0 AND bool_false > 0
+          THEN "sometimes"
+          WHEN bool_true > 0 AND bool_false = 0
+          THEN "always"
+          WHEN bool_true = 0 AND bool_false > 0
+          THEN "never"
+        END AS bucket
+        FROM summed_bools
+        WHERE bool_true > 0 OR bool_false > 0)
+
+      SELECT ARRAY_AGG((metric, metric_type, key, agg_type, bucket))
+      FROM booleans
+    )
+);
+
+WITH bucketed_booleans AS (
+  SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    udf_boolean_buckets(scalar_aggregates) AS scalar_aggregates
+  FROM
+    clients_scalar_aggregates_v1),
+
+bucketed_scalars AS (
+  SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    metric,
+    metric_type,
+    key,
+    agg_type,
+    SAFE_CAST(udf_bucket(SAFE_CAST(value AS FLOAT64)) AS STRING) AS bucket
+  FROM
+    clients_scalar_aggregates_v1
+  CROSS JOIN UNNEST(scalar_aggregates)
+  WHERE
+    metric_type = 'scalar' OR metric_type = 'keyed-scalar'),
+
+booleans_and_scalars AS (
+  SELECT * EXCEPT(scalar_aggregates)
+  FROM bucketed_booleans
+  CROSS JOIN UNNEST(scalar_aggregates)
+
+  UNION ALL
+
+  SELECT *
+  FROM bucketed_scalars)
+
+SELECT
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  metric,
+  metric_type,
+  key,
+  agg_type AS client_agg_type,
+  'histogram' AS agg_type,
+  bucket,
+  COUNT(*) AS count
+FROM
+  booleans_and_scalars
+GROUP BY
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  metric,
+  metric_type,
+  key,
+  client_agg_type,
+  bucket

--- a/templates/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
+++ b/templates/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
@@ -1,59 +1,8 @@
-CREATE TEMP FUNCTION udf_exponential_buckets(min FLOAT64, max FLOAT64, nBuckets FLOAT64)
-RETURNS ARRAY<FLOAT64>
-LANGUAGE js AS
-'''
-  let logMax = Math.log(max);
-  let current = min;
-  if (current === 0) {
-    current = 1;
-  } // If starting from 0, the second bucket should be 1 rather than 0
-  let retArray = [0, current];
-  for (let bucketIndex = 2; bucketIndex < nBuckets; bucketIndex++) {
-    let logCurrent = Math.log(current);
-    let logRatio = (logMax - logCurrent) / (nBuckets - bucketIndex);
-    let logNext = logCurrent + logRatio;
-    let nextValue =  Math.round(Math.exp(logNext));
-    current = nextValue > current ? nextValue : current + 1;
-    retArray[bucketIndex] = current;
-  }
-  return retArray
-''';
-
-CREATE TEMP FUNCTION udf_linear_buckets(min FLOAT64, max FLOAT64, nBuckets FLOAT64)
-RETURNS ARRAY<FLOAT64>
-LANGUAGE js AS
-'''
-  let result = [0];
-  for (let i = 1; i < nBuckets; i++) {
-    let linearRange = (min * (nBuckets - 1 - i) + max * (i - 1)) / (nBuckets - 2);
-    result.push(Math.round(linearRange));
-  }
-  return result;
-''';
-
-CREATE TEMP FUNCTION udf_to_string_arr(buckets ARRAY<INT64>)
+CREATE TEMP FUNCTION udf_get_buckets()
 RETURNS ARRAY<STRING> AS (
   (
     SELECT ARRAY_AGG(CAST(bucket AS STRING))
-    FROM UNNEST(buckets) AS bucket
-  )
-);
-
-CREATE TEMP FUNCTION udf_get_buckets(min INT64, max INT64, num INT64, metric_type STRING)
-RETURNS ARRAY<INT64> AS (
-  (
-    WITH buckets AS (
-      SELECT
-        CASE
-          WHEN metric_type = 'histogram-exponential'
-          THEN udf_exponential_buckets(min, max, num)
-          ELSE udf_linear_buckets(min, max, num)
-       END AS arr
-    )
-
-    SELECT ARRAY_AGG(CAST(item AS INT64))
-    FROM buckets
-    CROSS JOIN UNNEST(arr) AS item
+    FROM UNNEST([0, 1.0, 41.0, 81.0, 121.0, 162.0, 202.0, 242.0, 283.0, 323.0, 363.0, 404.0, 444.0, 484.0, 525.0, 565.0, 605.0, 646.0, 686.0, 726.0, 767.0, 807.0, 847.0, 888.0, 928.0, 968.0, 1008.0, 1049.0, 1089.0, 1129.0, 1170.0, 1210.0, 1250.0, 1291.0, 1331.0, 1371.0, 1412.0, 1452.0, 1492.0, 1533.0, 1573.0, 1613.0, 1654.0, 1694.0, 1734.0, 1775.0, 1815.0, 1855.0, 1895.0, 1936.0, 1976.0, 2016.0, 2057.0, 2097.0, 2137.0, 2178.0, 2218.0, 2258.0, 2299.0, 2339.0, 2379.0, 2420.0, 2460.0, 2500.0, 2541.0, 2581.0, 2621.0, 2662.0, 2702.0, 2742.0, 2782.0, 2823.0, 2863.0, 2903.0, 2944.0, 2984.0, 3024.0, 3065.0, 3105.0, 3145.0, 3186.0, 3226.0, 3266.0, 3307.0, 3347.0, 3387.0, 3428.0, 3468.0, 3508.0, 3549.0, 3589.0, 3629.0, 3669.0, 3710.0, 3750.0, 3790.0, 3831.0, 3871.0, 3911.0, 3952.0, 3992.0, 4032.0, 4073.0, 4113.0, 4153.0, 4194.0, 4234.0, 4274.0, 4315.0, 4355.0, 4395.0, 4436.0, 4476.0, 4516.0, 4556.0, 4597.0, 4637.0, 4677.0, 4718.0, 4758.0, 4798.0, 4839.0, 4879.0, 4919.0, 4960.0, 5000.0, 5040.0, 5081.0, 5121.0, 5161.0, 5202.0, 5242.0, 5282.0, 5323.0, 5363.0, 5403.0, 5444.0, 5484.0, 5524.0, 5564.0, 5605.0, 5645.0, 5685.0, 5726.0, 5766.0, 5806.0, 5847.0, 5887.0, 5927.0, 5968.0, 6008.0, 6048.0, 6089.0, 6129.0, 6169.0, 6210.0, 6250.0, 6290.0, 6331.0, 6371.0, 6411.0, 6451.0, 6492.0, 6532.0, 6572.0, 6613.0, 6653.0, 6693.0, 6734.0, 6774.0, 6814.0, 6855.0, 6895.0, 6935.0, 6976.0, 7016.0, 7056.0, 7097.0, 7137.0, 7177.0, 7218.0, 7258.0, 7298.0, 7338.0, 7379.0, 7419.0, 7459.0, 7500.0, 7540.0, 7580.0, 7621.0, 7661.0, 7701.0, 7742.0, 7782.0, 7822.0, 7863.0, 7903.0, 7943.0, 7984.0, 8024.0, 8064.0, 8105.0, 8145.0, 8185.0, 8225.0, 8266.0, 8306.0, 8346.0, 8387.0, 8427.0, 8467.0, 8508.0, 8548.0, 8588.0, 8629.0, 8669.0, 8709.0, 8750.0, 8790.0, 8830.0, 8871.0, 8911.0, 8951.0, 8992.0, 9032.0, 9072.0, 9112.0, 9153.0, 9193.0, 9233.0, 9274.0, 9314.0, 9354.0, 9395.0, 9435.0, 9475.0, 9516.0, 9556.0, 9596.0, 9637.0, 9677.0, 9717.0, 9758.0, 9798.0, 9838.0, 9879.0, 9919.0, 9959.0, 10000.0]) AS bucket
   )
 );
 
@@ -74,22 +23,6 @@ RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
        ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(record.key, record.value))
     FROM
       summed_counts
-  )
-);
-
-CREATE TEMP FUNCTION udf_bucket (
-  val FLOAT64,
-  min_bucket INT64,
-  max_bucket INT64,
-  num_buckets INT64,
-  metric_type STRING
-)
-RETURNS FLOAT64 AS (
-  -- Bucket `value` into a histogram with min_bucket, max_bucket and num_buckets
-  (
-    SELECT max(CAST(bucket AS INT64))
-    FROM UNNEST(udf_get_buckets(min_bucket, max_bucket, num_buckets, metric_type)) AS bucket
-    WHERE val >= CAST(bucket AS INT64)
   )
 );
 
@@ -114,52 +47,6 @@ RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
   )
 );
 
-WITH bucketed_scalars AS (
-  SELECT
-    client_id,
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    metric,
-    metric_type,
-    key,
-    agg_type,
-    CASE
-      WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
-        THEN SAFE_CAST(udf_bucket(SAFE_CAST(agg_value AS FLOAT64), 1, 1000, 50, 'scalar') AS STRING)
-      WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
-        THEN agg_value
-    END AS bucket
-  FROM
-    clients_scalar_aggregates_v1),
-
-bucket_counts AS (
-  SELECT
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    metric,
-    metric_type,
-    key,
-    agg_type AS client_agg_type,
-    'histogram' AS agg_type,
-    bucket,
-    COUNT(*) AS count
-  FROM
-    bucketed_scalars
-  GROUP BY
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    metric,
-    metric_type,
-    key,
-    client_agg_type,
-    bucket)
-
 SELECT
   os,
   app_version,
@@ -174,7 +61,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -182,7 +69,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   os,
   app_version,
@@ -210,7 +97,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -218,7 +105,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   app_version,
   app_build_id,
@@ -233,7 +120,7 @@ UNION ALL
 
 SELECT
   os,
-  CAST(NULL AS STRING) AS app_version,
+  CAST(NULL AS INT64) AS app_version,
   app_build_id,
   channel,
   metric,
@@ -245,7 +132,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -253,7 +140,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   os,
   app_build_id,
@@ -280,7 +167,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -288,7 +175,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   os,
   app_version,
@@ -303,7 +190,7 @@ UNION ALL
 
 SELECT
   os,
-  CAST(NULL AS STRING) AS app_version,
+  CAST(NULL AS INT64) AS app_version,
   CAST(NULL AS STRING) AS app_build_id,
   channel,
   metric,
@@ -315,7 +202,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -323,7 +210,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   os,
   channel,
@@ -349,7 +236,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -357,7 +244,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   app_version,
   channel,
@@ -383,7 +270,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -391,7 +278,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   app_version,
   metric,
@@ -404,7 +291,7 @@ UNION ALL
 
 SELECT
   os,
-  CAST(NULL AS STRING) AS app_version,
+  CAST(NULL AS INT64) AS app_version,
   CAST(NULL AS STRING) AS app_build_id,
   CAST(NULL AS STRING) AS channel,
   metric,
@@ -416,7 +303,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -424,7 +311,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   os,
   metric,
@@ -437,7 +324,7 @@ UNION ALL
 
 SELECT
   CAST(NULL AS STRING) AS os,
-  CAST(NULL AS STRING) AS app_version,
+  CAST(NULL AS INT64) AS app_version,
   CAST(NULL AS STRING) AS app_build_id,
   channel,
   metric,
@@ -449,7 +336,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -457,7 +344,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   channel,
   metric,
@@ -470,7 +357,7 @@ UNION ALL
 
 SELECT
   CAST(NULL AS STRING) AS os,
-  CAST(NULL AS STRING) AS app_version,
+  CAST(NULL AS INT64) AS app_version,
   CAST(NULL AS STRING) AS app_build_id,
   CAST(NULL AS STRING) AS channel,
   metric,
@@ -482,7 +369,7 @@ SELECT
     WHEN metric_type = 'scalar' OR metric_type = 'keyed-scalar'
     THEN udf_fill_buckets(
       udf_dedupe_map_sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
-      udf_to_string_arr(udf_get_buckets(1, 1000, 50, metric_type))
+      udf_get_buckets()
     )
     WHEN metric_type = 'boolean' OR metric_type = 'keyed-scalar-boolean'
     THEN udf_fill_buckets(
@@ -490,7 +377,7 @@ SELECT
       ['always','never','sometimes'])
    END AS aggregates
 FROM
-  bucket_counts
+  clients_scalar_bucket_counts_v1
 GROUP BY
   metric,
   metric_type,

--- a/templates/telemetry_derived/latest_versions/query.sql
+++ b/templates/telemetry_derived/latest_versions/query.sql
@@ -1,0 +1,13 @@
+SELECT channel, MAX(CAST(app_version AS INT64)) AS latest_version
+  FROM
+    (SELECT
+      normalized_channel AS channel,
+      SPLIT(application.version, '.')[OFFSET(0)] AS app_version,
+      COUNT(*)
+    FROM `moz-fx-data-shared-prod.telemetry_stable.main_v4`
+    WHERE DATE(submission_timestamp) > DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+      AND normalized_channel IN ("nightly", "beta", "release")
+    GROUP BY 1, 2
+    HAVING COUNT(DISTINCT client_id) > 2000
+    ORDER BY 1, 2 DESC)
+GROUP BY 1


### PR DESCRIPTION
There are a bunch of changes here to speed up the glam dag computations. Here is a summary:

* Both `clients_scalar_aggregates` and `clients_histogram_aggregates` are now computed by incorporating 1 new day of data at a time with existing aggregations. This is faster than processing 90 days of data each time

* Both `clients_scalar_aggregates` and `clients_histogram_aggregates` now have `init.sql` files that include partitions and clustering

* In some cases, data was being unnested and grouped prematurely and it was more efficient to group before unnesting.

* Computations for scalar buckets were redundant and resulted in a static array anyways, so I've hardcoded it for now. We're currently in discussion with Data Science to think of better bucketing strategies for scalars so this will likely be changing again.
