### PR TITLE
Bug fix: Make cohort_date a derived field

### DIFF
--- a/sql/telemetry/firefox_nondesktop_day_2_7_activation/view.sql
+++ b/sql/telemetry/firefox_nondesktop_day_2_7_activation/view.sql
@@ -2,6 +2,7 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_day_2_7_activation`
 AS
 SELECT
-  *
+  DATE_SUB(submission_date, INTERVAL 6 DAY) AS cohort_date,
+  * EXCEPT (submission_date)
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.firefox_nondesktop_day_2_7_activation_v1`

--- a/sql/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/query.sql
+++ b/sql/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/query.sql
@@ -1,5 +1,6 @@
 WITH base AS (
   SELECT
+    submission_date,
     CASE
       app_name
     WHEN
@@ -27,7 +28,6 @@ WITH base AS (
     os,
     normalized_channel,
     country,
-    DATE_SUB(submission_date, INTERVAL 6 DAY) AS cohort_date,
     COUNTIF(udf.pos_of_trailing_set_bit(days_created_profile_bits) = 6) AS new_profiles,
     COUNTIF(
       udf.pos_of_trailing_set_bit(days_created_profile_bits) = 6
@@ -49,7 +49,7 @@ SELECT
 FROM
   base
 WHERE
-  cohort_date = DATE_SUB(@submission_date, INTERVAL 6 DAY)
+  submission_date = @submission_date
   AND product IN (
     -- Fenix and Firefox Preview are excluded for now pending validation.
     -- 'Fenix',


### PR DESCRIPTION
Fix-up to #979 

I forgot during review that the telemetry-airflow machinery is going to replace partitions based on `submission_date`, and I had created this table with partitions based on `cohort_date`, causing a mismatch.

We should have the underlying table retain `submission_date`, and then we can present the shifted `cohort_date` as part of the user-facing view.

cc @gkabbz 