### PR TITLE
Fix last_updated integration test

### DIFF
--- a/tests/public_data/test_publish_public_data_json_script.py
+++ b/tests/public_data/test_publish_public_data_json_script.py
@@ -225,7 +225,7 @@ class TestPublishJsonScript(object):
 
         for blob in blobs:
             blob_count += 1
-            last_updated = blob.download_as_string()
-            datetime.strptime(last_updated.decode("utf-8"), "%Y-%m-%d %H:%M:%S")
+            last_updated = json.loads(blob.download_as_string().decode("utf-8"))
+            datetime.strptime(last_updated, "%Y-%m-%d %H:%M:%S")
 
         assert blob_count == 1


### PR DESCRIPTION
I changed for `last_updated` to store the timestamp as JSON but didn't update the integration test after.