### PR TITLE
Remove new init.sql from dry_run

### DIFF
--- a/script/dryrun
+++ b/script/dryrun
@@ -42,6 +42,7 @@ SKIP = {
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",
     "sql/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",
+    "sql/org_mozilla_firefox_derived/migrated_clients_v1/init.sql",
     "sql/org_mozilla_fenix_derived/clients_last_seen_v1/init.sql",
     "sql/org_mozilla_vrbrowser_derived/clients_last_seen_v1/init.sql",
     "sql/telemetry_derived/core_clients_last_seen_v1/init.sql",


### PR DESCRIPTION
fixes [dryrun failure on master](https://circleci.com/gh/mozilla/bigquery-etl/11323)
```
sql/org_mozilla_firefox_derived/migrated_clients_v1/init.sql ERROR
 [{'code': 409, 'errors': [{'message': 'Already Exists: Table moz-fx-data-shared-prod:org_mozilla_firefox_derived.migrated_clients_v1', 'domain': 'global', 'reason': 'duplicate'}], 'response': {'headers': {'alt-svc': 'quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,h3-T050=":443"; ma=2592000', 'cache-control': 'private', 'content-encoding': 'gzip', 'content-type': 'application/json; charset=UTF-8', 'date': 'Wed, 25 Mar 2020 17:04:34 GMT', 'server': 'ESF', 'transfer-encoding': 'chunked', 'vary': 'Origin, X-Origin, Referer', 'x-content-type-options': 'nosniff', 'x-frame-options': 'SAMEORIGIN', 'x-xss-protection': '0'}}, 'message': 'Already Exists: Table moz-fx-data-shared-prod:org_mozilla_firefox_derived.migrated_clients_v1'}]
```