### PR TITLE
Fix regressions in legacy parquet compatibility views

### DIFF
--- a/sql/telemetry/eng_workflow_build_parquet/view.sql
+++ b/sql/telemetry/eng_workflow_build_parquet/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-shared-prod.telemetry_derived.eng_workflow_build_parquet_v1`
+  `moz-fx-data-shared-prod.telemetry.eng_workflow_build_parquet_v1`

--- a/sql/telemetry/telemetry_mobile_event_parquet/view.sql
+++ b/sql/telemetry/telemetry_mobile_event_parquet/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-shared-prod.telemetry_derived.telemetry_mobile_event_parquet_v2`
+  `moz-fx-data-shared-prod.telemetry.telemetry_mobile_event_parquet_v2`


### PR DESCRIPTION
:dmu reported a query using one of these views that was not working due to
a schema incompatibility. Looks like we made a mistake in pointing the view
directly at a table rather than a view that unions with more recent data.