### PR TITLE
Specify project when generating glam_etl sql

### DIFF
--- a/script/glam/generate_glean_sql
+++ b/script/glam/generate_glean_sql
@@ -82,12 +82,12 @@ stage=${STAGE?$error}
 
 if [[ $stage == "daily" ]]; then
     write_clients_daily_aggregates "$product" "$src_project" "$dst_project"
-    python3 -m bigquery_etl.glam.generate --prefix "${product}" --daily-view-only
+    python3 -m bigquery_etl.glam.generate --project "$dst_project" --prefix "${product}" --daily-view-only
 elif [[ $stage == "incremental" ]]; then
-    python3 -m bigquery_etl.glam.generate --prefix "${product}"
+    python3 -m bigquery_etl.glam.generate --project "$dst_project" --prefix "${product}"
 elif [[ $stage == "all" ]]; then
     write_clients_daily_aggregates "$product" "$src_project" "$dst_project"
-    python3 -m bigquery_etl.glam.generate --prefix "${product}"
+    python3 -m bigquery_etl.glam.generate --project "$dst_project" --prefix "${product}"
 else
     echo "$error"
     exit 1


### PR DESCRIPTION
The `bigquery_etl.glam.generate` call was missing the `--project` option with the production location.