### PR TITLE
Fix out of memory in histogram_probe_counts UDF.

### DIFF
--- a/sql/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
+++ b/sql/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
@@ -24,7 +24,7 @@ RETURNS ARRAY<FLOAT64>
 LANGUAGE js AS
 '''
   let result = [0];
-  for (let i = 1; i < nBuckets; i++) {
+  for (let i = 1; i < Math.min(nBuckets, max); i++) {
     let linearRange = (min * (nBuckets - 1 - i) + max * (i - 1)) / (nBuckets - 2);
     result.push(Math.round(linearRange));
   }

--- a/templates/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
+++ b/templates/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
@@ -24,7 +24,7 @@ RETURNS ARRAY<FLOAT64>
 LANGUAGE js AS
 '''
   let result = [0];
-  for (let i = 1; i < nBuckets; i++) {
+  for (let i = 1; i < Math.min(nBuckets, max); i++) {
     let linearRange = (min * (nBuckets - 1 - i) + max * (i - 1)) / (nBuckets - 2);
     result.push(Math.round(linearRange));
   }


### PR DESCRIPTION
The `udf_linear_buckets` function was having out of memory issues. Turns out some probes had a very high value for `nBuckets` - higher than their `max` which doesn't make much sense. So choosing the min of the two fixes the problem and makes more sense.