### PR TITLE
Write files metadata to /files

### DIFF
--- a/bigquery_etl/public_data/publish_gcs_metadata.py
+++ b/bigquery_etl/public_data/publish_gcs_metadata.py
@@ -80,7 +80,7 @@ class GcsTableMetadata:
         if self.metadata.review_bug() is not None:
             metadata_json["review_link"] = REVIEW_LINK + self.metadata.review_bug()
 
-        metadata_json["files"] = self.files_uri
+        metadata_json["files_uri"] = self.files_uri
         metadata_json["last_updated"] = self.last_updated_uri
 
         return metadata_json

--- a/bigquery_etl/public_data/publish_gcs_metadata.py
+++ b/bigquery_etl/public_data/publish_gcs_metadata.py
@@ -80,8 +80,7 @@ class GcsTableMetadata:
         if self.metadata.review_bug() is not None:
             metadata_json["review_link"] = REVIEW_LINK + self.metadata.review_bug()
 
-        metadata_json["files_metadata"] = self.files_uri + "/metadata.json"
-        metadata_json["files_uri"] = self.files_uri
+        metadata_json["files"] = self.files_uri
         metadata_json["last_updated"] = self.last_updated_uri
 
         return metadata_json
@@ -160,17 +159,14 @@ def publish_all_datasets_metadata(table_metadata, output_file):
 def publish_table_metadata(storage_client, table_metadata, bucket):
     """Write metadata for each public table to GCS."""
     for metadata in table_metadata:
-        output_file = f"gs://{bucket}/{metadata.files_path}/metadata.json"
+        output_file = f"gs://{bucket}/{metadata.files_path}"
 
         logging.info(f"Write metadata to {output_file}")
         with smart_open.open(output_file, "w") as fout:
             fout.write(json.dumps(metadata.files_metadata_to_json(), indent=4))
 
         set_content_type(
-            storage_client,
-            bucket,
-            f"{metadata.files_path}/metadata.json",
-            "application/json",
+            storage_client, bucket, f"{metadata.files_path}", "application/json"
         )
 
 

--- a/tests/data/all_datasets.json
+++ b/tests/data/all_datasets.json
@@ -7,7 +7,7 @@
                 "incremental": false,
                 "incremental_export": false,
                 "review_link": "https://bugzilla.mozilla.org/show_bug.cgi?id=1999999",
-                "files": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/files",
+                "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/files",
                 "last_updated": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/last_updated"
             }
         }, 
@@ -18,7 +18,7 @@
                 "incremental": true,
                 "incremental_export": true,
                 "review_link": "https://bugzilla.mozilla.org/show_bug.cgi?id=123456",
-                "files": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/files",
+                "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/files",
                 "last_updated": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/last_updated"
             }
         }

--- a/tests/data/all_datasets.json
+++ b/tests/data/all_datasets.json
@@ -7,8 +7,7 @@
                 "incremental": false,
                 "incremental_export": false,
                 "review_link": "https://bugzilla.mozilla.org/show_bug.cgi?id=1999999",
-                "files_metadata": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/files/metadata.json",
-                "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/files",
+                "files": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/files",
                 "last_updated": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/last_updated"
             }
         }, 
@@ -19,8 +18,7 @@
                 "incremental": true,
                 "incremental_export": true,
                 "review_link": "https://bugzilla.mozilla.org/show_bug.cgi?id=123456",
-                "files_metadata": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/files/metadata.json",
-                "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/files",
+                "files": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/files",
                 "last_updated": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/last_updated"
             }
         }

--- a/tests/public_data/test_publish_gcs_metadata.py
+++ b/tests/public_data/test_publish_gcs_metadata.py
@@ -109,15 +109,14 @@ class TestPublishGcsMetadata(object):
 
         result = gcs_table_metadata.table_metadata_to_json()
 
-        assert len(result.items()) == 8
+        assert len(result.items()) == 7
         assert result["description"] == "Test table for a non-incremental query"
         assert result["friendly_name"] == "Test table for a non-incremental query"
         assert result["incremental"] is False
         assert result["incremental_export"] is False
         review_link = "https://bugzilla.mozilla.org/show_bug.cgi?id=1999999"
         assert result["review_link"] == review_link
-        assert result["files_uri"] == self.endpoint + files_path
-        assert result["files_metadata"] == self.endpoint + files_path + "/metadata.json"
+        assert result["files"] == self.endpoint + files_path
         assert result["last_updated"] == self.endpoint + last_updated_path
 
     def test_gcs_files_metadata_to_json(self):

--- a/tests/public_data/test_publish_gcs_metadata.py
+++ b/tests/public_data/test_publish_gcs_metadata.py
@@ -116,7 +116,7 @@ class TestPublishGcsMetadata(object):
         assert result["incremental_export"] is False
         review_link = "https://bugzilla.mozilla.org/show_bug.cgi?id=1999999"
         assert result["review_link"] == review_link
-        assert result["files"] == self.endpoint + files_path
+        assert result["files_uri"] == self.endpoint + files_path
         assert result["last_updated"] == self.endpoint + last_updated_path
 
     def test_gcs_files_metadata_to_json(self):


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/967

Currently the `all-datasets.json` has for each dataset two files entries:

```
"files_metadata": "https://public-data.telemetry.mozilla.org/api/v1/tables/telemetry_derived/ssl_ratios/v1/files/metadata.json",
"files_uri": "https://public-data.telemetry.mozilla.org/api/v1/tables/telemetry_derived/ssl_ratios/v1/files",
```

Opening `files_uri` currently results in an error which caused some confusion. Instead we should write the list of available files to a `files` file: 

```
"files": "https://public-data.telemetry.mozilla.org/api/v1/tables/telemetry_derived/ssl_ratios/v1/files",
```

Then we also don't have two entries and everything becomes hopefully less confusing.

If that change makes sense then I'll also update the docs in https://docs.telemetry.mozilla.org/public_data/index.html