### PR TITLE
Limit metrics published in deviations query

### DIFF
--- a/sql/telemetry_derived/deviations_v1/query.sql
+++ b/sql/telemetry_derived/deviations_v1/query.sql
@@ -7,5 +7,7 @@ SELECT
 FROM
   `moz-fx-data-shared-prod.analysis.deviations`
 WHERE
+  -- We explicitly enumerate allowed metric types here so that we do not automatically
+  -- publish new metric types publicly without review.
   metric IN ('desktop_dau', 'mean_active_hours_per_client')
   AND date = @submission_date

--- a/sql/telemetry_derived/deviations_v1/query.sql
+++ b/sql/telemetry_derived/deviations_v1/query.sql
@@ -6,4 +6,6 @@ SELECT
   metric
 FROM
   `moz-fx-data-shared-prod.analysis.deviations`
-WHERE date = @submission_date
+WHERE
+  metric IN ('desktop_dau', 'mean_active_hours_per_client')
+  AND date = @submission_date


### PR DESCRIPTION
To ensure we are not accidentally publishing data, only approved `metric`s from `deviations` are published. If there are more metrics in the future, those can be added after there has been a data review.

cc @jmccrosky