### PR TITLE
Use left joins for amo_stats_dau

### DIFF
--- a/sql/amo_prod/amo_stats_dau_v2/query.sql
+++ b/sql/amo_prod/amo_stats_dau_v2/query.sql
@@ -32,6 +32,7 @@ unnested AS (
     UNNEST(addons) AS addon
   WHERE
     submission_date = @submission_date
+    AND addon.id IS NOT NULL
 ),
 --
 per_addon_version AS (

--- a/sql/amo_prod/amo_stats_dau_v2/query.sql
+++ b/sql/amo_prod/amo_stats_dau_v2/query.sql
@@ -193,27 +193,27 @@ SELECT
   *
 FROM
   total_dau
-JOIN
+LEFT JOIN
   per_addon_version
 USING
   (submission_date, addon_id)
-JOIN
+LEFT JOIN
   per_app_version
 USING
   (submission_date, addon_id)
-JOIN
+LEFT JOIN
   per_fenix_build
 USING
   (submission_date, addon_id)
-JOIN
+LEFT JOIN
   per_locale
 USING
   (submission_date, addon_id)
-JOIN
+LEFT JOIN
   per_country
 USING
   (submission_date, addon_id)
-JOIN
+LEFT JOIN
   per_app_os
 USING
   (submission_date, addon_id)


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1643683

When we introduced Fenix data, we no longer are guaranteed to have values for
each of the per_* aggregations. In particular per_fenix_build will be empty
for any addon that's not compatible with Fenix. We need to use LEFT JOINS to
ensure we don't throw lose addons with no matching rows in per_fenix_build.