### PR TITLE
 Fix broken circleci deploy due to extra space in tag 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,8 @@ jobs:
           name: Early return if this build is from a forked PR
           command: |
             if [ -n "$CIRCLE_PR_NUMBER" ]; then
-            echo "Cannot pass creds to forked PRs,
-              so marking this step successful"
+              echo "Cannot pass creds to forked PRs,
+                so marking this step successful"
               circleci step halt
             fi
       - *build
@@ -157,11 +157,11 @@ jobs:
       - run:
           name: Build and deploy docs
           command: |
-           PATH="venv/bin:$PATH" script/generate_docs \
+            PATH="venv/bin:$PATH" script/generate_docs \
                 --output_dir=generated_docs/
             cd generated_docs/
-           mkdocs gh-deploy -m "[ci skip] Deployed
-            {sha} with MkDocs version: {version}"
+            mkdocs gh-deploy \
+              -m "[ci skip] Deployed {sha} with MkDocs version: {version}"
   deploy:
     parameters:
       image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,8 +177,7 @@ jobs:
           name: Determine docker image name
           command:
           # yamllint disable-line rule:line-length
-            echo 'IMAGE="${CIRCLE_PROJECT_USERNAME+$CIRCLE_PROJECT_USERNAME/} ${CIRCLE_PROJECT_REPONAME:-bigquery-etl}:${CIRCLE_TAG:-latest}"' > $BASH_ENV
-
+            echo 'IMAGE="${CIRCLE_PROJECT_USERNAME+$CIRCLE_PROJECT_USERNAME/}${CIRCLE_PROJECT_REPONAME:-bigquery-etl}:${CIRCLE_TAG:-latest}"' > $BASH_ENV
       - run:
           name: Build docker image
           command: docker build . --pull --tag "$IMAGE"


### PR DESCRIPTION
This fixes an issue introduced in https://github.com/mozilla/bigquery-etl/pull/1481 where a space was introduced into the tag, leading to the following issue:

```
#!/bin/bash -eo pipefail
docker build . --pull --tag "$IMAGE"

invalid argument "mozilla/ bigquery-etl:latest" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
```

https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/6662/workflows/27ab59d0-9eeb-433a-b94f-40746018e82e/jobs/33036