### PR TITLE
Bug 1667889 - Add stripe ETL to support Mozilla VPN dashboard

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -63,6 +63,15 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/apple_app_store/metrics_total/query.sql",
     "sql/moz-fx-data-shared-prod/monitoring/telemetry_distinct_docids_v1/query.sql",
     "sql/moz-fx-data-shared-prod/revenue_derived/client_ltv_normalized/query.sql",
+    "sql/moz-fx-data-shared-prod/stripe_derived/plan_events/view.sql",
+    "sql/moz-fx-data-shared-prod/stripe_derived/plans_v1/init.sql",
+    "sql/moz-fx-data-shared-prod/stripe_derived/plans_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/stripe_derived/product_events/view.sql",
+    "sql/moz-fx-data-shared-prod/stripe_derived/products_v1/init.sql",
+    "sql/moz-fx-data-shared-prod/stripe_derived/products_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/stripe_derived/subscription_events/view.sql",
+    "sql/moz-fx-data-shared-prod/stripe_derived/subscriptions_v1/init.sql",
+    "sql/moz-fx-data-shared-prod/stripe_derived/subscriptions_v1/query.sql",
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",  # noqa E501

--- a/dags.yaml
+++ b/dags.yaml
@@ -208,3 +208,12 @@ bqetl_account_ecosystem:
     email: ['jklukas@mozilla.com']
     retries: 2
     retry_delay: 30m
+
+bqetl_stripe:
+  schedule_interval: daily
+  default_args:
+    owner: dthorn@mozilla.com
+    start_date: '2020-10-05'
+    email: ['telemetry-alerts@mozilla.com', 'dthorn@mozilla.com']
+    retries: 2
+    retry_delay: 5m

--- a/dags/bqetl_stripe.py
+++ b/dags/bqetl_stripe.py
@@ -1,0 +1,71 @@
+# Generated via https://github.com/mozilla/bigquery-etl/blob/master/bigquery_etl/query_scheduling/generate_airflow_dags.py
+
+from airflow import DAG
+from airflow.operators.sensors import ExternalTaskSensor
+import datetime
+from utils.gcp import bigquery_etl_query
+
+default_args = {
+    "owner": "dthorn@mozilla.com",
+    "start_date": datetime.datetime(2020, 10, 5, 0, 0),
+    "email": ["telemetry-alerts@mozilla.com", "dthorn@mozilla.com"],
+    "depends_on_past": False,
+    "retry_delay": datetime.timedelta(seconds=300),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 2,
+}
+
+with DAG("bqetl_stripe", default_args=default_args, schedule_interval="@daily") as dag:
+
+    stripe_derived__plans__v1 = bigquery_etl_query(
+        task_id="stripe_derived__plans__v1",
+        destination_table="plans_v1",
+        dataset_id="stripe_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="dthorn@mozilla.com",
+        email=["dthorn@mozilla.com", "telemetry-alerts@mozilla.com"],
+        date_partition_parameter="date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    stripe_derived__products__v1 = bigquery_etl_query(
+        task_id="stripe_derived__products__v1",
+        destination_table="products_v1",
+        dataset_id="stripe_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="dthorn@mozilla.com",
+        email=["dthorn@mozilla.com", "telemetry-alerts@mozilla.com"],
+        date_partition_parameter="date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    stripe_derived__subscriptions__v1 = bigquery_etl_query(
+        task_id="stripe_derived__subscriptions__v1",
+        destination_table="subscriptions_v1",
+        dataset_id="stripe_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="dthorn@mozilla.com",
+        email=["dthorn@mozilla.com", "telemetry-alerts@mozilla.com"],
+        date_partition_parameter="date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    wait_for_stripe_stripe_import_events = ExternalTaskSensor(
+        task_id="wait_for_stripe_stripe_import_events",
+        external_dag_id="stripe",
+        external_task_id="stripe_import_events",
+        check_existence=True,
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+        dag=dag,
+    )
+
+    stripe_derived__plans__v1.set_upstream(wait_for_stripe_stripe_import_events)
+
+    stripe_derived__products__v1.set_upstream(wait_for_stripe_stripe_import_events)
+
+    stripe_derived__subscriptions__v1.set_upstream(wait_for_stripe_stripe_import_events)

--- a/sql/moz-fx-data-shared-prod/stripe/subscription_transitions/view.sql
+++ b/sql/moz-fx-data-shared-prod/stripe/subscription_transitions/view.sql
@@ -1,0 +1,98 @@
+CREATE OR REPLACE VIEW
+  subscription_transitions
+AS
+WITH subscriptions AS (
+  SELECT
+    products_v1.name AS product,
+    (
+      cancel_at_period_end
+      OR "cancelled_for_customer_at" IN (SELECT key FROM UNNEST(subscriptions_v1.metadata))
+    ) AS cancelled_for_customer,
+    DATE(start_date) AS start_date,
+    DATE(trial_end) AS trial_end,
+    DATE(ended_at) AS end_date,
+    MIN(DATE(start_date)) OVER (PARTITION BY customer) AS customer_start_date,
+    customer,
+  FROM
+    stripe_derived.subscriptions_v1
+  LEFT JOIN
+    stripe_derived.plans_v1
+  ON
+    (subscriptions_v1.plan = plans_v1.id)
+  LEFT JOIN
+    stripe_derived.products_v1
+  ON
+    (plans_v1.product = products_v1.id)
+  WHERE
+    status NOT IN ("incomplete", "incomplete_expired")
+),
+counts AS (
+  SELECT
+    `date`,
+    product,
+    transition,
+    -- make count negative for subscription ended counts
+    IF(
+      transition IN ("trial cancelled", "trial convert failed", "cancelled", "renew failed"),
+      -1,
+      1
+    ) * COUNT(*) AS subscription_count,
+  FROM
+    subscriptions
+  CROSS JOIN
+    UNNEST(
+      ARRAY[
+        STRUCT(
+          start_date AS date,
+          IF(
+            trial_end IS NOT NULL,
+            IF(start_date > customer_start_date, "resurrected trial", "new trial"),
+            IF(start_date > customer_start_date, "resurrected", "new")
+          ) AS transition
+        ),
+        STRUCT(
+          IF(trial_end < COALESCE(end_date, CURRENT_DATE), trial_end, NULL) AS date,
+          "converted" AS transition
+        ),
+        STRUCT(
+          end_date AS date,
+          IF(
+            end_date <= trial_end,
+            IF(cancelled_for_customer, "trial cancelled", "trial convert failed"),
+            IF(cancelled_for_customer, "cancelled", "renew failed")
+          ) AS transition
+        )
+      ]
+    )
+  WHERE
+    `date` IS NOT NULL
+  GROUP BY
+    `date`,
+    product,
+    transition
+),
+fill_groups AS (
+  SELECT
+    `date`,
+    product,
+    transition
+  FROM
+    (SELECT DISTINCT `date`, product FROM counts)
+  JOIN
+    (SELECT DISTINCT transition, product FROM counts)
+  USING
+    (product)
+)
+SELECT
+  `date`,
+  product,
+  transition,
+  COALESCE(subscription_count, 0) AS subscription_count,
+FROM
+  counts
+-- join on every combination of date/transition for each product to fill zeroes for subscription_count,
+-- to make it easier to control graphing order in re:dash visualizations
+FULL JOIN
+  fill_groups
+USING
+  (`date`, product, transition)

--- a/sql/moz-fx-data-shared-prod/stripe/subscription_volume/view.sql
+++ b/sql/moz-fx-data-shared-prod/stripe/subscription_volume/view.sql
@@ -1,0 +1,41 @@
+CREATE OR REPLACE VIEW
+  subscription_volume
+AS
+WITH subscriptions AS (
+  SELECT
+    DATE(start_date) AS start_date,
+    DATE(trial_end) AS trial_end,
+    COALESCE(DATE(ended_at), CURRENT_DATE) AS end_date,
+    products_v1.name AS product,
+  FROM
+    stripe_derived.subscriptions_v1
+  LEFT JOIN
+    stripe_derived.plans_v1
+  ON
+    (subscriptions_v1.plan = plans_v1.id)
+  LEFT JOIN
+    stripe_derived.products_v1
+  ON
+    (plans_v1.product = products_v1.id)
+  WHERE
+    status NOT IN ("incomplete", "incomplete_expired")
+)
+SELECT
+  `date`,
+  product,
+  COALESCE(`date` >= trial_end, TRUE) AS paying,
+  COUNT(*) AS subscription_count,
+FROM
+  subscriptions
+CROSS JOIN
+  UNNEST(
+    GENERATE_DATE_ARRAY(
+      start_date,
+      -- GENERATE_DATE_ARRAY is inclusive, so subtract one day to exclude end date
+      DATE_SUB(end_date, INTERVAL 1 DAY)
+    )
+  ) AS `date`
+GROUP BY
+  `date`,
+  product,
+  paying

--- a/sql/moz-fx-data-shared-prod/stripe_derived/plan_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/plan_events/view.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE VIEW
+  plan_events
+AS
+SELECT
+  created AS event_timestamp,
+  `data`.plan.*,
+FROM
+  stripe_external.events_v1
+WHERE
+  `data`.plan IS NOT NULL
+UNION ALL
+SELECT
+  created AS event_timestamp,
+  *,
+FROM
+  stripe_external.plans_v1

--- a/sql/moz-fx-data-shared-prod/stripe_derived/plans_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/plans_v1/init.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE TABLE
+  plans_v1
+PARTITION BY
+  DATE(event_timestamp)
+CLUSTER BY
+  id
+AS
+SELECT
+  id,
+  ARRAY_AGG(event ORDER BY event_timestamp DESC LIMIT 1)[OFFSET(0)].* EXCEPT (id),
+FROM
+  plan_events AS event
+GROUP BY
+  id

--- a/sql/moz-fx-data-shared-prod/stripe_derived/plans_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/plans_v1/metadata.yaml
@@ -1,0 +1,15 @@
+friendly_name: Stripe Plans
+description: Stripe plans as of UTC midnight. See bug 1667889.
+owners:
+  - dthorn@mozilla.com
+labels:
+  application: stripe
+  schedule: daily
+scheduling:
+  dag_name: bqetl_stripe
+  date_partition_parameter: date
+  depends_on:
+    - dag_name: stripe
+      task_id: stripe_import_events
+      schedule_interval: daily
+  referenced_tables: []

--- a/sql/moz-fx-data-shared-prod/stripe_derived/plans_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/plans_v1/query.sql
@@ -1,0 +1,24 @@
+WITH _current AS (
+  SELECT
+    id,
+    ARRAY_AGG(event ORDER BY event_timestamp DESC LIMIT 1)[OFFSET(0)].* EXCEPT (id),
+  FROM
+    plan_events AS event
+  WHERE
+    DATE(event_timestamp) = @date
+  GROUP BY
+    id
+)
+SELECT
+  IF(
+    _previous.id IS NULL
+    OR _current.event_timestamp > _previous.event_timestamp,
+    _current,
+    _previous
+  ).*
+FROM
+  _current
+FULL JOIN
+  stripe_derived.plans_v1 AS _previous
+USING
+  (id)

--- a/sql/moz-fx-data-shared-prod/stripe_derived/product_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/product_events/view.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE VIEW
+  product_events
+AS
+SELECT
+  created AS event_timestamp,
+  `data`.product.*,
+FROM
+  stripe_external.events_v1
+WHERE
+  `data`.product IS NOT NULL
+UNION ALL
+SELECT
+  created AS event_timestamp,
+  *,
+FROM
+  stripe_external.products_v1

--- a/sql/moz-fx-data-shared-prod/stripe_derived/products_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/products_v1/init.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE TABLE
+  products_v1
+PARTITION BY
+  DATE(event_timestamp)
+CLUSTER BY
+  id
+AS
+SELECT
+  id,
+  ARRAY_AGG(event ORDER BY event_timestamp DESC LIMIT 1)[OFFSET(0)].* EXCEPT (id),
+FROM
+  product_events AS event
+GROUP BY
+  id

--- a/sql/moz-fx-data-shared-prod/stripe_derived/products_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/products_v1/metadata.yaml
@@ -1,0 +1,15 @@
+friendly_name: Stripe Products
+description: Stripe products as of UTC midnight. See bug 1667889.
+owners:
+  - dthorn@mozilla.com
+labels:
+  application: stripe
+  schedule: daily
+scheduling:
+  dag_name: bqetl_stripe
+  date_partition_parameter: date
+  depends_on:
+    - dag_name: stripe
+      task_id: stripe_import_events
+      schedule_interval: daily
+  referenced_tables: []

--- a/sql/moz-fx-data-shared-prod/stripe_derived/products_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/products_v1/query.sql
@@ -1,0 +1,24 @@
+WITH _current AS (
+  SELECT
+    id,
+    ARRAY_AGG(event ORDER BY event_timestamp DESC LIMIT 1)[OFFSET(0)].* EXCEPT (id),
+  FROM
+    product_events AS event
+  WHERE
+    DATE(event_timestamp) = @date
+  GROUP BY
+    id
+)
+SELECT
+  IF(
+    _previous.id IS NULL
+    OR _current.event_timestamp > _previous.event_timestamp,
+    _current,
+    _previous
+  ).*
+FROM
+  _current
+FULL JOIN
+  stripe_derived.products_v1 AS _previous
+USING
+  (id)

--- a/sql/moz-fx-data-shared-prod/stripe_derived/subscription_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/subscription_events/view.sql
@@ -1,0 +1,35 @@
+CREATE OR REPLACE VIEW
+  subscription_events
+AS
+WITH raw AS (
+  SELECT
+    created AS event_timestamp,
+    `data`.subscription.*,
+  FROM
+    stripe_external.events_v1
+  WHERE
+    `data`.subscription IS NOT NULL
+  UNION ALL
+  SELECT
+    created AS event_timestamp,
+    *,
+  FROM
+    stripe_external.subscriptions_v1
+)
+SELECT
+  -- limit fields in stripe_derived so as not to expose sensitive data
+  created,
+  cancel_at,
+  cancel_at_period_end,
+  canceled_at,
+  customer,
+  ended_at,
+  event_timestamp,
+  id,
+  metadata,
+  plan.id AS plan,
+  start_date,
+  status,
+  trial_end,
+FROM
+  raw

--- a/sql/moz-fx-data-shared-prod/stripe_derived/subscriptions_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/subscriptions_v1/init.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE TABLE
+  subscriptions_v1
+PARTITION BY
+  DATE(event_timestamp)
+CLUSTER BY
+  plan
+AS
+SELECT
+  id,
+  ARRAY_AGG(event ORDER BY event_timestamp DESC LIMIT 1)[OFFSET(0)].* EXCEPT (id),
+FROM
+  subscription_events AS event
+GROUP BY
+  id

--- a/sql/moz-fx-data-shared-prod/stripe_derived/subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/subscriptions_v1/metadata.yaml
@@ -1,0 +1,15 @@
+friendly_name: Stripe Subscriptions
+description: Stripe subscriptions as of UTC midnight. See bug 1667889.
+owners:
+  - dthorn@mozilla.com
+labels:
+  application: stripe
+  schedule: daily
+scheduling:
+  dag_name: bqetl_stripe
+  date_partition_parameter: date
+  depends_on:
+    - dag_name: stripe
+      task_id: stripe_import_events
+      schedule_interval: daily
+  referenced_tables: []

--- a/sql/moz-fx-data-shared-prod/stripe_derived/subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/subscriptions_v1/query.sql
@@ -1,0 +1,24 @@
+WITH _current AS (
+  SELECT
+    id,
+    ARRAY_AGG(event ORDER BY event_timestamp DESC LIMIT 1)[OFFSET(0)].* EXCEPT (id),
+  FROM
+    subscription_events AS event
+  WHERE
+    DATE(event_timestamp) = @date
+  GROUP BY
+    id
+)
+SELECT
+  IF(
+    _previous.id IS NULL
+    OR _current.event_timestamp > _previous.event_timestamp,
+    _current,
+    _previous
+  ).*
+FROM
+  _current
+FULL JOIN
+  stripe_derived.subscriptions_v1 AS _previous
+USING
+  (id)


### PR DESCRIPTION
[Bug 1667889 - VPN subscription dashboard](https://bugzilla.mozilla.org/show_bug.cgi?id=1667889)
[Re:Dash Mozilla VPN Redux](https://sql.telemetry.mozilla.org/dashboard/mozilla-vpn-redux)