### PR TITLE
Bug 1649871 - Add new event to FxA Amplitude export

### DIFF
--- a/sql/firefox_accounts_derived/fxa_amplitude_export_v1/query.sql
+++ b/sql/firefox_accounts_derived/fxa_amplitude_export_v1/query.sql
@@ -29,7 +29,8 @@ base_events AS (
     AND jsonPayload.fields.event_type IN (
       'fxa_activity - cert_signed',
       'fxa_activity - access_token_checked',
-      'fxa_activity - access_token_created'
+      'fxa_activity - access_token_created',
+      'fxa_activity - oauth_access_token_created'
     )
     AND jsonPayload.fields.user_id IS NOT NULL
 ),


### PR DESCRIPTION
* Add the new `fxa_activity - oauth_access_token_created` event to the
list of events used to generate the daily rollup of users and devices.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1649871 for more details.