### PR TITLE
Add regular_users_v3 and new_or_resurrected_v3.

### DIFF
--- a/sql/telemetry/clients_last_seen_v1/view.sql
+++ b/sql/telemetry/clients_last_seen_v1/view.sql
@@ -13,6 +13,8 @@ SELECT
   CAST(
     SAFE.LOG(days_created_profile_bits & -days_created_profile_bits, 2) AS INT64
   ) AS days_since_created_profile,
+  BIT_COUNT(days_seen_bits & 0x0FFFFFFE) >= 14 AS regular_users_v3,
+  days_seen_bits & 0x0FFFFFFE = 0 AS new_or_resurrected_v3,
   * EXCEPT (
     active_experiment_id,
     scalar_parent_dom_contentprocess_troubled_due_to_memory_sum,

--- a/sql/telemetry/clients_last_seen_v1/view.sql
+++ b/sql/telemetry/clients_last_seen_v1/view.sql
@@ -13,8 +13,10 @@ SELECT
   CAST(
     SAFE.LOG(days_created_profile_bits & -days_created_profile_bits, 2) AS INT64
   ) AS days_since_created_profile,
-  BIT_COUNT(days_seen_bits & 0x0FFFFFFE) >= 14 AS regular_users_v3,
-  days_seen_bits & 0x0FFFFFFE = 0 AS new_or_resurrected_v3,
+  -- Segment definitions; see https://docs.telemetry.mozilla.org/concepts/segments.html
+  -- 0x0FFFFFFE is a bitmask that accepts the previous 27 days, excluding the current day (rightmost bit)
+  BIT_COUNT(days_seen_bits & 0x0FFFFFFE) >= 14 AS is_regular_user_v3,
+  days_seen_bits & 0x0FFFFFFE = 0 AS is_new_or_resurrected_v3,
   * EXCEPT (
     active_experiment_id,
     scalar_parent_dom_contentprocess_troubled_due_to_memory_sum,


### PR DESCRIPTION
These segments/user states got a DS review [when added to DTMO](https://github.com/mozilla/firefox-data-docs/pull/466).

Replaces #825.