### PR TITLE
Formalize product names in nondesktop_clients_last_seen

### DIFF
--- a/bigquery_etl/format_sql/format.py
+++ b/bigquery_etl/format_sql/format.py
@@ -87,7 +87,6 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_v2/query.sql",
     "sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_v2/query.sql",
     "sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_new_profiles_v2/query.sql",  # noqa E501
-    "sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_v2/query.sql",
     "sql/moz-fx-data-shared-prod/telemetry_derived/surveygizmo_daily_attitudes/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/fenix_metrics.template.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/mobile_search_clients_daily.template.sql",  # noqa E501

--- a/sql/moz-fx-data-shared-prod/telemetry/fenix_clients_last_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fenix_clients_last_seen/view.sql
@@ -1,0 +1,48 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fenix_clients_last_seen`
+AS
+-- For context on naming and channels of Fenix apps, see:
+-- https://docs.google.com/document/d/1Ym4eZyS0WngEP6WdwJjmCoxtoQbJSvORxlQwZpuSV2I/edit#heading=h.69hvvg35j8un
+WITH fenix_union AS (
+  SELECT
+    *,
+    'org_mozilla_fenix' AS _dataset
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_fenix.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    *,
+    'org_mozilla_fenix_nightly' AS _dataset
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_fenix_nightly.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    *,
+    'org_mozilla_firefox' AS _dataset
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_firefox.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    *,
+    'org_mozilla_firefox_beta' AS _dataset
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_firefox_beta.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    *,
+    'org_mozilla_fennec_aurora' AS _dataset
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_fennec_aurora.baseline_clients_last_seen`
+),
+fenix_app_info AS (
+  SELECT
+    *,
+    mozfun.norm.fenix_app_info(_dataset, app_build) AS _app_info
+  FROM
+    fenix_union
+)
+SELECT
+  * EXCEPT (_dataset, _app_info) REPLACE(_app_info.channel AS normalized_channel),
+  _app_info.app_name,
+FROM
+  fenix_app_info

--- a/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.nondesktop_clients_last_seen`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry.nondesktop_clients_last_seen_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
@@ -45,7 +45,6 @@ SELECT
   days_created_profile_bits,
   days_since_created_profile,
   app_name,
-  mozfun.norm.product_info(app_name, os).*,
   os,
   osversion AS os_version,
   normalized_channel,
@@ -53,7 +52,8 @@ SELECT
   country,
   locale,
   distribution_id,
-  metadata_app_version AS app_version
+  metadata_app_version AS app_version,
+  mozfun.norm.product_info(app_name, os).*,
 FROM
   `moz-fx-data-shared-prod.telemetry.core_clients_last_seen`
 UNION ALL
@@ -65,7 +65,6 @@ SELECT
   days_created_profile_bits,
   days_since_created_profile,
   app_name,
-  mozfun.norm.product_info(app_name, os).*,
   normalized_os AS os,
   normalized_os_version AS os_version,
   normalized_channel,
@@ -73,6 +72,7 @@ SELECT
   country,
   locale,
   NULL AS distribution_id,
-  app_display_version AS app_version
+  app_display_version AS app_version,
+  mozfun.norm.product_info(app_name, normalized_os).*,
 FROM
   glean_final

--- a/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
@@ -1,58 +1,11 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.nondesktop_clients_last_seen_v1`
 AS
--- For context on naming and channels of Fenix apps, see:
--- https://docs.google.com/document/d/1Ym4eZyS0WngEP6WdwJjmCoxtoQbJSvORxlQwZpuSV2I/edit#heading=h.69hvvg35j8un
-WITH fenix_union AS (
-  SELECT
-    *,
-    'org_mozilla_fenix' AS _dataset
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_fenix.baseline_clients_last_seen`
-  UNION ALL
-  SELECT
-    *,
-    'org_mozilla_fenix_nightly' AS _dataset
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_fenix_nightly.baseline_clients_last_seen`
-  UNION ALL
-  SELECT
-    *,
-    'org_mozilla_firefox' AS _dataset
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_firefox.baseline_clients_last_seen`
-  UNION ALL
-  SELECT
-    *,
-    'org_mozilla_firefox_beta' AS _dataset
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_firefox_beta.baseline_clients_last_seen`
-  UNION ALL
-  SELECT
-    *,
-    'org_mozilla_fennec_aurora' AS _dataset
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_fennec_aurora.baseline_clients_last_seen`
-),
-fenix_app_info AS (
-  SELECT
-    *,
-    mozfun.norm.fenix_app_info(_dataset, app_build) AS _app_info
-  FROM
-    fenix_union
-),
-fenix_normalized AS (
-  SELECT
-    * EXCEPT (_dataset, _app_info) REPLACE(_app_info.channel AS normalized_channel),
-    _app_info.app_name,
-  FROM
-    fenix_app_info
-),
-glean_union AS (
+WITH glean_final AS (
   SELECT
     *
   FROM
-    fenix_normalized
+    `moz-fx-data-shared-prod.telemetry.fenix_clients_last_seen`
   UNION ALL
   SELECT
     *,
@@ -92,6 +45,7 @@ SELECT
   days_created_profile_bits,
   days_since_created_profile,
   app_name,
+  mozfun.norm.product_info(app_name, os).*,
   os,
   osversion AS os_version,
   normalized_channel,
@@ -111,6 +65,7 @@ SELECT
   days_created_profile_bits,
   days_since_created_profile,
   app_name,
+  mozfun.norm.product_info(app_name, os).*,
   normalized_os AS os,
   normalized_os_version AS os_version,
   normalized_channel,
@@ -120,4 +75,4 @@ SELECT
   NULL AS distribution_id,
   app_display_version AS app_version
 FROM
-  glean_union
+  glean_final

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/query.sql
@@ -1,63 +1,24 @@
-WITH base AS (
-  SELECT
-    submission_date,
-    CASE
-      app_name
-    WHEN
-      'Fennec'
-    THEN
-      CONCAT(app_name, ' ', os)
-    WHEN
-      'Focus'
-    THEN
-      CONCAT(app_name, ' ', os)
-    WHEN
-      'Lockbox'
-    THEN
-      CONCAT('Lockwise ', os)
-    WHEN
-      'Zerda'
-    THEN
-      'Firefox Lite'
-    ELSE
-      app_name
-    END
-    AS product,
-    app_name,
-    SPLIT(app_version, '.')[offset(0)] AS app_version,
-    os,
-    normalized_channel,
-    country,
-    COUNTIF(udf.pos_of_trailing_set_bit(days_created_profile_bits) = 6) AS new_profiles,
-    COUNTIF(
-      udf.pos_of_trailing_set_bit(days_created_profile_bits) = 6
-      AND BIT_COUNT(days_seen_bits << 1 & udf.bitmask_lowest_7()) > 0
-    ) AS day_2_7_activated,
-  FROM
-    `moz-fx-data-shared-prod.telemetry.nondesktop_clients_last_seen_v1`
-  GROUP BY
-    product,
-    app_name,
-    app_version,
-    submission_date,
-    os,
-    normalized_channel,
-    country
-)
 SELECT
-  *
+  submission_date,
+  product,
+  SPLIT(app_version, '.')[offset(0)] AS app_version,
+  os,
+  normalized_channel,
+  country,
+  COUNTIF(udf.pos_of_trailing_set_bit(days_created_profile_bits) = 6) AS new_profiles,
+  COUNTIF(
+    udf.pos_of_trailing_set_bit(days_created_profile_bits) = 6
+    AND BIT_COUNT(days_seen_bits << 1 & udf.bitmask_lowest_7()) > 0
+  ) AS day_2_7_activated,
 FROM
-  base
+  `moz-fx-data-shared-prod.telemetry.nondesktop_clients_last_seen`
 WHERE
   submission_date = @submission_date
-  AND product IN (
-    'Fenix',
-    'Firefox Preview',
-    'Fennec Android',
-    'Focus Android',
-    'Fennec iOS',
-    'Focus iOS',
-    'Firefox Lite',
-    'FirefoxConnect',
-    'Lockwise Android'
-  )
+  AND contributes_to_2020_kpi
+GROUP BY
+  submission_date,
+  product,
+  app_version,
+  os,
+  normalized_channel,
+  country

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_v1/query.sql
@@ -9,52 +9,15 @@ SELECT
   MOD(ABS(FARM_FINGERPRINT(client_id)), 20) AS id_bucket,
   -- Instead of app_name and os, we provide a single clean "product" name
   -- that includes OS where necessary to disambiguate.
-  CASE
-    app_name
-  WHEN
-    'Fennec'
-  THEN
-    CONCAT(app_name, ' ', os)
-  WHEN
-    'Focus'
-  THEN
-    CONCAT(app_name, ' ', os)
-  WHEN
-    'Lockbox'
-  THEN
-    CONCAT('Lockwise ', os)
-  WHEN
-    'Zerda'
-  THEN
-    'Firefox Lite'
-  ELSE
-    app_name
-  END
-  AS product,
+  product,
   normalized_channel,
   campaign,
   country,
   distribution_id
 FROM
-  telemetry.nondesktop_clients_last_seen_v1
+  telemetry.nondesktop_clients_last_seen
 WHERE
-  -- This list corresponds to the products considered for 2019 nondesktop KPIs;
-  -- we apply this filter here rather than in the live view because this field
-  -- is not normalized and there are many single pings that come in with unique
-  -- nonsensical app_name values. App names are documented in
-  -- https://docs.telemetry.mozilla.org/concepts/choosing_a_dataset_mobile.html#products-overview
-  app_name IN (
-    'Fenix',
-    'Firefox Preview',
-    'Fennec', -- Firefox for Android and Firefox for iOS
-    'Focus',
-    'Lockbox', -- Lockwise
-    'Zerda', -- Firefox Lite, previously called Rocket
-    'FirefoxForFireTV', -- Amazon Fire TV
-    'FirefoxConnect' -- Amazon Echo Show
-  )
-  -- There are also many strange nonsensical entries for os, so we filter here.
-  AND os IN ('Android', 'iOS')
+  contributes_to_2020_kpi
   -- 2017-01-01 is the first populated day of telemetry_core_parquet, so start 28 days later.
   AND submission_date >= DATE '2017-01-28'
   -- Reprocess all dates by running this query with --parameter=submission_date:DATE:NULL

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_v2/query.sql
@@ -7,8 +7,6 @@ WITH base AS (
     telemetry.nondesktop_clients_last_seen
   WHERE
     product != 'Other'
-    -- There are many strange nonsensical entries for os, so we filter here.
-    AND os IN ('Android', 'iOS')
 ),
 --
 unioned AS (
@@ -53,7 +51,7 @@ nested AS (
     channel,
     attributed
   FROM
-    base
+    unioned
   WHERE
     client_id IS NOT NULL
     -- Reprocess all dates by running this query with --parameter=submission_date:DATE:NULL

--- a/sql/mozfun/norm/fenix_app_info/metadata.yaml
+++ b/sql/mozfun/norm/fenix_app_info/metadata.yaml
@@ -29,7 +29,7 @@ description: |
   view of the pings associated with a logical app channel, you may need to union together
   tables from multiple BigQuery datasets. To see data for all Fenix channels together, it
   is necessary to union together tables from all 5 datasets. For basic usage information,
-  consider using `telemetry.nondesktop_clients_last_seen` which already handles the union.
+  consider using `telemetry.fenix_clients_last_seen` which already handles the union.
   Otherwise, see the example below as a template for how construct a custom union.
 
   Mapping of channels to datasets:

--- a/sql/mozfun/norm/os/metadata.yaml
+++ b/sql/mozfun/norm/os/metadata.yaml
@@ -1,7 +1,6 @@
+friendly_name: Normalize OS
 description: |
   Normalize an operating system string to one of the three major desktop
   platforms, one of the two major mobile platforms, or "Other". 
 
-  Reimplementation of logic used in the data pipeline: 
-  https://github.com/mozilla/gcp-ingestion/blob/a6928fb089f1652856147c4605df715f327edfcd/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/NormalizeAttributes.java#L52-L74
-friendly_name: Normalize OS
+  This is a reimplementation of [logic used in the data pipeline](https://github.com/mozilla/gcp-ingestion/blob/a6928fb089f1652856147c4605df715f327edfcd/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/NormalizeAttributes.java#L52-L74) to populate `normalized_os`.


### PR DESCRIPTION
The `nondesktop_clients_last_seen_v1` view was developed mostly as an
internal implementation detail for downstream tables, but it has become
useful in its own right. This PR formalizes the view by providing an alias
without a version modifier and it adds a `product` field with application
names that are short but more meaningful than the `app_name` field.

See discussion in https://jira.mozilla.com/browse/DO-330 about confusion that
has resulted from the name "Fennec iOS" used in dashboards, etc. This is a
step toward reducing that kind of confusion.

This PR also adds `contributes_to_2019_kpi` and `contributes_to_2020_kpi` fields
as source of truth for how we count KPI metrics. That logic is currently
copied and pasted in several places, which could lead to errors.

This will need a fair amount of review from data users before moving forward.
It will also require backfilling several downstream tables and communicating
the change.