### PR TITLE
Fix search view reference

### DIFF
--- a/sql/search/search_clients_last_seen_v1/view.sql
+++ b/sql/search/search_clients_last_seen_v1/view.sql
@@ -11,7 +11,7 @@ SELECT
     days_searched_with_ads_bytes
   ) AS days_since_searched_with_ads,
   `moz-fx-data-shared-prod`.udf.bits_to_days_since_seen(
-    days_clicked_ad_bytes
+    days_clicked_ads_bytes
   ) AS days_since_clicked_ad,
   `moz-fx-data-shared-prod`.udf.bits_to_days_since_first_seen(
     days_created_profile_bytes


### PR DESCRIPTION
Ignored in dryrun due to being a search view, and failed on deploy like so:

    google.api_core.exceptions.BadRequest: 400 GET Unrecognized name: days_clicked_ad_bytes; Did you mean days_clicked_ads_bytes? at [14:5]

Side note: https://bugzilla.mozilla.org/show_bug.cgi?id=1623180 will likely open up access to this dataset at some point.