### PR TITLE
Fix public data DAG

### DIFF
--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -18,7 +18,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
     {{ task.task_name }} = GKEPodOperator(
         task_id="{{ task.task_name }}",
         name="{{ task.task_name }}",
-        arguments=["/script/publish_public_data_json"]
+        arguments=["script/publish_public_data_json"]
         + ["--query_file=sql/{{ task.dataset }}/{{ task.table }}_{{ task.version }}/query.sql"]
         + ["--destination_table={{ task.table }}{% if task.date_partition_parameter %}${% raw %}{{ds_nodash}}{% endraw %}{% endif %}"]
         + ["--dataset_id={{ task.dataset }}"]

--- a/dags/bqetl_public_data_json.py
+++ b/dags/bqetl_public_data_json.py
@@ -25,7 +25,7 @@ with DAG(
     export_public_data_json_telemetry_derived__ssl_ratios__v1 = GKEPodOperator(
         task_id="export_public_data_json_telemetry_derived__ssl_ratios__v1",
         name="export_public_data_json_telemetry_derived__ssl_ratios__v1",
-        arguments=["/script/publish_public_data_json"]
+        arguments=["script/publish_public_data_json"]
         + ["--query_file=sql/telemetry_derived/ssl_ratios_v1/query.sql"]
         + ["--destination_table=ssl_ratios${{ds_nodash}}"]
         + ["--dataset_id=telemetry_derived"]
@@ -38,7 +38,7 @@ with DAG(
     export_public_data_json_telemetry_derived__deviations__v1 = GKEPodOperator(
         task_id="export_public_data_json_telemetry_derived__deviations__v1",
         name="export_public_data_json_telemetry_derived__deviations__v1",
-        arguments=["/script/publish_public_data_json"]
+        arguments=["script/publish_public_data_json"]
         + ["--query_file=sql/telemetry_derived/deviations_v1/query.sql"]
         + ["--destination_table=deviations${{ds_nodash}}"]
         + ["--dataset_id=telemetry_derived"]

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -14,7 +14,7 @@ with DAG('bqetl_public_data_json', default_args=default_args, schedule_interval=
     export_public_data_json_test__non_incremental_query__v1 = GKEPodOperator(
         task_id="export_public_data_json_test__non_incremental_query__v1",
         name="export_public_data_json_test__non_incremental_query__v1",
-        arguments=["/script/publish_public_data_json"]
+        arguments=["script/publish_public_data_json"]
         + ["--query_file=sql/test/non_incremental_query_v1/query.sql"]
         + ["--destination_table=non_incremental_query${{ds_nodash}}"]
         + ["--dataset_id=test"]


### PR DESCRIPTION
This should fix the Airflow tasks failing with:

```
{logging_mixin.py:112} INFO - [2020-07-13 05:05:26,538] {pod_launcher.py:125} INFO - /app/script/entrypoint: line 38: /script/publish_public_data_json: No such file or directory
```