### PR TITLE
Add links to metadata.yaml editor and source dictory (#1242)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 .DS_Store
 .mypy_cache/
 venv/
+
+# ignore locally generated docs
+sql/**/docs
+sql/**/mkdocs.yml

--- a/bigquery_etl/docs/generate_docs.py
+++ b/bigquery_etl/docs/generate_docs.py
@@ -17,6 +17,8 @@ METADATA_FILE = "metadata.yaml"
 DOCS_DIR = "docs/"
 INDEX_MD = "index.md"
 SQL_REF_RE = r"@sql\((.+)\)"
+SOURCE_URL = "https://github.com/mozilla/bigquery-etl/blob/master"
+EDIT_URL = "https://github.com/mozilla/bigquery-etl/edit/master/"
 
 parser = ArgumentParser(description=__doc__)
 parser.add_argument(
@@ -63,6 +65,11 @@ def load_with_examples(file):
     return file_content
 
 
+def add_source_and_edit(source_url, edit_url):
+    """Add links to the function directory and metadata.yaml editor."""
+    return f"[Source]({source_url})  |  [Edit]({edit_url})"
+
+
 def main():
     """Generate documentation for project."""
     args = parser.parse_args()
@@ -96,6 +103,9 @@ def main():
                     else:
                         description = None
                         if METADATA_FILE in files:
+                            source_link = f"{SOURCE_URL}/{root}"
+                            edit_link = f"{EDIT_URL}/{root}/{METADATA_FILE}"
+
                             with open(os.path.join(root, METADATA_FILE)) as stream:
                                 try:
                                     description = yaml.safe_load(stream).get(
@@ -123,6 +133,9 @@ def main():
                                     dataset_doc_file.write(f"{formated}\n\n")
                                 # Inject the contents of the README.md
                                 dataset_doc_file.write(docfile_content)
+                                # Add links to source and edit
+                                sourced = add_source_and_edit(source_link, edit_link)
+                                dataset_doc_file.write(f"{sourced}\n\n")
                         else:
                             # dataset-level doc; create a new doc file
                             dest = out_dir / path / f"{name}.md"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,7 +4,7 @@ site_description: Mozilla BigQuery ETL
 site_author: Mozilla Data Platform Team
 
 # Repository
-repo_name: mozilla/bigquery-etl/
+repo_name: mozilla/bigquery-etl
 repo_url: https://github.com/mozilla/bigquery-etl/
 edit_uri: "" 
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,8 +3,12 @@ site_name: BigQuery ETL
 site_description: Mozilla BigQuery ETL
 site_author: Mozilla Data Platform Team
 
+# Repository
+repo_name: mozilla/bigquery-etl/
 repo_url: https://github.com/mozilla/bigquery-etl/
+edit_uri: "" 
 
+# Configuration
 theme:
     name: material
     features:


### PR DESCRIPTION
Fixes #1242.

Per @jklukas's suggestion, I added 2 new links at the end of each function's docs: Source that takes the user to the function directory, and Edit to the metadata.yaml edit interface.