### PR TITLE
Bug fix for days_interacted_bits in clients_last_seen

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/query.sql
@@ -102,7 +102,7 @@ SELECT
       _previous.days_opened_dev_tools_bits,
       _current.days_opened_dev_tools_bits
     ) AS days_opened_dev_tools_bits,
-    udf.coalesce_adjacent_days_28_bits(
+    udf.combine_adjacent_days_28_bits(
       _previous.days_interacted_bits,
       _current.days_interacted_bits
     ) AS days_interacted_bits,


### PR DESCRIPTION
As uncovered in https://bugzilla.mozilla.org/show_bug.cgi?id=1677609#c9
this field only ever had a single bit set because it was using the wrong UDF
for combining days.