### PR TITLE
Add script to list tables in glam_etl datasets

### DIFF
--- a/script/glam/README.md
+++ b/script/glam/README.md
@@ -1,0 +1,29 @@
+# Scripts for GLAM ETL
+
+This directory contains an assortment of scripts for managing the state of GLAM
+queries. Also refer to the `bqetl glam` CLI tool.
+
+The GLAM glean queries are situated within the `glam_etl` dataset under the
+`glam-fenix-dev` project. Each query is prefixed with the namespace of the the
+glean application.
+
+## Dropping tables
+
+Use the `list_tables` script to enumerate all of the tables for the GLAM
+dataset. For example, we may want to prune all of the tables that do not belong
+to the logical glam app ids for Fenix (e.g. `org_mozilla_fenix_glam_nightly`).
+We can use grep to limit the set of tables that we want to delete.
+
+```bash
+script/glam/list_tables glam_etl | \
+    grep -v clients_daily | grep -v fenix_glam | \
+    xargs -I {} echo "bq rm -f {}"
+```
+
+We generate the commands to drop incremental tables using the following:
+
+```bash
+script/glam/list_tables glam_etl | \
+    grep -v clients_daily | grep aggregates_v1 | \
+    xargs -I {} echo "bq rm -f {}"
+```

--- a/script/glam/list_tables
+++ b/script/glam/list_tables
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# List all of the tables within a dataset
+
+project=${PROJECT:-glam-fenix-dev}
+dataset=${1:-glam_etl_dev}
+bq ls -n 10000 --format json "$project:$dataset" | jq -r '.[].id'


### PR DESCRIPTION
I ran the following commands to prepare the `glam-fenix-dev:glam_etl` dataset to drop aggregates and unused tables.

```bash
script/glam/list_tables glam_etl | grep -v fenix_glam | grep -v clients_daily | xargs -I {} echo "bq rm -f {}"
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fennec_aurora__extract_user_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fennec_aurora__histogram_bucket_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fennec_aurora__histogram_percentiles_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fennec_aurora__histogram_probe_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fennec_aurora__latest_versions_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fennec_aurora__scalar_bucket_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fennec_aurora__scalar_percentiles_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fennec_aurora__scalar_probe_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fennec_aurora__view_probe_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fennec_aurora__view_user_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__clients_histogram_aggregates_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__clients_scalar_aggregates_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__extract_probe_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__extract_user_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__histogram_bucket_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__histogram_percentiles_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__histogram_probe_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__latest_versions_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__scalar_bucket_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__scalar_percentiles_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__scalar_probe_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__view_probe_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox__view_user_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__clients_histogram_aggregates_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__clients_scalar_aggregates_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__extract_probe_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__extract_user_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__histogram_bucket_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__histogram_percentiles_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__histogram_probe_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__latest_versions_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__scalar_bucket_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__scalar_percentiles_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__scalar_probe_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__view_probe_counts_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_firefox_beta__view_user_counts_v1

script/glam/list_tables glam_etl | grep -v clients_daily | grep aggregates_v1 | xargs -I {} echo "bq rm -f {}"
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fenix_glam_beta__clients_histogram_aggregates_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fenix_glam_beta__clients_scalar_aggregates_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fenix_glam_nightly__clients_histogram_aggregates_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fenix_glam_release__clients_histogram_aggregates_v1
bq rm -f glam-fenix-dev:glam_etl.org_mozilla_fenix_glam_release__clients_scalar_aggregates_v1
```