### PR TITLE
Separate queries on clients_scalar_aggregates by app_version

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -122,6 +122,8 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/telemetry_derived/asn_aggregates_v1/query.sql",
     # Dataset sql/glam-fenix-dev:glam_etl was not found
     *glob.glob("sql/glam-fenix-dev/glam_etl/**/*.sql", recursive=True),

--- a/script/glam/run_scalar_agg_clustered_query.py
+++ b/script/glam/run_scalar_agg_clustered_query.py
@@ -1,0 +1,92 @@
+"""Run a query on clients_scalar_aggregates on one app_version at a time."""
+import datetime
+from pathlib import Path
+
+import click
+from google.cloud import bigquery
+
+VERSION_QUERY_TEMPLATE = """
+SELECT
+  DISTINCT(app_version)
+FROM
+  `{project}.{dataset}.clients_scalar_aggregates_v1`
+WHERE
+  submission_date = '{date}'
+"""
+
+SQL_BASE_DIR = (
+        Path(__file__).parent.parent.parent / "sql"
+        / "moz-fx-data-shared-prod" / "telemetry_derived"
+)
+
+
+@click.command()
+@click.option("--submission-date", required=True, type=datetime.date.fromisoformat)
+@click.option("--dst-table", required=True)
+@click.option("--project", default="moz-fx-data-shared-prod")
+@click.option("--dataset", default="telemetry_derived")
+def main(submission_date, dst_table, project, dataset):
+    bq_client = bigquery.Client(project=project)
+
+    app_versions = [
+        row["app_version"] for row in
+        bq_client.query(
+            VERSION_QUERY_TEMPLATE.format(
+                date=submission_date, project=project, dataset=dataset
+            )
+        ).result()
+    ]
+
+    print(f"Found versions: {app_versions}")
+
+    sql_path = SQL_BASE_DIR / dst_table / "query.sql"
+
+    query_text = sql_path.read_text()
+
+    # Write to intermediate table to avoid partial writes to destination table
+    intermediate_table = f"{project}.analysis.glam_temp_clustered_query_{dst_table}"
+    print(f"Writing results to {intermediate_table}")
+
+    # TODO: add something to print periodically for airflow
+
+    for i, app_version in enumerate(app_versions):
+        print(f"Querying for app_version {app_version}")
+
+        query_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter(
+                    "submission_date", "DATE", str(submission_date)
+                ),
+                bigquery.ScalarQueryParameter("app_version", "INT64", app_version),
+            ],
+            destination=intermediate_table,
+            default_dataset=f"{project}.{dataset}",
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE if i == 0
+            else bigquery.WriteDisposition.WRITE_APPEND,
+        )
+
+        query_job = bq_client.query(query_text, job_config=query_config)
+
+        # Periodically print so airflow gke operator doesn't think job is dead
+        elapsed = 0
+        while not query_job.done(timeout=10):
+            elapsed += 10
+            if elapsed % 10:
+                print("Waiting on query...")
+
+        results = query_job.result()
+        print(f"{results.total_rows} rows in {intermediate_table}")
+
+    copy_config = bigquery.CopyJobConfig(
+        create_disposition=bigquery.CreateDisposition.CREATE_NEVER,
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+    )
+    bq_client.copy_table(
+        intermediate_table,
+        f"{project}.{dataset}.{dst_table}",
+        job_config=copy_config,
+    ).result()
+
+
+if __name__ == "__main__":
+    main()

--- a/script/glam/run_scalar_agg_clustered_query.py
+++ b/script/glam/run_scalar_agg_clustered_query.py
@@ -80,8 +80,8 @@ def main(submission_date, dst_table, project, dataset):
         # Periodically print so airflow gke operator doesn't think task is dead
         elapsed = 0
         while not query_job.done():
-            time.sleep(5)
-            elapsed += 5
+            time.sleep(10)
+            elapsed += 10
             if elapsed % 200 == 10:
                 print("Waiting on query...")
 

--- a/script/glam/run_scalar_agg_clustered_query.py
+++ b/script/glam/run_scalar_agg_clustered_query.py
@@ -16,8 +16,10 @@ WHERE
 """
 
 SQL_BASE_DIR = (
-        Path(__file__).parent.parent.parent / "sql"
-        / "moz-fx-data-shared-prod" / "telemetry_derived"
+    Path(__file__).parent.parent.parent
+    / "sql"
+    / "moz-fx-data-shared-prod"
+    / "telemetry_derived"
 )
 
 
@@ -27,11 +29,12 @@ SQL_BASE_DIR = (
 @click.option("--project", default="moz-fx-data-shared-prod")
 @click.option("--dataset", default="telemetry_derived")
 def main(submission_date, dst_table, project, dataset):
+    """Run query per app_version."""
     bq_client = bigquery.Client(project=project)
 
     app_versions = [
-        row["app_version"] for row in
-        bq_client.query(
+        row["app_version"]
+        for row in bq_client.query(
             VERSION_QUERY_TEMPLATE.format(
                 date=submission_date, project=project, dataset=dataset
             )
@@ -60,7 +63,8 @@ def main(submission_date, dst_table, project, dataset):
             ],
             destination=intermediate_table,
             default_dataset=f"{project}.{dataset}",
-            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE if i == 0
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE
+            if i == 0
             else bigquery.WriteDisposition.WRITE_APPEND,
         )
 

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
@@ -60,6 +60,10 @@ WITH flat_clients_scalar_aggregates AS (
     clients_scalar_aggregates_v1
   WHERE
     submission_date = @submission_date
+    AND (
+      @app_version IS NULL
+      OR app_version = @app_version
+    )
   ),
 
 log_min_max AS (

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/query.sql
@@ -5,6 +5,10 @@ WITH flat_clients_scalar_aggregates AS (
     clients_scalar_aggregates_v1
   WHERE
     submission_date = @submission_date
+    AND (
+      @app_version IS NULL
+      OR app_version = @app_version
+    )
 ),
 
 static_combos as (

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/test_aggregation/query_params.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/test_aggregation/query_params.yaml
@@ -2,3 +2,6 @@
 - name: submission_date
   type: DATE
   value: 2019-01-01
+- name: app_version
+  type: INT64
+  value: null


### PR DESCRIPTION
For #1432

This makes scalar_probe_counts and scalar_percentiles make multiple queries per app_version.  clients_scalar_aggregates_v1 is clustered by app_version so this is somewhat efficient.  app_versions are nicely distributed: proportions are about 0.39, 0.38, 0.19, 0.034, 0.0037.  Clustering for the larger proportions aren't very efficient and still need to scan most of the table though so this increases total query cost.

Airflow pr https://github.com/mozilla/telemetry-airflow/pull/1194