### PR TITLE
Fix mozfun references when publishing mozfun UDFs

### DIFF
--- a/bigquery_etl/routine/publish_routines.py
+++ b/bigquery_etl/routine/publish_routines.py
@@ -142,6 +142,7 @@ def publish_routine(
             # `mozfun`.stats.mode_last and `mozfun`.stats.mode_last_retain_nulls
             # since one name is a substring of the other
             definition = definition.replace(f"`{project_id}`.{udf}", udf)
+            definition = definition.replace(f"{project_id}.{udf}", udf)
             definition = definition.replace(udf, f"`{project_id}`.{udf}")
 
         # adjust paths for dependencies stored in GCS


### PR DESCRIPTION
mozfun is currently failing because [`glam.fenix_build_to_build_hour`](https://github.com/mozilla/bigquery-etl/blob/824ef5f6d57caa99d57d6a382bcb45ff68c77802/sql/mozfun/glam/fenix_build_to_build_hour/udf.sql#L3) calls another mozfun UDF, with project id specified