### PR TITLE
Use standard SQL when running queries

### DIFF
--- a/script/run_query
+++ b/script/run_query
@@ -36,14 +36,21 @@ parser.add_argument(
 )
 parser.add_argument("--dataset_id", help="Destination dataset")
 parser.add_argument("--query_file", help="File path to query to be executed")
+parser.add_argument(
+    "--use_legacy_sql",
+    help="Enable use of legacy SQL; Standard SQL by default",
+    default=False,
+)
 
 
 def main():
     args, query_arguments = parser.parse_known_args()
     query_file = args.query_file
 
-    # bq uses legacy SQL by default, force use of standard SQL
-    query_arguments.append("--use_legacy_sql=false")
+    # bq uses legacy SQL by default, force use of standard SQL if no flag is set
+    query_arguments.append(
+        "--use_legacy_sql={}".format(str(args.use_legacy_sql).lower())
+    )
 
     if args.dataset_id is not None:
         # dataset ID was parsed by argparse but needs to be passed as parameter

--- a/script/run_query
+++ b/script/run_query
@@ -42,6 +42,9 @@ def main():
     args, query_arguments = parser.parse_known_args()
     query_file = args.query_file
 
+    # bq uses legacy SQL by default, force use of standard SQL
+    query_arguments.append("--use_legacy_sql=false")
+
     if args.dataset_id is not None:
         # dataset ID was parsed by argparse but needs to be passed as parameter
         # when running the query


### PR DESCRIPTION
`bq` uses legacy SQL by default (see https://cloud.google.com/bigquery/docs/reference/bq-cli-reference). This causes some of the SQL queries that exceed 250,000 characters to fail running. 

Use standard SQL instead (which has 1MB limit and is also used for dryruns)

cc @emtwo 