### PR TITLE
Add UDF used to define proposed segments

### DIFF
--- a/udf/num_weeks_gte_n_from_bits.sql
+++ b/udf/num_weeks_gte_n_from_bits.sql
@@ -1,0 +1,13 @@
+/*
+
+Returns the number of weeks with >=n nonzero bits, given an integer representing
+a bit array for the last 4 weeks.
+
+*/
+CREATE OR REPLACE FUNCTION udf.num_weeks_gte_n_from_bits(b BYTES, n INT64) AS (
+  CAST(BIT_COUNT(b & udf.bitmask_range(1, 7)) >= n AS INT64) + CAST(
+    BIT_COUNT(b & udf.bitmask_range(8, 7)) >= n AS INT64
+  ) + CAST(BIT_COUNT(b & udf.bitmask_range(15, 7)) >= n AS INT64) + CAST(
+    BIT_COUNT(b & udf.bitmask_range(22, 7)) >= n AS INT64
+  )
+);


### PR DESCRIPTION
I'm proposing a [trio of segments](https://github.com/mozilla/firefox-data-docs/pull/428), including "regular users v1". It is currently possible to query these segments (see the firefox-data-docs PR, or the [mozanalysis PR](https://github.com/mozilla/mozanalysis/pull/76)), but it is not very user friendly.

If we add this UDF then it becomes much easier to compute the quantities in terms of which these segments are defined.

In [PR 825](https://github.com/mozilla/bigquery-etl/pull/825), I will separately propose to add a column to `clients_last_seen` that contains each user's segment.