### PR TITLE
Fix mozilla vpn waitlist update logic

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/waitlist_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/waitlist_v1/init.sql
@@ -6,7 +6,4 @@ AS
 SELECT
   *
 FROM
-  EXTERNAL_QUERY(
-    "moz-fx-guardian-prod-bfc7.us.guardian-sql-prod",
-    "SELECT * FROM vpn_waitlist LIMIT 0;"
-  )
+  EXTERNAL_QUERY("moz-fx-guardian-prod-bfc7.us.guardian-sql-prod", "SELECT * FROM vpn_waitlist")

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/waitlist_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/waitlist_v1/query.sql
@@ -1,5 +1,5 @@
 SELECT
-  COALESCE(_update, waitlist_v1).*
+  IF(_update.id IS NOT NULL, _update, waitlist_v1).*
 FROM
   EXTERNAL_QUERY(
     "moz-fx-guardian-prod-bfc7.us.guardian-sql-prod",


### PR DESCRIPTION
in a join, the table alias is never NULL, only the contents, so using `COALESCE` was causing all rows not updated to have all-null columns.