### PR TITLE
Tolerate new 10-digit Fenix app_build format

### DIFF
--- a/udf/fenix_build_to_datetime/metadata.yaml
+++ b/udf/fenix_build_to_datetime/metadata.yaml
@@ -1,6 +1,23 @@
-description: 'Convert the Fenix client_info.app_build-format string to a DATETIME.
-  May return NULL on failure.  The Fenix app_build format is documented here: https://github.com/mozilla-mobile/fenix/blob/c72834479eb3e13ee91f82b529e59aa08392a92d/automation/gradle/versionCode.gradle#L13  In
-  short it is yDDDHHmm  * y is years since 2018  * DDD is day of year, 0-padded, 001-366  *
-  HH is hour of day, 00-23  * mm is minute of hour, 00-59  After using this you may
-  wish to DATETIME_TRUNC(result, DAY) for grouping by build date.'
 friendly_name: Fenix Build To Datetime
+description: |
+  Convert the Fenix client_info.app_build-format string to a DATETIME. May return NULL on failure.
+
+  Fenix originally used an [8-digit app_build format](https://github.com/mozilla-mobile/fenix/blob/c7283447/automation/gradle/versionCode.gradle#L12-L16)
+
+  In short it is `yDDDHHmm`:
+
+   * y is years since 2018
+   * DDD is day of year, 0-padded, 001-366
+   * HH is hour of day, 00-23
+   * mm is minute of hour, 00-59
+
+  The last date seen with an 8-digit build ID is 2020-08-10.
+
+  Newer builds use a [10-digit format](https://github.com/mozilla-mobile/fenix/blob/e6ee13dc/buildSrc/src/main/java/Config.kt#L55-L112)
+  where the integer represents a pattern consisting of 32 bits.
+  The 17 bits starting 13 bits from the left represent a number of hours since
+  UTC midnight beginning 2014-12-28.
+
+  This function tolerates both formats.
+
+  After using this you may wish to `DATETIME_TRUNC(result, DAY)` for grouping by build date.

--- a/udf/fenix_build_to_datetime/udf.sql
+++ b/udf/fenix_build_to_datetime/udf.sql
@@ -1,36 +1,56 @@
-/*
-Convert the Fenix client_info.app_build-format string to a DATETIME.
-May return NULL on failure.
-
-The Fenix app_build format is documented here:
-https://github.com/mozilla-mobile/fenix/blob/c72834479eb3e13ee91f82b529e59aa08392a92d/automation/gradle/versionCode.gradle#L13
-
-In short it is yDDDHHmm
- * y is years since 2018
- * DDD is day of year, 0-padded, 001-366
- * HH is hour of day, 00-23
- * mm is minute of hour, 00-59
-
-After using this you may wish to DATETIME_TRUNC(result, DAY) for grouping
-by build date.
-
-*/
 CREATE OR REPLACE FUNCTION udf.fenix_build_to_datetime(app_build STRING) AS (
-  DATETIME_ADD(
+  CASE
+    LENGTH(app_build)
+  WHEN
+    8
+  THEN
+    -- Ideally, we would use PARSE_DATETIME, but that doesn't support
+    -- day of year (%j) or the custom single-character year used here.
     DATETIME_ADD(
-      DATETIME_ADD(
-        DATETIME_ADD(
-          DATETIME '2018-01-01 00:00:00',
-          INTERVAL SAFE_CAST(SUBSTR(app_build, 1, 1) AS INT64) YEAR
-        ),
-        INTERVAL SAFE_CAST(SUBSTR(app_build, 2, 3) AS INT64) - 1 DAY
+      DATETIME(
+        2018 + SAFE_CAST(
+          SUBSTR(app_build, 1, 1) AS INT64
+        ), -- year
+        1, -- placeholder month
+        1, -- placeholder year
+        SAFE_CAST(SUBSTR(app_build, 5, 2) AS INT64),
+        SAFE_CAST(SUBSTR(app_build, 7, 2) AS INT64),
+        0  -- seconds is always zero
       ),
-      INTERVAL SAFE_CAST(SUBSTR(app_build, 5, 2) AS INT64) HOUR
-    ),
-    INTERVAL SAFE_CAST(SUBSTR(app_build, 7, 2) AS INT64) MINUTE
-  )
+      INTERVAL SAFE_CAST(SUBSTR(app_build, 2, 3) AS INT64) - 1 DAY
+    )
+  WHEN
+    10
+  THEN
+    DATETIME_ADD(
+      DATETIME '2014-12-28 00:00:00',
+      INTERVAL(
+        SAFE_CAST(app_build AS INT64)
+        -- We shift left and then right again to erase all but the 20 rightmost bits
+        << (64 - 20) >> (64 - 20)
+        -- We then shift right to erase the last 3 bits, leaving just the 17 representing time
+        >> 3
+      ) HOUR
+    )
+  ELSE
+    NULL
+  END
 );
 
 -- Tests
 SELECT
-  assert_equals(DATETIME '2020-06-05 14:34:00', udf.fenix_build_to_datetime("21571434"))
+  assert_equals(DATETIME '2020-06-05 14:34:00', udf.fenix_build_to_datetime("21571434")),
+  assert_equals(DATETIME '2018-01-01 00:00:00', udf.fenix_build_to_datetime("00010000")),
+  assert_equals(DATETIME '2027-12-31 23:59:00', udf.fenix_build_to_datetime("93652359")),
+  assert_equals(DATETIME '2020-08-13 04:00:00', udf.fenix_build_to_datetime("2015757667")),
+  assert_equals(DATETIME '2014-12-28 00:00:00', udf.fenix_build_to_datetime("0000000000")),
+  assert_equals(DATETIME '2014-12-28 00:00:00', udf.fenix_build_to_datetime("0000000001")),
+  assert_equals(
+    DATETIME '2014-12-28 00:00:00',
+    udf.fenix_build_to_datetime(CAST(1 << 31 AS STRING))
+  ),
+  assert_equals(DATETIME '2014-12-28 01:00:00', udf.fenix_build_to_datetime("0000000009")),
+  assert_null(udf.fenix_build_to_datetime("7777777")),
+  assert_null(udf.fenix_build_to_datetime("999999999")),
+  assert_null(udf.fenix_build_to_datetime("3")),
+  assert_null(udf.fenix_build_to_datetime("hi"))


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/1248

~~Will consider this a draft until we here more from Fenix engineering in https://github.com/mozilla-mobile/fenix/issues/14031 about whether the hypothesis about epoch differences bears out.~~ This is now resolved and we have confirmation from the Fenix team that they're sticking with the modified epoch.