### PR TITLE
Add experiment analysis tables to shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -362,13 +362,14 @@ EXPERIMENT_ANALYSIS = "moz-fx-data-experiments"
 
 def find_experiment_analysis_targets(pool, client, project=EXPERIMENT_ANALYSIS):
     """Return a dict like DELETE_TARGETS for experiment analysis tables."""
-    datasets = {dataset.dataset_id for dataset in client.list_datasets(project)}
+    datasets = {dataset.reference for dataset in client.list_datasets(project)}
 
     tables = [
         table
         for tables in pool.map(
             client.list_tables,
-            [bigquery.DatasetReference(project, dataset_id) for dataset_id in datasets],
+            datasets,
+            chunksize=1,
         )
         for table in tables
         if table.table_type != "VIEW" and not table.table_id.startswith("statistics_")

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -376,6 +376,6 @@ def find_experiment_analysis_targets(pool, client, project=EXPERIMENT_ANALYSIS):
     ]
 
     return {
-        experiment_analysis_target(qualified_table_id(table)): DESKTOP_SRC
+        client_id_target(table=qualified_table_id(table)): DESKTOP_SRC
         for table in tables
     }

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -366,11 +366,7 @@ def find_experiment_analysis_targets(pool, client, project=EXPERIMENT_ANALYSIS):
 
     tables = [
         table
-        for tables in pool.map(
-            client.list_tables,
-            datasets,
-            chunksize=1,
-        )
+        for tables in pool.map(client.list_tables, datasets, chunksize=1,)
         for table in tables
         if table.table_type != "VIEW" and not table.table_id.startswith("statistics_")
     ]

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -121,7 +121,6 @@ impression_id_target = partial(DeleteTarget, field=IMPRESSION_ID)
 cfr_id_target = partial(DeleteTarget, field=CFR_ID)
 fxa_user_id_target = partial(DeleteTarget, field=FXA_USER_ID)
 user_id_target = partial(DeleteTarget, field=USER_ID)
-experiment_analysis_target = partial(DeleteTarget, field=CLIENT_ID)
 
 DELETE_TARGETS = {
     client_id_target(

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -401,7 +401,6 @@ def main():
             )
     with ThreadPool(args.parallelism) as pool:
         glean_targets = find_glean_targets(pool, client)
-    with ThreadPool(args.parallelism) as pool:
         experiment_analysis_targets = find_experiment_analysis_targets(pool, client)
     tasks = [
         task


### PR DESCRIPTION
This adds experiment analysis tables to shredder.

Tables for experiment analyses are stored as part of `moz-fx-data-experiments`. Currently, there is only one dataset, `mozanalysis`, with tables that are named like: `<some experiment identifier>_<day|week|overall>_<n>`. The dataset also contains some views that have names similar to the tables and tables with aggregated data that start with `statistics_` but do not contain any user identifiers.

Is there a good way to test this?