### PR TITLE
Bug 1676229 - Add materialized table for missing columns in telemetry dataset

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -181,7 +181,7 @@ class DryRun:
 
     def get_referenced_tables(self):
         """Return referenced tables by dry running the SQL file."""
-        if not self.is_valid() and self.sqlfile not in SKIP:
+        if self.sqlfile not in SKIP and not self.is_valid():
             raise Exception(f"Error when dry running SQL file {self.sqlfile}")
 
         if self.sqlfile in SKIP:

--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -93,6 +93,7 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/mozilla_vpn_external/subscriptions_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_external/waitlist_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/query.sql",
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",  # noqa E501
@@ -180,8 +181,11 @@ class DryRun:
 
     def get_referenced_tables(self):
         """Return referenced tables by dry running the SQL file."""
-        if not self.is_valid():
+        if not self.is_valid() and self.sqlfile not in SKIP:
             raise Exception(f"Error when dry running SQL file {self.sqlfile}")
+
+        if self.sqlfile in SKIP:
+            print(f"Ignoring dryrun results for {self.sqlfile}")
 
         if (
             self.dry_run_result

--- a/dags.yaml
+++ b/dags.yaml
@@ -273,7 +273,7 @@ bqetl_monitoring:
   schedule_interval: 0 2 * * *
   default_args:
     owner: ascholtz@mozilla.com
-    email: ['ascholtz@mozilla.com']
+    email: ['ascholtz@mozilla.com', 'amiyaguchi@mozilla.com']
     start_date: '2018-10-30'
     retries: 2
     retry_delay: 30m

--- a/dags.yaml
+++ b/dags.yaml
@@ -273,7 +273,7 @@ bqetl_monitoring:
   schedule_interval: 0 2 * * *
   default_args:
     owner: ascholtz@mozilla.com
-    email: ['ascholtz@mozilla.com', 'amiyaguchi@mozilla.com']
+    email: ['ascholtz@mozilla.com']
     start_date: '2018-10-30'
     retries: 2
     retry_delay: 30m

--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -8,7 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "ascholtz@mozilla.com",
     "start_date": datetime.datetime(2018, 10, 30, 0, 0),
-    "email": ["ascholtz@mozilla.com", "amiyaguchi@mozilla.com"],
+    "email": ["ascholtz@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),
     "email_on_failure": True,
@@ -29,7 +29,7 @@ with DAG(
         + ["--date", "{{ ds }}"],
         docker_image="mozilla/bigquery-etl:latest",
         owner="ascholtz@mozilla.com",
-        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
+        email=["ascholtz@mozilla.com"],
     )
 
     monitoring__bigquery_etl_scheduled_query_usage__v1 = gke_command(
@@ -41,7 +41,7 @@ with DAG(
         + ["--date", "{{ ds }}"],
         docker_image="mozilla/bigquery-etl:latest",
         owner="ascholtz@mozilla.com",
-        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
+        email=["ascholtz@mozilla.com"],
     )
 
     monitoring__column_size__v1 = gke_command(
@@ -53,7 +53,7 @@ with DAG(
         + ["--date", "{{ ds }}"],
         docker_image="mozilla/bigquery-etl:latest",
         owner="ascholtz@mozilla.com",
-        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
+        email=["ascholtz@mozilla.com"],
     )
 
     monitoring__stable_table_sizes__v1 = gke_command(
@@ -65,7 +65,7 @@ with DAG(
         + ["--date", "{{ ds }}"],
         docker_image="mozilla/bigquery-etl:latest",
         owner="ascholtz@mozilla.com",
-        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
+        email=["ascholtz@mozilla.com"],
     )
 
     monitoring__structured_distinct_docids__v1 = gke_command(
@@ -77,7 +77,7 @@ with DAG(
         + ["--date", "{{ ds }}"],
         docker_image="mozilla/bigquery-etl:latest",
         owner="bewu@mozilla.com",
-        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com", "bewu@mozilla.com"],
+        email=["ascholtz@mozilla.com", "bewu@mozilla.com"],
     )
 
     monitoring__telemetry_distinct_docids__v1 = bigquery_etl_query(
@@ -86,7 +86,7 @@ with DAG(
         dataset_id="monitoring",
         project_id="moz-fx-data-shared-prod",
         owner="bewu@mozilla.com",
-        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com", "bewu@mozilla.com"],
+        email=["ascholtz@mozilla.com", "bewu@mozilla.com"],
         date_partition_parameter="submission_date",
         depends_on_past=False,
         dag=dag,

--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -142,7 +142,3 @@ with DAG(
     monitoring__telemetry_distinct_docids__v1.set_upstream(
         wait_for_copy_deduplicate_main_ping
     )
-
-    monitoring__telemetry_missing_columns__v3.set_upstream(
-        wait_for_copy_deduplicate_copy_deduplicate_main_ping
-    )

--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -142,3 +142,7 @@ with DAG(
     monitoring__telemetry_distinct_docids__v1.set_upstream(
         wait_for_copy_deduplicate_main_ping
     )
+
+    monitoring__telemetry_missing_columns__v3.set_upstream(
+        wait_for_copy_deduplicate_copy_deduplicate_main_ping
+    )

--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -8,7 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "ascholtz@mozilla.com",
     "start_date": datetime.datetime(2018, 10, 30, 0, 0),
-    "email": ["ascholtz@mozilla.com"],
+    "email": ["ascholtz@mozilla.com", "amiyaguchi@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),
     "email_on_failure": True,
@@ -29,7 +29,7 @@ with DAG(
         + ["--date", "{{ ds }}"],
         docker_image="mozilla/bigquery-etl:latest",
         owner="ascholtz@mozilla.com",
-        email=["ascholtz@mozilla.com"],
+        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
     )
 
     monitoring__bigquery_etl_scheduled_query_usage__v1 = gke_command(
@@ -41,7 +41,7 @@ with DAG(
         + ["--date", "{{ ds }}"],
         docker_image="mozilla/bigquery-etl:latest",
         owner="ascholtz@mozilla.com",
-        email=["ascholtz@mozilla.com"],
+        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
     )
 
     monitoring__column_size__v1 = gke_command(
@@ -53,7 +53,7 @@ with DAG(
         + ["--date", "{{ ds }}"],
         docker_image="mozilla/bigquery-etl:latest",
         owner="ascholtz@mozilla.com",
-        email=["ascholtz@mozilla.com"],
+        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
     )
 
     monitoring__stable_table_sizes__v1 = gke_command(
@@ -65,7 +65,7 @@ with DAG(
         + ["--date", "{{ ds }}"],
         docker_image="mozilla/bigquery-etl:latest",
         owner="ascholtz@mozilla.com",
-        email=["ascholtz@mozilla.com"],
+        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
     )
 
     monitoring__structured_distinct_docids__v1 = gke_command(
@@ -77,7 +77,7 @@ with DAG(
         + ["--date", "{{ ds }}"],
         docker_image="mozilla/bigquery-etl:latest",
         owner="bewu@mozilla.com",
-        email=["ascholtz@mozilla.com", "bewu@mozilla.com"],
+        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com", "bewu@mozilla.com"],
     )
 
     monitoring__telemetry_distinct_docids__v1 = bigquery_etl_query(
@@ -86,7 +86,19 @@ with DAG(
         dataset_id="monitoring",
         project_id="moz-fx-data-shared-prod",
         owner="bewu@mozilla.com",
-        email=["ascholtz@mozilla.com", "bewu@mozilla.com"],
+        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com", "bewu@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    monitoring__telemetry_missing_columns__v3 = bigquery_etl_query(
+        task_id="monitoring__telemetry_missing_columns__v3",
+        destination_table="telemetry_missing_columns_v3",
+        dataset_id="monitoring",
+        project_id="moz-fx-data-shared-prod",
+        owner="amiyaguchi@mozilla.com",
+        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
         date_partition_parameter="submission_date",
         depends_on_past=False,
         dag=dag,

--- a/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/metadata.yaml
@@ -1,0 +1,12 @@
+---
+friendly_name: Telemetry Missing Columns
+description: >
+  Enumerated paths in additional properties for the Telemetry namespace. This
+  excludes the main ping and its variants for the sake of efficiency.
+owners:
+  - amiyaguchi@mozilla.com
+labels:
+  schedule: daily
+  incremental: false
+scheduling:
+  dag_name: bqetl_monitoring

--- a/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/metadata.yaml
@@ -10,3 +10,7 @@ labels:
   incremental: false
 scheduling:
   dag_name: bqetl_monitoring
+  depends_on:
+    - task_id: copy_deduplicate_main_ping
+      dag_name: copy_deduplicate
+      execution_delta: 1h

--- a/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/metadata.yaml
@@ -10,7 +10,3 @@ labels:
   incremental: false
 scheduling:
   dag_name: bqetl_monitoring
-  depends_on:
-    - task_id: copy_deduplicate_main_ping
-      dag_name: copy_deduplicate
-      execution_delta: 1h

--- a/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/query.sql
@@ -1,0 +1,61 @@
+WITH placeholder_table_names AS (
+  SELECT
+    DISTINCT table_name
+  FROM
+    `moz-fx-data-shared-prod`.telemetry_stable.INFORMATION_SCHEMA.TABLE_OPTIONS
+  WHERE
+    option_value LIKE '%placeholder_schema%'
+),
+extracted AS (
+  SELECT
+    TIMESTAMP_TRUNC(submission_timestamp, DAY) AS day,
+    'telemetry' AS document_namespace,
+    `moz-fx-data-shared-prod`.udf.extract_document_type(_TABLE_SUFFIX) AS document_type,
+    `moz-fx-data-shared-prod`.udf.extract_document_version(_TABLE_SUFFIX) AS document_version,
+    additional_properties
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.*`
+  WHERE
+    -- only observe full days of data
+    DATE(submission_timestamp) = DATE_SUB(current_date, INTERVAL 1 day)
+    -- https://cloud.google.com/bigquery/docs/querying-wildcard-tables#filtering_selected_tables_using_table_suffix
+    -- exclude pings derived from main schema to save on space, 300GB vs 3TB
+    AND _TABLE_SUFFIX NOT IN ('main_v4', 'saved_session_v4', 'first_shutdown_v4')
+    AND _TABLE_SUFFIX NOT IN (SELECT * FROM placeholder_table_names)
+)
+SELECT
+  * EXCEPT (additional_properties),
+  COUNT(*) AS path_count
+FROM
+  extracted,
+  UNNEST(
+    `moz-fx-data-shared-prod`.udf_js.json_extract_missing_cols(
+      additional_properties,
+      [],
+        -- Manually curated list of known missing sections. The process to
+        -- generate list is to change the project for the live table to
+        -- moz-fx-data-shar-nonprod-efed to obtain a 1% sample. Run this query
+        -- except with the following list empty. This generates a total of
+        -- O(1e5) total distinct (document, path) rows. All nodes with a large
+        -- number of subpaths are added to the following list, e.g. activeAddons
+        -- or histograms. The list is then curated such that there are
+        -- approximately less than 1000 distinct paths.
+      [
+          -- common environment
+        "activeAddons",
+        "userPrefs",
+        "experiments",
+          -- common measures
+        "keyedScalars",
+        "scalars",
+        "histograms",
+        "keyedHistograms"
+      ]
+    )
+  ) AS path
+GROUP BY
+  day,
+  document_namespace,
+  document_type,
+  document_version,
+  path


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1676229)

This generates missing paths in the telemetry namespace using table globs. This doesn't work with the new table ACLs, so one way of getting around this is to schedule it via Airflow. I can't think of a great way to test this, I'm relying on the fact that this has already been around in `telemetry_missing_columns_v2`. 