### PR TITLE
Add event-based usage criteria to clients_last_seen

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/query.sql
@@ -66,7 +66,7 @@ _previous AS (
       -- Event-based criteria
       days_logged_event_bits,
       days_viewed_protection_report_bits,
-      days_used_pip_bits,
+      days_used_picture_in_picture_bits,
       days_had_cert_error_bits,
       -- Dates
       submission_date,
@@ -95,7 +95,7 @@ SELECT
   IF(cfs.second_seen_date > @submission_date, NULL, cfs.second_seen_date) AS second_seen_date,
   els.days_logged_event_bits,
   els.days_viewed_protection_report_bits,
-  els.days_used_pip_bits,
+  els.days_used_picture_in_picture_bits,
   els.days_had_cert_error_bits,
   IF(_current.client_id IS NOT NULL, _current, _previous).* REPLACE (
     udf.combine_adjacent_days_28_bits(
@@ -141,10 +141,15 @@ FULL JOIN
   _previous
 USING
   (client_id)
+-- We join with events_last_seen to get usage patterns based on event pings.
+-- Note that this left join will ignore clients that haven't sent a main ping,
+-- meaning that we won't show event usage if it appears on the submission_date
+-- before a client's first main ping is sent.
 LEFT JOIN
   events_last_seen AS els
 USING
   (client_id)
+-- We join with clients_first_seen to get first_seen_date over all time.
 LEFT JOIN
   clients_first_seen_v1 AS cfs
 USING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_last_seen_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_last_seen_v1/init.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.telemetry_derived.events_last_seen_v1`
+PARTITION BY
+  submission_date
+CLUSTER BY
+  sample_id
+AS
+SELECT
+  submission_date,
+  sample_id,
+  client_id,
+  CAST(FALSE AS INT64) AS days_logged_event_bits,
+  CAST(FALSE AS INT64) AS days_viewed_protection_report_bits,
+  CAST(FALSE AS INT64) AS days_used_pip_bits,
+  CAST(FALSE AS INT64) AS days_had_cert_error_bits,
+FROM
+  telemetry.events
+WHERE
+  FALSE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_last_seen_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_last_seen_v1/init.sql
@@ -11,7 +11,7 @@ SELECT
   client_id,
   CAST(FALSE AS INT64) AS days_logged_event_bits,
   CAST(FALSE AS INT64) AS days_viewed_protection_report_bits,
-  CAST(FALSE AS INT64) AS days_used_pip_bits,
+  CAST(FALSE AS INT64) AS days_used_picture_in_picture_bits,
   CAST(FALSE AS INT64) AS days_had_cert_error_bits,
 FROM
   telemetry.events

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_last_seen_v1/metadata.yaml
@@ -1,0 +1,13 @@
+friendly_name: Events Last Seen
+description: >
+  Used to define bit patterns on top of events that represent usage of desktop
+  features over 28-day windows. Includes no dimensions, since these fields are intended
+  to be joined in as part of the clients_last_seen query.
+
+  Note that the join with clients_last_seen is a LEFT JOIN to avoid allowing rows
+  where no main pings have been seen. As a result, clients_last_seen will not reflect
+  any events which arrive on the date before the first main ping is received.
+labels:
+  incremental: true
+owners:
+- jklukas@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_last_seen_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_last_seen_v1/query.sql
@@ -1,0 +1,59 @@
+WITH _current AS (
+  SELECT
+    submission_date,
+    sample_id,
+    client_id,
+    -- In this raw table, we capture the history of activity over the past
+    -- 28 days for each usage criterion as a single 64-bit integer. The
+    -- rightmost bit represents whether the user was active in the current day.
+    CAST(TRUE AS INT64) AS days_logged_event_bits,
+    CAST(
+      LOGICAL_OR(event_method = 'show' AND event_object = 'protection_report') AS INT64
+    ) AS days_viewed_protection_report_bits,
+    CAST(
+      LOGICAL_OR(event_category = 'pictureinpicture' AND event_method = 'create') AS INT64
+    ) AS days_used_pip_bits,
+    CAST(
+      LOGICAL_OR(event_string_value = 'SEC_ERROR_UNKNOWN_ISSUER') AS INT64
+    ) AS days_had_cert_error_bits,
+  FROM
+    telemetry.events
+  WHERE
+    submission_date = @submission_date
+),
+--
+_previous AS (
+  SELECT
+    *
+  FROM
+    events_last_seen_v1
+  WHERE
+    submission_date = DATE_SUB(@submission_date, INTERVAL 1 DAY)
+    -- Filter out rows from yesterday that have now fallen outside the 28-day window.
+    AND udf.shift_28_bits_one_day(days_logged_events_bits) > 0
+)
+--
+SELECT
+  @submission_date AS submission_date,
+  udf.combine_adjacent_days_28_bits(
+    _previous.days_logged_event_bits,
+    _current.days_logged_event_bits
+  ) AS days_logged_event_bits,
+  udf.combine_adjacent_days_28_bits(
+    _previous.days_viewed_protection_report_bits,
+    _current.days_viewed_protection_report_bits
+  ) AS days_viewed_protection_report_bits,
+  udf.combine_adjacent_days_28_bits(
+    _previous.days_used_pip_bits,
+    _current.days_used_pip_bits
+  ) AS days_used_pip_bits,
+  udf.combine_adjacent_days_28_bits(
+    _previous.days_had_cert_error_bits,
+    _current.days_had_cert_error_bits
+  ) AS days_had_cert_error_bits,
+FROM
+  _current
+FULL JOIN
+  _previous
+USING
+  (client_id)

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_last_seen_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_last_seen_v1/query.sql
@@ -12,7 +12,7 @@ WITH _current AS (
     ) AS days_viewed_protection_report_bits,
     CAST(
       LOGICAL_OR(event_category = 'pictureinpicture' AND event_method = 'create') AS INT64
-    ) AS days_used_pip_bits,
+    ) AS days_used_picture_in_picture_bits,
     CAST(
       LOGICAL_OR(event_string_value = 'SEC_ERROR_UNKNOWN_ISSUER') AS INT64
     ) AS days_had_cert_error_bits,
@@ -44,9 +44,9 @@ SELECT
     _current.days_viewed_protection_report_bits
   ) AS days_viewed_protection_report_bits,
   udf.combine_adjacent_days_28_bits(
-    _previous.days_used_pip_bits,
-    _current.days_used_pip_bits
-  ) AS days_used_pip_bits,
+    _previous.days_used_picture_in_picture_bits,
+    _current.days_used_picture_in_picture_bits
+  ) AS days_used_picture_in_picture_bits,
   udf.combine_adjacent_days_28_bits(
     _previous.days_had_cert_error_bits,
     _current.days_had_cert_error_bits


### PR DESCRIPTION
This is proposed as part of the Data Warehouse [daily per-client aggregations project](https://docs.google.com/document/d/1Lml-hWiqhvUazjn_-sDF6TUvwAEA3jMG3LJbyIC7fEc/edit#) to allow event-based feature usage definitions.

This is initially presented as a draft for feedback on the approach; scheduling has not yet been implemented.