### PR TITLE
Fix GLAM JSON generation.

### DIFF
--- a/sql/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql
+++ b/sql/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql
@@ -5,12 +5,11 @@ RETURNS STRING
 LANGUAGE js
 AS
 '''
-    let data = histogram.map(function(r) {
-        let obj = {};
+    let obj = {};
+    histogram.map(function(r) {
         obj[r.key] = parseFloat(r.value.toFixed(4));
-        return obj;
     });
-    return JSON.stringify(data);
+    return JSON.stringify(obj);
 ''';
 
 SELECT


### PR DESCRIPTION
This was mistaking producing an array of objects with a single key/value
pair instead of a single object with multiple key/value pairs.