### PR TITLE
Truncate experiments table on load

### DIFF
--- a/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
@@ -213,7 +213,7 @@ def main():
         ),
     )
 
-    job_config = bigquery.QueryJobConfig(
+    job_config = bigquery.LoadJobConfig(
         destination=destination_table, write_disposition="WRITE_TRUNCATE"
     )
     job_config.schema = bq_schema
@@ -224,7 +224,7 @@ def main():
     )
 
     client.load_table_from_json(
-        converter.unstructure(experiments), destination_table, job_config
+        converter.unstructure(experiments), destination_table, job_config=job_config
     ).result()
     print(f"Loaded {len(experiments)} experiments")
 


### PR DESCRIPTION
The signature of load_table_from_json is
`load_table_from_json(json_rows, destination, num_retries=6, job_id=None, job_id_prefix=None, location=None, project=None, job_config=None, timeout=None)`
so we should pass job_config as a named parameter.