### PR TITLE
Set country to NULL for unknown search engines

### DIFF
--- a/udf/map_revenue_country.sql
+++ b/udf/map_revenue_country.sql
@@ -28,7 +28,7 @@ CREATE OR REPLACE FUNCTION udf.map_revenue_country(engine STRING, country STRING
   THEN
     country
   ELSE
-    ERROR(CONCAT("Engine ", COALESCE(engine, "null"), " is not aggregated at this time"))
+    NULL
   END
 );
 
@@ -37,4 +37,5 @@ SELECT
   assert_equals('US', udf.map_revenue_country('Google', 'US')),
   assert_equals('US', udf.map_revenue_country('Bing', 'US')),
   assert_equals('Other', udf.map_revenue_country('Bing', 'AU')),
-  assert_equals('ROW', udf.map_revenue_country('Google', 'AU'))
+  assert_equals('ROW', udf.map_revenue_country('Google', 'AU')),
+  assert_equals(NULL, udf.map_revenue_country('Amazon', 'US'))

--- a/udf/map_revenue_country.sql
+++ b/udf/map_revenue_country.sql
@@ -38,4 +38,4 @@ SELECT
   assert_equals('US', udf.map_revenue_country('Bing', 'US')),
   assert_equals('Other', udf.map_revenue_country('Bing', 'AU')),
   assert_equals('ROW', udf.map_revenue_country('Google', 'AU')),
-  assert_equals(NULL, udf.map_revenue_country('Amazon', 'US'))
+  assert_equals(CAST(NULL AS STRING), udf.map_revenue_country('Amazon', 'US'))


### PR DESCRIPTION
Previously the behavior was to error on unknown search engines
in the revenue join. However this causes failures when we
add new normalized search engines but don't have revenue data
available for them.

Instead we will set the country to NULL, and let this data
fall out during the join with revenue data, which won't
have that country.