### PR TITLE
Revert "Use mozfun.norm.fenix_app_info for nondesktop_clients_last_seen"

### DIFF
--- a/sql/telemetry/nondesktop_clients_last_seen_v1/view.sql
+++ b/sql/telemetry/nondesktop_clients_last_seen_v1/view.sql
@@ -3,56 +3,38 @@ CREATE OR REPLACE VIEW
 AS
 -- For context on naming and channels of Fenix apps, see:
 -- https://docs.google.com/document/d/1Ym4eZyS0WngEP6WdwJjmCoxtoQbJSvORxlQwZpuSV2I/edit#heading=h.69hvvg35j8un
-WITH fenix_union AS (
+WITH glean_union AS (
+  -- Fenix apps
   SELECT
-    *,
-    'org_mozilla_fenix' AS _dataset
+    * REPLACE ('beta' AS normalized_channel),
+    'Firefox Preview' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_fenix.baseline_clients_last_seen`
   UNION ALL
   SELECT
-    *,
-    'org_mozilla_fenix_nightly' AS _dataset
+    * REPLACE ('nightly' AS normalized_channel),
+    'Firefox Preview' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_fenix_nightly.baseline_clients_last_seen`
   UNION ALL
   SELECT
-    *,
-    'org_mozilla_firefox' AS _dataset
+    * REPLACE ('release' AS normalized_channel),
+    'Fenix' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_firefox.baseline_clients_last_seen`
   UNION ALL
   SELECT
-    *,
-    'org_mozilla_firefox_beta' AS _dataset
+    * REPLACE ('beta' AS normalized_channel),
+    'Fenix' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_firefox_beta.baseline_clients_last_seen`
   UNION ALL
   SELECT
-    *,
-    'org_mozilla_fennec_aurora' AS _dataset
+    * REPLACE ('nightly' AS normalized_channel),
+    'Fenix' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_fennec_aurora.baseline_clients_last_seen`
-),
-fenix_app_info AS (
-  SELECT
-    *,
-    mozfun.norm.fenix_app_info(_dataset, app_build) AS _app_info
-  FROM
-    fenix_union
-),
-fenix_normalized AS (
-  SELECT
-    * EXCEPT (_dataset, _app_info) REPLACE(_app_info.channel AS normalized_channel),
-    _app_info.app_name,
-  FROM
-    fenix_app_info
-),
-glean_union AS (
-  SELECT
-    *
-  FROM
-    fenix_normalized
+  -- Other apps that send Glean telemetry
   UNION ALL
   SELECT
     *,


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#1245

This approach is currently broken due to a recent change in app_build format being reported by Fenix (see https://github.com/mozilla/bigquery-etl/issues/1248).