### PR TITLE
CI build step for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,6 @@ jobs:
           name: Verify that BigQuery validates each query
           command: script/dryrun
   integration:
-    <<: *build
     docker:
     - image: python:3.8
     steps:
@@ -57,12 +56,7 @@ jobs:
             echo "Cannot pass creds to forked PRs, so marking this step successful"
             circleci step halt
           fi
-    - &build
-      run:
-        name: Build
-        command: |
-          python3.8 -m venv venv/
-          venv/bin/pip install --upgrade -r requirements.txt
+    - *build
     - &pytest_integration_test
       run:
         name: PyTest Integration Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,12 @@ jobs:
             echo "Cannot pass creds to forked PRs, so marking this step successful"
             circleci step halt
           fi
+    - &build
+      run:
+        name: Build
+        command: |
+          python3.8 -m venv venv/
+          venv/bin/pip install --upgrade -r requirements.txt
     - &pytest_integration_test
       run:
         name: PyTest Integration Test

--- a/tests/README.md
+++ b/tests/README.md
@@ -118,3 +118,27 @@ Additional Guidelines and Options
      they are mutually exclusive
    - File extensions `yaml`, `json` and `ndjson` are supported
    - Preferred format is `yaml` for readability
+
+How to Run CircleCI locally
+===
+
+- Install the [CircleCI Local CI](https://circleci.com/docs/2.0/local-cli/)
+- Download GCP [service account](https://cloud.google.com/iam/docs/service-accounts) keys
+   - Integration tests will only successfully run with service account keys
+     that belong to the `circleci` service account in the `biguqery-etl-integration-test` project
+- Run `circleci build` and set required environment variables `GOOGLE_PROJECT_ID` and
+  `GCLOUD_SERVICE_KEY`:
+
+```
+gcloud_service_key=`cat /path/to/key_file.json`
+
+# to run a specific job, e.g. integration:
+circleci build --job integration \
+  --env GOOGLE_PROJECT_ID=bigquery-etl-integration-test \
+  --env GCLOUD_SERVICE_KEY=$gcloud_service_key
+
+# to run all jobs
+circleci build \
+  --env GOOGLE_PROJECT_ID=bigquery-etl-integration-test \
+  --env GCLOUD_SERVICE_KEY=$gcloud_service_key
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -119,7 +119,7 @@ Additional Guidelines and Options
    - File extensions `yaml`, `json` and `ndjson` are supported
    - Preferred format is `yaml` for readability
 
-How to Run CircleCI locally
+How to Run CircleCI Locally
 ===
 
 - Install the [CircleCI Local CI](https://circleci.com/docs/2.0/local-cli/)


### PR DESCRIPTION
When running integration tests it currently fails with: 

```
script/entrypoint: line 25: exec: pytest: not found
```

