### PR TITLE
Allow using bigquery-etl with python 3.9 (fixes #1611)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     ],
     long_description="Tooling for building derived datasets in BigQuery",
     long_description_content_type="text/markdown",
-    python_requires="==3.8.*",
+    python_requires=">=3.8",
     entry_points="""
         [console_scripts]
         bqetl=bigquery_etl.cli:cli


### PR DESCRIPTION
This is untested, but I don't think there's any reason this shouldn't work. If there are problems, we can address
them in a followup.