### PR TITLE
Deschedule fenix event_types query temporarily

### DIFF
--- a/dags/bqetl_fenix_event_rollup.py
+++ b/dags/bqetl_fenix_event_rollup.py
@@ -20,18 +20,6 @@ with DAG(
     "bqetl_fenix_event_rollup", default_args=default_args, schedule_interval="0 2 * * *"
 ) as dag:
 
-    org_mozilla_firefox_derived__event_types__v1 = bigquery_etl_query(
-        task_id="org_mozilla_firefox_derived__event_types__v1",
-        destination_table="event_types_v1",
-        dataset_id="org_mozilla_firefox_derived",
-        project_id="moz-fx-data-shared-prod",
-        owner="frank@mozilla.com",
-        email=["frank@mozilla.com"],
-        date_partition_parameter="submission_date",
-        depends_on_past=True,
-        dag=dag,
-    )
-
     org_mozilla_firefox_derived__events_daily__v1 = bigquery_etl_query(
         task_id="org_mozilla_firefox_derived__events_daily__v1",
         destination_table="events_daily_v1",
@@ -52,10 +40,6 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
-    )
-
-    org_mozilla_firefox_derived__event_types__v1.set_upstream(
-        wait_for_copy_deduplicate_all
     )
 
     org_mozilla_firefox_derived__events_daily__v1.set_upstream(

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/event_types_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/event_types_v1/metadata.yaml
@@ -8,6 +8,8 @@ labels:
   application: firefox-android
   incremental: false
   schedule: daily
-scheduling:
-  dag_name: bqetl_fenix_event_rollup
-  depends_on_past: true
+# TODO: Uncomment this section to reschedule once logic is fixed.
+# See https://github.com/mozilla/bigquery-etl/pull/1624
+# scheduling:
+#   dag_name: bqetl_fenix_event_rollup
+#   depends_on_past: true


### PR DESCRIPTION
This query is failing as of 2020-11-18 due to unexpected input.
We are descheduling it until the logic is updated to handle this situation,
since new DAG runs are staying in the running state, waiting on past
runs that will never complete.