### PR TITLE
Fix generate_views version parsing

### DIFF
--- a/bigquery_etl/generate_views.py
+++ b/bigquery_etl/generate_views.py
@@ -93,10 +93,9 @@ def create_views_if_not_exist(client, views, exclude, sql_dir):
             continue
 
         version = max(
-            int(match.group()[2:])
+            int(VERSION_RE.search(table).group()[2:])
             for table in tables
-            for match in VERSION_RE.search(table)
-            if match is not None
+            if VERSION_RE.search(table) is not None
         )
 
         project, dataset, viewname = view.split(".")

--- a/bigquery_etl/generate_views.py
+++ b/bigquery_etl/generate_views.py
@@ -93,9 +93,10 @@ def create_views_if_not_exist(client, views, exclude, sql_dir):
             continue
 
         version = max(
-            int(VERSION_RE.search(table).group()[2:])
+            int(match.group()[2:])
             for table in tables
-            if VERSION_RE.search(table) is not None
+            for match in [VERSION_RE.search(table)]
+            if match is not None
         )
 
         project, dataset, viewname = view.split(".")


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/896

`re.search` doesn't return an iterable, because of that an error is thrown in the list comprehension for determining the table version.