### PR TITLE
Add ETL for Mozilla VPN acquisition funnel

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -68,6 +68,7 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/apple_app_store/metrics_total/query.sql",
     "sql/moz-fx-data-shared-prod/monitoring/telemetry_distinct_docids_v1/query.sql",
     "sql/moz-fx-data-shared-prod/revenue_derived/client_ltv_normalized/query.sql",
+    "sql/moz-fx-data-shared-prod/stripe_derived/customers_v1/query.sql",
     "sql/moz-fx-data-shared-prod/stripe_derived/plans_v1/query.sql",
     "sql/moz-fx-data-shared-prod/stripe_derived/products_v1/query.sql",
     "sql/moz-fx-data-shared-prod/stripe_derived/subscriptions_v1/query.sql",
@@ -83,11 +84,15 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/stripe_external/products_v1/query.sql",
     "sql/moz-fx-data-shared-prod/stripe_external/setup_intents_v1/query.sql",
     "sql/moz-fx-data-shared-prod/stripe_external/subscriptions_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/protected_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/users_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/waitlist_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_external/devices_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/mozilla_vpn_external/subscriptions_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_external/waitlist_v1/query.sql",
-    "sql/moz-fx-data-shared-prod/mozilla_vpn_external/subscriptions_v1/query.sql",
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",  # noqa E501

--- a/dags/bqetl_stripe.py
+++ b/dags/bqetl_stripe.py
@@ -18,6 +18,18 @@ default_args = {
 
 with DAG("bqetl_stripe", default_args=default_args, schedule_interval="@daily") as dag:
 
+    stripe_derived__customers__v1 = bigquery_etl_query(
+        task_id="stripe_derived__customers__v1",
+        destination_table="customers_v1",
+        dataset_id="stripe_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="dthorn@mozilla.com",
+        email=["dthorn@mozilla.com", "telemetry-alerts@mozilla.com"],
+        date_partition_parameter=None,
+        depends_on_past=False,
+        dag=dag,
+    )
+
     stripe_derived__plans__v1 = bigquery_etl_query(
         task_id="stripe_derived__plans__v1",
         destination_table="plans_v1",
@@ -209,6 +221,8 @@ with DAG("bqetl_stripe", default_args=default_args, schedule_interval="@daily") 
         parameters=["date:DATE:{{ds}}"],
         dag=dag,
     )
+
+    stripe_derived__customers__v1.set_upstream(stripe_external__customers__v1)
 
     stripe_derived__plans__v1.set_upstream(stripe_external__plans__v1)
 

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/add_device_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/add_device_events/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mozilla_vpn.add_device_events`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod`.mozilla_vpn_derived.add_device_events_v1

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/login_flows/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/login_flows/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mozilla_vpn.login_flows`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod`.mozilla_vpn_derived.login_flows_v1

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/protected/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/protected/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mozilla_vpn.protected`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod`.mozilla_vpn_derived.protected_v1

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/users/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/users/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mozilla_vpn.users`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod`.mozilla_vpn_derived.users_v1

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/init.sql
@@ -1,0 +1,13 @@
+-- Don't OR REPLACE because this table has longer retention than its sources
+CREATE TABLE IF NOT EXISTS
+  mozilla_vpn_derived.add_device_events_v1
+PARTITION BY
+  DATE(`timestamp`)
+AS
+SELECT
+  TO_HEX(SHA256(jsonPayload.fields.fxa_uid)) AS fxa_uid,
+  `timestamp`,
+FROM
+  `moz-fx-guardian-prod-bfc7`.log_storage.stdout
+WHERE
+  jsonPayload.type LIKE "%.api.addDevice"

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Mozilla VPN add device events
+description: >
+  Event timestamps where accounts added a device
+owners:
+  - dthorn@mozilla.com
+labels:
+  application: mozilla_vpn
+  schedule: daily
+scheduling:
+  dag_name: bqetl_mozilla_vpn
+  referenced_tables: []

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/query.sql
@@ -1,0 +1,8 @@
+SELECT
+  TO_HEX(SHA256(jsonPayload.fields.fxa_uid)) AS fxa_uid,
+  `timestamp`,
+FROM
+  `moz-fx-guardian-prod-bfc7`.log_storage.stdout
+WHERE
+  jsonPayload.type LIKE "%.api.addDevice"
+  AND DATE(`timestamp`) = @submission_date

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/init.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS
+  login_flows_v1(
+    flow_id STRING,
+    flow_started TIMESTAMP,
+    flow_completed TIMESTAMP,
+    fxa_uids ARRAY<STRING>,
+    viewed_email_first_page BOOL
+  )

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/metadata.yaml
@@ -1,0 +1,17 @@
+friendly_name: Mozilla VPN FxA Login Flows
+description: >
+  A list of users that attempted to login to FxA, to sign up for or login to Mozilla VPN.
+owners:
+  - dthorn@mozilla.com
+labels:
+  application: mozilla_vpn
+  schedule: daily
+scheduling:
+  dag_name: bqetl_mozilla_vpn
+  # destination is the whole table, not a single partition, so don't use date_partition_parameter
+  date_partition_parameter: null
+  parameters:
+  - "date:DATE:{{ds}}"
+  referenced_tables:
+  - ["moz-fx-data-shared-prod", "firefox_accounts_derived", "fxa_auth_events_v1"]
+  - ["moz-fx-data-shared-prod", "firefox_accounts_derived", "fxa_content_events_v1"]

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql
@@ -1,0 +1,40 @@
+WITH base AS (
+  SELECT
+    flow_id,
+    MIN(`timestamp`) AS flow_started,
+    MIN(
+      IF(event_type IN ("fxa_login - complete", "fxa_reg - complete"), `timestamp`, NULL)
+    ) AS flow_completed,
+    ARRAY_AGG(
+      DISTINCT IF(
+        event_type IN ("fxa_login - complete", "fxa_reg - complete"),
+        user_id,
+        NULL
+      ) IGNORE NULLS
+    ) AS fxa_uids,
+    LOGICAL_OR(event_type = "fxa_email_first - view") AS viewed_email_first_page,
+  FROM
+    firefox_accounts.fxa_content_auth_events
+  WHERE
+    IF(@date IS NULL, DATE(`timestamp`) < CURRENT_DATE, DATE(`timestamp`) = @date)
+    AND service = "guardian-vpn"
+  GROUP BY
+    flow_id
+  UNION ALL
+  SELECT
+    *
+  FROM
+    login_flows_v1
+)
+SELECT
+  flow_id,
+  MIN(flow_started) AS flow_started,
+  MIN(flow_completed) AS flow_completed,
+  ARRAY_AGG(DISTINCT fxa_uid IGNORE NULLS) AS fxa_uids,
+  LOGICAL_OR(viewed_email_first_page) AS viewed_email_first_page,
+FROM
+  base
+LEFT JOIN
+  UNNEST(fxa_uids) AS fxa_uid
+GROUP BY
+  flow_id

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/protected_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/protected_v1/init.sql
@@ -1,0 +1,14 @@
+-- Don't OR REPLACE because this table has longer retention than its source
+CREATE TABLE IF NOT EXISTS
+  protected_v1
+AS
+-- WARNING: on mobile this is undercounted and may not be measurable
+SELECT
+  TO_HEX(SHA256(jsonPayload.fields.fxa_uid)) AS fxa_uid,
+  MIN(`timestamp`) AS first_protected,
+FROM
+  `moz-fx-guardian-prod-bfc7`.log_storage.stdout
+WHERE
+  jsonPayload.fields.isprotected
+GROUP BY
+  fxa_uid

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/protected_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/protected_v1/metadata.yaml
@@ -1,0 +1,15 @@
+friendly_name: Mozilla VPN protected users
+description: >
+  First time that accounts were protected by the Mozilla VPN
+owners:
+  - dthorn@mozilla.com
+labels:
+  application: mozilla_vpn
+  schedule: daily
+scheduling:
+  dag_name: bqetl_mozilla_vpn
+  # destination is the whole table, not a single partition, so don't use date_partition_parameter
+  date_partition_parameter: null
+  parameters:
+  - "date:DATE:{{ds}}"
+  referenced_tables: []

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/protected_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/protected_v1/query.sql
@@ -1,0 +1,27 @@
+-- WARNING: on mobile this is undercounted and may not be measurable
+WITH _current AS (
+  SELECT
+    TO_HEX(SHA256(jsonPayload.fields.fxa_uid)) AS fxa_uid,
+    MIN(`timestamp`) AS first_protected,
+  FROM
+    `moz-fx-guardian-prod-bfc7`.log_storage.stdout
+  WHERE
+    jsonPayload.fields.isprotected
+    AND DATE(`timestamp`) = @date
+  GROUP BY
+    fxa_uid
+)
+SELECT
+  fxa_uid,
+  IF(
+    _previous.first_protected IS NULL
+    OR _previous.first_protected > _current.first_protected,
+    _current,
+    previous
+  ).first_protected,
+FROM
+  protected_v1 AS _previous
+FULL JOIN
+  _current
+USING
+  (fxa_uid)

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/users_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/users_v1/metadata.yaml
@@ -1,0 +1,13 @@
+friendly_name: Mozilla VPN Users
+description: >
+  A subset of Mozilla VPN users columns that are accessible to a broader audience.
+owners:
+  - dthorn@mozilla.com
+labels:
+  application: mozilla_vpn
+  schedule: daily
+scheduling:
+  dag_name: bqetl_mozilla_vpn
+  # destination is the whole table, not a single partition, so don't use date_partition_parameter
+  date_partition_parameter: null
+  referenced_tables: [["moz-fx-data-shared-prod", "mozilla_vpn_external","users_v1"]]

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/users_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/users_v1/query.sql
@@ -1,0 +1,5 @@
+SELECT
+  fxa_uid,
+  created_at,
+FROM
+  mozilla_vpn_external.users_v1

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/init.sql
@@ -4,6 +4,6 @@ PARTITION BY
   DATE(updated_at)
 AS
 SELECT
-  *
+  * REPLACE (TO_HEX(SHA256(fxa_uid)) AS fxa_uid)
 FROM
   EXTERNAL_QUERY("moz-fx-guardian-prod-bfc7.us.guardian-sql-prod", "SELECT * FROM users")

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/query.sql
@@ -1,5 +1,7 @@
 SELECT
-  COALESCE(_update, users_v1).*
+  COALESCE(_current, _previous).* REPLACE (
+    COALESCE(TO_HEX(SHA256(_current.fxa_uid)), _previous.fxa_uid) AS fxa_uid
+  )
 FROM
   EXTERNAL_QUERY(
     "moz-fx-guardian-prod-bfc7.us.guardian-sql-prod",
@@ -8,8 +10,8 @@ FROM
     -- so the entire value must be provided as a STRING query parameter to handle specific dates:
     -- "SELECT * FROM users WHERE DATE(updated_at) = DATE '{{ds}}'"
     @external_database_query
-  ) AS _update
+  ) AS _current
 FULL JOIN
-  users_v1
+  users_v1 AS _previous
 USING
   (id)

--- a/sql/moz-fx-data-shared-prod/stripe/customers/view.sql
+++ b/sql/moz-fx-data-shared-prod/stripe/customers/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.stripe.customers`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod`.stripe_derived.customers_v1

--- a/sql/moz-fx-data-shared-prod/stripe_derived/customers_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/customers_v1/metadata.yaml
@@ -1,0 +1,12 @@
+friendly_name: Stripe Customers
+description: Stripe Customers as of UTC midnight.
+owners:
+  - dthorn@mozilla.com
+labels:
+  application: stripe
+  schedule: daily
+scheduling:
+  dag_name: bqetl_stripe
+  # destination is the whole table, not a single partition, so don't use date_partition_parameter
+  date_partition_parameter:
+  referenced_tables: [['moz-fx-data-shared-prod', 'stripe_external', 'customers_v1']]

--- a/sql/moz-fx-data-shared-prod/stripe_derived/customers_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/customers_v1/query.sql
@@ -1,0 +1,7 @@
+SELECT
+  -- limit fields in stripe_derived so as not to expose sensitive data
+  created,
+  id,
+  metadata,
+FROM
+  stripe_external.customers_v1


### PR DESCRIPTION
All of these tables feed into a redash query that combines them into a funnel: https://sql.telemetry.mozilla.org/queries/75572/source#188990