### PR TITLE
Messaging system ETL following clients_last_seen methodology

### DIFF
--- a/script/dryrun
+++ b/script/dryrun
@@ -49,6 +49,7 @@ SKIP = {
     "sql/telemetry/fxa_users_last_seen_raw_v1/init.sql",
     "sql/telemetry_derived/core_clients_first_seen_v1/init.sql",
     "sql/telemetry_derived/fxa_users_services_last_seen_v1/init.sql",
+    "sql/messaging_system_derived/cfr_users_last_seen_v1/init.sql",
     # Reference table not found
     "sql/monitoring/structured_detailed_error_counts_v1/view.sql",
     # Access denied for search

--- a/sql/messaging_system/cfr_users_daily/view.sql
+++ b/sql/messaging_system/cfr_users_daily/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.messaging_system.cfr_users_daily`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.messaging_system_derived.cfr_users_daily_v1`

--- a/sql/messaging_system/cfr_users_last_seen/view.sql
+++ b/sql/messaging_system/cfr_users_last_seen/view.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.messaging_system.cfr_users_last_seen`
+AS
+SELECT
+  `moz-fx-data-shared-prod.udf.pos_of_trailing_set_bit`(days_seen_bits) AS days_since_seen,
+  *
+FROM
+  `moz-fx-data-shared-prod.messaging_system_derived.cfr_users_last_seen_v1`

--- a/sql/messaging_system_derived/cfr_users_daily_v1/query.sql
+++ b/sql/messaging_system_derived/cfr_users_daily_v1/query.sql
@@ -1,0 +1,46 @@
+WITH windowed AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    impression_id,
+    client_id,
+    ROW_NUMBER() OVER w1_unframed AS _n,
+    --
+    -- For all dimensions, we use the mode of observed values in the day.
+    udf.mode_last(ARRAY_AGG(release_channel) OVER w1) AS release_channel,
+    udf.mode_last(ARRAY_AGG(addon_version) OVER w1) AS addon_version,
+    udf.mode_last(ARRAY_AGG(metadata.geo.country) OVER w1) AS country,
+    udf.mode_last(ARRAY_AGG(version) OVER w1) AS version,
+  FROM
+    messaging_system.cfr
+  WHERE
+    -- Reprocess all dates by running this query with --parameter=submission_date:DATE:NULL
+    (@submission_date IS NULL OR @submission_date = DATE(submission_timestamp))
+  WINDOW
+    w1 AS (
+      PARTITION BY
+        sample_id,
+        client_id,
+        DATE(submission_timestamp)
+      ORDER BY
+        submission_timestamp
+      ROWS BETWEEN
+        UNBOUNDED PRECEDING
+        AND UNBOUNDED FOLLOWING
+    ),
+    -- We must provide a modified window for ROW_NUMBER which cannot accept a frame clause.
+    w1_unframed AS (
+      PARTITION BY
+        sample_id,
+        client_id,
+        DATE(submission_timestamp)
+      ORDER BY
+        submission_timestamp
+    )
+)
+--
+SELECT
+  * EXCEPT (_n)
+FROM
+  windowed
+WHERE
+  _n = 1

--- a/sql/messaging_system_derived/cfr_users_last_seen_v1/init.sql
+++ b/sql/messaging_system_derived/cfr_users_last_seen_v1/init.sql
@@ -1,0 +1,21 @@
+CREATE TABLE
+  cfr_users_last_seen_v1
+PARTITION BY
+  submission_date
+CLUSTER BY
+  release_channel
+OPTIONS
+  (require_partition_filter = TRUE)
+AS
+SELECT
+  CAST(NULL AS INT64) AS days_seen_bits,
+-- We make sure to delay * until the end so that as new columns are added
+-- to the daily table, we can add those columns in the same order to the end
+-- of this schema, which may be necessary for the daily join query between
+-- the two tables to validate.
+  *
+FROM
+  cfr_users_daily_v1
+WHERE
+-- Output empty table and read no input rows
+  FALSE

--- a/sql/messaging_system_derived/cfr_users_last_seen_v1/query.sql
+++ b/sql/messaging_system_derived/cfr_users_last_seen_v1/query.sql
@@ -1,0 +1,42 @@
+WITH _current AS (
+  SELECT
+-- In this raw table, we capture the history of activity over the past
+-- 28 days as a single 64-bit integer. The rightmost bit represents
+-- whether the user was active in the current day.
+    CAST(TRUE AS INT64) AS days_seen_bits,
+    * EXCEPT (submission_date)
+  FROM
+    cfr_users_daily_v1
+  WHERE
+    submission_date = @submission_date
+),
+--
+_previous AS (
+  SELECT
+    * EXCEPT (submission_date)
+  FROM
+    cfr_users_last_seen_v1
+  WHERE
+    submission_date = DATE_SUB(@submission_date, INTERVAL 1 DAY)
+    AND udf.shift_28_bits_one_day(days_seen_bits) > 0
+)
+--
+SELECT
+  @submission_date AS submission_date,
+  IF(
+    _current.impression_id IS NOT NULL
+    OR _current.client_id IS NOT NULL,
+    _current,
+    _previous
+  ).* REPLACE (
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_seen_bits,
+      _current.days_seen_bits
+    ) AS days_seen_bits
+  )
+FROM
+  _current
+FULL JOIN
+  _previous
+USING
+  (impression_id, client_id)


### PR DESCRIPTION
Proposed as an alternative to https://github.com/mozilla/bigquery-etl/pull/793

In this formulation, MAU can be recovered via:

```
SELECT
  submission_date,
  release_channel,
  COUNTIF(days_since_seen < 1) AS dau,
  COUNTIF(days_since_seen < 7) AS wau,
  COUNTIF(days_since_seen < 28) AS mau,
FROM
  `moz-fx-data-shared-prod.messaging_system.cfr_users_last_seen`
WHERE
  submission_date > '2020-01-01'
GROUP BY
  1,
  2
```

