### PR TITLE
Schedule deviations query until EOY

### DIFF
--- a/bigquery_etl/_version.py
+++ b/bigquery_etl/_version.py
@@ -1,3 +1,3 @@
 """Provides bigquery-etl version information."""
 
-__version__ = "20.12.1"
+__version__ = "20.12.2"

--- a/bigquery_etl/_version.py
+++ b/bigquery_etl/_version.py
@@ -1,3 +1,3 @@
 """Provides bigquery-etl version information."""
 
-__version__ = "20.10.1"
+__version__ = "20.12.1"

--- a/bigquery_etl/query_scheduling/dag.py
+++ b/bigquery_etl/query_scheduling/dag.py
@@ -3,7 +3,7 @@
 import attr
 import cattr
 from jinja2 import Environment, PackageLoader
-from typing import List
+from typing import List, Optional
 
 from bigquery_etl.query_scheduling.task import Task, TaskRef
 from bigquery_etl.query_scheduling import formatters
@@ -59,6 +59,7 @@ class DagDefaultArgs:
 
     owner: str = attr.ib()
     start_date: str = attr.ib()
+    end_date: Optional[str] = attr.ib(None)
     email: List[str] = attr.ib([])
     depends_on_past: bool = attr.ib(False)
     retry_delay: str = attr.ib("30m")
@@ -87,9 +88,10 @@ class DagDefaultArgs:
                 "Timedeltas should be specified like: 1h, 30m, 1h15m, 1d4h45m, ..."
             )
 
+    @end_date.validator
     @start_date.validator
-    def validate_start_date(self, attribute, value):
-        """Check that start_date has YYYY-MM-DD format."""
+    def validate_date(self, attribute, value):
+        """Check that start_date and end_date has YYYY-MM-DD format."""
         if value is not None and not is_date_string(value):
             raise ValueError(
                 f"Invalid date definition for {attribute}: {value}."

--- a/bigquery_etl/query_scheduling/formatters.py
+++ b/bigquery_etl/query_scheduling/formatters.py
@@ -29,6 +29,8 @@ def format_attr(d, attribute, formatter_name):
 
 def format_date(date_string):
     """Format a date string to a datetime object."""
+    if date_string is None:
+        return None
     return datetime.strptime(date_string, "%Y-%m-%d")
 
 

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -7,7 +7,8 @@ from utils.gcp import bigquery_etl_query, gke_command
 
 default_args = {{ 
     default_args.to_dict() | 
-    format_attr("start_date", "format_date") | 
+    format_attr("start_date", "format_date") |
+    format_attr("end_date", "format_date") |
     format_attr("retry_delay", "format_timedelta") 
 }}
 

--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -8,7 +8,8 @@ from utils.gcp import gke_command
 
 default_args = {{ 
     default_args.to_dict() | 
-    format_attr("start_date", "format_date") | 
+    format_attr("start_date", "format_date") |
+    format_attr("end_date", "format_date") |
     format_attr("retry_delay", "format_timedelta") 
 }}
 

--- a/dags.yaml
+++ b/dags.yaml
@@ -315,3 +315,12 @@ bqetl_desktop_platform:
     retries: 2
     retry_delay: 30m
 
+bqetl_deviations:
+  schedule_interval: 0 4 * * *
+  default_args:
+      owner: ascholtz@mozilla.com
+      start_date: '2020-10-01'
+      end_date: '2021-01-01'
+      email: ['telemetry-alerts@mozilla.com', 'ascholtz@mozilla.com', 'aplacitelli@mozilla.com']
+      retries: 2
+      retry_delay: 30m

--- a/dags.yaml
+++ b/dags.yaml
@@ -321,6 +321,11 @@ bqetl_deviations:
       owner: ascholtz@mozilla.com
       start_date: '2020-10-01'
       end_date: '2021-01-01'
-      email: ['telemetry-alerts@mozilla.com', 'ascholtz@mozilla.com', 'aplacitelli@mozilla.com']
+      email: 
+        [
+          'telemetry-alerts@mozilla.com',
+          'ascholtz@mozilla.com',
+          'aplacitelli@mozilla.com'
+        ]
       retries: 2
       retry_delay: 30m

--- a/dags/bqetl_account_ecosystem.py
+++ b/dags/bqetl_account_ecosystem.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2020, 9, 17, 0, 0),
+    "end_date": None,
     "email": ["jklukas@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_activity_stream.py
+++ b/dags/bqetl_activity_stream.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=300),

--- a/dags/bqetl_addons.py
+++ b/dags/bqetl_addons.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "bmiroglio@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 27, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "bmiroglio@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_amo_stats.py
+++ b/dags/bqetl_amo_stats.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2020, 6, 1, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_asn_aggregates.py
+++ b/dags/bqetl_asn_aggregates.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "ascholtz@mozilla.com",
     "start_date": datetime.datetime(2020, 4, 5, 0, 0),
+    "end_date": None,
     "email": ["ascholtz@mozilla.com", "tdsmith@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_core.py
+++ b/dags/bqetl_core.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=300),

--- a/dags/bqetl_deletion_request_volume.py
+++ b/dags/bqetl_deletion_request_volume.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "dthorn@mozilla.com",
     "start_date": datetime.datetime(2020, 6, 29, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "dthorn@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_desktop_platform.py
+++ b/dags/bqetl_desktop_platform.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 1, 0, 0),
+    "end_date": None,
     "email": [
         "telemetry-alerts@mozilla.com",
         "jklukas@mozilla.com",

--- a/dags/bqetl_deviations.py
+++ b/dags/bqetl_deviations.py
@@ -1,0 +1,54 @@
+# Generated via https://github.com/mozilla/bigquery-etl/blob/master/bigquery_etl/query_scheduling/generate_airflow_dags.py
+
+from airflow import DAG
+from airflow.operators.sensors import ExternalTaskSensor
+import datetime
+from utils.gcp import bigquery_etl_query, gke_command
+
+default_args = {
+    "owner": "ascholtz@mozilla.com",
+    "start_date": datetime.datetime(2020, 10, 1, 0, 0),
+    "email": [
+        "telemetry-alerts@mozilla.com",
+        "ascholtz@mozilla.com",
+        "aplacitelli@mozilla.com",
+    ],
+    "depends_on_past": False,
+    "retry_delay": datetime.timedelta(seconds=1800),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 2,
+}
+
+with DAG(
+    "bqetl_deviations", default_args=default_args, schedule_interval="0 4 * * *"
+) as dag:
+
+    telemetry_derived__deviations__v1 = bigquery_etl_query(
+        task_id="telemetry_derived__deviations__v1",
+        destination_table="deviations_v1",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="ascholtz@mozilla.com",
+        email=[
+            "aplacitelli@mozilla.com",
+            "ascholtz@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    wait_for_anomdtct_anomdtct = ExternalTaskSensor(
+        task_id="wait_for_anomdtct_anomdtct",
+        external_dag_id="anomdtct",
+        external_task_id="anomdtct",
+        execution_delta=datetime.timedelta(seconds=3600),
+        check_existence=True,
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+        dag=dag,
+    )
+
+    telemetry_derived__deviations__v1.set_upstream(wait_for_anomdtct_anomdtct)

--- a/dags/bqetl_deviations.py
+++ b/dags/bqetl_deviations.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "ascholtz@mozilla.com",
     "start_date": datetime.datetime(2020, 10, 1, 0, 0),
+    "end_date": datetime.datetime(2021, 1, 1, 0, 0),
     "email": [
         "telemetry-alerts@mozilla.com",
         "ascholtz@mozilla.com",

--- a/dags/bqetl_devtools.py
+++ b/dags/bqetl_devtools.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 27, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_document_sample.py
+++ b/dags/bqetl_document_sample.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "amiyaguchi@mozilla.com",
     "start_date": datetime.datetime(2020, 2, 17, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "amiyaguchi@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_error_aggregates.py
+++ b/dags/bqetl_error_aggregates.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "bewu@mozilla.com",
     "start_date": datetime.datetime(2019, 11, 1, 0, 0),
+    "end_date": None,
     "email": [
         "telemetry-alerts@mozilla.com",
         "bewu@mozilla.com",

--- a/dags/bqetl_experiments_daily.py
+++ b/dags/bqetl_experiments_daily.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "ssuh@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 27, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_fenix_event_rollup.py
+++ b/dags/bqetl_fenix_event_rollup.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "frank@mozilla.com",
     "start_date": datetime.datetime(2020, 9, 9, 0, 0),
+    "end_date": None,
     "email": ["frank@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 3, 1, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=600),

--- a/dags/bqetl_google_analytics_derived.py
+++ b/dags/bqetl_google_analytics_derived.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "bewu@mozilla.com",
     "start_date": datetime.datetime(2020, 10, 31, 0, 0),
+    "end_date": None,
     "email": ["bewu@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_gud.py
+++ b/dags/bqetl_gud.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=300),

--- a/dags/bqetl_internet_outages.py
+++ b/dags/bqetl_internet_outages.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "aplacitelli@mozilla.com",
     "start_date": datetime.datetime(2020, 1, 1, 0, 0),
+    "end_date": None,
     "email": ["aplacitelli@mozilla.com", "sguha@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "dthorn@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 27, 0, 0),
+    "end_date": None,
     "email": [
         "telemetry-alerts@mozilla.com",
         "dthorn@mozilla.com",

--- a/dags/bqetl_marketing_fetch.py
+++ b/dags/bqetl_marketing_fetch.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "bewu@mozilla.com",
     "start_date": datetime.datetime(2020, 11, 30, 0, 0),
+    "end_date": None,
     "email": ["bewu@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_messaging_system.py
+++ b/dags/bqetl_messaging_system.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "najiang@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "najiang@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=300),

--- a/dags/bqetl_mobile_search.py
+++ b/dags/bqetl_mobile_search.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "bewu@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "bewu@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=300),

--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "ascholtz@mozilla.com",
     "start_date": datetime.datetime(2018, 10, 30, 0, 0),
+    "end_date": None,
     "email": ["ascholtz@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_mozilla_vpn.py
+++ b/dags/bqetl_mozilla_vpn.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "dthorn@mozilla.com",
     "start_date": datetime.datetime(2020, 10, 8, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "dthorn@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=300),

--- a/dags/bqetl_org_mozilla_fenix_derived.py
+++ b/dags/bqetl_org_mozilla_fenix_derived.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "amiyaguchi@mozilla.com",
     "start_date": datetime.datetime(2020, 10, 18, 0, 0),
+    "end_date": None,
     "email": ["amiyaguchi@mozilla.com", "telemetry-alerts@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_public_data_json.py
+++ b/dags/bqetl_public_data_json.py
@@ -9,6 +9,7 @@ from utils.gcp import gke_command
 default_args = {
     "owner": "ascholtz@mozilla.com",
     "start_date": datetime.datetime(2020, 4, 14, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "ascholtz@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),
@@ -21,6 +22,21 @@ with DAG(
     "bqetl_public_data_json", default_args=default_args, schedule_interval="0 4 * * *"
 ) as dag:
     docker_image = "mozilla/bigquery-etl:latest"
+
+    export_public_data_json_telemetry_derived__deviations__v1 = GKEPodOperator(
+        task_id="export_public_data_json_telemetry_derived__deviations__v1",
+        name="export_public_data_json_telemetry_derived__deviations__v1",
+        arguments=["script/publish_public_data_json"]
+        + [
+            "--query_file=sql/moz-fx-data-shared-prod/telemetry_derived/deviations_v1/query.sql"
+        ]
+        + ["--destination_table=deviations${{ds_nodash}}"]
+        + ["--dataset_id=telemetry_derived"]
+        + ["--project_id=moz-fx-data-shared-prod"]
+        + ["--parameter=submission_date:DATE:{{ds}}"],
+        image=docker_image,
+        dag=dag,
+    )
 
     export_public_data_json_telemetry_derived__ssl_ratios__v1 = GKEPodOperator(
         task_id="export_public_data_json_telemetry_derived__ssl_ratios__v1",
@@ -35,6 +51,19 @@ with DAG(
         + ["--parameter=submission_date:DATE:{{ds}}"],
         image=docker_image,
         dag=dag,
+    )
+
+    wait_for_telemetry_derived__deviations__v1 = ExternalTaskSensor(
+        task_id="wait_for_telemetry_derived__deviations__v1",
+        external_dag_id="bqetl_deviations",
+        external_task_id="telemetry_derived__deviations__v1",
+        check_existence=True,
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    export_public_data_json_telemetry_derived__deviations__v1.set_upstream(
+        wait_for_telemetry_derived__deviations__v1
     )
 
     wait_for_telemetry_derived__ssl_ratios__v1 = ExternalTaskSensor(
@@ -60,6 +89,7 @@ with DAG(
 
     public_data_gcs_metadata.set_upstream(
         [
+            export_public_data_json_telemetry_derived__deviations__v1,
             export_public_data_json_telemetry_derived__ssl_ratios__v1,
         ]
     )

--- a/dags/bqetl_search.py
+++ b/dags/bqetl_search.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "bewu@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 27, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "bewu@mozilla.com", "frank@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_search_dashboard.py
+++ b/dags/bqetl_search_dashboard.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "ssuh@mozilla.com",
     "start_date": datetime.datetime(2020, 12, 14, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_ssl_ratios.py
+++ b/dags/bqetl_ssl_ratios.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "chutten@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 20, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "chutten@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/dags/bqetl_stripe.py
+++ b/dags/bqetl_stripe.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "dthorn@mozilla.com",
     "start_date": datetime.datetime(2020, 10, 5, 0, 0),
+    "end_date": None,
     "email": ["telemetry-alerts@mozilla.com", "dthorn@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=300),

--- a/dags/bqetl_vrbrowser.py
+++ b/dags/bqetl_vrbrowser.py
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
+    "end_date": None,
     "email": [
         "telemetry-alerts@mozilla.com",
         "jklukas@mozilla.com",

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/deviations_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/deviations_v1/metadata.yaml
@@ -3,11 +3,18 @@ friendly_name: Deviations
 description: >-
   Deviation of different metrics from forecast.
 owners:
-  - jmccrosky@mozilla.com
+  - ascholtz@mozilla.com
 labels:
   incremental: true
+  schedule: daily
   public_json: true
   public_bigquery: true
   review_bugs: 
    - 1624528
   incremental_export: false
+scheduling:
+  dag_name: bqetl_deviations
+  depends_on:
+    - task_id: anomdtct
+      dag_name: anomdtct
+      execution_delta: 1h

--- a/tests/data/dags/python_script_test_dag
+++ b/tests/data/dags/python_script_test_dag
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 1, 1, 0, 0),
+    "end_date": None,
     "email": ["test@example.org"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=3600),

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 1, 1, 0, 0),
+    "end_date": None,
     "email": ["test@example.org"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=3600),

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 1, 1, 0, 0),
+    "end_date": None,
     "email": [],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/tests/data/dags/test_dag_external_dependency
+++ b/tests/data/dags/test_dag_external_dependency
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 5, 25, 0, 0),
+    "end_date": None,
     "email": [],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -8,6 +8,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 5, 25, 0, 0),
+    "end_date": None,
     "email": [],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -9,6 +9,7 @@ from utils.gcp import gke_command
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 1, 1, 0, 0),
+    "end_date": None,
     "email": ["test@example.org"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=3600),

--- a/tests/query_scheduling/test_formatters.py
+++ b/tests/query_scheduling/test_formatters.py
@@ -24,8 +24,7 @@ class TestFormatters:
         ) == {"interval": "'@daily'", "a": 12}
 
     def test_format_date(self):
-        with pytest.raises(TypeError):
-            assert format_date(None)
+        assert format_date(None) is None
 
         with pytest.raises(ValueError):
             assert format_date("March 12th 2020")


### PR DESCRIPTION
There is renewed interest in the deviations dataset. Data is only needed until the end of the year, so I added support to add an `end_date` to DAGs.

Depends on https://github.com/mozilla/telemetry-airflow/pull/1207

cc @Dexterp37 