### PR TITLE
Fix #779 - Ignore view deploys to glam_etl

### DIFF
--- a/script/publish_views
+++ b/script/publish_views
@@ -13,11 +13,16 @@ from google.cloud import bigquery
 import sqlparse
 
 
-AUTHORIZED_VIEWS_TO_SKIP = ("activity_stream/tile_id_types/view.sql",)
+VIEWS_TO_SKIP = (
+    # Access Denied
+    "activity_stream/tile_id_types/view.sql",
+    # Dataset moz-fx-data-shared-prod:glam_etl was not found
+    "glam_etl/fenix_view_clients_daily_scalar_aggregates_v1/view.sql",
+)
 
 
 def process_file(client, args, filepath):
-    if any(filepath.endswith(p) for p in AUTHORIZED_VIEWS_TO_SKIP):
+    if any(filepath.endswith(p) for p in VIEWS_TO_SKIP):
         print(f"Skipping authorized view definition {filepath}")
         return True
     with open(filepath) as f:


### PR DESCRIPTION
Fixes #779. The `glam_etl` dataset does not exist and breaks the `publish_views` flow. This adds the view to the ignore list. 