### PR TITLE
Fix join logic for mozilla_vpn_external.users_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/query.sql
@@ -1,6 +1,6 @@
 SELECT
-  COALESCE(_current, _previous).* REPLACE (
-    COALESCE(TO_HEX(SHA256(_current.fxa_uid)), _previous.fxa_uid) AS fxa_uid
+  IF(_current.id IS NULL, _previous, _current).* REPLACE (
+    IF(_current.id IS NULL, _previous.fxa_uid, TO_HEX(SHA256(_current.fxa_uid))) AS fxa_uid
   )
 FROM
   EXTERNAL_QUERY(


### PR DESCRIPTION
`COALESCE` doesn't work with table aliases, because BigQuery returns a struct with null contents for table aliases that were not matched in a `JOIN`, so instead use `IF(table_alias_2.join_key IS NULL, table_alias_1, table_alias_2)`