### PR TITLE
Coalesce the client_info.locale value in baseline ping views

### DIFF
--- a/script/generate_views
+++ b/script/generate_views
@@ -159,6 +159,13 @@ def create_views_if_not_exist(client, views, exclude, sql_dir):
                     "`moz-fx-data-shared-prod.udf.normalize_glean_ping_info`(ping_info)"
                     " AS ping_info"
                 ]
+                if table.table_id == "baseline_v1":
+                    replacements += [
+                        "`moz-fx-data-shared-prod.udf"
+                        ".normalize_glean_baseline_client_info`"
+                        "(client_info, metrics)"
+                        " AS client_info"
+                    ]
                 if table.dataset_id.startswith(
                     "org_mozilla_fenix"
                 ) and table.table_id.startswith("metrics"):

--- a/udf/normalize_glean_baseline_client_info.sql
+++ b/udf/normalize_glean_baseline_client_info.sql
@@ -1,0 +1,47 @@
+/*
+
+Accepts a glean client_info struct as input and returns a modified struct that
+includes a few parsed or normalized variants of the input fields.
+
+*/
+CREATE OR REPLACE FUNCTION udf.normalize_glean_baseline_client_info(
+  client_info ANY TYPE,
+  metrics ANY TYPE
+) AS (
+  (
+    SELECT AS STRUCT
+      client_info.* REPLACE (
+        COALESCE(client_info.locale, metrics.string.glean_baseline_locale) AS locale
+      )
+  )
+);
+
+-- Tests
+SELECT
+  assert_equals(
+    'en-US',
+    udf.normalize_glean_baseline_client_info(
+      STRUCT('en-US' AS locale),
+      STRUCT(STRUCT('en-GB' AS glean_baseline_locale) AS string)
+    ).locale
+  ),
+  assert_equals(
+    'en-US',
+    udf.normalize_glean_baseline_client_info(
+      STRUCT('en-US' AS locale),
+      STRUCT(STRUCT(CAST(NULL AS STRING) AS glean_baseline_locale) AS string)
+    ).locale
+  ),
+  assert_equals(
+    'en-GB',
+    udf.normalize_glean_baseline_client_info(
+      STRUCT(CAST(NULL AS STRING) AS locale),
+      STRUCT(STRUCT('en-GB' AS glean_baseline_locale) AS string)
+    ).locale
+  ),
+  assert_null(
+    udf.normalize_glean_baseline_client_info(
+      STRUCT(CAST(NULL AS STRING) AS locale),
+      STRUCT(STRUCT(CAST(NULL AS STRING) AS glean_baseline_locale) AS string)
+    ).locale
+  )


### PR DESCRIPTION
Glean pings now contain a client_info.locale field; baseline pings
previously reported locale as a string metric. This change provides
some historical continuity so that views on baseline pings show
client_info.locale values even if only the old metric is populated.

See the [announcement on the fx-data-dev mailing list](https://mail.mozilla.org/pipermail/fx-data-dev/2020-February/000321.html)