### PR TITLE
Add support for tags when publishing metadata

### DIFF
--- a/script/publish_metadata
+++ b/script/publish_metadata
@@ -40,7 +40,12 @@ def publish_metadata(client, dataset, table, metadata_file):
                 table.labels = {}
 
                 for key, label in metadata["labels"].items():
-                    if is_valid_label(str(key)) and is_valid_label(str(label)):
+                    if isinstance(label, bool) and is_valid_label(str(key)):
+                        # key-value pair with boolean value should get published as tag
+                        if label:
+                            table.labels[str(key)] = ""
+                    elif is_valid_label(str(key)) and is_valid_label(str(label)):
+                        # all other pairs get published as key-value pair label
                         table.labels[str(key)] = str(label)
                     else:
                         print(


### PR DESCRIPTION
BigQuery supports adding labels as tags. For labels with a boolean value it makes sense to add them as tags instead of key-value pairs. This is, for example, the case for: 
```yaml
labels:
  public_bigquery: true  # would appear as "public_bigquery" in the labels attached to the table 
  public_json: false  # would not be part of the table labels
```