### PR TITLE
Coalesce search metrics in desktop_search_aggregates_by_userstate_v1 …

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/query.sql
@@ -36,12 +36,12 @@ FROM
 WHERE
   submission_date = @submission_date
   AND days_since_seen = 0
-  AND search_count_all < 10000
-  AND search_with_ads_count_all < 10000
-  AND ad_clicks_count_all < 10000
-  AND search_count_tagged_follow_on < 10000
-  AND search_count_tagged_sap < 10000
-  AND search_count_organic < 10000
+  AND COALESCE(search_count_all, 0) < 10000
+  AND COALESCE(search_with_ads_count_all, 0) < 10000
+  AND COALESCE(ad_clicks_count_all, 0) < 10000
+  AND COALESCE(search_count_tagged_follow_on, 0) < 10000
+  AND COALESCE(search_count_tagged_sap, 0) < 10000
+  AND COALESCE(search_count_organic, 0) < 10000
 GROUP BY
   1,
   2,


### PR DESCRIPTION
…before filtering

Whoops – the previous query removed all clients where any of these metrics were null (including all clients before 6/30/2020 since it appears one of the columns is newer)