### PR TITLE
Use stable tables rather than live

### DIFF
--- a/sql/monitoring/telemetry_missing_columns_v2/view.sql
+++ b/sql/monitoring/telemetry_missing_columns_v2/view.sql
@@ -17,7 +17,7 @@ extracted AS (
     `moz-fx-data-shared-prod`.udf.extract_document_version(_TABLE_SUFFIX) AS document_version,
     additional_properties
   FROM
-    `moz-fx-data-shared-prod.telemetry_live.*`
+    `moz-fx-data-shared-prod.telemetry_stable.*`
   WHERE
     -- only observe full days of data
     (

--- a/sql/telemetry/fenix_events_v1/view.sql
+++ b/sql/telemetry/fenix_events_v1/view.sql
@@ -29,6 +29,6 @@ SELECT
       STRUCT(client_info.architecture AS arch)
     ) AS user_properties
 FROM
-    `moz-fx-data-shared-prod.org_mozilla_fenix_live.events_v1`
+    `moz-fx-data-shared-prod.org_mozilla_fenix_stable.events_v1`
 CROSS JOIN
     UNNEST(events) AS event


### PR DESCRIPTION
These two cases look like mistakes where we should be referencing stable rather than live tables.