### PR TITLE
Glam: Build ID filtering and more sample_id partition usage

### DIFF
--- a/script/dryrun
+++ b/script/dryrun
@@ -68,6 +68,8 @@ SKIP = {
     "sql/telemetry_derived/latest_versions/query.sql",
     # Query parameter not found
     "sql/telemetry_derived/experiments_v1/query.sql",
+    "sql/telemetry_derived/clients_histogram_aggregates_v1/query.sql",
+    "sql/telemetry_derived/clients_histogram_aggregates_old_v1/query.sql",
     "sql/telemetry_derived/clients_histogram_aggregates_merged_v1/query.sql",
     # Dataset moz-fx-data-shared-prod:glam_etl was not found
     "sql/glam_etl/fenix_clients_scalar_aggregates_v1/query.sql",

--- a/sql/telemetry_derived/clients_histogram_aggregates_old_v1/query.sql
+++ b/sql/telemetry_derived/clients_histogram_aggregates_old_v1/query.sql
@@ -1,3 +1,9 @@
+WITH clients_histogram_aggregates_partition AS
+  (SELECT *
+  FROM clients_histogram_aggregates_v1
+  WHERE sample_id >= @min_sample_id
+    AND sample_id <= @max_sample_id)
+
 SELECT
   sample_id,
   client_id,
@@ -7,7 +13,7 @@ SELECT
   hist_aggs.channel AS channel,
   CONCAT(client_id, os, app_version, app_build_id, hist_aggs.channel) AS join_key,
   histogram_aggregates
-FROM clients_histogram_aggregates_v1 AS hist_aggs
+FROM clients_histogram_aggregates_partition AS hist_aggs
 LEFT JOIN latest_versions
 ON latest_versions.channel = hist_aggs.channel
 WHERE app_version >= (latest_version - 2)

--- a/sql/telemetry_derived/clients_histogram_aggregates_v1/query.sql
+++ b/sql/telemetry_derived/clients_histogram_aggregates_v1/query.sql
@@ -59,6 +59,12 @@ CREATE TEMP FUNCTION udf_merged_user_data(old_aggs ANY TYPE, new_aggs ANY TYPE)
   )
 );
 
+WITH clients_histogram_merged_partition AS
+  (SELECT *
+  FROM clients_histogram_aggregates_merged_v1
+  WHERE sample_id >= @min_sample_id
+    AND sample_id <= @max_sample_id)
+
 SELECT
   sample_id,
   client_id,
@@ -67,4 +73,4 @@ SELECT
   app_build_id,
   channel,
   udf_merged_user_data(old_aggs, new_aggs) AS histogram_aggregates
-FROM clients_histogram_aggregates_merged_v1
+FROM clients_histogram_merged_partition


### PR DESCRIPTION
Build ID Filtering:
Essentially keeping only the top two build IDs each day for each channel based on client count. 

Sample ID Partitioning:
I preemptively added more of this here since those other queries were also processing 30T+. We also get the added bonus that some of the processing can run in parallel.