### PR TITLE
Fix GCS integration test issues

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -76,9 +76,6 @@ def test_bucket():
 
     yield bucket
 
-    # cleanup test bucket
-    bucket.delete_blobs(bucket.list_blobs())
-
 
 @pytest.fixture
 def temporary_gcs_folder():


### PR DESCRIPTION
Running integration tests in parallel resulted in some of them failing since one test run deleted files that were still accessed by another test run. This should fix the problem.