### PR TITLE
Add days_since_created_profile to Fenix clients_last_seen

### DIFF
--- a/sql/org_mozilla_firefox/clients_last_seen/view.sql
+++ b/sql/org_mozilla_firefox/clients_last_seen/view.sql
@@ -9,6 +9,7 @@ SELECT
   `moz-fx-data-shared-prod.udf.pos_of_trailing_set_bit`(
     baseline.days_seen_session_end_bits
   ) AS days_since_seen_session_end,
+  DATE_DIFF(submission_date, baseline.first_run_date, DAY) AS days_since_created_profile,
   * EXCEPT (baseline, metrics),
   baseline.*,
   metrics.*


### PR DESCRIPTION
This was an omission that should have been included in #731.

This field is needed to stay in parallel with desktop clients_last_seen.