### PR TITLE
Drop submission_date from event types view

### DIFF
--- a/sql/org_mozilla_firefox/event_types_v1/query.sql
+++ b/sql/org_mozilla_firefox/event_types_v1/query.sql
@@ -5,7 +5,7 @@ EXECUTE IMMEDIATE CONCAT(
     org_mozilla_firefox.event_types
   AS
   SELECT
-    *
+    * EXCEPT (submission_date)
   FROM
     org_mozilla_firefox_derived.event_types_v1
   WHERE


### PR DESCRIPTION
Pretty annoying to have it in there when joining with events_daily.