### PR TITLE
Remove unnecessary distinct from shredder delete query

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -167,7 +167,7 @@ def delete_from_partition(
               `{sql_table_id(target)}`
             WHERE
               {target.field} IN (
-                SELECT DISTINCT
+                SELECT
                   {source.field}
                 FROM
                   `{sql_table_id(source)}`


### PR DESCRIPTION
the `deletion_request` tables generally do not contain duplicates, and deleting from `main_v4` for `2020-01-14` failed 6 times in a row due to "memory usage", which i'm hoping will be fixed by removing `DISTINCT` in this subquery expression.