### PR TITLE
Lower-friction scheduled queries: Support custom task name definitions

### DIFF
--- a/bigquery_etl/query_scheduling/dag.py
+++ b/bigquery_etl/query_scheduling/dag.py
@@ -120,6 +120,19 @@ class Dag:
                 f"Invalid DAG name {value}. Name must start with 'bqetl_'."
             )
 
+    @tasks.validator
+    def validate_tasks(self, attribute, value):
+        """Validate tasks."""
+        task_names = list(map(lambda t: t.task_name, value))
+        duplicate_task_names = set(
+            [task_name for task_name in task_names if task_names.count(task_name) > 1]
+        )
+
+        if len(duplicate_task_names) > 0:
+            raise ValueError(
+                f"Duplicate task names encountered: {duplicate_task_names}."
+            )
+
     @schedule_interval.validator
     def validate_schedule_interval(self, attribute, value):
         """
@@ -135,6 +148,7 @@ class Dag:
     def add_tasks(self, tasks):
         """Add tasks to be scheduled as part of the DAG."""
         self.tasks = self.tasks.copy() + tasks
+        self.validate_tasks(None, self.tasks)
 
     @classmethod
     def from_dict(cls, d):

--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -63,10 +63,10 @@ class Task:
     query_file: str
     owner: str = attr.ib()
     email: List[str] = attr.ib([])
+    task_name: Optional[str] = attr.ib(None)
     dataset: str = attr.ib(init=False)
     table: str = attr.ib(init=False)
     version: str = attr.ib(init=False)
-    task_name: str = attr.ib(init=False)
     depends_on_past: bool = attr.ib(False)
     start_date: Optional[str] = attr.ib(None)
     date_partition_parameter: Union[Optional[str], Ignore] = attr.ib(Ignore)
@@ -107,7 +107,9 @@ class Task:
             self.dataset = query_file_re.group(1)
             self.table = query_file_re.group(2)
             self.version = query_file_re.group(3)
-            self.task_name = f"{self.dataset}__{self.table}__{self.version}"
+
+            if self.task_name is None:
+                self.task_name = f"{self.dataset}__{self.table}__{self.version}"
         else:
             raise ValueError(
                 "query_file must be a path with format:"

--- a/dags/bqetl_kpi_dashboard.py
+++ b/dags/bqetl_kpi_dashboard.py
@@ -42,8 +42,8 @@ with DAG(
         dag=dag,
     )
 
-    telemetry__firefox_kpi_dashboard__v1 = bigquery_etl_query(
-        task_id="telemetry__firefox_kpi_dashboard__v1",
+    kpi_dashboard = bigquery_etl_query(
+        task_id="kpi_dashboard",
         destination_table="firefox_kpi_dashboard_v1",
         dataset_id="telemetry",
         project_id="moz-fx-data-shared-prod",

--- a/sql/telemetry/firefox_kpi_dashboard_v1/metadata.yaml
+++ b/sql/telemetry/firefox_kpi_dashboard_v1/metadata.yaml
@@ -9,3 +9,4 @@ scheduling:
   depends_on_past: false
   date_partition_parameter: null
   email: ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com']
+  task_name: kpi_dashboard

--- a/tests/query_scheduling/test_task.py
+++ b/tests/query_scheduling/test_task.py
@@ -93,6 +93,29 @@ class TestTask:
         task = Task.of_query(query_file, metadata)
         assert task.dag_name == "bqetl_test_dag"
         assert task.depends_on_past is False
+        assert task.task_name == "test__incremental_query__v1"
+
+    def test_task_instantiation_custom_name(self):
+        query_file = (
+            TEST_DIR
+            / "data"
+            / "test_sql"
+            / "test"
+            / "incremental_query_v1"
+            / "query.sql"
+        )
+
+        scheduling = {
+            "dag_name": "bqetl_test_dag",
+            "default_args": {"owner": "test@example.org"},
+            "task_name": "custom_task_name",
+        }
+
+        metadata = Metadata("test", "test", ["test@example.org"], {}, scheduling)
+
+        task = Task.of_query(query_file, metadata)
+        assert task.dag_name == "bqetl_test_dag"
+        assert task.task_name == "custom_task_name"
 
     def test_dag_name_validation(self):
         query_file = (


### PR DESCRIPTION
Follow-up to: https://github.com/mozilla/bigquery-etl/pull/980#discussion_r432116695

Support for optionally defining a different name for scheduled tasks.