### PR TITLE
Fix field name error causing Shredder to miss FxA account deletions

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/query.sql
@@ -12,9 +12,9 @@ WITH hmac_key AS (
 )
 SELECT
   `timestamp` AS submission_timestamp,
-  TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id,
+  TO_HEX(SHA256(jsonPayload.fields.uid)) AS user_id,
   TO_HEX(
-    udf.hmac_sha256((SELECT * FROM hmac_key), CAST(jsonPayload.fields.user_id AS BYTES))
+    udf.hmac_sha256((SELECT * FROM hmac_key), CAST(jsonPayload.fields.uid AS BYTES))
   ) AS hmac_user_id,
 FROM
   `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_20*`
@@ -22,4 +22,4 @@ WHERE
   _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', @submission_date)
   AND jsonPayload.type = 'activityEvent'
   AND jsonPayload.fields.event = 'account.deleted'
-  AND jsonPayload.fields.user_id IS NOT NULL
+  AND jsonPayload.fields.uid IS NOT NULL


### PR DESCRIPTION
While looking at Shredder logs, I noticed that all entries for FxA-related
derived tables show 0 deletions, like:

> 712215424909 bytes and deleted 0 rows from moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_daily_v1

It appears that `account.deleted` events populate a field named `uid` rather
than `user_id`. I was able to verify this by choosing a recent `uid` value
from a deletion event and counting events where that same value appears as
`user_id` in FxA logs. There were matching messages.