### PR TITLE
Bug: make skipping authorized views more robust

### DIFF
--- a/script/publish_views
+++ b/script/publish_views
@@ -11,11 +11,11 @@ from google.cloud import bigquery
 import sqlparse
 
 
-AUTHORIZED_VIEWS_TO_SKIP = ("sql/activity_stream/tile_id_types/view.sql",)
+AUTHORIZED_VIEWS_TO_SKIP = ("activity_stream/tile_id_types/view.sql",)
 
 
 def process_file(client, args, filepath):
-    if filepath in AUTHORIZED_VIEWS_TO_SKIP:
+    if any(filepath.endswith(p) for p in AUTHORIZED_VIEWS_TO_SKIP):
         print(f"Skipping authorized view definition {filepath}")
         return
     with open(filepath) as f:


### PR DESCRIPTION
This was not working in the production context where the target sql dir is
under /tmp as discussed in https://github.com/mozilla/bigquery-etl/pull/655#issuecomment-572789847