### PR TITLE
Create bqetl_activity_stream DAG

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -88,6 +88,15 @@ bqetl_messaging_system:
     email: ['telemetry-alerts@mozilla.com', 'najiang@mozilla.com']
     retries: 1
     retry_delay: 5m
+
+bqetl_activity_stream:
+  schedule_interval: 0 1 * * *
+  default_args:
+    owner: jklukas@mozilla.com
+    start_date: '2019-07-25'
+    email: ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com']
+    retries: 1
+    retry_delay: 5m
     
 # DAG for exporting query data marked as public to GCS
 # queries should not be explicitly assigned to this DAG (it's done automatically)

--- a/dags/bqetl_activity_stream.py
+++ b/dags/bqetl_activity_stream.py
@@ -1,0 +1,46 @@
+# Generated via https://github.com/mozilla/bigquery-etl/blob/master/bigquery_etl/query_scheduling/generate_airflow_dags.py
+
+from airflow import DAG
+from airflow.operators.sensors import ExternalTaskSensor
+import datetime
+from utils.gcp import bigquery_etl_query
+
+default_args = {
+    "owner": "jklukas@mozilla.com",
+    "start_date": datetime.datetime(2019, 7, 25, 0, 0),
+    "email": ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
+    "depends_on_past": False,
+    "retry_delay": datetime.timedelta(seconds=300),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 1,
+}
+
+with DAG(
+    "bqetl_activity_stream", default_args=default_args, schedule_interval="0 1 * * *"
+) as dag:
+
+    activity_stream_bi__impression_stats_flat__v1 = bigquery_etl_query(
+        task_id="activity_stream_bi__impression_stats_flat__v1",
+        destination_table="impression_stats_flat_v1",
+        dataset_id="activity_stream_bi",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=["jklukas@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    wait_for_copy_deduplicate_copy_deduplicate_all = ExternalTaskSensor(
+        task_id="wait_for_copy_deduplicate_copy_deduplicate_all",
+        external_dag_id="copy_deduplicate",
+        external_task_id="copy_deduplicate_all",
+        check_existence=True,
+        mode="reschedule",
+        dag=dag,
+    )
+
+    activity_stream_bi__impression_stats_flat__v1.set_upstream(
+        wait_for_copy_deduplicate_copy_deduplicate_all
+    )

--- a/sql/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
+++ b/sql/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
@@ -1,0 +1,12 @@
+friendly_name: Impression Stats Flat
+description: Flattened impression stats.
+owners:
+  - jklukas@mozilla.com
+labels:
+  application: activity_stream
+  schedule: daily
+scheduling:
+  dag_name: bqetl_activity_stream
+  depends_on:
+    - dag_name: copy_deduplicate
+      task_id: copy_deduplicate_all

--- a/sql/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
+++ b/sql/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: Impression Stats Flat
-description: Flattened impression stats.
+description: Unnested representation of tile impression statistics
 owners:
   - jklukas@mozilla.com
 labels:


### PR DESCRIPTION
Scheduling `impression_stats_flat_v1` query so that it can moved out of `copy_deduplicate`.

Generates https://github.com/mozilla/telemetry-airflow/pull/1030