### PR TITLE
Add quotes to preserve spaces in query args

### DIFF
--- a/script/entrypoint
+++ b/script/entrypoint
@@ -28,7 +28,7 @@ elif [ "$1" = "query" ]; then
     #     query [options] FILE
     # we dispatch to a script that inspects metadata and emulates the following call:
     #     bq query [options] < FILE 
-    exec script/run_query --query_file="${@: -1}" ${@:1:$#-1}
+    exec script/run_query --query_file="${@: -1}" "${@:1:$#-1}"
 elif [ "$XCOM_PUSH" = "true" ]; then
     # KubernetesPodOperator will extract the contents of /airflow/xcom/return.json as an xcom
     # if the xcom_push parameter is true


### PR DESCRIPTION
For an explanation of what quoting "$@" does (as opposed to quoting "$*"), see https://stackoverflow.com/a/12316565

this fixes an error in [the mozilla vpn waitlist job in airflow](https://workflow.telemetry.mozilla.org/log?task_id=mozilla_vpn_external__waitlist__v1&dag_id=bqetl_mozilla_vpn&execution_date=2020-10-11T00%3A00%3A00%2B00%3A00)