### PR TITLE
Use subprocess.check_call when running queries

### DIFF
--- a/script/run_query
+++ b/script/run_query
@@ -87,8 +87,7 @@ def main():
 
     with open(query_file) as query_stream:
         # run the query as shell command so that passed parameters can be used as is
-        sql = query_stream.read()
-        subprocess.call(["bq"] + query_arguments + [sql])
+        subprocess.check_call(["bq"] + query_arguments, stdin=query_stream)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[`subprocess.check_call`](https://docs.python.org/2/library/subprocess.html#subprocess.check_call) will wait for command to complete. If the return code was zero then return, otherwise raise `CalledProcessError`

https://github.com/mozilla/bigquery-etl/issues/806 https://github.com/mozilla/bigquery-etl/issues/807