### PR TITLE
Publish descriptions for UDFs

### DIFF
--- a/bigquery_etl/udf/publish_udfs.py
+++ b/bigquery_etl/udf/publish_udfs.py
@@ -1,6 +1,7 @@
 """Publish UDFs and resources to the public mozfun GCP project."""
 
 from argparse import ArgumentParser
+import json
 import os
 import re
 
@@ -17,8 +18,9 @@ DEFAULT_GCS_BUCKET = "moz-fx-data-prod-bigquery-etl"
 DEFAULT_GCS_PATH = ""
 
 OPTIONS_LIB_RE = re.compile(r'library = "gs://[^"]+/([^"]+)"')
+OPTIONS_RE = re.compile(r"OPTIONS(\n|\s)*\(")
 
-SKIP = {"udf/main_summary_scalars/udf.sql"}
+SKIP = ["udf/main_summary_scalars/udf.sql"]
 
 parser = ArgumentParser(description=__doc__)
 parser.add_argument(
@@ -133,6 +135,14 @@ def publish_udf(
         query = OPTIONS_LIB_RE.sub(
             fr'library = "gs://{gcs_bucket}/{gcs_path}\1"', definition
         )
+
+        # add UDF descriptions
+        if raw_udf.filepath not in SKIP:
+            escaped_description = json.dumps(str(raw_udf.description))
+            query = OPTIONS_RE.sub(f"OPTIONS(description={escaped_description},", query)
+
+            if "OPTIONS(" not in query and query[-1] == ";":
+                query = query[:-1] + f"OPTIONS(description={escaped_description});"
 
         print(f"Publish {raw_udf.name}")
         client.query(query).result()

--- a/bigquery_etl/udf/publish_udfs.py
+++ b/bigquery_etl/udf/publish_udfs.py
@@ -138,6 +138,8 @@ def publish_udf(
 
         # add UDF descriptions
         if raw_udf.filepath not in SKIP:
+            # descriptions need to be escaped since quotation marks and other
+            # characters, such as \x01, will make the query invalid otherwise
             escaped_description = json.dumps(str(raw_udf.description))
             query = OPTIONS_RE.sub(f"OPTIONS(description={escaped_description},", query)
 

--- a/tests/data/udf/test_js_udf/metadata.yaml
+++ b/tests/data/udf/test_js_udf/metadata.yaml
@@ -1,0 +1,2 @@
+description: Some description
+friendly_name: UDF JS

--- a/tests/data/udf/test_js_udf/udf.sql
+++ b/tests/data/udf/test_js_udf/udf.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION udf.test_js_udf(input BYTES)
+RETURNS STRING DETERMINISTIC
+LANGUAGE js
+AS
+  """return 1;"""
+OPTIONS
+  (library = "gs://path/script.js");

--- a/tests/udf/test_parse_udf.py
+++ b/tests/udf/test_parse_udf.py
@@ -95,7 +95,7 @@ class TestParseUdf:
     def test_read_udf_dirs(self):
         udf_dir = TEST_DIR / "data" / "udf"
         raw_udfs = parse_udf.read_udf_dirs((udf_dir))
-        assert len(raw_udfs.keys()) == 4
+        assert len(raw_udfs.keys()) == 5
         assert "udf.test_shift_28_bits_one_day" in raw_udfs
         assert "udf.test_safe_crc32_uuid" in raw_udfs
         assert "udf.test_safe_sample_id" in raw_udfs
@@ -109,7 +109,7 @@ class TestParseUdf:
     def test_parse_udf_dirs(self):
         udf_dir = TEST_DIR / "data" / "udf"
         parsed_udfs = list(parse_udf.parse_udf_dirs((udf_dir)))
-        assert len(parsed_udfs) == 4
+        assert len(parsed_udfs) == 5
         bitmask_lowest_28 = [
             u for u in parsed_udfs if u.name == "udf.test_bitmask_lowest_28"
         ][0]
@@ -190,3 +190,13 @@ class TestParseUdf:
         )
         result = parse_udf.udf_tests_sql(raw_udf, raw_udfs)
         assert result == []
+
+    def test_udf_description(self):
+        udf_dir = TEST_DIR / "data" / "udf"
+        raw_udf = parse_udf.RawUdf.from_file(
+            udf_dir / "test_shift_28_bits_one_day" / "udf.sql"
+        )
+        assert (
+            raw_udf.description
+            == "Shift input bits one day left and drop any bits beyond 28 days."
+        )

--- a/tests/udf/test_parse_udf.py
+++ b/tests/udf/test_parse_udf.py
@@ -44,7 +44,7 @@ class TestParseUdf:
                 "CREATE OR REPLACE FUNCTION udf.test_udf() "
                 + "AS (SELECT mozfun.json.parse('{}'))"
             )
-            result = parse_udf.RawUdf.from_text(text, "udf", "test_udf")
+            result = parse_udf.RawUdf.from_text(text, "udf", "test_udf", description="")
             assert result.name == "udf.test_udf"
             assert len(result.definitions) == 1
             assert len(result.dependencies) == 1
@@ -52,7 +52,7 @@ class TestParseUdf:
             assert result.tests == []
 
             text = "CREATE OR REPLACE FUNCTION json.parse() " + "AS (SELECT 1)"
-            result = parse_udf.RawUdf.from_text(text, "json", "parse")
+            result = parse_udf.RawUdf.from_text(text, "json", "parse", description="")
             assert result.name == "json.parse"
             assert len(result.definitions) == 1
             assert result.dependencies == []

--- a/tests/udf/test_publish_udfs.py
+++ b/tests/udf/test_publish_udfs.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from unittest import mock
+from unittest.mock import MagicMock
+
+from bigquery_etl.udf import parse_udf, publish_udfs
+
+TEST_DIR = Path(__file__).parent.parent
+
+
+class TestPublishUdfs:
+    @mock.patch("google.cloud.bigquery.Client")
+    def test_publish_udf_with_description(self, mock_client):
+        udf_dir = TEST_DIR / "data" / "udf"
+        raw_udf = parse_udf.RawUdf.from_file(
+            udf_dir / "test_shift_28_bits_one_day" / "udf.sql"
+        )
+        mock_client.query = MagicMock()
+        publish_udfs.publish_udf(
+            raw_udf, mock_client, "test-project", "", "", [], False
+        )
+        query = (
+            "CREATE OR REPLACE FUNCTION udf.test_shift_28_bits_one_day(x INT64)"
+            + " AS (\n  IFNULL((x << 1) & udf.test_bitmask_lowest_28(), 0)\n)"
+            + 'OPTIONS(description="Shift input bits one day left and drop any bits'
+            + ' beyond 28 days.");'
+        )
+        mock_client.query.assert_called_with(query)
+
+    @mock.patch("google.cloud.bigquery.Client")
+    def test_publish_js_udf_with_description(self, mock_client):
+        udf_dir = TEST_DIR / "data" / "udf"
+        raw_udf = parse_udf.RawUdf.from_file(udf_dir / "test_js_udf" / "udf.sql")
+        mock_client.query = MagicMock()
+        publish_udfs.publish_udf(
+            raw_udf, mock_client, "test-project", "", "", [], False
+        )
+        query = (
+            "CREATE OR REPLACE FUNCTION udf.test_js_udf(input BYTES)\nRETURNS "
+            + "STRING DETERMINISTIC\nLANGUAGE js\nAS\n "
+            + ' """return 1;"""\nOPTIONS(description="Some description",\n '
+            + '   library = "gs:///script.js"\n  );'
+        )
+        mock_client.query.assert_called_with(query)

--- a/tests/udf/test_publish_udfs.py
+++ b/tests/udf/test_publish_udfs.py
@@ -37,7 +37,7 @@ class TestPublishUdfs:
         query = (
             "CREATE OR REPLACE FUNCTION udf.test_js_udf(input BYTES)\nRETURNS "
             + "STRING DETERMINISTIC\nLANGUAGE js\nAS\n "
-            + ' """return 1;"""\nOPTIONS(description="Some description",\n '
-            + '   library = "gs:///script.js"\n  );'
+            + ' """return 1;"""\nOPTIONS(description="Some description",'
+            + 'library = "gs:///script.js");'
         )
         mock_client.query.assert_called_with(query)

--- a/tests/validation/hmac_sha256.py
+++ b/tests/validation/hmac_sha256.py
@@ -38,7 +38,7 @@ def generate_raw_udf(test_cases):
     test_sql_stmnts = [test_sql_fixture.format(**test_case) for test_case in test_cases]
 
     return RawUdf.from_text(
-        "\n".join(test_sql_stmnts), "udf", "hmac_sha256", is_defined=False
+        "\n".join(test_sql_stmnts), "udf", "hmac_sha256", description="", is_defined=False
     )
 
 

--- a/tests/validation/hmac_sha256.py
+++ b/tests/validation/hmac_sha256.py
@@ -38,7 +38,11 @@ def generate_raw_udf(test_cases):
     test_sql_stmnts = [test_sql_fixture.format(**test_case) for test_case in test_cases]
 
     return RawUdf.from_text(
-        "\n".join(test_sql_stmnts), "udf", "hmac_sha256", description="", is_defined=False
+        "\n".join(test_sql_stmnts),
+        "udf",
+        "hmac_sha256",
+        description="",
+        is_defined=False,
     )
 
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/1164

This turned out hairier than I would have hoped. Unlike tables, there is no API for adding descriptions to existing UDFs, so descriptions have to be added to the queries defining UDFs.