### PR TITLE
Implement fxa_amplitude_user_ids table

### DIFF
--- a/script/dryrun
+++ b/script/dryrun
@@ -47,6 +47,7 @@ SKIP = {
     "sql/search/search_clients_last_seen/view.sql",
     "sql/firefox_accounts_derived/fxa_amplitude_export_v1/query.sql",
     "sql/firefox_accounts_derived/fxa_amplitude_user_ids_v1/query.sql",
+    "sql/firefox_accounts_derived/fxa_amplitude_user_ids_v1/init.sql",
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",
     "sql/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",

--- a/script/dryrun
+++ b/script/dryrun
@@ -46,6 +46,7 @@ SKIP = {
     "sql/search/search_clients_last_seen_v1/view.sql",
     "sql/search/search_clients_last_seen/view.sql",
     "sql/firefox_accounts_derived/fxa_amplitude_export_v1/query.sql",
+    "sql/firefox_accounts_derived/fxa_amplitude_user_ids_v1/query.sql",
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",
     "sql/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",

--- a/sql/firefox_accounts/sync_send_tab_export/view.sql
+++ b/sql/firefox_accounts/sync_send_tab_export/view.sql
@@ -1,7 +1,7 @@
 -- Sampled view on send tab metrics intended for sending to Amplitude;
 -- see https://bugzilla.mozilla.org/show_bug.cgi?id=1628740
 CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.telemetry_derived.sync_send_tab_events_v1`
+  `moz-fx-data-shared-prod.firefox_accounts_derived.sync_send_tab_export`
 AS
 WITH events AS (
   SELECT
@@ -38,7 +38,7 @@ cleaned AS (
 )
 SELECT
   cleaned.submission_timestamp,
-  e.user_id,
+  ids.user_id,
   device_id,
   ARRAY_TO_STRING(
     [device_id, event_category, event_method, event_object, server_time, flow_id],
@@ -67,7 +67,7 @@ SELECT
         FROM
           UNNEST(
             [
-              STRUCT('fxa_uid' AS key, e.user_id AS value),
+              STRUCT('fxa_uid' AS key, ids.user_id AS value),
               STRUCT('ua_browser', metadata.user_agent.browser),
               STRUCT('ua_version', metadata.user_agent.version)
             ]
@@ -98,12 +98,9 @@ FROM
 -- first 32 characters of the 64-character hash sent to Amplitude by other producers;
 -- we join based on the prefix to recover the full 64-character hash.
 LEFT JOIN
-  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_amplitude_export_v1` AS e
+  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_amplitude_user_ids_v1` AS ids
 ON
-  (
-    cleaned.payload.uid = SUBSTR(e.user_id, 1, 32)
-    AND DATE(cleaned.submission_timestamp) = DATE(e.submission_timestamp)
-  )
+  cleaned.payload.uid = SUBSTR(ids.user_id, 1, 32)
 WHERE
   -- To save on Amplitude budget, we take a 10% sample based on user ID.
   MOD(ABS(FARM_FINGERPRINT(payload.uid)), 100) < 10

--- a/sql/firefox_accounts_derived/fxa_amplitude_user_ids_v1/init.sql
+++ b/sql/firefox_accounts_derived/fxa_amplitude_user_ids_v1/init.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE TABLE
+  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_amplitude_user_ids_v1`
+AS
+WITH hmac_key AS (
+  SELECT
+    AEAD.DECRYPT_BYTES(
+      (SELECT keyset FROM `moz-fx-dataops-secrets.airflow_query_keys.fxa_prod`),
+      ciphertext,
+      CAST(key_id AS BYTES)
+    ) AS value
+  FROM
+    `moz-fx-data-shared-prod.firefox_accounts_derived.encrypted_keys_v1`
+  WHERE
+    key_id = 'fxa_hmac_prod'
+)
+SELECT
+  DISTINCT TO_HEX(
+    udf.hmac_sha256((SELECT * FROM hmac_key), CAST(jsonPayload.fields.user_id AS BYTES))
+  ) AS user_id
+FROM
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_20*`

--- a/sql/firefox_accounts_derived/fxa_amplitude_user_ids_v1/metadata.yaml
+++ b/sql/firefox_accounts_derived/fxa_amplitude_user_ids_v1/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: FxA Hashed User IDs
+description: >
+  Contains exactly one entry for each FxA user, giving the 64-character hashed
+  user ID used for all exports to Amplitude. This table is useful as a lookup
+  for sync pings which contain a truncated 32-character version of the same hash.
+owners:
+  - jklukas@mozilla.com
+labels:
+  application: FxA
+  incremental: true
+  schedule: daily

--- a/sql/firefox_accounts_derived/fxa_amplitude_user_ids_v1/query.sql
+++ b/sql/firefox_accounts_derived/fxa_amplitude_user_ids_v1/query.sql
@@ -1,0 +1,25 @@
+WITH hmac_key AS (
+  SELECT
+    AEAD.DECRYPT_BYTES(
+      (SELECT keyset FROM `moz-fx-dataops-secrets.airflow_query_keys.fxa_prod`),
+      ciphertext,
+      CAST(key_id AS BYTES)
+    ) AS value
+  FROM
+    `moz-fx-data-shared-prod.firefox_accounts_derived.encrypted_keys_v1`
+  WHERE
+    key_id = 'fxa_hmac_prod'
+)
+SELECT
+  TO_HEX(
+    udf.hmac_sha256((SELECT * FROM hmac_key), CAST(jsonPayload.fields.user_id AS BYTES))
+  ) AS user_id
+FROM
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_20*`
+WHERE
+  _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', @submission_date)
+UNION DISTINCT
+SELECT
+  user_id
+FROM
+  fxa_amplitude_user_ids_v1


### PR DESCRIPTION
And we refactor the sync send tab view to use this new table, pulling it under the `firefox_accounts` namespace.