### PR TITLE
Fix #1470 - Wait on process ids from backgrounded tasks in run_glam_sql

### DIFF
--- a/script/glam/run_glam_sql
+++ b/script/glam/run_glam_sql
@@ -177,6 +177,16 @@ function run_desktop_sql {
     run_query "glam_user_counts_v1"
 }
 
+function wait_pids {
+    # Wait for the results from a list of pids, so the script can exit on the
+    # first encountered error.
+    # https://stackoverflow.com/a/356154
+    # https://askubuntu.com/a/674347
+    local pids=("$@")
+    for pid in "${pids[@]}"; do
+        wait "$pid"
+    done
+}
 
 function run_glean_sql {
     local error="STAGE must be one of (daily, incremental, all)"
@@ -185,6 +195,9 @@ function run_glean_sql {
     local start_stage=${START_STAGE:-0}
     local backfill_only=${BACKFILL_ONLY:-false}
     local export_only=${EXPORT_ONLY:-false}
+
+    # used to store any process ids
+    declare -a pids=()
 
     if [[ $backfill_only = true && $export_only = true ]]; then
         echo "BACKFILL_ONLY and EXPORT_ONLY are mutually exclusive"
@@ -197,17 +210,24 @@ function run_glean_sql {
     fi
     if [[ $stage == "daily" || $stage == "all" ]]; then
         if ((start_stage <= 0)) && [[ $export_only = false ]]; then
+            pids=()
             for directory in sql/$PROJECT/glam_etl/"${product}"__clients_daily_scalar_aggregates*/; do
                 run_query "$(basename "$directory")" true &
+                pids+=($!)
             done
             for directory in sql/$PROJECT/glam_etl/"${product}"__clients_daily_histogram_aggregates*/; do
                 run_query "$(basename "$directory")" true &
+                pids+=($!)
             done
-            wait
+            wait_pids "${pids[@]}"
+
+            pids=()
             # run in daily and incremental
             run_view "${product}__view_clients_daily_scalar_aggregates_v1" &
+            pids+=($!)
             run_view "${product}__view_clients_daily_histogram_aggregates_v1" &
-            wait
+            pids+=($!)
+            wait_pids "${pids[@]}"
         fi
     fi
     if [[ $stage == "incremental" || $stage == "all" ]]; then
@@ -217,33 +237,58 @@ function run_glean_sql {
             run_view "${product}__view_clients_daily_scalar_aggregates_v1"
             run_query "${product}__latest_versions_v1"
 
+            pids=()
             run_init "${product}__clients_scalar_aggregates_v1" &
+            pids+=($!)
             run_init "${product}__clients_histogram_aggregates_v1" &
-            wait
+            pids+=($!)
+            wait_pids "${pids[@]}"
+
+            pids=()
             run_query "${product}__clients_scalar_aggregates_v1" &
+            pids+=($!)
             run_query "${product}__clients_histogram_aggregates_v1" &
-            wait
+            pids+=($!)
+            wait_pids "${pids[@]}"
         fi
         if [[ $backfill_only = true ]]; then
             return
         fi
         if ((start_stage <= 2)); then
+            pids=()
             run_query "${product}__scalar_bucket_counts_v1" &
+            pids+=($!)
             run_query "${product}__histogram_bucket_counts_v1" &
-            wait
+            pids+=($!)
+            wait_pids "${pids[@]}"
+
+            pids=()
             run_query "${product}__scalar_probe_counts_v1" &
+            pids+=($!)
             run_query "${product}__histogram_probe_counts_v1" &
-            wait
+            pids+=($!)
+            wait_pids "${pids[@]}"
+
+            pids=()
             run_query "${product}__scalar_percentiles_v1" &
+            pids+=($!)
             run_query "${product}__histogram_percentiles_v1" &
-            wait
+            pids+=($!)
+            wait_pids "${pids[@]}"
         fi
+        pids=()
         run_view "${product}__view_probe_counts_v1" &
+        pids+=($!)
         run_view "${product}__view_user_counts_v1" &
-        wait
+        pids+=($!)
+        wait_pids "${pids[@]}"
+
+        pids=()
         run_query "${product}__extract_user_counts_v1" &
+        pids+=($!)
         run_query "${product}__extract_probe_counts_v1" &
-        wait
+        pids+=($!)
+        wait_pids "${pids[@]}"
     fi
 }
 


### PR DESCRIPTION
Fixes #1470. 

Tested by writing giberish into the clients daily SQL and running `./script/glam/test/test_glean_org_mozilla_fenix_glam_nightly`. 

```bash
...
Updated property [core/project].
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_baseline_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_bookmarks_sync_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_activation_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_deletion_request_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_events_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_first_session_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_history_sync_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_installation_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_logins_sync_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_migration_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_metrics_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_sync_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_startup_timeline_v1/query.sql
running sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_histogram_aggregates_metrics_v1/query.sql
Error in query string: Error processing job 'glam-fenix-dev:bqjob_r56bf45528cb1d664_0000017552113dca_1': Syntax
error: Expected ")" but got "." at [451:25]
Waiting on bqjob_r3cfeb0097c4be525_0000017552113e21_1 ... (0s) Current status: DONE   
Waiting on bqjob_r69787d773dfd07eb_0000017552113e06_1 ... (0s) Current status: DONE   
Waiting on bqjob_r4e75d87686c49915_0000017552113dda_1 ... (0s) Current status: DONE   
Waiting on bqjob_r4dbd4e0241e12df4_0000017552113e23_1 ... (0s) Current status: DONE   
Waiting on bqjob_r473f6be7a0b9d39c_0000017552113e0d_1 ... (0s) Current status: DONE   
Waiting on bqjob_r3defba3f8fe6430f_0000017552113e22_1 ... (0s) Current status: DONE   
Waiting on bqjob_r35fa1c118bfeea27_0000017552113dbc_1 ... (0s) Current status: DONE   
Waiting on bqjob_r6f3ae6b87fd70888_0000017552113dbe_1 ... (1s) Current status: DONE   
Waiting on bqjob_r1a42a8df985b0fe7_0000017552113dac_1 ... (1s) Current status: DONE   
Waiting on bqjob_r484073484b1d346_0000017552113dc2_1 ... (1s) Current status: DONE   G
Waiting on bqjob_r25709b1216341e7c_0000017552113dcb_1 ... (2s) Current status: DONE   
Waiting on bqjob_r58db5afaa087b100_0000017552113e1e_1 ... (2s) Current status: DONE   
Waiting on bqjob_r1a6852a12c53bd38_0000017552113dc3_1 ... (15s) Current status: DONE   
Updated property [core/project].
```