### PR TITLE
Use numeric order instead of string ordering when filling buckets

### DIFF
--- a/sql/mozfun/glam/histogram_fill_buckets/udf.sql
+++ b/sql/mozfun/glam/histogram_fill_buckets/udf.sql
@@ -16,7 +16,7 @@ RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
     ON
       key = e.key
     ORDER BY
-      key
+      SAFE_CAST(key AS FLOAT64)
   )
 );
 
@@ -37,11 +37,19 @@ SELECT
       ["0"]
     )
   ),
-  -- return ordered keys by string value
+  -- return ordered keys by its numeric value
   assert.array_equals(
-    ARRAY<STRUCT<key STRING, value FLOAT64>>[("11", 0.0), ("2", 1.0)],
+    ARRAY<STRUCT<key STRING, value FLOAT64>>[("2", 1.0), ("11", 0.0)],
     glam.histogram_fill_buckets(
       ARRAY<STRUCT<key STRING, value FLOAT64>>[("0", 1.0), ("2", 1.0)],
       ["11", "2"]
+    )
+  ),
+  -- ...except if it contains string, then order is not well defined
+  assert.array_equals(
+    ARRAY<STRUCT<key STRING, value FLOAT64>>[("foo", 1.0), ("bar", 1.0)],
+    glam.histogram_fill_buckets(
+      ARRAY<STRUCT<key STRING, value FLOAT64>>[("foo", 1.0), ("bar", 1.0)],
+      ["foo", "bar"]
     )
   )


### PR DESCRIPTION
This attempts to fix #1521 by ordering the buckets during the `probe_counts` stage using the natural sort. This used the string sort before because of the boolean type, but ordering on the boolean type doesn't actually matter. This affects the generated percentiles because they will automatically use the ordering of the histogram in probe counts:

```sql
SELECT
  * EXCEPT (aggregates) REPLACE('percentiles' AS agg_type),
  ARRAY<STRUCT<key STRING, value FLOAT64>>[
    ('5', mozfun.glam.percentile(5, aggregates, metric_type)),
    ('25', mozfun.glam.percentile(25, aggregates, metric_type)),
    ('50', mozfun.glam.percentile(50, aggregates, metric_type)),
    ('75', mozfun.glam.percentile(75, aggregates, metric_type)),
    ('95', mozfun.glam.percentile(95, aggregates, metric_type))
  ] AS aggregates
FROM
  glam_etl.{{ prefix }}__histogram_probe_counts_v1
```