### PR TITLE
Add `bqetl view publish`

### DIFF
--- a/bigquery_etl/cli/__init__.py
+++ b/bigquery_etl/cli/__init__.py
@@ -10,6 +10,7 @@ from ..cli.dryrun import dryrun
 from ..cli.format import format
 from ..cli.query import query
 from ..cli.routine import mozfun, routine
+from ..cli.view import view
 from ..glam.cli import glam
 from ..stripe import stripe_
 
@@ -25,6 +26,7 @@ def cli(prog_name=None):
         "mozfun": mozfun,
         "stripe": stripe_,
         "glam": glam,
+        "view": view,
     }
 
     @click.group(commands=commands)

--- a/bigquery_etl/cli/__init__.py
+++ b/bigquery_etl/cli/__init__.py
@@ -1,16 +1,16 @@
 """bigquery-etl CLI."""
 
-import click
 import warnings
 
+import click
 
-from ..cli.query import query
+from .._version import __version__
 from ..cli.dag import dag
 from ..cli.dryrun import dryrun
 from ..cli.format import format
-from ..cli.routine import routine, mozfun
+from ..cli.query import query
+from ..cli.routine import mozfun, routine
 from ..glam.cli import glam
-from .._version import __version__
 from ..stripe import stripe_
 
 

--- a/bigquery_etl/cli/dag.py
+++ b/bigquery_etl/cli/dag.py
@@ -1,16 +1,17 @@
 """bigquery-etl CLI dag command."""
 
-import click
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
+
+import click
 import yaml
 
-from ..query_scheduling.dag_collection import DagCollection
-from ..query_scheduling.dag import Dag
-from ..query_scheduling.generate_airflow_dags import get_dags
 from ..cli.utils import is_valid_dir, is_valid_file
-from ..metadata.parse_metadata import Metadata, METADATA_FILE
+from ..metadata.parse_metadata import METADATA_FILE, Metadata
+from ..query_scheduling.dag import Dag
+from ..query_scheduling.dag_collection import DagCollection
+from ..query_scheduling.generate_airflow_dags import get_dags
 
 dags_config_option = click.option(
     "--dags_config",

--- a/bigquery_etl/cli/dryrun.py
+++ b/bigquery_etl/cli/dryrun.py
@@ -1,14 +1,15 @@
 """bigquery-etl CLI dryrun command."""
 
-import click
-from google.cloud import bigquery
 import os
+import sys
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-import sys
 
-from ..dryrun import DryRun, SKIP
+import click
+from google.cloud import bigquery
+
 from ..cli.utils import is_authenticated
+from ..dryrun import SKIP, DryRun
 
 
 @click.command(

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1,23 +1,23 @@
 """bigquery-etl CLI query command."""
 
+import re
+import string
+import sys
+from datetime import date, timedelta
+from fnmatch import fnmatchcase
+from pathlib import Path
+
 import click
 from google.cloud import bigquery
-from fnmatch import fnmatchcase
-from datetime import date, timedelta
-from pathlib import Path
-import re
-import sys
-import string
 
-from ..metadata.parse_metadata import Metadata, METADATA_FILE
-from ..metadata import validate_metadata
-from ..format_sql.formatter import reformat
-from ..query_scheduling.generate_airflow_dags import get_dags
-from ..cli.utils import is_valid_dir, is_authenticated, is_valid_project
-from ..cli.format import format
 from ..cli.dryrun import dryrun
+from ..cli.format import format
+from ..cli.utils import is_authenticated, is_valid_dir, is_valid_project
+from ..format_sql.formatter import reformat
+from ..metadata import validate_metadata
+from ..metadata.parse_metadata import METADATA_FILE, Metadata
+from ..query_scheduling.generate_airflow_dags import get_dags
 from ..run_query import run
-
 
 QUERY_NAME_RE = re.compile(r"(?P<dataset>[a-zA-z0-9_]+)\.(?P<name>[a-zA-z0-9_]+)")
 SQL_FILE_RE = re.compile(

--- a/bigquery_etl/cli/routine.py
+++ b/bigquery_etl/cli/routine.py
@@ -1,22 +1,23 @@
 """bigquery-etl CLI UDF command."""
 
-import click
-from fnmatch import fnmatchcase
 import os
-from pathlib import Path
-import pytest
 import re
 import shutil
 import string
 import sys
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+import click
+import pytest
 import yaml
 
-from ..cli.utils import is_valid_dir, is_authenticated, is_valid_project
-from ..format_sql.formatter import reformat
 from ..cli.format import format
+from ..cli.utils import is_authenticated, is_valid_dir, is_valid_project
+from ..docs import validate_docs
+from ..format_sql.formatter import reformat
 from ..routine import publish_routines
 from ..routine.parse_routine import PROCEDURE_FILE, UDF_FILE
-from ..docs import validate_docs
 from ..util.common import project_dirs
 
 ROUTINE_NAME_RE = re.compile(r"^(?P<dataset>[a-zA-z0-9_]+)\.(?P<name>[a-zA-z0-9_]+)$")

--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -1,9 +1,10 @@
 """Utility functions used by the CLI."""
 
-from google.cloud import bigquery
-import click
 import os
 from pathlib import Path
+
+import click
+from google.cloud import bigquery
 
 from bigquery_etl.util.common import project_dirs
 

--- a/bigquery_etl/cli/view.py
+++ b/bigquery_etl/cli/view.py
@@ -1,0 +1,13 @@
+"""bigquery-etl CLI view command."""
+import click
+
+from bigquery_etl.view import publish_views
+
+
+@click.group(help="Commands for managing views.")
+def view():
+    """Create the CLI group for the view command."""
+    pass
+
+
+view.add_command(publish_views.main, "publish")

--- a/bigquery_etl/view/generate_views.py
+++ b/bigquery_etl/view/generate_views.py
@@ -8,15 +8,16 @@ Run as:
   ./script/generate_views 'moz-fx-data-shared-prod:*_stable.*'
 """
 
-from argparse import ArgumentParser
-from fnmatch import fnmatchcase
 import logging
 import os
 import re
-from bigquery_etl.util.bigquery_tables import get_tables_matching_patterns
-from bigquery_etl.util import standard_args
+from argparse import ArgumentParser
+from fnmatch import fnmatchcase
 
 from google.cloud import bigquery
+
+from bigquery_etl.util import standard_args
+from bigquery_etl.util.bigquery_tables import get_tables_matching_patterns
 
 VERSION_RE = re.compile(r"_v([0-9]+)$")
 WHITESPACE_RE = re.compile(r"\s+")

--- a/bigquery_etl/view/publish_views.py
+++ b/bigquery_etl/view/publish_views.py
@@ -1,17 +1,17 @@
 """Find view definition files and execute them."""
 
-from argparse import ArgumentParser
-from functools import partial
-from pathlib import Path
 import logging
-from multiprocessing.pool import ThreadPool
 import os
 import sys
 import time
+from argparse import ArgumentParser
+from functools import partial
+from multiprocessing.pool import ThreadPool
+from pathlib import Path
 
+import sqlparse
 from google.api_core.exceptions import BadRequest
 from google.cloud import bigquery
-import sqlparse
 
 VIEWS_TO_SKIP = (
     # Access Denied

--- a/tests/cli/test_cli_view.py
+++ b/tests/cli/test_cli_view.py
@@ -1,0 +1,30 @@
+import pytest
+from click.testing import CliRunner
+
+from bigquery_etl.cli.view import view
+
+
+class TestPublish:
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_publish_invalid_view(self, runner, tmp_path):
+        (tmp_path / "view.sql").write_text("SELECT 42 as test")
+        result = runner.invoke(view, ["publish", tmp_path.as_posix(), "--dry-run"])
+        assert result.exit_code == 1
+        assert "does not appear to be a CREATE OR REPLACE VIEW" in result.output
+
+    def test_publish_valid_view(self, runner, tmp_path):
+        # In order to be agnostic with respect to individual projects in GCP,
+        # we'll try to dry-run a query with a resource that certainly should not
+        # exist.
+        (tmp_path / "view.sql").write_text(
+            """
+            CREATE OR REPLACE VIEW test.test.test AS
+            SELECT 42 as test
+        """
+        )
+        result = runner.invoke(view, ["publish", tmp_path.as_posix(), "--dry-run"])
+        assert result.exit_code == 1
+        assert "Not found" in result.exc_info[1].message


### PR DESCRIPTION
This ports the `bigquery_etl.view.publish_view` module to use click instead of argparse and adds it to the main cli entrypoint. I've tested this using `script/publish_view --dryrun sql` and `bqetl view publish --dry-run sql`.  

The first commit sorts imports in the `cli/` and `view/` with isort. I didn't add `generate_view` because it utilizes the `bigquery_etl.standard_args` module. 


