### PR TITLE
Break up histogram processing and update probe counts view

### DIFF
--- a/sql/telemetry/client_probe_counts_v1/view.sql
+++ b/sql/telemetry/client_probe_counts_v1/view.sql
@@ -1,9 +1,29 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.client_probe_counts`
-AS SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.telemetry_derived.client_probe_counts_v1`
+AS
+
+WITH all_counts AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.client_probe_counts_v1`
+
+  UNION ALL
+
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.scalar_percentiles_v1`
+
+  UNION ALL
+
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.histogram_percentiles_v1`)
+
+SELECT *
+FROM all_counts
 WHERE metric != "search_counts"
     AND metric NOT LIKE "%browser_search%"
     AND metric NOT LIKE "%browser_engagement_navigation%"

--- a/sql/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql
+++ b/sql/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql
@@ -1,0 +1,142 @@
+CREATE TEMP FUNCTION udf_normalized_sum (arrs ARRAY<STRUCT<key STRING, value INT64>>)
+RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
+  -- Returns the normalized sum of the input maps.
+  -- It returns the total_count[k] / SUM(total_count)
+  -- for each key k.
+  (
+    WITH total_counts AS (
+      SELECT
+        sum(a.value) AS total_count
+      FROM
+        UNNEST(arrs) AS a
+    ),
+
+    summed_counts AS (
+      SELECT
+        a.key AS k,
+        SUM(a.value) AS v
+      FROM
+        UNNEST(arrs) AS a
+      GROUP BY
+        a.key
+    ),
+
+    final_values AS (
+      SELECT
+        STRUCT<key STRING, value FLOAT64>(
+          k,
+          COALESCE(SAFE_DIVIDE(1.0 * v, total_count), 0)
+        ) AS record
+      FROM
+        summed_counts
+      CROSS JOIN
+        total_counts
+    )
+
+    SELECT
+        ARRAY_AGG(record)
+    FROM
+      final_values
+  )
+);
+
+CREATE TEMP FUNCTION udf_normalize_histograms (
+  arrs ARRAY<STRUCT<
+    first_bucket INT64,
+    last_bucket INT64,
+    num_buckets INT64,
+    latest_version INT64,
+    metric STRING,
+    metric_type STRING,
+    key STRING,
+    agg_type STRING,
+    aggregates ARRAY<STRUCT<key STRING, value INT64>>>>)
+RETURNS ARRAY<STRUCT<
+  first_bucket INT64,
+  last_bucket INT64,
+  num_buckets INT64,
+  latest_version INT64,
+  metric STRING,
+  metric_type STRING,
+  key STRING,
+  agg_type STRING,
+  aggregates ARRAY<STRUCT<key STRING, value FLOAT64>>>> AS (
+(
+    WITH normalized AS (
+      SELECT
+        first_bucket,
+        last_bucket,
+        num_buckets,
+        latest_version,
+        metric,
+        metric_type,
+        key,
+        agg_type,
+        udf_normalized_sum(aggregates) AS aggregates
+      FROM UNNEST(arrs))
+
+    SELECT ARRAY_AGG((first_bucket, last_bucket, num_buckets, latest_version, metric, metric_type, key, agg_type, aggregates))
+    FROM normalized
+));
+
+WITH normalized_histograms AS (
+  SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    udf_normalize_histograms(histogram_aggregates) AS histogram_aggregates
+  FROM clients_histogram_aggregates_v1),
+
+unnested AS (
+  SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    first_bucket,
+    last_bucket,
+    num_buckets,
+    latest_version,
+    metric,
+    metric_type,
+    agg_type,
+    histogram_aggregates.key AS key,
+    aggregates.key AS bucket,
+    aggregates.value
+  FROM normalized_histograms
+  CROSS JOIN UNNEST(histogram_aggregates) AS histogram_aggregates
+  CROSS JOIN UNNEST(aggregates) AS aggregates)
+
+SELECT
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  first_bucket,
+  last_bucket,
+  num_buckets,
+  metric,
+  metric_type,
+  key,
+  agg_type,
+  STRUCT<key STRING, value FLOAT64>(
+    CAST(bucket AS STRING),
+    1.0 * SUM(value)
+  ) AS record
+FROM unnested
+GROUP BY
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  first_bucket,
+  last_bucket,
+  num_buckets,
+  metric,
+  metric_type,
+  key,
+  agg_type,
+  bucket

--- a/sql/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
+++ b/sql/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
@@ -111,150 +111,6 @@ RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
   )
 );
 
-CREATE TEMP FUNCTION udf_normalized_sum (arrs ARRAY<STRUCT<key STRING, value INT64>>)
-RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
-  -- Returns the normalized sum of the input maps.
-  -- It returns the total_count[k] / SUM(total_count)
-  -- for each key k.
-  (
-    WITH total_counts AS (
-      SELECT
-        sum(a.value) AS total_count
-      FROM
-        UNNEST(arrs) AS a
-    ),
-
-    summed_counts AS (
-      SELECT
-        a.key AS k,
-        SUM(a.value) AS v
-      FROM
-        UNNEST(arrs) AS a
-      GROUP BY
-        a.key
-    ),
-
-    final_values AS (
-      SELECT
-        STRUCT<key STRING, value FLOAT64>(
-          k,
-          COALESCE(SAFE_DIVIDE(1.0 * v, total_count), 0)
-        ) AS record
-      FROM
-        summed_counts
-      CROSS JOIN
-        total_counts
-    )
-
-    SELECT
-        ARRAY_AGG(record)
-    FROM
-      final_values
-  )
-);
-
-CREATE TEMP FUNCTION udf_normalize_histograms (
-  arrs ARRAY<STRUCT<
-    first_bucket INT64,
-    last_bucket INT64,
-    num_buckets INT64,
-    latest_version INT64,
-    metric STRING,
-    metric_type STRING,
-    key STRING,
-    agg_type STRING,
-    aggregates ARRAY<STRUCT<key STRING, value INT64>>>>)
-RETURNS ARRAY<STRUCT<
-  first_bucket INT64,
-  last_bucket INT64,
-  num_buckets INT64,
-  latest_version INT64,
-  metric STRING,
-  metric_type STRING,
-  key STRING,
-  agg_type STRING,
-  aggregates ARRAY<STRUCT<key STRING, value FLOAT64>>>> AS (
-(
-    WITH normalized AS (
-      SELECT
-        first_bucket,
-        last_bucket,
-        num_buckets,
-        latest_version,
-        metric,
-        metric_type,
-        key,
-        agg_type,
-        udf_normalized_sum(aggregates) AS aggregates
-      FROM UNNEST(arrs))
-
-    SELECT ARRAY_AGG((first_bucket, last_bucket, num_buckets, latest_version, metric, metric_type, key, agg_type, aggregates))
-    FROM normalized
-));
-
-WITH normalized_histograms AS (
-  SELECT
-    client_id,
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    udf_normalize_histograms(histogram_aggregates) AS histogram_aggregates
-  FROM clients_histogram_aggregates_v1),
-
-unnested AS (
-  SELECT
-    client_id,
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    first_bucket,
-    last_bucket,
-    num_buckets,
-    latest_version,
-    metric,
-    metric_type,
-    agg_type,
-    histogram_aggregates.key AS key,
-    aggregates.key AS bucket,
-    aggregates.value
-  FROM normalized_histograms
-  CROSS JOIN UNNEST(histogram_aggregates) AS histogram_aggregates
-  CROSS JOIN UNNEST(aggregates) AS aggregates),
-
-bucket_counts AS (
-  SELECT
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    first_bucket,
-    last_bucket,
-    num_buckets,
-    metric,
-    metric_type,
-    key,
-    agg_type,
-    STRUCT<key STRING, value FLOAT64>(
-      CAST(bucket AS STRING),
-      1.0 * SUM(value)
-    ) AS record
-  FROM unnested
-  GROUP BY
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    first_bucket,
-    last_bucket,
-    num_buckets,
-    metric,
-    metric_type,
-    key,
-    agg_type,
-    bucket)
-
 SELECT
   os,
   app_version,
@@ -269,7 +125,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   os,
@@ -300,7 +156,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   app_version,
@@ -330,7 +186,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   os,
@@ -360,7 +216,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   os,
@@ -390,7 +246,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   os,
@@ -419,7 +275,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   app_version,
@@ -448,7 +304,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   app_version,
@@ -476,7 +332,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   os,
@@ -504,7 +360,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   channel,
@@ -532,7 +388,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   metric,

--- a/templates/telemetry/client_probe_counts_v1/view.sql
+++ b/templates/telemetry/client_probe_counts_v1/view.sql
@@ -1,9 +1,29 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.client_probe_counts`
-AS SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.telemetry_derived.client_probe_counts_v1`
+AS
+
+WITH all_counts AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.client_probe_counts_v1`
+
+  UNION ALL
+
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.scalar_percentiles_v1`
+
+  UNION ALL
+
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.histogram_percentiles_v1`)
+
+SELECT *
+FROM all_counts
 WHERE metric != "search_counts"
     AND metric NOT LIKE "%browser_search%"
     AND metric NOT LIKE "%browser_engagement_navigation%"

--- a/templates/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql
+++ b/templates/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql
@@ -1,0 +1,142 @@
+CREATE TEMP FUNCTION udf_normalized_sum (arrs ARRAY<STRUCT<key STRING, value INT64>>)
+RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
+  -- Returns the normalized sum of the input maps.
+  -- It returns the total_count[k] / SUM(total_count)
+  -- for each key k.
+  (
+    WITH total_counts AS (
+      SELECT
+        sum(a.value) AS total_count
+      FROM
+        UNNEST(arrs) AS a
+    ),
+
+    summed_counts AS (
+      SELECT
+        a.key AS k,
+        SUM(a.value) AS v
+      FROM
+        UNNEST(arrs) AS a
+      GROUP BY
+        a.key
+    ),
+
+    final_values AS (
+      SELECT
+        STRUCT<key STRING, value FLOAT64>(
+          k,
+          COALESCE(SAFE_DIVIDE(1.0 * v, total_count), 0)
+        ) AS record
+      FROM
+        summed_counts
+      CROSS JOIN
+        total_counts
+    )
+
+    SELECT
+        ARRAY_AGG(record)
+    FROM
+      final_values
+  )
+);
+
+CREATE TEMP FUNCTION udf_normalize_histograms (
+  arrs ARRAY<STRUCT<
+    first_bucket INT64,
+    last_bucket INT64,
+    num_buckets INT64,
+    latest_version INT64,
+    metric STRING,
+    metric_type STRING,
+    key STRING,
+    agg_type STRING,
+    aggregates ARRAY<STRUCT<key STRING, value INT64>>>>)
+RETURNS ARRAY<STRUCT<
+  first_bucket INT64,
+  last_bucket INT64,
+  num_buckets INT64,
+  latest_version INT64,
+  metric STRING,
+  metric_type STRING,
+  key STRING,
+  agg_type STRING,
+  aggregates ARRAY<STRUCT<key STRING, value FLOAT64>>>> AS (
+(
+    WITH normalized AS (
+      SELECT
+        first_bucket,
+        last_bucket,
+        num_buckets,
+        latest_version,
+        metric,
+        metric_type,
+        key,
+        agg_type,
+        udf_normalized_sum(aggregates) AS aggregates
+      FROM UNNEST(arrs))
+
+    SELECT ARRAY_AGG((first_bucket, last_bucket, num_buckets, latest_version, metric, metric_type, key, agg_type, aggregates))
+    FROM normalized
+));
+
+WITH normalized_histograms AS (
+  SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    udf_normalize_histograms(histogram_aggregates) AS histogram_aggregates
+  FROM clients_histogram_aggregates_v1),
+
+unnested AS (
+  SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    first_bucket,
+    last_bucket,
+    num_buckets,
+    latest_version,
+    metric,
+    metric_type,
+    agg_type,
+    histogram_aggregates.key AS key,
+    aggregates.key AS bucket,
+    aggregates.value
+  FROM normalized_histograms
+  CROSS JOIN UNNEST(histogram_aggregates) AS histogram_aggregates
+  CROSS JOIN UNNEST(aggregates) AS aggregates)
+
+SELECT
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  first_bucket,
+  last_bucket,
+  num_buckets,
+  metric,
+  metric_type,
+  key,
+  agg_type,
+  STRUCT<key STRING, value FLOAT64>(
+    CAST(bucket AS STRING),
+    1.0 * SUM(value)
+  ) AS record
+FROM unnested
+GROUP BY
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  first_bucket,
+  last_bucket,
+  num_buckets,
+  metric,
+  metric_type,
+  key,
+  agg_type,
+  bucket

--- a/templates/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
+++ b/templates/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
@@ -111,150 +111,6 @@ RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
   )
 );
 
-CREATE TEMP FUNCTION udf_normalized_sum (arrs ARRAY<STRUCT<key STRING, value INT64>>)
-RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
-  -- Returns the normalized sum of the input maps.
-  -- It returns the total_count[k] / SUM(total_count)
-  -- for each key k.
-  (
-    WITH total_counts AS (
-      SELECT
-        sum(a.value) AS total_count
-      FROM
-        UNNEST(arrs) AS a
-    ),
-
-    summed_counts AS (
-      SELECT
-        a.key AS k,
-        SUM(a.value) AS v
-      FROM
-        UNNEST(arrs) AS a
-      GROUP BY
-        a.key
-    ),
-
-    final_values AS (
-      SELECT
-        STRUCT<key STRING, value FLOAT64>(
-          k,
-          COALESCE(SAFE_DIVIDE(1.0 * v, total_count), 0)
-        ) AS record
-      FROM
-        summed_counts
-      CROSS JOIN
-        total_counts
-    )
-
-    SELECT
-        ARRAY_AGG(record)
-    FROM
-      final_values
-  )
-);
-
-CREATE TEMP FUNCTION udf_normalize_histograms (
-  arrs ARRAY<STRUCT<
-    first_bucket INT64,
-    last_bucket INT64,
-    num_buckets INT64,
-    latest_version INT64,
-    metric STRING,
-    metric_type STRING,
-    key STRING,
-    agg_type STRING,
-    aggregates ARRAY<STRUCT<key STRING, value INT64>>>>)
-RETURNS ARRAY<STRUCT<
-  first_bucket INT64,
-  last_bucket INT64,
-  num_buckets INT64,
-  latest_version INT64,
-  metric STRING,
-  metric_type STRING,
-  key STRING,
-  agg_type STRING,
-  aggregates ARRAY<STRUCT<key STRING, value FLOAT64>>>> AS (
-(
-    WITH normalized AS (
-      SELECT
-        first_bucket,
-        last_bucket,
-        num_buckets,
-        latest_version,
-        metric,
-        metric_type,
-        key,
-        agg_type,
-        udf_normalized_sum(aggregates) AS aggregates
-      FROM UNNEST(arrs))
-
-    SELECT ARRAY_AGG((first_bucket, last_bucket, num_buckets, latest_version, metric, metric_type, key, agg_type, aggregates))
-    FROM normalized
-));
-
-WITH normalized_histograms AS (
-  SELECT
-    client_id,
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    udf_normalize_histograms(histogram_aggregates) AS histogram_aggregates
-  FROM clients_histogram_aggregates_v1),
-
-unnested AS (
-  SELECT
-    client_id,
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    first_bucket,
-    last_bucket,
-    num_buckets,
-    latest_version,
-    metric,
-    metric_type,
-    agg_type,
-    histogram_aggregates.key AS key,
-    aggregates.key AS bucket,
-    aggregates.value
-  FROM normalized_histograms
-  CROSS JOIN UNNEST(histogram_aggregates) AS histogram_aggregates
-  CROSS JOIN UNNEST(aggregates) AS aggregates),
-
-bucket_counts AS (
-  SELECT
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    first_bucket,
-    last_bucket,
-    num_buckets,
-    metric,
-    metric_type,
-    key,
-    agg_type,
-    STRUCT<key STRING, value FLOAT64>(
-      CAST(bucket AS STRING),
-      1.0 * SUM(value)
-    ) AS record
-  FROM unnested
-  GROUP BY
-    os,
-    app_version,
-    app_build_id,
-    channel,
-    first_bucket,
-    last_bucket,
-    num_buckets,
-    metric,
-    metric_type,
-    key,
-    agg_type,
-    bucket)
-
 SELECT
   os,
   app_version,
@@ -269,7 +125,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   os,
@@ -300,7 +156,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   app_version,
@@ -330,7 +186,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   os,
@@ -360,7 +216,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   os,
@@ -390,7 +246,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   os,
@@ -419,7 +275,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   app_version,
@@ -448,7 +304,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   app_version,
@@ -476,7 +332,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   os,
@@ -504,7 +360,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   channel,
@@ -532,7 +388,7 @@ SELECT
   udf_fill_buckets(udf_dedupe_map_sum(
       ARRAY_AGG(record)
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
-FROM bucket_counts
+FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
 GROUP BY
   metric,


### PR DESCRIPTION
This PR includes 2 changes:

1. The histogram probe counts query has been broken up into two pieces as I've done with the scalar probe counts. The query was starting to run long on airflow and this change gives significant performance wins based on my testing so far.

2. I've updated the probe counts view to include percentiles. This is beneficial to the Glam app server so it only needs to query one place for all the data instead of 3.

The associated airflow PR is here: https://github.com/mozilla/telemetry-airflow/pull/799