### PR TITLE
Fix #1356 - Add extra validation before casting 8 digit build ids

### DIFF
--- a/udf/fenix_build_to_datetime/udf.sql
+++ b/udf/fenix_build_to_datetime/udf.sql
@@ -3,26 +3,23 @@ CREATE OR REPLACE FUNCTION udf.fenix_build_to_datetime(app_build STRING) AS (
     LENGTH(app_build)
   WHEN
     8
+    AND SUBSTR(app_build, 5, 2) < "24"
+    AND SUBSTR(app_build, 7, 2) < "60"
   THEN
     -- Ideally, we would use PARSE_DATETIME, but that doesn't support
     -- day of year (%j) or the custom single-character year used here.
-    IF(
-      SUBSTR(app_build, 5, 2) < "24"
-      AND SUBSTR(app_build, 7, 2) < "60",
-      DATETIME_ADD(
-        DATETIME(
-          2018 + SAFE_CAST(
-            SUBSTR(app_build, 1, 1) AS INT64
-          ), -- year
-          1, -- placeholder month
-          1, -- placeholder year
-          SAFE_CAST(SUBSTR(app_build, 5, 2) AS INT64),
-          SAFE_CAST(SUBSTR(app_build, 7, 2) AS INT64),
-          0  -- seconds is always zero
-        ),
-        INTERVAL SAFE_CAST(SUBSTR(app_build, 2, 3) AS INT64) - 1 DAY
+    DATETIME_ADD(
+      DATETIME(
+        2018 + SAFE_CAST(
+          SUBSTR(app_build, 1, 1) AS INT64
+        ), -- year
+        1, -- placeholder month
+        1, -- placeholder year
+        SAFE_CAST(SUBSTR(app_build, 5, 2) AS INT64),
+        SAFE_CAST(SUBSTR(app_build, 7, 2) AS INT64),
+        0  -- seconds is always zero
       ),
-      NULL
+      INTERVAL SAFE_CAST(SUBSTR(app_build, 2, 3) AS INT64) - 1 DAY
     )
   WHEN
     10

--- a/udf/fenix_build_to_datetime/udf.sql
+++ b/udf/fenix_build_to_datetime/udf.sql
@@ -1,8 +1,7 @@
 CREATE OR REPLACE FUNCTION udf.fenix_build_to_datetime(app_build STRING) AS (
   CASE
-    LENGTH(app_build)
   WHEN
-    8
+    LENGTH(app_build) = 8
     AND SUBSTR(app_build, 5, 2) < "24"
     AND SUBSTR(app_build, 7, 2) < "60"
   THEN
@@ -22,7 +21,7 @@ CREATE OR REPLACE FUNCTION udf.fenix_build_to_datetime(app_build STRING) AS (
       INTERVAL SAFE_CAST(SUBSTR(app_build, 2, 3) AS INT64) - 1 DAY
     )
   WHEN
-    10
+    LENGTH(app_build) = 10
   THEN
     DATETIME_ADD(
       DATETIME '2014-12-28 00:00:00',


### PR DESCRIPTION
This fixes the `fenix_build_to_datetime` for 8 digit builds with invalid minutes (and hours). See #1356 for details. 