### PR TITLE
Ensure lowercase client_id for mobile pings

### DIFF
--- a/sql/telemetry/core/view.sql
+++ b/sql/telemetry/core/view.sql
@@ -22,6 +22,10 @@ WITH unioned AS (
   --
 SELECT
   * REPLACE(
+    -- The pipeline ensures lowercase client_id since 2020-01-10, but we apply
+    -- LOWER here to provide continuity for older data that still contains
+    -- some uppercase IDs; see https://github.com/mozilla/gcp-ingestion/pull/1069
+    LOWER(client_id) AS client_id,
     `moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata)
 FROM
   unioned

--- a/sql/telemetry/focus_event/view.sql
+++ b/sql/telemetry/focus_event/view.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.focus_event`
+AS
+SELECT
+  * REPLACE (
+    -- The pipeline ensures lowercase client_id since 2020-01-10, but we apply
+    -- LOWER here to provide continuity for older data that still contains
+    -- some uppercase IDs; see https://github.com/mozilla/gcp-ingestion/pull/1069
+    LOWER(client_id) AS client_id,
+    `moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata
+  )
+FROM
+  `moz-fx-data-shared-prod.telemetry_stable.focus_event_v1`

--- a/sql/telemetry/mobile_event/view.sql
+++ b/sql/telemetry/mobile_event/view.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.mobile_event`
+AS
+SELECT
+  * REPLACE (
+    -- The pipeline ensures lowercase client_id since 2020-01-10, but we apply
+    -- LOWER here to provide continuity for older data that still contains
+    -- some uppercase IDs; see https://github.com/mozilla/gcp-ingestion/pull/1069
+    LOWER(client_id) AS client_id,
+    `moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata
+  )
+FROM
+  `moz-fx-data-shared-prod.telemetry_stable.mobile_event_v1`

--- a/templates/telemetry/core/view.sql
+++ b/templates/telemetry/core/view.sql
@@ -22,6 +22,10 @@ WITH unioned AS (
   --
 SELECT
   * REPLACE(
+    -- The pipeline ensures lowercase client_id since 2020-01-10, but we apply
+    -- LOWER here to provide continuity for older data that still contains
+    -- some uppercase IDs; see https://github.com/mozilla/gcp-ingestion/pull/1069
+    LOWER(client_id) AS client_id,
     `moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata)
 FROM
   unioned

--- a/templates/telemetry/focus_event/view.sql
+++ b/templates/telemetry/focus_event/view.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.focus_event`
+AS
+SELECT
+  * REPLACE (
+    -- The pipeline ensures lowercase client_id since 2020-01-10, but we apply
+    -- LOWER here to provide continuity for older data that still contains
+    -- some uppercase IDs; see https://github.com/mozilla/gcp-ingestion/pull/1069
+    LOWER(client_id) AS client_id,
+    `moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata
+  )
+FROM
+  `moz-fx-data-shared-prod.telemetry_stable.focus_event_v1`

--- a/templates/telemetry/mobile_event/view.sql
+++ b/templates/telemetry/mobile_event/view.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.mobile_event`
+AS
+SELECT
+  * REPLACE (
+    -- The pipeline ensures lowercase client_id since 2020-01-10, but we apply
+    -- LOWER here to provide continuity for older data that still contains
+    -- some uppercase IDs; see https://github.com/mozilla/gcp-ingestion/pull/1069
+    LOWER(client_id) AS client_id,
+    `moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata
+  )
+FROM
+  `moz-fx-data-shared-prod.telemetry_stable.mobile_event_v1`


### PR DESCRIPTION
We see uppercase client_ids from some clients in core, focus_event,
and mobile_event pings. We are fixing this in the pipeline (see
https://github.com/mozilla/gcp-ingestion/pull/1069) and this PR ensures
lowercase for older data in user-facing views.