### PR TITLE
Fix GCS metadata publishing for new project structure

### DIFF
--- a/bigquery_etl/public_data/publish_gcs_metadata.py
+++ b/bigquery_etl/public_data/publish_gcs_metadata.py
@@ -125,6 +125,8 @@ def get_public_gcs_table_metadata(
         GcsTableMetadata(list(blobs), endpoint, target_dir)
         for table, blobs in groupby(blobs, dataset_table_version_from_gcs_blob)
         if table is not None
+        and table[0] in os.listdir(target_dir)
+        and f"{table[1]}_{table[2]}" in os.listdir(os.path.join(target_dir, table[0]))
     ]
 
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/1390

Something that might need a follow-up: if data from different projects is published and there are two datasets with the same name (same GCP dataset, destination table and version) then the dataset published last will overwrite previously published datasets. 