### PR TITLE
Reduce complexity of mozfun.norm.product_info

### DIFF
--- a/sql/mozfun/norm/product_info/generate_body.sql
+++ b/sql/mozfun/norm/product_info/generate_body.sql
@@ -18,7 +18,7 @@ lines AS (
 structured AS (
   SELECT AS STRUCT
     fields[OFFSET(0)] AS app_name,
-    fields[OFFSET(1)] AS os,
+    fields[OFFSET(1)] AS normalized_os,
     fields[OFFSET(2)] AS product,
     fields[OFFSET(3)] AS canonical_name,
     fields[OFFSET(4)] AS contributes_to_2019_kpi,
@@ -48,9 +48,9 @@ formatted AS (
     *,
     CONCAT(
       FORMAT(
-        "WHEN app_name LIKE %T AND norm.os(os) LIKE %T THEN STRUCT(%T AS product, %T AS canonical_name, %s AS contributes_to_2019_kpi, %s AS contributes_to_2020_kpi)",
+        "WHEN app_name LIKE %T AND normalized_os LIKE %T THEN STRUCT(%T AS product, %T AS canonical_name, %s AS contributes_to_2019_kpi, %s AS contributes_to_2020_kpi)",
         app_name,
-        os,
+        normalized_os,
         product,
         canonical_name,
         contributes_to_2019_kpi,

--- a/sql/mozfun/norm/product_info/metadata.yaml
+++ b/sql/mozfun/norm/product_info/metadata.yaml
@@ -1,7 +1,7 @@
 friendly_name: Normalize Product Info
 description: |
   Returns a normalized `product` name and a `canonical_name` for a product
-  based on the raw `app_name` and `os` values that appear in pings.
+  based on the raw `app_name` and `normalized_os` values that appear in pings.
 
   The returned `product` name is intended to be readable and unambiguous, but
   short and easy to type. This value is suitable for use as a key in derived
@@ -14,9 +14,9 @@ description: |
   canonical reference for whether the given application is included in KPI
   reporting. Additional fields may be added for future years.
 
-  The `os` value that's passed in should be the top-level `normalized_os` value
-  present in any ping table, although this function does normalize the value to
-  tolerate more raw operating system values.
+  The `normalized_os` value that's passed in should be the top-level `normalized_os`
+  value present in any ping table or you may want to wrap a raw value in `mozfun.norm.os`
+  like `mozfun.norm.product_info(app_name, mozfun.norm.os(os))`.
 
   For legacy telemetry pings like `main` ping for desktop and `core` ping for
   mobile products, `app_name` should come from the submission URI (stored as
@@ -34,21 +34,21 @@ description: |
 
   The mappings are as follows:
 
-  app_name         | os      | product          | canonical_name              | 2019  | 2020
-  ---------------- | ------- | ---------------- | --------------------------- | ----- | ----
-  Firefox          | *       | Firefox          | Firefox for Desktop         | true  | true
-  Fenix            | Android | Fenix            | Firefox for Android (Fenix) | true  | true
-  Fennec           | Android | Fennec           | Firefox for Android (Fennec)| true  | true
-  Firefox Preview  | Android | Firefox Preview  | Firefox Preview for Android | true  | true
-  Fennec           | iOS     | Firefox iOS      | Firefox for iOS             | true  | true
-  FirefoxForFireTV | Android | Firefox Fire TV  | Firefox for Fire TV         | false | false
-  FirefoxConnect   | Android | Firefox Echo     | Firefox for Echo Show       | true  | true
-  Zerda            | Android | Firefox Lite     | Firefox Lite                | true  | true
-  Zerda_cn         | Android | Firefox Lite CN  | Firefox Lite (China)        | false | false
-  Focus            | Android | Focus Android    | Firefox Focus for Android   | true  | true
-  Focus            | iOS     | Focus iOS        | Firefox Focus for iOS       | true  | true
-  Klar             | Android | Klar Android     | Firefox Klar for Android    | false | false
-  Klar             | iOS     | Klar iOS         | Firefox Klar for iOS        | false | false
-  Lockbox          | Android | Lockwise Android | Lockwise for Android        | true  | true
-  Lockbox          | iOS     | Lockwise iOS     | Lockwise for iOS            | true  | true
-  FirefoxReality*  | Android | Firefox Reality  | Firefox Reality             | true  | true
+  app_name         | normalized_os | product          | canonical_name              | 2019  | 2020
+  ---------------- | ------------- | ---------------- | --------------------------- | ----- | ----
+  Firefox          | *             | Firefox          | Firefox for Desktop         | true  | true
+  Fenix            | Android       | Fenix            | Firefox for Android (Fenix) | true  | true
+  Fennec           | Android       | Fennec           | Firefox for Android (Fennec)| true  | true
+  Firefox Preview  | Android       | Firefox Preview  | Firefox Preview for Android | true  | true
+  Fennec           | iOS           | Firefox iOS      | Firefox for iOS             | true  | true
+  FirefoxForFireTV | Android       | Firefox Fire TV  | Firefox for Fire TV         | false | false
+  FirefoxConnect   | Android       | Firefox Echo     | Firefox for Echo Show       | true  | true
+  Zerda            | Android       | Firefox Lite     | Firefox Lite                | true  | true
+  Zerda_cn         | Android       | Firefox Lite CN  | Firefox Lite (China)        | false | false
+  Focus            | Android       | Focus Android    | Firefox Focus for Android   | true  | true
+  Focus            | iOS           | Focus iOS        | Firefox Focus for iOS       | true  | true
+  Klar             | Android       | Klar Android     | Firefox Klar for Android    | false | false
+  Klar             | iOS           | Klar iOS         | Firefox Klar for iOS        | false | false
+  Lockbox          | Android       | Lockwise Android | Lockwise for Android        | true  | true
+  Lockbox          | iOS           | Lockwise iOS     | Lockwise for iOS            | true  | true
+  FirefoxReality*  | Android       | Firefox Reality  | Firefox Reality             | true  | true

--- a/sql/mozfun/norm/product_info/udf.sql
+++ b/sql/mozfun/norm/product_info/udf.sql
@@ -4,7 +4,7 @@ The case statement below can be generated based on the markdown table
 in metadata.yaml via the query in generate_body.sql
 
 */
-CREATE OR REPLACE FUNCTION norm.product_info(app_name STRING, os STRING)
+CREATE OR REPLACE FUNCTION norm.product_info(app_name STRING, normalized_os STRING)
 RETURNS STRUCT<
   product STRING,
   canonical_name STRING,
@@ -14,7 +14,7 @@ RETURNS STRUCT<
   CASE
   WHEN
     app_name LIKE "Firefox"
-    AND norm.os(os) LIKE "%"
+    AND normalized_os LIKE "%"
   THEN
     STRUCT(
       "Firefox" AS product,
@@ -24,7 +24,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Fenix"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Fenix" AS product,
@@ -34,7 +34,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Fennec"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Fennec" AS product,
@@ -44,7 +44,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Firefox Preview"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Firefox Preview" AS product,
@@ -54,7 +54,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Fennec"
-    AND norm.os(os) LIKE "iOS"
+    AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
       "Firefox iOS" AS product,
@@ -64,7 +64,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "FirefoxForFireTV"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Firefox Fire TV" AS product,
@@ -74,7 +74,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "FirefoxConnect"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Firefox Echo" AS product,
@@ -84,7 +84,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Zerda"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Firefox Lite" AS product,
@@ -94,7 +94,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Zerda_cn"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Firefox Lite CN" AS product,
@@ -104,7 +104,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Focus"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Focus Android" AS product,
@@ -114,7 +114,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Focus"
-    AND norm.os(os) LIKE "iOS"
+    AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
       "Focus iOS" AS product,
@@ -124,7 +124,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Klar"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Klar Android" AS product,
@@ -134,7 +134,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Klar"
-    AND norm.os(os) LIKE "iOS"
+    AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
       "Klar iOS" AS product,
@@ -144,7 +144,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Lockbox"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Lockwise Android" AS product,
@@ -154,7 +154,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Lockbox"
-    AND norm.os(os) LIKE "iOS"
+    AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
       "Lockwise iOS" AS product,
@@ -164,7 +164,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "FirefoxReality%"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Firefox Reality" AS product,
@@ -174,7 +174,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Firefox iOS"
-    AND norm.os(os) LIKE "iOS"
+    AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
       "Firefox iOS" AS product,
@@ -184,7 +184,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Firefox Fire TV"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Firefox Fire TV" AS product,
@@ -194,7 +194,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Firefox Echo"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Firefox Echo" AS product,
@@ -204,7 +204,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Firefox Lite"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Firefox Lite" AS product,
@@ -214,7 +214,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Firefox Lite CN"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Firefox Lite CN" AS product,
@@ -224,7 +224,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Focus Android"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Focus Android" AS product,
@@ -234,7 +234,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Focus iOS"
-    AND norm.os(os) LIKE "iOS"
+    AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
       "Focus iOS" AS product,
@@ -244,7 +244,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Klar Android"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Klar Android" AS product,
@@ -254,7 +254,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Klar iOS"
-    AND norm.os(os) LIKE "iOS"
+    AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
       "Klar iOS" AS product,
@@ -264,7 +264,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Lockwise Android"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Lockwise Android" AS product,
@@ -274,7 +274,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Lockwise iOS"
-    AND norm.os(os) LIKE "iOS"
+    AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
       "Lockwise iOS" AS product,
@@ -284,7 +284,7 @@ RETURNS STRUCT<
     )
   WHEN
     app_name LIKE "Firefox Reality"
-    AND norm.os(os) LIKE "Android"
+    AND normalized_os LIKE "Android"
   THEN
     STRUCT(
       "Firefox Reality" AS product,
@@ -315,11 +315,6 @@ SELECT
   assert.equals(
     STRUCT('Lockwise iOS', 'Lockwise for iOS', TRUE, TRUE),
     norm.product_info('Lockbox', 'iOS')
-  ),
-  -- Make sure os normalization works.
-  assert.equals(
-    STRUCT('Firefox iOS', 'Firefox for iOS', TRUE, TRUE),
-    norm.product_info('Fennec', 'iPhone OS')
   ),
   -- Make sure we can pass in product values for app_name.
   assert.equals(


### PR DESCRIPTION
While testing https://github.com/mozilla/bigquery-etl/pull/1380
I was getting "query too complex" errors. It looks like that stems from the
many calls to `mozfun.norm.os` within the `product_info` function.