### PR TITLE
Add bits_from_offsets UDF

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf/bits_from_offsets/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf/bits_from_offsets/metadata.yaml
@@ -1,0 +1,18 @@
+---
+friendly_name: Bits From Offsets
+description: >
+  Returns a bit pattern of type BYTES compactly encoding the given array of
+  positive integer offsets.
+
+  This is primarily useful to generate a compact encoding of dates on which
+  a feature was used, with arbitrarily long history. Example aggregation:
+
+      bits_from_offsets(ARRAY_AGG(IF(foo, DATE_DIFF(anchor_date, submission_date, DAY), NULL) IGNORE NULLS))
+
+  The resulting value can be cast to an INT64 representing the most recent 64 days via:
+
+      CAST(CONCAT('0x', TO_HEX(RIGHT(bits >> i, 4))) AS INT64)
+
+  Or representing the most recent 28 days (compatible with bits28 functions) via:
+
+      CAST(CONCAT('0x', TO_HEX(RIGHT(bits >> i, 4))) AS INT64) << 36 >> 36

--- a/sql/moz-fx-data-shared-prod/udf/bits_from_offsets/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf/bits_from_offsets/metadata.yaml
@@ -7,12 +7,23 @@ description: >
   This is primarily useful to generate a compact encoding of dates on which
   a feature was used, with arbitrarily long history. Example aggregation:
 
-      bits_from_offsets(ARRAY_AGG(IF(foo, DATE_DIFF(anchor_date, submission_date, DAY), NULL) IGNORE NULLS))
+  ```sql
+  bits_from_offsets(
+    ARRAY_AGG(IF(foo, DATE_DIFF(anchor_date, submission_date, DAY), NULL)
+              IGNORE NULLS)
+  )
+  ```
 
-  The resulting value can be cast to an INT64 representing the most recent 64 days via:
+  The resulting value can be cast to an INT64 representing the most recent 64
+  days via:
 
-      CAST(CONCAT('0x', TO_HEX(RIGHT(bits >> i, 4))) AS INT64)
+  ```sql
+  CAST(CONCAT('0x', TO_HEX(RIGHT(bits >> i, 4))) AS INT64)
+  ```
 
-  Or representing the most recent 28 days (compatible with bits28 functions) via:
+  Or representing the most recent 28 days (compatible with bits28 functions)
+  via:
 
-      CAST(CONCAT('0x', TO_HEX(RIGHT(bits >> i, 4))) AS INT64) << 36 >> 36
+  ```sql
+  CAST(CONCAT('0x', TO_HEX(RIGHT(bits >> i, 4))) AS INT64) << 36 >> 36
+  ```

--- a/sql/moz-fx-data-shared-prod/udf/bits_from_offsets/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf/bits_from_offsets/udf.sql
@@ -45,4 +45,6 @@ SELECT
   assert.equals(b'\x03', udf.bits_from_offsets([0, 1])),
   assert.equals(b'\xff', udf.bits_from_offsets([0, 1, 2, 3, 4, 5, 6, 7])),
   assert.equals(b'\x01\xff', udf.bits_from_offsets([0, 1, 2, 3, 4, 5, 6, 7, 8])),
-  assert.equals(b'\x01\xff', udf.bits_from_offsets([8, 0, 1, 2, 3, 4, 5, 6, 7]));
+  assert.equals(b'\x01\xff', udf.bits_from_offsets([8, 0, 1, 2, 3, 4, 5, 6, 7])),
+  assert.equals(b'\x01', udf.bits_from_offsets([0, 2048])),
+  assert.equals(CONCAT(b'\x80', REPEAT(b'\x00', 255)), udf.bits_from_offsets([2047]));

--- a/sql/moz-fx-data-shared-prod/udf/bits_from_offsets/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf/bits_from_offsets/udf.sql
@@ -1,0 +1,48 @@
+CREATE OR REPLACE FUNCTION udf.bits_from_offsets(offsets ARRAY<INT64>) AS (
+  (
+    SELECT
+      LTRIM(
+        STRING_AGG(
+          (
+            SELECT
+              -- CODE_POINTS_TO_BYTES is the best available interface for converting
+              -- an array of numeric values to a BYTES field; it requires that values
+              -- are valid extended ASCII characters, so we can only aggregate 8 bits
+              -- at a time, and then concat all those chunks together with STRING_AGG.
+              CODE_POINTS_TO_BYTES(
+                [
+                  BIT_OR(
+                    (
+                      IF(
+                        DIV(n - (8 * i), 8) = 0
+                        AND (n - (8 * i)) >= 0,
+                        1 << MOD(n - (8 * i), 8),
+                        0
+                      )
+                    )
+                  )
+                ]
+              )
+            FROM
+              UNNEST(offsets) AS n
+          ),
+          b''
+        ),
+        b'\x00'
+      )
+    FROM
+      -- Each iteration handles 8 bits, so 256 iterations gives us 2048 bits,
+      -- about 5.6 years worth. This function performs an LTRIM, so additional
+      -- bits are dropped and it's safe to expand this range arbitrarily.
+      UNNEST(GENERATE_ARRAY(255, 0, -1)) AS i
+  )
+);
+
+-- Tests
+SELECT
+  assert.equals(b'\x01', udf.bits_from_offsets([0])),
+  assert.equals(b'\x02', udf.bits_from_offsets([1])),
+  assert.equals(b'\x03', udf.bits_from_offsets([0, 1])),
+  assert.equals(b'\xff', udf.bits_from_offsets([0, 1, 2, 3, 4, 5, 6, 7])),
+  assert.equals(b'\x01\xff', udf.bits_from_offsets([0, 1, 2, 3, 4, 5, 6, 7, 8])),
+  assert.equals(b'\x01\xff', udf.bits_from_offsets([8, 0, 1, 2, 3, 4, 5, 6, 7]));


### PR DESCRIPTION
This is relevant to the emerging "clients_all_time" work drafted in
https://github.com/mozilla/bigquery-etl/pull/1480

I'm proposing we add this under `udf` rather than in `mozfun` because I'm not
yet certain about the naming. If we want to have additional functionality to
support all-time bit patterns, I would like to have those organized under a
single `mozfun` namespace, and it's not clear yet what the interface should
look like.

This function on its own should be enough to empower a new DS workflow for
experimenting with new usage definitions before committing them to clients_daily
and clients_last_seen (evolving documentation in [the daily per-client aggregates project doc](https://docs.google.com/document/d/1Lml-hWiqhvUazjn_-sDF6TUvwAEA3jMG3LJbyIC7fEc/edit#heading=h.uqc5x9ri7ie8)).