### PR TITLE
Bug 1632635 - Make FxA Amplitude export PDT-based

### DIFF
--- a/sql/firefox_accounts/fxa_amplitude_export/view.sql
+++ b/sql/firefox_accounts/fxa_amplitude_export/view.sql
@@ -3,6 +3,7 @@ CREATE OR REPLACE VIEW
 AS
 WITH active_users AS (
   SELECT
+    TIMESTAMP(submission_date_pacific, "America/Los_Angeles") AS submission_timestamp,
     `moz-fx-data-shared-prod`.udf.active_values_from_days_seen_map(
       os_used_month,
       0,
@@ -18,7 +19,7 @@ WITH active_users AS (
       -27,
       28
     ) AS os_used_month,
-    * EXCEPT (days_seen_bits, os_used_month)
+    * EXCEPT (days_seen_bits, os_used_month, submission_date_pacific)
   FROM
     `moz-fx-data-shared-prod`.firefox_accounts_derived.fxa_amplitude_export_v1
   WHERE

--- a/sql/firefox_accounts/fxa_amplitude_export/view.sql
+++ b/sql/firefox_accounts/fxa_amplitude_export/view.sql
@@ -18,9 +18,7 @@ WITH active_users AS (
       -27,
       28
     ) AS os_used_month,
-    * EXCEPT (days_seen_bits, os_used_month) REPLACE(
-      TIMESTAMP(timestamp, "America/Los_Angeles") AS timestamp
-    )
+    * EXCEPT (days_seen_bits, os_used_month)
   FROM
     `moz-fx-data-shared-prod`.firefox_accounts_derived.fxa_amplitude_export_v1
   WHERE

--- a/sql/firefox_accounts_derived/fxa_amplitude_export_v1/init.sql
+++ b/sql/firefox_accounts_derived/fxa_amplitude_export_v1/init.sql
@@ -1,13 +1,13 @@
 CREATE OR REPLACE TABLE
   `moz-fx-data-shared-prod`.firefox_accounts_derived.fxa_amplitude_export_v1
 PARTITION BY
-  (DATE(submission_timestamp))
+  (submission_date_pacific)
 CLUSTER BY
   (user_id)
 AS
 WITH columns AS (
   SELECT
-    CAST(NULL AS TIMESTAMP) AS submission_timestamp,
+    CAST(NULL AS DATE) AS submission_date_pacific,
     CAST(NULL AS STRING) AS user_id,
     CAST(NULL AS STRING) AS insert_id,
     CAST(NULL AS DATETIME) AS timestamp,


### PR DESCRIPTION
The FxA Amplitude project uses PDT-based days. The previous approach of using UTC-based days and casting to PDT-based is wrong, since the day offsets are actually different for the two timezones.

This approach assumes we run the airflow DAG at EOD-PDT, rather than EOD-UTC.