### PR TITLE
Remove all references to derived-datasets in views

### DIFF
--- a/sql/telemetry/clients_daily/view.sql
+++ b/sql/telemetry/clients_daily/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.clients_daily_v6`
+  `moz-fx-data-shared-prod.telemetry_derived.clients_daily_v6`

--- a/sql/telemetry/crash_aggregates/view.sql
+++ b/sql/telemetry/crash_aggregates/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.crash_aggregates_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.crash_aggregates_v1`

--- a/sql/telemetry/crash_summary/view.sql
+++ b/sql/telemetry/crash_summary/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.crash_summary_v2`
+  `moz-fx-data-shared-prod.telemetry_derived.crash_summary_v2`

--- a/sql/telemetry/eng_workflow_build_parquet/view.sql
+++ b/sql/telemetry/eng_workflow_build_parquet/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.eng_workflow_build_parquet_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.eng_workflow_build_parquet_v1`

--- a/sql/telemetry/events/view.sql
+++ b/sql/telemetry/events/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.events_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.events_v1`

--- a/sql/telemetry/experiments/view.sql
+++ b/sql/telemetry/experiments/view.sql
@@ -188,4 +188,4 @@ SELECT
     scalar_parent_webrtc_peerconnection_connected
   )
 FROM
-  `moz-fx-data-derived-datasets.telemetry.experiments_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.experiments_v1`

--- a/sql/telemetry/experiments_aggregates/view.sql
+++ b/sql/telemetry/experiments_aggregates/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.experiments_aggregates_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.experiments_aggregates_v1`

--- a/sql/telemetry/first_shutdown_summary/view.sql
+++ b/sql/telemetry/first_shutdown_summary/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.first_shutdown_summary_v4`
+  `moz-fx-data-shared-prod.telemetry_derived.first_shutdown_summary_v4`

--- a/sql/telemetry/lockwise_mobile_events_v1/view.sql
+++ b/sql/telemetry/lockwise_mobile_events_v1/view.sql
@@ -11,7 +11,7 @@ WITH
         device,
         metadata.app_build_id,
         e.*
-    FROM `moz-fx-data-derived-datasets.telemetry.telemetry_mobile_event_parquet_v2`, UNNEST(events) AS e
+    FROM `moz-fx-data-shared-prod.telemetry.telemetry_mobile_event_parquet_v2`, UNNEST(events) AS e
     WHERE metadata.app_name = 'Lockbox'
     AND os = 'Android'
     -- Filter out test data before the Android launch date.
@@ -28,7 +28,7 @@ WITH
         metadata.app_build_id,
         e.*
     FROM
-    `moz-fx-data-derived-datasets.telemetry.telemetry_focus_event_parquet_v1`, UNNEST(events) AS e
+    `moz-fx-data-shared-prod.telemetry.telemetry_focus_event_parquet_v1`, UNNEST(events) AS e
     WHERE metadata.app_name = 'Lockbox'
     AND os = 'iOS'
     -- Filter out test data before the iOS launch date.

--- a/sql/telemetry/socorro_crash/view.sql
+++ b/sql/telemetry/socorro_crash/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.socorro_crash_v2`
+  `moz-fx-data-shared-prod.telemetry_derived.socorro_crash_v2`

--- a/sql/telemetry/ssl_ratios/view.sql
+++ b/sql/telemetry/ssl_ratios/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.ssl_ratios_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1`

--- a/sql/telemetry/telemetry_core_parquet/view.sql
+++ b/sql/telemetry/telemetry_core_parquet/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.telemetry_core_parquet_v3`
+  `moz-fx-data-shared-prod.telemetry_derived.telemetry_core_parquet_v3`

--- a/sql/telemetry/telemetry_focus_event_parquet/view.sql
+++ b/sql/telemetry/telemetry_focus_event_parquet/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.telemetry_focus_event_parquet_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.telemetry_focus_event_parquet_v1`

--- a/sql/telemetry/telemetry_mobile_event_parquet/view.sql
+++ b/sql/telemetry/telemetry_mobile_event_parquet/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.telemetry_mobile_event_parquet_v2`
+  `moz-fx-data-shared-prod.telemetry_derived.telemetry_mobile_event_parquet_v2`

--- a/sql/telemetry/telemetry_new_profile_parquet/view.sql
+++ b/sql/telemetry/telemetry_new_profile_parquet/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.telemetry_new_profile_parquet_v2`
+  `moz-fx-data-shared-prod.telemetry_derived.telemetry_new_profile_parquet_v2`

--- a/sql/telemetry/telemetry_shield_study_parquet/view.sql
+++ b/sql/telemetry/telemetry_shield_study_parquet/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-derived-datasets.telemetry.telemetry_shield_study_parquet_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.telemetry_shield_study_parquet_v1`


### PR DESCRIPTION
These references are all to views that existed in both projects or to static tables that have been copied into shared-prod.

Closes https://github.com/mozilla/bigquery-etl/pull/879 which was a previous attempt at this that got stale.