### PR TITLE
Use resource id, not event id, when updating stripe resource tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/stripe_external/charges_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/charges_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.charge.id,
     created AS event_timestamp,
     `data`.charge.* EXCEPT (id),
   FROM

--- a/sql/moz-fx-data-shared-prod/stripe_external/credit_notes_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/credit_notes_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.credit_note.id,
     created AS event_timestamp,
     `data`.credit_note.* EXCEPT (id),
   FROM

--- a/sql/moz-fx-data-shared-prod/stripe_external/customers_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/customers_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.customer.id,
     created AS event_timestamp,
     `data`.customer.* EXCEPT (id),
   FROM

--- a/sql/moz-fx-data-shared-prod/stripe_external/disputes_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/disputes_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.dispute.id,
     created AS event_timestamp,
     `data`.dispute.* EXCEPT (id),
   FROM

--- a/sql/moz-fx-data-shared-prod/stripe_external/invoices_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/invoices_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.invoice.id,
     created AS event_timestamp,
     `data`.invoice.* EXCEPT (id),
   FROM

--- a/sql/moz-fx-data-shared-prod/stripe_external/payment_intents_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/payment_intents_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.payment_intent.id,
     created AS event_timestamp,
     `data`.payment_intent.* EXCEPT (id),
   FROM

--- a/sql/moz-fx-data-shared-prod/stripe_external/payouts_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/payouts_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.payout.id,
     created AS event_timestamp,
     `data`.payout.* EXCEPT (id),
   FROM

--- a/sql/moz-fx-data-shared-prod/stripe_external/plans_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/plans_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.plan.id,
     created AS event_timestamp,
     `data`.plan.* EXCEPT (id),
   FROM

--- a/sql/moz-fx-data-shared-prod/stripe_external/prices_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/prices_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.price.id,
     created AS event_timestamp,
     `data`.price.* EXCEPT (id),
   FROM

--- a/sql/moz-fx-data-shared-prod/stripe_external/products_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/products_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.product.id,
     created AS event_timestamp,
     `data`.product.* EXCEPT (id),
   FROM

--- a/sql/moz-fx-data-shared-prod/stripe_external/setup_intents_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/setup_intents_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.setup_intent.id,
     created AS event_timestamp,
     `data`.setup_intent.* EXCEPT (id),
   FROM

--- a/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_v1/query.sql
@@ -1,6 +1,6 @@
 WITH events AS (
   SELECT
-    id,
+    `data`.subscription.id,
     created AS event_timestamp,
     `data`.subscription.* EXCEPT (id),
   FROM


### PR DESCRIPTION
resources are deduped by id, but this was incorrectly using event id, causing all update events to be considered a new resource