### PR TITLE
Draft query showing a proof-of-concept for clients_all_time

### DIFF
--- a/clients_all_time.sql
+++ b/clients_all_time.sql
@@ -1,0 +1,54 @@
+/*
+
+The underlying "clients_all_time_v0" table has one row per client for all time,
+but this view on top of it explodes the dates so that we get one row per client
+per day, similar to the clients_last_seen structure we're already familiar with.
+
+The differences between this view and clients_last_seen are:
+
+- The bit patterns are BYTES rather than INT64
+- The bit patterns include all history, so we could use them for LTV-type calculations
+  that depend on activity 1 year ago
+- This view includes first_seen_date, which previously required a separate table
+- We get both first_seen and last_seen values for dimensions like country;
+  we can use the first_seen values to ensure that clients are not moving from one
+  group to another across different dates
+- We have a full history of country values seen on different dates
+
+*/
+
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.analysis.klukas_clients_all_time`
+AS
+WITH exploded AS (
+  SELECT
+    DATE_SUB(CURRENT_DATE(), INTERVAL i day) AS submission_date,
+    DATE_SUB(
+      CURRENT_DATE(),
+      INTERVAL udf.bits_to_days_since_first_seen(days_seen_bits) day
+    ) AS first_seen_date,
+    sample_id,
+    client_id,
+    days_seen_bits >> i AS days_seen_bits,
+    first_seen_country,
+    last_seen_country,
+    ARRAY(
+      SELECT AS STRUCT
+        key,
+        value >> i AS value
+      FROM
+        UNNEST(days_seen_in_country_bytes)
+    ) AS days_seen_in_country_bits,
+  FROM
+    `moz-fx-data-shared-prod.analysis.klukas_clients_all_time_v1`
+  -- The cross join parses each input row into one row per day since the client
+  -- was first seen, emulating the format of the existing clients_last_seen table.
+  CROSS JOIN
+    UNNEST(GENERATE_ARRAY(0, 2048)) AS i
+  WHERE BIT_COUNT(days_seen_bits) > 0
+)
+SELECT
+  *,
+  udf.bits_to_days_since_seen(days_seen_bits) AS days_since_seen,
+FROM
+  exploded

--- a/clients_all_time_v0.sql
+++ b/clients_all_time_v0.sql
@@ -51,7 +51,6 @@ WITH base AS (
     -- Only do one sample_id at a time to limit shuffling.
     AND sample_id = 0
 ),
-
 -- This per_client ETL is where we can define BYTES fields for capturing history
 -- for various usage criteria, and also capture the first-seen and last-seen
 -- values for various dimensions.
@@ -66,7 +65,8 @@ per_client1 AS (
   FROM
     base
   GROUP BY
-    sample_id, client_id
+    sample_id,
+    client_id
 ),
 per_client2 AS (
   SELECT
@@ -78,7 +78,6 @@ per_client2 AS (
   FROM
     per_client1
 ),
-
 -- This per-country section demonstrates how we can maintain a BYTES field per dimension.
 -- For a user that only ever appears in one country, this will recreate the top-level days_seen_bits,
 -- but for a client that appears in more than one country, we get an array with one entry per

--- a/clients_all_time_v0.sql
+++ b/clients_all_time_v0.sql
@@ -5,6 +5,10 @@ CREATE TEMP FUNCTION offsets_to_bytes(offsets ARRAY<INT64>) AS (
         STRING_AGG(
           (
             SELECT
+              -- CODE_POINTS_TO_BYTES is the best available interface for converting
+              -- an array of numeric values to a BYTES field; it requires that values
+              -- are valid extended ASCII characters, so we can only aggregate 8 bits
+              -- at a time, and then append all those chunks together with STRING_AGG.
               CODE_POINTS_TO_BYTES(
                 [
                   BIT_OR(

--- a/clients_all_time_v0.sql
+++ b/clients_all_time_v0.sql
@@ -1,0 +1,120 @@
+CREATE TEMP FUNCTION offsets_to_bytes(offsets ARRAY<INT64>) AS (
+  (
+    SELECT
+      LTRIM(
+        STRING_AGG(
+          (
+            SELECT
+              CODE_POINTS_TO_BYTES(
+                [
+                  BIT_OR(
+                    (
+                      IF(
+                        DIV(n - (8 * i), 8) = 0
+                        AND (n - (8 * i)) >= 0,
+                        1 << MOD(n - (8 * i), 8),
+                        0
+                      )
+                    )
+                  )
+                ]
+              )
+            FROM
+              UNNEST(offsets) AS n
+          ),
+          b''
+        ),
+        b'\x00'
+      )
+    FROM
+      -- Each iteration handles 8 bits, so 256 iterations gives us
+      -- 2048 bits, about 5.6 years worth.
+      UNNEST(GENERATE_ARRAY(255, 0, -1)) AS i
+  )
+);
+
+CREATE OR REPLACE TABLE
+  analysis.klukas_clients_all_time_v1
+AS
+WITH base AS (
+  SELECT
+    submission_timestamp,
+    DATE(submission_timestamp) AS submission_date,
+    client_id,
+    sample_id,
+    metadata.geo.country,
+  FROM
+    telemetry_stable.main_v4
+  WHERE
+    -- Include all time.
+    DATE(submission_timestamp) > '2010-01-01'
+    -- Only do one sample_id at a time to limit shuffling.
+    AND sample_id = 0
+),
+
+-- This per_client ETL is where we can define BYTES fields for capturing history
+-- for various usage criteria, and also capture the first-seen and last-seen
+-- values for various dimensions.
+per_client1 AS (
+  SELECT
+    client_id,
+    sample_id,
+    offsets_to_bytes(
+      ARRAY_AGG(DISTINCT DATE_DIFF(CURRENT_DATE(), submission_date, DAY))
+    ) AS days_seen_bits,
+    ARRAY_AGG(country IGNORE NULLS ORDER BY submission_timestamp) AS countries
+  FROM
+    base
+  GROUP BY
+    sample_id, client_id
+),
+per_client2 AS (
+  SELECT
+    client_id,
+    sample_id,
+    days_seen_bits,
+    countries[safe_offset(0)] AS first_seen_country,
+    array_reverse(countries)[safe_offset(0)] AS last_seen_country,
+  FROM
+    per_client1
+),
+
+-- This per-country section demonstrates how we can maintain a BYTES field per dimension.
+-- For a user that only ever appears in one country, this will recreate the top-level days_seen_bits,
+-- but for a client that appears in more than one country, we get an array with one entry per
+-- country that client has appeared in, and we have the full history of days on which the client
+-- appeared in that country.
+per_country AS (
+  SELECT
+    client_id,
+    sample_id,
+    country,
+    offsets_to_bytes(
+      ARRAY_AGG(DISTINCT DATE_DIFF(CURRENT_DATE(), submission_date, DAY))
+    ) AS days_seen_bits,
+  FROM
+    base
+  GROUP BY
+    sample_id,
+    client_id,
+    country
+),
+per_country2 AS (
+  SELECT
+    client_id,
+    sample_id,
+    ARRAY_AGG(STRUCT(country AS key, days_seen_bits AS value)) AS days_seen_in_country_bytes
+  FROM
+    per_country
+  GROUP BY
+    sample_id,
+    client_id
+)
+SELECT
+  *
+FROM
+  per_client2
+LEFT JOIN
+  per_country2
+USING
+  (sample_id, client_id)


### PR DESCRIPTION
## clients_all_time

The concept of `clients_all_time` is to provide an interface very similar to `clients_last_seen`, but the underlying data model is a single row per client over all time. Instead of having a moving 28-day window, we rewrite the entire table every day, incorporating the new day's observations. At query time, the view logic unpacks this one-row-per-client representation into a per-client-per-day representation much like clients_last_seen.

Another way of looking at this is that it gives us clients_first_seen + clients_last_seen without needing a join. It also unlocks the possibility of doing LTV-type calculation that rely on history from 1 year ago.

### Prototype

The query given here considers just a single dimension, a single usage criterion, and is for a 1% sample of the desktop population, but it runs over the entire history contained in `main_v4` to demonstrate the concept.

It ran in approx. 45 minutes and scanned 100 GB. The resulting table is about 1 GB in size.

We can infer from this that the storage size on disk will be about 0.5 GB per BYTES column per sample_id.

### Trying it out

We provide a clients_last_seen-like view on top of it that can be queried like:

```
SELECT
  * 
FROM 
  `moz-fx-data-shared-prod.analysis.klukas_clients_all_time` 
LIMIT 1000
```

See a preview of results at https://sql.telemetry.mozilla.org/queries/74697/source