### PR TITLE
Fix monthly_searches to account for null

### DIFF
--- a/sql/search_derived/search_clients_last_seen_v1/query.sql
+++ b/sql/search_derived/search_clients_last_seen_v1/query.sql
@@ -56,16 +56,16 @@ CREATE TEMP FUNCTION
                            curr ARRAY<STRUCT<key STRING, value STRUCT<total_searches ARRAY<INT64>, tagged_searches ARRAY<INT64>, search_with_ads ARRAY<INT64>, ad_click ARRAY<INT64>>>>,
                            submission_date DATE) AS (ARRAY(
   WITH prev_tbl AS (
-    SELECT * REPLACE (COALESCE(key, "missing_search_engine") AS key)
+    SELECT * REPLACE(COALESCE(key, "null_engine") AS key)
     FROM UNNEST(prev)
   ), curr_tbl AS (
-    SELECT * REPLACE (COALESCE(key, "missing_search_engine") AS key)
+    SELECT * REPLACE(COALESCE(key, "null_engine") AS key)
     FROM UNNEST(curr)
   )
 
   SELECT
     STRUCT(
-      NULLIF(key, "missing_search_engine"),
+      NULLIF(key, "null_engine") AS key,
       udf_add_monthly_engine_searches(
         COALESCE(p.value, udf_new_monthly_engine_searches_struct()),
         COALESCE(c.value, udf_new_monthly_engine_searches_struct()),

--- a/udf/add_monthly_searches.sql
+++ b/udf/add_monthly_searches.sql
@@ -30,6 +30,7 @@ CREATE TEMP FUNCTION
   FULL OUTER JOIN
       prev_tbl AS p
       USING (key)
+));
 
 -- Tests
 /*

--- a/udf/get_key_with_null.sql
+++ b/udf/get_key_with_null.sql
@@ -1,0 +1,25 @@
+/*
+Fetch the value associated with a given key from an array of key/value structs.
+
+Because map types aren't available in BigQuery, we model maps as arrays
+of structs instead, and this function provides map-like access to such fields.
+
+This version matches NULL keys as well.
+
+*/
+
+CREATE TEMP FUNCTION udf_get_key_with_null(map ANY TYPE, k ANY TYPE) AS (
+ (
+   SELECT key_value.value
+   FROM UNNEST(map) AS key_value
+   WHERE key_value.key = k
+         OR key_value.key IS NULL and k IS NULL
+   LIMIT 1
+ )
+);
+
+-- Tests
+
+SELECT
+  assert_equals(12, udf_get_key_with_null([STRUCT('foo' AS key, 42 AS value), ('bar', 12)], 'bar')),
+  assert_equals(12, udf_get_key_with_null([STRUCT('foo' AS key, 42 AS value), (CAST(NULL AS STRING), 12)], CAST(NULL AS STRING)));


### PR DESCRIPTION
Now I'm remembering why I used `"none"` instead of `null`! A full outer join with two `NULL` keys doesn't match and returns two separate rows.