### PR TITLE
ExternalTaskSensor pool

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -69,6 +69,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         {% endif -%}
         check_existence=True,
         mode='reschedule',
+        pool='DATA_ENG_EXTERNALTASKSENSOR',
     )
     {{ wait_for_seen.append((dependency.dag_name, dependency.task_id)) or "" }}
     {% endif -%}
@@ -89,6 +90,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         {% endif -%}
         check_existence=True,
         mode='reschedule',
+        pool='DATA_ENG_EXTERNALTASKSENSOR',
         dag=dag,
     )
     {{ wait_for_seen.append((task_ref.dag_name, task_ref.task_id)) or "" }}

--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -45,6 +45,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         {% endif -%}
         check_existence=True,
         mode='reschedule',
+        pool='DATA_ENG_EXTERNALTASKSENSOR',
     )
         
     {{ task.task_name }}.set_upstream(wait_for_{{ dependency.task_id }})

--- a/dags/bqetl_activity_stream.py
+++ b/dags/bqetl_activity_stream.py
@@ -39,6 +39,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     activity_stream_bi__impression_stats_flat__v1.set_upstream(

--- a/dags/bqetl_addons.py
+++ b/dags/bqetl_addons.py
@@ -75,6 +75,7 @@ with DAG(
         external_task_id="search_derived__search_clients_daily__v8",
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__addons_daily__v1.set_upstream(
@@ -87,6 +88,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__addons_daily__v1.set_upstream(
@@ -100,6 +102,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=7200),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__addons__v2.set_upstream(wait_for_copy_deduplicate_main_ping)

--- a/dags/bqetl_amo_stats.py
+++ b/dags/bqetl_amo_stats.py
@@ -103,6 +103,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     amo_prod__amo_stats_installs__v1.set_upstream(
@@ -116,6 +117,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=7200),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     amo_prod__fenix_addons_by_client__v1.set_upstream(wait_for_copy_deduplicate_all)
@@ -131,6 +133,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=7200),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     amo_prod__desktop_addons_by_client__v1.set_upstream(

--- a/dags/bqetl_asn_aggregates.py
+++ b/dags/bqetl_asn_aggregates.py
@@ -40,6 +40,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__asn_aggregates__v1.set_upstream(wait_for_bq_main_events)

--- a/dags/bqetl_core.py
+++ b/dags/bqetl_core.py
@@ -51,6 +51,7 @@ with DAG("bqetl_core", default_args=default_args, schedule_interval="0 2 * * *")
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__core_clients_daily__v1.set_upstream(

--- a/dags/bqetl_deviations.py
+++ b/dags/bqetl_deviations.py
@@ -47,6 +47,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
         dag=dag,
     )
 

--- a/dags/bqetl_devtools.py
+++ b/dags/bqetl_devtools.py
@@ -40,6 +40,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__devtools_panel_usage__v1.set_upstream(

--- a/dags/bqetl_experiments_daily.py
+++ b/dags/bqetl_experiments_daily.py
@@ -39,6 +39,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__experiments_daily_active_clients__v1.set_upstream(

--- a/dags/bqetl_gud.py
+++ b/dags/bqetl_gud.py
@@ -121,6 +121,7 @@ with DAG("bqetl_gud", default_args=default_args, schedule_interval="0 3 * * *") 
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__smoot_usage_desktop__v2.set_upstream(
@@ -146,6 +147,7 @@ with DAG("bqetl_gud", default_args=default_args, schedule_interval="0 3 * * *") 
         execution_delta=datetime.timedelta(seconds=5400),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__smoot_usage_fxa__v2.set_upstream(
@@ -175,6 +177,7 @@ with DAG("bqetl_gud", default_args=default_args, schedule_interval="0 3 * * *") 
         execution_delta=datetime.timedelta(seconds=7200),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__smoot_usage_nondesktop__v2.set_upstream(
@@ -187,6 +190,7 @@ with DAG("bqetl_gud", default_args=default_args, schedule_interval="0 3 * * *") 
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__smoot_usage_nondesktop__v2.set_upstream(

--- a/dags/bqetl_internet_outages.py
+++ b/dags/bqetl_internet_outages.py
@@ -39,6 +39,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=7200),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     internet_outages__global_outages__v1.set_upstream(
@@ -51,6 +52,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     internet_outages__global_outages__v1.set_upstream(
@@ -63,6 +65,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=7200),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     internet_outages__global_outages__v1.set_upstream(wait_for_copy_deduplicate_all)

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -147,6 +147,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__main_summary__v4.set_upstream(

--- a/dags/bqetl_messaging_system.py
+++ b/dags/bqetl_messaging_system.py
@@ -135,6 +135,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     messaging_system_derived__onboarding_users_daily__v1.set_upstream(

--- a/dags/bqetl_mobile_search.py
+++ b/dags/bqetl_mobile_search.py
@@ -52,6 +52,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     search_derived__mobile_search_clients_daily__v1.set_upstream(

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -63,6 +63,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=7200),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__firefox_nondesktop_day_2_7_activation__v1.set_upstream(
@@ -75,6 +76,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__firefox_nondesktop_day_2_7_activation__v1.set_upstream(

--- a/dags/bqetl_public_data_json.py
+++ b/dags/bqetl_public_data_json.py
@@ -55,6 +55,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=7200),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     export_public_data_json_telemetry_derived__ssl_ratios__v1.set_upstream(
@@ -67,6 +68,7 @@ with DAG(
         external_task_id="telemetry_derived__deviations__v1",
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     export_public_data_json_telemetry_derived__deviations__v1.set_upstream(

--- a/dags/bqetl_search.py
+++ b/dags/bqetl_search.py
@@ -92,6 +92,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     search_derived__search_clients_daily__v8.set_upstream(

--- a/dags/bqetl_ssl_ratios.py
+++ b/dags/bqetl_ssl_ratios.py
@@ -39,6 +39,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     telemetry_derived__ssl_ratios__v1.set_upstream(wait_for_copy_deduplicate_main_ping)

--- a/dags/bqetl_vrbrowser.py
+++ b/dags/bqetl_vrbrowser.py
@@ -95,6 +95,7 @@ with DAG(
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     org_mozilla_vrbrowser_derived__baseline_daily__v1.set_upstream(

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -39,6 +39,7 @@ with DAG('bqetl_test_dag', default_args=default_args, schedule_interval='@daily'
         external_task_id="task1",
         check_existence=True,
         mode='reschedule',
+        pool='DATA_ENG_EXTERNALTASKSENSOR',
         dag=dag,
     )
     

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -51,6 +51,7 @@ with DAG('bqetl_test_dag', default_args=default_args, schedule_interval='@daily'
         external_task_id='{{ temporary_dataset }}__external_table__v1',
         check_existence=True,
         mode='reschedule',
+        pool='DATA_ENG_EXTERNALTASKSENSOR',
     )
     
     {{ temporary_dataset }}__query__v1.set_upstream(wait_for_{{ temporary_dataset }}__external_table__v1)

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -30,6 +30,7 @@ with DAG('bqetl_public_data_json', default_args=default_args, schedule_interval=
         external_task_id='test__non_incremental_query__v1',
         check_existence=True,
         mode='reschedule',
+        pool='DATA_ENG_EXTERNALTASKSENSOR',
     )
         
     export_public_data_json_test__non_incremental_query__v1.set_upstream(wait_for_test__non_incremental_query__v1)


### PR DESCRIPTION
There is now a `DATA_ENG_EXTERNALTASKSENSOR` pool in Airflow which can be used for `ExternalTaskSensors`. Currently, it has 10 slots, we might need to increase this number? Or first start testing by assigning the pool to only a couple of task sensors before going all in?