### PR TITLE
Glam bug fixes

### DIFF
--- a/sql/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
+++ b/sql/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
@@ -8,7 +8,7 @@ LANGUAGE js AS
     current = 1;
   } // If starting from 0, the second bucket should be 1 rather than 0
   let retArray = [0, current];
-  for (let bucketIndex = 2; bucketIndex < Math.min(nBuckets, max); bucketIndex++) {
+  for (let bucketIndex = 2; bucketIndex < Math.min(nBuckets, max, 10000); bucketIndex++) {
     let logCurrent = Math.log(current);
     let logRatio = (logMax - logCurrent) / (nBuckets - bucketIndex);
     let logNext = logCurrent + logRatio;
@@ -24,7 +24,7 @@ RETURNS ARRAY<FLOAT64>
 LANGUAGE js AS
 '''
   let result = [0];
-  for (let i = 1; i < Math.min(nBuckets, max); i++) {
+  for (let i = 1; i < Math.min(nBuckets, max, 10000); i++) {
     let linearRange = (min * (nBuckets - 1 - i) + max * (i - 1)) / (nBuckets - 2);
     result.push(Math.round(linearRange));
   }

--- a/sql/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
+++ b/sql/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
@@ -127,6 +127,7 @@ SELECT
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
 FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
+  AND os IS NOT NULL
 GROUP BY
   os,
   app_version,
@@ -188,6 +189,7 @@ SELECT
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
 FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
+  AND os IS NOT NULL
 GROUP BY
   os,
   app_build_id,
@@ -218,6 +220,7 @@ SELECT
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
 FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
+  AND os IS NOT NULL
 GROUP BY
   os,
   app_version,
@@ -248,6 +251,7 @@ SELECT
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
 FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
+  AND os IS NOT NULL
 GROUP BY
   os,
   channel,
@@ -334,6 +338,7 @@ SELECT
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
 FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
+  AND os IS NOT NULL
 GROUP BY
   os,
   metric,

--- a/sql/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
+++ b/sql/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
@@ -71,6 +71,7 @@ SELECT
    END AS aggregates
 FROM
   clients_scalar_bucket_counts_v1
+WHERE os IS NOT NULL
 GROUP BY
   os,
   app_version,
@@ -144,6 +145,7 @@ SELECT
    END AS aggregates
 FROM
   clients_scalar_bucket_counts_v1
+WHERE os IS NOT NULL
 GROUP BY
   os,
   app_build_id,
@@ -180,6 +182,7 @@ SELECT
    END AS aggregates
 FROM
   clients_scalar_bucket_counts_v1
+WHERE os IS NOT NULL
 GROUP BY
   os,
   app_version,
@@ -216,6 +219,7 @@ SELECT
    END AS aggregates
 FROM
   clients_scalar_bucket_counts_v1
+WHERE os IS NOT NULL
 GROUP BY
   os,
   channel,
@@ -320,6 +324,7 @@ SELECT
    END AS aggregates
 FROM
   clients_scalar_bucket_counts_v1
+WHERE os IS NOT NULL
 GROUP BY
   os,
   metric,

--- a/templates/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
+++ b/templates/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
@@ -8,7 +8,7 @@ LANGUAGE js AS
     current = 1;
   } // If starting from 0, the second bucket should be 1 rather than 0
   let retArray = [0, current];
-  for (let bucketIndex = 2; bucketIndex < Math.min(nBuckets, max); bucketIndex++) {
+  for (let bucketIndex = 2; bucketIndex < Math.min(nBuckets, max, 10000); bucketIndex++) {
     let logCurrent = Math.log(current);
     let logRatio = (logMax - logCurrent) / (nBuckets - bucketIndex);
     let logNext = logCurrent + logRatio;
@@ -24,7 +24,7 @@ RETURNS ARRAY<FLOAT64>
 LANGUAGE js AS
 '''
   let result = [0];
-  for (let i = 1; i < Math.min(nBuckets, max); i++) {
+  for (let i = 1; i < Math.min(nBuckets, max, 10000); i++) {
     let linearRange = (min * (nBuckets - 1 - i) + max * (i - 1)) / (nBuckets - 2);
     result.push(Math.round(linearRange));
   }

--- a/templates/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
+++ b/templates/telemetry_derived/clients_histogram_probe_counts_v1/query.sql
@@ -127,6 +127,7 @@ SELECT
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
 FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
+  AND os IS NOT NULL
 GROUP BY
   os,
   app_version,
@@ -188,6 +189,7 @@ SELECT
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
 FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
+  AND os IS NOT NULL
 GROUP BY
   os,
   app_build_id,
@@ -218,6 +220,7 @@ SELECT
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
 FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
+  AND os IS NOT NULL
 GROUP BY
   os,
   app_version,
@@ -248,6 +251,7 @@ SELECT
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
 FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
+  AND os IS NOT NULL
 GROUP BY
   os,
   channel,
@@ -334,6 +338,7 @@ SELECT
   ), udf_to_string_arr(udf_get_buckets(first_bucket, last_bucket, num_buckets, metric_type))) AS aggregates
 FROM clients_histogram_bucket_counts_v1
 WHERE first_bucket IS NOT NULL
+  AND os IS NOT NULL
 GROUP BY
   os,
   metric,

--- a/templates/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
+++ b/templates/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
@@ -71,6 +71,7 @@ SELECT
    END AS aggregates
 FROM
   clients_scalar_bucket_counts_v1
+WHERE os IS NOT NULL
 GROUP BY
   os,
   app_version,
@@ -144,6 +145,7 @@ SELECT
    END AS aggregates
 FROM
   clients_scalar_bucket_counts_v1
+WHERE os IS NOT NULL
 GROUP BY
   os,
   app_build_id,
@@ -180,6 +182,7 @@ SELECT
    END AS aggregates
 FROM
   clients_scalar_bucket_counts_v1
+WHERE os IS NOT NULL
 GROUP BY
   os,
   app_version,
@@ -216,6 +219,7 @@ SELECT
    END AS aggregates
 FROM
   clients_scalar_bucket_counts_v1
+WHERE os IS NOT NULL
 GROUP BY
   os,
   channel,
@@ -320,6 +324,7 @@ SELECT
    END AS aggregates
 FROM
   clients_scalar_bucket_counts_v1
+WHERE os IS NOT NULL
 GROUP BY
   os,
   metric,


### PR DESCRIPTION
This PR contains 2 bug fixes:

1. There are new out of memory errors triggered by buckets again. This time its due to the number of buckets being too high. This query shows us a row that triggers this issue:

```
SELECT payload.histograms.memory_total
FROM `moz-fx-data-shared-prod.telemetry_stable.main_v4`
WHERE DATE(submission_timestamp) = '2020-01-08'
  AND normalized_os = 'Windows'
  AND application.build_id = '20191202093317'
  AND normalized_channel = 'release'
  AND SPLIT(application.version, '.')[OFFSET(0)] = '71'
  AND client_id IS NOT NULL
  AND JSON_EXTRACT(payload.histograms.memory_total, "$.bucket_count") = '813824896'
```

It looks like `813824896` is a bogus number of buckets. So I looked at the probe info service and it seems the max number of buckets is actually `10000` which explains the change I've made in the code. However, this is a temporary solution as it does not get rid of bogus rows of data. As a follow up, I've filed an issue here to handle the issue by looking at the probe info service: https://github.com/mozilla/bigquery-etl/issues/672

2. Unexpectedly `normalized_os` in main ping has some values that are null. However, these get mixed up with `NULL` being a representation of *all* OS's. This results in duplicate rows where `os = NULL`. As such, when os is null, it should not be included as the name of an OS.



