### PR TITLE
Update Glam ETL for Fenix

### DIFF
--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_histogram_aggregates_v1.sql
@@ -1,14 +1,21 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_glam_beta__view_clients_daily_histogram_aggregates_v1
 AS
+WITH extracted AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_histogram_aggregates_v1
+  WHERE
+    `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) < date "2020-07-03"
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox_beta__view_clients_daily_histogram_aggregates_v1
+)
 SELECT
-  *
+  * EXCEPT (channel),
+  "*" AS channel
 FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_histogram_aggregates_v1
-WHERE
-  `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) < date "2020-07-03"
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox_beta__view_clients_daily_histogram_aggregates_v1
+  extracted

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_histogram_aggregates_v1.sql
@@ -7,7 +7,7 @@ FROM
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_histogram_aggregates_v1
 WHERE
   `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) < date "2020-07-03"
-UNION
+UNION ALL
 SELECT
   *
 FROM

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_scalar_aggregates_v1.sql
@@ -1,14 +1,21 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_glam_beta__view_clients_daily_scalar_aggregates_v1
 AS
+WITH extracted AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_scalar_aggregates_v1
+  WHERE
+    `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) < date "2020-07-03"
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox_beta__view_clients_daily_scalar_aggregates_v1
+)
 SELECT
-  *
+  * EXCEPT (channel),
+  "*" AS channel
 FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_scalar_aggregates_v1
-WHERE
-  `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) < date "2020-07-03"
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox_beta__view_clients_daily_scalar_aggregates_v1
+  extracted

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_scalar_aggregates_v1.sql
@@ -7,7 +7,7 @@ FROM
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_scalar_aggregates_v1
 WHERE
   `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) < date "2020-07-03"
-UNION
+UNION ALL
 SELECT
   *
 FROM

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
@@ -1,19 +1,26 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1
 AS
+WITH extracted AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_histogram_aggregates_v1
+  WHERE
+    `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) >= date "2020-07-03"
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_nightly__view_clients_daily_histogram_aggregates_v1
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_histogram_aggregates_v1
+)
 SELECT
-  *
+  * EXCEPT (channel),
+  "*" AS channel
 FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_histogram_aggregates_v1
-WHERE
-  `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) >= date "2020-07-03"
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_nightly__view_clients_daily_histogram_aggregates_v1
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_histogram_aggregates_v1
+  extracted

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
@@ -7,12 +7,12 @@ FROM
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_histogram_aggregates_v1
 WHERE
   `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) >= date "2020-07-03"
-UNION
+UNION ALL
 SELECT
   *
 FROM
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_nightly__view_clients_daily_histogram_aggregates_v1
-UNION
+UNION ALL
 SELECT
   *
 FROM

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
@@ -7,12 +7,12 @@ FROM
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_scalar_aggregates_v1
 WHERE
   `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) >= date "2020-07-03"
-UNION
+UNION ALL
 SELECT
   *
 FROM
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_nightly__view_clients_daily_scalar_aggregates_v1
-UNION
+UNION ALL
 SELECT
   *
 FROM

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
@@ -1,19 +1,26 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1
 AS
+WITH extracted AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_scalar_aggregates_v1
+  WHERE
+    `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) >= date "2020-07-03"
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_nightly__view_clients_daily_scalar_aggregates_v1
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_scalar_aggregates_v1
+)
 SELECT
-  *
+  * EXCEPT (channel),
+  "*" AS channel
 FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix__view_clients_daily_scalar_aggregates_v1
-WHERE
-  `moz-fx-data-shared-prod`.udf.fenix_build_to_datetime(app_build_id) >= date "2020-07-03"
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_nightly__view_clients_daily_scalar_aggregates_v1
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_scalar_aggregates_v1
+  extracted

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_release__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_release__view_clients_daily_histogram_aggregates_v1.sql
@@ -1,7 +1,14 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_glam_release__view_clients_daily_histogram_aggregates_v1
 AS
+WITH extracted AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox__view_clients_daily_histogram_aggregates_v1
+)
 SELECT
-  *
+  * EXCEPT (channel),
+  "*" AS channel
 FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox__view_clients_daily_histogram_aggregates_v1
+  extracted

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_release__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_release__view_clients_daily_scalar_aggregates_v1.sql
@@ -1,7 +1,14 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_glam_release__view_clients_daily_scalar_aggregates_v1
 AS
+WITH extracted AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox__view_clients_daily_scalar_aggregates_v1
+)
 SELECT
-  *
+  * EXCEPT (channel),
+  "*" AS channel
 FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox__view_clients_daily_scalar_aggregates_v1
+  extracted

--- a/script/glam/test/test_glean_all_fenix
+++ b/script/glam/test/test_glean_all_fenix
@@ -5,7 +5,6 @@
 
 set -e
 
-skip_generate=${SKIP_GENERATE:-false}
 app_id="org_mozilla_firefox"
 logical_app_id="org_mozilla_fenix_glam_release"
 

--- a/script/glam/test/test_glean_all_fenix
+++ b/script/glam/test/test_glean_all_fenix
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Script for running all of the normalized channels for glam. Do not check in
+# the results of this script. This is mean to be used for diagnostic purposes.
+# Bash equivalent of: https://github.com/mozilla/telemetry-airflow/pull/1124
+
+set -e
+
+skip_generate=${SKIP_GENERATE:-false}
+app_id="org_mozilla_firefox"
+logical_app_id="org_mozilla_fenix_glam_release"
+
+dir="$(dirname "$0")/.."
+
+app_ids=(
+    "org_mozilla_fenix"
+    "org_mozilla_fenix_nightly"
+    "org_mozilla_firefox"
+    "org_mozilla_firefox_beta"
+    "org_mozilla_fennec_aurora"
+)
+logical_app_ids=(
+    "org_mozilla_fenix_glam_nightly"
+    "org_mozilla_fenix_glam_beta"
+    "org_mozilla_fenix_glam_release"
+)
+
+for app_id in "${app_ids[@]}"; do
+    PRODUCT=$app_id STAGE=daily $dir/generate_glean_sql &
+done
+for logical_app_id in "${logical_app_ids[@]}"; do
+    PRODUCT=$logical_app_id STAGE=incremental $dir/generate_glean_sql &
+done
+wait
+
+for app_id in "${app_ids[@]}"; do
+    PRODUCT=$app_id STAGE=daily $dir/run_glam_sql &
+done
+
+wait
+for logical_app_id in "${logical_app_ids[@]}"; do
+    PRODUCT=$logical_app_id STAGE=incremental $dir/run_glam_sql &
+done
+wait
+
+

--- a/script/glam/test/test_glean_org_mozilla_firefox
+++ b/script/glam/test/test_glean_org_mozilla_firefox
@@ -7,7 +7,7 @@ skip_generate=${SKIP_GENERATE:-false}
 app_id="org_mozilla_firefox"
 logical_app_id="org_mozilla_fenix_glam_release"
 
-dir="$(dirname "$0")"
+dir="$(dirname "$0")/.."
 
 if [[ $skip_generate == false ]]; then
     PRODUCT=$app_id STAGE=daily $dir/generate_glean_sql

--- a/sql/glam_etl/org_mozilla_fenix_glam_release__view_clients_daily_histogram_aggregates_v1/view.sql
+++ b/sql/glam_etl/org_mozilla_fenix_glam_release__view_clients_daily_histogram_aggregates_v1/view.sql
@@ -1,7 +1,14 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_glam_release__view_clients_daily_histogram_aggregates_v1
 AS
+WITH extracted AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox__view_clients_daily_histogram_aggregates_v1
+)
 SELECT
-  *
+  * EXCEPT (channel),
+  "*" AS channel
 FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox__view_clients_daily_histogram_aggregates_v1
+  extracted

--- a/sql/glam_etl/org_mozilla_fenix_glam_release__view_clients_daily_scalar_aggregates_v1/view.sql
+++ b/sql/glam_etl/org_mozilla_fenix_glam_release__view_clients_daily_scalar_aggregates_v1/view.sql
@@ -1,7 +1,14 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod`.glam_etl.org_mozilla_fenix_glam_release__view_clients_daily_scalar_aggregates_v1
 AS
+WITH extracted AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox__view_clients_daily_scalar_aggregates_v1
+)
 SELECT
-  *
+  * EXCEPT (channel),
+  "*" AS channel
 FROM
-  `moz-fx-data-shared-prod`.glam_etl.org_mozilla_firefox__view_clients_daily_scalar_aggregates_v1
+  extracted


### PR DESCRIPTION
Followup to #1221 

This adds a new script that runs all of the newly generated ETL. It also fixes the views so they run properly e.g. `UNION ALL` instead of `UNION`. Finally, the channel gets completely ignored for the dataset. At this point, it might actually be worth taking the union of all of the products into a single logical one.