### PR TITLE
WIP - fission in glam

### DIFF
--- a/sql/telemetry/clients_histogram_aggregates_fission/view.sql
+++ b/sql/telemetry/clients_histogram_aggregates_fission/view.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE VIEW `moz-fx-data-shared-prod.telemetry.clients_histogram_aggregates_fission` AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.clients_histogram_aggregates_v1`
+LEFT JOIN
+  `moz-fx-data-shared-prod.telemetry_derived.clients_has_fission_v1`
+USING
+  (submission_date, client_id, os, channel, app_version, app_build_id)

--- a/sql/telemetry/clients_scalar_aggregates_fission/view.sql
+++ b/sql/telemetry/clients_scalar_aggregates_fission/view.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW `moz-fx-data-shared-prod.telemetry_derived.clients_scalar_aggregates_fission` AS
+SELECT
+  * EXCEPT (has_fission),
+  COALESCE(has_fission, 1) AS has_fission,
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.clients_scalar_aggregates_v1`
+LEFT JOIN
+  `moz-fx-data-shared-prod.telemetry_derived.clients_has_fission_v1`
+USING
+  (client_id, os, channel, app_version, app_build_id)

--- a/sql/telemetry_derived/clients_has_fission_v1/query.sql
+++ b/sql/telemetry_derived/clients_has_fission_v1/query.sql
@@ -1,0 +1,20 @@
+SELECT
+  client_id,
+  normalized_os,
+  normalized_channel,
+  SPLIT(application.version, '.')[OFFSET(0)] AS app_version,
+  application.build_id AS app_build_id,
+  SUM(DISTINCT(IF(prefs.value = 'true', 2, 1))) AS has_fission,
+FROM
+  `moz-fx-data-shared-prod.telemetry_stable.main_v4`
+CROSS JOIN
+  UNNEST(environment.settings.user_prefs) prefs
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND prefs.key = 'fission.autostart'
+GROUP BY
+  client_id,
+  normalized_os,
+  normalized_channel,
+  app_version,
+  app_build_id

--- a/sql/telemetry_derived/clients_has_fission_v1/query.sql
+++ b/sql/telemetry_derived/clients_has_fission_v1/query.sql
@@ -1,10 +1,10 @@
 SELECT
   client_id,
-  normalized_os,
-  normalized_channel,
+  normalized_os AS os,
+  normalized_channel AS channel,
   SPLIT(application.version, '.')[OFFSET(0)] AS app_version,
   application.build_id AS app_build_id,
-  SUM(DISTINCT(IF(prefs.value = 'true', 2, 1))) AS has_fission,
+  SUM(DISTINCT(IF(prefs.value = 'true', 2, 1))) AS has_fission,  -- 1 is non-fission, 2 is fission, 3 is mixed
 FROM
   `moz-fx-data-shared-prod.telemetry_stable.main_v4`
 CROSS JOIN
@@ -18,3 +18,5 @@ GROUP BY
   normalized_channel,
   app_version,
   app_build_id
+HAVING
+  has_fission != 1

--- a/sql/telemetry_derived/clients_histogram_bucket_counts_fission_v1/query.sql
+++ b/sql/telemetry_derived/clients_histogram_bucket_counts_fission_v1/query.sql
@@ -1,0 +1,162 @@
+CREATE TEMP FUNCTION udf_normalized_sum(arrs ARRAY<STRUCT<key STRING, value INT64>>, sampled BOOL)
+RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
+  -- Input: one histogram for a single client.
+  -- Returns the normalized sum of the input maps.
+  -- It returns the total_count[k] / SUM(total_count)
+  -- for each key k.
+  (
+    WITH total_counts AS (
+      SELECT
+        sum(a.value) AS total_count
+      FROM
+        UNNEST(arrs) AS a
+    ),
+    summed_counts AS (
+      SELECT
+        a.key AS k,
+        SUM(a.value) AS v
+      FROM
+        UNNEST(arrs) AS a
+      GROUP BY
+        a.key
+    ),
+    final_values AS (
+      SELECT
+        STRUCT<key STRING, value FLOAT64>(
+          k,
+          -- Weight probes from Windows release clients to account for 10% sampling
+          COALESCE(SAFE_DIVIDE(1.0 * v, total_count), 0) * IF(sampled, 10, 1)
+        ) AS record
+      FROM
+        summed_counts
+      CROSS JOIN
+        total_counts
+    )
+    SELECT
+      ARRAY_AGG(record)
+    FROM
+      final_values
+  )
+);
+
+WITH filtered_data AS (
+  SELECT
+    sample_id,
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    has_fission,
+    first_bucket,
+    last_bucket,
+    num_buckets,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type,
+    aggregates,
+    os = 'Windows'
+    AND channel = 'release' AS sampled,
+  FROM
+    clients_histogram_aggregates_v1
+  CROSS JOIN
+    UNNEST(histogram_aggregates)
+  WHERE
+    submission_date = @submission_date
+    AND first_bucket IS NOT NULL
+    AND sample_id >= @min_sample_id
+    AND sample_id <= @max_sample_id
+),
+static_combos AS (
+  SELECT
+    NULL AS os,
+    NULL AS app_build_id
+  UNION ALL
+  SELECT
+    NULL AS os,
+    '*' AS app_build_id
+  UNION ALL
+  SELECT
+    '*' AS os,
+    NULL AS app_build_id
+  UNION ALL
+  SELECT
+    '*' AS os,
+    '*' AS app_build_id
+),
+all_combos AS (
+  SELECT
+    * EXCEPT (os, app_build_id),
+    COALESCE(combo.os, table.os) AS os,
+    COALESCE(combo.app_build_id, table.app_build_id) AS app_build_id
+  FROM
+    filtered_data table
+  CROSS JOIN
+    static_combos combo
+),
+normalized_histograms AS (
+  SELECT
+    * EXCEPT (sampled) REPLACE(
+    -- This returns true if at least 1 row has sampled=true.
+    -- ~0.0025% of the population uses more than 1 os for the same set of dimensions
+    -- and in this case we treat them as Windows+Release users when fudging numbers
+      udf_normalized_sum(udf.map_sum(ARRAY_CONCAT_AGG(aggregates)), MAX(sampled)) AS aggregates
+    )
+  FROM
+    all_combos
+  GROUP BY
+    sample_id,
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    has_fission,
+    first_bucket,
+    last_bucket,
+    num_buckets,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type
+)
+SELECT
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  has_fission,
+  first_bucket,
+  last_bucket,
+  num_buckets,
+  metric,
+  metric_type,
+  normalized_histograms.key AS key,
+  process,
+  agg_type,
+  STRUCT<key STRING, value FLOAT64>(
+    CAST(aggregates.key AS STRING),
+    1.0 * SUM(aggregates.value)
+  ) AS record,
+FROM
+  normalized_histograms
+CROSS JOIN
+  UNNEST(aggregates) AS aggregates
+GROUP BY
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  has_fission,
+  first_bucket,
+  last_bucket,
+  num_buckets,
+  metric,
+  metric_type,
+  key,
+  process,
+  agg_type,
+  aggregates.key,

--- a/sql/telemetry_derived/clients_scalar_bucket_counts_fission_v1/query.sql
+++ b/sql/telemetry_derived/clients_scalar_bucket_counts_fission_v1/query.sql
@@ -1,0 +1,268 @@
+CREATE TEMP FUNCTION udf_bucket (
+  val FLOAT64
+)
+RETURNS FLOAT64 AS (
+  -- Bucket `value` into a histogram with min_bucket, max_bucket and num_buckets
+  (
+    SELECT max(CAST(bucket AS INT64))
+    FROM UNNEST([0, 1.0, 41.0, 81.0, 121.0, 162.0, 202.0, 242.0, 283.0, 323.0, 363.0, 404.0, 444.0, 484.0, 525.0, 565.0, 605.0, 646.0, 686.0, 726.0, 767.0, 807.0, 847.0, 888.0, 928.0, 968.0, 1008.0, 1049.0, 1089.0, 1129.0, 1170.0, 1210.0, 1250.0, 1291.0, 1331.0, 1371.0, 1412.0, 1452.0, 1492.0, 1533.0, 1573.0, 1613.0, 1654.0, 1694.0, 1734.0, 1775.0, 1815.0, 1855.0, 1895.0, 1936.0, 1976.0, 2016.0, 2057.0, 2097.0, 2137.0, 2178.0, 2218.0, 2258.0, 2299.0, 2339.0, 2379.0, 2420.0, 2460.0, 2500.0, 2541.0, 2581.0, 2621.0, 2662.0, 2702.0, 2742.0, 2782.0, 2823.0, 2863.0, 2903.0, 2944.0, 2984.0, 3024.0, 3065.0, 3105.0, 3145.0, 3186.0, 3226.0, 3266.0, 3307.0, 3347.0, 3387.0, 3428.0, 3468.0, 3508.0, 3549.0, 3589.0, 3629.0, 3669.0, 3710.0, 3750.0, 3790.0, 3831.0, 3871.0, 3911.0, 3952.0, 3992.0, 4032.0, 4073.0, 4113.0, 4153.0, 4194.0, 4234.0, 4274.0, 4315.0, 4355.0, 4395.0, 4436.0, 4476.0, 4516.0, 4556.0, 4597.0, 4637.0, 4677.0, 4718.0, 4758.0, 4798.0, 4839.0, 4879.0, 4919.0, 4960.0, 5000.0, 5040.0, 5081.0, 5121.0, 5161.0, 5202.0, 5242.0, 5282.0, 5323.0, 5363.0, 5403.0, 5444.0, 5484.0, 5524.0, 5564.0, 5605.0, 5645.0, 5685.0, 5726.0, 5766.0, 5806.0, 5847.0, 5887.0, 5927.0, 5968.0, 6008.0, 6048.0, 6089.0, 6129.0, 6169.0, 6210.0, 6250.0, 6290.0, 6331.0, 6371.0, 6411.0, 6451.0, 6492.0, 6532.0, 6572.0, 6613.0, 6653.0, 6693.0, 6734.0, 6774.0, 6814.0, 6855.0, 6895.0, 6935.0, 6976.0, 7016.0, 7056.0, 7097.0, 7137.0, 7177.0, 7218.0, 7258.0, 7298.0, 7338.0, 7379.0, 7419.0, 7459.0, 7500.0, 7540.0, 7580.0, 7621.0, 7661.0, 7701.0, 7742.0, 7782.0, 7822.0, 7863.0, 7903.0, 7943.0, 7984.0, 8024.0, 8064.0, 8105.0, 8145.0, 8185.0, 8225.0, 8266.0, 8306.0, 8346.0, 8387.0, 8427.0, 8467.0, 8508.0, 8548.0, 8588.0, 8629.0, 8669.0, 8709.0, 8750.0, 8790.0, 8830.0, 8871.0, 8911.0, 8951.0, 8992.0, 9032.0, 9072.0, 9112.0, 9153.0, 9193.0, 9233.0, 9274.0, 9314.0, 9354.0, 9395.0, 9435.0, 9475.0, 9516.0, 9556.0, 9596.0, 9637.0, 9677.0, 9717.0, 9758.0, 9798.0, 9838.0, 9879.0, 9919.0, 9959.0, 10000.0]) AS bucket
+    WHERE val >= CAST(bucket AS INT64)
+  )
+);
+
+CREATE TEMP FUNCTION udf_boolean_buckets(
+  scalar_aggs ARRAY<STRUCT<metric STRING, metric_type STRING, key STRING, process STRING, agg_type STRING, value FLOAT64>>)
+  RETURNS ARRAY<STRUCT<metric STRING,
+    metric_type STRING,
+    key STRING,
+    process STRING,
+    agg_type STRING,
+    bucket STRING>> AS (
+    (
+      WITH boolean_columns AS
+        (SELECT
+          metric,
+          metric_type,
+          key,
+          process,
+          agg_type,
+          CASE agg_type
+            WHEN 'true' THEN value ELSE 0
+          END AS bool_true,
+          CASE agg_type
+            WHEN 'false' THEN value ELSE 0
+          END AS bool_false
+        FROM UNNEST(scalar_aggs)
+        WHERE metric_type in ("boolean", "keyed-scalar-boolean")),
+
+      summed_bools AS
+        (SELECT
+          metric,
+          metric_type,
+          key,
+          process,
+          '' AS agg_type,
+          SUM(bool_true) AS bool_true,
+          SUM(bool_false) AS bool_false
+        FROM boolean_columns
+        GROUP BY 1,2,3,4),
+
+      booleans AS
+        (SELECT * EXCEPT(bool_true, bool_false),
+        CASE
+          WHEN bool_true > 0 AND bool_false > 0
+          THEN "sometimes"
+          WHEN bool_true > 0 AND bool_false = 0
+          THEN "always"
+          WHEN bool_true = 0 AND bool_false > 0
+          THEN "never"
+        END AS bucket
+        FROM summed_bools
+        WHERE bool_true > 0 OR bool_false > 0)
+
+      SELECT ARRAY_AGG((metric, metric_type, key, process, agg_type, bucket))
+      FROM booleans
+    )
+);
+
+WITH bucketed_booleans AS (
+  SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    os = 'Windows' and channel = 'release' AS sampled,
+    has_fission,
+    udf_boolean_buckets(scalar_aggregates) AS scalar_aggregates,
+  FROM
+    telemetry.clients_scalar_aggregates_fission),
+
+bucketed_scalars AS (
+  SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    os = 'Windows' and channel = 'release' AS sampled,
+    has_fission,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type,
+    SAFE_CAST(udf_bucket(SAFE_CAST(value AS FLOAT64)) AS STRING) AS bucket,
+  FROM
+    telemetry.clients_scalar_aggregates_fission
+  CROSS JOIN UNNEST(scalar_aggregates)
+  WHERE
+    metric_type = 'scalar' OR metric_type = 'keyed-scalar'),
+
+booleans_and_scalars AS (
+  SELECT * EXCEPT(scalar_aggregates)
+  FROM bucketed_booleans
+  CROSS JOIN UNNEST(scalar_aggregates)
+
+  UNION ALL
+
+  SELECT *
+  FROM bucketed_scalars),
+
+aggregated_scalars AS (
+  SELECT
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    has_fission,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type,
+    bucket,
+    -- Fudge the numbers for the 10% sample.
+    -- MAX(sampled) returns true if at least 1 row has sampled=true.
+    COUNT(*) * IF(MAX(sampled), 10, 1) AS count
+  FROM booleans_and_scalars
+  WHERE os IS NOT NULL
+  GROUP BY
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    has_fission,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type,
+    bucket
+
+  UNION ALL
+
+  SELECT
+    client_id,
+    NULL AS os,
+    app_version,
+    app_build_id,
+    channel,
+    has_fission,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type,
+    bucket,
+    -- Fudge the numbers for the 10% sample.
+    -- MAX(sampled) returns true if at least 1 row has sampled=true.
+    COUNT(*) * IF(MAX(sampled), 10, 1) AS count
+  FROM booleans_and_scalars
+  GROUP BY
+    client_id,
+    app_version,
+    app_build_id,
+    channel,
+    has_fission,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type,
+    bucket
+
+  UNION ALL
+
+  SELECT
+    client_id,
+    os,
+    app_version,
+    NULL AS app_build_id,
+    channel,
+    has_fission,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type,
+    bucket,
+    -- Fudge the numbers for the 10% sample.
+    -- MAX(sampled) returns true if at least 1 row has sampled=true.
+    COUNT(*) * IF(MAX(sampled), 10, 1) AS count
+  FROM booleans_and_scalars
+  WHERE os IS NOT NULL
+  GROUP BY
+    client_id,
+    os,
+    app_version,
+    channel,
+    has_fission,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type,
+    bucket
+
+  UNION ALL
+
+  SELECT
+    client_id,
+    NULL AS os,
+    app_version,
+    NULL AS app_build_id,
+    channel,
+    has_fission,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type,
+    bucket,
+    -- Fudge the numbers for the 10% sample.
+    -- MAX(sampled) returns true if at least 1 row has sampled=true.
+    COUNT(*) * IF(MAX(sampled), 10, 1) AS count
+  FROM booleans_and_scalars
+  GROUP BY
+    client_id,
+    app_version,
+    channel,
+    has_fission,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type,
+    bucket
+)
+
+SELECT
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  has_fission,
+  metric,
+  metric_type,
+  key,
+  process,
+  agg_type AS client_agg_type,
+  'histogram' AS agg_type,
+  bucket,
+  COUNT(*) AS count
+FROM aggregated_scalars
+GROUP BY
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  has_fission,
+  metric,
+  metric_type,
+  key,
+  process,
+  client_agg_type,
+  bucket

--- a/sql/telemetry_derived/scalar_percentiles_fission_v1/query.sql
+++ b/sql/telemetry_derived/scalar_percentiles_fission_v1/query.sql
@@ -1,0 +1,144 @@
+CREATE TEMP FUNCTION udf_get_values(required ARRAY<FLOAT64>, values ARRAY<FLOAT64>)
+RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
+  (
+    SELECT ARRAY_AGG(record)
+    FROM (
+      SELECT
+        STRUCT<key STRING, value FLOAT64>(
+          CAST(k AS STRING),
+          values[OFFSET(CAST(k AS INT64))]
+        ) as record
+      FROM
+        UNNEST(required) AS k
+    )
+  )
+);
+
+WITH flat_clients_scalar_aggregates AS (
+  SELECT * EXCEPT(scalar_aggregates)
+  FROM telemetry.clients_scalar_aggregates_fission
+  CROSS JOIN UNNEST(scalar_aggregates)),
+
+percentiles AS (
+  SELECT
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type AS client_agg_type,
+    'percentiles' AS agg_type,
+    COUNT(*) AS total_users,
+    APPROX_QUANTILES(value, 100)  AS aggregates,
+    has_fission,
+  FROM
+    flat_clients_scalar_aggregates
+  WHERE os IS NOT NULL
+  GROUP BY
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    metric,
+    metric_type,
+    key,
+    process,
+    client_agg_type,
+    has_fissioon
+
+  UNION ALL
+
+  SELECT
+    CAST(NULL AS STRING) as os,
+    app_version,
+    app_build_id,
+    channel,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type AS client_agg_type,
+    'percentiles' AS agg_type,
+    COUNT(*) AS total_users,
+    APPROX_QUANTILES(value, 100)  AS aggregates,
+    has_fission,
+  FROM
+    flat_clients_scalar_aggregates
+  GROUP BY
+    app_version,
+    app_build_id,
+    channel,
+    metric,
+    metric_type,
+    key,
+    process,
+    client_agg_type,
+    has_fission
+
+  UNION ALL
+
+  SELECT
+    os,
+    app_version,
+    CAST(NULL AS STRING) AS app_build_id,
+    channel,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type AS client_agg_type,
+    'percentiles' AS agg_type,
+    COUNT(*) AS total_users,
+    APPROX_QUANTILES(value, 100)  AS aggregates,
+    has_fission,
+  FROM
+    flat_clients_scalar_aggregates
+  WHERE os IS NOT NULL
+  GROUP BY
+    os,
+    app_version,
+    channel,
+    metric,
+    metric_type,
+    key,
+    process,
+    client_agg_type,
+    has_fission
+
+  UNION ALL
+
+  SELECT
+    CAST(NULL AS STRING) AS os,
+    app_version,
+    CAST(NULL AS STRING) AS app_build_id,
+    channel,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type AS client_agg_type,
+    'percentiles' AS agg_type,
+    COUNT(*) AS total_users,
+    APPROX_QUANTILES(value, 100)  AS aggregates,
+    has_fission,
+  FROM
+    flat_clients_scalar_aggregates
+  GROUP BY
+    app_version,
+    channel,
+    metric,
+    metric_type,
+    key,
+    process,
+    client_agg_type,
+    has_fission)
+
+SELECT *
+REPLACE(udf_get_values(
+  [5.0, 25.0, 50.0, 75.0, 95.0],
+  aggregates
+) AS aggregates)
+FROM percentiles


### PR DESCRIPTION
`clients_histogram_bucket_counts_fission_v1` fails due to shuffle size limit because of the join in the `clients_histogram_aggregates_fission` view.

Scalar queries work fine