### PR TITLE
Remove `total_searches`

### DIFF
--- a/sql/search/search_clients_last_seen_v1/view.sql
+++ b/sql/search/search_clients_last_seen_v1/view.sql
@@ -2,6 +2,7 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.search.search_clients_last_seen_v1`
 AS
 SELECT
+  * EXCEPT (total_searches),
   `moz-fx-data-shared-prod`.udf.bits_to_days_since_seen(days_seen_bytes) AS days_since_seen,
   `moz-fx-data-shared-prod`.udf.bits_to_days_since_seen(days_searched_bytes) AS days_since_searched,
   `moz-fx-data-shared-prod`.udf.bits_to_days_since_seen(
@@ -15,7 +16,6 @@ SELECT
   ) AS days_since_clicked_ad,
   `moz-fx-data-shared-prod`.udf.bits_to_days_since_first_seen(
     days_created_profile_bytes
-  ) AS days_since_created_profile,
-  *
+  ) AS days_since_created_profile  
 FROM
   `moz-fx-data-shared-prod.search_derived.search_clients_last_seen_v1`

--- a/sql/search/search_clients_last_seen_v1/view.sql
+++ b/sql/search/search_clients_last_seen_v1/view.sql
@@ -16,6 +16,6 @@ SELECT
   ) AS days_since_clicked_ad,
   `moz-fx-data-shared-prod`.udf.bits_to_days_since_first_seen(
     days_created_profile_bytes
-  ) AS days_since_created_profile  
+  ) AS days_since_created_profile
 FROM
   `moz-fx-data-shared-prod.search_derived.search_clients_last_seen_v1`


### PR DESCRIPTION
The way `total_searches` is defined as sum over several other search-related metrics is not proper (but ok in determining whether user searched as used in this case). Misusage of total_searches value can be misleading, so we prefer to remove it from the view.