### PR TITLE
Allow baseline pings with 'foreground' reason in KPIs

### DIFF
--- a/bigquery_etl/glean_usage/templates/baseline_clients_daily_v1.sql
+++ b/bigquery_etl/glean_usage/templates/baseline_clients_daily_v1.sql
@@ -37,11 +37,11 @@ WITH base AS (
     normalized_os_version,
   FROM
     `{{ baseline_table }}`
-  WHERE
-    -- We specifically want to exclude the new 'startup' baseline ping until we've
-    -- fully analyzed its effect and gotten sign off on including it for KPIs.
-    -- See https://bugzilla.mozilla.org/show_bug.cgi?id=1627286
-    (ping_info.reason IN ('background', 'dirty_startup') OR ping_info.reason IS NULL)
+  -- Baseline pings with 'foreground' reason were first introduced in early April 2020;
+  -- we initially excluded them from baseline_clients_daily so that we could measure
+  -- effects on KPIs. On 2020-08-25, we removed the filter on reason and backfilled. See:
+  -- https://bugzilla.mozilla.org/show_bug.cgi?id=1627286
+  -- https://jira.mozilla.com/browse/DS-1018
 ),
 --
 with_dates AS (


### PR DESCRIPTION
After merging, I will need to backfill these tables back to early April.

@harterrt formally requested this change in https://jira.mozilla.com/browse/DS-1018