### PR TITLE
Bug 1660066 - Create view for onboarding user retention analysis in Amplitude

### DIFF
--- a/sql/messaging_system/onboarding_retention_events_amplitude/view.sql
+++ b/sql/messaging_system/onboarding_retention_events_amplitude/view.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.messaging_system.onboarding_retention_events_amplitude`
+AS
+SELECT
+  submission_timestamp_min AS submission_timestamp,
+  client_id AS device_id,
+  CONCAT(client_id, submission_date) AS insert_id,
+  "RETENTION" AS event_type,
+  submission_timestamp_min AS timestamp,
+  app_version,
+  REGEXP_EXTRACT(os, '^\\w+') AS platform,
+  os AS os_name,
+  os_version,
+  cd.country AS country,
+  geo_subdivision1 AS region,
+  city,
+  -- No `event_properties` for this event
+  TO_JSON_STRING(
+    STRUCT(
+      cd.locale AS locale,
+      channel AS release_channel,
+      ARRAY(SELECT CONCAT(key, " - ", value) FROM UNNEST(experiments)) AS experiments
+    )
+  ) AS user_properties
+FROM
+  `moz-fx-data-shared-prod.messaging_system.onboarding_users_last_seen`
+JOIN
+  `moz-fx-data-shared-prod.telemetry.clients_daily` cd
+USING
+  (client_id, submission_date)


### PR DESCRIPTION
This view is built on top of the `clients_day` and `onboarding_users_last_seen` to allow us to do browser user retention in Amplitude.

It creates a dummy `event_type` "RETENTION" for all users who have been "seen" in `onboarding_users_last_seen` for the past 28 days. With this event, we can calculate browser user retention (from day 1 - day 28)in Amplitude.

See more details in this [document](https://docs.google.com/document/d/1VaddkFkzuOh38ypngj627XloH-82l_Q-P37XK2scwio/edit#heading=h.c2kv8xnxojgx). 

 