### PR TITLE
Bug 1671517: Add event counts to clients daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
@@ -375,7 +375,13 @@ SELECT
   ) AS ad_clicks_count_all,
   SUM(
     (SELECT SUM(value) FROM UNNEST(scalar_parent_browser_search_with_ads))
-  ) AS search_with_ads_count_all
+  ) AS search_with_ads_count_all,
+  udf.map_sum(
+    ARRAY_CONCAT_AGG(scalar_parent_telemetry_event_counts)
+  ) AS scalar_parent_telemetry_event_counts_sum,
+  udf.map_sum(
+    ARRAY_CONCAT_AGG(scalar_content_telemetry_event_counts)
+  ) AS scalar_content_telemetry_event_counts_sum
 FROM
   main_summary_v4
 LEFT JOIN

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/test_aggregation/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/test_aggregation/expect.yaml
@@ -116,6 +116,7 @@
   scalar_combined_webrtc_nicer_turn_438s_sum: 4
   scalar_content_navigator_storage_estimate_count_sum: 2
   scalar_content_navigator_storage_persist_count_sum: 2
+  scalar_content_telemetry_event_counts_sum: []
   scalar_parent_aushelper_websense_reg_version: second
   scalar_parent_browser_engagement_max_concurrent_tab_count_max: 3
   scalar_parent_browser_engagement_max_concurrent_window_count_max: 3
@@ -132,6 +133,7 @@
   scalar_parent_navigator_storage_estimate_count_sum: 2
   scalar_parent_navigator_storage_persist_count_sum: 2
   scalar_parent_storage_sync_api_usage_extensions_using_sum: 2
+  scalar_parent_telemetry_event_counts_sum: []
   search_cohort: second
   search_count_abouthome: 0
   search_count_all: 0

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/test_aggregation/main_summary_v4.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/test_aggregation/main_summary_v4.schema.json
@@ -1037,5 +1037,39 @@
     "type": "RECORD",
     "name": "scalar_parent_browser_search_with_ads",
     "mode": "REPEATED"
+  },
+  {
+    "fields": [
+      {
+        "type": "STRING",
+        "name": "key",
+        "mode": "NULLABLE"
+      },
+      {
+        "type": "INTEGER",
+        "name": "value",
+        "mode": "NULLABLE"
+      }
+    ],
+    "type": "RECORD",
+    "name": "scalar_parent_telemetry_event_counts",
+    "mode": "REPEATED"
+  },
+  {
+    "fields": [
+      {
+        "type": "STRING",
+        "name": "key",
+       "mode": "NULLABLE"
+      },
+      {
+        "type": "INTEGER",
+        "name": "value",
+        "mode": "NULLABLE"
+      }
+    ],
+    "type": "RECORD",
+    "name": "scalar_content_telemetry_event_counts",
+    "mode": "REPEATED"
   }
 ]


### PR DESCRIPTION
Per a data science request, adds an aggregation of `scalar_parent_telemetry_event_counts_sum` and `scalar_content_telemetry_event_counts_sum` to clients daily