### PR TITLE
Add multiple review bug support to metadata (fixes #938)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ labels:
   schedule: daily       # scheduled in Airflow to run daily
   public_json: true
   public_bigquery: true
-  review_bug: 1414839   # Bugzilla bug ID of data review
+  review_bugs: 
+   - 1414839   # Bugzilla bug ID of data review
   incremental_export: false  # non-incremental JSON export writes all data to a single location
 ```
 

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -36,21 +36,18 @@ class Metadata:
     def validate_labels(self, attribute, value):
         """Check that labels are valid."""
         for key, label in value.items():
-            if not isinstance(label, bool):
+            if key == "review_bugs" and label != "":
+                if isinstance(label, list):
+                    for bug in label:
+                        if not Metadata.is_valid_label(str(bug)):
+                            raise ValueError(f"Invalid label format: {bug}")
+                else:
+                    raise ValueError("Error: review_bugs needs to be a list.")
+            elif not isinstance(label, bool):
                 if not Metadata.is_valid_label(str(key)):
-                    raise ValueError(
-                        f"""Invalid label key format: {key}.
-                                    Key cannot be empty. Only hyphens(-), underscores(_),
-                                    lowercase characters, and numbers are allowed.
-                                    International characters are not allowed."""
-                    )
-                elif not Metadata.is_valid_label(str(label)) and not label == "":
-                    raise ValueError(
-                        f"""Invalid label value format: {label}.
-                                    Value be empty. Only hyphens(-), underscores(_),
-                                    lowercase characters, and numbers are allowed.
-                                    International characters are not allowed."""
-                    )
+                    raise ValueError(f"Invalid label format: {key}")
+                elif not Metadata.is_valid_label(str(label)) and label != "":
+                    raise ValueError(f"Invalid label format: {label}")
 
     @staticmethod
     def is_valid_label(label):
@@ -113,6 +110,8 @@ class Metadata:
                             # publish key-value pair with bool value as tag
                             if label:
                                 labels[str(key)] = ""
+                        elif isinstance(label, list):
+                            labels[str(key)] = list(map(str, label))
                         else:
                             # all other pairs get published as key-value pair label
                             labels[str(key)] = str(label)
@@ -165,6 +164,6 @@ class Metadata:
         """Return true if the incremental_export flag is set."""
         return "incremental_export" in self.labels
 
-    def review_bug(self):
+    def review_bugs(self):
         """Return the bug ID of the data review bug in bugzilla."""
-        return self.labels.get("review_bug", None)
+        return self.labels.get("review_bugs", None)

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -20,7 +20,7 @@ def validate_public_data(metadata, path):
     is_valid = True
 
     if metadata.is_public_bigquery() or metadata.is_public_json():
-        if not metadata.review_bug():
+        if not metadata.review_bugs():
             logging.error(f"Missing review bug for public data: {path}")
             is_valid = False
 

--- a/bigquery_etl/public_data/publish_gcs_metadata.py
+++ b/bigquery_etl/public_data/publish_gcs_metadata.py
@@ -75,8 +75,11 @@ class GcsTableMetadata:
         metadata_json["incremental"] = self.metadata.is_incremental()
         metadata_json["incremental_export"] = self.metadata.is_incremental_export()
 
-        if self.metadata.review_bug() is not None:
-            metadata_json["review_link"] = REVIEW_LINK + self.metadata.review_bug()
+        if self.metadata.review_bugs() is not None:
+            review_links = list(
+                map(lambda bug: REVIEW_LINK + str(bug), self.metadata.review_bugs())
+            )
+            metadata_json["review_link"] = review_links
 
         metadata_json["files_uri"] = self.files_uri
         metadata_json["last_updated"] = self.last_updated_uri

--- a/bigquery_etl/public_data/publish_gcs_metadata.py
+++ b/bigquery_etl/public_data/publish_gcs_metadata.py
@@ -79,7 +79,7 @@ class GcsTableMetadata:
             review_links = list(
                 map(lambda bug: REVIEW_LINK + str(bug), self.metadata.review_bugs())
             )
-            metadata_json["review_link"] = review_links
+            metadata_json["review_links"] = review_links
 
         metadata_json["files_uri"] = self.files_uri
         metadata_json["last_updated"] = self.last_updated_uri

--- a/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/metadata.yaml
@@ -33,7 +33,8 @@ labels:
   incremental: true
   public_json: false
   public_bigquery: false
-  review_bug: 1640204
+  review_bugs: 
+    - 1640204
   incremental_export: false
 scheduling:
   dag_name: bqetl_internet_outages

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/deviations_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/deviations_v1/metadata.yaml
@@ -7,5 +7,6 @@ labels:
   incremental: true
   public_json: true
   public_bigquery: true
-  review_bug: 1624528
+  review_bugs: 
+   - 1624528
   incremental_export: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/italy_covid19_outage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/italy_covid19_outage_v1/metadata.yaml
@@ -27,5 +27,6 @@ labels:
   incremental: true
   public_json: true
   public_bigquery: true
-  review_bug: 1633681
+  review_bugs: 
+    - 1633681
   incremental_export: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -9,7 +9,8 @@ labels:
   incremental: true
   public_json: true
   public_bigquery: true
-  review_bug: 1414839
+  review_bugs: 
+   - 1414839
   incremental_export: false
 scheduling:
   dag_name: bqetl_ssl_ratios

--- a/tests/data/all_datasets.json
+++ b/tests/data/all_datasets.json
@@ -6,7 +6,7 @@
                 "description": "Test table for a non-incremental query",
                 "incremental": false,
                 "incremental_export": false,
-                "review_links": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1999999"],
+                "review_links": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1999999", "https://bugzilla.mozilla.org/show_bug.cgi?id=12121212"],
                 "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/files",
                 "last_updated": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/last_updated"
             }

--- a/tests/data/all_datasets.json
+++ b/tests/data/all_datasets.json
@@ -6,7 +6,7 @@
                 "description": "Test table for a non-incremental query",
                 "incremental": false,
                 "incremental_export": false,
-                "review_link": "https://bugzilla.mozilla.org/show_bug.cgi?id=1999999",
+                "review_links": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1999999"],
                 "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/files",
                 "last_updated": "https://test.endpoint.mozilla.com/api/v1/tables/test/non_incremental_query/v1/last_updated"
             }
@@ -17,7 +17,7 @@
                 "description": "Test table for an incremental query",
                 "incremental": true,
                 "incremental_export": true,
-                "review_link": "https://bugzilla.mozilla.org/show_bug.cgi?id=123456",
+                "review_links": ["https://bugzilla.mozilla.org/show_bug.cgi?id=123456"],
                 "files_uri": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/files",
                 "last_updated": "https://test.endpoint.mozilla.com/api/v1/tables/test/incremental_query/v1/last_updated"
             }

--- a/tests/data/test_sql/moz-fx-data-test-project-2/test_2/test_query_v1/metadata.yaml
+++ b/tests/data/test_sql/moz-fx-data-test-project-2/test_2/test_query_v1/metadata.yaml
@@ -7,7 +7,8 @@ labels:
   public_json: true
   incremental: true
   incremental_export: true
-  review_bug: 123456
+  review_bugs: 
+    - 123456
 scheduling:
   dag_name: "bqetl_events"
   depends_on_past: false

--- a/tests/data/test_sql/moz-fx-data-test-project/test/incremental_query_non_incremental_export_v1/metadata.yaml
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/incremental_query_non_incremental_export_v1/metadata.yaml
@@ -8,7 +8,8 @@ labels:
   public_json: true
   incremental: true
   incremental_export: false
-  review_bug: 123456
+  review_bugs: 
+    - 123456
 scheduling:
   dag_name: "bqetl_events"
   depends_on_past: false

--- a/tests/data/test_sql/moz-fx-data-test-project/test/incremental_query_v1/metadata.yaml
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/incremental_query_v1/metadata.yaml
@@ -7,7 +7,8 @@ labels:
   public_json: true
   incremental: true
   incremental_export: true
-  review_bug: 123456
+  review_bugs: 
+   - 123456
 scheduling:
   dag_name: "bqetl_events"
   depends_on_past: false

--- a/tests/data/test_sql/moz-fx-data-test-project/test/multipart_query_v1/metadata.yaml
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/multipart_query_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   public_json: false
   incremental: false
   incremental_export: false
-  review_bug: 1999999
+  review_bugs: 
+   - 1999999
 scheduling:
   dag_name: "bqetl_core"

--- a/tests/data/test_sql/moz-fx-data-test-project/test/non_incremental_query_v1/metadata.yaml
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/non_incremental_query_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   incremental_export: false
   review_bugs: 
    - 1999999
+   - 12121212
 scheduling:
   dag_name: "bqetl_core"
   depends_on_past: true

--- a/tests/data/test_sql/moz-fx-data-test-project/test/non_incremental_query_v1/metadata.yaml
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/non_incremental_query_v1/metadata.yaml
@@ -7,7 +7,8 @@ labels:
   public_json: true
   incremental: false
   incremental_export: false
-  review_bug: 1999999
+  review_bugs: 
+   - 1999999
 scheduling:
   dag_name: "bqetl_core"
   depends_on_past: true

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -104,7 +104,7 @@ class TestParseMetadata(object):
 
         assert metadata.friendly_name == "Test table for a non-incremental query"
         assert metadata.description == "Test table for a non-incremental query"
-        assert metadata.review_bugs() == ["1999999"]
+        assert metadata.review_bugs() == ["1999999", "12121212"]
 
     def test_of_sql_file_no_metadata(self):
         metadata_file = (
@@ -129,7 +129,7 @@ class TestParseMetadata(object):
 
         assert metadata.friendly_name == "Test table for a non-incremental query"
         assert metadata.description == "Test table for a non-incremental query"
-        assert metadata.review_bugs() == ["1999999"]
+        assert metadata.review_bugs() == ["1999999", "12121212"]
 
     def test_of_non_existing_table(self):
         with pytest.raises(FileNotFoundError):

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -38,6 +38,18 @@ class TestParseMetadata(object):
                 {"foo": "INVALID-VALUE"},
             )
 
+    def test_invalid_review_bugs(self):
+        assert Metadata(
+            "Test", "Description", ["test@test.org"], {"review_bugs": [123456]}
+        )
+        with pytest.raises(ValueError):
+            Metadata(
+                "Test",
+                "Description",
+                ["test@example.org"],
+                {"review_bugs": 123456},
+            )
+
     def test_is_valid_label(self):
         assert Metadata.is_valid_label("valid_label")
         assert Metadata.is_valid_label("valid-label1")
@@ -63,7 +75,7 @@ class TestParseMetadata(object):
         assert metadata.is_public_json()
         assert metadata.is_incremental()
         assert metadata.is_incremental_export()
-        assert metadata.review_bug() is None
+        assert metadata.review_bugs() is None
         assert "1232341234" in metadata.labels
         assert "1234_abcd" in metadata.labels
         assert "number_value" in metadata.labels
@@ -92,7 +104,7 @@ class TestParseMetadata(object):
 
         assert metadata.friendly_name == "Test table for a non-incremental query"
         assert metadata.description == "Test table for a non-incremental query"
-        assert metadata.review_bug() == "1999999"
+        assert metadata.review_bugs() == ["1999999"]
 
     def test_of_sql_file_no_metadata(self):
         metadata_file = (
@@ -117,7 +129,7 @@ class TestParseMetadata(object):
 
         assert metadata.friendly_name == "Test table for a non-incremental query"
         assert metadata.description == "Test table for a non-incremental query"
-        assert metadata.review_bug() == "1999999"
+        assert metadata.review_bugs() == ["1999999"]
 
     def test_of_non_existing_table(self):
         with pytest.raises(FileNotFoundError):

--- a/tests/metadata/test_validate_metadata.py
+++ b/tests/metadata/test_validate_metadata.py
@@ -11,7 +11,7 @@ class TestValidateMetadata(object):
             "Public json data",
             "Public json data",
             [],
-            {"public_json": True, "review_bug": 123456},
+            {"public_json": True, "review_bugs": [123456]},
             {},
         )
         assert validate_public_data(metadata_valid_public, "test/path/metadata.yaml")
@@ -20,7 +20,7 @@ class TestValidateMetadata(object):
             "Public BigQuery data",
             "Public BigQuery data",
             [],
-            {"public_bigquery": True, "review_bug": 123456},
+            {"public_bigquery": True, "review_bugs": [123456]},
             {},
         )
         assert validate_public_data(metadata_valid_public, "test/path/metadata.yaml")

--- a/tests/public_data/test_publish_gcs_metadata.py
+++ b/tests/public_data/test_publish_gcs_metadata.py
@@ -91,7 +91,7 @@ class TestPublishGcsMetadata(object):
         assert gcs_table_metadata.version == "v1"
         assert gcs_table_metadata.metadata.is_incremental() is False
         assert gcs_table_metadata.metadata.is_incremental_export() is False
-        assert gcs_table_metadata.metadata.review_bug() == "1999999"
+        assert gcs_table_metadata.metadata.review_bugs() == ["1999999"]
         assert gcs_table_metadata.last_updated_path == last_updated_path
         assert gcs_table_metadata.last_updated_uri == self.endpoint + last_updated_path
 
@@ -114,8 +114,8 @@ class TestPublishGcsMetadata(object):
         assert result["friendly_name"] == "Test table for a non-incremental query"
         assert result["incremental"] is False
         assert result["incremental_export"] is False
-        review_link = "https://bugzilla.mozilla.org/show_bug.cgi?id=1999999"
-        assert result["review_link"] == review_link
+        review_link = ["https://bugzilla.mozilla.org/show_bug.cgi?id=1999999"]
+        assert result["review_links"] == review_link
         assert result["files_uri"] == self.endpoint + files_path
         assert result["last_updated"] == self.endpoint + last_updated_path
 

--- a/tests/public_data/test_publish_gcs_metadata.py
+++ b/tests/public_data/test_publish_gcs_metadata.py
@@ -91,7 +91,7 @@ class TestPublishGcsMetadata(object):
         assert gcs_table_metadata.version == "v1"
         assert gcs_table_metadata.metadata.is_incremental() is False
         assert gcs_table_metadata.metadata.is_incremental_export() is False
-        assert gcs_table_metadata.metadata.review_bugs() == ["1999999"]
+        assert gcs_table_metadata.metadata.review_bugs() == ["1999999", "12121212"]
         assert gcs_table_metadata.last_updated_path == last_updated_path
         assert gcs_table_metadata.last_updated_uri == self.endpoint + last_updated_path
 
@@ -114,7 +114,10 @@ class TestPublishGcsMetadata(object):
         assert result["friendly_name"] == "Test table for a non-incremental query"
         assert result["incremental"] is False
         assert result["incremental_export"] is False
-        review_link = ["https://bugzilla.mozilla.org/show_bug.cgi?id=1999999"]
+        review_link = [
+            "https://bugzilla.mozilla.org/show_bug.cgi?id=1999999",
+            "https://bugzilla.mozilla.org/show_bug.cgi?id=12121212",
+        ]
         assert result["review_links"] == review_link
         assert result["files_uri"] == self.endpoint + files_path
         assert result["last_updated"] == self.endpoint + last_updated_path

--- a/tests/test_run_query.py
+++ b/tests/test_run_query.py
@@ -41,7 +41,7 @@ class TestRunQuery:
             "friendly_name": "test",
             "description": "test",
             "owners": ["test@example.org"],
-            "labels": {"public_bigquery": True, "review_bug": 222222},
+            "labels": {"public_bigquery": True, "review_bugs": [222222]},
         }
 
         metadata_file = query_file_path / "metadata.yaml"
@@ -70,7 +70,7 @@ class TestRunQuery:
             "friendly_name": "test",
             "description": "test",
             "owners": ["test@example.org"],
-            "labels": {"public_bigquery": True, "review_bug": 222222},
+            "labels": {"public_bigquery": True, "review_bugs": [222222]},
         }
 
         metadata_file = query_file_path / "metadata.yaml"


### PR DESCRIPTION
Fixes #938.

**What I did**:
- Change `review_bugs` to list and add validator
- Update `review_bugs` in tests and metadata files to lists
- Update README

The failed build test seems to be a GCP-related issue. I tested my code locally and the only failed tests were GCP-related too. Any advice on how to fix this @scholtzan? Maybe something similar to [this](https://github.com/mozilla/bigquery-etl/pull/1481#issuecomment-716631697)? Thank you for your help.