### PR TITLE
Add ltv view without revenue fields

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -60,6 +60,7 @@ SKIP = {
     "sql/apple_app_store/metrics_by_web_referrer/query.sql",
     "sql/apple_app_store/metrics_total/query.sql",
     "sql/monitoring/telemetry_distinct_docids_v1/query.sql",
+    "sql/revenue_derived/client_ltv_normalized/query.sql",
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",
     "sql/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",

--- a/sql/revenue_derived/client_ltv_normalized/query.sql
+++ b/sql/revenue_derived/client_ltv_normalized/query.sql
@@ -15,3 +15,5 @@ SELECT
   )
 FROM
   `moz-it-eip-revenue-users.ltv_derived.client_ltv_v1`
+WHERE
+  submission_date = @submission_date

--- a/sql/revenue_derived/client_ltv_normalized/query.sql
+++ b/sql/revenue_derived/client_ltv_normalized/query.sql
@@ -1,6 +1,3 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.telemetry.client_ltv`
-AS
 SELECT
   * EXCEPT (
     avg_client_ad_click_value,

--- a/sql/telemetry/client_ltv/view.sql
+++ b/sql/telemetry/client_ltv/view.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.client_ltv`
+AS
+SELECT
+  * EXCEPT (
+    avg_client_ad_click_value,
+    avg_client_search_with_ads_value,
+    avg_client_search_value,
+    avg_client_tagged_search_value,
+    ltv_ad_clicks_current,
+    ltv_search_with_ads_current,
+    ltv_search_current,
+    ltv_tagged_search_current,
+    ltv_ad_clicks_future,
+    ltv_search_with_ads_future,
+    ltv_search_future,
+    ltv_tagged_search_future
+  )
+FROM
+  `moz-it-eip-revenue-users.ltv_derived.client_ltv_v1`


### PR DESCRIPTION
Adding a view for LTV that doesn't require permissions for the revenue tables. @fbertsch Please take a look when you get back. I'm not confident this is reading from the correct table.