### PR TITLE
Rewrite duplicated map udfs to mozfun shims

### DIFF
--- a/script/format_sql
+++ b/script/format_sql
@@ -126,7 +126,6 @@ SKIP = {
     "udf/extract_count_histogram_value.sql",
     "udf/extract_document_type.sql",
     "udf/extract_document_version.sql",
-    "udf/get_key_with_null.sql",
     "udf/glean_timespan_nanos.sql",
     "udf/glean_timespan_seconds.sql",
     "udf/int_to_365_bits.sql",

--- a/udf/get_key.sql
+++ b/udf/get_key.sql
@@ -1,12 +1,6 @@
-/*
-Fetch the value associated with a given key from an array of key/value structs.
-
-Because map types aren't available in BigQuery, we model maps as arrays
-of structs instead, and this function provides map-like access to such fields.
-
-*/
+-- Legacy wrapper around a function moved to mozfun.
 CREATE OR REPLACE FUNCTION udf.get_key(map ANY TYPE, k ANY TYPE) AS (
-  (SELECT key_value.value FROM UNNEST(map) AS key_value WHERE key_value.key = k LIMIT 1)
+  mozfun.map.get_key(map, k)
 );
 
 -- Tests

--- a/udf/get_key_with_null.sql
+++ b/udf/get_key_with_null.sql
@@ -1,21 +1,6 @@
-/*
-Fetch the value associated with a given key from an array of key/value structs.
-
-Because map types aren't available in BigQuery, we model maps as arrays
-of structs instead, and this function provides map-like access to such fields.
-
-This version matches NULL keys as well.
-
-*/
-
+-- Legacy wrapper around a function moved to mozfun.
 CREATE OR REPLACE FUNCTION udf.get_key_with_null(map ANY TYPE, k ANY TYPE) AS (
- (
-   SELECT key_value.value
-   FROM UNNEST(map) AS key_value
-   WHERE key_value.key = k
-         OR key_value.key IS NULL and k IS NULL
-   LIMIT 1
- )
+  mozfun.map.get_key_with_null(map, k)
 );
 
 -- Tests

--- a/udf/get_key_with_null.sql
+++ b/udf/get_key_with_null.sql
@@ -4,7 +4,12 @@ CREATE OR REPLACE FUNCTION udf.get_key_with_null(map ANY TYPE, k ANY TYPE) AS (
 );
 
 -- Tests
-
 SELECT
   assert_equals(12, udf.get_key_with_null([STRUCT('foo' AS key, 42 AS value), ('bar', 12)], 'bar')),
-  assert_equals(12, udf.get_key_with_null([STRUCT('foo' AS key, 42 AS value), (CAST(NULL AS STRING), 12)], CAST(NULL AS STRING)));
+  assert_equals(
+    12,
+    udf.get_key_with_null(
+      [STRUCT('foo' AS key, 42 AS value), (CAST(NULL AS STRING), 12)],
+      CAST(NULL AS STRING)
+    )
+  );


### PR DESCRIPTION
This is a trivial follow-up PR after #1208. It removes the duplicated `map/get_key` and `map/get_key_with_null` by wrapper around mozfun functions.