### PR TITLE
Add build_id column to telemetry_derived.events_live

### DIFF
--- a/sql/telemetry_derived/events_live/view.sql
+++ b/sql/telemetry_derived/events_live/view.sql
@@ -10,6 +10,7 @@ AS (
     environment.settings.locale AS locale,
     normalized_app_name AS app_name,
     metadata.uri.app_version AS app_version,
+    environment.build.build_id AS build_id,
     normalized_os AS os,
     normalized_os_version AS os_version,
     environment.experiments AS experiments,


### PR DESCRIPTION
I used the name `build_id` to keep it consistent with `telemetry.events_v1` so it's easy to switch queries between the two views.