### PR TITLE
Update deviations DAG

### DIFF
--- a/dags/bqetl_amo_stats.py
+++ b/dags/bqetl_amo_stats.py
@@ -1,4 +1,4 @@
-# Generated via query_scheduling/generate_airflow_dags
+# Generated via https://github.com/mozilla/bigquery-etl/blob/master/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor

--- a/dags/bqetl_deviations.py
+++ b/dags/bqetl_deviations.py
@@ -36,11 +36,11 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_public_analysis_anomdtct = ExternalTaskSensor(
-        task_id="wait_for_public_analysis_anomdtct",
-        external_dag_id="public_analysis",
+    wait_for_anomdtct_anomdtct = ExternalTaskSensor(
+        task_id="wait_for_anomdtct_anomdtct",
+        external_dag_id="anomdtct",
         external_task_id="anomdtct",
         dag=dag,
     )
 
-    telemetry_derived__deviations__v1.set_upstream(wait_for_public_analysis_anomdtct)
+    telemetry_derived__deviations__v1.set_upstream(wait_for_anomdtct_anomdtct)

--- a/sql/telemetry_derived/deviations_v1/metadata.yaml
+++ b/sql/telemetry_derived/deviations_v1/metadata.yaml
@@ -14,4 +14,4 @@ scheduling:
   dag_name: bqetl_deviations
   depends_on:
     - task_id: anomdtct
-      dag_name: public_analysis
+      dag_name: anomdtct


### PR DESCRIPTION
I moved the `anomdtct` pipeline to its own DAG in https://github.com/mozilla/telemetry-airflow/pull/1013