### PR TITLE
Add Fenix, Fx Lite to Day 2-7 Activation

### DIFF
--- a/sql/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/query.sql
+++ b/sql/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/query.sql
@@ -51,9 +51,10 @@ FROM
 WHERE
   submission_date = @submission_date
   AND product IN (
-    -- Fenix and Firefox Preview are excluded for now pending validation.
-    -- 'Fenix',
-    -- 'Firefox Preview',
+    -- Fenix and Firefox Preview were previously excluded pending:
+    -- https://jira.mozilla.com/browse/DS-696
+    'Fenix',
+    'Firefox Preview',
     'Fennec Android',
     'Focus Android',
     'Fennec iOS',

--- a/sql/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/query.sql
+++ b/sql/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/query.sql
@@ -51,8 +51,6 @@ FROM
 WHERE
   submission_date = @submission_date
   AND product IN (
-    -- Fenix and Firefox Preview were previously excluded pending:
-    -- https://jira.mozilla.com/browse/DS-696
     'Fenix',
     'Firefox Preview',
     'Fennec Android',


### PR DESCRIPTION
Fenix and Firefox Lite were previously filtered from the Day 2-7 Activation metric pending validation in https://jira.mozilla.com/browse/DS-696