### PR TITLE
Fix bqetl CLI setup

### DIFF
--- a/bigquery_etl/_version.py
+++ b/bigquery_etl/_version.py
@@ -1,5 +1,3 @@
 """Provides bigquery-etl version information."""
-from incremental import Version
 
-__version__ = Version("bigquery_etl/", 20, 9, 2)
-__all__ = ["__version__"]
+__version__ = "20.9.6"

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,6 @@ cattrs==1.0.0
 attrs==20.2.0
 typing==3.7.4.3
 click==7.1.2
-incremental==17.5.0
 stripe==2.54.0
 ujson==3.2.0
 pandas==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -215,10 +215,6 @@ idna==2.10 \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0 \
     # via requests, yarl
-incremental==17.5.0 \
-    --hash=sha256:717e12246dddf231a349175f48d74d93e2897244939173b01974ab6661406b9f \
-    --hash=sha256:7b751696aaf36eebfab537e458929e194460051ccad279c72b755a167eebd4b3 \
-    # via -r requirements.in
 iniconfig==1.0.1 \
     --hash=sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437 \
     --hash=sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69 \

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ def get_version():
 setup(
     name="mozilla-bigquery-etl",
     version=get_version(),
-    use_incremental=True,
     author="Mozilla Corporation",
     author_email="fx-data-dev@mozilla.org",
     description="Tooling for building derived datasets in BigQuery",
@@ -39,6 +38,8 @@ setup(
         "typing",
         "click",
         "pandas",
+        "ujson",
+        "stripe",
     ],
     long_description="Tooling for building derived datasets in BigQuery",
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I removed the `incremental` dependency. It was required to be installed for `pip install mozilla-bigquery-etl` to work and was causing some confusion for people trying to install the CLI. Also added some missing dependencies that to `setup.py` that are used by the CLI.