### PR TITLE
Disable destination_table for script.sql

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -296,6 +296,7 @@ class Task:
         """
         task = cls.of_query(query_file, metadata, dag_collection)
         task.sql_file_path = query_file
+        task.destination_table = None
         return task
 
     def _get_referenced_tables(self):

--- a/dags/bqetl_account_ecosystem.py
+++ b/dags/bqetl_account_ecosystem.py
@@ -46,7 +46,7 @@ with DAG(
 
     account_ecosystem_derived__ecosystem_user_id_lookup__v1 = bigquery_etl_query(
         task_id="account_ecosystem_derived__ecosystem_user_id_lookup__v1",
-        destination_table="ecosystem_user_id_lookup_v1",
+        destination_table=None,
         dataset_id="account_ecosystem_derived",
         project_id="moz-fx-data-shared-prod",
         owner="jklukas@mozilla.com",


### PR DESCRIPTION
Bug fix for #1288

Currently, the one script.sql task we have fails in Airflow due to having destination_table set in the query job, which is disallowed for scripts.