### PR TITLE
Expose mozilla vpn users attribution column to wider audience

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/users_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/users_v1/query.sql
@@ -1,5 +1,6 @@
 SELECT
   fxa_uid,
   created_at,
+  attribution,
 FROM
   mozilla_vpn_external.users_v1


### PR DESCRIPTION
it's needed by data science for analysis

cc @felixlawrence 