### PR TITLE
Add last_updated to GCS datasets metadata

### DIFF
--- a/bigquery_etl/public_data/publish_gcs_metadata.py
+++ b/bigquery_etl/public_data/publish_gcs_metadata.py
@@ -68,7 +68,6 @@ class GcsTableMetadata:
 
         self.last_updated_path = self.blobs[0].name.split("files")[0] + "last_updated"
         self.last_updated_uri = endpoint + self.last_updated_path
-        self.last_updated = min(self.blobs, key=lambda b: b.updated).updated
 
     def table_metadata_to_json(self):
         """Return a JSON object of the table metadata for GCS."""
@@ -167,16 +166,6 @@ def publish_table_metadata(table_metadata, bucket):
             fout.write(json.dumps(metadata.files_metadata_to_json(), indent=4))
 
 
-def publish_last_modified(table_metadata, bucket):
-    """Write the timestamp when file of the dataset were last modified to GCS."""
-    for metadata in table_metadata:
-        output_file = f"gs://{bucket}/{metadata.last_updated_path}"
-
-        logging.info(f"Write last_updated to {output_file}")
-        with smart_open.open(output_file, "w") as fout:
-            fout.write(metadata.last_updated.strftime("%Y-%m-%d %H:%M:%S"))
-
-
 def main():
     """Generate and upload GCS metadata."""
     args = parser.parse_args()
@@ -200,7 +189,6 @@ def main():
         output_file = f"gs://{args.target_bucket}/all_datasets.json"
         publish_all_datasets_metadata(gcs_table_metadata, output_file)
         publish_table_metadata(gcs_table_metadata, args.target_bucket)
-        publish_last_modified(gcs_table_metadata, args.target_bucket)
     else:
         print(
             f"Invalid target: {args.target}, target must be a directory with"

--- a/tests/data/all_datasets.json
+++ b/tests/data/all_datasets.json
@@ -7,7 +7,8 @@
                 "incremental": false,
                 "incremental_export": false,
                 "review_link": "https://bugzilla.mozilla.org/show_bug.cgi?id=1999999",
-                "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/files"
+                "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/files",
+                "last_updated": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/last_updated"
             }
         }, 
         "incremental_query": {
@@ -16,7 +17,8 @@
                 "description": "Test table for an incremental query",
                 "incremental": true,
                 "incremental_export": true,
-                "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/files"
+                "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/files",
+                "last_updated": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/last_updated"
             }
         }
     }

--- a/tests/data/all_datasets.json
+++ b/tests/data/all_datasets.json
@@ -7,6 +7,7 @@
                 "incremental": false,
                 "incremental_export": false,
                 "review_link": "https://bugzilla.mozilla.org/show_bug.cgi?id=1999999",
+                "files_metadata": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/files/metadata.json",
                 "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/files",
                 "last_updated": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/last_updated"
             }
@@ -17,6 +18,7 @@
                 "description": "Test table for an incremental query",
                 "incremental": true,
                 "incremental_export": true,
+                "files_metadata": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/files/metadata.json",
                 "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/files",
                 "last_updated": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/last_updated"
             }

--- a/tests/public_data/test_publish_gcs_metadata.py
+++ b/tests/public_data/test_publish_gcs_metadata.py
@@ -94,7 +94,6 @@ class TestPublishGcsMetadata(object):
         assert gcs_table_metadata.metadata.review_bug() == "1999999"
         assert gcs_table_metadata.last_updated_path == last_updated_path
         assert gcs_table_metadata.last_updated_uri == self.endpoint + last_updated_path
-        assert gcs_table_metadata.last_updated == datetime(2020, 4, 3, 11, 30, 1)
 
     def test_gcs_table_metadata_to_json(self):
         mock_blob = Mock()
@@ -279,46 +278,3 @@ class TestPublishGcsMetadata(object):
                 call(json.dumps(expected_incremental_query_json, indent=4)),
             ]
         )
-
-    def test_last_updated(self):
-        mock_blob1 = Mock()
-        mock_blob1.name = (
-            "api/v1/tables/test/non_incremental_query/v1/files/000000000000.json.gz"
-        )
-        mock_blob1.updated = datetime(2020, 4, 3, 11, 25, 5)
-
-        mock_blob2 = Mock()
-        mock_blob2.name = (
-            "api/v1/tables/test/non_incremental_query/v1/files/000000000001.json.gz"
-        )
-        mock_blob2.updated = datetime(2020, 4, 3, 11, 20, 5)
-
-        mock_blob3 = Mock()
-        mock_blob3.name = (
-            "api/v1/tables/test/non_incremental_query/v1/files/000000000002.json.gz"
-        )
-        mock_blob3.updated = datetime(2020, 4, 3, 12, 20, 5)
-
-        gcs_metadata = pgm.GcsTableMetadata(
-            [mock_blob1, mock_blob2, mock_blob3], self.endpoint, self.sql_dir
-        )
-        assert gcs_metadata.last_updated == datetime(2020, 4, 3, 11, 20, 5)
-
-    def test_publish_last_updated_to_gcs(self):
-        mock_blob1 = Mock()
-        mock_blob1.name = (
-            "api/v1/tables/test/non_incremental_query/v1/files/000000000000.json.gz"
-        )
-        mock_blob1.updated = datetime(2020, 4, 3, 11, 25, 5)
-
-        gcs_table_metadata = [
-            pgm.GcsTableMetadata([mock_blob1], self.endpoint, self.sql_dir)
-        ]
-
-        mock_out = MagicMock()
-        file_handler = MagicMock()
-        file_handler.__enter__.return_value = mock_out
-        smart_open.open = MagicMock(return_value=file_handler)
-
-        pgm.publish_last_modified(gcs_table_metadata, self.test_bucket)
-        mock_out.write.assert_called_with("2020-04-03 11:25:05")

--- a/tests/public_data/test_publish_gcs_metadata.py
+++ b/tests/public_data/test_publish_gcs_metadata.py
@@ -109,7 +109,7 @@ class TestPublishGcsMetadata(object):
 
         result = gcs_table_metadata.table_metadata_to_json()
 
-        assert len(result.items()) == 7
+        assert len(result.items()) == 8
         assert result["description"] == "Test table for a non-incremental query"
         assert result["friendly_name"] == "Test table for a non-incremental query"
         assert result["incremental"] is False
@@ -117,6 +117,7 @@ class TestPublishGcsMetadata(object):
         review_link = "https://bugzilla.mozilla.org/show_bug.cgi?id=1999999"
         assert result["review_link"] == review_link
         assert result["files_uri"] == self.endpoint + files_path
+        assert result["files_metadata"] == self.endpoint + files_path + "/metadata.json"
         assert result["last_updated"] == self.endpoint + last_updated_path
 
     def test_gcs_files_metadata_to_json(self):
@@ -262,7 +263,9 @@ class TestPublishGcsMetadata(object):
         file_handler.__enter__.return_value = mock_out
         smart_open.open = MagicMock(return_value=file_handler)
 
-        pgm.publish_table_metadata(gcs_table_metadata, self.test_bucket)
+        pgm.publish_table_metadata(
+            self.mock_storage_client, gcs_table_metadata, self.test_bucket
+        )
 
         metadata_file = TEST_DIR / "data" / "incremental_query_gcs_metadata.json"
         with open(metadata_file) as f:

--- a/tests/public_data/test_publish_json.py
+++ b/tests/public_data/test_publish_json.py
@@ -161,7 +161,7 @@ class TestPublishJson(object):
             self.mock_client,
             self.mock_storage_client,
             self.project_id,
-            self.incremental_sql_path,
+            str(self.incremental_sql_path),
             self.api_version,
             self.test_bucket,
             ["submission_date:DATE:2020-03-15"],

--- a/tests/public_data/test_publish_public_data_json_script.py
+++ b/tests/public_data/test_publish_public_data_json_script.py
@@ -4,6 +4,7 @@ import pytest
 import subprocess
 import zlib
 
+from pathlib import Path
 from datetime import datetime
 from google.cloud import bigquery
 from google.cloud import storage


### PR DESCRIPTION
This fixes https://github.com/mozilla/bigquery-etl/issues/886

This writes the timestamp of when the data of a dataset on GCS was last updated to GCS. In the `all_datasets.json` metadata file, for each dataset a `last_updated` entry got added which links to the corresponding `last_updated` file for this dataset.