### PR TITLE
Add CREATE OR REPLACE VIEW clause to geckoview_versions and move it to org_mozilla_fenix

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix/geckoview_version/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix/geckoview_version/view.sql
@@ -1,7 +1,7 @@
 -- Return the most likely version over many windows of the estimated major
 -- version
 CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod`.org_mozilla_fenix_derived.geckoview_version
+  `moz-fx-data-shared-prod`.org_mozilla_fenix.geckoview_version
 AS
 WITH agg AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version/view.sql
@@ -1,5 +1,8 @@
 -- Return the most likely version over many windows of the estimated major
 -- version
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod`.org_mozilla_fenix_derived.geckoview_version
+AS
 WITH agg AS (
   SELECT
     array_agg(t ORDER BY geckoview_major_version DESC, n_pings DESC LIMIT 1)[offset(0)] AS top_row


### PR DESCRIPTION
Not having a `CREATE OR REPLACE VIEW` DDL statement at the top of the view breaks validation when runnning `scripts/publish_view`. 