### PR TITLE
Bug 1684935 - Use non-ISO 8601 years for FxA Log retrieval

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_export_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_export_v1/query.sql
@@ -22,8 +22,8 @@ base_events AS (
     -- submission date.
     -- See https://console.cloud.google.com/bigquery?sq=768515352537:e63d2d2faa85431dbf0e5440021af837
     (
-      _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', @submission_date)
-      OR _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', DATE_ADD(@submission_date, INTERVAL 1 DAY))
+      _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)
+      OR _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', DATE_ADD(@submission_date, INTERVAL 1 DAY))
     )
     AND DATE(`timestamp`, "America/Los_Angeles") = @submission_date
     AND jsonPayload.fields.event_type IN (

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_user_ids_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_user_ids_v1/query.sql
@@ -17,7 +17,7 @@ SELECT
 FROM
   `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_20*`
 WHERE
-  _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', @submission_date)
+  _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)
 UNION DISTINCT
 SELECT
   user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_bounce_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_bounce_events_v1/query.sql
@@ -17,4 +17,4 @@ WHERE
   jsonPayload.type = 'amplitudeEvent'
   AND jsonPayload.fields.event_type IS NOT NULL
   AND jsonPayload.fields.user_id IS NOT NULL
-  AND _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', @submission_date)
+  AND _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
@@ -19,7 +19,7 @@ WITH base AS (
   FROM
     `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_20*`
   WHERE
-    _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', @submission_date)
+    _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)
 )
   --
 SELECT

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/query.sql
@@ -16,4 +16,4 @@ FROM
 WHERE
   jsonPayload.type = 'amplitudeEvent'
   AND jsonPayload.fields.event_type IS NOT NULL
-  AND _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', @submission_date)
+  AND _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/query.sql
@@ -19,7 +19,7 @@ SELECT
 FROM
   `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_20*`
 WHERE
-  _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', @submission_date)
+  _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)
   AND jsonPayload.type = 'activityEvent'
   AND jsonPayload.fields.event = 'account.deleted'
   AND jsonPayload.fields.uid IS NOT NULL

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_auth_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_auth_events_v1/query.sql
@@ -32,4 +32,4 @@ WHERE
       'sms.installFirefox.sent'
     )
   )
-  AND _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', @submission_date)
+  AND _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/query.sql
@@ -41,4 +41,4 @@ WHERE
   -- Device command metrics were first deployed and stable on 2020-07-08;
   -- there is some data for earlier dates but it's from a failed deployment so we don't count it.
   AND _TABLE_SUFFIX >= '200708'
-  AND _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', @submission_date)
+  AND _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_oauth_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_oauth_events_v1/query.sql
@@ -30,7 +30,7 @@ WITH base AS (
   FROM
     `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_oauth_20*`
   WHERE
-    _TABLE_SUFFIX = FORMAT_DATE('%g%m%d', @submission_date)
+    _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)
 )
   --
 SELECT


### PR DESCRIPTION
ISO 8601 years are week-numbering years. Specifically, an ISO
year begins on the first Monday of Week 01; so if in the
Gregorian calendar the year starts on a Friday, the Friday,
Saturday, and Sunday will all fall in the previous year.

We run into this problem here. %g uses the ISO year, so for
2021-01-01 and 2021-01-02, that is year '20'. This has no match
in the underlying data (no 20-01-01 in FxA logs). Switching to
%y gives us year '21' for this data, and a match in the FxA logs.

https://en.wikipedia.org/wiki/ISO_8601#Week_dates