### PR TITLE
CLI UDF rename command

### DIFF
--- a/bigquery_etl/_version.py
+++ b/bigquery_etl/_version.py
@@ -1,5 +1,5 @@
 """Provides bigquery-etl version information."""
 from incremental import Version
 
-__version__ = Version("bigquery_etl/", 20, 9, 1)
+__version__ = Version("bigquery_etl/", 20, 9, 2)
 __all__ = ["__version__"]

--- a/bigquery_etl/cli/udf.py
+++ b/bigquery_etl/cli/udf.py
@@ -275,8 +275,8 @@ mozfun.add_command(publish)
     help="Rename UDF or UDF dataset.",
 )
 @click.argument("name", required=True)
+@click.argument("new_name", required=True)
 @path_option
-@click.option("--new_name", "-n", help="New UDF or dataset name", required=True)
 @click.option(
     "--sql_path",
     "--sql-path",
@@ -291,16 +291,16 @@ def rename(ctx, name, path, new_name, sql_path):
     if path and is_valid_dir(None, None, path):
         udf_dirs = (path,)
 
-    if UDF_NAME_RE.match(name) and UDF_NAME_RE.match(new_name):
+    udf_files = _udfs_matching_name_pattern(name, udf_dirs)
+
+    if UDF_NAME_RE.match(new_name) and len(udf_files) <= 1:
         # rename UDF
-        udf_files = _udfs_matching_name_pattern(name, udf_dirs)
         match = UDF_NAME_RE.match(new_name)
         new_udf_name = match.group("name")
         new_udf_dataset = match.group("dataset")
-    elif UDF_DATASET_RE.match(name) and UDF_DATASET_RE.match(new_name):
+    elif UDF_DATASET_RE.match(new_name):
         # rename UDF dataset
         match = UDF_DATASET_RE.match(new_name)
-        udf_files = _udfs_matching_name_pattern(f"{name}.*", udf_dirs)
         new_udf_name = None
         new_udf_dataset = match.group("dataset")
     else:

--- a/tests/cli/test_cli_udf.py
+++ b/tests/cli/test_cli_udf.py
@@ -3,7 +3,7 @@ import pytest
 from click.testing import CliRunner
 import yaml
 
-from bigquery_etl.cli.udf import create, info
+from bigquery_etl.cli.udf import create, info, rename
 
 
 class TestUdf:
@@ -101,3 +101,106 @@ class TestUdf:
             assert result.exit_code == 0
             assert "udf.another_udf" in result.output
             assert "udf.test_udf" not in result.output
+
+    def test_udf_renaming_invalid_naming(self, runner):
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                rename, ["dataset", "-n", "something.else"], obj={"UDF_DIRS": ("udf",)}
+            )
+            assert result.exit_code == 1
+
+            result = runner.invoke(
+                rename, ["dataset.udf", "-n", "something"], obj={"UDF_DIRS": ("udf",)}
+            )
+            assert result.exit_code == 1
+
+            result = runner.invoke(rename, ["dataset.udf"])
+            assert result.exit_code == 2
+
+    def test_udf_renaming(self, runner):
+        with runner.isolated_filesystem():
+            os.mkdir("udf")
+            os.mkdir("udf/test_udf")
+            with open("udf/test_udf/udf.sql", "w") as f:
+                f.write("CREATE OR REPLACE FUNCTION udf.test_udf() AS (TRUE)")
+
+            os.mkdir("udf/another_udf")
+            with open("udf/another_udf/udf.sql", "w") as f:
+                f.write(
+                    "CREATE OR REPLACE FUNCTION udf.another_udf() AS (udf.test_udf())"
+                )
+
+            os.mkdir("sql")
+            os.mkdir("sql/telemetry_derived")
+            os.mkdir("sql/telemetry_derived/query_v1")
+            with open("sql/telemetry_derived/query_v1/query.sql", "w") as f:
+                f.write("SELECT udf.test_udf()")
+
+            result = runner.invoke(
+                rename,
+                ["udf.test_udf", "-n", "udf.renamed_udf"],
+                obj={"UDF_DIRS": ("udf",)},
+            )
+            assert result.exit_code == 0
+            assert "test_udf" not in os.listdir("udf")
+            assert "another_udf" in os.listdir("udf")
+            assert "renamed_udf" in os.listdir("udf")
+
+            with open("sql/telemetry_derived/query_v1/query.sql", "r") as f:
+                sql = f.read()
+                assert "udf.renamed_udf" in sql
+                assert "udf.test_udf" not in sql
+
+            with open("udf/another_udf/udf.sql", "r") as f:
+                sql = f.read()
+                assert "udf.renamed_udf" in sql
+                assert "udf.test_udf" not in sql
+
+            with open("udf/renamed_udf/udf.sql", "r") as f:
+                sql = f.read()
+                assert "udf.renamed_udf" in sql
+                assert "udf.test_udf" not in sql
+
+    def test_mozfun_dataset_renaming(self, runner):
+        with runner.isolated_filesystem():
+            os.mkdir("mozfun")
+            os.mkdir("mozfun/udf")
+            os.mkdir("mozfun/udf/test_udf")
+            with open("mozfun/udf/test_udf/udf.sql", "w") as f:
+                f.write("CREATE OR REPLACE FUNCTION udf.test_udf() AS (TRUE)")
+
+            os.mkdir("mozfun/udf/another_udf")
+            with open("mozfun/udf/another_udf/udf.sql", "w") as f:
+                f.write(
+                    "CREATE OR REPLACE FUNCTION udf.another_udf() AS (udf.test_udf())"
+                )
+
+            os.mkdir("sql")
+            os.mkdir("sql/telemetry_derived")
+            os.mkdir("sql/telemetry_derived/query_v1")
+            with open("sql/telemetry_derived/query_v1/query.sql", "w") as f:
+                f.write("SELECT udf.test_udf()")
+
+            result = runner.invoke(
+                rename, ["udf", "-n", "new_dataset"], obj={"UDF_DIRS": ("mozfun",)}
+            )
+            assert result.exit_code == 0
+            assert "udf" not in os.listdir("mozfun")
+            assert "new_dataset" in os.listdir("mozfun")
+            assert "another_udf" in os.listdir("mozfun/new_dataset")
+            assert "test_udf" in os.listdir("mozfun/new_dataset")
+
+            with open("sql/telemetry_derived/query_v1/query.sql", "r") as f:
+                sql = f.read()
+                assert "new_dataset.test_udf" in sql
+                assert "udf.test_udf" not in sql
+
+            with open("mozfun/new_dataset/another_udf/udf.sql", "r") as f:
+                sql = f.read()
+                assert "new_dataset.test_udf" in sql
+                assert "udf.test_udf" not in sql
+
+            with open("mozfun/new_dataset/test_udf/udf.sql", "r") as f:
+                sql = f.read()
+                assert "new_dataset.test_udf" in sql
+                assert "udf.test_udf" not in sql


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/1341

This `bqetl udf rename` and `bqetl mozfun rename` command supports renaming UDFs and UDF datasets:

```
# to rename datasets:
bqetl mozfun rename bits28 -n new_bits28

# to rename UDFs:
bqetl mozfun rename bits28.range -n bits28.better_range
bqetl mozfun rename bits28.range -n new_bits28.better_range
bqetl mozfun rename bits28.range -n new_bits28.range
```