### PR TITLE
Add script to generate desktop glam queries

### DIFF
--- a/script/glam/generate_and_run_desktop_sql
+++ b/script/glam/generate_and_run_desktop_sql
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# import run_query procedure from run_glam_sql without running the script
+IMPORT=true source script/glam/run_glam_sql
+
+
+function generate_and_run_sql {
+    local probe_type=$1
+    local windows_release_sample_percent=$2
+    local script_type
+    local query_name
+    local destination_table
+    local write_disposition
+
+    echo "generating sql for ${probe_type}"
+
+    case $probe_type in
+        histogram | keyed_histogram)
+            script_type="histogram"
+            ;;
+        scalar | keyed_scalar | keyed_boolean)
+            script_type="scalar"
+            ;;
+        *)
+            echo "probe probe_type must be one of { histogram | keyed_histogram | scalar | keyed_scalar | keyed_boolean }"
+            exit 1
+            ;;
+    esac
+
+    python3 "sql/telemetry_derived/clients_daily_${script_type}_aggregates_v1.sql.py" \
+        "--agg-type=${probe_type}s" \
+        > "sql/telemetry_derived/clients_daily_${probe_type}_aggregates_v1/query.sql"
+
+    echo "generated sql/telemetry_derived/clients_daily_${probe_type}_aggregates_v1/query.sql"
+
+    if [[ -z $RUN_QUERY ]]; then
+        return
+    fi
+
+    if [[ -n $APPEND ]]; then
+        write_disposition="--append_table"
+    else
+        write_disposition="--replace"
+    fi
+
+    run_query "clients_daily_${script_type}_aggregates_v1" \
+        true 0 99 "clients_daily_${probe_type}_aggregates_v1" \
+        "$write_disposition --clustering_fields=app_version,channel --time_partitioning_field=submission_date" \
+        "$(if [[ -n $windows_release_sample_percent ]]; then echo $windows_release_sample_percent; fi)"
+
+}
+
+probe_types=${1:-"scalar" "keyed_boolean" "keyed_scalar" "histogram" "keyed_histogram"}
+
+for probe_type in ${probe_types[@]}; do
+    generate_and_run_sql $probe_type $2
+done

--- a/script/glam/run_glam_sql
+++ b/script/glam/run_glam_sql
@@ -108,51 +108,73 @@ function run_partitioned_query {
     local table_name=$1
     local num_partitions=${2:-5}
     local partitioned_result=${3:-true}
+    local partitioning_field="$(if [ -n "$4" ]; then echo --time_partitioning_field=$4; fi)"
+    local clustering_fields="$(if [ -n "$5" ]; then echo --clustering_fields=$5; fi)"
+    local additional_arguments="--append_table ${partitioning_field} ${clustering_fields}"
 
     local NUM_SAMPLE_IDS=100
     local PARTITION_SIZE=$((NUM_SAMPLE_IDS / num_partitions))
 
-    run_query $table_name true 0 $((PARTITION_SIZE - 1))
+    run_query $table_name true 0 $((PARTITION_SIZE - 1)) \
+        $table_name "$additional_arguments"
+
     for partition in $(seq 1 $((num_partitions - 1))); do
         local min_param=$((partition * PARTITION_SIZE))
         local max_param=$((min_param + PARTITION_SIZE - 1))
         run_query $table_name $partitioned_result $min_param $max_param \
-            $table_name "--append_table"
+            $table_name "$additional_arguments"
     done
 }
 
 
 function run_desktop_sql {
-    run_query "latest_versions"
+    local start_stage=${START_STAGE:-0}
+
+    if ((start_stage <= 0)); then
+        run_query "latest_versions"
+    fi
 
     # Run clients_daily_*_scalar_aggregates
-    run_init "clients_daily_scalar_aggregates_v1"
-    run_query "clients_daily_scalar_aggregates_v1" true
-    run_query "clients_daily_scalar_aggregates_v1" \
-        true 0 0 "clients_daily_keyed_scalar_aggregates_v1" \
-        "--append_table"
-    run_query "clients_daily_scalar_aggregates_v1" \
-        true 0 0 "clients_daily_keyed_boolean_aggregates_v1" \
-        "--append_table"
+    if ((start_stage <= 1)); then
+        run_init "clients_daily_scalar_aggregates_v1"
+        run_query "clients_daily_scalar_aggregates_v1" \
+            true 0 0 "clients_daily_scalar_aggregates_v1" \
+            "--replace --clustering_fields=app_version,channel --time_partitioning_field=submission_date"
+        run_query "clients_daily_scalar_aggregates_v1" \
+            true 0 0 "clients_daily_keyed_scalar_aggregates_v1" \
+            "--append_table --clustering_fields=app_version,channel --time_partitioning_field=submission_date"
+        run_query "clients_daily_scalar_aggregates_v1" \
+            true 0 0 "clients_daily_keyed_boolean_aggregates_v1" \
+            "--append_table --clustering_fields=app_version,channel --time_partitioning_field=submission_date"
+    fi
 
     # Run clients_daily_*_histogram_aggregates
-    run_init "clients_daily_histogram_aggregates_v1"
-    run_query "clients_daily_histogram_aggregates_v1" true 0 0
-    run_query "clients_daily_histogram_aggregates_v1" \
-        true 0 0 "clients_daily_keyed_histogram_aggregates_v1" \
-        "--append_table"
+    if ((start_stage <= 2)); then
+        run_init "clients_daily_histogram_aggregates_v1"
+        run_query "clients_daily_histogram_aggregates_v1" \
+            true 0 0 "clients_daily_histogram_aggregates_v1" \
+            "--replace --clustering_fields=app_version,channel --time_partitioning_field=submission_date"
+        run_query "clients_daily_histogram_aggregates_v1" \
+            true 0 0 "clients_daily_keyed_histogram_aggregates_v1" \
+            "--append_table --clustering_fields=app_version,channel --time_partitioning_field=submission_date"
+    fi
 
     # Run the rest of the clients scalar pipeline
-    run_init "clients_scalar_aggregates_v1"
-    run_query "clients_scalar_aggregates_v1"
-    run_query "clients_scalar_bucket_counts_v1"
-    run_query "clients_scalar_probe_counts_v1"
-    run_query "scalar_percentiles_v1"
+    if ((start_stage <= 3)); then
+        run_init "clients_scalar_aggregates_v1"
+        run_query "clients_scalar_aggregates_v1"
+        run_query "clients_scalar_bucket_counts_v1"
+        run_query "clients_scalar_probe_counts_v1"
+        run_query "scalar_percentiles_v1"
+    fi
 
     # Run the rest of the clients histogram pipeline
-    run_init "clients_histogram_aggregates_v1"
-    run_query "clients_histogram_aggregates_new_v1"
-    run_partitioned_query "clients_histogram_aggregates_v1"
+    if ((start_stage <= 4)); then
+        run_init "clients_histogram_aggregates_v1"
+        run_query "clients_histogram_aggregates_new_v1"
+        run_partitioned_query "clients_histogram_aggregates_v1" \
+            true "submission_date" "sample_id,app_version,channel"
+    fi
 
     run_partitioned_query "clients_histogram_bucket_counts_v1" 10 false
     run_query "clients_histogram_probe_counts_v1"
@@ -235,4 +257,6 @@ function main {
     fi
 }
 
-main
+if [[ -z "$IMPORT" ]]; then
+    main
+fi

--- a/sql/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
+++ b/sql/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
@@ -22,7 +22,7 @@ p = argparse.ArgumentParser()
 p.add_argument(
     "--agg-type",
     type=str,
-    help="One of scalar/keyed-scalar/keyed-boolean",
+    help="One of scalars/keyed_scalars/keyed_booleans",
     required=True,
 )
 p.add_argument(
@@ -72,7 +72,7 @@ def generate_sql(
                 AND normalized_channel in (
                   "release", "beta", "nightly"
                 )
-                AND client_id IS NOT NULL)
+                AND client_id IS NOT NULL),
 
         {additional_queries}
 


### PR DESCRIPTION
(fixes #760)

Separate script for generating query to match fenix pattern.  So both generate and run can be run through airflow like `bash script/glam/generate_desktop_sql && script/glam/run_glam_sql`.

A follow-up to this could be to simplify tests by having some `local` argument in the generate scripts that generate the queries using constant set of probes so we don't need to update the schemas every time.  We can commit that to the repo since we don't need to keep the real queries here anymore.