### PR TITLE
Ensure the sql directory for glam-fenix exists

### DIFF
--- a/script/glam/generate_glean_sql
+++ b/script/glam/generate_glean_sql
@@ -80,6 +80,9 @@ dst_project=${DST_PROJECT:-${PROJECT:-glam-fenix-dev}}
 product=${PRODUCT?PRODUCT must be defined}
 stage=${STAGE?$error}
 
+# ensure the sql directory exists
+mkdir -p sql/$dst_project/glam_etl
+
 if [[ $stage == "daily" ]]; then
     write_clients_daily_aggregates "$product" "$src_project" "$dst_project"
     python3 -m bigquery_etl.glam.generate --project "$dst_project" --prefix "${product}" --daily-view-only


### PR DESCRIPTION
I reproduced a bug found in the last airflow dag run:

```bash
% PROJECT="test-test" PRODUCT=org_mozilla_fenix_glam_nightly GENERATE_ONLY=true STAGE=incremental script/glam/generate_glean_sql
Traceback (most recent call last):
  ...
  File "/Users/amiyaguchi/Work/bigquery-etl/bigquery_etl/glam/generate.py", line 83, in main
    raise NotADirectoryError(f"path to {dataset_path} not found")
NotADirectoryError: path to sql/test-test/glam_etl not found
```

See  https://workflow.telemetry.mozilla.org/log?task_id=incremental_org_mozilla_fenix_glam_beta&dag_id=glam_fenix&execution_date=2020-12-08T02%3A00%3A00%2B00%3A00