### PR TITLE
Remove final references to derived-datasets.telemetry_derived

### DIFF
--- a/sql/telemetry/active_profiles/view.sql
+++ b/sql/telemetry/active_profiles/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.active_profiles_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.active_profiles_v1`

--- a/sql/telemetry/addon_aggregates_v2/view.sql
+++ b/sql/telemetry/addon_aggregates_v2/view.sql
@@ -5,4 +5,4 @@ SELECT
   submission_date AS submission_date_s3,
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.addon_aggregates_v2`
+  `moz-fx-data-shared-prod.telemetry_derived.addon_aggregates_v2`

--- a/sql/telemetry/addons/view.sql
+++ b/sql/telemetry/addons/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.addons_v2`
+  `moz-fx-data-shared-prod.telemetry_derived.addons_v2`

--- a/sql/telemetry/addons_v2/view.sql
+++ b/sql/telemetry/addons_v2/view.sql
@@ -5,4 +5,4 @@ SELECT
   submission_date AS submission_date_s3,
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.addons_v2`
+  `moz-fx-data-shared-prod.telemetry_derived.addons_v2`

--- a/sql/telemetry/socorro_crash_v2/view.sql
+++ b/sql/telemetry/socorro_crash_v2/view.sql
@@ -30,4 +30,4 @@ SELECT
     ) AS memory_report
   )
 FROM
-  `moz-fx-data-derived-datasets.telemetry_derived.socorro_crash_v2`
+  `moz-fx-data-shared-prod.telemetry_derived.socorro_crash_v2`

--- a/sql/telemetry/ssl_ratios_v1/view.sql
+++ b/sql/telemetry/ssl_ratios_v1/view.sql
@@ -6,7 +6,7 @@ WITH windowed AS (
     *,
     SUM(ssl_loads) OVER w1 + SUM(non_ssl_loads) OVER w1 AS total_loads
   FROM
-    `moz-fx-data-derived-datasets.telemetry_derived.ssl_ratios_v1`
+    `moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1`
   WINDOW
     w1 AS (
       ORDER BY


### PR DESCRIPTION
I have copied these tables over and have staged PRs such that Airflow will
start populating the shared-prod versions:

https://github.com/mozilla/telemetry-airflow/pull/893
https://github.com/mozilla/telemetry-airflow/pull/889