### PR TITLE
Parallelize run_glam_sql script for glean data

### DIFF
--- a/script/glam/run_glam_sql
+++ b/script/glam/run_glam_sql
@@ -76,7 +76,7 @@ function run_init {
     local destination_table=$1
     local init="sql/$PROD_DATASET/$destination_table/init.sql"
     # run if needed
-    if ! bq show --quiet "${DATASET}.${destination_table}"; then
+    if ! bq show "${DATASET}.${destination_table}" &> /dev/null; then
         echo "running $init"
         local tmp
         tmp=$(mktemp)
@@ -190,39 +190,42 @@ function run_glean_sql {
 
     if ((start_stage <= 0)); then
         for directory in sql/glam_etl/"${product}"__clients_daily_scalar_aggregates*/; do
-            run_query "$(basename "$directory")" true
+            run_query "$(basename "$directory")" true &
         done
         for directory in sql/glam_etl/"${product}"__clients_daily_histogram_aggregates*/; do
-            run_query "$(basename "$directory")" true
+            run_query "$(basename "$directory")" true &
         done
+        wait
     fi
-    # NOTE: there isn't a mechanism to test the incremental query here
+    # TODO: testing mechanism
     if ((start_stage <= 1)); then
-        run_query "${product}__latest_versions_v1"
-
-        run_view "${product}__view_clients_daily_scalar_aggregates_v1"
-        run_init "${product}__clients_scalar_aggregates_v1"
-        run_query "${product}__clients_scalar_aggregates_v1"
+        run_query "${product}__latest_versions_v1" &
+        run_view "${product}__view_clients_daily_scalar_aggregates_v1" &
+        run_view "${product}__view_clients_daily_histogram_aggregates_v1" &
+        run_init "${product}__clients_scalar_aggregates_v1" &
+        run_init "${product}__clients_histogram_aggregates_v1" &
+        wait
+        run_query "${product}__clients_scalar_aggregates_v1" &
+        run_query "${product}__clients_histogram_aggregates_v1" &
+        wait
     fi
     if ((start_stage <= 2)); then
-        run_query "${product}__scalar_bucket_counts_v1"
-        run_query "${product}__scalar_probe_counts_v1"
-        run_query "${product}__scalar_percentiles_v1"
+        run_query "${product}__scalar_bucket_counts_v1" &
+        run_query "${product}__histogram_bucket_counts_v1" &
+        wait
+        run_query "${product}__scalar_probe_counts_v1" &
+        run_query "${product}__histogram_probe_counts_v1" &
+        wait
+        run_query "${product}__scalar_percentiles_v1" &
+        run_query "${product}__histogram_percentiles_v1" &
+        wait
     fi
-    if ((start_stage <= 3)); then
-        run_view "${product}__view_clients_daily_histogram_aggregates_v1"
-        run_init "${product}__clients_histogram_aggregates_v1"
-        run_query "${product}__clients_histogram_aggregates_v1"
-    fi
-    if ((start_stage <= 4)); then
-        run_query "${product}__histogram_bucket_counts_v1"
-        run_query "${product}__histogram_probe_counts_v1"
-        run_query "${product}__histogram_percentiles_v1"
-    fi
-    run_view "${product}__view_probe_counts_v1"
-    run_view "${product}__view_user_counts_v1"
-    run_query "${product}__extract_user_counts_v1"
-    run_query "${product}__extract_probe_counts_v1"
+    run_view "${product}__view_probe_counts_v1" &
+    run_view "${product}__view_user_counts_v1" &
+    wait
+    run_query "${product}__extract_user_counts_v1" &
+    run_query "${product}__extract_probe_counts_v1" &
+    wait
 }
 
 
@@ -245,7 +248,7 @@ function main {
     if $reset; then
         bq rm -r -f "$DATASET"
     fi
-    if ! bq ls "${PROJECT}:${DATASET}"; then
+    if ! bq ls "${PROJECT}:${DATASET}" &> /dev/null; then
         bq mk "$DATASET"
     fi
 

--- a/script/glam/run_glam_sql
+++ b/script/glam/run_glam_sql
@@ -187,6 +187,18 @@ function run_desktop_sql {
 function run_glean_sql {
     local product=$1
     local start_stage=${START_STAGE:-0}
+    local reset=${RESET:-false}
+    local backfill_only=${BACKFILL_ONLY:-false}
+    local export_only=${EXPORT_ONLY:-false}
+
+    if [[ $backfill_only = true && $export_only = true ]]; then
+        echo "BACKFILL_ONLY and EXPORT_ONLY are mutually exclusive"
+        exit 1
+    fi
+    if [[ $reset = true && $export_only = true ]]; then
+        echo "RESET and EXPORT_ONLY are mutually exclusive"
+        exit 1
+    fi
 
     if ((start_stage <= 0)); then
         for directory in sql/glam_etl/"${product}"__clients_daily_scalar_aggregates*/; do
@@ -197,8 +209,7 @@ function run_glean_sql {
         done
         wait
     fi
-    # TODO: testing mechanism
-    if ((start_stage <= 1)); then
+    if ((start_stage <= 1)) && [[ $export_only = false ]]; then
         run_query "${product}__latest_versions_v1" &
         run_view "${product}__view_clients_daily_scalar_aggregates_v1" &
         run_view "${product}__view_clients_daily_histogram_aggregates_v1" &
@@ -208,6 +219,9 @@ function run_glean_sql {
         run_query "${product}__clients_scalar_aggregates_v1" &
         run_query "${product}__clients_histogram_aggregates_v1" &
         wait
+    fi
+    if [[ $backfill_only = true ]]; then
+        return
     fi
     if ((start_stage <= 2)); then
         run_query "${product}__scalar_bucket_counts_v1" &

--- a/script/glam/run_glam_sql
+++ b/script/glam/run_glam_sql
@@ -187,7 +187,6 @@ function run_desktop_sql {
 function run_glean_sql {
     local product=$1
     local start_stage=${START_STAGE:-0}
-    local reset=${RESET:-false}
     local backfill_only=${BACKFILL_ONLY:-false}
     local export_only=${EXPORT_ONLY:-false}
 
@@ -195,12 +194,8 @@ function run_glean_sql {
         echo "BACKFILL_ONLY and EXPORT_ONLY are mutually exclusive"
         exit 1
     fi
-    if [[ $reset = true && $export_only = true ]]; then
-        echo "RESET and EXPORT_ONLY are mutually exclusive"
-        exit 1
-    fi
 
-    if ((start_stage <= 0)); then
+    if ((start_stage <= 0)) && [[ $export_only = false ]]; then
         for directory in sql/glam_etl/"${product}"__clients_daily_scalar_aggregates*/; do
             run_query "$(basename "$directory")" true &
         done
@@ -247,7 +242,13 @@ function main {
     cd "$(dirname "$0")/../.."
 
     local reset=${RESET:-false}
+    local export_only=${EXPORT_ONLY:-false}
     local product=${PRODUCT:-org_mozilla_fenix}
+
+    if [[ $reset = true && $export_only = true ]]; then
+        echo "RESET and EXPORT_ONLY are mutually exclusive"
+        exit 1
+    fi
 
     # revert to the original default project in the environment
     original_project=$(gcloud config get-value project)


### PR DESCRIPTION
I noticed that backfilling data takes longer than I expected. This is because there is a lot of unnecessary work being done when running the jobs sequentially. I've parallelized the jobs where it makes sense, and added two options. BACKFILL_ONLY will run the queries that build up the clients aggregate state. EXPORT_ONLY will take the current clients aggregate state and generate the downstream probes tables. 

```bash
# before
RESET=true DATASET=glam_etl_dev_perf script/glam/run_glam_sql 
16.35s user 9.30s system 8% cpu 5:02.60 total

# after
RESET=true DATASET=glam_etl_dev_perf script/glam/run_glam_sql 
20.09s user 14.62s system 15% cpu 3:46.25 total

BACKFILL_ONLY=true RESET=true DATASET=glam_etl_dev_perf script/glam/run_glam_sql  
16.07s user 12.06s system 34% cpu 1:20.94 total

EXPORT_ONLY=true DATASET=glam_etl_dev_perf script/glam/run_glam_sql  
5.88s user 3.69s system 6% cpu 2:31.78 total
```

Here's a backfill script that I threw together: https://gist.github.com/acmiyaguchi/c6b7f7ccb803ff29c3fcecfe19dc3b51