### PR TITLE
Fix #1232 - Ignore glam_etl directory when publishing views

### DIFF
--- a/script/publish_views
+++ b/script/publish_views
@@ -4,6 +4,7 @@
 
 from argparse import ArgumentParser
 from functools import partial
+from pathlib import Path
 import logging
 from multiprocessing.pool import ThreadPool
 import os
@@ -14,6 +15,8 @@ from google.api_core.exceptions import BadRequest
 from google.cloud import bigquery
 import sqlparse
 
+sql_root = Path(__file__).resolve().parent.parent / "sql"
+assert sql_root.exists(), f"{sql_root} not found"
 
 VIEWS_TO_SKIP = (
     # Access Denied
@@ -22,10 +25,10 @@ VIEWS_TO_SKIP = (
     "pocket/pocket_reach_mau/view.sql",
     "telemetry/buildhub2/view.sql",
     # Dataset moz-fx-data-shared-prod:glam_etl was not found
-    "glam_etl/org_mozilla_fenix__view_clients_daily_scalar_aggregates_v1/view.sql",
-    "glam_etl/org_mozilla_fenix__view_clients_daily_histogram_aggregates_v1/view.sql",
-    "glam_etl/org_mozilla_fenix__view_probe_counts_v1/view.sql",
-    "glam_etl/org_mozilla_fenix__view_user_counts_v1/view.sql",
+    *[
+        str(path.relative_to(sql_root))
+        for path in sql_root.glob("glam_etl/**/view.sql")
+    ],
     # View in project other than prod
     "sql/shredder_state/progress/view.sql",
 )


### PR DESCRIPTION
This should fix #1232 

The `VIEWS_TO_SKIP` set is the following:

```
('activity_stream/tile_id_types/view.sql', 'firefox_accounts/fxa_amplitude_email_clicks/view.sql', 'pocket/pocket_reach_mau/view.sql', 'telemetry/buildhub2/view.sql', 'glam_etl/org_mozilla_firefox__view_clients_daily_histogram_aggregates_v1/view.sql', 'glam_etl/org_mozilla_fenix_glam_release__view_user_counts_v1/view.sql', 'glam_etl/org_mozilla_fenix_glam_release__view_clients_daily_scalar_aggregates_v1/view.sql', 'glam_etl/org_mozilla_fenix_glam_release__view_probe_counts_v1/view.sql', 'glam_etl/org_mozilla_fenix_glam_release__view_clients_daily_histogram_aggregates_v1/view.sql', 'glam_etl/org_mozilla_firefox__view_clients_daily_scalar_aggregates_v1/view.sql', 'sql/shredder_state/progress/view.sql')
```