### PR TITLE
Bug 1593773 - Move the main summary cutover date back to 2019-10-25

### DIFF
--- a/sql/telemetry/clients_last_seen_v1/view.sql
+++ b/sql/telemetry/clients_last_seen_v1/view.sql
@@ -51,7 +51,7 @@ WITH unioned AS (
   FROM
     `moz-fx-data-derived-datasets.telemetry_derived.clients_last_seen_v1`
   WHERE
-    submission_date < DATE '2019-11-14'
+    submission_date < DATE '2019-10-25'
   UNION ALL
   SELECT
     * REPLACE (
@@ -66,7 +66,7 @@ WITH unioned AS (
   FROM
     `moz-fx-data-shared-prod.telemetry_derived.clients_last_seen_v1`
   WHERE
-    submission_date >= DATE '2019-11-14'
+    submission_date >= DATE '2019-10-25'
 )
 SELECT
   -- We cannot use UDFs in a view, so we paste the body of udf_bitpos(bits) literally here.

--- a/sql/telemetry/main_summary_v4/view.sql
+++ b/sql/telemetry/main_summary_v4/view.sql
@@ -401,7 +401,7 @@ SELECT
 FROM
   `moz-fx-data-derived-datasets.telemetry_derived.main_summary_v4`
 WHERE
-  submission_date < DATE '2019-11-09'
+  submission_date < DATE '2019-10-25'
 UNION ALL
 SELECT
   submission_date AS submission_date_s3,
@@ -606,4 +606,4 @@ SELECT
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.main_summary_v4`
 WHERE
-  submission_date >= DATE '2019-11-09'
+  submission_date >= DATE '2019-10-25'

--- a/templates/telemetry/clients_last_seen_v1/view.sql
+++ b/templates/telemetry/clients_last_seen_v1/view.sql
@@ -51,7 +51,7 @@ WITH unioned AS (
   FROM
     `moz-fx-data-derived-datasets.telemetry_derived.clients_last_seen_v1`
   WHERE
-    submission_date < DATE '2019-11-14'
+    submission_date < DATE '2019-10-25'
   UNION ALL
   SELECT
     * REPLACE (
@@ -66,7 +66,7 @@ WITH unioned AS (
   FROM
     `moz-fx-data-shared-prod.telemetry_derived.clients_last_seen_v1`
   WHERE
-    submission_date >= DATE '2019-11-14'
+    submission_date >= DATE '2019-10-25'
 )
 SELECT
   -- We cannot use UDFs in a view, so we paste the body of udf_bitpos(bits) literally here.

--- a/templates/telemetry/main_summary_v4/view.sql
+++ b/templates/telemetry/main_summary_v4/view.sql
@@ -401,7 +401,7 @@ SELECT
 FROM
   `moz-fx-data-derived-datasets.telemetry_derived.main_summary_v4`
 WHERE
-  submission_date < DATE '2019-11-09'
+  submission_date < DATE '2019-10-25'
 UNION ALL
 SELECT
   submission_date AS submission_date_s3,
@@ -606,4 +606,4 @@ SELECT
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.main_summary_v4`
 WHERE
-  submission_date >= DATE '2019-11-09'
+  submission_date >= DATE '2019-10-25'


### PR DESCRIPTION
draft so that this isn't merged until backfilling to 2019-10-25 finishes