### PR TITLE
Add script to backfill glam tables for a glean product

### DIFF
--- a/script/glam/backfill_glean
+++ b/script/glam/backfill_glean
@@ -1,0 +1,35 @@
+#!/bin/bash
+# example: START_DATE=2020-04-01 END_DATE=2020-07-01 backfill_glean
+
+set -ex
+
+function ds_range {
+    DS_START=$1 DS_END=$2 python3 - <<EOD
+from datetime import date, timedelta, datetime
+from os import environ
+def parse(ds):
+    return datetime.strptime(ds, "%Y-%m-%d")
+start_date = parse(environ["DS_START"])
+end_date = parse(environ["DS_END"])
+dates = []
+for i in range((end_date - start_date).days):
+    dt = start_date + timedelta(i)
+    dates.append(dt.strftime("%Y-%m-%d"))
+print("\n".join(dates))
+EOD
+}
+
+START_DATE=${START_DATE?}
+END_DATE=${END_DATE?}
+PRODUCT=${PRODUCT?}
+
+for ds in $(ds_range "$START_DATE" "$END_DATE"); do
+        echo $ds
+        BACKFILL_ONLY=true \
+        PRODUCT=org_mozilla_fenix_nightly \
+        SUBMISSION_DATE=$ds \
+            script/glam/run_glam_sql
+done
+
+EXPORT_ONLY=true PRODUCT=$PRODUCT script/glam/run_glam_sql
+PRODUCT=$PRODUCT script/glam/export_csv

--- a/script/glam/backfill_glean
+++ b/script/glam/backfill_glean
@@ -1,5 +1,9 @@
 #!/bin/bash
-# example: START_DATE=2020-04-01 END_DATE=2020-07-01 backfill_glean
+# example:
+#   START_DATE=2020-04-01 \
+#   END_DATE=2020-07-01 \
+#   PRODUCT=org_mozilla_fenix \
+#       backfill_glean
 
 set -ex
 

--- a/script/glam/backfill_glean
+++ b/script/glam/backfill_glean
@@ -19,6 +19,8 @@ print("\n".join(dates))
 EOD
 }
 
+export DATASET=${DATASET:-glam_etl_dev}
+
 START_DATE=${START_DATE?}
 END_DATE=${END_DATE?}
 PRODUCT=${PRODUCT?}
@@ -26,7 +28,7 @@ PRODUCT=${PRODUCT?}
 for ds in $(ds_range "$START_DATE" "$END_DATE"); do
         echo $ds
         BACKFILL_ONLY=true \
-        PRODUCT=org_mozilla_fenix_nightly \
+        PRODUCT=$PRODUCT \
         SUBMISSION_DATE=$ds \
             script/glam/run_glam_sql
 done

--- a/script/glam/backfill_glean
+++ b/script/glam/backfill_glean
@@ -9,12 +9,10 @@ set -ex
 
 function ds_range {
     DS_START=$1 DS_END=$2 python3 - <<EOD
-from datetime import date, timedelta, datetime
+from datetime import datetime, date, timedelta, datetime
 from os import environ
-def parse(ds):
-    return datetime.strptime(ds, "%Y-%m-%d")
-start_date = parse(environ["DS_START"])
-end_date = parse(environ["DS_END"])
+start_date = datetime.fromisoformat(environ["DS_START"])
+end_date = datetime.fromisoformat(environ["DS_END"])
 dates = []
 for i in range((end_date - start_date).days):
     dt = start_date + timedelta(i)


### PR DESCRIPTION
This adds a script that will backfill a table for a glean product. It doesn't not check if the data has already been processed -- this means that it is possible to aggregate the same date twice. However, if the dates are being properly tracked in a log, then this should do the right amount of work to bring a table up to a current state.

