### PR TITLE
Bug 1598002 - add submission_timestamp_min to clients_daily

### DIFF
--- a/sql/telemetry_derived/clients_daily_v6/query.sql
+++ b/sql/telemetry_derived/clients_daily_v6/query.sql
@@ -323,7 +323,8 @@ SELECT
   SUM(web_notification_shown) AS web_notification_shown_sum,
   udf_mode_last(ARRAY_AGG(windows_build_number ORDER BY `timestamp`)) AS windows_build_number,
   udf_mode_last(ARRAY_AGG(windows_ubr ORDER BY `timestamp`)) AS windows_ubr,
-  SUM(scalar_parent_contentblocking_trackers_blocked_count) AS trackers_blocked_sum
+  SUM(scalar_parent_contentblocking_trackers_blocked_count) AS trackers_blocked_sum,
+  TIMESTAMP_MICROS(DIV(MIN(`timestamp`), 1000)) AS submission_timestamp_min
 FROM
   main_summary_v4
 LEFT JOIN

--- a/templates/telemetry_derived/clients_daily_v6/query.sql
+++ b/templates/telemetry_derived/clients_daily_v6/query.sql
@@ -181,7 +181,8 @@ SELECT
   SUM(web_notification_shown) AS web_notification_shown_sum,
   udf_mode_last(ARRAY_AGG(windows_build_number ORDER BY `timestamp`)) AS windows_build_number,
   udf_mode_last(ARRAY_AGG(windows_ubr ORDER BY `timestamp`)) AS windows_ubr,
-  SUM(scalar_parent_contentblocking_trackers_blocked_count) AS trackers_blocked_sum
+  SUM(scalar_parent_contentblocking_trackers_blocked_count) AS trackers_blocked_sum,
+  TIMESTAMP_MICROS(DIV(MIN(`timestamp`), 1000)) AS submission_timestamp_min
 FROM
   main_summary_v4
 LEFT JOIN

--- a/tests/telemetry_derived/clients_daily_v6/test_aggregation/expect.yaml
+++ b/tests/telemetry_derived/clients_daily_v6/test_aggregation/expect.yaml
@@ -145,6 +145,7 @@
   ssl_handshake_result_failure_sum: 2
   ssl_handshake_result_success_sum: 2
   submission_date: '2019-01-01'
+  submission_timestamp_min: '2019-01-01T08:00:00+00:00'
   subsession_hours_sum: '2'
   sync_configured: true
   sync_count_desktop_mean: 2


### PR DESCRIPTION
when this is merged, the column will need to be added to `clients_daily` and `clients_last_seen` to prevent errors in airflow