### PR TITLE
Add fxa usage criterion that filters out monitor email engagement

### DIFF
--- a/sql/telemetry/fxa_all_events_v1/view.sql
+++ b/sql/telemetry/fxa_all_events_v1/view.sql
@@ -12,7 +12,8 @@ WITH
       jsonPayload.fields.app_version,
       jsonPayload.fields.os_name,
       jsonPayload.fields.os_version,
-      jsonPayload.fields.event_type
+      jsonPayload.fields.event_type,
+      jsonPayload.fields.service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_auth_events_v1`
   ),
@@ -28,7 +29,8 @@ WITH
       jsonPayload.fields.app_version,
       CAST(NULL AS STRING),
       CAST(NULL AS STRING),
-      jsonPayload.fields.event_type
+      jsonPayload.fields.event_type,
+      jsonPayload.fields.service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_auth_bounce_events_v1`
   ),
@@ -42,7 +44,8 @@ WITH
       jsonPayload.fields.app_version,
       jsonPayload.fields.os_name,
       jsonPayload.fields.os_version,
-      jsonPayload.fields.event_type
+      jsonPayload.fields.event_type,
+      jsonPayload.fields.service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_content_events_v1`
   ),
@@ -56,7 +59,8 @@ WITH
       jsonPayload.fields.app_version,
       CAST(NULL AS STRING) AS os_name,
       CAST(NULL AS STRING) AS os_version,
-      jsonPayload.fields.event_type
+      jsonPayload.fields.event_type,
+      jsonPayload.fields.service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_oauth_events_v1`
   )

--- a/sql/telemetry/fxa_all_events_v1/view.sql
+++ b/sql/telemetry/fxa_all_events_v1/view.sql
@@ -13,7 +13,7 @@ WITH
       jsonPayload.fields.os_name,
       jsonPayload.fields.os_version,
       jsonPayload.fields.event_type,
-      jsonPayload.fields.service
+      JSON_EXTRACT(jsonPayload.fields.event_properties, '$.service') AS service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_auth_events_v1`
   ),
@@ -30,7 +30,7 @@ WITH
       CAST(NULL AS STRING),
       CAST(NULL AS STRING),
       jsonPayload.fields.event_type,
-      jsonPayload.fields.service
+      JSON_EXTRACT(jsonPayload.fields.event_properties, '$.service') AS service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_auth_bounce_events_v1`
   ),
@@ -45,7 +45,7 @@ WITH
       jsonPayload.fields.os_name,
       jsonPayload.fields.os_version,
       jsonPayload.fields.event_type,
-      jsonPayload.fields.service
+      JSON_EXTRACT(jsonPayload.fields.event_properties, '$.service') AS service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_content_events_v1`
   ),
@@ -60,7 +60,7 @@ WITH
       CAST(NULL AS STRING) AS os_name,
       CAST(NULL AS STRING) AS os_version,
       jsonPayload.fields.event_type,
-      jsonPayload.fields.service
+      JSON_EXTRACT(jsonPayload.fields.event_properties, '$.service') AS service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_oauth_events_v1`
   )

--- a/sql/telemetry/fxa_users_daily_v1/query.sql
+++ b/sql/telemetry/fxa_users_daily_v1/query.sql
@@ -59,7 +59,8 @@ WITH
     udf_mode_last(ARRAY_AGG(os_name) OVER w1) AS os_name,
     udf_mode_last(ARRAY_AGG(os_version) OVER w1) AS os_version,
     udf_contains_tier1_country(ARRAY_AGG(country) OVER w1) AS seen_in_tier1_country,
-    udf_contains_registration(ARRAY_AGG(event_type) OVER w1) AS registered
+    udf_contains_registration(ARRAY_AGG(event_type) OVER w1) AS registered,
+    COUNTIF(event_type != 'fxa_rp - engage') OVER w1 = 0 AS rp_engage_only
   FROM
     fxa_all_events_v1
   WHERE

--- a/sql/telemetry/fxa_users_daily_v1/query.sql
+++ b/sql/telemetry/fxa_users_daily_v1/query.sql
@@ -60,7 +60,7 @@ WITH
     udf_mode_last(ARRAY_AGG(os_version) OVER w1) AS os_version,
     udf_contains_tier1_country(ARRAY_AGG(country) OVER w1) AS seen_in_tier1_country,
     udf_contains_registration(ARRAY_AGG(event_type) OVER w1) AS registered,
-    COUNTIF(event_type != 'fxa_rp - engage') OVER w1 = 0 AS rp_engage_only
+    COUNTIF(NOT (event_type = 'fxa_rp - engage' AND service = 'fx-monitor')) OVER w1 = 0 AS monitor_only
   FROM
     fxa_all_events_v1
   WHERE

--- a/sql/telemetry/fxa_users_last_seen_raw_v1/init.sql
+++ b/sql/telemetry/fxa_users_last_seen_raw_v1/init.sql
@@ -11,6 +11,7 @@ SELECT
   0 AS days_seen_bits,
   0 AS days_seen_in_tier1_country_bits,
   0 AS days_registered_bits,
+  0 AS days_seen_no_monitor_bits,
   -- We make sure to delay * until the end so that as new columns are added
   -- to fxa_users_daily, we can add those columns in the same order to the end
   -- of this schema, which may be necessary for the daily join query between

--- a/sql/telemetry/fxa_users_last_seen_raw_v1/query.sql
+++ b/sql/telemetry/fxa_users_last_seen_raw_v1/query.sql
@@ -27,6 +27,7 @@ WITH
     -- 28 days even if the most recent "country" value is not in this set.
     CAST(seen_in_tier1_country AS INT64) AS days_seen_in_tier1_country_bits,
     CAST(registered AS INT64) AS days_registered_bits,
+    CAST(NOT rp_engage_only AS INT64) AS days_seen_no_monitor_bits,
     * EXCEPT (submission_date, seen_in_tier1_country, registered)
   FROM
     fxa_users_daily_v1
@@ -52,7 +53,10 @@ IF
     udf_combine_adjacent_days_bits(_previous.days_seen_in_tier1_country_bits,
       _current.days_seen_in_tier1_country_bits) AS days_seen_in_tier1_country_bits,
     udf_coalesce_adjacent_days_bits(_previous.days_registered_bits,
-      _current.days_registered_bits) AS days_registered_bits )
+      _current.days_registered_bits) AS days_registered_bits,
+    udf_combine_adjacent_days_bits(_previous.days_seen_no_monitor_bits,
+      _current.days_seen_no_monitor_bits) AS days_seen_no_monitor_bits )
+)
 FROM
   _current
 FULL JOIN

--- a/sql/telemetry/fxa_users_last_seen_raw_v1/query.sql
+++ b/sql/telemetry/fxa_users_last_seen_raw_v1/query.sql
@@ -27,7 +27,7 @@ WITH
     -- 28 days even if the most recent "country" value is not in this set.
     CAST(seen_in_tier1_country AS INT64) AS days_seen_in_tier1_country_bits,
     CAST(registered AS INT64) AS days_registered_bits,
-    CAST(NOT rp_engage_only AS INT64) AS days_seen_no_monitor_bits,
+    CAST(NOT monitor_only AS INT64) AS days_seen_no_monitor_bits,
     * EXCEPT (submission_date, seen_in_tier1_country, registered)
   FROM
     fxa_users_daily_v1
@@ -56,7 +56,6 @@ IF
       _current.days_registered_bits) AS days_registered_bits,
     udf_combine_adjacent_days_bits(_previous.days_seen_no_monitor_bits,
       _current.days_seen_no_monitor_bits) AS days_seen_no_monitor_bits )
-)
 FROM
   _current
 FULL JOIN

--- a/sql/telemetry/fxa_users_last_seen_raw_v1/query.sql
+++ b/sql/telemetry/fxa_users_last_seen_raw_v1/query.sql
@@ -27,8 +27,8 @@ WITH
     -- 28 days even if the most recent "country" value is not in this set.
     CAST(seen_in_tier1_country AS INT64) AS days_seen_in_tier1_country_bits,
     CAST(registered AS INT64) AS days_registered_bits,
-    CAST(NOT monitor_only AS INT64) AS days_seen_no_monitor_bits,
-    * EXCEPT (submission_date, seen_in_tier1_country, registered)
+    * EXCEPT (submission_date, seen_in_tier1_country, registered, monitor_only),
+    CAST(NOT monitor_only AS INT64) AS days_seen_no_monitor_bits
   FROM
     fxa_users_daily_v1
   WHERE

--- a/sql/telemetry/fxa_users_last_seen_v1/view.sql
+++ b/sql/telemetry/fxa_users_last_seen_v1/view.sql
@@ -5,6 +5,7 @@ SELECT
   CAST(SAFE.LOG(days_seen_bits & -days_seen_bits, 2) AS INT64) AS days_since_seen,
   CAST(SAFE.LOG(days_seen_in_tier1_country_bits & -days_seen_in_tier1_country_bits, 2) AS INT64) AS days_since_seen_in_tier1_country,
   CAST(SAFE.LOG(days_registered_bits & -days_registered_bits, 2) AS INT64) AS days_since_registered,
+  CAST(SAFE.LOG(days_seen_no_monitor_bits & -days_seen_no_monitor_bits, 2) AS INT64) AS days_since_seen_no_monitor,
   *
 FROM
   `moz-fx-data-derived-datasets.telemetry.fxa_users_last_seen_raw_v1`

--- a/templates/telemetry/fxa_all_events_v1/view.sql
+++ b/templates/telemetry/fxa_all_events_v1/view.sql
@@ -12,7 +12,8 @@ WITH
       jsonPayload.fields.app_version,
       jsonPayload.fields.os_name,
       jsonPayload.fields.os_version,
-      jsonPayload.fields.event_type
+      jsonPayload.fields.event_type,
+      jsonPayload.fields.service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_auth_events_v1`
   ),
@@ -28,7 +29,8 @@ WITH
       jsonPayload.fields.app_version,
       CAST(NULL AS STRING),
       CAST(NULL AS STRING),
-      jsonPayload.fields.event_type
+      jsonPayload.fields.event_type,
+      jsonPayload.fields.service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_auth_bounce_events_v1`
   ),
@@ -42,7 +44,8 @@ WITH
       jsonPayload.fields.app_version,
       jsonPayload.fields.os_name,
       jsonPayload.fields.os_version,
-      jsonPayload.fields.event_type
+      jsonPayload.fields.event_type,
+      jsonPayload.fields.service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_content_events_v1`
   ),
@@ -56,7 +59,8 @@ WITH
       jsonPayload.fields.app_version,
       CAST(NULL AS STRING) AS os_name,
       CAST(NULL AS STRING) AS os_version,
-      jsonPayload.fields.event_type
+      jsonPayload.fields.event_type,
+      jsonPayload.fields.service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_oauth_events_v1`
   )

--- a/templates/telemetry/fxa_all_events_v1/view.sql
+++ b/templates/telemetry/fxa_all_events_v1/view.sql
@@ -13,7 +13,7 @@ WITH
       jsonPayload.fields.os_name,
       jsonPayload.fields.os_version,
       jsonPayload.fields.event_type,
-      jsonPayload.fields.service
+      JSON_EXTRACT(jsonPayload.fields.event_properties, '$.service') AS service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_auth_events_v1`
   ),
@@ -30,7 +30,7 @@ WITH
       CAST(NULL AS STRING),
       CAST(NULL AS STRING),
       jsonPayload.fields.event_type,
-      jsonPayload.fields.service
+      JSON_EXTRACT(jsonPayload.fields.event_properties, '$.service') AS service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_auth_bounce_events_v1`
   ),
@@ -45,7 +45,7 @@ WITH
       jsonPayload.fields.os_name,
       jsonPayload.fields.os_version,
       jsonPayload.fields.event_type,
-      jsonPayload.fields.service
+      JSON_EXTRACT(jsonPayload.fields.event_properties, '$.service') AS service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_content_events_v1`
   ),
@@ -60,7 +60,7 @@ WITH
       CAST(NULL AS STRING) AS os_name,
       CAST(NULL AS STRING) AS os_version,
       jsonPayload.fields.event_type,
-      jsonPayload.fields.service
+      JSON_EXTRACT(jsonPayload.fields.event_properties, '$.service') AS service
     FROM
       `moz-fx-data-derived-datasets.telemetry.fxa_oauth_events_v1`
   )

--- a/templates/telemetry/fxa_users_daily_v1/query.sql
+++ b/templates/telemetry/fxa_users_daily_v1/query.sql
@@ -41,7 +41,8 @@ WITH
     udf_mode_last(ARRAY_AGG(os_name) OVER w1) AS os_name,
     udf_mode_last(ARRAY_AGG(os_version) OVER w1) AS os_version,
     udf_contains_tier1_country(ARRAY_AGG(country) OVER w1) AS seen_in_tier1_country,
-    udf_contains_registration(ARRAY_AGG(event_type) OVER w1) AS registered
+    udf_contains_registration(ARRAY_AGG(event_type) OVER w1) AS registered,
+    COUNTIF(event_type != 'fxa_rp - engage') OVER w1 = 0 AS rp_engage_only
   FROM
     fxa_all_events_v1
   WHERE

--- a/templates/telemetry/fxa_users_daily_v1/query.sql
+++ b/templates/telemetry/fxa_users_daily_v1/query.sql
@@ -42,7 +42,7 @@ WITH
     udf_mode_last(ARRAY_AGG(os_version) OVER w1) AS os_version,
     udf_contains_tier1_country(ARRAY_AGG(country) OVER w1) AS seen_in_tier1_country,
     udf_contains_registration(ARRAY_AGG(event_type) OVER w1) AS registered,
-    COUNTIF(event_type != 'fxa_rp - engage') OVER w1 = 0 AS rp_engage_only
+    COUNTIF(NOT (event_type = 'fxa_rp - engage' AND service = 'fx-monitor')) OVER w1 = 0 AS monitor_only
   FROM
     fxa_all_events_v1
   WHERE

--- a/templates/telemetry/fxa_users_last_seen_raw_v1/init.sql
+++ b/templates/telemetry/fxa_users_last_seen_raw_v1/init.sql
@@ -11,6 +11,7 @@ SELECT
   0 AS days_seen_bits,
   0 AS days_seen_in_tier1_country_bits,
   0 AS days_registered_bits,
+  0 AS days_seen_no_monitor_bits,
   -- We make sure to delay * until the end so that as new columns are added
   -- to fxa_users_daily, we can add those columns in the same order to the end
   -- of this schema, which may be necessary for the daily join query between

--- a/templates/telemetry/fxa_users_last_seen_raw_v1/query.sql
+++ b/templates/telemetry/fxa_users_last_seen_raw_v1/query.sql
@@ -11,6 +11,7 @@ WITH
     -- 28 days even if the most recent "country" value is not in this set.
     CAST(seen_in_tier1_country AS INT64) AS days_seen_in_tier1_country_bits,
     CAST(registered AS INT64) AS days_registered_bits,
+    CAST(NOT rp_engage_only AS INT64) AS days_seen_no_monitor_bits,
     * EXCEPT (submission_date, seen_in_tier1_country, registered)
   FROM
     fxa_users_daily_v1
@@ -36,7 +37,10 @@ IF
     udf_combine_adjacent_days_bits(_previous.days_seen_in_tier1_country_bits,
       _current.days_seen_in_tier1_country_bits) AS days_seen_in_tier1_country_bits,
     udf_coalesce_adjacent_days_bits(_previous.days_registered_bits,
-      _current.days_registered_bits) AS days_registered_bits )
+      _current.days_registered_bits) AS days_registered_bits,
+    udf_combine_adjacent_days_bits(_previous.days_seen_no_monitor_bits,
+      _current.days_seen_no_monitor_bits) AS days_seen_no_monitor_bits )
+)
 FROM
   _current
 FULL JOIN

--- a/templates/telemetry/fxa_users_last_seen_raw_v1/query.sql
+++ b/templates/telemetry/fxa_users_last_seen_raw_v1/query.sql
@@ -11,8 +11,8 @@ WITH
     -- 28 days even if the most recent "country" value is not in this set.
     CAST(seen_in_tier1_country AS INT64) AS days_seen_in_tier1_country_bits,
     CAST(registered AS INT64) AS days_registered_bits,
-    CAST(NOT monitor_only AS INT64) AS days_seen_no_monitor_bits,
-    * EXCEPT (submission_date, seen_in_tier1_country, registered)
+    * EXCEPT (submission_date, seen_in_tier1_country, registered, monitor_only),
+    CAST(NOT monitor_only AS INT64) AS days_seen_no_monitor_bits
   FROM
     fxa_users_daily_v1
   WHERE

--- a/templates/telemetry/fxa_users_last_seen_raw_v1/query.sql
+++ b/templates/telemetry/fxa_users_last_seen_raw_v1/query.sql
@@ -11,7 +11,7 @@ WITH
     -- 28 days even if the most recent "country" value is not in this set.
     CAST(seen_in_tier1_country AS INT64) AS days_seen_in_tier1_country_bits,
     CAST(registered AS INT64) AS days_registered_bits,
-    CAST(NOT rp_engage_only AS INT64) AS days_seen_no_monitor_bits,
+    CAST(NOT monitor_only AS INT64) AS days_seen_no_monitor_bits,
     * EXCEPT (submission_date, seen_in_tier1_country, registered)
   FROM
     fxa_users_daily_v1
@@ -40,7 +40,6 @@ IF
       _current.days_registered_bits) AS days_registered_bits,
     udf_combine_adjacent_days_bits(_previous.days_seen_no_monitor_bits,
       _current.days_seen_no_monitor_bits) AS days_seen_no_monitor_bits )
-)
 FROM
   _current
 FULL JOIN

--- a/templates/telemetry/fxa_users_last_seen_v1/view.sql
+++ b/templates/telemetry/fxa_users_last_seen_v1/view.sql
@@ -5,6 +5,7 @@ SELECT
   CAST(SAFE.LOG(days_seen_bits & -days_seen_bits, 2) AS INT64) AS days_since_seen,
   CAST(SAFE.LOG(days_seen_in_tier1_country_bits & -days_seen_in_tier1_country_bits, 2) AS INT64) AS days_since_seen_in_tier1_country,
   CAST(SAFE.LOG(days_registered_bits & -days_registered_bits, 2) AS INT64) AS days_since_registered,
+  CAST(SAFE.LOG(days_seen_no_monitor_bits & -days_seen_no_monitor_bits, 2) AS INT64) AS days_since_seen_no_monitor,
   *
 FROM
   `moz-fx-data-derived-datasets.telemetry.fxa_users_last_seen_raw_v1`

--- a/tests/telemetry/fxa_users_daily_v1/test_aggregation/expect.ndjson
+++ b/tests/telemetry/fxa_users_daily_v1/test_aggregation/expect.ndjson
@@ -1,6 +1,7 @@
-{"submission_date":"2019-01-01","user_id":"a","seen_in_tier1_country":false,"registered":false}
-{"submission_date":"2019-01-01","user_id":"b","country":"Spain","seen_in_tier1_country":false,"registered":false}
-{"submission_date":"2019-01-01","user_id":"c","country":"France","seen_in_tier1_country":true,"registered":false}
-{"submission_date":"2019-01-01","user_id":"d","country":"","seen_in_tier1_country":false,"registered":false}
-{"submission_date":"2019-01-01","user_id":"e","country":"","seen_in_tier1_country":true,"registered":true}
-{"submission_date":"2019-01-01","user_id":"f","country":"Canada","seen_in_tier1_country":true,"registered":false}
+{"submission_date":"2019-01-01","user_id":"a","seen_in_tier1_country":false,"registered":false,"monitor_only":false}
+{"submission_date":"2019-01-01","user_id":"b","country":"Spain","seen_in_tier1_country":false,"registered":false,"monitor_only":false}
+{"submission_date":"2019-01-01","user_id":"c","country":"France","seen_in_tier1_country":true,"registered":false,"monitor_only":false}
+{"submission_date":"2019-01-01","user_id":"d","country":"","seen_in_tier1_country":false,"registered":false,"monitor_only":false}
+{"submission_date":"2019-01-01","user_id":"e","country":"","seen_in_tier1_country":true,"registered":true,"monitor_only":false}
+{"submission_date":"2019-01-01","user_id":"f","country":"Canada","seen_in_tier1_country":true,"registered":false,"monitor_only":false}
+{"submission_date":"2019-01-01","user_id":"g","country":"Spain","seen_in_tier1_country":false,"registered":false,"monitor_only":true}

--- a/tests/telemetry/fxa_users_daily_v1/test_aggregation/fxa_all_events_v1.ndjson
+++ b/tests/telemetry/fxa_users_daily_v1/test_aggregation/fxa_all_events_v1.ndjson
@@ -18,3 +18,4 @@
 {"submission_timestamp":"2019-01-01 00:00:06.000000Z","user_id":"f","country":"Spain","event_type":"mktg - email_sent"}
 {"submission_timestamp":"2019-01-01 00:00:07.000000Z","user_id":"f","country":"Spain","event_type":"mktg - email_sent"}
 {"submission_timestamp":"2019-01-01 00:00:08.000000Z","user_id":"f","country":"Spain","event_type":""}
+{"submission_timestamp":"2019-01-01 00:00:08.000000Z","user_id":"g","country":"Spain","event_type":"fxa_rp - engage","service":"fx-monitor"}


### PR DESCRIPTION
This change allows us to compare FxA MAU calculations that include or exclude the monitor email engagement events as added in https://github.com/mozilla/fxa/issues/2743