### PR TITLE
Bug 1677609 Add first_seen and core active to clients_last_seen view

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen_v1/view.sql
@@ -100,15 +100,15 @@ SELECT
     'other'
   END
   AS activity_segments_v1,
-  --     0x7f = mozfun.bits28.from_string('0000000000000000000001111111')
+  --     0x7F = mozfun.bits28.from_string('0000000000000000000001111111')
   days_since_created_profile = 6
-  AND BIT_COUNT(days_seen_bits & 0x7f) >= 5 AS new_profile_7_day_activated_v1,
-  --   0x3fff = mozfun.bits28.from_string('0000000000000011111111111111')
+  AND BIT_COUNT(days_seen_bits & 0x7F) >= 5 AS new_profile_7_day_activated_v1,
+  --   0x3FFF = mozfun.bits28.from_string('0000000000000011111111111111')
   days_since_created_profile = 13
-  AND BIT_COUNT(days_seen_bits & 0x3fff) >= 8 AS new_profile_14_day_activated_v1,
-  -- 0x1fffff = mozfun.bits28.from_string('0000000111111111111111111111')
+  AND BIT_COUNT(days_seen_bits & 0x3FFF) >= 8 AS new_profile_14_day_activated_v1,
+  -- 0x1FFFFF = mozfun.bits28.from_string('0000000111111111111111111111')
   days_since_created_profile = 20
-  AND BIT_COUNT(days_seen_bits & 0x1fffff) >= 12 AS new_profile_21_day_activated_v1,
+  AND BIT_COUNT(days_seen_bits & 0x1FFFFF) >= 12 AS new_profile_21_day_activated_v1,
   * EXCEPT (
     active_experiment_id,
     scalar_parent_dom_contentprocess_troubled_due_to_memory_sum,

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen_v1/view.sql
@@ -100,15 +100,21 @@ SELECT
     'other'
   END
   AS activity_segments_v1,
-  --     0x7F = mozfun.bits28.from_string('0000000000000000000001111111')
-  days_since_created_profile = 6
-  AND BIT_COUNT(days_seen_bits & 0x7F) >= 5 AS new_profile_7_day_activated_v1,
-  --   0x3FFF = mozfun.bits28.from_string('0000000000000011111111111111')
-  days_since_created_profile = 13
-  AND BIT_COUNT(days_seen_bits & 0x3FFF) >= 8 AS new_profile_14_day_activated_v1,
-  -- 0x1FFFFF = mozfun.bits28.from_string('0000000111111111111111111111')
-  days_since_created_profile = 20
-  AND BIT_COUNT(days_seen_bits & 0x1FFFFF) >= 12 AS new_profile_21_day_activated_v1,
+  (
+    days_since_first_seen = 6
+    -- 0x7F = mozfun.bits28.from_string('0000000000000000000001111111')
+    AND BIT_COUNT(days_seen_bits & 0x7F) >= 5
+  ) AS new_profile_7_day_activated_v1,
+  (
+    days_since_first_seen = 13
+    -- 0x3FFF = mozfun.bits28.from_string('0000000000000011111111111111')
+    AND BIT_COUNT(days_seen_bits & 0x3FFF) >= 8
+  ) AS new_profile_14_day_activated_v1,
+  (
+    days_since_first_seen = 20
+    -- 0x1FFFFF = mozfun.bits28.from_string('0000000111111111111111111111')
+    AND BIT_COUNT(days_seen_bits & 0x1FFFFF) >= 12
+  ) AS new_profile_21_day_activated_v1,
   * EXCEPT (
     active_experiment_id,
     scalar_parent_dom_contentprocess_troubled_due_to_memory_sum,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/query.sql
@@ -11,16 +11,14 @@ WITH _current AS (
     -- https://docs.telemetry.mozilla.org/cookbooks/active_dau.html
     CAST(
       scalar_parent_browser_engagement_total_uri_count_sum >= 1 AS INT64
-    ) AS days_visited_1_uri_bits, -- Added 2020-11
+    ) AS days_visited_1_uri_bits,
     CAST(
       scalar_parent_browser_engagement_total_uri_count_sum >= 5 AS INT64
     ) AS days_visited_5_uri_bits,
     CAST(
       scalar_parent_browser_engagement_total_uri_count_sum >= 10 AS INT64
-    ) AS days_visited_10_uri_bits, -- Added 2020-11
-    CAST(
-      active_hours_sum >= 0.011 AS INT64
-    ) AS days_had_8_active_ticks_bits, -- Added 2020-11
+    ) AS days_visited_10_uri_bits,
+    CAST(active_hours_sum >= 0.011 AS INT64) AS days_had_8_active_ticks_bits,
     CAST(devtools_toolbox_opened_count_sum > 0 AS INT64) AS days_opened_dev_tools_bits,
     CAST(active_hours_sum > 0 AS INT64) AS days_interacted_bits,
     -- We only trust profile_date if it is within one week of the ping submission,


### PR DESCRIPTION
Follow-up to https://github.com/mozilla/bigquery-etl/pull/1561 now that the backfill is complete.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1677609