### PR TITLE
Fix #1402 - Use org_mozilla_fenix.geckoview_version view for app_version in GLAM

### DIFF
--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -147,19 +147,18 @@ def main():
     config = {
         "org_mozilla_fenix_glam_nightly": {
             "build_date_udf": "mozfun.glam.build_hour_to_datetime",
-            "filter_version": False,
-            # this value is ignored due to filter version
-            "num_versions_to_keep": 1000,
+            "filter_version": True,
+            "num_versions_to_keep": 3,
         },
         "org_mozilla_fenix_glam_beta": {
             "build_date_udf": "mozfun.glam.build_hour_to_datetime",
             "filter_version": True,
-            "num_versions_to_keep": 2,
+            "num_versions_to_keep": 3,
         },
         "org_mozilla_fenix_glam_release": {
             "build_date_udf": "mozfun.glam.build_hour_to_datetime",
             "filter_version": True,
-            "num_versions_to_keep": 2,
+            "num_versions_to_keep": 3,
         },
     }
     validate(instance=config, schema=config_schema)

--- a/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
@@ -15,7 +15,7 @@
       -- only keep builds from the last year
       AND {{ build_date_udf }}(app_build_id) > DATE_SUB(@submission_date, INTERVAL 365 day)
       {% if filter_version %}
-      AND app_version >= (latest_version - {{ num_versions_to_keep }})
+      AND app_version > (latest_version - {{ num_versions_to_keep }})
       {% endif %}
 {% endset %}
 

--- a/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
@@ -15,7 +15,7 @@
       -- only keep builds from the last year
       AND {{ build_date_udf }}(app_build_id) > DATE_SUB(@submission_date, INTERVAL 365 day)
       {% if filter_version %}
-      AND app_version >= (latest_version - {{ num_versions_to_keep }})
+      AND app_version > (latest_version - {{ num_versions_to_keep }})
       {% endif %}
 {% endset %}
 

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
@@ -18,14 +18,35 @@ WITH extracted AS (
     *
   FROM
     `{{ project }}`.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_histogram_aggregates_v1
+),
+with_app_build_id AS (
+  SELECT
+    * EXCEPT (app_build_id, channel, app_version),
+    mozfun.glam.fenix_build_to_build_hour(app_build_id) AS app_build_id,
+    "*" AS channel,
+  FROM
+    extracted
+),
+with_build_hour AS (
+  SELECT
+    *,
+    mozfun.glam.build_hour_to_datetime(app_build_id) AS build_hour
+  FROM
+    with_app_build_id
+),
+with_geckoview_version_renamed AS (
+  SELECT
+    build_hour,
+    geckoview_major_version AS app_version
+  FROM
+    `moz-fx-data-shared-prod`.org_mozilla_fenix.geckoview_version
 )
 SELECT
-  -- NOTE: app_version is dropped due to a lack of semantic versioning. We opt
-  -- to use a build id as a placeholder. See
-  -- https://github.com/mozilla/bigquery-etl/issues/1329
-  * EXCEPT (app_build_id, channel, app_version),
-  mozfun.glam.fenix_build_to_build_hour(app_build_id) AS app_build_id,
-  "*" AS channel,
-  SAFE_CAST(app_build_id AS INT64) AS app_version,
+  * EXCEPT (build_hour),
+  app_version
 FROM
-  extracted
+  with_build_hour
+JOIN
+  with_geckoview_version_renamed
+USING
+  (build_hour)

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
@@ -42,8 +42,7 @@ with_geckoview_version_renamed AS (
     `moz-fx-data-shared-prod`.org_mozilla_fenix.geckoview_version
 )
 SELECT
-  * EXCEPT (build_hour),
-  app_version
+  * EXCEPT (build_hour)
 FROM
   with_build_hour
 JOIN

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
@@ -18,7 +18,7 @@ WITH extracted AS (
     *
   FROM
     `{{ project }}`.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_scalar_aggregates_v1
-)
+),
 with_app_build_id AS (
   SELECT
     * EXCEPT (app_build_id, channel, app_version),
@@ -42,8 +42,7 @@ with_geckoview_version_renamed AS (
     `moz-fx-data-shared-prod`.org_mozilla_fenix.geckoview_version
 )
 SELECT
-  * EXCEPT (build_hour),
-  app_version
+  * EXCEPT (build_hour)
 FROM
   with_build_hour
 JOIN

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_histogram_aggregates_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_histogram_aggregates_v1/query.sql
@@ -72,7 +72,7 @@ filtered_accumulated AS (
       @submission_date,
       INTERVAL 365 day
     )
-    AND app_version >= (latest_version - 3)
+    AND app_version > (latest_version - 3)
 ),
 -- unnest the daily data
 extracted_daily AS (
@@ -113,7 +113,7 @@ filtered_daily AS (
       @submission_date,
       INTERVAL 365 day
     )
-    AND app_version >= (latest_version - 3)
+    AND app_version > (latest_version - 3)
 ),
 -- re-aggregate based on the latest version
 aggregated_daily AS (

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_histogram_aggregates_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_histogram_aggregates_v1/query.sql
@@ -59,6 +59,10 @@ filtered_accumulated AS (
     histogram_aggregates
   FROM
     extracted_accumulated
+  LEFT JOIN
+    glam_etl.org_mozilla_fenix_glam_nightly__latest_versions_v1
+  USING
+    (channel)
   WHERE
       -- allow for builds to be slighly ahead of the current submission date, to
       -- account for a reasonable amount of clock skew
@@ -68,6 +72,7 @@ filtered_accumulated AS (
       @submission_date,
       INTERVAL 365 day
     )
+    AND app_version >= (latest_version - 3)
 ),
 -- unnest the daily data
 extracted_daily AS (
@@ -95,6 +100,10 @@ filtered_daily AS (
     histogram_aggregates.*
   FROM
     extracted_daily
+  LEFT JOIN
+    glam_etl.org_mozilla_fenix_glam_nightly__latest_versions_v1
+  USING
+    (channel)
   WHERE
       -- allow for builds to be slighly ahead of the current submission date, to
       -- account for a reasonable amount of clock skew
@@ -104,6 +113,7 @@ filtered_daily AS (
       @submission_date,
       INTERVAL 365 day
     )
+    AND app_version >= (latest_version - 3)
 ),
 -- re-aggregate based on the latest version
 aggregated_daily AS (

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1/query.sql
@@ -143,7 +143,7 @@ version_filtered_new AS (
       @submission_date,
       INTERVAL 365 day
     )
-    AND app_version >= (latest_version - 3)
+    AND app_version > (latest_version - 3)
 ),
 scalar_aggregates_new AS (
   SELECT
@@ -224,7 +224,7 @@ filtered_old AS (
       @submission_date,
       INTERVAL 365 day
     )
-    AND app_version >= (latest_version - 3)
+    AND app_version > (latest_version - 3)
 ),
 joined_new_old AS (
   SELECT

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1/query.sql
@@ -130,6 +130,10 @@ version_filtered_new AS (
     value
   FROM
     filtered_aggregates AS scalar_aggs
+  LEFT JOIN
+    glam_etl.org_mozilla_fenix_glam_nightly__latest_versions_v1
+  USING
+    (channel)
   WHERE
       -- allow for builds to be slighly ahead of the current submission date, to
       -- account for a reasonable amount of clock skew
@@ -139,6 +143,7 @@ version_filtered_new AS (
       @submission_date,
       INTERVAL 365 day
     )
+    AND app_version >= (latest_version - 3)
 ),
 scalar_aggregates_new AS (
   SELECT
@@ -206,6 +211,10 @@ filtered_old AS (
     scalar_aggregates
   FROM
     glam_etl.org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1 AS scalar_aggs
+  LEFT JOIN
+    glam_etl.org_mozilla_fenix_glam_nightly__latest_versions_v1
+  USING
+    (channel)
   WHERE
       -- allow for builds to be slighly ahead of the current submission date, to
       -- account for a reasonable amount of clock skew
@@ -215,6 +224,7 @@ filtered_old AS (
       @submission_date,
       INTERVAL 365 day
     )
+    AND app_version >= (latest_version - 3)
 ),
 joined_new_old AS (
   SELECT

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1/view.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1/view.sql
@@ -18,14 +18,34 @@ WITH extracted AS (
     *
   FROM
     `glam-fenix-dev`.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_histogram_aggregates_v1
+),
+with_app_build_id AS (
+  SELECT
+    * EXCEPT (app_build_id, channel, app_version),
+    mozfun.glam.fenix_build_to_build_hour(app_build_id) AS app_build_id,
+    "*" AS channel,
+  FROM
+    extracted
+),
+with_build_hour AS (
+  SELECT
+    *,
+    mozfun.glam.build_hour_to_datetime(app_build_id) AS build_hour
+  FROM
+    with_app_build_id
+),
+with_geckoview_version_renamed AS (
+  SELECT
+    build_hour,
+    geckoview_major_version AS app_version
+  FROM
+    `moz-fx-data-shared-prod`.org_mozilla_fenix.geckoview_version
 )
 SELECT
-  -- NOTE: app_version is dropped due to a lack of semantic versioning. We opt
-  -- to use a build id as a placeholder. See
-  -- https://github.com/mozilla/bigquery-etl/issues/1329
-  * EXCEPT (app_build_id, channel, app_version),
-  mozfun.glam.fenix_build_to_build_hour(app_build_id) AS app_build_id,
-  "*" AS channel,
-  SAFE_CAST(app_build_id AS INT64) AS app_version,
+  * EXCEPT (build_hour)
 FROM
-  extracted
+  with_build_hour
+JOIN
+  with_geckoview_version_renamed
+USING
+  (build_hour)

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1/view.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1/view.sql
@@ -18,14 +18,34 @@ WITH extracted AS (
     *
   FROM
     `glam-fenix-dev`.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_scalar_aggregates_v1
+),
+with_app_build_id AS (
+  SELECT
+    * EXCEPT (app_build_id, channel, app_version),
+    mozfun.glam.fenix_build_to_build_hour(app_build_id) AS app_build_id,
+    "*" AS channel,
+  FROM
+    extracted
+),
+with_build_hour AS (
+  SELECT
+    *,
+    mozfun.glam.build_hour_to_datetime(app_build_id) AS build_hour
+  FROM
+    with_app_build_id
+),
+with_geckoview_version_renamed AS (
+  SELECT
+    build_hour,
+    geckoview_major_version AS app_version
+  FROM
+    `moz-fx-data-shared-prod`.org_mozilla_fenix.geckoview_version
 )
 SELECT
-  -- NOTE: app_version is dropped due to a lack of semantic versioning. We opt
-  -- to use a build id as a placeholder. See
-  -- https://github.com/mozilla/bigquery-etl/issues/1329
-  * EXCEPT (app_build_id, channel, app_version),
-  mozfun.glam.fenix_build_to_build_hour(app_build_id) AS app_build_id,
-  "*" AS channel,
-  SAFE_CAST(app_build_id AS INT64) AS app_version,
+  * EXCEPT (build_hour)
 FROM
-  extracted
+  with_build_hour
+JOIN
+  with_geckoview_version_renamed
+USING
+  (build_hour)


### PR DESCRIPTION
Fixes #1402. Depends on #1458 due to the indiscriminate nature of the `replace_project_and_dataset` function in `run_glam_sql`. This means the reference to the geckoview_version view in shared-prod points to one in `glam-fenix-dev` which doesn't exist.