### PR TITLE
Query for monitoring experiment analysis costs

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -91,6 +91,7 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_external/waitlist_v1/query.sql",
     "sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/query.sql",
+    "sql/moz-fx-data-experiments/monitoring/query_cost_v1/query.sql",
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",  # noqa E501

--- a/dags/bqetl_experiments_daily.py
+++ b/dags/bqetl_experiments_daily.py
@@ -57,6 +57,22 @@ with DAG(
         dag=dag,
     )
 
+    monitoring__query_cost__v1 = bigquery_etl_query(
+        task_id="monitoring__query_cost__v1",
+        destination_table="query_cost_v1",
+        dataset_id="monitoring",
+        project_id="moz-fx-data-experiments",
+        owner="ascholtz@mozilla.com",
+        email=[
+            "ascholtz@mozilla.com",
+            "ssuh@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
     telemetry_derived__experiments_daily_active_clients__v1 = bigquery_etl_query(
         task_id="telemetry_derived__experiments_daily_active_clients__v1",
         destination_table="experiments_daily_active_clients_v1",

--- a/dags/bqetl_experiments_daily.py
+++ b/dags/bqetl_experiments_daily.py
@@ -33,6 +33,18 @@ with DAG(
         dag=dag,
     )
 
+    monitoring__query_cost__v1 = bigquery_etl_query(
+        task_id="monitoring__query_cost__v1",
+        destination_table="query_cost_v1",
+        dataset_id="monitoring",
+        project_id="moz-fx-data-experiments",
+        owner="ascholtz@mozilla.com",
+        email=["ascholtz@mozilla.com", "telemetry-alerts@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
     telemetry_derived__experiment_enrollment_aggregates__v1 = bigquery_etl_query(
         task_id="telemetry_derived__experiment_enrollment_aggregates__v1",
         destination_table="experiment_enrollment_aggregates_v1",
@@ -52,22 +64,6 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="ascholtz@mozilla.com",
         email=["ascholtz@mozilla.com", "telemetry-alerts@mozilla.com"],
-        date_partition_parameter="submission_date",
-        depends_on_past=False,
-        dag=dag,
-    )
-
-    monitoring__query_cost__v1 = bigquery_etl_query(
-        task_id="monitoring__query_cost__v1",
-        destination_table="query_cost_v1",
-        dataset_id="monitoring",
-        project_id="moz-fx-data-experiments",
-        owner="ascholtz@mozilla.com",
-        email=[
-            "ascholtz@mozilla.com",
-            "ssuh@mozilla.com",
-            "telemetry-alerts@mozilla.com",
-        ],
         date_partition_parameter="submission_date",
         depends_on_past=False,
         dag=dag,

--- a/sql/moz-fx-data-experiments/monitoring/query_cost_v1/metadata.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/query_cost_v1/metadata.yaml
@@ -1,0 +1,9 @@
+description: Cost of executed experiment analysis queries. 
+friendly_name: Experiment Analysis Query Costs
+labels:
+  incremental: true
+owners:
+- ascholtz@mozilla.com
+scheduling:
+  dag_name: bqetl_experiments_daily
+  referenced_tables: [['region-us', 'INFORMATION_SCHEMA', 'JOBS_BY_PROJECT']]

--- a/sql/moz-fx-data-experiments/monitoring/query_cost_v1/query.sql
+++ b/sql/moz-fx-data-experiments/monitoring/query_cost_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  creation_time AS submission_timestamp,
+  destination_table.table_id AS destination_table,
+  query,
+  total_bytes_processed,
+  total_bytes_processed / 1024 / 1024 / 1024 / 1024 * 5 AS cost_usd
+FROM
+  `region-us`.INFORMATION_SCHEMA.JOBS_BY_PROJECT
+WHERE
+  DATE(creation_time) = @submission_date
+  AND destination_table.dataset_id = "mozanalysis"
+  AND total_bytes_processed IS NOT NULL


### PR DESCRIPTION
This is for adding some alerting based on the cost of queries executed by jetstream. I'll add alerts in Redash that will get triggered if the cost of a query exceeds a certain amount. Since Redash doesn't have access to `INFORMATION_SCHEMA.JOBS_BY_PROJECT` for `moz-fx-data-experiments`, we need this scheduled query which writes cost related data to a destination Redash has access to.