### PR TITLE
Fix onboarding events user properties

### DIFF
--- a/sql/messaging_system/onboarding_events_amplitude/view.sql
+++ b/sql/messaging_system/onboarding_events_amplitude/view.sql
@@ -20,16 +20,11 @@ SELECT
       [STRUCT("message_id" AS key, message_id AS value)]
     )
   ) AS event_properties,
-  (
-    `moz-fx-data-shared-prod.udf.kv_array_to_json_string`(
-      [
-        STRUCT("locale" AS key, locale AS value),
-        STRUCT("release_channel" AS key, release_channel AS value),
-        STRUCT(
-          "experiments" AS key,
-          TO_JSON_STRING(ARRAY(SELECT CONCAT(key, " - ", value.branch) FROM UNNEST(experiments)))
-        )
-      ]
+  TO_JSON_STRING(
+    STRUCT(
+      locale,
+      release_channel,
+      ARRAY(SELECT CONCAT(key, " - ", value.branch) FROM UNNEST(experiments)) AS experiments
     )
   ) AS user_properties
 FROM


### PR DESCRIPTION
The experiments in user properties were previously created as a
string in and of themselves; this led to a stringified array:
    "[\"exp-1\", \"exp-2\"]"
when in fact what we want is:
    ["exp-1", "exp-2"]

This change fixes that.