### PR TITLE
Bug 1681208 - Expose subset of `stripe_external.invoices_v1`

### DIFF
--- a/sql/moz-fx-data-shared-prod/stripe/invoices/view.sql
+++ b/sql/moz-fx-data-shared-prod/stripe/invoices/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.stripe.invoices`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod`.stripe_derived.invoices_v1

--- a/sql/moz-fx-data-shared-prod/stripe_derived/invoices_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/invoices_v1/metadata.yaml
@@ -1,0 +1,16 @@
+---
+friendly_name: Stripe Invoices
+description: Stripe Invoices as of UTC midnight. See bug 1681208.
+owners:
+  - dthorn@mozilla.com
+  - amiyaguchi@mozilla.com
+labels:
+  application: stripe
+  schedule: daily
+scheduling:
+  dag_name: bqetl_stripe
+  # destination is the whole table, not a single partition,
+  # so don't use date_partition_parameter
+  date_partition_parameter:
+  referenced_tables: [['moz-fx-data-shared-prod', 'stripe_external',
+                       'invoices_v1']]

--- a/sql/moz-fx-data-shared-prod/stripe_derived/invoices_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/invoices_v1/query.sql
@@ -1,0 +1,22 @@
+SELECT
+  -- limit fields in stripe_derived so as not to expose sensitive data
+  id,
+  billing_reason,
+  customer,
+  status,
+  status_transitions,
+  ARRAY(
+    SELECT
+      STRUCT(
+        line.id,
+        line.amount,
+        line.currency,
+        STRUCT(line.period.start, line.period.`end`) AS period,
+        line.subscription,
+        STRUCT(line.plan.id, line.plan.amount, line.plan.currency) AS plan
+      ) AS lines
+    FROM
+      UNNEST(lines) AS line
+  ) AS lines
+FROM
+  stripe_external.invoices_v1


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1681208)

This exposes a subset of columns that does not expose sensitive user data and can therefore be viewable as `mozilla-confidential`.