### PR TITLE
Bug 1649871 - Include rolled up event types

### DIFF
--- a/sql/firefox_accounts/fxa_amplitude_export/view.sql
+++ b/sql/firefox_accounts/fxa_amplitude_export/view.sql
@@ -34,7 +34,7 @@ active_events AS (
     insert_id,
     'fxa_activity - active' AS event_type,
     timestamp,
-    TO_JSON_STRING(STRUCT(services AS service, oauth_client_ids)) AS event_properties,
+    TO_JSON_STRING(STRUCT(services AS service, oauth_client_ids, rollup_events)) AS event_properties,
     region,
     country,
     `LANGUAGE`,

--- a/sql/firefox_accounts/fxa_amplitude_export/view.sql
+++ b/sql/firefox_accounts/fxa_amplitude_export/view.sql
@@ -34,7 +34,9 @@ active_events AS (
     insert_id,
     'fxa_activity - active' AS event_type,
     timestamp,
-    TO_JSON_STRING(STRUCT(services AS service, oauth_client_ids, rollup_events)) AS event_properties,
+    TO_JSON_STRING(
+      STRUCT(services AS service, oauth_client_ids, rollup_events)
+    ) AS event_properties,
     region,
     country,
     `LANGUAGE`,

--- a/sql/firefox_accounts_derived/fxa_amplitude_export_v1/query.sql
+++ b/sql/firefox_accounts_derived/fxa_amplitude_export_v1/query.sql
@@ -104,6 +104,7 @@ grouped_by_user AS (
     ) AS ua_browser,
     MAX(CAST(jsonPayload.fields.app_version AS FLOAT64)) AS app_version,
     CAST(TRUE AS INT64) AS days_seen_bits,
+    ARRAY_AGG(DISTINCT jsonPayload.fields.event_type) AS rollup_events
   FROM
     base_events
   GROUP BY


### PR DESCRIPTION
This event property can be used to determine which events activated the "active" event.