### PR TITLE
Fix generated docs path

### DIFF
--- a/bigquery_etl/docs/generate_docs.py
+++ b/bigquery_etl/docs/generate_docs.py
@@ -85,7 +85,7 @@ def main():
                     # remove empty strings from path parts
                     path_parts = list(filter(None, root.split(os.sep)))
                     name = path_parts[-1]
-                    path = Path(os.sep.join(path_parts[:-1]))
+                    path = Path(os.sep.join(path_parts[1:-1]))
 
                     if os.path.split(root)[1] == "":
                         # project level-doc file


### PR DESCRIPTION
This will fix the generated docs path and drop the `sql/` part of the URL. The URL to the `event_analysis` dataset would then again be https://mozilla.github.io/bigquery-etl/mozfun/event_analysis/