### PR TITLE
Add instructions on how to publish data for a static dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,17 @@ labels:
       - https://public-data.telemetry.mozilla.org/api/v1/tables/telemetry_derived/ssl_ratios/v1/files/2020-03-15/000000000000.json
 - For each dataset, a `metadata.json` gets published listing all available files, for example: https://public-data.telemetry.mozilla.org/api/v1/tables/telemetry_derived/ssl_ratios/v1/files/metadata.json
 - The timestamp when the dataset was last updated is recorded in `last_updated`, e.g.: https://public-data.telemetry.mozilla.org/api/v1/tables/telemetry_derived/ssl_ratios/v1/last_updated
+- To publish data of queries not scheduled via Airflow, e.g. for static datasets, run: `./script/entrypoint query <path/to/query.sql> --use_legacy_sql=false --parameter=some_parameter:INT:123`
+    - Credentials with permissions to read and write BigQuery data in `moz-fx-data-shared-prod` need to be made available in the current environment, for example by running `gcloud auth application-default login`
+    - It is recommended to set up a [virtual environment](https://docs.python.org/3/library/venv.html) and install all requirements:
+```
+# create a venv
+python3.8 -m venv venv/
+
+# install requirements
+venv/bin/pip install -r requirements.txt
+```
+    - All parameters and options that are offered by the [bq CLI](https://cloud.google.com/bigquery/docs/bq-command-line-tool) can be used when calling `entrypoint`
 
 Scheduling Queries in Airflow
 ---


### PR DESCRIPTION
Related to https://github.com/mozilla/bigquery-etl/pull/934

I added some instructions on how to publish data for a query once as is the case for some static datasets.

I don't think this should get merged. Instead, our current efforts with providing lower-friction scheduled queries will take this use case into account and support in metadata files something like:

```yaml
# ...
labels:
  incremental: false
  schedule: once
``` 

Publishing the results to a private GCP sandbox project will require creating a bucket and running: 

```
./script/entrypoint query <path/to/query.sql> --use_legacy_sql=false --public_project_id=<GCP sandbox project> --target_bucket=<name of the bucket to publish data to>
```

cc @Dexterp37 