### PR TITLE
Bug 1639345 - Fix ping type using static name from table id

### DIFF
--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 from jinja2 import Environment, PackageLoader
 
 from bigquery_etl.format_sql.formatter import reformat
-from .utils import get_schema
+from .utils import get_schema, ping_type_from_table
 
 ATTRIBUTES = ",".join(
     [
@@ -115,6 +115,7 @@ def main():
             submission_date=submission_date,
             attributes=ATTRIBUTES,
             histograms=metrics_sql,
+            ping_type=ping_type_from_table(args.source_table),
         )
     )
 

--- a/bigquery_etl/glam/clients_daily_scalar_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_scalar_aggregates.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 from jinja2 import Environment, PackageLoader
 
 from bigquery_etl.format_sql.formatter import reformat
-from .utils import get_schema
+from .utils import get_schema, ping_type_from_table
 
 ATTRIBUTES = ",".join(
     [
@@ -154,6 +154,7 @@ def main():
             attributes=ATTRIBUTES,
             unlabeled_metrics=unlabeled_metrics,
             labeled_metrics=labeled_metrics,
+            ping_type=ping_type_from_table(args.source_table),
         )
     )
 

--- a/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "{{ ping_type }}" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.{{ source_table }}`
   WHERE
     DATE(submission_timestamp) = {{ submission_date }}
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 histograms AS (

--- a/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
@@ -5,7 +5,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "{{ ping_type }}" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -17,7 +17,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.{{ source_table }}`
   WHERE
     DATE(submission_timestamp) = {{ submission_date }}
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/bigquery_etl/glam/utils.py
+++ b/bigquery_etl/glam/utils.py
@@ -31,6 +31,12 @@ def get_schema(table: str, project: str = "moz-fx-data-shared-prod"):
     return json.loads(stdout)
 
 
+def ping_type_from_table(qualified_table):
+    table_id = qualified_table.split(".")[-1]
+    ping_name = table_id.rsplit("_", 1)[0]
+    return ping_name.replace("_", "-")
+
+
 def get_custom_distribution_metadata(product_name) -> List[CustomDistributionMeta]:
     """Get metadata for reconstructing custom distribution buckets in Glean metrics."""
     # GleanPing.get_repos -> List[Tuple[name: str, app_id: str]]

--- a/bigquery_etl/glam/utils.py
+++ b/bigquery_etl/glam/utils.py
@@ -32,6 +32,10 @@ def get_schema(table: str, project: str = "moz-fx-data-shared-prod"):
 
 
 def ping_type_from_table(qualified_table):
+    """Return the name of a ping as defined in mozilla-pipeline-schemas.
+
+    Example: org_mozilla_fenix_stable.deletion_request_v1 -> deletion-request
+    """
     table_id = qualified_table.split(".")[-1]
     ping_name = table_id.rsplit("_", 1)[0]
     return ping_name.replace("_", "-")

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_histogram_aggregates_metrics_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_histogram_aggregates_metrics_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "metrics" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.metrics_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 histograms AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_activation_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_activation_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "activation" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.activation_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_baseline_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_baseline_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "baseline" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.baseline_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_bookmarks_sync_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_bookmarks_sync_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "bookmarks-sync" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.bookmarks_sync_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_deletion_request_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_deletion_request_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "deletion-request" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.deletion_request_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_events_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_events_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "events" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.events_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_history_sync_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_history_sync_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "history-sync" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.history_sync_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_installation_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_installation_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "installation" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.installation_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_logins_sync_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_logins_sync_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "logins-sync" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.logins_sync_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_metrics_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_metrics_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "metrics" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.metrics_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_migration_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_migration_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "migration" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.migration_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_startup_timeline_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_startup_timeline_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "startup-timeline" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.startup_timeline_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (

--- a/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_sync_v1/query.sql
+++ b/sql/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_sync_v1/query.sql
@@ -4,7 +4,7 @@ WITH extracted AS (
     *,
     DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
-    REPLACE(ping_info.ping_type, "_", "-") AS ping_type,
+    "sync" AS ping_type,
     COALESCE(
       SAFE_CAST(SPLIT(client_info.app_display_version, '.')[OFFSET(0)] AS INT64),
       0
@@ -16,7 +16,6 @@ WITH extracted AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_stable.sync_v1`
   WHERE
     DATE(submission_timestamp) = @submission_date
-    AND client_info.app_channel IN ("release", "fenixProduction")
     AND client_info.client_id IS NOT NULL
 ),
 unlabeled_metrics AS (


### PR DESCRIPTION
This fixes the ping type by relying on the ping type encoded in the path to the table instead of the field in the ping. See [bug 1639345](https://bugzilla.mozilla.org/show_bug.cgi?id=1639345) for more context. 