### PR TITLE
Move field cleaning to table in main_1pct

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/main_1pct/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_1pct/view.sql
@@ -2,9 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.main_1pct`
 AS
 SELECT
-  * REPLACE (
-    mozfun.norm.metadata(metadata) AS metadata,
-    `moz-fx-data-shared-prod.udf.normalize_main_payload`(payload) AS payload
-  )
+  *
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.main_1pct_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/query.sql
@@ -7,7 +7,14 @@ SELECT
   -- avalanche effect, and is _different_ from sample_id. We use this same approach
   -- for choosing id_bucket in exact_mau28 tables.
   MOD(ABS(FARM_FINGERPRINT(client_id)), 100) AS subsample_id,
-  *
+  -- We apply field cleaning at the table level rather than the view level because
+  -- the logic here ends up becoming the bottleneck for simple queries on top of
+  -- this table. The limited size and retention policy on this table makes it feasible
+  -- to perform full backfills as needed if this logic changes.
+  * REPLACE (
+    mozfun.norm.metadata(metadata) AS metadata,
+    `moz-fx-data-shared-prod.udf.normalize_main_payload`(payload) AS payload
+  )
 FROM
   telemetry_stable.main_v4
 WHERE


### PR DESCRIPTION
To be truly useful for quick investigations, the standard approach to views
doesn't work here.

The following query runs in 4 seconds:

```
SELECT
  DATE(submission_timestamp) AS dt,
  COUNT(*)
FROM
  `moz-fx-data-shared-prod.telemetry_derived.main_1pct_v1`
WHERE
  DATE(submission_timestamp) >= '2020-11-24'
  AND subsample_id = 0
GROUP BY
  1
ORDER BY
  1 DESC
```

But the equivalent on top of the existing view takes more than 30 seconds,
bottlenecked on query planning.