### PR TITLE
Glam histogram aggregates table is partitioned by submission_date and clustered by client_id.

### DIFF
--- a/sql/telemetry_derived/clients_histogram_aggregates_v1/init.sql
+++ b/sql/telemetry_derived/clients_histogram_aggregates_v1/init.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS
   `moz-fx-data-shared-prod.telemetry_derived.clients_histogram_aggregates_v1` (
+    submission_date DATE,
     sample_id INT64,
     client_id STRING,
     os STRING,
@@ -19,5 +20,9 @@ CREATE TABLE IF NOT EXISTS
       aggregates ARRAY<STRUCT<key STRING, value INT64>>
     >>
 )
-PARTITION BY RANGE_BUCKET(sample_id, GENERATE_ARRAY(0, 100, 1))
-CLUSTER BY app_version, channel, client_id
+PARTITION BY submission_date
+CLUSTER BY sample_id, app_version, channel
+OPTIONS(
+  require_partition_filter=true,
+  partition_expiration_days=3
+);

--- a/sql/telemetry_derived/clients_histogram_aggregates_v1/query.sql
+++ b/sql/telemetry_derived/clients_histogram_aggregates_v1/query.sql
@@ -152,7 +152,8 @@ WITH clients_histogram_aggregates_new AS
 clients_histogram_aggregates_partition AS
   (SELECT *
   FROM clients_histogram_aggregates_v1
-  WHERE sample_id >= @min_sample_id
+  WHERE submission_date = DATE_SUB(@submission_date, INTERVAL 1 DAY)
+    AND sample_id >= @min_sample_id
     AND sample_id <= @max_sample_id),
 
 clients_histogram_aggregates_old AS
@@ -185,6 +186,7 @@ merged AS
     ON new_data.join_key = old_data.join_key)
 
 SELECT
+  DATE(@submission_date) AS submission_date,
   sample_id,
   client_id,
   os,


### PR DESCRIPTION
The main point here is to be able to query the previous day's `clients_histogram_aggregates` in intermediate steps. But it's also nice to keep a history of what this table looked like in the past rather than replacing it entirely on every run.