### PR TITLE
Add workgroups metadata for activity_stream_bi

### DIFF
--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
@@ -10,3 +10,8 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_activity_stream
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential
+      - workgroup:pocket/external

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
@@ -13,5 +13,7 @@ scheduling:
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
-      - workgroup:mozilla-confidential
+      # to avoid permissions desync mozilla-confidential access is only granted
+      # at the dataset-level for now
+      # - workgroup:mozilla-confidential
       - workgroup:pocket/external

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
@@ -8,3 +8,8 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_activity_stream
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential
+      - workgroup:pocket/external

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
@@ -11,5 +11,7 @@ scheduling:
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
-      - workgroup:mozilla-confidential
+      # to avoid permissions desync mozilla-confidential access is only granted
+      # at the dataset-level for now
+      # - workgroup:mozilla-confidential
       - workgroup:pocket/external


### PR DESCRIPTION
This uses the same workgroups identifier format as the [MPS draft PR](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/646). This metadata will give us the primitives we need to selectively grant table-level access to non-ingestion tables, which for example obviates the need for a separate `activity_stream_bi` dataset. This is intended to be illustrative as opposed to functional (this is a no-op to the dataset ACLs). It's meant to be used by the following terraform:

```terraform
locals {
  project_id  = "moz-fx-data-shared-prod"
  path_prefix = "bigquery-etl/sql/${local.project_id}"
  metadata_all = {
    for f in fileset(".", "${local.path_prefix}/*/*/metadata.yaml") :
    f => yamldecode(file(f))
  }
  # since we're creating iam bindings, we pull out the nested workgroups list
  # (which can include multiple roles)
  metadata = merge([for k, v in local.metadata_all :
    { for access in v.workgroup_access :
      "${k}:${access.role}" => {
        project           = split("/", k)[2],
        dataset_id        = split("/", k)[3],
        table_id          = split("/", k)[4],
        role              = access.role
        workgroup_members = access.members
      }
    }
    if length(lookup(v, "workgroup_access", [])) > 0
  ]...)
  # pull out the lists of workgroups to extract members lists for
  workgroups = distinct(flatten([for k, v in local.metadata :
    jsonencode(v.workgroup_members)
  ]))
}

module "workgroups" {
  for_each = toset(local.workgroups)
  source   = "git@github.com:mozilla-services/cloudops-infra-terraform-modules.git//data-workgroup?ref=master"
  ids      = jsondecode(each.value)
}

locals {
  # translate workgroup_members into an actual members list via the
  # data-workgroup module
  metadata_workgroups = { for k, v in local.metadata :
    k => merge(v,
    { members = module.workgroups[jsonencode(v.workgroup_members)].members })
  }
}

resource "google_bigquery_table_iam_binding" "binding" {
  for_each   = local.metadata_workgroups
  project    = each.value.project
  dataset_id = each.value.dataset_id
  table_id   = each.value.table_id
  role       = each.value.role
  members    = each.value.members
}
```

There are a few use cases for this outlined in the [mozdata provisioning bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1671934). For now these cases will be annotated manually but the hope is to automate ACL lineage and propagation some time next year. This is particularly relevant for non-authorized views, which :jasonthomas and I were recently discussing, since using a view requires access to the underlying dataset, making data that is not `mozilla-confidential` also require a similar acl entry in e.g. [ingestion table acls](https://github.com/mozilla-services/cloudops-infra/blob/master/projects/data-shared/tf/prod/envs/prod/bigquery/namespaces.tfvars.json#L303).

This would be expected to run every time ops infrastructure detects a workgroup change, and (possibly) every time bq-etl is updated. I'm not sure if all views and data defined in bq-etl master exist at the time a new container is created, but if not we'll need to sort this out. Ops logic needs to be developed to determine when to wait for operator input when workgroups are being changed in metadata.