### PR TITLE
Inject null for negative session_length and event timestamps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
             templates/telemetry_derived/fxa_users_services_first_seen_v1/init.sql
             templates/telemetry_derived/main_summary_v4
             udf/safe_crc32_uuid.sql
+            udf/normalize_main_payload.sql
   dry-run-sql:
     docker:
       - image: python:3.8

--- a/script/generate_views
+++ b/script/generate_views
@@ -153,10 +153,16 @@ def create_views_if_not_exist(client, views, exclude, sql_dir):
                 " AS metadata"
             ]
             # Add special replacements for Glean pings.
-            if table.labels.get("schema_id", None) == "glean_ping_1":
+            schema_id = table.labels.get("schema_id", None)
+            if schema_id == "glean_ping_1":
                 replacements += [
                     "`moz-fx-data-shared-prod.udf.normalize_glean_ping_info`(ping_info)"
                     " AS ping_info"
+                ]
+            elif schema_id in ("main_ping_1", "main_ping_4"):
+                replacements += [
+                    "`moz-fx-data-shared-prod.udf.normalize_main_payload`(payload)"
+                    " AS payload"
                 ]
             replacements = ",\n    ".join(replacements)
             view_query = VIEW_QUERY_TEMPLATE.format(

--- a/sql/telemetry/core/view.sql
+++ b/sql/telemetry/core/view.sql
@@ -21,6 +21,7 @@ WITH unioned AS (
   SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v10`)
   --
 SELECT
-  * REPLACE(`moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata)
+  * REPLACE(
+    `moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata)
 FROM
   unioned

--- a/sql/telemetry/sync/view.sql
+++ b/sql/telemetry/sync/view.sql
@@ -1,4 +1,7 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.sync`
-AS SELECT * FROM
+AS SELECT
+  * REPLACE(
+    `moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata)
+FROM
   `moz-fx-data-shared-prod.telemetry_stable.sync_v4`

--- a/sql/telemetry_derived/main_summary_v4/part1.sql
+++ b/sql/telemetry_derived/main_summary_v4/part1.sql
@@ -720,7 +720,7 @@ SELECT
     NULL AS room_share
   ) AS loop_activity_counter
 FROM
-  `moz-fx-data-shared-prod.telemetry_stable.main_v4`
+  `moz-fx-data-shared-prod.telemetry.main`
 WHERE
   DATE(submission_timestamp) = @submission_date
   AND normalized_app_name = 'Firefox'

--- a/sql/telemetry_derived/main_summary_v4/part2.sql
+++ b/sql/telemetry_derived/main_summary_v4/part2.sql
@@ -840,7 +840,7 @@ WITH histogram_lists AS (
         UNNEST(histograms)
     ) AS keyed_categorical_histograms
   FROM
-    `moz-fx-data-shared-prod.telemetry_stable.main_v4`
+    `moz-fx-data-shared-prod.telemetry.main`
   WHERE
     DATE(submission_timestamp) = @submission_date
     AND normalized_app_name = 'Firefox'

--- a/templates/telemetry/core/view.sql
+++ b/templates/telemetry/core/view.sql
@@ -21,6 +21,7 @@ WITH unioned AS (
   SELECT * FROM `moz-fx-data-shared-prod.telemetry_stable.core_v10`)
   --
 SELECT
-  * REPLACE(`moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata)
+  * REPLACE(
+    `moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata)
 FROM
   unioned

--- a/templates/telemetry/sync/view.sql
+++ b/templates/telemetry/sync/view.sql
@@ -1,4 +1,7 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.sync`
-AS SELECT * FROM
+AS SELECT
+  * REPLACE(
+    `moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata)
+FROM
   `moz-fx-data-shared-prod.telemetry_stable.sync_v4`

--- a/templates/telemetry_derived/main_summary_v4/part1.sql
+++ b/templates/telemetry_derived/main_summary_v4/part1.sql
@@ -517,7 +517,7 @@ SELECT
     NULL AS room_share
   ) AS loop_activity_counter
 FROM
-  `moz-fx-data-shared-prod.telemetry_stable.main_v4`
+  `moz-fx-data-shared-prod.telemetry.main`
 WHERE
   DATE(submission_timestamp) = @submission_date
   AND normalized_app_name = 'Firefox'

--- a/templates/telemetry_derived/main_summary_v4/part2.sql
+++ b/templates/telemetry_derived/main_summary_v4/part2.sql
@@ -470,7 +470,7 @@ WITH histogram_lists AS (
         UNNEST(histograms)
     ) AS keyed_categorical_histograms
   FROM
-    `moz-fx-data-shared-prod.telemetry_stable.main_v4`
+    `moz-fx-data-shared-prod.telemetry.main`
   WHERE
     DATE(submission_timestamp) = @submission_date
     AND normalized_app_name = 'Firefox'

--- a/udf/normalize_main_payload.sql
+++ b/udf/normalize_main_payload.sql
@@ -4,33 +4,31 @@ Accepts a pipeline metadata struct as input and returns a modified struct that
 includes a few parsed or normalized variants of the input metadata fields.
 
 */
-
-CREATE TEMP FUNCTION
-  udf_normalize_main_payload(payload ANY TYPE) AS ((
-    SELECT
-      AS STRUCT payload.* REPLACE ( (
-        SELECT
-          AS STRUCT payload.info.* REPLACE (
-          IF
-            (payload.info.session_length < 0,
-              NULL,
-              payload.info.session_length) AS session_length)) AS info)) );
-
+CREATE TEMP FUNCTION udf_normalize_main_payload(payload ANY TYPE) AS (
+  (
+    SELECT AS STRUCT
+      payload.* REPLACE(
+        (
+          SELECT AS STRUCT
+            payload.info.* REPLACE(
+              IF(
+                payload.info.session_length < 0,
+                NULL,
+                payload.info.session_length
+              ) AS session_length
+            )
+        ) AS info
+      )
+  )
+);
 -- Tests
-
 SELECT
-assert_equals(
-  3,
-  udf_normalize_main_payload(
-    STRUCT(
-      STRUCT(
-        3 AS session_length
-      ) AS info)
-  ).info.session_length),
-assert_null(
-  udf_normalize_main_payload(
-    STRUCT(
-      STRUCT(
-        -98984108 AS session_length
-      ) AS info)
-    ).info.session_length);
+  assert_equals(
+    3,
+    udf_normalize_main_payload(STRUCT(STRUCT(3 AS session_length) AS info)).info.session_length
+  ),
+  assert_null(
+    udf_normalize_main_payload(
+      STRUCT(STRUCT(-98984108 AS session_length) AS info)
+    ).info.session_length
+  );

--- a/udf/normalize_main_payload.sql
+++ b/udf/normalize_main_payload.sql
@@ -1,0 +1,36 @@
+/*
+
+Accepts a pipeline metadata struct as input and returns a modified struct that
+includes a few parsed or normalized variants of the input metadata fields.
+
+*/
+
+CREATE TEMP FUNCTION
+  udf_normalize_main_payload(payload ANY TYPE) AS ((
+    SELECT
+      AS STRUCT payload.* REPLACE ( (
+        SELECT
+          AS STRUCT payload.info.* REPLACE (
+          IF
+            (payload.info.session_length < 0,
+              NULL,
+              payload.info.session_length) AS session_length)) AS info)) );
+
+-- Tests
+
+SELECT
+assert_equals(
+  3,
+  udf_normalize_main_payload(
+    STRUCT(
+      STRUCT(
+        3 AS session_length
+      ) AS info)
+  ).info.session_length),
+assert_null(
+  udf_normalize_main_payload(
+    STRUCT(
+      STRUCT(
+        -98984108 AS session_length
+      ) AS info)
+    ).info.session_length);


### PR DESCRIPTION
As of https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/474
we will be allowing negative values for session lengths and event timestamps.
We provide some safety by modifying the user-facing view for main pings to null
out these negative values (since large negative values may cause significant
skew in aggregations).

We don't modify the user-facing view for event pings, but rather assume users
will be applying the deanonymize_events UDF and handle nulling negative values
there.

See bugs
https://bugzilla.mozilla.org/show_bug.cgi?id=1592012
and
https://bugzilla.mozilla.org/show_bug.cgi?id=1602521