### PR TITLE
DAG for messaging system queries

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -79,6 +79,15 @@ bqetl_gud:
     email: ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com']
     retries: 1
     retry_delay: 5m
+
+bqetl_messaging_system:
+  schedule_interval: 0 1 * * *
+  default_args:
+    owner: najiang@mozilla.com
+    start_date: '2019-07-25'
+    email: ['telemetry-alerts@mozilla.com', 'najiang@mozilla.com']
+    retries: 1
+    retry_delay: 5m
     
 # DAG for exporting query data marked as public to GCS
 # queries should not be explicitly assigned to this DAG (it's done automatically)

--- a/dags/bqetl_messaging_system.py
+++ b/dags/bqetl_messaging_system.py
@@ -1,0 +1,174 @@
+# Generated via https://github.com/mozilla/bigquery-etl/blob/master/bigquery_etl/query_scheduling/generate_airflow_dags.py
+
+from airflow import DAG
+from airflow.operators.sensors import ExternalTaskSensor
+import datetime
+from utils.gcp import bigquery_etl_query
+
+default_args = {
+    "owner": "najiang@mozilla.com",
+    "start_date": datetime.datetime(2019, 7, 25, 0, 0),
+    "email": ["telemetry-alerts@mozilla.com", "najiang@mozilla.com"],
+    "depends_on_past": False,
+    "retry_delay": datetime.timedelta(seconds=300),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 1,
+}
+
+with DAG(
+    "bqetl_messaging_system", default_args=default_args, schedule_interval="0 1 * * *"
+) as dag:
+
+    messaging_system_derived__onboarding_users_daily__v1 = bigquery_etl_query(
+        task_id="messaging_system_derived__onboarding_users_daily__v1",
+        destination_table="onboarding_users_daily_v1",
+        dataset_id="messaging_system_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="najiang@mozilla.com",
+        email=["najiang@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    messaging_system_derived__cfr_users_daily__v1 = bigquery_etl_query(
+        task_id="messaging_system_derived__cfr_users_daily__v1",
+        destination_table="cfr_users_daily_v1",
+        dataset_id="messaging_system_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="najiang@mozilla.com",
+        email=["najiang@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    messaging_system_derived__snippets_users_daily__v1 = bigquery_etl_query(
+        task_id="messaging_system_derived__snippets_users_daily__v1",
+        destination_table="snippets_users_daily_v1",
+        dataset_id="messaging_system_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="najiang@mozilla.com",
+        email=["najiang@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    messaging_system_onboarding_exact_mau28_by_dimensions = bigquery_etl_query(
+        task_id="messaging_system_onboarding_exact_mau28_by_dimensions",
+        destination_table="onboarding_exact_mau28_by_dimensions_v1",
+        dataset_id="messaging_system_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="najiang@mozilla.com",
+        email=["najiang@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    messaging_system_derived__cfr_users_last_seen__v1 = bigquery_etl_query(
+        task_id="messaging_system_derived__cfr_users_last_seen__v1",
+        destination_table="cfr_users_last_seen_v1",
+        dataset_id="messaging_system_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="najiang@mozilla.com",
+        email=["najiang@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=True,
+        dag=dag,
+    )
+
+    messaging_system_derived__snippets_users_last_seen__v1 = bigquery_etl_query(
+        task_id="messaging_system_derived__snippets_users_last_seen__v1",
+        destination_table="snippets_users_last_seen_v1",
+        dataset_id="messaging_system_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="najiang@mozilla.com",
+        email=["najiang@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=True,
+        dag=dag,
+    )
+
+    messaging_system_derived__onboarding_users_last_seen__v1 = bigquery_etl_query(
+        task_id="messaging_system_derived__onboarding_users_last_seen__v1",
+        destination_table="onboarding_users_last_seen_v1",
+        dataset_id="messaging_system_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="najiang@mozilla.com",
+        email=["najiang@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=True,
+        dag=dag,
+    )
+
+    messaging_system_snippets_exact_mau28_by_dimensions = bigquery_etl_query(
+        task_id="messaging_system_snippets_exact_mau28_by_dimensions",
+        destination_table="snippets_exact_mau28_by_dimensions_v1",
+        dataset_id="messaging_system_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="najiang@mozilla.com",
+        email=["najiang@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    messaging_system_derived__cfr_exact_mau28_by_dimensions__v1 = bigquery_etl_query(
+        task_id="messaging_system_derived__cfr_exact_mau28_by_dimensions__v1",
+        destination_table="cfr_exact_mau28_by_dimensions_v1",
+        dataset_id="messaging_system_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="najiang@mozilla.com",
+        email=["najiang@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    wait_for_copy_deduplicate_copy_deduplicate_all = ExternalTaskSensor(
+        task_id="wait_for_copy_deduplicate_copy_deduplicate_all",
+        external_dag_id="copy_deduplicate",
+        external_task_id="copy_deduplicate_all",
+        check_existence=True,
+        mode="reschedule",
+        dag=dag,
+    )
+
+    messaging_system_derived__onboarding_users_daily__v1.set_upstream(
+        wait_for_copy_deduplicate_copy_deduplicate_all
+    )
+
+    messaging_system_derived__cfr_users_daily__v1.set_upstream(
+        wait_for_copy_deduplicate_copy_deduplicate_all
+    )
+
+    messaging_system_derived__snippets_users_daily__v1.set_upstream(
+        wait_for_copy_deduplicate_copy_deduplicate_all
+    )
+
+    messaging_system_onboarding_exact_mau28_by_dimensions.set_upstream(
+        messaging_system_derived__onboarding_users_last_seen__v1
+    )
+
+    messaging_system_derived__cfr_users_last_seen__v1.set_upstream(
+        messaging_system_derived__cfr_users_daily__v1
+    )
+
+    messaging_system_derived__snippets_users_last_seen__v1.set_upstream(
+        messaging_system_derived__snippets_users_daily__v1
+    )
+
+    messaging_system_derived__onboarding_users_last_seen__v1.set_upstream(
+        messaging_system_derived__onboarding_users_daily__v1
+    )
+
+    messaging_system_snippets_exact_mau28_by_dimensions.set_upstream(
+        messaging_system_derived__snippets_users_last_seen__v1
+    )
+
+    messaging_system_derived__cfr_exact_mau28_by_dimensions__v1.set_upstream(
+        messaging_system_derived__cfr_users_last_seen__v1
+    )

--- a/sql/messaging_system_derived/cfr_exact_mau28_by_dimensions_v1/metadata.yaml
+++ b/sql/messaging_system_derived/cfr_exact_mau28_by_dimensions_v1/metadata.yaml
@@ -1,0 +1,9 @@
+friendly_name: Messaging System CFR Exact MAU by Dimensions
+description: >
+  Monthly active users using CFR aggregated across unique sets of dimensions.
+owners:
+  - najiang@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_messaging_system

--- a/sql/messaging_system_derived/cfr_users_daily_v1/metadata.yaml
+++ b/sql/messaging_system_derived/cfr_users_daily_v1/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Messaging System CFR Users Daily
+description: Daily users of CFR, partitioned by day
+owners:
+  - najiang@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_messaging_system
+  depends_on:
+    - dag_name: copy_deduplicate
+      task_id: copy_deduplicate_all

--- a/sql/messaging_system_derived/cfr_users_last_seen_v1/metadata.yaml
+++ b/sql/messaging_system_derived/cfr_users_last_seen_v1/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Messaging System CFR Users Last Seen
+description: >
+  Captures history of activity of each client using CFR in 28 day
+  windows for each submission date.
+owners:
+  - najiang@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_messaging_system
+  depends_on_past: true

--- a/sql/messaging_system_derived/onboarding_exact_mau28_by_dimensions_v1/metadata.yaml
+++ b/sql/messaging_system_derived/onboarding_exact_mau28_by_dimensions_v1/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Messaging System Onboarding Exact MAU by Dimensions
+description: >
+  Monthly active users using Onboarding aggregated across unique sets of dimensions.
+owners:
+  - najiang@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_messaging_system
+  task_name: messaging_system_onboarding_exact_mau28_by_dimensions

--- a/sql/messaging_system_derived/onboarding_users_daily_v1/metadata.yaml
+++ b/sql/messaging_system_derived/onboarding_users_daily_v1/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Messaging System Onboarding Users Daily
+description: Daily users of Onboarding, partitioned by day
+owners:
+  - najiang@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_messaging_system
+  depends_on:
+    - dag_name: copy_deduplicate
+      task_id: copy_deduplicate_all

--- a/sql/messaging_system_derived/onboarding_users_last_seen_v1/metadata.yaml
+++ b/sql/messaging_system_derived/onboarding_users_last_seen_v1/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Messaging System Onboarding Users Last Seen
+description: >
+  Captures history of activity of each client using Onboarding in 28 day
+  windows for each submission date.
+owners:
+  - najiang@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_messaging_system
+  depends_on_past: true

--- a/sql/messaging_system_derived/snippets_exact_mau28_by_dimensions_v1/metadata.yaml
+++ b/sql/messaging_system_derived/snippets_exact_mau28_by_dimensions_v1/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Messaging System Snippets Exact MAU by Dimensions
+description: >
+  Monthly active users using Snippets aggregated across unique sets of dimensions.
+owners:
+  - najiang@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_messaging_system
+  task_name: messaging_system_snippets_exact_mau28_by_dimensions

--- a/sql/messaging_system_derived/snippets_users_daily_v1/metadata.yaml
+++ b/sql/messaging_system_derived/snippets_users_daily_v1/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Messaging System Snippets Users Daily
+description: Daily users of Snippets, partitioned by day
+owners:
+  - najiang@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_messaging_system
+  depends_on:
+    - dag_name: copy_deduplicate
+      task_id: copy_deduplicate_all

--- a/sql/messaging_system_derived/snippets_users_last_seen_v1/metadata.yaml
+++ b/sql/messaging_system_derived/snippets_users_last_seen_v1/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Messaging System Snippets Users Last Seen
+description: >
+  Captures history of activity of each client using Snippets in 28 day
+  windows for each submission date.
+owners:
+  - najiang@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_messaging_system
+  depends_on_past: true


### PR DESCRIPTION
Continuing the migration of queries to generate Airflow DAGs. 

The generated DAG and changes are added to telemetry-airflow in https://github.com/mozilla/telemetry-airflow/pull/1026

---
@ncloudioj For some more context: we added a mechanism that allows to generate Airflow DAGs for queries based on metadata specified in `metadata.yaml` files. The mechanism also automatically determines query dependencies and adds those to the generated DAG. In the near future, telemetry-airflow will automatically pick up DAGs that are generated in this repository making. That way it won't be necessary to manually write DAGs in telemetry-airflow anymore.

Currently, we are manually migrating queries to make sure nothing breaks before switching to a fully automated approach.