### PR TITLE
Replace udf.fenix_build_to_datetime with mozfun reference

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf/fenix_build_to_datetime/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf/fenix_build_to_datetime/udf.sql
@@ -1,41 +1,5 @@
 CREATE OR REPLACE FUNCTION udf.fenix_build_to_datetime(app_build STRING) AS (
-  CASE
-  WHEN
-    LENGTH(app_build) = 8
-    AND SUBSTR(app_build, 5, 2) < "24"
-    AND SUBSTR(app_build, 7, 2) < "60"
-  THEN
-    -- Ideally, we would use PARSE_DATETIME, but that doesn't support
-    -- day of year (%j) or the custom single-character year used here.
-    DATETIME_ADD(
-      DATETIME(
-        2018 + SAFE_CAST(
-          SUBSTR(app_build, 1, 1) AS INT64
-        ), -- year
-        1, -- placeholder month
-        1, -- placeholder year
-        SAFE_CAST(SUBSTR(app_build, 5, 2) AS INT64),
-        SAFE_CAST(SUBSTR(app_build, 7, 2) AS INT64),
-        0  -- seconds is always zero
-      ),
-      INTERVAL SAFE_CAST(SUBSTR(app_build, 2, 3) AS INT64) - 1 DAY
-    )
-  WHEN
-    LENGTH(app_build) = 10
-  THEN
-    DATETIME_ADD(
-      DATETIME '2014-12-28 00:00:00',
-      INTERVAL(
-        SAFE_CAST(app_build AS INT64)
-        -- We shift left and then right again to erase all but the 20 rightmost bits
-        << (64 - 20) >> (64 - 20)
-        -- We then shift right to erase the last 3 bits, leaving just the 17 representing time
-        >> 3
-      ) HOUR
-    )
-  ELSE
-    NULL
-  END
+  mozfun.norm.fenix_build_to_datetime(app_build)
 );
 
 -- Tests


### PR DESCRIPTION
This was moved into into mozfun to support testing for `mozfun.glam` udfs.