### PR TITLE
Add script for tracking migration of udfs into mozfun

### DIFF
--- a/script/check_udf_migration
+++ b/script/check_udf_migration
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from difflib import get_close_matches
+from types import SimpleNamespace
+
+
+def parse_legacy(path):
+    assert len(path.parts) == 2, path
+    return SimpleNamespace(
+        project="legacy",
+        dataset=path.parts[0],
+        name=path.parts[1].split(".")[0],
+        path=path,
+    )
+
+
+def parse_mozfun(path):
+    assert len(path.parts) == 4
+    return SimpleNamespace(
+        project="mozfun", dataset=path.parts[1], name=path.parts[2], path=path
+    )
+
+
+def main():
+    root = Path(__file__).parent.parent
+
+    legacy = [
+        parse_legacy(path)
+        for path in (
+            list(root.glob("udf/**/*.sql"))
+            + list(root.glob("udf_js/**/*.sql"))
+            + list(root.glob("udf_legacy/**/*.sql"))
+        )
+    ]
+    mozfun = [parse_mozfun(path) for path in root.glob("mozfun/**/udf.sql")]
+
+    legacy_index = {f"{udf.dataset}.{udf.name}": udf for udf in legacy}
+    mozfun_index = {f"{udf.dataset}.{udf.name}": udf for udf in mozfun}
+
+    mapping = []
+    for key, value in mozfun_index.items():
+        matches = get_close_matches(key, legacy_index.keys())
+        match = matches[0] if matches else None
+        mapping.append(SimpleNamespace(mozfun=key, legacy=match))
+
+    def print_two_columns(header, values, size=32):
+        print(f"{header[0]: <{size}}| {header[1]}")
+        print("-" * size + "|" + "-" * size)
+        for value in values:
+            print(f"{value[0]: <{size}}| {value[1]}")
+        print()
+
+    migrated = set([mapped.legacy for mapped in mapping if mapped.legacy])
+    print("## Summary")
+    print()
+    print(f"Migrated {len(migrated)} out of {len(legacy_index.keys())} udfs.")
+    print()
+
+    print("## migrated legacy udfs")
+    print()
+    print_two_columns(
+        ["legacy", "mozfun"],
+        [(item.legacy, item.mozfun) for item in mapping if item.legacy],
+    )
+
+    print("## mozfun only")
+    print()
+    print_two_columns(
+        ["udf", "path"],
+        [
+            (item.mozfun, mozfun_index[item.mozfun].path)
+            for item in mapping
+            if item.legacy is None
+        ],
+    )
+
+    print("## legacy only")
+    print()
+    print_two_columns(
+        ["udf", "path"],
+        [
+            (key, value.path)
+            for key, value in legacy_index.items()
+            if key not in migrated
+        ],
+        size=48,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This script prints out some markdown that can be used to track how many udfs are left in our legacy udf datasets.


## Summary

Migrated 24 out of 124 udfs.

## migrated legacy udfs

legacy                          | mozfun
--------------------------------|--------------------------------
udf.normalize_glean_baseline_client_info| norm.glean_baseline_client_info
udf.normalize_glean_ping_info   | norm.glean_ping_info
udf.normalize_metadata          | norm.metadata
udf.get_key_with_null           | map.get_key_with_null
udf.map_mode_last               | map.mode_last
udf.map_sum                     | map.sum
udf.get_key                     | map.get_key
udf.json_mode_last              | json.mode_last
udf.json_extract_int_map        | json.extract_int_map
udf.glean_timespan_seconds      | glean.timespan_seconds
udf.glean_timespan_nanos        | glean.timespan_nanos
udf.histogram_merge             | hist.merge
udf.histogram_normalize         | hist.normalize
udf.histogram_percentiles       | hist.percentiles
udf.histogram_to_threshold_count| hist.threshold_count
udf.bits28_to_string            | bits28.to_string
udf.bits28_days_since_seen      | bits28.days_since_seen
udf.bits28_retention            | bits28.retention
udf.bits28_active_in_range      | bits28.active_in_range
udf.bits28_to_dates             | bits28.to_dates
udf.bits28_range                | bits28.range
udf.bits28_from_string          | bits28.from_string
udf.mode_last_retain_nulls      | stats.mode_last_retain_nulls
udf.mode_last                   | stats.mode_last

## mozfun only

udf                             | path
--------------------------------|--------------------------------
norm.os                         | mozfun/norm/os/udf.sql
hist.mean                       | mozfun/hist/mean/udf.sql
hist.extract                    | mozfun/hist/extract/udf.sql

## legacy only

udf                                             | path
------------------------------------------------|------------------------------------------------
udf.bitmask_365                                 | udf/bitmask_365.sql
udf.bitmask_lowest_28                           | udf/bitmask_lowest_28.sql
udf.zero_as_365_bits                            | udf/zero_as_365_bits.sql
udf.kv_array_append_to_json_string              | udf/kv_array_append_to_json_string.sql
udf.vector_add                                  | udf/vector_add.sql
udf.hmac_sha256                                 | udf/hmac_sha256.sql
udf.main_summary_scalars                        | udf/main_summary_scalars.sql
udf.array_11_zeroes_then                        | udf/array_11_zeroes_then.sql
udf.bits_to_days_since_seen                     | udf/bits_to_days_since_seen.sql
udf.shift_365_bits_one_day                      | udf/shift_365_bits_one_day.sql
udf.null_if_empty_list                          | udf/null_if_empty_list.sql
udf.int_to_365_bits                             | udf/int_to_365_bits.sql
udf.bits_to_days_seen                           | udf/bits_to_days_seen.sql
udf.extract_histogram_sum                       | udf/extract_histogram_sum.sql
udf.parse_desktop_telemetry_uri                 | udf/parse_desktop_telemetry_uri.sql
udf.extract_document_type                       | udf/extract_document_type.sql
udf.country_code_to_flag                        | udf/country_code_to_flag.sql
udf.histogram_max_key_with_nonzero_value        | udf/histogram_max_key_with_nonzero_value.sql
udf.combine_experiment_days                     | udf/combine_experiment_days.sql
udf.one_as_365_bits                             | udf/one_as_365_bits.sql
udf.gzip_length_footer                          | udf/gzip_length_footer.sql
udf.combine_adjacent_days_28_bits               | udf/combine_adjacent_days_28_bits.sql
udf.zeroed_array                                | udf/zeroed_array.sql
udf.map_revenue_country                         | udf/map_revenue_country.sql
udf.boolean_histogram_to_boolean                | udf/boolean_histogram_to_boolean.sql
udf.json_extract_histogram                      | udf/json_extract_histogram.sql
udf.bitmask_lowest_7                            | udf/bitmask_lowest_7.sql
udf.fenix_build_to_datetime                     | udf/fenix_build_to_datetime.sql
udf.normalize_os                                | udf/normalize_os.sql
udf.safe_sample_id                              | udf/safe_sample_id.sql
udf.map_bing_revenue_country_to_country_code    | udf/map_bing_revenue_country_to_country_code.sql
udf.deanonymize_event                           | udf/deanonymize_event.sql
udf.extract_document_version                    | udf/extract_document_version.sql
udf.days_seen_bytes_to_rfm                      | udf/days_seen_bytes_to_rfm.sql
udf.extract_count_histogram_value               | udf/extract_count_histogram_value.sql
udf.coalesce_adjacent_days_365_bits             | udf/coalesce_adjacent_days_365_bits.sql
udf.normalize_main_payload                      | udf/normalize_main_payload.sql
udf.normalize_fenix_metrics                     | udf/normalize_fenix_metrics.sql
udf.decode_int64                                | udf/decode_int64.sql
udf.shift_one_day                               | udf/shift_one_day.sql
udf.histogram_to_mean                           | udf/histogram_to_mean.sql
udf.array_of_12_zeroes                          | udf/array_of_12_zeroes.sql
udf.combine_adjacent_days_365_bits              | udf/combine_adjacent_days_365_bits.sql
udf.smoot_usage_from_28_bits                    | udf/smoot_usage_from_28_bits.sql
udf.new_monthly_engine_searches_struct          | udf/new_monthly_engine_searches_struct.sql
udf.bits_to_active_n_weeks_ago                  | udf/bits_to_active_n_weeks_ago.sql
udf.int_to_hex_string                           | udf/int_to_hex_string.sql
udf.safe_crc32_uuid                             | udf/safe_crc32_uuid.sql
udf.parquet_array_sum                           | udf/parquet_array_sum.sql
udf.mod_uint128                                 | udf/mod_uint128.sql
udf.aggregate_search_map                        | udf/aggregate_search_map.sql
udf.dedupe_array                                | udf/dedupe_array.sql
udf.aggregate_map_first                         | udf/aggregate_map_first.sql
udf.bool_to_365_bits                            | udf/bool_to_365_bits.sql
udf.bits_to_days_since_first_seen               | udf/bits_to_days_since_first_seen.sql
udf.combine_days_seen_maps                      | udf/combine_days_seen_maps.sql
udf.extract_schema_validation_path              | udf/extract_schema_validation_path.sql
udf.array_drop_first_and_append                 | udf/array_drop_first_and_append.sql
udf.round_timestamp_to_minute                   | udf/round_timestamp_to_minute.sql
udf.coalesce_adjacent_days_28_bits              | udf/coalesce_adjacent_days_28_bits.sql
udf.shift_28_bits_one_day                       | udf/shift_28_bits_one_day.sql
udf.bitmask_range                               | udf/bitmask_range.sql
udf.active_values_from_days_seen_map            | udf/active_values_from_days_seen_map.sql
udf.merge_scalar_user_data                      | udf/merge_scalar_user_data.sql
udf.add_searches_by_index                       | udf/add_searches_by_index.sql
udf.aggregate_active_addons                     | udf/aggregate_active_addons.sql
udf.geo_struct                                  | udf/geo_struct.sql
udf.pos_of_trailing_set_bit                     | udf/pos_of_trailing_set_bit.sql
udf.normalize_monthly_searches                  | udf/normalize_monthly_searches.sql
udf.active_n_weeks_ago                          | udf/active_n_weeks_ago.sql
udf.keyed_histogram_get_sum                     | udf/keyed_histogram_get_sum.sql
udf.array_slice                                 | udf/array_slice.sql
udf.parse_iso8601_date                          | udf/parse_iso8601_date.sql
udf.quantile_search_metric_contribution         | udf/quantile_search_metric_contribution.sql
udf.normalize_search_engine                     | udf/normalize_search_engine.sql
udf.bitcount_lowest_7                           | udf/bitcount_lowest_7.sql
udf.kv_array_to_json_string                     | udf/kv_array_to_json_string.sql
udf.add_monthly_searches                        | udf/add_monthly_searches.sql
udf.pos_of_leading_set_bit                      | udf/pos_of_leading_set_bit.sql
udf.days_since_created_profile_as_28_bits       | udf/days_since_created_profile_as_28_bits.sql
udf.aggregate_search_counts                     | udf/aggregate_search_counts.sql
udf.add_monthly_engine_searches                 | udf/add_monthly_engine_searches.sql
udf_js.crc32                                    | udf_js/crc32.sql
udf_js.main_summary_active_addons               | udf_js/main_summary_active_addons.sql
udf_js.sample_id                                | udf_js/sample_id.sql
udf_js.main_summary_addon_scalars               | udf_js/main_summary_addon_scalars.sql
udf_js.json_extract_histogram                   | udf_js/json_extract_histogram.sql
udf_js.jackknife_sum_ci                         | udf_js/jackknife_sum_ci.sql
udf_js.main_summary_disabled_addons             | udf_js/main_summary_disabled_addons.sql
udf_js.jackknife_ratio_ci                       | udf_js/jackknife_ratio_ci.sql
udf_js.json_extract_events                      | udf_js/json_extract_events.sql
udf_js.jackknife_mean_ci                        | udf_js/jackknife_mean_ci.sql
udf_js.glean_percentile                         | udf_js/glean_percentile.sql
udf_js.gunzip                                   | udf_js/gunzip.sql
udf_js.json_extract_missing_cols                | udf_js/json_extract_missing_cols.sql
udf_js.json_extract_keyed_histogram             | udf_js/json_extract_keyed_histogram.sql
udf_legacy.to_iso8601                           | udf_legacy/to_iso8601.sql
udf_legacy.contains                             | udf_legacy/contains.sql
udf_legacy.date_format                          | udf_legacy/date_format.sql
udf_legacy.date_trunc                           | udf_legacy/date_trunc.sql