### PR TITLE
Remove mozfun reference in mozfun UDF definition

### DIFF
--- a/mozfun/hist/extract/udf.sql
+++ b/mozfun/hist/extract/udf.sql
@@ -14,7 +14,7 @@ CREATE OR REPLACE FUNCTION hist.extract(input STRING) AS (
         FROM
           UNNEST(JSON_EXTRACT_ARRAY(input, '$.range')) AS bound
       ) AS `range`,
-      mozfun.json.extract_int_map(JSON_EXTRACT(input, '$.values')) AS `values`
+      json.extract_int_map(JSON_EXTRACT(input, '$.values')) AS `values`
     )
   WHEN
     ARRAY_LENGTH(SPLIT(input, ';')) = 5


### PR DESCRIPTION
Airflow's publishing of mozfun definitions failed last night due to
https://github.com/mozilla/bigquery-etl/pull/1287

Long-term we should enforce that mozfun function definitions don't directly reference mozfun: see https://github.com/mozilla/bigquery-etl/issues/1293