### PR TITLE
Create udf for search engine normalization

### DIFF
--- a/udf/normalize_search_engine.sql
+++ b/udf/normalize_search_engine.sql
@@ -1,0 +1,34 @@
+/*
+
+Return normalized engine name for recognized engines
+
+*/
+
+CREATE TEMP FUNCTION
+  udf_normalize_search_engine(engine STRING) AS (
+    CASE
+      WHEN STARTS_WITH(engine, 'google')
+      OR STARTS_WITH(engine, 'Google')
+      OR STARTS_WITH(engine, 'other-Google') THEN 'Google'
+      WHEN STARTS_WITH(engine, 'ddg')
+      OR STARTS_WITH(engine, 'duckduckgo')
+      OR STARTS_WITH(engine, 'DuckDuckGo')
+      OR STARTS_WITH(engine, 'other-DuckDuckGo') THEN 'DuckDuckGo'
+      WHEN STARTS_WITH(engine, 'bing')
+      OR STARTS_WITH(engine, 'Bing')
+      OR STARTS_WITH(engine, 'other-Bing') THEN 'Bing'
+      WHEN STARTS_WITH(engine, 'yandex')
+      OR STARTS_WITH(engine, 'Yandex')
+      OR STARTS_WITH(engine, 'other-Yandex') THEN 'Yandex'
+      ELSE 'Other'
+    END
+  );
+
+-- Test
+
+SELECT
+  assert_equals('Google', udf_normalize_search_engine('google')),
+  assert_equals('Google', udf_normalize_search_engine('Google-abc')),
+  assert_equals('Other', udf_normalize_search_engine('not-bing')),
+  assert_equals('Other', udf_normalize_search_engine('engine'))
+


### PR DESCRIPTION
There are two approaches here.  One with a static table to map engine prefix to normalized name and the other is a udf with engines hardcoded in.  The table would work well but the issue is that outer joins require an equality from both sides of the join so something like this wouldn't work:

```sql
SELECT
  normalized_engine,
  COUNT(*) AS count
FROM
  `moz-fx-data-shared-prod.search_derived.mobile_search_aggregates_v1`
LEFT JOIN
  static.normalized_search_engine
ON 
  (STARTS_WITH(engine, engine_prefix))
```
An outer join is needed because we want to treat unrecognized engines as `Other`.  I haven't thought of a good workaround for this other than not using a static table and just putting everything in a udf.

Other ideas I had are having a table of all possible engine values and scheduling a query to update the list.  Another thing I tried is turning static table into udfs so that the data can be accessed from a udf (https://github.com/mozilla/bigquery-etl/commit/a6192012d1f4aaee9c29da250f160cf23ea411f6).  But both of these are very messy and more trouble than it's worth.

I think a udf fits the use case the best and a static table isn't needed.  @jklukas thoughts on this or ideas to workaround the outer join problem?