### PR TITLE
Set content type for last_updated files

### DIFF
--- a/bigquery_etl/public_data/publish_json.py
+++ b/bigquery_etl/public_data/publish_json.py
@@ -4,6 +4,7 @@ from argparse import ArgumentParser
 from google.cloud import storage
 from google.cloud import bigquery
 import datetime
+import json
 import smart_open
 import logging
 import sys
@@ -250,13 +251,14 @@ class JsonPublisher:
         logging.info(f"Write last_updated to {output_file}")
 
         with smart_open.open(output_file, "w") as fout:
-            fout.write(self.last_updated.strftime("%Y-%m-%d %H:%M:%S"))
+            last_updated = self.last_updated.strftime("%Y-%m-%d %H:%M:%S")
+            fout.write(json.dumps(last_updated))
 
         # set Content-Type to plain text so that timestamp is displayed in the browser
         blob = self.storage_client.get_bucket(self.target_bucket).get_blob(
             last_updated_path
         )
-        blob.content_type = "text/plain"
+        blob.content_type = "application/json"
         blob.patch()
 
 

--- a/bigquery_etl/public_data/publish_json.py
+++ b/bigquery_etl/public_data/publish_json.py
@@ -252,6 +252,13 @@ class JsonPublisher:
         with smart_open.open(output_file, "w") as fout:
             fout.write(self.last_updated.strftime("%Y-%m-%d %H:%M:%S"))
 
+        # set Content-Type to plain text so that timestamp is displayed in the browser
+        blob = self.storage_client.get_bucket(self.target_bucket).get_blob(
+            last_updated_path
+        )
+        blob.content_type = "text/plain"
+        blob.patch()
+
 
 parser = ArgumentParser(description=__doc__)
 parser.add_argument(

--- a/sql/telemetry_derived/asn_aggregates_v1/metadata.yaml
+++ b/sql/telemetry_derived/asn_aggregates_v1/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: ASN Aggregates
-description: >
+description: >-
   A daily aggregate of clients per ASN (Autonomous System Number) and 
   DoH (DNS over HTTPS) usage, partitioned by day. Only ASNs with more 
   than a critical threshold of clients are considered.

--- a/sql/telemetry_derived/deviations_v1/metadata.yaml
+++ b/sql/telemetry_derived/deviations_v1/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: Deviations
-description: >
+description: >-
   Deviation of different metrics from forecast.
 owners:
   - jmccrosky@mozilla.com

--- a/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: SSL Ratios
-description: >
+description: >-
   Percentages of page loads Firefox users have performed that were 
   conducted over SSL broken down by country.
 owners:

--- a/tests/public_data/test_publish_json.py
+++ b/tests/public_data/test_publish_json.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import smart_open
 from pathlib import Path
@@ -178,5 +179,5 @@ class TestPublishJson(object):
 
         assert publisher.last_updated is not None
         mock_out.write.assert_called_with(
-            publisher.last_updated.strftime("%Y-%m-%d %H:%M:%S")
+            json.dumps(publisher.last_updated.strftime("%Y-%m-%d %H:%M:%S"))
         )


### PR DESCRIPTION
This explicitly updates the Content-Type for `last_updated` files to `text/plain`. That way when the files are opened in the browser the timestamp will get displayed directly. Currently, the browser will download the file.