### PR TITLE
Add review links to public datasets and make deviations non-incremental

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ labels:
   schedule: daily       # scheduled in Airflow to run daily
   public_json: true
   public_bigquery: true
+  review_bug: 1414839   # Bugzilla bug ID of data review
 ```
 
 ### Publishing Datasets
@@ -205,9 +206,9 @@ labels:
     by everyone, also external users
 - To make query results publicly available as JSON, `public_json` flag must be set in 
   `metadata.yaml`
-  - Data will be accessible under https://public-data.prod.dataops.mozgcp.net
-  - For example: https://public-data.prod.dataops.mozgcp.net/api/v1/tables/telemetry/ssl_ratios/v1/files/0000
-  - This feature is currently under development and not available yet
+  - Data will be accessible under https://http.public-data.prod.dataops.mozgcp.net
+  - For example: http://http.public-data.prod.dataops.mozgcp.net/api/v1/tables/telemetry_derived/ssl_ratios/v1/files/000000000000.json.gz
+  - This feature is currently under development
 
 Scheduling Queries in Airflow
 ---

--- a/sql/telemetry_derived/deviations_v1/metadata.yaml
+++ b/sql/telemetry_derived/deviations_v1/metadata.yaml
@@ -8,4 +8,4 @@ labels:
   schedule: daily
   public_json: true
   public_bigquery: true
-  review_link: https://bugzilla.mozilla.org/show_bug.cgi?id=1624528
+  review_bug: 1624528

--- a/sql/telemetry_derived/deviations_v1/metadata.yaml
+++ b/sql/telemetry_derived/deviations_v1/metadata.yaml
@@ -4,7 +4,8 @@ description: >
 owners:
   - jmccrosky@mozilla.com
 labels:
-  incremental: true
+  incremental: false
   schedule: daily
   public_json: true
   public_bigquery: true
+  review_link: https://bugzilla.mozilla.org/show_bug.cgi?id=1624528

--- a/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -6,8 +6,9 @@ owners:
   - chutten@mozilla.com
 labels:
   application: firefox
+  # Note: the query is incremental but exported data is treated as non-incremental
   incremental: false
   schedule: daily
   public_json: true
   public_bigquery: true
-  review_link: https://bugzilla.mozilla.org/show_bug.cgi?id=1414839
+  review_bug: 1414839

--- a/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -6,7 +6,8 @@ owners:
   - chutten@mozilla.com
 labels:
   application: firefox
-  incremental: true
+  incremental: false
   schedule: daily
   public_json: true
   public_bigquery: true
+  review_link: https://bugzilla.mozilla.org/show_bug.cgi?id=1414839


### PR DESCRIPTION
The `deviations_v1` and `ssl_ratios` queries should be marked as non-incremental. That way, all data will get exported to one file instead of 1 file per day. 

As a next future step, metadata about existing public datasets will be published to GCS. This metadata should also contain a link to the data review.