### PR TITLE
Exempt a few files from dry run due to new table-level ACLs

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -23,12 +23,15 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/account_ecosystem_derived/ecosystem_client_id_lookup_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/account_ecosystem_derived/desktop_clients_daily_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/account_ecosystem_restricted/ecosystem_client_id_deletion_v1/query.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/account_ecosystem_derived/fxa_logging_users_daily_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/activity_stream/impression_stats_flat/view.sql",
     "sql/moz-fx-data-shared-prod/activity_stream/tile_id_types/view.sql",
     "sql/moz-fx-data-shared-prod/monitoring/deletion_request_volume_v1/query.sql",
     "sql/moz-fx-data-shared-prod/monitoring/document_sample_nonprod_v1/query.sql",
     "sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v1/view.sql",
     "sql/moz-fx-data-shared-prod/monitoring/structured_error_counts_v1/view.sql",
+    "sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v1/view.sql",
+    "sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v2/view.sql",
     "sql/moz-fx-data-shared-prod/pocket/pocket_reach_mau/view.sql",
     "sql/moz-fx-data-shared-prod/telemetry/buildhub2/view.sql",
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/query.sql",  # noqa E501

--- a/sql/moz-fx-data-shared-prod/account_ecosystem_derived/fxa_logging_users_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/account_ecosystem_derived/fxa_logging_users_daily_v1/metadata.yaml
@@ -1,4 +1,4 @@
-friendly_name: AET Desktop Clients Daily
+friendly_name: AET Logging Users Daily
 description: >
   One row per canonical_id per oauth service per day aggregating all AET events received for that user.
 owners:
@@ -9,3 +9,8 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_account_ecosystem
+  # We access a restricted table for getting an HMAC key, so cannot dry run
+  # and must explicitly list referenced tables.
+  referenced_tables:
+    - ['moz-fx-data-shared-prod', 'firefox_accounts_stable', 'account_ecosystem_v1']
+    - ['moz-fx-data-shared-prod', 'account_ecosystem_derived', 'ecosystem_user_id_lookup_v1']


### PR DESCRIPTION
The dry run service can no longer perform queries with wildcard table specifications or access raw AET data. See mozilla-services/cloudops-infra#2599