### PR TITLE
Add more data to `amo_dev.amo_stats_dau`

### DIFF
--- a/sql/amo_dev/amo_stats_dau_v2/query.sql
+++ b/sql/amo_dev/amo_stats_dau_v2/query.sql
@@ -15,5 +15,11 @@ WHERE
     '{7e7eda8f-2e5d-4f43-86a9-07c6139e7a08}', -- :mat
     'close-tabs-by-pattern@virgule.net',      -- :mat
     '{46607a7b-1b2a-40ce-9afe-91cda52c46a6}', -- theme owned by :scolville
-    '{0ec56aba-6955-43fb-a5cf-ed3f3ab66e7e}'  -- theme owned by :caitmuenster
+    '{0ec56aba-6955-43fb-a5cf-ed3f3ab66e7e}', -- theme owned by :caitmuenster
+    '@contain-facebook',
+    '@testpilot-containers',
+    'FirefoxColor@mozilla.com',
+    'private-relay@firefox.com',
+    'notes@mozilla.com',
+    '1b2383b324c8520974ee097e46301d5ca4e076de387c02886f1c6b1503671586@pokeinthe.io' -- Laboratory
   )


### PR DESCRIPTION
This patch adds 6 new GUIDs to "copy" data from prod to dev for the AMO usage stats. These 6 add-ons are all Mozilla-owned add-ons and I asked their maintainers first, see [this gdoc](https://docs.google.com/document/d/1cNk_stSbpNG33XcPWIBKP8OHGyxIICFPeADmm8Vr-xY/edit?usp=sharing) for more info.