### PR TITLE
Bug 1621703 - Hide deprecated client_id field in default_browser view

### DIFF
--- a/script/dryrun
+++ b/script/dryrun
@@ -81,6 +81,7 @@ SKIP = {
     "sql/telemetry_derived/clients_last_seen_v1/init.sql",
     # HTTP Error 408: Request Time-out
     "sql/telemetry_derived/latest_versions/query.sql",
+    "sql/telemetry_derived/italy_covid19_outage_v1/query.sql",
     # Query parameter not found
     "sql/telemetry_derived/experiments_v1/query.sql",
     "sql/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql",

--- a/sql/default_browser_agent/default_browser/view.sql
+++ b/sql/default_browser_agent/default_browser/view.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.default_browser_agent.default_browser`
+SELECT
+  * EXCEPT (
+    client_id  -- This field is deprecated and was never actually sent.
+  ) REPLACE(`moz-fx-data-shared-prod.udf.normalize_metadata`(metadata) AS metadata)
+FROM
+  `moz-fx-data-shared-prod.default_browser_agent_stable.default_browser_v1`

--- a/sql/default_browser_agent/default_browser/view.sql
+++ b/sql/default_browser_agent/default_browser/view.sql
@@ -1,5 +1,6 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.default_browser_agent.default_browser`
+AS
 SELECT
   * EXCEPT (
     client_id  -- This field is deprecated and was never actually sent.


### PR DESCRIPTION
Also see https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/557

cc @bytesized