### PR TITLE
[Bug 1633754] Add queries for anomaly detection pipeline

### DIFF
--- a/sql/telemetry_derived/clients_daily_active_hours_by_country_aggregates_v1/metadata.yaml
+++ b/sql/telemetry_derived/clients_daily_active_hours_by_country_aggregates_v1/metadata.yaml
@@ -1,0 +1,9 @@
+friendly_name: Clients daily active hours by country aggregates
+description: >-
+  Mean active hours of daily active clients by country, partitioned by day.
+owners:
+  - jmccrosky@mozilla.com
+  - ascholtz@mozilla.com
+labels:
+  incremental: true
+  schedule: daily

--- a/sql/telemetry_derived/clients_daily_active_hours_by_country_aggregates_v1/query.sql
+++ b/sql/telemetry_derived/clients_daily_active_hours_by_country_aggregates_v1/query.sql
@@ -1,0 +1,42 @@
+WITH geo_t AS (
+  SELECT
+    client_id,
+    geo
+  FROM
+    (
+      SELECT
+        client_id,
+        country AS geo,
+        ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY submission_date DESC) AS rn
+      FROM
+        `moz-fx-data-shared-prod.telemetry.clients_daily` AS cd_t
+      WHERE
+        submission_date = @submission_date
+    )
+  WHERE
+    rn = 1
+)
+SELECT
+  submission_date AS date,
+  AVG(active_hours_sum) AS value,
+  COUNT(client_id) AS dau,
+  geo_t.geo AS geo
+FROM
+  (
+    SELECT
+      active_hours_sum,
+      client_id,
+      submission_date,
+    FROM
+      `moz-fx-data-shared-prod.telemetry.clients_daily`
+    WHERE
+      submission_date = @submission_date
+      AND attribution.content IS NOT NULL
+  )
+INNER JOIN
+  geo_t
+USING
+  (client_id)
+GROUP BY
+  geo,
+  submission_date

--- a/sql/telemetry_derived/clients_daily_active_hours_by_top_city_aggregates_v1/metadata.yaml
+++ b/sql/telemetry_derived/clients_daily_active_hours_by_top_city_aggregates_v1/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Clients daily active hours by top cities aggregates
+description: >-
+  Mean active hours of daily active clients by city, partitioned by day and
+  restricted to the top 1000 cities according to DAU on an arbitrary day.
+owners:
+  - jmccrosky@mozilla.com
+  - ascholtz@mozilla.com
+labels:
+  incremental: true
+  schedule: daily

--- a/sql/telemetry_derived/clients_daily_active_hours_by_top_city_aggregates_v1/query.sql
+++ b/sql/telemetry_derived/clients_daily_active_hours_by_top_city_aggregates_v1/query.sql
@@ -1,0 +1,65 @@
+WITH top_cities_t AS (
+  SELECT
+    COUNT(client_id) AS dau,
+    CONCAT(country, ":", geo_subdivision1, ":", geo_subdivision2, ":", city) AS geo
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date = "2020-03-01"
+    AND city != "??"
+  GROUP BY
+    country,
+    geo_subdivision1,
+    geo_subdivision2,
+    city
+  ORDER BY
+    dau DESC
+  LIMIT
+    1000
+),
+geo_t AS (
+  SELECT
+    client_id,
+    geo
+  FROM
+    (
+      SELECT
+        client_id,
+        CONCAT(country, ":", geo_subdivision1, ":", geo_subdivision2, ":", cd_t.city) AS geo,
+        ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY submission_date DESC) AS rn
+      FROM
+        `moz-fx-data-shared-prod.telemetry.clients_daily` AS cd_t
+      INNER JOIN
+        (SELECT geo FROM top_cities_t) AS top_cities_t
+      ON
+        CONCAT(country, ":", geo_subdivision1, ":", geo_subdivision2, ":", city) = top_cities_t.geo
+      WHERE
+        submission_date = @submission_date
+    )
+  WHERE
+    rn = 1
+)
+SELECT
+  submission_date AS date,
+  AVG(active_hours_sum) AS value,
+  COUNT(client_id) AS dau,
+  geo_t.geo AS geo
+FROM
+  (
+    SELECT
+      active_hours_sum,
+      client_id,
+      submission_date,
+    FROM
+      `moz-fx-data-shared-prod.telemetry.clients_daily`
+    WHERE
+      submission_date = @submission_date
+      AND attribution.content IS NOT NULL
+  )
+INNER JOIN
+  geo_t
+USING
+  (client_id)
+GROUP BY
+  geo,
+  submission_date

--- a/sql/telemetry_derived/clients_daily_by_country_aggregates_v1/metadata.yaml
+++ b/sql/telemetry_derived/clients_daily_by_country_aggregates_v1/metadata.yaml
@@ -1,0 +1,9 @@
+friendly_name: Clients daily by country aggregates
+description: >-
+  Number of daily active clients by country, partitioned by day.
+owners:
+  - jmccrosky@mozilla.com
+  - ascholtz@mozilla.com
+labels:
+  incremental: true
+  schedule: daily

--- a/sql/telemetry_derived/clients_daily_by_country_aggregates_v1/query.sql
+++ b/sql/telemetry_derived/clients_daily_by_country_aggregates_v1/query.sql
@@ -1,0 +1,41 @@
+WITH geo_t AS (
+  SELECT
+    client_id,
+    geo
+  FROM
+    (
+      SELECT
+        client_id,
+        country AS geo,
+        ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY submission_date DESC) AS rn
+      FROM
+        `moz-fx-data-shared-prod.telemetry.clients_daily` AS cd_t
+      WHERE
+        submission_date = @submission_date
+    )
+  WHERE
+    rn = 1
+)
+SELECT
+  submission_date AS date,
+  COUNT(client_id) AS value,
+  COUNT(client_id) AS dau,
+  geo_t.geo AS geo
+FROM
+  (
+    SELECT
+      client_id,
+      submission_date,
+    FROM
+      `moz-fx-data-shared-prod.telemetry.clients_daily`
+    WHERE
+      submission_date = @submission_date
+      AND attribution.content IS NOT NULL
+  )
+INNER JOIN
+  geo_t
+USING
+  (client_id)
+GROUP BY
+  geo,
+  submission_date

--- a/sql/telemetry_derived/clients_daily_by_top_city_aggregates_v1/metadata.yaml
+++ b/sql/telemetry_derived/clients_daily_by_top_city_aggregates_v1/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Clients daily by top cities aggregates
+description: >-
+  Number of daily active clients by city, partitioned by day and
+  restricted to the top 1000 cities according to DAU on an arbitrary day.
+owners:
+  - jmccrosky@mozilla.com
+  - ascholtz@mozilla.com
+labels:
+  incremental: true
+  schedule: daily

--- a/sql/telemetry_derived/clients_daily_by_top_city_aggregates_v1/query.sql
+++ b/sql/telemetry_derived/clients_daily_by_top_city_aggregates_v1/query.sql
@@ -1,0 +1,64 @@
+WITH top_cities_t AS (
+  SELECT
+    COUNT(client_id) AS dau,
+    CONCAT(country, ":", geo_subdivision1, ":", geo_subdivision2, ":", city) AS geo
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date = "2020-03-01"
+    AND city != "??"
+  GROUP BY
+    country,
+    geo_subdivision1,
+    geo_subdivision2,
+    city
+  ORDER BY
+    dau DESC
+  LIMIT
+    1000
+),
+geo_t AS (
+  SELECT
+    client_id,
+    geo
+  FROM
+    (
+      SELECT
+        client_id,
+        CONCAT(country, ":", geo_subdivision1, ":", geo_subdivision2, ":", cd_t.city) AS geo,
+        ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY submission_date DESC) AS rn
+      FROM
+        `moz-fx-data-shared-prod.telemetry.clients_daily` AS cd_t
+      INNER JOIN
+        (SELECT geo FROM top_cities_t) AS top_cities_t
+      ON
+        CONCAT(country, ":", geo_subdivision1, ":", geo_subdivision2, ":", city) = top_cities_t.geo
+      WHERE
+        submission_date = @submission_date
+    )
+  WHERE
+    rn = 1
+)
+SELECT
+  submission_date AS date,
+  COUNT(client_id) AS value,
+  COUNT(client_id) AS dau,
+  geo_t.geo AS geo
+FROM
+  (
+    SELECT
+      client_id,
+      submission_date,
+    FROM
+      `moz-fx-data-shared-prod.telemetry.clients_daily`
+    WHERE
+      submission_date = @submission_date
+      AND attribution.content IS NOT NULL
+  )
+INNER JOIN
+  geo_t
+USING
+  (client_id)
+GROUP BY
+  geo,
+  submission_date


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1633754

The anomaly detection pipeline in https://github.com/mozilla/forecasting/pull/27 depends on these tables.

I'll have to do a backfill once this gets approved since the anomaly detection pipeline depends on all the past data.

cc @jmccrosky