### PR TITLE
Bug 1678344 - Add attribution source and ua to onboarding_events_amplitude

### DIFF
--- a/sql/moz-fx-data-shared-prod/messaging_system/onboarding_events_amplitude/view.sql
+++ b/sql/moz-fx-data-shared-prod/messaging_system/onboarding_events_amplitude/view.sql
@@ -24,7 +24,9 @@ SELECT
     STRUCT(
       locale,
       release_channel,
-      ARRAY(SELECT CONCAT(key, " - ", value.branch) FROM UNNEST(experiments)) AS experiments
+      ARRAY(SELECT CONCAT(key, " - ", value.branch) FROM UNNEST(experiments)) AS experiments,
+      attribution.source AS attribution_source,
+      attribution.ua AS attribution_ua
     )
   ) AS user_properties
 FROM


### PR DESCRIPTION
This fixes bug [1678344](https://bugzilla.mozilla.org/show_bug.cgi?id=1678344).

Note that we don't need to do the backfilling here since attribution is a new collection.