### PR TITLE
Bug fixes for AET daily ETL

### DIFF
--- a/sql/account_ecosystem_derived/desktop_clients_daily_v1/query.sql
+++ b/sql/account_ecosystem_derived/desktop_clients_daily_v1/query.sql
@@ -82,6 +82,8 @@ SELECT
       [1, 3, 7, 13, 22, 39, 71, 126, 227, 432, 37284]
     )
   ) AS scalar_parent_browser_engagement_total_uri_count_sum,
+  SUM(payload.scalars.parent.browser_engagement_total_uri_count) >= 5 AS visited_5_uri,
+  SUM(payload.scalars.parent.browser_engagement_total_uri_count) >= 10 AS visited_10_uri,
   mozfun.stats.mode_last(ARRAY_AGG(normalized_channel)) AS normalized_channel,
   mozfun.stats.mode_last(ARRAY_AGG(normalized_os)) AS normalized_os,
   mozfun.stats.mode_last(ARRAY_AGG(normalized_country_code)) AS normalized_country_code,

--- a/sql/account_ecosystem_derived/ecosystem_client_id_lookup_v1/query.sql
+++ b/sql/account_ecosystem_derived/ecosystem_client_id_lookup_v1/query.sql
@@ -31,6 +31,23 @@ hashed AS (
     unioned
   WHERE
     DATE(submission_timestamp) = @submission_date
+),
+euil AS (
+  SELECT
+    ecosystem_user_id,
+    canonical_id
+  FROM
+    ecosystem_user_id_lookup_v1
+  WHERE
+    first_seen_date <= @submission_date
+),
+existing AS (
+  SELECT
+    ecosystem_client_id_hash
+  FROM
+    ecosystem_client_id_lookup_v1
+  WHERE
+    first_seen_date < @submission_date
 )
 SELECT
   ecosystem_client_id_hash,
@@ -38,12 +55,12 @@ SELECT
   hashed.first_seen_date,
 FROM
   hashed
-JOIN
-  ecosystem_user_id_lookup_v1 AS euil
+LEFT JOIN
+  euil
 USING
   (ecosystem_user_id)
 LEFT JOIN
-  ecosystem_client_id_lookup_v1 AS existing
+  existing
 USING
   (ecosystem_client_id_hash)
 WHERE

--- a/sql/account_ecosystem_derived/ecosystem_user_id_lookup_v1/script.sql
+++ b/sql/account_ecosystem_derived/ecosystem_user_id_lookup_v1/script.sql
@@ -14,6 +14,13 @@ WITH unioned AS (
     previous_ecosystem_user_ids[SAFE_OFFSET(0)] AS previous_ecosystem_user_id
   FROM
     firefox_accounts_stable.account_ecosystem_v1
+  UNION ALL
+  SELECT
+    submission_timestamp,
+    payload.ecosystem_user_id,
+    payload.previous_ecosystem_user_ids[SAFE_OFFSET(0)] AS previous_ecosystem_user_id
+  FROM
+    telemetry_stable.account_ecosystem_v4
 ),
 aggregated AS (
   SELECT
@@ -72,7 +79,7 @@ LOOP
 
   SET checksum_post = (
     SELECT
-      BIT_XOR(FARM_FINGERPRINT(TO_JSON_STRING(working_set)))
+      IFNULL(BIT_XOR(FARM_FINGERPRINT(TO_JSON_STRING(working_set))), 0)
     FROM
       working_set
   );

--- a/tests/account_ecosystem_derived/ecosystem_user_id_lookup_v1/test_script/telemetry_stable.account_ecosystem_v4.yaml
+++ b/tests/account_ecosystem_derived/ecosystem_user_id_lookup_v1/test_script/telemetry_stable.account_ecosystem_v4.yaml
@@ -1,0 +1,4 @@
+- submission_timestamp: 2020-04-01 22:09:03.243074 UTC
+  payload:
+    ecosystem_user_id: a0
+    previous_ecosystem_user_ids: [a3]


### PR DESCRIPTION
This fixes a bug about missing uids in the daily table as reported in
https://bugzilla.mozilla.org/show_bug.cgi?id=1637926#c5

It also adds some boolean fields to allow the daily table to specifically
address questions about whether a given client was 5-uri active per day.