### PR TITLE
Update deviations query for Airflow anomdtct pipeline usage

### DIFF
--- a/script/dryrun
+++ b/script/dryrun
@@ -45,7 +45,6 @@ SKIP = {
     "sql/search/search_rfm/view.sql",
     "sql/search/search_clients_last_seen_v1/view.sql",
     "sql/search/search_clients_last_seen/view.sql",
-    "sql/telemetry_derived/deviations_v1/query.sql",
     "sql/firefox_accounts_derived/fxa_amplitude_export_v1/query.sql",
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",

--- a/sql/telemetry_derived/deviations_v1/query.sql
+++ b/sql/telemetry_derived/deviations_v1/query.sql
@@ -5,7 +5,7 @@ SELECT
   geography,
   metric
 FROM
-  `moz-fx-data-shared-prod.analysis.deviations`
+  `moz-fx-data-shared-prod.telemetry_derived.deviations_v1`
 WHERE
   -- We explicitly enumerate allowed metric types here so that we do not automatically
   -- publish new metric types publicly without review.

--- a/sql/telemetry_derived/deviations_v1/query.sql
+++ b/sql/telemetry_derived/deviations_v1/query.sql
@@ -5,7 +5,7 @@ SELECT
   geography,
   metric
 FROM
-  `moz-fx-data-shared-prod.telemetry_derived.deviations_v1`
+  deviations_anomdtct_v1
 WHERE
   -- We explicitly enumerate allowed metric types here so that we do not automatically
   -- publish new metric types publicly without review.


### PR DESCRIPTION
The anomaly detection pipeline scheduled via Airflow in https://github.com/mozilla/telemetry-airflow/pull/977 writes data to `telemetry_derived.deviations_v1`. In order for the data to get published we need to run this query. What is a bit unusual is that it will read the partition of the date to be processed and replace it at the same time.