### PR TITLE
Fix second_seen_date bug in clients_first_seen

### DIFF
--- a/sql/telemetry_derived/clients_first_seen_v1/query.sql
+++ b/sql/telemetry_derived/clients_first_seen_v1/query.sql
@@ -42,6 +42,12 @@ SELECT
       NULL
     WHEN
       previous.second_seen_date IS NULL
+      AND today.client_id IS NULL
+    THEN
+      NULL
+    WHEN
+      previous.second_seen_date IS NULL
+      AND today.client_id IS NOT NULL
     THEN
       @submission_date
     ELSE

--- a/sql/telemetry_derived/clients_first_seen_v1/query.sql
+++ b/sql/telemetry_derived/clients_first_seen_v1/query.sql
@@ -24,36 +24,18 @@ SELECT
   -- client has been seen; otherwise, we copy over the existing dimensions
   -- from the first sighting.
   IF(previous.client_id IS NULL, today, previous).* REPLACE (
-    -- Logic for first_seen_date
-    CASE
-    WHEN
-      previous.first_seen_date IS NULL
-    THEN
-      @submission_date
-    ELSE
+    IF(
+      previous.first_seen_date IS NULL,
+      @submission_date,
       previous.first_seen_date
-    END
-    AS first_seen_date,
-    -- Logic for second_seen_date
-    CASE
-    WHEN
-      previous.first_seen_date IS NULL
-    THEN
-      NULL
-    WHEN
+    ) AS first_seen_date,
+    IF(
       previous.second_seen_date IS NULL
-      AND today.client_id IS NULL
-    THEN
-      NULL
-    WHEN
-      previous.second_seen_date IS NULL
-      AND today.client_id IS NOT NULL
-    THEN
-      @submission_date
-    ELSE
+      AND previous.first_seen_date IS NOT NULL
+      AND today.client_id IS NOT NULL,
+      @submission_date,
       previous.second_seen_date
-    END
-    AS second_seen_date
+    ) AS second_seen_date
   )
 FROM
   previous


### PR DESCRIPTION
With the previous logic, we were always filling in second_seen_date where it was null. We should only do so if we see a ping for the given client on the current day.

cc @jmccrosky