### PR TITLE
Lower-friction scheduled queries: Support manual definition of external dependencies

### DIFF
--- a/bigquery_etl/query_scheduling/dag.py
+++ b/bigquery_etl/query_scheduling/dag.py
@@ -226,9 +226,9 @@ class PublicDataJsonDag(Dag):
             logging.warn(f"Task {task.task_name} not marked as public JSON.")
             return
 
-        # clone original task and make sure it's not accidentally modified
         converter = cattr.Converter()
-        task_dict = task.__dict__.copy()
+        task_dict = converter.unstructure(task)
+
         del task_dict["dataset"]
         del task_dict["table"]
         del task_dict["version"]

--- a/bigquery_etl/query_scheduling/formatters.py
+++ b/bigquery_etl/query_scheduling/formatters.py
@@ -58,3 +58,8 @@ def format_optional_string(val):
         return "None"
     else:
         return "'" + val + "'"
+
+
+def format_repr(val):
+    """Return representation of a object."""
+    return repr(val)

--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -46,6 +46,20 @@ class UnscheduledTask(Exception):
 
 
 @attr.s(auto_attribs=True)
+class TaskRef:
+    """
+    Representation of a reference to another task.
+
+    The task can be defined in bigquery-etl or in telemetry-airflow.
+    Uses attrs to simplify the class definition and provide validation.
+    Docs: https://www.attrs.org
+    """
+
+    dag_name: str = attr.ib()
+    task_id: str = attr.ib()
+
+
+@attr.s(auto_attribs=True)
 class Task:
     """
     Representation of a task scheduled in Airflow.
@@ -67,6 +81,7 @@ class Task:
     date_partition_parameter: Optional[str] = "submission_date"
     # indicate whether data should be published as JSON
     public_json: bool = attr.ib(False)
+    depends_on: List[TaskRef] = attr.ib([])
 
     @owner.validator
     def validate_owner(self, attribute, value):

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -53,6 +53,9 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         task_id="wait_for_{{ task_ref.dag_name }}_{{ task_ref.task_id }}",
         external_dag_id="{{ task_ref.dag_name }}",
         external_task_id="{{ task_ref.task_id }}",
+        {% if task_ref.execution_delta -%}
+        execution_delta={{ task_ref.execution_delta | format_timedelta | format_repr }},
+        {% endif -%}
         dag=dag,
     )
 

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -47,4 +47,15 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
     {{ task.task_name }}.set_upstream(wait_for_{{ dependency.task_name }})
     {% endif -%}
     {% endfor -%}
+
+    {% for task_ref in task.depends_on %}
+    wait_for_{{ task_ref.dag_name }}_{{ task_ref.task_id }} = ExternalTaskSensor(
+        task_id="wait_for_{{ task_ref.dag_name }}_{{ task_ref.task_id }}",
+        external_dag_id="{{ task_ref.dag_name }}",
+        external_task_id="{{ task_ref.task_id }}",
+        dag=dag,
+    )
+
+    {{ task.task_name }}.set_upstream(wait_for_{{ task_ref.dag_name }}_{{ task_ref.task_id }})
+    {% endfor -%}
 {% endfor -%}

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -20,7 +20,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         project_id='moz-fx-data-shared-prod',
         owner='{{ task.owner }}',
         {%+ if task.email | length > 0 -%}
-        email={{ task.email }},
+        email={{ task.email | sort }},
         {%+ endif -%}
         {%+ if task.start_date -%}
         start_date={{ task.start_date | format_date }},

--- a/bigquery_etl/query_scheduling/utils.py
+++ b/bigquery_etl/query_scheduling/utils.py
@@ -10,7 +10,7 @@ def is_timedelta_string(s):
 
     Timedeltas in configs are specified like: 1h, 30m, 1h15m, ...
     """
-    timedelta_regex = re.compile(r"(\d+h)?(\d+m)?(\d+s)?")
+    timedelta_regex = re.compile(r"^(\d+h)?(\d+m)?(\d+s)?$")
     return timedelta_regex.match(s)
 
 

--- a/dags.yaml
+++ b/dags.yaml
@@ -28,6 +28,15 @@ bqetl_ssl_ratios:
       retries: 2
       retry_delay: 30m
 
+bqetl_deviations:
+  schedule_interval: 0 1 * * *
+  default_args:
+      owner: ascholtz@mozilla.com
+      start_date: '2020-03-29'
+      email: ['telemetry-alerts@mozilla.com', 'ascholtz@mozilla.com', 'jmccrosky@mozilla.com']
+      retries: 2
+      retry_delay: 30m
+
 # DAG for exporting query data marked as public to GCS
 # queries should not be explicitly assigned to this DAG (it's done automatically)
 bqetl_public_data_json:

--- a/dags/bqetl_deviations.py
+++ b/dags/bqetl_deviations.py
@@ -1,0 +1,46 @@
+# Generated via query_scheduling/generate_airflow_dags
+
+from airflow import DAG
+from airflow.operators.sensors import ExternalTaskSensor
+import datetime
+from utils.gcp import bigquery_etl_query
+
+default_args = {
+    "owner": "ascholtz@mozilla.com",
+    "start_date": datetime.datetime(2020, 3, 29, 0, 0),
+    "email": [
+        "telemetry-alerts@mozilla.com",
+        "ascholtz@mozilla.com",
+        "jmccrosky@mozilla.com",
+    ],
+    "depends_on_past": False,
+    "retry_delay": datetime.timedelta(seconds=1800),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 2,
+}
+
+with DAG(
+    "bqetl_deviations", default_args=default_args, schedule_interval="0 1 * * *"
+) as dag:
+
+    telemetry_derived__deviations__v1 = bigquery_etl_query(
+        task_id="telemetry_derived__deviations__v1",
+        destination_table="deviations_v1",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="jmccrosky@mozilla.com",
+        email=["jmccrosky@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    wait_for_public_analysis_anomdtct = ExternalTaskSensor(
+        task_id="wait_for_public_analysis_anomdtct",
+        external_dag_id="public_analysis",
+        external_task_id="anomdtct",
+        dag=dag,
+    )
+
+    telemetry_derived__deviations__v1.set_upstream(wait_for_public_analysis_anomdtct)

--- a/dags/bqetl_kpi_dashboard.py
+++ b/dags/bqetl_kpi_dashboard.py
@@ -50,7 +50,7 @@ with DAG(
         dataset_id="telemetry",
         project_id="moz-fx-data-shared-prod",
         owner="jklukas@mozilla.com",
-        email=["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
+        email=["jklukas@mozilla.com", "telemetry-alerts@mozilla.com"],
         date_partition_parameter=None,
         depends_on_past=False,
         dag=dag,

--- a/sql/telemetry_derived/deviations_v1/metadata.yaml
+++ b/sql/telemetry_derived/deviations_v1/metadata.yaml
@@ -10,3 +10,8 @@ labels:
   public_bigquery: true
   review_bug: 1624528
   incremental_export: false
+scheduling:
+  dag_name: bqetl_deviations
+  depends_on:
+    - task_id: anomdtct
+      dag_name: public_analysis

--- a/tests/query_scheduling/test_dag.py
+++ b/tests/query_scheduling/test_dag.py
@@ -182,11 +182,16 @@ class TestDag:
     def test_dag_default_args_retry_delay_validation(self):
         with pytest.raises(ValueError):
             assert DagDefaultArgs(
-                owner="test@example.com", start_date="March 12th 2020", retry_delay="90"
+                owner="test@example.com", start_date="2020-12-12", retry_delay="90"
+            )
+
+        with pytest.raises(ValueError):
+            assert DagDefaultArgs(
+                owner="test@example.com", start_date="2020-12-12", retry_delay="1d1h1m"
             )
 
         assert DagDefaultArgs(
-            owner="test@example.com", start_date="2020-12-12", retry_delay="1d3h15m"
+            owner="test@example.com", start_date="2020-12-12", retry_delay="3h15m1s"
         )
 
         assert DagDefaultArgs(


### PR DESCRIPTION
Depends on https://github.com/mozilla/bigquery-etl/pull/1020

There are a few cases where queries are dependent on tasks scheduled in telemetry-airflow (for example, if data is loaded into tables by a job running on GKE). I think it might be useful to have an option in query `metadata.yaml` files to specify these external dependencies.