### PR TITLE
Fix missing json asset for alchemer script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description="Tooling for building derived datasets in BigQuery",
     url="https://github.com/mozilla/bigquery-etl",
     packages=find_namespace_packages(include=["bigquery_etl.*", "bigquery_etl"]),
-    package_data={'bigquery_etl': ['query_scheduling/templates/*.j2']},
+    package_data={'bigquery_etl': ['query_scheduling/templates/*.j2', 'alchemer/*.json']},
     include_package_data=True,
     install_requires=[
         "gcloud",


### PR DESCRIPTION
This is a followup to #1634. The `bqetl_mozilla_vpn` tasks of importing surveygizmo/alchemer data is failing in Airflow with the following error:

```
[2021-01-05 01:04:18,422] {pod_launcher.py:156} INFO - b"FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.8/site-packages/bigquery_etl/alchemer/response.schema.json'\n"
```
[link](https://workflow.telemetry.mozilla.org/log?task_id=mozilla_vpn_external__survey_cancellation_of_service__v1&dag_id=bqetl_mozilla_vpn&execution_date=2021-01-04T00%3A00%3A00%2B00%3A00)

To reproduce, on master run the following commands:

```bash
% docker build -t bqetl:latest .
% docker run -w /app/sql -it bqetl:latest  python -c "from bigquery_etl.alchemer.survey import response_schema; print(response_schema())"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.8/site-packages/bigquery_etl/alchemer/survey.py", line 100, in response_schema
    {"name": "root", "type": "RECORD", "fields": json.loads(path.read_text())}
  File "/usr/local/lib/python3.8/pathlib.py", line 1229, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/usr/local/lib/python3.8/pathlib.py", line 1215, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/usr/local/lib/python3.8/pathlib.py", line 1071, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.8/site-packages/bigquery_etl/alchemer/response.schema.json'
```

When run from the root directory, this works fine because the module references the local script directory e.g. the package is installed using `-e`.

After the patch:

```bash
% docker run -w /app/sql -it bqetl:latest  python -c "from bigquery_etl.alchemer.survey import response_schema; print(response_schema())"
(SchemaField('survey_data', 'RECORD', 'REPEATED', None, (SchemaField('answer_id', 'INTEGER', 'NULLABLE', None, (), None), SchemaField('answer', 'STRING', 'NULLABLE', None, (), None), SchemaField('question', 'STRING', 'NULLABLE', None, (), None), SchemaField('id', 'INTEGER', 'NULLABLE', None, (), None), SchemaField('section_id', 'INTEGER', 'NULLABLE', None, (), None), SchemaField('shown', 'BOOLEAN', 'NULLABLE', None, (), None), SchemaField('type', 'STRING', 'NULLABLE', None, (), None)), None), SchemaField('response_time', 'INTEGER', 'NULLABLE', None, (), None), SchemaField('session_id', 'STRING', 'NULLABLE', None, (), None), SchemaField('submission_date', 'DATE', 'NULLABLE', '%E4Y-%m-%d', (), None), SchemaField('id', 'INTEGER', 'NULLABLE', None, (), None), SchemaField('status', 'STRING', 'NULLABLE', None, (), None))
```





