### PR TITLE
Remove ordering clause in schema error counts

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v2/query.sql
@@ -36,7 +36,3 @@ SELECT
   *
 FROM
   count_errors
-ORDER BY
-  document_namespace,
-  document_type,
-  hour


### PR DESCRIPTION
Apparently, you cannot write into a clustered table if the query is ordered. 

```
[2020-11-17 19:56:06,125] {pod_launcher.py:173} INFO - Event: monitoring--schema-error-counts--v2-a1f3d02736144587a735dd99951f804e had an event of type Running
[2020-11-17 19:56:09,321] {pod_launcher.py:156} INFO - b'\rWaiting on bqjob_r184a361726ed5818_00000175d7c759d1_1 ... (0s) Current status: RUNNING\r                                                                                      \rWaiting on bqjob_r184a361726ed5818_00000175d7c759d1_1 ... (0s) Current status: DONE   \n'
[2020-11-17 19:56:09,322] {pod_launcher.py:156} INFO - b"Error in query string: Error processing job 'moz-fx-data-shared-\n"
[2020-11-17 19:56:09,322] {pod_launcher.py:156} INFO - b"prod:bqjob_r184a361726ed5818_00000175d7c759d1_1': Result of ORDER BY queries\n"
[2020-11-17 19:56:09,322] {pod_launcher.py:156} INFO - b'cannot be clustered.\n'
```