### PR TITLE
Create UDF for `extract_event_counts_with_properties`

### DIFF
--- a/sql/mozfun/event_analysis/extract_event_counts/README.md
+++ b/sql/mozfun/event_analysis/extract_event_counts/README.md
@@ -1,7 +1,7 @@
 ### Usage
 ```
 extract_event_counts(
-events STRING
+    events STRING
 )
 ```
 

--- a/sql/mozfun/event_analysis/extract_event_counts_with_properties/README.md
+++ b/sql/mozfun/event_analysis/extract_event_counts_with_properties/README.md
@@ -1,0 +1,21 @@
+### Usage
+```
+extract_event_counts_with_properties(
+    events STRING
+)
+```
+
+`events` - A comma-separated events string,
+where each event is represented as a string
+of unicode chars.
+
+### Example
+See [this query](https://sql.telemetry.mozilla.org/queries/75082)
+for example usage.
+
+### Caveats
+This function extracts both counts for events with each property,
+and for all events without their properties.
+
+This allows us to include both total counts for an event (with any
+property value), and events that don't have properties.

--- a/sql/mozfun/event_analysis/extract_event_counts_with_properties/metadata.yaml
+++ b/sql/mozfun/event_analysis/extract_event_counts_with_properties/metadata.yaml
@@ -1,0 +1,6 @@
+description: >
+  Extract events with event properties and their associated counts.
+
+  Also extracts raw events and their counts. This allows for querying
+  with and without properties in the same dashboard.
+friendly_name: Extract Event Counts With Properties

--- a/sql/mozfun/event_analysis/extract_event_counts_with_properties/udf.sql
+++ b/sql/mozfun/event_analysis/extract_event_counts_with_properties/udf.sql
@@ -77,7 +77,6 @@ SELECT
     with_event_props[OFFSET(0)]
   ),
   assert_struct_equals(
-  assert_struct_equals(
     STRUCT('a' AS event_index, 1 AS property_index, 'a' AS property_value_index, 1 AS count),
     with_event_props[OFFSET(1)]
   ),

--- a/sql/mozfun/event_analysis/extract_event_counts_with_properties/udf.sql
+++ b/sql/mozfun/event_analysis/extract_event_counts_with_properties/udf.sql
@@ -1,0 +1,140 @@
+CREATE OR REPLACE FUNCTION event_analysis.extract_event_counts_with_properties(events STRING)
+RETURNS ARRAY<
+  STRUCT<event_index STRING, property_index INT64, property_value_index STRING, count INT64>
+> AS (
+  ARRAY(
+    SELECT AS STRUCT
+      SUBSTR(event_with_props, -1, 1) AS event_index,
+      IF(COALESCE(off, 0) = 0, NULL, off) AS property_index,
+      IF(COALESCE(off, 0) = 0, NULL, property) AS property_value_index,
+      COUNT(*) AS count
+    FROM
+      UNNEST(SPLIT(events, ',')) AS event_with_props
+    LEFT JOIN
+      UNNEST(SPLIT(REVERSE(event_with_props), '')) AS property
+      WITH OFFSET off
+    WHERE
+      LENGTH(event_with_props) > 0
+    GROUP BY
+      event_index,
+      property_index,
+      property_value_index
+    ORDER BY
+      event_index ASC,
+      property_index ASC,
+      property_value_index ASC
+  )
+);
+
+-- Tests
+WITH results AS (
+  SELECT
+    event_analysis.extract_event_counts_with_properties('a,a,b,') AS multi,
+    event_analysis.extract_event_counts_with_properties('b,b,b,') AS single,
+    event_analysis.extract_event_counts_with_properties('aa,ba,ca,')
+  AS
+    with_event_props,
+    event_analysis.extract_event_counts_with_properties('aaaa,aab,')
+  AS
+    with_many_props,
+)
+SELECT
+  assert_struct_equals(
+    STRUCT(
+      'a' AS event_index,
+      NULL AS property_index,
+      CAST(NULL AS STRING) AS property_value_index,
+      2 AS count
+    ),
+    multi[OFFSET(0)]
+  ),
+  assert_struct_equals(
+    STRUCT(
+      'b' AS event_index,
+      NULL AS property_index,
+      CAST(NULL AS STRING) AS property_value_index,
+      1 AS count
+    ),
+    multi[OFFSET(1)]
+  ),
+  assert_struct_equals(
+    STRUCT(
+      'b' AS event_index,
+      NULL AS property_index,
+      CAST(NULL AS STRING) AS property_value_index,
+      3 AS count
+    ),
+    single[OFFSET(0)]
+  ),
+  assert_equals(4, ARRAY_LENGTH(with_event_props)),
+  assert_struct_equals(
+    STRUCT(
+      'a' AS event_index,
+      NULL AS property_index,
+      CAST(NULL AS STRING) AS property_value_index,
+      3 AS count
+    ),
+    with_event_props[OFFSET(0)]
+  ),
+  assert_struct_equals(
+    STRUCT(
+      'a' AS event_index,
+      NULL AS property_index,
+      CAST(NULL AS STRING) AS property_value_index,
+      3 AS count
+    ),
+    with_event_props[OFFSET(0)]
+  ),
+  assert_struct_equals(
+    STRUCT('a' AS event_index, 1 AS property_index, 'a' AS property_value_index, 1 AS count),
+    with_event_props[OFFSET(1)]
+  ),
+  assert_struct_equals(
+    STRUCT('a' AS event_index, 1 AS property_index, 'b' AS property_value_index, 1 AS count),
+    with_event_props[OFFSET(2)]
+  ),
+  assert_struct_equals(
+    STRUCT('a' AS event_index, 1 AS property_index, 'c' AS property_value_index, 1 AS count),
+    with_event_props[OFFSET(3)]
+  ),
+  assert_equals(7, ARRAY_LENGTH(with_many_props)),
+  assert_struct_equals(
+    STRUCT(
+      'a' AS event_index,
+      NULL AS property_index,
+      CAST(NULL AS STRING) AS property_value_index,
+      1 AS count
+    ),
+    with_many_props[OFFSET(0)]
+  ),
+  assert_struct_equals(
+    STRUCT('a' AS event_index, 1 AS property_index, 'a' AS property_value_index, 1 AS count),
+    with_many_props[OFFSET(1)]
+  ),
+  assert_struct_equals(
+    STRUCT('a' AS event_index, 2 AS property_index, 'a' AS property_value_index, 1 AS count),
+    with_many_props[OFFSET(2)]
+  ),
+  assert_struct_equals(
+    STRUCT('a' AS event_index, 3 AS property_index, 'a' AS property_value_index, 1 AS count),
+    with_many_props[OFFSET(3)]
+  ),
+  assert_struct_equals(
+    STRUCT(
+      'b' AS event_index,
+      NULL AS property_index,
+      CAST(NULL AS STRING) AS property_value_index,
+      1 AS count
+    ),
+    with_many_props[OFFSET(4)]
+  ),
+  assert_struct_equals(
+    STRUCT('b' AS event_index, 1 AS property_index, 'a' AS property_value_index, 1 AS count),
+    with_many_props[OFFSET(5)]
+  ),
+  assert_struct_equals(
+    STRUCT('b' AS event_index, 2 AS property_index, 'a' AS property_value_index, 1 AS count),
+    with_many_props[OFFSET(6)]
+  ),
+FROM
+  results

--- a/sql/mozfun/event_analysis/extract_event_counts_with_properties/udf.sql
+++ b/sql/mozfun/event_analysis/extract_event_counts_with_properties/udf.sql
@@ -77,14 +77,6 @@ SELECT
     with_event_props[OFFSET(0)]
   ),
   assert_struct_equals(
-    STRUCT(
-      'a' AS event_index,
-      NULL AS property_index,
-      CAST(NULL AS STRING) AS property_value_index,
-      3 AS count
-    ),
-    with_event_props[OFFSET(0)]
-  ),
   assert_struct_equals(
     STRUCT('a' AS event_index, 1 AS property_index, 'a' AS property_value_index, 1 AS count),
     with_event_props[OFFSET(1)]

--- a/tests/assert/struct_equals/metadata.yaml
+++ b/tests/assert/struct_equals/metadata.yaml
@@ -1,0 +1,2 @@
+description: ''
+friendly_name: Struct Equals

--- a/tests/assert/struct_equals/udf.sql
+++ b/tests/assert/struct_equals/udf.sql
@@ -1,0 +1,23 @@
+CREATE TEMP FUNCTION assert_struct_equals(expected ANY TYPE, actual ANY TYPE) AS (
+  IF(
+    ARRAY_LENGTH(
+      ARRAY(
+        SELECT
+          DISTINCT
+        AS
+          STRUCT *
+        FROM
+          (SELECT * FROM UNNEST([expected]) UNION ALL SELECT * FROM UNNEST([actual]))
+      )
+    ) = 1,
+    TRUE,
+    ERROR(CONCAT('Expected struct', TO_JSON_STRING(expected), ' but got ', TO_JSON_STRING(actual)))
+  )
+);
+
+SELECT
+  assert_struct_equals(STRUCT('a' AS a, 'b' AS b, 3 AS c), STRUCT('a' AS a, 'b' AS b, 3 AS c)),
+  assert_struct_equals(STRUCT('a' AS a, NULL AS b, 3 AS c), STRUCT('a' AS a, NULL AS b, 3 AS c)),
+#xfail
+SELECT
+  assert_struct_equals(STRUCT('a' AS a, 'b' AS b, 3 AS c), STRUCT('a' AS a, 'b' AS b, 4 AS c))


### PR DESCRIPTION
This is a follow-up to `extract_event_counts`. This is to support dashboards that need a breakdown of events w/ properties.