### PR TITLE
Fix null date partition condition in shredder

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -204,6 +204,8 @@ def get_partition(table, partition_expr, end_date, id_=None) -> Optional[Partiti
             return Partition(f"{partition_expr} < '{end_date}'")
         return Partition("TRUE")
     if id_ == NULL_PARTITION_ID:
+        if table.time_partitioning:
+            return Partition(f"{table.time_partitioning.field} IS NULL", id_)
         return Partition(f"{partition_expr} IS NULL", id_)
     if table.time_partitioning:
         date = datetime.strptime(id_, "%Y%m%d").date()


### PR DESCRIPTION
by changing the partition condition from `CAST(submission_timestamp AS DATE) IS NULL` to `submission_timestamp IS NULL`.

tested, fixes errors like `Cannot query over table 'moz-fx-data-shared-prod.telemetry_stable.update_v4' without a filter over column(s) 'submission_timestamp' that can be used for partition elimination`.