### PR TITLE
Bug 1661250 - prepare Shredder script for adding Pioneer support

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -34,7 +34,8 @@ OUTSIDE_RANGE_PARTITION_ID = "__UNPARTITIONED__"
 
 parser = ArgumentParser(description=__doc__)
 standard_args.add_dry_run(parser)
-parser.add_argument("--environment",
+parser.add_argument(
+    "--environment",
     default="telemetry",
     const="telemetry",
     nargs="?",

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -42,7 +42,7 @@ parser.add_argument(
     choices=["telemetry", "pioneer"],
     help="environment to run in (dictates the choice of source and target tables):"
     "telemetry - standard environment"
-    "pioneer - restricted pioneer environment"
+    "pioneer - restricted pioneer environment",
 )
 parser.add_argument(
     "--partition-limit",

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -34,6 +34,15 @@ OUTSIDE_RANGE_PARTITION_ID = "__UNPARTITIONED__"
 
 parser = ArgumentParser(description=__doc__)
 standard_args.add_dry_run(parser)
+parser.add_argument("--environment",
+    default="telemetry",
+    const="telemetry",
+    nargs="?",
+    choices=["telemetry", "pioneer"],
+    help="environment to run in (dictates the choice of source and target tables):"
+    "telemetry - standard environment"
+    "pioneer - restricted pioneer environment"
+)
 parser.add_argument(
     "--partition-limit",
     "--partition_limit",
@@ -399,16 +408,22 @@ def main():
                     )
                 ).result()
             )
-    with ThreadPool(args.parallelism) as pool:
-        glean_targets = find_glean_targets(pool, client)
-        experiment_analysis_targets = find_experiment_analysis_targets(pool, client)
-    tasks = [
-        task
-        for target, sources in chain(
+
+    if args.environment == "telemetry":
+        with ThreadPool(args.parallelism) as pool:
+            glean_targets = find_glean_targets(pool, client)
+            experiment_analysis_targets = find_experiment_analysis_targets(pool, client)
+        targets_with_sources = chain(
             DELETE_TARGETS.items(),
             glean_targets.items(),
             experiment_analysis_targets.items(),
         )
+    elif args.environment == "pioneer":
+        raise NotImplementedError
+
+    tasks = [
+        task
+        for target, sources in targets_with_sources
         if args.table_filter(target.table)
         for task in delete_from_table(
             client=client,


### PR DESCRIPTION
This adds a new `environment` parameter to Shredder delete script, accepting either `telemetry` or `pioneer` values.
The goal of this parameter is to have a way for choosing different source and target tables. By default it is set to `telemetry` (which keeps current behavior unchanged).

Next step is to define logic for discovering Pioneer study tables in `config.py` and invoke it in delete script (`NotImplementedError`).