### PR TITLE
ExternalTaskSensor use reschedule mode

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -50,6 +50,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         external_dag_id='{{ dependency.dag_name }}',
         external_task_id='{{ dependency.task_name }}',
         check_existence=True,
+        mode='reschedule',
     )
     {{ wait_for_seen.append((dependency.dag_name, dependency.task_name)) or "" }}
     {% endif -%}
@@ -69,6 +70,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         execution_delta={{ task_ref.execution_delta | format_timedelta | format_repr }},
         {% endif -%}
         check_existence=True,
+        mode='reschedule',
         dag=dag,
     )
     {{ wait_for_seen.append((task_ref.dag_name, task_ref.task_id)) or "" }}

--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -41,6 +41,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         external_dag_id='{{ dependency.dag_name }}',
         external_task_id='{{ dependency.task_name }}',
         check_existence=True,
+        mode='reschedule',
     )
         
     {{ task.task_name }}.set_upstream(wait_for_{{ dependency.task_name }})

--- a/dags/bqetl_amo_stats.py
+++ b/dags/bqetl_amo_stats.py
@@ -77,6 +77,7 @@ with DAG(
         external_dag_id="main_summary",
         external_task_id="clients_daily",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/bqetl_core.py
+++ b/dags/bqetl_core.py
@@ -47,6 +47,7 @@ with DAG("bqetl_core", default_args=default_args, schedule_interval="0 1 * * *")
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/bqetl_deviations.py
+++ b/dags/bqetl_deviations.py
@@ -41,6 +41,7 @@ with DAG(
         external_dag_id="anomdtct",
         external_task_id="anomdtct",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/bqetl_gud.py
+++ b/dags/bqetl_gud.py
@@ -95,6 +95,7 @@ with DAG("bqetl_gud", default_args=default_args, schedule_interval="0 1 * * *") 
         external_dag_id="main_summary",
         external_task_id="clients_last_seen",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 
@@ -127,6 +128,7 @@ with DAG("bqetl_gud", default_args=default_args, schedule_interval="0 1 * * *") 
         external_dag_id="bqetl_core",
         external_task_id="telemetry_derived__core_clients_last_seen__v1",
         check_existence=True,
+        mode="reschedule",
     )
 
     telemetry_derived__smoot_usage_nondesktop__v2.set_upstream(
@@ -137,6 +139,7 @@ with DAG("bqetl_gud", default_args=default_args, schedule_interval="0 1 * * *") 
         external_dag_id="copy_deduplicate",
         external_task_id="baseline_clients_last_seen",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/bqetl_mobile_search.py
+++ b/dags/bqetl_mobile_search.py
@@ -49,6 +49,7 @@ with DAG(
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -61,6 +61,7 @@ with DAG(
         external_dag_id="bqetl_core",
         external_task_id="telemetry_derived__core_clients_last_seen__v1",
         check_existence=True,
+        mode="reschedule",
     )
 
     telemetry_derived__firefox_nondesktop_day_2_7_activation__v1.set_upstream(
@@ -71,6 +72,7 @@ with DAG(
         external_dag_id="copy_deduplicate",
         external_task_id="baseline_clients_last_seen",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/bqetl_public_data_json.py
+++ b/dags/bqetl_public_data_json.py
@@ -53,6 +53,7 @@ with DAG(
         external_dag_id="bqetl_ssl_ratios",
         external_task_id="telemetry_derived__ssl_ratios__v1",
         check_existence=True,
+        mode="reschedule",
     )
 
     export_public_data_json_telemetry_derived__ssl_ratios__v1.set_upstream(
@@ -64,6 +65,7 @@ with DAG(
         external_dag_id="bqetl_deviations",
         external_task_id="telemetry_derived__deviations__v1",
         check_existence=True,
+        mode="reschedule",
     )
 
     export_public_data_json_telemetry_derived__deviations__v1.set_upstream(

--- a/dags/bqetl_vrbrowser.py
+++ b/dags/bqetl_vrbrowser.py
@@ -77,6 +77,7 @@ with DAG(
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -38,6 +38,7 @@ with DAG('bqetl_test_dag', default_args=default_args, schedule_interval='@daily'
         external_dag_id="external",
         external_task_id="task1",
         check_existence=True,
+        mode='reschedule',
         dag=dag,
     )
     

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -50,6 +50,7 @@ with DAG('bqetl_test_dag', default_args=default_args, schedule_interval='@daily'
         external_dag_id='bqetl_external_test_dag',
         external_task_id='{{ temporary_dataset }}__external_table__v1',
         check_existence=True,
+        mode='reschedule',
     )
     
     {{ temporary_dataset }}__query__v1.set_upstream(wait_for_{{ temporary_dataset }}__external_table__v1)

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -29,6 +29,7 @@ with DAG('bqetl_public_data_json', default_args=default_args, schedule_interval=
         external_dag_id='bqetl_core',
         external_task_id='test__non_incremental_query__v1',
         check_existence=True,
+        mode='reschedule',
     )
         
     export_public_data_json_test__non_incremental_query__v1.set_upstream(wait_for_test__non_incremental_query__v1)


### PR DESCRIPTION
Right now we seem to be running into issues with Airflow as it seems we have more sensors than available slots resulting in a deadlock. We can use `mode='reschedule'` which will reschedule the task when it's blocked in free up slots.
See also: https://godatadriven.com/blog/highlights-from-the-new-apache-airflow-1-10-2-release/