### PR TITLE
Use full outer join for error views

### DIFF
--- a/sql/monitoring/structured_detailed_error_counts_v1/view.sql
+++ b/sql/monitoring/structured_detailed_error_counts_v1/view.sql
@@ -29,13 +29,14 @@ structured_detailed_hourly_errors AS (
     document_namespace,
     document_type,
     document_version,
+    error_type,
     structured_hourly_errors.ping_count,
-    error_examples.error_count,
+    COALESCE(error_examples.error_count, 0) AS error_count,
     error_message,
     sample_payload
   FROM
     `moz-fx-data-shared-prod.monitoring.structured_error_counts_v1` structured_hourly_errors
-  INNER JOIN
+  FULL OUTER JOIN
     error_examples
   USING
     (hour, document_namespace, document_type, document_version, error_type)

--- a/sql/monitoring/structured_error_counts_v1/view.sql
+++ b/sql/monitoring/structured_error_counts_v1/view.sql
@@ -44,11 +44,11 @@ structured_hourly_errors AS (
     document_type,
     document_version,
     error_type,
-    ping_count + error_counts.error_count AS ping_count,
-    error_counts.error_count
+    COALESCE(ping_count, 0) + COALESCE(error_count, 0) AS ping_count,
+    COALESCE(error_count, 0) AS error_count
   FROM
     ping_counts
-  INNER JOIN
+  FULL OUTER JOIN
     error_counts
   USING
     (hour, document_namespace, document_type, document_version)

--- a/templates/monitoring/structured_detailed_error_counts_v1/view.sql
+++ b/templates/monitoring/structured_detailed_error_counts_v1/view.sql
@@ -29,13 +29,14 @@ structured_detailed_hourly_errors AS (
     document_namespace,
     document_type,
     document_version,
+    error_type,
     structured_hourly_errors.ping_count,
-    error_examples.error_count,
+    COALESCE(error_examples.error_count, 0) AS error_count,
     error_message,
     sample_payload
   FROM
     `moz-fx-data-shared-prod.monitoring.structured_error_counts_v1` structured_hourly_errors
-  INNER JOIN
+  FULL OUTER JOIN
     error_examples
   USING
     (hour, document_namespace, document_type, document_version, error_type)

--- a/templates/monitoring/structured_error_counts_v1/view.sql
+++ b/templates/monitoring/structured_error_counts_v1/view.sql
@@ -44,11 +44,11 @@ structured_hourly_errors AS (
     document_type,
     document_version,
     error_type,
-    ping_count + error_counts.error_count AS ping_count,
-    error_counts.error_count
+    COALESCE(ping_count, 0) + COALESCE(error_count, 0) AS ping_count,
+    COALESCE(error_count, 0) AS error_count
   FROM
     ping_counts
-  INNER JOIN
+  FULL OUTER JOIN
     error_counts
   USING
     (hour, document_namespace, document_type, document_version)


### PR DESCRIPTION
Previously we used inner join, which left out pings which either
had no errors or no valid pings. This change will let those
flow through to be monitored.