### PR TITLE
Bug 1657360 Exclude pings with "automation" tag from stable

### DIFF
--- a/script/copy_deduplicate
+++ b/script/copy_deduplicate
@@ -48,6 +48,10 @@ WITH
         INTERVAL @num_preceding_days DAY
     )
     AND submission_timestamp < @end_time
+    -- Bug 1657360
+    AND 'automation' NOT IN (
+      SELECT TRIM(t) FROM UNNEST(SPLIT(metadata.header.x_source_tags, ',')) t
+    )
   GROUP BY
     document_id
   HAVING


### PR DESCRIPTION
We will also need to update monitoring queries to account for this when counting unique document_ids in decoded and live tables.