### PR TITLE
Support python script query scheduling

### DIFF
--- a/bigquery_etl/cli/dag.py
+++ b/bigquery_etl/cli/dag.py
@@ -196,7 +196,7 @@ def remove(name, dags_config, output_dir):
         sys.exit(1)
 
     for task in dag_tbr.tasks:
-        metadata = Metadata.of_sql_file(task.query_file)
+        metadata = Metadata.of_query_file(task.query_file)
         sql_path = Path(os.path.dirname(task.query_file))
         metadata.scheduling = {}
         metadata_file = sql_path / METADATA_FILE

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -246,7 +246,7 @@ def schedule(name, sql_dir, project_id, dag, depends_on_past, task_name):
 
     for query_file in query_files:
         try:
-            metadata = Metadata.of_sql_file(query_file)
+            metadata = Metadata.of_query_file(query_file)
         except FileNotFoundError:
             click.echo(f"Cannot schedule {query_file}. No metadata.yaml found.")
             continue
@@ -326,7 +326,7 @@ def info(name, sql_dir, project_id, cost, last_updated):
         project = query_file_path.parent.parent.parent.name
 
         try:
-            metadata = Metadata.of_sql_file(query_file)
+            metadata = Metadata.of_query_file(query_file)
         except FileNotFoundError:
             metadata = None
 

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -127,7 +127,7 @@ class Metadata:
                 raise e
 
     @classmethod
-    def of_sql_file(cls, sql_file):
+    def of_query_file(cls, sql_file):
         """Return the metadata that is associated with the provided SQL file."""
         path, _ = os.path.split(sql_file)
         metadata_file = os.path.join(path, METADATA_FILE)

--- a/bigquery_etl/public_data/publish_json.py
+++ b/bigquery_etl/public_data/publish_json.py
@@ -58,7 +58,7 @@ class JsonPublisher:
         self.date = None
         self.stage_gcs_path = self.gcs_path + "stage/json/"
 
-        self.metadata = Metadata.of_sql_file(self.query_file)
+        self.metadata = Metadata.of_query_file(self.query_file)
 
         # only for incremental exports files are written into separate directories
         # for each date, ignore date parameters for non-incremental exports
@@ -311,7 +311,7 @@ def main():
     args, query_arguments = parser.parse_known_args()
 
     try:
-        metadata = Metadata.of_sql_file(args.query_file)
+        metadata = Metadata.of_query_file(args.query_file)
     except FileNotFoundError:
         print("No metadata file for: {}".format(args.query_file))
         return

--- a/bigquery_etl/query_scheduling/generate_airflow_dags.py
+++ b/bigquery_etl/query_scheduling/generate_airflow_dags.py
@@ -15,6 +15,7 @@ DEFAULT_DAGS_FILE = "dags.yaml"
 QUERY_FILE = "query.sql"
 QUERY_PART_FILE = "part1.sql"
 SCRIPT_FILE = "script.sql"
+PYTHON_SCRIPT_FILE = "query.py"
 DEFAULT_DAGS_DIR = "dags"
 TELEMETRY_AIRFLOW_GITHUB = "https://github.com/mozilla/telemetry-airflow.git"
 
@@ -70,6 +71,11 @@ def get_dags(project_id, dags_config):
                     elif SCRIPT_FILE in files:
                         query_file = os.path.join(root, SCRIPT_FILE)
                         task = Task.of_script(query_file, dag_collection=dag_collection)
+                    elif PYTHON_SCRIPT_FILE in files:
+                        query_file = os.path.join(root, PYTHON_SCRIPT_FILE)
+                        task = Task.of_python_script(
+                            query_file, dag_collection=dag_collection
+                        )
                     else:
                         continue
                 except FileNotFoundError:

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -57,7 +57,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             task_id='{{ task.task_name }}',
             command=[
                 'python',
-                '{{ task.query_file_path }}',
+                'sql/{{ task.project }}/{{ task.dataset }}/{{ task.table }}_{{ task.version }}/query.py',
             ] + {{ task.arguments }},
             docker_image='mozilla/bigquery-etl:latest',
             owner='{{ task.owner }}',

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {{ 
     default_args.to_dict() | 
@@ -13,44 +13,57 @@ default_args = {{
 
 with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None -%}, schedule_interval={{ schedule_interval | format_timedelta | format_schedule_interval }}{%+ endif -%}) as dag:
 {% for task in tasks | sort(attribute='task_name') %}
-    {{ task.task_name }} = bigquery_etl_query(
-        task_id='{{ task.task_name }}',
-        destination_table={%+ if task.destination_table -%}'{{ task.destination_table }}'
-                          {%+ else -%}None
-                          {%+ endif -%},
-        dataset_id='{{ task.dataset }}',
-        project_id='{{ task.project }}',
-        owner='{{ task.owner }}',
-        {%+ if task.email | length > 0 -%}
-        email={{ task.email | sort }},
-        {%+ endif -%}
-        {%+ if task.start_date -%}
-        start_date={{ task.start_date | format_date | format_repr }},
-        {%+ endif -%}
-        {%+ if task.date_partition_parameter == None or task.date_partition_parameter is string -%}
-        date_partition_parameter={{ task.date_partition_parameter | format_optional_string }},
-        {%+ endif -%}
-        depends_on_past={{ task.depends_on_past }},
-        {%+ if task.arguments | length > 0 -%}
-        arguments={{ task.arguments }},
-        {%+ endif -%}
-        {%+ if task.parameters | length > 0 -%}
-        parameters={{ task.parameters }},
-        {%+ endif -%}
-        {%+ if task.multipart -%}
-        multipart={{ task.multipart }},
-        {%+ endif -%}
-        {%+ if task.sql_file_path -%}
-        sql_file_path={{ task.sql_file_path | format_repr }},
-        {%+ endif -%}
-        {%+ if task.priority -%}
-        priority_weight={{ task.priority }},
-        {%+ endif -%}
-        {%+ if task.allow_field_addition_on_date -%}
-        allow_field_addition_on_date={{ task.allow_field_addition_on_date | format_repr }},
-        {%+ endif -%}
-        dag=dag,
-    )
+    {% if not task.is_python_script -%}
+        {{ task.task_name }} = bigquery_etl_query(
+            task_id='{{ task.task_name }}',
+            destination_table={%+ if task.destination_table -%}'{{ task.destination_table }}'
+                            {%+ else -%}None
+                            {%+ endif -%},
+            dataset_id='{{ task.dataset }}',
+            project_id='{{ task.project }}',
+            owner='{{ task.owner }}',
+            {%+ if task.email | length > 0 -%}
+            email={{ task.email | sort }},
+            {%+ endif -%}
+            {%+ if task.start_date -%}
+            start_date={{ task.start_date | format_date | format_repr }},
+            {%+ endif -%}
+            {%+ if task.date_partition_parameter == None or task.date_partition_parameter is string -%}
+            date_partition_parameter={{ task.date_partition_parameter | format_optional_string }},
+            {%+ endif -%}
+            depends_on_past={{ task.depends_on_past }},
+            {%+ if task.arguments | length > 0 -%}
+            arguments={{ task.arguments }},
+            {%+ endif -%}
+            {%+ if task.parameters | length > 0 -%}
+            parameters={{ task.parameters }},
+            {%+ endif -%}
+            {%+ if task.multipart -%}
+            multipart={{ task.multipart }},
+            {%+ endif -%}
+            {%+ if task.query_file_path -%}
+            query_file_path={{ task.query_file_path | format_repr }},
+            {%+ endif -%}
+            {%+ if task.priority -%}
+            priority_weight={{ task.priority }},
+            {%+ endif -%}
+            {%+ if task.allow_field_addition_on_date -%}
+            allow_field_addition_on_date={{ task.allow_field_addition_on_date | format_repr }},
+            {%+ endif -%}
+            dag=dag,
+        )
+    {%+ else -%}
+        {{ task.task_name }} = gke_command(
+            task_id='{{ task.task_name }}',
+            command=[
+                'python',
+                '{{ task.query_file_path }}',
+            ] + {{ task.arguments }},
+            docker_image='mozilla/bigquery-etl:latest',
+            owner='{{ task.owner }}',
+            email={{ task.email | sort }},
+        )
+    {% endif -%}
 {% endfor -%}
 
 {% set wait_for_seen = [] -%}

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -13,7 +13,18 @@ default_args = {{
 
 with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None -%}, schedule_interval={{ schedule_interval | format_timedelta | format_schedule_interval }}{%+ endif -%}) as dag:
 {% for task in tasks | sort(attribute='task_name') %}
-    {% if not task.is_python_script -%}
+    {% if task.is_python_script -%}
+        {{ task.task_name }} = gke_command(
+            task_id='{{ task.task_name }}',
+            command=[
+                'python',
+                'sql/{{ task.project }}/{{ task.dataset }}/{{ task.table }}_{{ task.version }}/query.py',
+            ] + {{ task.arguments }},
+            docker_image='mozilla/bigquery-etl:latest',
+            owner='{{ task.owner }}',
+            email={{ task.email | sort }},
+        )
+    {%+ else -%}
         {{ task.task_name }} = bigquery_etl_query(
             task_id='{{ task.task_name }}',
             destination_table={%+ if task.destination_table -%}'{{ task.destination_table }}'
@@ -51,17 +62,6 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             allow_field_addition_on_date={{ task.allow_field_addition_on_date | format_repr }},
             {%+ endif -%}
             dag=dag,
-        )
-    {%+ else -%}
-        {{ task.task_name }} = gke_command(
-            task_id='{{ task.task_name }}',
-            command=[
-                'python',
-                'sql/{{ task.project }}/{{ task.dataset }}/{{ task.table }}_{{ task.version }}/query.py',
-            ] + {{ task.arguments }},
-            docker_image='mozilla/bigquery-etl:latest',
-            owner='{{ task.owner }}',
-            email={{ task.email | sort }},
         )
     {% endif -%}
 {% endfor -%}

--- a/bigquery_etl/run_query.py
+++ b/bigquery_etl/run_query.py
@@ -48,7 +48,7 @@ def run(
     use_public_table = False
 
     try:
-        metadata = Metadata.of_sql_file(query_file)
+        metadata = Metadata.of_query_file(query_file)
         if metadata.is_public_bigquery():
             if not validate_public_data(metadata, query_file):
                 sys.exit(1)

--- a/dags/bqetl_account_ecosystem.py
+++ b/dags/bqetl_account_ecosystem.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "jklukas@mozilla.com",

--- a/dags/bqetl_account_ecosystem.py
+++ b/dags/bqetl_account_ecosystem.py
@@ -54,7 +54,7 @@ with DAG(
         date_partition_parameter=None,
         depends_on_past=True,
         parameters=["submission_date:DATE:{{ds}}"],
-        sql_file_path="sql/moz-fx-data-shared-prod/account_ecosystem_derived/ecosystem_user_id_lookup_v1/script.sql",
+        query_file_path="sql/moz-fx-data-shared-prod/account_ecosystem_derived/ecosystem_user_id_lookup_v1/script.sql",
         dag=dag,
     )
 

--- a/dags/bqetl_activity_stream.py
+++ b/dags/bqetl_activity_stream.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "jklukas@mozilla.com",

--- a/dags/bqetl_addons.py
+++ b/dags/bqetl_addons.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "bmiroglio@mozilla.com",

--- a/dags/bqetl_amo_stats.py
+++ b/dags/bqetl_amo_stats.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "jklukas@mozilla.com",

--- a/dags/bqetl_asn_aggregates.py
+++ b/dags/bqetl_asn_aggregates.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "ascholtz@mozilla.com",

--- a/dags/bqetl_core.py
+++ b/dags/bqetl_core.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "jklukas@mozilla.com",

--- a/dags/bqetl_deletion_request_volume.py
+++ b/dags/bqetl_deletion_request_volume.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "dthorn@mozilla.com",

--- a/dags/bqetl_devtools.py
+++ b/dags/bqetl_devtools.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "jklukas@mozilla.com",

--- a/dags/bqetl_document_sample.py
+++ b/dags/bqetl_document_sample.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "amiyaguchi@mozilla.com",

--- a/dags/bqetl_error_aggregates.py
+++ b/dags/bqetl_error_aggregates.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "bewu@mozilla.com",

--- a/dags/bqetl_experiments_daily.py
+++ b/dags/bqetl_experiments_daily.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "ssuh@mozilla.com",

--- a/dags/bqetl_fenix_event_rollup.py
+++ b/dags/bqetl_fenix_event_rollup.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "frank@mozilla.com",

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "jklukas@mozilla.com",

--- a/dags/bqetl_google_analytics_derived.py
+++ b/dags/bqetl_google_analytics_derived.py
@@ -44,7 +44,7 @@ with DAG(
         date_partition_parameter="submission_date",
         depends_on_past=False,
         parameters=["submission_date:DATE:{{ds}}"],
-        sql_file_path="sql/moz-fx-data-marketing-prod/ga_derived/blogs_empty_check_v1/query.sql",
+        query_file_path="sql/moz-fx-data-marketing-prod/ga_derived/blogs_empty_check_v1/query.sql",
         dag=dag,
     )
 
@@ -105,7 +105,7 @@ with DAG(
         email=["bewu@mozilla.com"],
         date_partition_parameter="submission_date",
         depends_on_past=False,
-        sql_file_path="sql/moz-fx-data-marketing-prod/ga_derived/www_empty_check_v1/query.sql",
+        query_file_path="sql/moz-fx-data-marketing-prod/ga_derived/www_empty_check_v1/query.sql",
         dag=dag,
     )
 

--- a/dags/bqetl_google_analytics_derived.py
+++ b/dags/bqetl_google_analytics_derived.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "bewu@mozilla.com",

--- a/dags/bqetl_gud.py
+++ b/dags/bqetl_gud.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "jklukas@mozilla.com",

--- a/dags/bqetl_internet_outages.py
+++ b/dags/bqetl_internet_outages.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "aplacitelli@mozilla.com",

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -130,7 +130,7 @@ with DAG(
         date_partition_parameter="submission_date",
         depends_on_past=False,
         multipart=True,
-        sql_file_path="sql/moz-fx-data-shared-prod/telemetry_derived/main_summary_v4",
+        query_file_path="sql/moz-fx-data-shared-prod/telemetry_derived/main_summary_v4",
         priority_weight=90,
         allow_field_addition_on_date="2020-11-02",
         dag=dag,

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "dthorn@mozilla.com",

--- a/dags/bqetl_messaging_system.py
+++ b/dags/bqetl_messaging_system.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "najiang@mozilla.com",

--- a/dags/bqetl_mobile_search.py
+++ b/dags/bqetl_mobile_search.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "bewu@mozilla.com",

--- a/dags/bqetl_mozilla_vpn.py
+++ b/dags/bqetl_mozilla_vpn.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "dthorn@mozilla.com",

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "jklukas@mozilla.com",

--- a/dags/bqetl_org_mozilla_fenix_derived.py
+++ b/dags/bqetl_org_mozilla_fenix_derived.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "amiyaguchi@mozilla.com",

--- a/dags/bqetl_search.py
+++ b/dags/bqetl_search.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "bewu@mozilla.com",

--- a/dags/bqetl_ssl_ratios.py
+++ b/dags/bqetl_ssl_ratios.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "chutten@mozilla.com",

--- a/dags/bqetl_stripe.py
+++ b/dags/bqetl_stripe.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "dthorn@mozilla.com",

--- a/dags/bqetl_vrbrowser.py
+++ b/dags/bqetl_vrbrowser.py
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "jklukas@mozilla.com",

--- a/sql/moz-fx-data-marketing-prod/ga_derived/blogs_empty_check_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/blogs_empty_check_v1/metadata.yaml
@@ -8,6 +8,6 @@ owners:
 scheduling:
   dag_name: bqetl_google_analytics_derived
   destination_table: null
-  sql_file_path: sql/moz-fx-data-marketing-prod/ga_derived/blogs_empty_check_v1/query.sql
+  query_file_path: sql/moz-fx-data-marketing-prod/ga_derived/blogs_empty_check_v1/query.sql
   referenced_tables: []
   parameters: ['submission_date:DATE:{{ds}}']

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_empty_check_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_empty_check_v1/metadata.yaml
@@ -8,5 +8,5 @@ owners:
 scheduling:
   dag_name: bqetl_google_analytics_derived
   destination_table: null
-  sql_file_path: sql/moz-fx-data-marketing-prod/ga_derived/www_empty_check_v1/query.sql
+  query_file_path: sql/moz-fx-data-marketing-prod/ga_derived/www_empty_check_v1/query.sql
   referenced_tables: []

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox/event_types_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox/event_types_v1/metadata.yaml
@@ -10,7 +10,7 @@ labels:
 scheduling:
   dag_name: bqetl_fenix_event_rollup
   destination_table: null
-  sql_file_path: 'sql/moz-fx-data-shared-prod/org_mozilla_firefox
+  query_file_path: 'sql/moz-fx-data-shared-prod/org_mozilla_firefox
   /event_types_v1/query.sql'
   referenced_tables: [['moz-fx-data-shared-prod', 'org_mozilla_firefox_derived',
                        'event_types_v1']]

--- a/tests/data/dags/python_script_test_dag
+++ b/tests/data/dags/python_script_test_dag
@@ -20,15 +20,14 @@ with DAG(
     "bqetl_test_dag", default_args=default_args, schedule_interval="@daily"
 ) as dag:
 
-    test__non_incremental_query__v1 = bigquery_etl_query(
-        task_id="test__non_incremental_query__v1",
-        destination_table="non_incremental_query_v1",
-        dataset_id="test",
-        project_id="moz-fx-data-test-project",
+    test__python_script_query__v1 = gke_command(
+        task_id="test__python_script_query__v1",
+        command=[
+            "python",
+            "sql/moz-fx-data-test-project/test/python_script_query_v1/query.py",
+        ]
+        + ["--date", "{{ds}}"],
+        docker_image="mozilla/bigquery-etl:latest",
         owner="test@example.com",
         email=["test@example.com"],
-        date_partition_parameter="submission_date",
-        depends_on_past=True,
-        arguments=["--append_table"],
-        dag=dag,
     )

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "test@example.org",

--- a/tests/data/dags/test_dag_external_dependency
+++ b/tests/data/dags/test_dag_external_dependency
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "test@example.org",

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -3,7 +3,7 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 import datetime
-from utils.gcp import bigquery_etl_query
+from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {
     "owner": "test@example.org",

--- a/tests/data/test_sql/moz-fx-data-test-project/test/python_script_query_v1/metadata.yaml
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/python_script_query_v1/metadata.yaml
@@ -1,0 +1,12 @@
+---
+friendly_name: "Test table for a Python script query"
+description: "Test table for a Python script query"
+owners:
+  - test@mozilla.com
+labels:
+  schedule: daily
+  incremental: false
+scheduling:
+  dag_name: "bqetl_core"
+  depends_on_past: true
+  arguments: ["--date", "{{ds}}"]

--- a/tests/data/test_sql/moz-fx-data-test-project/test/python_script_query_v1/query.py
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/python_script_query_v1/query.py
@@ -1,0 +1,14 @@
+SELECT
+  DATE '2020-03-15' AS d,
+  "val1" AS a,
+  2 AS b
+UNION ALL
+SELECT
+  DATE '2020-03-16' AS d,
+  "val2" AS a,
+  34 AS b
+UNION ALL
+SELECT
+  DATE '2020-03-16' AS d,
+  "val3" AS a,
+  8 AS b

--- a/tests/data/test_sql/moz-fx-data-test-project/test/python_script_query_v1/query.py
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/python_script_query_v1/query.py
@@ -1,14 +1,10 @@
-SELECT
-  DATE '2020-03-15' AS d,
-  "val1" AS a,
-  2 AS b
-UNION ALL
-SELECT
-  DATE '2020-03-16' AS d,
-  "val2" AS a,
-  34 AS b
-UNION ALL
-SELECT
-  DATE '2020-03-16' AS d,
-  "val3" AS a,
-  8 AS b
+"""Python query test script."""
+
+
+def main():
+    """Do main stuff."""
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -90,7 +90,7 @@ class TestParseMetadata(object):
         with pytest.raises(FileNotFoundError):
             Metadata.from_file(metadata_file)
 
-    def test_of_sql_file(self):
+    def test_of_query_file(self):
         metadata_file = (
             TEST_DIR
             / "data"
@@ -100,13 +100,13 @@ class TestParseMetadata(object):
             / "non_incremental_query_v1"
             / "query.sql"
         )
-        metadata = Metadata.of_sql_file(metadata_file)
+        metadata = Metadata.of_query_file(metadata_file)
 
         assert metadata.friendly_name == "Test table for a non-incremental query"
         assert metadata.description == "Test table for a non-incremental query"
         assert metadata.review_bugs() == ["1999999", "12121212"]
 
-    def test_of_sql_file_no_metadata(self):
+    def test_of_query_file_no_metadata(self):
         metadata_file = (
             TEST_DIR
             / "data"
@@ -117,7 +117,7 @@ class TestParseMetadata(object):
             / "query.sql"
         )
         with pytest.raises(FileNotFoundError):
-            Metadata.of_sql_file(metadata_file)
+            Metadata.of_query_file(metadata_file)
 
     def test_of_table(self):
         metadata = Metadata.of_table(

--- a/tests/query_scheduling/test_dag_collection.py
+++ b/tests/query_scheduling/test_dag_collection.py
@@ -315,7 +315,9 @@ class TestDagCollection:
 
         dags.to_airflow_dags(tmp_path)
         result = (tmp_path / "bqetl_test_dag.py").read_text().strip()
-        expected = (TEST_DIR / "data" / "dags" / "python_script_test_dag").read_text().strip()
+        expected = (
+            (TEST_DIR / "data" / "dags" / "python_script_test_dag").read_text().strip()
+        )
 
         assert result == expected
 

--- a/tests/query_scheduling/test_generate_airflow_dags.py
+++ b/tests/query_scheduling/test_generate_airflow_dags.py
@@ -23,4 +23,4 @@ class TestGenerateAirflowDags(object):
         assert events_dag.tasks[1].depends_on_past is False
 
         core_dag = dags.dag_by_name("bqetl_core")
-        assert len(core_dag.tasks) == 2
+        assert len(core_dag.tasks) == 3

--- a/tests/query_scheduling/test_task.py
+++ b/tests/query_scheduling/test_task.py
@@ -77,6 +77,29 @@ class TestTask:
         assert task.multipart
         assert task.query_file_path == os.path.dirname(query_file)
 
+    def test_of_python_script(self):
+        query_file = (
+            TEST_DIR
+            / "data"
+            / "test_sql"
+            / "moz-fx-data-test-project"
+            / "test"
+            / "incremental_query_v1"
+            / "query.sql"
+        )
+
+        task = Task.of_python_script(query_file)
+
+        assert task.query_file == str(query_file)
+        assert task.dataset == "test"
+        assert task.project == "moz-fx-data-test-project"
+        assert task.table == "incremental_query"
+        assert task.version == "v1"
+        assert task.task_name == "test__incremental_query__v1"
+        assert task.dag_name == "bqetl_events"
+        assert task.depends_on_past is False
+        assert task.is_python_script
+
     def test_of_non_existing_query(self):
         with pytest.raises(FileNotFoundError):
             Task.of_query("non_existing_query/query.sql")

--- a/tests/query_scheduling/test_task.py
+++ b/tests/query_scheduling/test_task.py
@@ -75,7 +75,7 @@ class TestTask:
         assert task.dag_name == "bqetl_core"
         assert task.depends_on_past is False
         assert task.multipart
-        assert task.sql_file_path == os.path.dirname(query_file)
+        assert task.query_file_path == os.path.dirname(query_file)
 
     def test_of_non_existing_query(self):
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
This adds support to schedule `query.py` files.

Next step will be to migrate the [monitoring](https://github.com/mozilla/telemetry-airflow/blob/master/dags/monitoring.py) and other telemetry-airflow DAGs to use this instead.