### PR TITLE
Materialize dataset for schema error counts

### DIFF
--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -56,6 +56,18 @@ with DAG(
         email=["ascholtz@mozilla.com"],
     )
 
+    monitoring__schema_error_counts__v2 = bigquery_etl_query(
+        task_id="monitoring__schema_error_counts__v2",
+        destination_table="schema_error_counts_v2",
+        dataset_id="monitoring",
+        project_id="moz-fx-data-shared-prod",
+        owner="amiyaguchi@mozilla.com",
+        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
     monitoring__stable_table_sizes__v1 = gke_command(
         task_id="monitoring__stable_table_sizes__v1",
         command=[

--- a/sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v2/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v2/init.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.monitoring.schema_error_counts_v2`(
+    submission_date DATE,
+    document_namespace STRING,
+    document_type STRING,
+    document_version STRING,
+    hour TIMESTAMP,
+    job_name STRING,
+    path STRING,
+    error_count INT64
+  )
+PARTITION BY
+  submission_date
+CLUSTER BY
+  document_namespace,
+  document_type,
+  path,
+  job_name

--- a/sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v2/metadata.yaml
@@ -1,0 +1,11 @@
+---
+friendly_name: Schema Error Counts
+description: >
+  Counts the number of schema errors in the error stream per hour.
+owners:
+  - amiyaguchi@mozilla.com
+labels:
+  schedule: daily
+  incremental: false
+scheduling:
+  dag_name: bqetl_monitoring

--- a/sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v2/metadata.yaml
@@ -6,6 +6,6 @@ owners:
   - amiyaguchi@mozilla.com
 labels:
   schedule: daily
-  incremental: false
+  incremental: true
 scheduling:
   dag_name: bqetl_monitoring

--- a/sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v2/query.sql
@@ -1,0 +1,42 @@
+WITH extracted AS (
+  SELECT
+    TIMESTAMP_TRUNC(submission_timestamp, HOUR) AS hour,
+    job_name,
+    document_namespace,
+    document_type,
+    document_version,
+    error_message
+  FROM
+    `moz-fx-data-shared-prod.payload_bytes_error.*`
+  WHERE
+    date(submission_timestamp) = @submission_date
+    AND exception_class = 'org.everit.json.schema.ValidationException'
+),
+count_errors AS (
+  SELECT
+    document_namespace,
+    document_type,
+    document_version,
+    hour,
+    job_name,
+    `moz-fx-data-shared-prod.udf.extract_schema_validation_path`(error_message) AS path,
+    COUNT(*) AS error_count
+  FROM
+    extracted
+  GROUP BY
+    document_namespace,
+    document_type,
+    document_version,
+    hour,
+    job_name,
+    path
+)
+SELECT
+  @submission_date AS submission_date,
+  *
+FROM
+  count_errors
+ORDER BY
+  document_namespace,
+  document_type,
+  hour


### PR DESCRIPTION
This adds a new materialized table for schema errors. 

I want to materialize this data to use for the normalized schema error counts, which costs ~500gb per run. https://sql.telemetry.mozilla.org/queries/69311/source