### PR TITLE
Bug 1655146 Add impression_stats_by_experiment

### DIFF
--- a/dags/bqetl_activity_stream.py
+++ b/dags/bqetl_activity_stream.py
@@ -32,6 +32,18 @@ with DAG(
         dag=dag,
     )
 
+    activity_stream_bi__impression_stats_by_experiment__v1 = bigquery_etl_query(
+        task_id="activity_stream_bi__impression_stats_by_experiment__v1",
+        destination_table="impression_stats_by_experiment_v1",
+        dataset_id="activity_stream_bi",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=["jklukas@mozilla.com", "telemetry-alerts@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
     wait_for_copy_deduplicate_all = ExternalTaskSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
@@ -44,4 +56,8 @@ with DAG(
 
     activity_stream_bi__impression_stats_flat__v1.set_upstream(
         wait_for_copy_deduplicate_all
+    )
+
+    activity_stream_bi__impression_stats_by_experiment__v1.set_upstream(
+        activity_stream_bi__impression_stats_flat__v1
     )

--- a/sql/activity_stream/impression_stats_by_experiment/view.sql
+++ b/sql/activity_stream/impression_stats_by_experiment/view.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.activity_stream.impression_stats_by_experiment`
+AS
+SELECT
+  tile_id,
+  tile_id_types.type AS tile_type,
+  stats.* EXCEPT (tile_id)
+FROM
+  `moz-fx-data-shared-prod.activity_stream_bi.impression_stats_by_experiment_v1` AS stats
+LEFT JOIN
+  `moz-fx-data-shared-prod.activity_stream.tile_id_types` AS tile_id_types
+USING
+  (tile_id)

--- a/sql/activity_stream_bi/impression_stats_by_experiment_v1/init.sql
+++ b/sql/activity_stream_bi/impression_stats_by_experiment_v1/init.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE TABLE
+  activity_stream_bi.impression_stats_by_experiment_v1
+PARTITION BY
+  DATE(submission_timestamp)
+CLUSTER BY
+  experiment_id
+OPTIONS
+  (
+    require_partition_filter = TRUE, --
+    partition_expiration_days = 180
+  )
+AS
+SELECT
+  submission_timestamp,
+  experiment.key AS experiment_id,
+  experiment.value.branch AS experiment_branch,
+  client_id,
+  blocked,
+  clicks,
+  impressions,
+  position,
+  source,
+  tile_id,
+  user_prefs,
+FROM
+  activity_stream_bi.impression_stats_flat_v1
+CROSS JOIN
+  UNNEST(experiments) AS experiment
+WHERE
+  DATE(submission_timestamp) >= DATE_SUB(CURRENT_DATE, INTERVAL 180 DAY)

--- a/sql/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
+++ b/sql/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
@@ -1,0 +1,9 @@
+friendly_name: Impression Stats By Experiment
+description: Representation of tile impression statistics, clustered by experiment_id to allow efficient analysis of individual experiments
+owners:
+  - jklukas@mozilla.com
+labels:
+  application: activity_stream
+  schedule: daily
+scheduling:
+  dag_name: bqetl_activity_stream

--- a/sql/activity_stream_bi/impression_stats_by_experiment_v1/query.sql
+++ b/sql/activity_stream_bi/impression_stats_by_experiment_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  submission_timestamp,
+  experiment.key AS experiment_id,
+  experiment.value.branch AS experiment_branch,
+  client_id,
+  blocked,
+  clicks,
+  impressions,
+  position,
+  source,
+  tile_id,
+  user_prefs,
+FROM
+  activity_stream_bi.impression_stats_flat_v1
+CROSS JOIN
+  UNNEST(experiments) AS experiment
+WHERE
+  DATE(submission_timestamp) = @submission_date


### PR DESCRIPTION
This table will be a bit larger than impression_stats_flat, about 1 TB/day
uncompressed. But it will be much more efficient for the class of queries
that are concerned with evaluating performance of a single experiment.