### PR TITLE
CLI support name patterns with wildcards

### DIFF
--- a/bigquery_etl/_version.py
+++ b/bigquery_etl/_version.py
@@ -1,5 +1,5 @@
 """Provides bigquery-etl version information."""
 from incremental import Version
 
-__version__ = Version("bigquery_etl/", 20, 9, 0)
+__version__ = Version("bigquery_etl/", 20, 9, 1)
 __all__ = ["__version__"]

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -270,8 +270,8 @@ def schedule(name, path, dag, depends_on_past, task_name):
 
     # re-run DAG generation for the affected DAG
     for d in dags_to_be_generated:
-        print(f"Running DAG generation for {existing_dag.name}")
         existing_dag = dags.dag_by_name(d)
+        print(f"Running DAG generation for {existing_dag.name}")
         output_dir = sql_dir.parent / "dags"
         dags.dag_to_airflow(output_dir, existing_dag)
 

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -20,7 +20,7 @@ from ..run_query import run
 
 
 QUERY_NAME_RE = re.compile(r"(?P<dataset>[a-zA-z0-9_]+)\.(?P<name>[a-zA-z0-9_]+)")
-QUERY_FILE_RE = re.compile(
+SQL_FILE_RE = re.compile(
     r"^.*/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+_v[0-9]+)/"
     r"(?:query\.sql|part1\.sql|script\.sql)$"
 )
@@ -29,19 +29,19 @@ VERSION_RE = re.compile(r"_v[0-9]+")
 
 def _queries_matching_name_pattern(pattern, sql_path):
     """Return paths to queries matching the name pattern."""
-    all_query_files = Path(sql_path).rglob("*.sql")
-    query_files = []
+    all_sql_files = Path(sql_path).rglob("*.sql")
+    sql_files = []
 
-    for query_file in all_query_files:
-        match = QUERY_FILE_RE.match(str(query_file))
+    for sql_file in all_sql_files:
+        match = SQL_FILE_RE.match(str(sql_file))
         if match:
             dataset = match.group(1)
             table = match.group(2)
             query_name = f"{dataset}.{table}"
             if fnmatchcase(query_name, pattern):
-                query_files.append(query_file)
+                sql_files.append(sql_file)
 
-    return query_files
+    return sql_files
 
 
 path_option = click.option(

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -468,7 +468,10 @@ def validate(ctx, name, path, use_cloud_function, project):
     for query in query_files:
         ctx.invoke(format, path=str(query))
         ctx.invoke(
-            dryrun, path=str(query), use_cloud_function=use_cloud_function, project=project
+            dryrun,
+            path=str(query),
+            use_cloud_function=use_cloud_function,
+            project=project,
         )
         validate_metadata.validate(query.parent)
 

--- a/bigquery_etl/cli/udf.py
+++ b/bigquery_etl/cli/udf.py
@@ -236,3 +236,23 @@ def publish(ctx, path, project, dependency_dir, gcs_bucket, gcs_path):
 
 
 mozfun.add_command(publish)
+
+
+@udf.command(
+    help="Rename a UDF.",
+)
+@click.argument("path", type=click.Path(file_okay=False), required=False)
+@click.pass_context
+def validate(ctx, path):
+    """Validate UDFs by formatting and running tests."""
+    udf_dirs = ctx.obj["UDF_DIRS"]
+    if path and is_valid_dir(None, None, path):
+        udf_dirs = (path,)
+
+    validate_docs.validate(udf_dirs)
+    for udf_dir in udf_dirs:
+        ctx.invoke(format, path=udf_dir)
+        pytest.main([udf_dir])
+
+
+mozfun.add_command(validate)


### PR DESCRIPTION
This adds support for expressing query and UDF names with wildcards. Instead of specifying paths to queries or UDFs, the CLI now works with query and UDF names. This way, users do not necessarily need to know the underlying folder structure for using the CLI.

The CLI now supports things like:
`bqetl query info "*.clients*"` or `bqetl query info "telemetry_derived.*_v6"`
