### PR TITLE
Use SAFE_CAST with bucket values

### DIFF
--- a/bigquery_etl/glam/templates/histogram_bucket_counts_v1.sql
+++ b/bigquery_etl/glam/templates/histogram_bucket_counts_v1.sql
@@ -79,7 +79,7 @@ distribution_metadata AS (
       metric_type,
       metric,
       NULL AS range_min,
-      MAX(CAST(bucket AS INT64)) AS range_max,
+      MAX(SAFE_CAST(bucket AS INT64)) AS range_max,
       NULL AS bucket_count,
       NULL AS histogram_type
     FROM

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_bucket_counts_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_bucket_counts_v1/query.sql
@@ -252,7 +252,7 @@ distribution_metadata AS (
     metric_type,
     metric,
     NULL AS range_min,
-    MAX(CAST(bucket AS INT64)) AS range_max,
+    MAX(SAFE_CAST(bucket AS INT64)) AS range_max,
     NULL AS bucket_count,
     NULL AS histogram_type
   FROM

--- a/sql/mozfun/glam/histogram_normalized_sum/udf.sql
+++ b/sql/mozfun/glam/histogram_normalized_sum/udf.sql
@@ -31,7 +31,7 @@ RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
           COALESCE(SAFE_DIVIDE(1.0 * v, total_count), 0) * weight
         )
         ORDER BY
-          CAST(k AS INT64)
+          SAFE_CAST(k AS INT64)
       )
     FROM
       summed_counts

--- a/sql/mozfun/glam/map_from_array_offsets/udf.sql
+++ b/sql/mozfun/glam/map_from_array_offsets/udf.sql
@@ -7,7 +7,7 @@ RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
   (
     SELECT
       ARRAY_AGG(
-        STRUCT<key STRING, value FLOAT64>(CAST(key AS STRING), `values`[OFFSET(CAST(key AS INT64))])
+        STRUCT<key STRING, value FLOAT64>(CAST(key AS STRING), `values`[OFFSET(SAFE_CAST(key AS INT64))])
         ORDER BY
           key
       )

--- a/sql/mozfun/glam/map_from_array_offsets/udf.sql
+++ b/sql/mozfun/glam/map_from_array_offsets/udf.sql
@@ -7,7 +7,10 @@ RETURNS ARRAY<STRUCT<key STRING, value FLOAT64>> AS (
   (
     SELECT
       ARRAY_AGG(
-        STRUCT<key STRING, value FLOAT64>(CAST(key AS STRING), `values`[OFFSET(SAFE_CAST(key AS INT64))])
+        STRUCT<key STRING, value FLOAT64>(
+          CAST(key AS STRING),
+          `values`[OFFSET(SAFE_CAST(key AS INT64))]
+        )
         ORDER BY
           key
       )


### PR DESCRIPTION
This should fix #1490. Running the following query results in a few rows where the number of bits exceeds 63.

glam-fenix-dev:US.bquxjob_335606eb_1759f9f0074

```sql
SELECT
  x.key
FROM
  `glam-fenix-dev.glam_etl.org_mozilla_fenix_glam_release__clients_histogram_aggregates_v1`,
  unnest(histogram_aggregates) as agg,
  unnest(agg.value) as x
order by
  length(x.key) desc
limit 1000
```

```json
[
  {
    "key": "11961233684655493120"
  },
  {
    "key": "16915738899553708032"
  },
  {
    "key": "10058158527438782464"
  },
  {
    "key": "10968499650544994304"
  },
  {
    "key": "13043817825332967424"
  },
...
```

Looking at the top result in python:

```python
>>> x = 11961233684655493120
>>> x.bit_length()
64
```

Casting happens a few places inside of the bucket counts for histogram aggregates. If we safe_cast instead, this should resolve issues with these gigantic buckets.