### PR TITLE
Add a segment for regular users.

### DIFF
--- a/sql/telemetry/clients_last_seen_v1/view.sql
+++ b/sql/telemetry/clients_last_seen_v1/view.sql
@@ -13,6 +13,36 @@ SELECT
   CAST(
     SAFE.LOG(days_created_profile_bits & -days_created_profile_bits, 2) AS INT64
   ) AS days_since_created_profile,
+  CASE
+    CAST(
+      BIT_COUNT(
+        days_visited_5_uri_bits & `moz-fx-data-shared-prod.udf.bitmask_range`(2, 6)
+      ) >= 1 AS INT64
+    ) + CAST(
+      BIT_COUNT(
+        days_visited_5_uri_bits & `moz-fx-data-shared-prod.udf.bitmask_range`(8, 7)
+      ) >= 2 AS INT64
+    ) + CAST(
+      BIT_COUNT(
+        days_visited_5_uri_bits & `moz-fx-data-shared-prod.udf.bitmask_range`(15, 7)
+      ) >= 2 AS INT64
+    ) + CAST(
+      BIT_COUNT(
+        days_visited_5_uri_bits & `moz-fx-data-shared-prod.udf.bitmask_range`(22, 7)
+      ) >= 2 AS INT64
+    )
+  WHEN
+    4
+  THEN
+    'regular_v1'
+  WHEN
+    0
+  THEN
+    'new_irregular_v1'
+  ELSE
+    'semi_regular_v1'
+  END
+  AS segment_regular_users_v1,
   * EXCEPT (
     active_experiment_id,
     scalar_parent_dom_contentprocess_troubled_due_to_memory_sum,

--- a/sql/telemetry/clients_last_seen_v1/view.sql
+++ b/sql/telemetry/clients_last_seen_v1/view.sql
@@ -15,17 +15,17 @@ SELECT
   ) AS days_since_created_profile,
   CASE
   WHEN
-    BIT_COUNT(days_visited_5_uri_bits) & 0x0FFFFFFE = 0
+    BIT_COUNT(days_visited_5_uri_bits & 0x0FFFFFFE) = 0
   THEN
     'new_irregular_users_v1'
   WHEN
-    BIT_COUNT(days_visited_5_uri_bits) & 0x0FFFFFFE
+    BIT_COUNT(days_visited_5_uri_bits & 0x0FFFFFFE)
     BETWEEN 1
     AND 7
   THEN
     'semi_regular_users_v1'
   WHEN
-    BIT_COUNT(days_visited_5_uri_bits) & 0x0FFFFFFE
+    BIT_COUNT(days_visited_5_uri_bits & 0x0FFFFFFE)
     BETWEEN 8
     AND 27
   THEN

--- a/sql/telemetry/clients_last_seen_v1/view.sql
+++ b/sql/telemetry/clients_last_seen_v1/view.sql
@@ -34,15 +34,15 @@ SELECT
   WHEN
     4
   THEN
-    'regular_v1'
+    'regular_users_v1'
   WHEN
     0
   THEN
-    'new_irregular_v1'
+    'new_irregular_users_v1'
   ELSE
-    'semi_regular_v1'
+    'semi_regular_users_v1'
   END
-  AS segment_regular_users_v1,
+  AS segment_usage_regularity_v1,
   * EXCEPT (
     active_experiment_id,
     scalar_parent_dom_contentprocess_troubled_due_to_memory_sum,

--- a/sql/telemetry/clients_last_seen_v1/view.sql
+++ b/sql/telemetry/clients_last_seen_v1/view.sql
@@ -17,21 +17,21 @@ SELECT
   WHEN
     BIT_COUNT(days_visited_5_uri_bits & 0x0FFFFFFE) = 0
   THEN
-    'new_irregular_users_v1'
+    'new_irregular_users_v2'
   WHEN
     BIT_COUNT(days_visited_5_uri_bits & 0x0FFFFFFE)
     BETWEEN 1
     AND 7
   THEN
-    'semi_regular_users_v1'
+    'semi_regular_users_v2'
   WHEN
     BIT_COUNT(days_visited_5_uri_bits & 0x0FFFFFFE)
     BETWEEN 8
     AND 27
   THEN
-    'regular_users_v1'
+    'regular_users_v2'
   END
-  AS segment_usage_regularity_v1,
+  AS segment_usage_regularity_v2,
   * EXCEPT (
     active_experiment_id,
     scalar_parent_dom_contentprocess_troubled_due_to_memory_sum,

--- a/sql/telemetry/clients_last_seen_v1/view.sql
+++ b/sql/telemetry/clients_last_seen_v1/view.sql
@@ -14,33 +14,22 @@ SELECT
     SAFE.LOG(days_created_profile_bits & -days_created_profile_bits, 2) AS INT64
   ) AS days_since_created_profile,
   CASE
-    CAST(
-      BIT_COUNT(
-        days_visited_5_uri_bits & `moz-fx-data-shared-prod.udf.bitmask_range`(2, 6)
-      ) >= 1 AS INT64
-    ) + CAST(
-      BIT_COUNT(
-        days_visited_5_uri_bits & `moz-fx-data-shared-prod.udf.bitmask_range`(8, 7)
-      ) >= 2 AS INT64
-    ) + CAST(
-      BIT_COUNT(
-        days_visited_5_uri_bits & `moz-fx-data-shared-prod.udf.bitmask_range`(15, 7)
-      ) >= 2 AS INT64
-    ) + CAST(
-      BIT_COUNT(
-        days_visited_5_uri_bits & `moz-fx-data-shared-prod.udf.bitmask_range`(22, 7)
-      ) >= 2 AS INT64
-    )
   WHEN
-    4
-  THEN
-    'regular_users_v1'
-  WHEN
-    0
+    BIT_COUNT(days_visited_5_uri_bits) & 0x0FFFFFFE = 0
   THEN
     'new_irregular_users_v1'
-  ELSE
+  WHEN
+    BIT_COUNT(days_visited_5_uri_bits) & 0x0FFFFFFE
+    BETWEEN 1
+    AND 7
+  THEN
     'semi_regular_users_v1'
+  WHEN
+    BIT_COUNT(days_visited_5_uri_bits) & 0x0FFFFFFE
+    BETWEEN 8
+    AND 27
+  THEN
+    'regular_users_v1'
   END
   AS segment_usage_regularity_v1,
   * EXCEPT (


### PR DESCRIPTION
This is a straw man proposal. Before accepting the PR:

1. With feedback from Data Science, the precise definition of the segment might be tweaked.
2. We should decide whether to include the version (v1) in the column name, column values, both, or neither. (The goal is to iterate on this definition rather than lock us into something suboptimal).
3. We should decide whether to extend `days_seen_bits` and friends to include 29 days - so that we can use 28 days of history as context for the current day (day 29).
4. My code should probably be rewritten following whatever style and naming conventions are applicable to this project!

This is related to [GUD issue #60](https://github.com/mozilla/GUD/issues/60)