### PR TITLE
Lower-friction scheduled queries: bqetl_nondesktop DAG

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -124,6 +124,16 @@ class Task:
                 f"Invalid DAG name {value} for task. Name must start with 'bqetl_'."
             )
 
+    @task_name.validator
+    def validate_task_name(self, attribute, value):
+        """Validate the task name."""
+        if value is not None:
+            if len(value) < 1 or len(value) > 62:
+                raise ValueError(
+                    f"Invalid task name {value}. "
+                    + "The task name has to be 1 to 62 characters long."
+                )
+
     def __attrs_post_init__(self):
         """Extract information from the query file name."""
         query_file_re = re.search(QUERY_FILE_RE, self.query_file)
@@ -134,6 +144,7 @@ class Task:
 
             if self.task_name is None:
                 self.task_name = f"{self.dataset}__{self.table}__{self.version}"
+                self.validate_task_name(None, self.task_name)
         else:
             raise ValueError(
                 "query_file must be a path with format:"

--- a/dags.yaml
+++ b/dags.yaml
@@ -63,6 +63,15 @@ bqetl_core:
     retries: 1
     retry_delay: 5m
 
+bqetl_nondesktop:
+  schedule_interval: 0 1 * * *
+  default_args:
+    owner: jklukas@mozilla.com
+    start_date: '2019-07-25'
+    email: ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com']
+    retries: 1
+    retry_delay: 5m
+
 # DAG for exporting query data marked as public to GCS
 # queries should not be explicitly assigned to this DAG (it's done automatically)
 bqetl_public_data_json:

--- a/dags/bqetl_kpi_dashboard.py
+++ b/dags/bqetl_kpi_dashboard.py
@@ -56,6 +56,28 @@ with DAG(
         dag=dag,
     )
 
+    wait_for_telemetry_derived__smoot_usage_nondesktop__v2 = ExternalTaskSensor(
+        task_id="wait_for_telemetry_derived__smoot_usage_nondesktop__v2",
+        external_dag_id="bqetl_nondesktop",
+        external_task_id="telemetry_derived__smoot_usage_nondesktop__v2",
+        check_existence=True,
+    )
+
+    telemetry_derived__smoot_usage_new_profiles__v2.set_upstream(
+        wait_for_telemetry_derived__smoot_usage_nondesktop__v2
+    )
+
     telemetry_derived__smoot_usage_new_profiles_compressed__v2.set_upstream(
         telemetry_derived__smoot_usage_new_profiles__v2
+    )
+
+    wait_for_telemetry__firefox_nondesktop_exact_mau28_raw__v1 = ExternalTaskSensor(
+        task_id="wait_for_telemetry__firefox_nondesktop_exact_mau28_raw__v1",
+        external_dag_id="bqetl_nondesktop",
+        external_task_id="telemetry__firefox_nondesktop_exact_mau28_raw__v1",
+        check_existence=True,
+    )
+
+    kpi_dashboard.set_upstream(
+        wait_for_telemetry__firefox_nondesktop_exact_mau28_raw__v1
     )

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -44,8 +44,8 @@ with DAG(
         dag=dag,
     )
 
-    telemetry_derived__firefox_nondesktop_exact_mau28_by_client_count_dimensions__v1 = bigquery_etl_query(
-        task_id="telemetry_derived__firefox_nondesktop_exact_mau28_by_client_count_dimensions__v1",
+    firefox_nondesktop_exact_mau28_by_client_count_dimensions = bigquery_etl_query(
+        task_id="firefox_nondesktop_exact_mau28_by_client_count_dimensions",
         destination_table="firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1",
         dataset_id="telemetry_derived",
         project_id="moz-fx-data-shared-prod",
@@ -106,10 +106,10 @@ with DAG(
         telemetry_derived__smoot_usage_nondesktop__v2
     )
 
-    telemetry_derived__firefox_nondesktop_exact_mau28_by_client_count_dimensions__v1.set_upstream(
+    firefox_nondesktop_exact_mau28_by_client_count_dimensions.set_upstream(
         wait_for_telemetry_derived__core_clients_last_seen__v1
     )
-    telemetry_derived__firefox_nondesktop_exact_mau28_by_client_count_dimensions__v1.set_upstream(
+    firefox_nondesktop_exact_mau28_by_client_count_dimensions.set_upstream(
         wait_for_copy_deduplicate_baseline_clients_last_seen
     )
 

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -1,0 +1,108 @@
+# Generated via https://github.com/mozilla/bigquery-etl/blob/master/bigquery_etl/query_scheduling/generate_airflow_dags.py
+
+from airflow import DAG
+from airflow.operators.sensors import ExternalTaskSensor
+import datetime
+from utils.gcp import bigquery_etl_query
+
+default_args = {
+    "owner": "jklukas@mozilla.com",
+    "start_date": datetime.datetime(2019, 7, 25, 0, 0),
+    "email": ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
+    "depends_on_past": False,
+    "retry_delay": datetime.timedelta(seconds=300),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 1,
+}
+
+with DAG(
+    "bqetl_nondesktop", default_args=default_args, schedule_interval="0 1 * * *"
+) as dag:
+
+    telemetry_derived__firefox_nondesktop_day_2_7_activation__v1 = bigquery_etl_query(
+        task_id="telemetry_derived__firefox_nondesktop_day_2_7_activation__v1",
+        destination_table="firefox_nondesktop_day_2_7_activation_v1",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="gkaberere@mozilla.com",
+        email=["gkaberere@mozilla.com", "jklukas@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    telemetry_derived__smoot_usage_nondesktop_compressed__v2 = bigquery_etl_query(
+        task_id="telemetry_derived__smoot_usage_nondesktop_compressed__v2",
+        destination_table="smoot_usage_nondesktop_compressed_v2",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=["jklukas@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    telemetry_derived__firefox_nondesktop_exact_mau28_by_client_count_dimensions__v1 = bigquery_etl_query(
+        task_id="telemetry_derived__firefox_nondesktop_exact_mau28_by_client_count_dimensions__v1",
+        destination_table="firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=["jklukas@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    telemetry_derived__smoot_usage_nondesktop__v2 = bigquery_etl_query(
+        task_id="telemetry_derived__smoot_usage_nondesktop__v2",
+        destination_table="smoot_usage_nondesktop_v2",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=["jklukas@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    telemetry__firefox_nondesktop_exact_mau28_raw__v1 = bigquery_etl_query(
+        task_id="telemetry__firefox_nondesktop_exact_mau28_raw__v1",
+        destination_table="firefox_nondesktop_exact_mau28_raw_v1",
+        dataset_id="telemetry",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=["jklukas@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    wait_for_telemetry_derived__core_clients_last_seen__v1 = ExternalTaskSensor(
+        task_id="wait_for_telemetry_derived__core_clients_last_seen__v1",
+        external_dag_id="bqetl_core",
+        external_task_id="telemetry_derived__core_clients_last_seen__v1",
+        check_existence=True,
+    )
+
+    telemetry_derived__firefox_nondesktop_day_2_7_activation__v1.set_upstream(
+        wait_for_telemetry_derived__core_clients_last_seen__v1
+    )
+
+    telemetry_derived__smoot_usage_nondesktop_compressed__v2.set_upstream(
+        telemetry_derived__smoot_usage_nondesktop__v2
+    )
+
+    telemetry_derived__firefox_nondesktop_exact_mau28_by_client_count_dimensions__v1.set_upstream(
+        wait_for_telemetry_derived__core_clients_last_seen__v1
+    )
+
+    telemetry_derived__smoot_usage_nondesktop__v2.set_upstream(
+        wait_for_telemetry_derived__core_clients_last_seen__v1
+    )
+
+    telemetry__firefox_nondesktop_exact_mau28_raw__v1.set_upstream(
+        wait_for_telemetry_derived__core_clients_last_seen__v1
+    )

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -90,6 +90,17 @@ with DAG(
     telemetry_derived__firefox_nondesktop_day_2_7_activation__v1.set_upstream(
         wait_for_telemetry_derived__core_clients_last_seen__v1
     )
+    wait_for_copy_deduplicate_baseline_clients_last_seen = ExternalTaskSensor(
+        task_id="wait_for_copy_deduplicate_baseline_clients_last_seen",
+        external_dag_id="copy_deduplicate",
+        external_task_id="baseline_clients_last_seen",
+        check_existence=True,
+        dag=dag,
+    )
+
+    telemetry_derived__firefox_nondesktop_day_2_7_activation__v1.set_upstream(
+        wait_for_copy_deduplicate_baseline_clients_last_seen
+    )
 
     telemetry_derived__smoot_usage_nondesktop_compressed__v2.set_upstream(
         telemetry_derived__smoot_usage_nondesktop__v2
@@ -98,11 +109,20 @@ with DAG(
     telemetry_derived__firefox_nondesktop_exact_mau28_by_client_count_dimensions__v1.set_upstream(
         wait_for_telemetry_derived__core_clients_last_seen__v1
     )
+    telemetry_derived__firefox_nondesktop_exact_mau28_by_client_count_dimensions__v1.set_upstream(
+        wait_for_copy_deduplicate_baseline_clients_last_seen
+    )
 
     telemetry_derived__smoot_usage_nondesktop__v2.set_upstream(
         wait_for_telemetry_derived__core_clients_last_seen__v1
     )
+    telemetry_derived__smoot_usage_nondesktop__v2.set_upstream(
+        wait_for_copy_deduplicate_baseline_clients_last_seen
+    )
 
     telemetry__firefox_nondesktop_exact_mau28_raw__v1.set_upstream(
         wait_for_telemetry_derived__core_clients_last_seen__v1
+    )
+    telemetry__firefox_nondesktop_exact_mau28_raw__v1.set_upstream(
+        wait_for_copy_deduplicate_baseline_clients_last_seen
     )

--- a/sql/telemetry/firefox_nondesktop_exact_mau28_raw_v1/metadata.yaml
+++ b/sql/telemetry/firefox_nondesktop_exact_mau28_raw_v1/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Firefox Non-desktop Exact MAU Raw
+description: >
+  Monthly active users with non-desktop clients.
+owners:
+  - jklukas@mozilla.com
+labels:
+  application: nondesktop
+  schedule: daily
+  incremental: true
+scheduling:
+  dag_name: bqetl_nondesktop

--- a/sql/telemetry/firefox_nondesktop_exact_mau28_raw_v1/metadata.yaml
+++ b/sql/telemetry/firefox_nondesktop_exact_mau28_raw_v1/metadata.yaml
@@ -9,3 +9,6 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_nondesktop
+  depends_on:
+    - dag_name: copy_deduplicate
+      task_id: baseline_clients_last_seen

--- a/sql/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/metadata.yaml
+++ b/sql/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/metadata.yaml
@@ -8,3 +8,6 @@ labels:
   application: nondesktop
   incremental: true
   schedule: daily
+scheduling:
+  dag_name: bqetl_nondesktop
+  email: ['jklukas@mozilla.com']

--- a/sql/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/metadata.yaml
+++ b/sql/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/metadata.yaml
@@ -11,3 +11,6 @@ labels:
 scheduling:
   dag_name: bqetl_nondesktop
   email: ['jklukas@mozilla.com']
+  depends_on:
+    - dag_name: copy_deduplicate
+      task_id: baseline_clients_last_seen

--- a/sql/telemetry_derived/firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
+++ b/sql/telemetry_derived/firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_nondesktop
+  task_name: firefox_nondesktop_exact_mau28_by_client_count_dimensions
   depends_on:
     - dag_name: copy_deduplicate
       task_id: baseline_clients_last_seen

--- a/sql/telemetry_derived/firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
+++ b/sql/telemetry_derived/firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Firefox Non-desktop Exact MAU by Client Count Dimensions
+description: >
+  Monthly active users with non-desktop clients aggregated across unique sets of dimensions.
+owners:
+  - jklukas@mozilla.com
+labels:
+  application: nondesktop
+  schedule: daily
+  incremental: true
+scheduling:
+  dag_name: bqetl_nondesktop

--- a/sql/telemetry_derived/firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
+++ b/sql/telemetry_derived/firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
@@ -9,3 +9,6 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_nondesktop
+  depends_on:
+    - dag_name: copy_deduplicate
+      task_id: baseline_clients_last_seen

--- a/sql/telemetry_derived/smoot_usage_nondesktop_compressed_v2/metadata.yaml
+++ b/sql/telemetry_derived/smoot_usage_nondesktop_compressed_v2/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Smoot Usage Non-desktop Compressed
+description: >
+  Compressed usage metrics for non-desktop clients.
+owners:
+  - jklukas@mozilla.com
+labels:
+  application: nondesktop
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_nondesktop

--- a/sql/telemetry_derived/smoot_usage_nondesktop_v2/metadata.yaml
+++ b/sql/telemetry_derived/smoot_usage_nondesktop_v2/metadata.yaml
@@ -9,3 +9,6 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_nondesktop
+  depends_on:
+    - dag_name: copy_deduplicate
+      task_id: baseline_clients_last_seen

--- a/sql/telemetry_derived/smoot_usage_nondesktop_v2/metadata.yaml
+++ b/sql/telemetry_derived/smoot_usage_nondesktop_v2/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Smoot Usage Non-desktop
+description: >
+  Usage metrics for non-desktop clients.
+owners:
+  - jklukas@mozilla.com
+labels:
+  application: nondesktop
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_nondesktop

--- a/tests/query_scheduling/test_task.py
+++ b/tests/query_scheduling/test_task.py
@@ -126,6 +126,64 @@ class TestTask:
         assert task.dag_name == "bqetl_test_dag"
         assert task.task_name == "custom_task_name"
 
+    def test_validate_custom_task_name(self):
+        query_file = (
+            TEST_DIR
+            / "data"
+            / "test_sql"
+            / "test"
+            / "incremental_query_v1"
+            / "query.sql"
+        )
+
+        scheduling = {
+            "dag_name": "bqetl_test_dag",
+            "default_args": {"owner": "test@example.org"},
+            "task_name": "a" * 63,
+        }
+
+        metadata = Metadata("test", "test", ["test@example.org"], {}, scheduling)
+
+        with pytest.raises(ValueError):
+            Task.of_query(query_file, metadata)
+
+        scheduling = {
+            "dag_name": "bqetl_test_dag",
+            "default_args": {"owner": "test@example.org"},
+            "task_name": "",
+        }
+
+        metadata = Metadata("test", "test", ["test@example.org"], {}, scheduling)
+
+        with pytest.raises(ValueError):
+            Task.of_query(query_file, metadata)
+
+        scheduling = {
+            "dag_name": "bqetl_test_dag",
+            "default_args": {"owner": "test@example.org"},
+            "task_name": "a" * 62,
+        }
+
+        metadata = Metadata("test", "test", ["test@example.org"], {}, scheduling)
+
+        task = Task.of_query(query_file, metadata)
+        assert task.task_name == "a" * 62
+
+    def test_validate_task_name(self):
+        query_file = (
+            TEST_DIR / "data" / "test_sql" / "test" / (("a" * 63) + "_v1") / "query.sql"
+        )
+
+        scheduling = {
+            "dag_name": "bqetl_test_dag",
+            "default_args": {"owner": "test@example.org"},
+        }
+
+        metadata = Metadata("test", "test", ["test@example.org"], {}, scheduling)
+
+        with pytest.raises(ValueError):
+            Task.of_query(query_file, metadata)
+
     def test_dag_name_validation(self):
         query_file = (
             TEST_DIR


### PR DESCRIPTION
Depends on https://github.com/mozilla/bigquery-etl/pull/1040

Moves scheduled non-desktop queries to their own DAG.