### PR TITLE
Add mode_last_retain_nulls

### DIFF
--- a/udf/mode_last.sql
+++ b/udf/mode_last.sql
@@ -5,6 +5,8 @@ Returns the most frequently occuring element in an array.
 In the case of multiple values tied for the highest count, it returns the value
 that appears latest in the array. Nulls are ignored.
 
+See also: `udf.mode_last_retain_nulls`, which retains nulls.
+
 */
 
 CREATE OR REPLACE FUNCTION

--- a/udf/mode_last_retain_nulls.sql
+++ b/udf/mode_last_retain_nulls.sql
@@ -1,0 +1,30 @@
+/*
+
+Returns the most frequently occuring element in an array.
+
+In the case of multiple values tied for the highest count, it returns the value
+that appears latest in the array. Nulls are retained.
+
+*/
+CREATE OR REPLACE FUNCTION udf.mode_last_retain_nulls(list ANY TYPE) AS (
+  (
+    SELECT
+      _value
+    FROM
+      UNNEST(list) AS _value
+      WITH OFFSET AS _offset
+    GROUP BY
+      _value
+    ORDER BY
+      COUNT(*) DESC,
+      MAX(_offset) DESC
+    LIMIT
+      1
+  )
+);
+
+-- Test
+SELECT
+  assert_equals('bar', udf.mode_last_retain_nulls(['foo', 'bar', 'baz', 'bar', 'fred'])),
+  assert_equals('baz', udf.mode_last_retain_nulls(['foo', 'bar', 'baz', 'bar', 'baz', 'fred'])),
+  assert_equals(CAST(NULL AS STRING), udf.mode_last_retain_nulls([NULL, 'foo', NULL]));

--- a/udf/mode_last_retain_nulls.sql
+++ b/udf/mode_last_retain_nulls.sql
@@ -5,6 +5,8 @@ Returns the most frequently occuring element in an array.
 In the case of multiple values tied for the highest count, it returns the value
 that appears latest in the array. Nulls are retained.
 
+See also: `udf.mode_last`, which ignores nulls.
+
 */
 CREATE OR REPLACE FUNCTION udf.mode_last_retain_nulls(list ANY TYPE) AS (
   (


### PR DESCRIPTION
When aggregating columns, it may be surprising for some people
to have the most frequent non-null column be returned for
`udf_mode_last`. This introduces a new function which will
return null if that is the most frequent value.