### PR TITLE
Update json_extract_missing_cols to get missing columns from arrays

### DIFF
--- a/udf_js/json_extract_missing_cols.sql
+++ b/udf_js/json_extract_missing_cols.sql
@@ -86,11 +86,11 @@ WITH
           "other-second": "value",
           "array": [
             {
-              "array-element": "value",
-              "another-array-element": "value"
+              "duplicate-array-element": "value",
+              "unique-array-element": "value"
             },
             {
-              "array-element": "value", 
+              "duplicate-array-element": "value", 
               "nested-array-element": {"nested": "value"}
             }
           ]
@@ -108,11 +108,11 @@ WITH
     --
     SELECT
       assert_array_equals_any_order(no_args, ARRAY['`first`.`second`.`third`', '`first`.`other-second`',
-        '`first`.`array`.[...].`nested-array-element`.`nested`', '`first`.`array`.[...].`array-element`', 
-        '`first`.`array`.[...].`another-array-element`']),
+        '`first`.`array`.[...].`nested-array-element`.`nested`', '`first`.`array`.[...].`duplicate-array-element`', 
+        '`first`.`array`.[...].`unique-array-element`']),
       assert_array_equals_any_order(indicates_node_arg, ARRAY['`first`.`second`', '`first`.`other-second`', 
-        '`first`.`array`.[...].`nested-array-element`.`nested`', '`first`.`array`.[...].`array-element`',
-        '`first`.`array`.[...].`another-array-element`']),
+        '`first`.`array`.[...].`nested-array-element`.`nested`', '`first`.`array`.[...].`duplicate-array-element`',
+        '`first`.`array`.[...].`unique-array-element`']),
       assert_array_equals_any_order(is_node_arg, ARRAY['`first`'])
   FROM
     extracted


### PR DESCRIPTION
The missing columns dashboard doesn't show missing columns in arrays. I updated the missing_cols UDF to also extract those columns. Key paths with arrays would be represented like 

`first`.`array`.[...].`nested-array-element`.`nested` 

with [...] indicating that the element is an array.