### PR TITLE
Fix: large number of files when exporting tables to JSON 

### DIFF
--- a/bigquery_etl/publish_json.py
+++ b/bigquery_etl/publish_json.py
@@ -14,7 +14,9 @@ SUBMISSION_DATE_RE = re.compile(r"^submission_date:DATE:(\d\d\d\d-\d\d-\d\d)$")
 QUERY_FILE_RE = re.compile(r"^.*/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)_(v[0-9]+)/query\.sql$")
 MAX_JSON_SIZE = 1 * 1024 * 1024 * 1024  # 1 GB as max. size of exported JSON files
 # maximum number of JSON output files, output file names are only up to 12 characters
-MAX_FILE_COUNT = 999_999_999_999
+MAX_FILE_COUNT = 10_000
+# exported file name format: 000000000000.json.gz, 000000000001.json.gz, ...
+MAX_JSON_NAME_LENGTH = 12
 
 logging.basicConfig(
     level=logging.DEBUG, format="%(asctime)s: %(levelname)s: %(message)s"
@@ -166,7 +168,9 @@ class JsonPublisher:
 
                         tmp_blob_name = "/".join(blob.name.split("/")[:-1])
                         tmp_blob_name += (
-                            "/" + str(output_file_counter).zfill(12) + ".json.tmp.gz"
+                            "/"
+                            + str(output_file_counter).zfill(MAX_JSON_NAME_LENGTH)
+                            + ".json.tmp.gz"
                         )
                         tmp_blob_path = f"gs://{self.target_bucket}/{tmp_blob_name}"
 
@@ -176,7 +180,7 @@ class JsonPublisher:
                         output_file.write("[")
                         first_line = True
                         output_file_counter += 1
-                        output_size = 3
+                        output_size = 1
 
                     # skip the first line, it has no preceding json object
                     if not first_line:

--- a/bigquery_etl/publish_json.py
+++ b/bigquery_etl/publish_json.py
@@ -46,7 +46,7 @@ class JsonPublisher:
 
         self.metadata = Metadata.of_sql_file(self.query_file)
 
-        if self.parameter:
+        if self.metadata.is_incremental() and self.parameter:
             for p in self.parameter:
                 date_search = re.search(SUBMISSION_DATE_RE, p)
 
@@ -171,11 +171,12 @@ class JsonPublisher:
                     # skip the first line, it has no preceding json object
                     if not first_line:
                         output_file.write(",\n")
-                        first_line = False
 
                     output_file.write(line.replace("\n", ""))
                     output_size += len(line) + 1
+                    first_line = False
 
+        output_file.write("]")
         output_file.close()
 
         # move all files from stage directory to target directory

--- a/bigquery_etl/publish_json.py
+++ b/bigquery_etl/publish_json.py
@@ -154,6 +154,12 @@ class JsonPublisher:
                             output_file.write("]")
                             output_file.close()
 
+                        if output_file_counter >= 1000000000000:
+                            logging.error(
+                                "Maximum number of JSON output files reached."
+                            )
+                            sys.exit(1)
+
                         tmp_blob_name = "/".join(blob.name.split("/")[:-1])
                         tmp_blob_name += (
                             "/" + str(output_file_counter).zfill(12) + ".json.tmp.gz"

--- a/tests/publish_public_data_json/test_publish_json.py
+++ b/tests/publish_public_data_json/test_publish_json.py
@@ -25,7 +25,7 @@ class TestPublishJson(object):
 
     mock_blob = Mock()
     mock_blob.download_as_string.return_value = bytes("[]", "utf-8")
-    mock_blob.name = "blob_path"
+    mock_blob.name = "blob_path/000000000000.ndjson"
 
     mock_bucket = Mock()
     mock_bucket.blob.return_value = mock_blob
@@ -142,11 +142,11 @@ class TestPublishJson(object):
 
         smart_open.open.assert_has_calls(
             [
-                call("gs://test-bucket/blob_path"),
-                call("gs://test-bucket/blob_path.tmp.gz", "w"),
+                call("gs://test-bucket/blob_path/000000000000.ndjson"),
+                call("gs://test-bucket/blob_path/000000000000.json.tmp.gz", "w"),
             ]
         )
 
-        mock_out.write.assert_has_calls(
+        file_handler.write.assert_has_calls(
             [call("[\n"), call('{"a": 1}'), call(",\n"), call('{"b": "cc"}'), call("]")]
         )

--- a/tests/publish_public_data_json/test_publish_json.py
+++ b/tests/publish_public_data_json/test_publish_json.py
@@ -148,5 +148,5 @@ class TestPublishJson(object):
         )
 
         file_handler.write.assert_has_calls(
-            [call("[\n"), call('{"a": 1}'), call(",\n"), call('{"b": "cc"}'), call("]")]
+            [call("["), call('{"a": 1}'), call(","), call('{"b": "cc"}'), call("]")]
         )

--- a/tests/publish_public_data_json/test_publish_public_data_json_script.py
+++ b/tests/publish_public_data_json/test_publish_public_data_json_script.py
@@ -46,7 +46,10 @@ class TestPublishJsonScript(object):
         try:
             self.client.get_table(self.non_incremental_table)
         except NotFound:
-            job_config = bigquery.QueryJobConfig(destination=self.non_incremental_table)
+            date_partition = bigquery.table.TimePartitioning(field="d")
+            job_config = bigquery.QueryJobConfig(
+                destination=self.non_incremental_table, time_partitioning=date_partition
+            )
 
             # create table for non-incremental query
             with open(self.non_incremental_sql_path) as query_stream:

--- a/tests/publish_public_data_json/test_sql/test/non_incremental_query_v1/query.sql
+++ b/tests/publish_public_data_json/test_sql/test/non_incremental_query_v1/query.sql
@@ -1,11 +1,14 @@
 SELECT
+  DATE '2020-03-15' AS d,
   "val1" AS a,
   2 AS b
 UNION ALL
 SELECT
+  DATE '2020-03-16' AS d,
   "val2" AS a,
   34 AS b
 UNION ALL
 SELECT
+  DATE '2020-03-16' AS d,
   "val3" AS a,
   8 AS b


### PR DESCRIPTION
This fixes https://github.com/mozilla/bigquery-etl/issues/865

For exporting data as JSON to GCS, `extract_table` is currently used. When exporting a table, data gets exported into a lot of separate files. E.g. in the case of `ssl_ratios`, a new file is created for each date. This can result in a very large number of files.

First I suspected that this is only the case for partitioned tables, but I ran some tests and it is also the case for tables that are not partitioned

The fix here: when converting ndjson to json the output will be written to one file until the output file size limit of 1 GB is reached. If the limit is exceeded a new output file is created.