### PR TITLE
Allow partitions for destination_table names in run_query

### DIFF
--- a/script/run_query
+++ b/script/run_query
@@ -22,7 +22,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from bigquery_etl.parse_metadata import Metadata  # noqa E402
 
 
-DESTINATION_TABLE_RE = re.compile(r"^[a-zA-Z0-9_]{0,1024}$")
+DESTINATION_TABLE_RE = re.compile(r"^[a-zA-Z0-9_$]{0,1024}$")
 
 
 parser = ArgumentParser(description=__doc__)


### PR DESCRIPTION
Destination tables names passed from telemetry-airflow can contain partitions, eg. `--destination_table=ssl_ratios_v1$20200310`. This resulted in `ssl_ratios` failing last night.