### PR TITLE
Add init for telemetry_missing_columns_v3

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/init.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.monitoring.telemetry_missing_columns_v3`(
+    submission_date DATE,
+    document_namespace STRING,
+    document_type STRING,
+    document_version STRING,
+    path STRING,
+    path_count INT64
+  )
+PARTITION BY
+  submission_date

--- a/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns_v3/query.sql
@@ -8,7 +8,7 @@ WITH placeholder_table_names AS (
 ),
 extracted AS (
   SELECT
-    TIMESTAMP_TRUNC(submission_timestamp, DAY) AS day,
+    @submission_date AS submission_date,
     'telemetry' AS document_namespace,
     `moz-fx-data-shared-prod`.udf.extract_document_type(_TABLE_SUFFIX) AS document_type,
     `moz-fx-data-shared-prod`.udf.extract_document_version(_TABLE_SUFFIX) AS document_version,
@@ -17,21 +17,22 @@ extracted AS (
     `moz-fx-data-shared-prod.telemetry_stable.*`
   WHERE
     -- only observe full days of data
-    DATE(submission_timestamp) = DATE_SUB(current_date, INTERVAL 1 day)
+    DATE(submission_timestamp) = @submission_date
     -- https://cloud.google.com/bigquery/docs/querying-wildcard-tables#filtering_selected_tables_using_table_suffix
     -- exclude pings derived from main schema to save on space, 300GB vs 3TB
     AND _TABLE_SUFFIX NOT IN ('main_v4', 'saved_session_v4', 'first_shutdown_v4')
     AND _TABLE_SUFFIX NOT IN (SELECT * FROM placeholder_table_names)
-)
-SELECT
-  * EXCEPT (additional_properties),
-  COUNT(*) AS path_count
-FROM
-  extracted,
-  UNNEST(
-    `moz-fx-data-shared-prod`.udf_js.json_extract_missing_cols(
-      additional_properties,
-      [],
+),
+transformed AS (
+  SELECT
+    * EXCEPT (additional_properties),
+    COUNT(*) AS path_count
+  FROM
+    extracted,
+    UNNEST(
+      `moz-fx-data-shared-prod`.udf_js.json_extract_missing_cols(
+        additional_properties,
+        [],
         -- Manually curated list of known missing sections. The process to
         -- generate list is to change the project for the live table to
         -- moz-fx-data-shar-nonprod-efed to obtain a 1% sample. Run this query
@@ -40,22 +41,32 @@ FROM
         -- number of subpaths are added to the following list, e.g. activeAddons
         -- or histograms. The list is then curated such that there are
         -- approximately less than 1000 distinct paths.
-      [
+        [
           -- common environment
-        "activeAddons",
-        "userPrefs",
-        "experiments",
+          "activeAddons",
+          "userPrefs",
+          "experiments",
           -- common measures
-        "keyedScalars",
-        "scalars",
-        "histograms",
-        "keyedHistograms"
-      ]
-    )
-  ) AS path
-GROUP BY
-  day,
+          "keyedScalars",
+          "scalars",
+          "histograms",
+          "keyedHistograms"
+        ]
+      )
+    ) AS path
+  GROUP BY
+    submission_date,
+    document_namespace,
+    document_type,
+    document_version,
+    path
+)
+SELECT
+  submission_date,
   document_namespace,
   document_type,
   document_version,
-  path
+  path,
+  path_count
+FROM
+  transformed


### PR DESCRIPTION
This is a followup for #1551, which failed when running:

```bash
[2020-11-13 19:33:59,363] {pod_launcher.py:173} INFO - Event: monitoring--telemetry-missing-columns--v3-ebb05ca922b241629d1ead91cd0e4611 had an event of type Running
[2020-11-13 19:34:02,637] {pod_launcher.py:156} INFO - b"BigQuery error in query operation: Error processing job 'moz-fx-data-shared-\n"
[2020-11-13 19:34:02,638] {pod_launcher.py:156} INFO - b"prod:bqjob_r3a02ea7452eb5325_00000175c319af0d_1': Partitioning specification\n"
[2020-11-13 19:34:02,640] {pod_launcher.py:156} INFO - b'must be provided in order to create partitioned table\n'
[2020-11-13 19:34:02,846] {pod_launcher.py:156} INFO - b'Traceback (most recent call last):\n'
[2020-11-13 19:34:02,847] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/runpy.py", line 194, in _run_module_as_main\n'
[2020-11-13 19:34:02,847] {pod_launcher.py:156} INFO - b'    return _run_code(code, main_globals, None,\n'
[2020-11-13 19:34:02,847] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/runpy.py", line 87, in _run_code\n'
[2020-11-13 19:34:02,847] {pod_launcher.py:156} INFO - b'    exec(code, run_globals)\n'
[2020-11-13 19:34:02,847] {pod_launcher.py:156} INFO - b'  File "/app/bigquery_etl/run_query.py", line 107, in <module>\n'
[2020-11-13 19:34:02,848] {pod_launcher.py:156} INFO - b'    main()\n'
[2020-11-13 19:34:02,848] {pod_launcher.py:156} INFO - b'  File "/app/bigquery_etl/run_query.py", line 97, in main\n'
[2020-11-13 19:34:02,848] {pod_launcher.py:156} INFO - b'    run(\n'
[2020-11-13 19:34:02,848] {pod_launcher.py:156} INFO - b'  File "/app/bigquery_etl/run_query.py", line 91, in run\n'
[2020-11-13 19:34:02,848] {pod_launcher.py:156} INFO - b'    subprocess.check_call(["bq"] + query_arguments, stdin=query_stream)\n'
[2020-11-13 19:34:02,848] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/subprocess.py", line 364, in check_call\n'
[2020-11-13 19:34:02,848] {pod_launcher.py:156} INFO - b'    raise CalledProcessError(retcode, cmd)\n'
```