### PR TITLE
Remove ORDER BY in global_outages query

### DIFF
--- a/sql/internet_outages/global_outages_v1/query.sql
+++ b/sql/internet_outages/global_outages_v1/query.sql
@@ -524,6 +524,3 @@ LEFT JOIN
   ssl_error_prop AS ssl
 USING
   (datetime, country, city)
-ORDER BY
-  1,
-  2


### PR DESCRIPTION
BQ reports an error "Result of ORDER BY queries cannot be clustered".