### PR TITLE
Add metadata.yaml to ssl_ratios query

### DIFF
--- a/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -1,6 +1,7 @@
 friendly_name: SSL Ratios
 description: >
-  Percentages of page loads Firefox users have performed that were conducted over SSL.
+  Percentages of page loads Firefox users have performed that were 
+  conducted over SSL broken down by country.
 owners:
   - chutten@mozilla.com
 labels:

--- a/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -6,6 +6,6 @@ owners:
   - chutten@mozilla.com
 labels:
   application: firefox
-  schedule: daily
+  incremental: true
   public_json: true
   public_bigquery: true

--- a/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -7,5 +7,6 @@ owners:
 labels:
   application: firefox
   incremental: true
+  schedule: daily
   public_json: true
   public_bigquery: true

--- a/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: SSL Ratios
+description: >
+  Percentages of page loads Firefox users have performed that were conducted over SSL.
+owners:
+  - chutten@mozilla.com
+labels:
+  application: firefox
+  schedule: daily
+  public_json: true
+  public_bigquery: true


### PR DESCRIPTION
This adds `metadata.yaml` for the `ssl_ratios_v1` query. This will be the first table being part of the public dataset.