### PR TITLE
Add udf.normalize_metadata

### DIFF
--- a/sql/telemetry/core/view.sql
+++ b/sql/telemetry/core/view.sql
@@ -21,7 +21,6 @@ WITH unioned AS (
   SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v10`)
   --
 SELECT
-  *
+  * REPLACE(`moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata)
 FROM
   unioned
-

--- a/templates/telemetry/core/view.sql
+++ b/templates/telemetry/core/view.sql
@@ -21,7 +21,6 @@ WITH unioned AS (
   SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v10`)
   --
 SELECT
-  *
+  * REPLACE(`moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata)
 FROM
   unioned
-

--- a/udf/normalize_metadata.sql
+++ b/udf/normalize_metadata.sql
@@ -1,0 +1,25 @@
+/*
+
+Accepts a pipeline metadata struct as input and returns a modified struct that
+includes a few parsed or normalized variants of the input metadata fields.
+
+*/
+
+CREATE TEMP FUNCTION
+  udf_normalize_metadata(metadata ANY TYPE) AS ((
+    SELECT
+      AS STRUCT metadata.* REPLACE ( (
+        SELECT
+          AS STRUCT metadata.header.*,
+            PARSE_TIMESTAMP('%a, %d %b %Y %T %Z', metadata.header.`date`) AS parsed_date) AS header )) );
+
+-- Tests
+
+SELECT
+assert_equals(
+  STRUCT(STRUCT(
+    'Thu, 21 Nov 2019 22:06:06 GMT' AS `date`,
+    TIMESTAMP '2019-11-21 22:06:06' AS parsed_date) AS header),
+  udf_normalize_metadata(
+    STRUCT(STRUCT(
+      'Thu, 21 Nov 2019 22:06:06 GMT' AS `date`) AS header)));


### PR DESCRIPTION
Addresses https://github.com/mozilla/gcp-ingestion/issues/631

This uses the new UDF only in the `core` view. We will need to update
the schema deploy pipeline after this is merged so that all default
views on top of historical ping tables use this function as well.

Note that this is now adding a persistent UDF call to a published view, which we had previously been avoiding, but persistent SQL UDFs have reached GA release, which should unblock us from using functions like this in views.