### PR TITLE
Add query for structured missing columns

### DIFF
--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -92,6 +92,18 @@ with DAG(
         email=["ascholtz@mozilla.com", "bewu@mozilla.com"],
     )
 
+    monitoring__structured_missing_columns__v1 = gke_command(
+        task_id="monitoring__structured_missing_columns__v1",
+        command=[
+            "python",
+            "sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/query.py",
+        ]
+        + ["--date", "{{ ds }}"],
+        docker_image="mozilla/bigquery-etl:latest",
+        owner="amiyaguchi@mozilla.com",
+        email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
+    )
+
     monitoring__telemetry_distinct_docids__v1 = bigquery_etl_query(
         task_id="monitoring__telemetry_distinct_docids__v1",
         destination_table="telemetry_distinct_docids_v1",
@@ -146,6 +158,10 @@ with DAG(
     )
     monitoring__structured_distinct_docids__v1.set_upstream(
         wait_for_copy_deduplicate_main_ping
+    )
+
+    monitoring__structured_missing_columns__v1.set_upstream(
+        wait_for_copy_deduplicate_all
     )
 
     monitoring__telemetry_distinct_docids__v1.set_upstream(

--- a/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/init.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.monitoring.structured_missing_columns_v1`(
+    submission_date DATE,
+    document_namespace STRING,
+    document_type STRING,
+    document_version STRING,
+    path STRING,
+    path_count INT64
+  )
+PARTITION BY
+  submission_date

--- a/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/metadata.yaml
@@ -1,0 +1,20 @@
+---
+friendly_name: Structured Distinct Document IDs
+description: >
+  Compares number of document IDs in structured decoded, live,
+  and stable tables.
+owners:
+  - bewu@mozilla.com
+labels:
+  schedule: daily
+  incremental: true
+scheduling:
+  dag_name: bqetl_monitoring
+  arguments: ["--date", "{{ ds }}"]
+  referenced_tables:
+    - ['moz-fx-data-shared-prod', 
+       'payload_bytes_decoded', 
+       'structured_*']
+    - ['moz-fx-data-shared-prod', 'payload_bytes_decoded', 'stub_installer_*']
+    - ['moz-fx-data-shared-prod', '*_stable', '*']
+    - ['moz-fx-data-shared-prod', 'telemetry_stable', 'main_v4']

--- a/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/metadata.yaml
@@ -1,10 +1,9 @@
 ---
-friendly_name: Structured Distinct Document IDs
+friendly_name: Structured missing columns
 description: >
-  Compares number of document IDs in structured decoded, live,
-  and stable tables.
+  Generates the list of missing columns in structured datasets.
 owners:
-  - bewu@mozilla.com
+  - amiyaguchi@mozilla.com
 labels:
   schedule: daily
   incremental: true
@@ -12,9 +11,4 @@ scheduling:
   dag_name: bqetl_monitoring
   arguments: ["--date", "{{ ds }}"]
   referenced_tables:
-    - ['moz-fx-data-shared-prod', 
-       'payload_bytes_decoded', 
-       'structured_*']
-    - ['moz-fx-data-shared-prod', 'payload_bytes_decoded', 'stub_installer_*']
     - ['moz-fx-data-shared-prod', '*_stable', '*']
-    - ['moz-fx-data-shared-prod', 'telemetry_stable', 'main_v4']

--- a/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/query.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+"""Compare number of document IDs in structured decoded, live, and stable tables."""
+import datetime
+from argparse import ArgumentParser
+from collections import defaultdict
+
+from google.cloud import bigquery
+
+NAMESPACE_QUERY = """
+SELECT
+  schema_name
+FROM
+  `moz-fx-data-shared-prod`.INFORMATION_SCHEMA.SCHEMATA
+WHERE
+  schema_name LIKE "%_stable"
+  AND schema_name NOT LIKE "%telemetry%"
+ORDER BY
+  schema_name
+"""
+
+QUERY = """
+-- missing columns {date} {namespace};
+WITH extracted AS (
+  SELECT
+    DATE "{date}" AS submission_date,
+    "{namespace}" AS document_namespace,
+    `moz-fx-data-shared-prod`.udf.extract_document_type(_TABLE_SUFFIX) AS document_type,
+    `moz-fx-data-shared-prod`.udf.extract_document_version(_TABLE_SUFFIX) AS document_version,
+    additional_properties
+  FROM
+    `moz-fx-data-shared-prod.{namespace}_stable.*`
+  WHERE
+    -- only observe full days of data
+    DATE(submission_timestamp) = date "{date}"
+    -- https://cloud.google.com/bigquery/docs/querying-wildcard-tables#filtering_selected_tables_using_table_suffix
+    -- IT's also possible to exclude tables in this query
+    -- AND _TABLE_SUFFIX NOT IN ('main_v4', 'saved_session_v4', 'first_shutdown_v4')
+),
+transformed AS (
+  SELECT
+    * EXCEPT (additional_properties),
+    COUNT(*) AS path_count
+  FROM
+    extracted,
+    UNNEST(
+      `moz-fx-data-shared-prod`.udf_js.json_extract_missing_cols(
+        additional_properties,
+        [],
+        -- TODO: manually curate known missing schema bits
+        []
+      )
+    ) AS path
+  GROUP BY
+    submission_date,
+    document_namespace,
+    document_type,
+    document_version,
+    path
+)
+SELECT
+  submission_date,
+  document_namespace,
+  document_type,
+  document_version,
+  path,
+  path_count
+FROM
+  transformed
+"""
+
+# handy query for table sizes, although some tables should have less additional
+# properties than others.
+"""
+select *, round(byte_size/pow(1024,3), 2) as gb_size
+from monitoring.stable_table_sizes_v1
+where submission_date = "2020-11-11"
+and dataset_id <> "telemetry_stable"
+order by gb_size desc
+"""
+
+
+def structured_missing_columns(date, project, destination_dataset, destination_table):
+    """Get missing columns for structured ingestion."""
+    client = bigquery.Client(project=project)
+    print("Getting the list of namespaces...")
+    namespaces = [
+        row.schema_name.split("_stable")[0]
+        for row in client.query(NAMESPACE_QUERY).result()
+        # NOTE: making an exception for this namespace, because it's large.
+        if row.schema_name != "activity_stream_stable"
+    ]
+    print(namespaces)
+
+    for i, namespace in enumerate(namespaces[:10]):
+        print(f"Running job for {namespace}")
+        client.query(
+            QUERY.format(date=date, namespace=namespace),
+            job_config=bigquery.QueryJobConfig(
+                time_partitioning=bigquery.TimePartitioning(field="submission_date"),
+                create_disposition=bigquery.CreateDisposition.CREATE_IF_NEEDED,
+                write_disposition=(
+                    bigquery.WriteDisposition.WRITE_TRUNCATE
+                    if i == 0
+                    else bigquery.WriteDisposition.WRITE_APPEND
+                ),
+                destination=(
+                    f"{project}.{destination_dataset}.{destination_table}"
+                    f"${date.strftime('%Y%m%d')}"
+                ),
+            ),
+        ).result()
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--date", type=datetime.date.fromisoformat, required=True)
+    parser.add_argument("--project", default="moz-fx-data-shared-prod")
+    parser.add_argument("--destination-dataset", default="monitoring")
+    parser.add_argument("--destination-table", default="structured_missing_columns_v1")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    structured_missing_columns(
+        args.date,
+        args.project,
+        args.destination_dataset,
+        args.destination_table,
+    )

--- a/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/query.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""Compare number of document IDs in structured decoded, live, and stable tables."""
+"""Generates the list of missing columns in structured datasets."""
 import datetime
 import json
 from argparse import ArgumentParser
@@ -90,8 +90,6 @@ def structured_missing_columns(
     namespaces = [
         row.schema_name.split("_stable")[0]
         for row in client.query(NAMESPACE_QUERY).result()
-        # NOTE: making an exception for this namespace, because it's large.
-        if row.schema_name != "activity_stream_stable"
     ]
     print(namespaces)
 

--- a/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1/query.py
@@ -70,16 +70,6 @@ FROM
   transformed
 """
 
-# handy query for table sizes, although some tables should have less additional
-# properties than others.
-"""
-select *, round(byte_size/pow(1024,3), 2) as gb_size
-from monitoring.stable_table_sizes_v1
-where submission_date = "2020-11-11"
-and dataset_id <> "telemetry_stable"
-order by gb_size desc
-"""
-
 
 def structured_missing_columns(
     date, project, destination_dataset, destination_table, skip_exceptions


### PR DESCRIPTION
This adds structured missing columns in the same fashion as `monitoring.telemetry_missing_columns_v3`.  I set this up in a sandbox project and ran it like so:

```bash
cd sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns_v1
python query.py --project amiyaguchi-dev --date 2020-11-14 --skip-exceptions
```

The data scanned in mb, with exceptions for tables without permissions.

```json
{
  "activity_stream": 53438.7,
  "burnham": 0.0,
  "coverage": 0.0,
  "default_browser_agent": 746.3,
  "edge_validator": 0.0,
  "eng_workflow": 0.1,
  "firefox_desktop": 2.9,
  "firefox_installer": 12.6,
  "firefox_launcher_process": 23.8,
  "glean_js_tmp": 0.0,
  "messaging_system": 13138.2,
  "mobile": 1.2,
  "mozdata": 0.0,
  "mozilla_lockbox": 0.6,
  "mozilla_mach": 0.0,
  "mozphab": 0.0,
  "mozza": 0.0,
  "org_mozilla_connect_firefox": 8.6,
  "org_mozilla_fenix_nightly": 0.3,
  "org_mozilla_fenix": 31.5,
  "org_mozilla_fennec_aurora": 1.7,
  "org_mozilla_firefox_beta": 70.3,
  "org_mozilla_firefox": 2768.2,
  "org_mozilla_firefoxreality": 0.0,
  "org_mozilla_ios_fennec": 0.0,
  "org_mozilla_ios_firefox": 320.5,
  "org_mozilla_ios_firefoxbeta": 0.1,
  "org_mozilla_ios_lockbox": 0.1,
  "org_mozilla_mozregression": 0.0,
  "org_mozilla_reference_browser": 0.2,
  "org_mozilla_tv_firefox": 11.1,
  "org_mozilla_vrbrowser": 0.9,
  "pocket": 1.1,
  "webpagetest": 0.0
}
```
