### PR TITLE
Fix event timestamps

### DIFF
--- a/sql/org_mozilla_firefox_derived/event_types_v1/init.sql
+++ b/sql/org_mozilla_firefox_derived/event_types_v1/init.sql
@@ -9,7 +9,9 @@ AS
 WITH sample AS (
   SELECT
     name AS event,
-    * EXCEPT (name)
+    * EXCEPT (name) REPLACE(
+      TIMESTAMP_ADD(submission_timestamp, INTERVAL timestamp MILLISECOND) AS timestamp
+    )
   FROM
     org_mozilla_firefox.events e
   CROSS JOIN

--- a/sql/org_mozilla_firefox_derived/event_types_v1/query.sql
+++ b/sql/org_mozilla_firefox_derived/event_types_v1/query.sql
@@ -1,7 +1,9 @@
 WITH current_events AS (
   SELECT
     name AS event,
-    * EXCEPT (name)
+    * EXCEPT (name) REPLACE(
+      TIMESTAMP_ADD(submission_timestamp, INTERVAL timestamp MILLISECOND) AS timestamp
+    )
   FROM
     org_mozilla_firefox.events
   CROSS JOIN

--- a/tests/org_mozilla_firefox_derived/event_types_v1/test_init/expect.yaml
+++ b/tests/org_mozilla_firefox_derived/event_types_v1/test_init/expect.yaml
@@ -3,7 +3,7 @@
   submission_date: '2020-01-02'
   category: first_category
   event: first_event
-  first_timestamp: '2020-01-01T00:00:01+00:00'
+  first_timestamp: '2020-01-02T00:00:01+00:00'
   numeric_index: 1
   index: "\U00000001"
   event_properties:
@@ -31,7 +31,7 @@
   submission_date: '2020-01-02'
   category: second_category
   event: second_event
-  first_timestamp: '2020-01-01T00:00:02+00:00'
+  first_timestamp: '2020-01-02T00:00:02+00:00'
   numeric_index: 2
   index: "\U00000002"
   event_properties:
@@ -51,7 +51,7 @@
   submission_date: '2020-01-02'
   category: first_category
   event: third_event
-  first_timestamp: '2020-01-01T00:00:04+00:00'
+  first_timestamp: '2020-01-02T00:00:04+00:00'
   numeric_index: 3
   index: "\U00000003"
   event_properties: []

--- a/tests/org_mozilla_firefox_derived/event_types_v1/test_init/org_mozilla_firefox.events.yaml
+++ b/tests/org_mozilla_firefox_derived/event_types_v1/test_init/org_mozilla_firefox.events.yaml
@@ -3,7 +3,7 @@
   submission_timestamp: '2020-01-02 00:00:00'
   events:
     -
-      timestamp: '2020-01-01 00:00:01'
+      timestamp: 1000
       name: first_event
       category: first_category
       extra:
@@ -14,7 +14,7 @@
           key: time_ms
           value: "1000"
     -
-      timestamp: '2020-01-01 00:00:02'
+      timestamp: 2000
       name: second_event
       category: second_category
       extra:
@@ -22,7 +22,7 @@
           key: second_property
           value: second_property_value_1
     -
-      timestamp: '2020-01-01 00:00:03'
+      timestamp: 3000
       name: second_event
       category: second_category
       extra:
@@ -30,14 +30,14 @@
           key: second_property
           value: second_property_value_2
     -
-      timestamp: '2020-01-01 00:00:04'
+      timestamp: 4000
       name: third_event
       category: first_category
 -
   submission_timestamp: '2020-01-02 00:00:00'
   events:
     -
-      timestamp: '2020-01-01 00:01:01'
+      timestamp: 1000
       name: first_event
       category: first_category
       extra:

--- a/tests/org_mozilla_firefox_derived/event_types_v1/test_new_day/expect.yaml
+++ b/tests/org_mozilla_firefox_derived/event_types_v1/test_new_day/expect.yaml
@@ -79,7 +79,7 @@
   submission_date: '2020-01-03'
   category: new_category
   event: new_event_no_props
-  first_timestamp: '2020-01-02T00:00:01+00:00'
+  first_timestamp: '2020-01-03T00:00:01+00:00'
   numeric_index: 4
   index: "\U00000004"
   event_properties: []
@@ -87,7 +87,7 @@
   submission_date: '2020-01-03'
   category: new_category
   event: new_event_with_props
-  first_timestamp: '2020-01-02T00:00:02+00:00'
+  first_timestamp: '2020-01-03T00:00:02+00:00'
   numeric_index: 5
   index: "\U00000005"
   event_properties:

--- a/tests/org_mozilla_firefox_derived/event_types_v1/test_new_day/org_mozilla_firefox.events.yaml
+++ b/tests/org_mozilla_firefox_derived/event_types_v1/test_new_day/org_mozilla_firefox.events.yaml
@@ -3,11 +3,11 @@
   submission_timestamp: '2020-01-03 00:00:00'
   events:
     - 
-      timestamp: '2020-01-02 00:00:01'
+      timestamp: 1000
       name: new_event_no_props
       category: new_category
     - 
-      timestamp: '2020-01-02 00:00:02'
+      timestamp: 2000
       name: new_event_with_props
       category: new_category
       extra:
@@ -15,7 +15,7 @@
           key: new_event_prop
           value: new_event_prop_value_1
     - 
-      timestamp: '2020-01-02 00:00:03'
+      timestamp: 3000
       name: third_event
       category: first_category
       extra:
@@ -23,7 +23,7 @@
           key: third_event_prop
           value: third_event_prop_value_1
     - 
-      timestamp: '2020-01-02 00:00:03'
+      timestamp: 3000
       name: second_event
       category: second_category
       extra:
@@ -31,7 +31,7 @@
           key: third_property
           value: third_property_value_1
     - 
-      timestamp: '2020-01-02 00:01:01'
+      timestamp: 1000
       name: first_event
       category: first_category
       extra:
@@ -39,7 +39,7 @@
           key: first_property
           value: first_property_value_3
     - 
-      timestamp: '2020-01-02 00:01:01'
+      timestamp: 1000
       name: first_event
       category: first_category
       extra:


### PR DESCRIPTION
Glean event timestamps are actually millisecond ints, starting at 0 for the first event. We account for that now.