### PR TITLE
Explicit project ID for UDFs in experiment_search_aggregates_live

### DIFF
--- a/sql/telemetry_derived/experiment_search_aggregates_live_v1/view.sql.py
+++ b/sql/telemetry_derived/experiment_search_aggregates_live_v1/view.sql.py
@@ -57,7 +57,7 @@ def generate_sql(opts):
                 SELECT AS STRUCT
                   SUBSTR(_key, 0, pos - 2) AS engine,
                   SUBSTR(_key, pos) AS source,
-                  udf.extract_histogram_sum(value) AS `count`
+                  `moz-fx-data-shared-prod`.udf.extract_histogram_sum(value) AS `count`
                 FROM
                   UNNEST(payload.keyed_histograms.search_counts),
                   UNNEST([REPLACE(key, 'in-content.', 'in-content:')]) AS _key,


### PR DESCRIPTION
The Airflow job for generating and deploying the experiments_search_aggregates_live view is currently failing with:

```
[2020-08-18 19:41:49,900] {logging_mixin.py:112} INFO - [2020-08-18 19:41:49,900] {pod_launcher.py:125} INFO - b"datasets:bqjob_r748ea107f0634b2a_0000017403178819_1': Within a standard SQL\n"
[2020-08-18 19:41:49,900] {logging_mixin.py:112} INFO - [2020-08-18 19:41:49,900] {pod_launcher.py:125} INFO - b'view, references to functions/procedures require explicit project IDs unless the\n'
[2020-08-18 19:41:49,900] {logging_mixin.py:112} INFO - [2020-08-18 19:41:49,900] {pod_launcher.py:125} INFO - b'entity is created in the same project that is issuing the query, but these\n'
[2020-08-18 19:41:49,900] {logging_mixin.py:112} INFO - [2020-08-18 19:41:49,900] {pod_launcher.py:125} INFO - b'references are not project-qualified: "udf.extract_histogram_sum"\n'
```