### PR TITLE
Full qualify 1-week retention view

### DIFF
--- a/sql/telemetry/desktop_retention_1_week/view.sql
+++ b/sql/telemetry/desktop_retention_1_week/view.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE VIEW
-  `desktop_retention_1_week`
+  `moz-fx-data-shared-prod.telemetry.desktop_retention_1_week`
 AS
 SELECT
   client_id,


### PR DESCRIPTION
The error behavior is interesting in that the view looks like this when publishing is attempted:

                                -----Query Job SQL Follows-----

        |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |
       1:CREATE OR REPLACE VIEW
       2:  `moz-fx-data-shared-prod`
       3:AS
       4:SELECT
       5:  client_id,
       6:  DATE_SUB(submission_date, INTERVAL 13 DAY) AS `date`,
       7:  -- active week 1
       8:  `moz-fx-data-shared-prod`.udf.active_n_weeks_ago(days_seen_bits, 0) AS retained,
       9:FROM
      10:  `moz-fx-data-shared-prod.telemetry.clients_last_seen`
      11:WHERE
      12:  -- active week 0
      13:  `moz-fx-data-shared-prod`.udf.active_n_weeks_ago(days_seen_bits, 1)
        |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |

resulting in `google.api_core.exceptions.BadRequest: 400 Table name "moz-fx-data-shared-prod" missing dataset while no default dataset is set in the request.`.