### PR TITLE
Add exact_mau28 tables/views for Messaging System

### DIFF
--- a/sql/messaging_system/cfr_exact_mau28_by_dimensions/view.sql
+++ b/sql/messaging_system/cfr_exact_mau28_by_dimensions/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.messaging_system.cfr_exact_mau28_by_dimensions`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.messaging_system_derived.cfr_exact_mau28_by_dimensions_v1`

--- a/sql/messaging_system/cfr_users_last_seen/view.sql
+++ b/sql/messaging_system/cfr_users_last_seen/view.sql
@@ -3,7 +3,9 @@ CREATE OR REPLACE VIEW
 AS
 SELECT
   `moz-fx-data-shared-prod.udf.pos_of_trailing_set_bit`(days_seen_bits) AS days_since_seen,
-  `moz-fx-data-shared-prod.udf.pos_of_trailing_set_bit`(days_seen_whats_new_bits) AS days_since_seen_whats_new,
+  `moz-fx-data-shared-prod.udf.pos_of_trailing_set_bit`(
+    days_seen_whats_new_bits
+  ) AS days_since_seen_whats_new,
   *
 FROM
   `moz-fx-data-shared-prod.messaging_system_derived.cfr_users_last_seen_v1`

--- a/sql/messaging_system/onboarding_exact_mau28_by_dimensions/view.sql
+++ b/sql/messaging_system/onboarding_exact_mau28_by_dimensions/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.messaging_system.onboarding_exact_mau28_by_dimensions`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.messaging_system_derived.onboarding_exact_mau28_by_dimensions_v1`

--- a/sql/messaging_system/snippets_exact_mau28_by_dimensions/view.sql
+++ b/sql/messaging_system/snippets_exact_mau28_by_dimensions/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.messaging_system.snippets_exact_mau28_by_dimensions`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.messaging_system_derived.snippets_exact_mau28_by_dimensions_v1`

--- a/sql/messaging_system_derived/cfr_exact_mau28_by_dimensions_v1/query.sql
+++ b/sql/messaging_system_derived/cfr_exact_mau28_by_dimensions_v1/query.sql
@@ -1,0 +1,30 @@
+SELECT
+  submission_date,
+  release_channel,
+  country,
+  COALESCE(cc.name, culs.country) AS country_name,
+  locale,
+  version,
+  COUNTIF(days_since_seen < 28) AS mau,
+  COUNTIF(days_since_seen < 7) AS wau,
+  COUNTIF(days_since_seen < 1) AS dau,
+  COUNTIF(days_since_seen_whats_new < 28) AS whats_new_mau,
+  COUNTIF(days_since_seen_whats_new < 7) AS whats_new_wau,
+  COUNTIF(days_since_seen_whats_new < 1) AS whats_new_dau
+FROM
+  messaging_system.cfr_users_last_seen AS culs
+LEFT JOIN
+  static.country_codes_v1 AS cc
+ON
+  (culs.country = cc.code)
+WHERE
+  (client_id IS NOT NULL OR impression_id IS NOT NULL)
+  -- Reprocess all dates by running this query with --parameter=submission_date:DATE:NULL
+  AND (@submission_date IS NULL OR @submission_date = submission_date)
+GROUP BY
+  submission_date,
+  release_channel,
+  country,
+  country_name,
+  locale,
+  version

--- a/sql/messaging_system_derived/cfr_users_last_seen_v1/query.sql
+++ b/sql/messaging_system_derived/cfr_users_last_seen_v1/query.sql
@@ -35,8 +35,8 @@ SELECT
       _current.days_seen_bits
     ) AS days_seen_bits,
     udf.combine_adjacent_days_28_bits(
-        _previous.days_seen_whats_new_bits,
-        _current.days_seen_whats_new_bits
+      _previous.days_seen_whats_new_bits,
+      _current.days_seen_whats_new_bits
     ) AS days_seen_whats_new_bits
   )
 FROM

--- a/sql/messaging_system_derived/onboarding_exact_mau28_by_dimensions_v1/query.sql
+++ b/sql/messaging_system_derived/onboarding_exact_mau28_by_dimensions_v1/query.sql
@@ -1,0 +1,27 @@
+SELECT
+  submission_date,
+  release_channel,
+  country,
+  COALESCE(cc.name, ouls.country) AS country_name,
+  locale,
+  version,
+  COUNTIF(days_since_seen < 28) AS mau,
+  COUNTIF(days_since_seen < 7) AS wau,
+  COUNTIF(days_since_seen < 1) AS dau,
+FROM
+  messaging_system.onboarding_users_last_seen AS ouls
+LEFT JOIN
+  static.country_codes_v1 AS cc
+ON
+  (ouls.country = cc.code)
+WHERE
+  client_id IS NOT NULL
+  -- Reprocess all dates by running this query with --parameter=submission_date:DATE:NULL
+  AND (@submission_date IS NULL OR @submission_date = submission_date)
+GROUP BY
+  submission_date,
+  release_channel,
+  country,
+  country_name,
+  locale,
+  version

--- a/sql/messaging_system_derived/snippets_exact_mau28_by_dimensions_v1/query.sql
+++ b/sql/messaging_system_derived/snippets_exact_mau28_by_dimensions_v1/query.sql
@@ -1,0 +1,27 @@
+SELECT
+  submission_date,
+  release_channel,
+  country,
+  COALESCE(cc.name, suls.country) AS country_name,
+  locale,
+  version,
+  COUNTIF(days_since_seen < 28) AS mau,
+  COUNTIF(days_since_seen < 7) AS wau,
+  COUNTIF(days_since_seen < 1) AS dau,
+FROM
+  messaging_system.snippets_users_last_seen AS suls
+LEFT JOIN
+  static.country_codes_v1 AS cc
+ON
+  (suls.country = cc.code)
+WHERE
+  client_id IS NOT NULL
+  -- Reprocess all dates by running this query with --parameter=submission_date:DATE:NULL
+  AND (@submission_date IS NULL OR @submission_date = submission_date)
+GROUP BY
+  submission_date,
+  release_channel,
+  country,
+  country_name,
+  locale,
+  version


### PR DESCRIPTION
r? @jklukas 

This is a follow up to precomputer the mau/dau/wau for those `user_last_seen` tables defined in Messaging System.