### PR TITLE
Bug 1672191 Inject 'Firefox' as normalized_app_name for FOG

### DIFF
--- a/bigquery_etl/view/generate_views.py
+++ b/bigquery_etl/view/generate_views.py
@@ -132,6 +132,11 @@ def create_views_if_not_exist(client, views, exclude, sql_dir):
                         "(client_info.telemetry_sdk_build, metrics)"
                         " AS metrics"
                     ]
+                if table.dataset_id.startswith("firefox_desktop"):
+                    # Bug 1672191
+                    replacements += [
+                        "'Firefox' AS normalized_app_name",
+                    ]
             elif schema_id in ("main_ping_1", "main_ping_4"):
                 replacements += [
                     "`moz-fx-data-shared-prod.udf.normalize_main_payload`(payload)"


### PR DESCRIPTION
We may want to replace this eventually with a more generalized solution for
Glean applications. See https://github.com/mozilla/bigquery-etl/issues/1466