### PR TITLE
Update alchemer import for full set of columns

### DIFF
--- a/bigquery_etl/alchemer/response.schema.json
+++ b/bigquery_etl/alchemer/response.schema.json
@@ -62,6 +62,11 @@
             "mode": "NULLABLE"
           }
         ]
+      },
+      {
+        "type": "STRING",
+        "name": "subquestions",
+        "mode": "NULLABLE"
       }
     ],
     "type": "RECORD",

--- a/bigquery_etl/alchemer/response.schema.json
+++ b/bigquery_etl/alchemer/response.schema.json
@@ -13,6 +13,11 @@
       },
       {
         "type": "STRING",
+        "name": "original_answer",
+        "mode": "NULLABLE"
+      },
+      {
+        "type": "STRING",
         "name": "question",
         "mode": "NULLABLE"
       },
@@ -35,6 +40,28 @@
         "type": "STRING",
         "name": "type",
         "mode": "NULLABLE"
+      },
+      {
+        "type": "RECORD",
+        "name": "options",
+        "mode": "REPEATED",
+        "fields": [
+          {
+            "type": "INTEGER",
+            "name": "id",
+            "mode": "NULLABLE"
+          },
+          {
+            "type": "STRING",
+            "name": "option",
+            "mode": "NULLABLE"
+          },
+          {
+            "type": "STRING",
+            "name": "answer",
+            "mode": "NULLABLE"
+          }
+        ]
       }
     ],
     "type": "RECORD",

--- a/bigquery_etl/alchemer/survey.py
+++ b/bigquery_etl/alchemer/survey.py
@@ -35,12 +35,7 @@ def format_responses(s, date):
     # Note that we are omitted date_submission and date_completed because the
     # timezone is not ISO compliant. The submission date that is passed in as
     # the time parameter should suffice.
-    fields = [
-        "id",
-        "session_id",
-        "status",
-        "response_time",
-    ]
+    fields = ["id", "session_id", "status", "response_time"]
     return {
         # this is used as the partitioning field
         "submission_date": date,
@@ -110,11 +105,13 @@ def insert_to_bq(
     job_config = bigquery.LoadJobConfig(
         # We may also infer the schema by setting `autodetect=True`
         schema=response_schema(),
+        schema_update_options=bigquery.SchemaUpdateOption.ALLOW_FIELD_ADDITION,
         write_disposition=write_disposition,
         time_partitioning=bigquery.table.TimePartitioning(field="submission_date"),
     )
     partition = f"{table}${date.replace('-', '')}"
     job = client.load_table_from_json(data, partition, job_config=job_config)
+    print(f"Running job {job.job_id}")
     # job.result() returns a LoadJob object if successful, or raises an exception if not
     job.result()
 

--- a/bigquery_etl/alchemer/survey.py
+++ b/bigquery_etl/alchemer/survey.py
@@ -1,6 +1,7 @@
 """Import data from alchemer (surveygizmo) surveys into BigQuery."""
 import datetime as dt
 import json
+import re
 from pathlib import Path
 
 import click
@@ -38,6 +39,13 @@ def format_responses(s, date):
     fields = ["id", "session_id", "status", "response_time"]
     results = []
     for data in s.get("survey_data", {}).values():
+        # There can be answer_id's like "123456-other"
+        if data.get("answer_id") and isinstance(data["answer_id"], str):
+            numeric = re.findall(r"\d+", data["answer_id"])
+            if numeric:
+                data["answer_id"] = int(numeric[0])
+            else:
+                del data["answer_id"]
         if data.get("options"):
             data["options"] = list(data["options"].values())
         if data.get("subquestions"):

--- a/bigquery_etl/alchemer/survey.py
+++ b/bigquery_etl/alchemer/survey.py
@@ -40,6 +40,8 @@ def format_responses(s, date):
     for data in s.get("survey_data", {}).values():
         if data.get("options"):
             data["options"] = list(data["options"].values())
+        if data.get("subquestions"):
+            data["subquestions"] = json.dumps(data["subquestions"])
         results.append(data)
 
     return {

--- a/bigquery_etl/alchemer/survey.py
+++ b/bigquery_etl/alchemer/survey.py
@@ -36,11 +36,17 @@ def format_responses(s, date):
     # timezone is not ISO compliant. The submission date that is passed in as
     # the time parameter should suffice.
     fields = ["id", "session_id", "status", "response_time"]
+    results = []
+    for data in s.get("survey_data", {}).values():
+        if data.get("options"):
+            data["options"] = list(data["options"].values())
+        results.append(data)
+
     return {
         # this is used as the partitioning field
         "submission_date": date,
         **{field: s[field] for field in fields},
-        "survey_data": list(s.get("survey_data", {}).values()),
+        "survey_data": results,
     }
 
 

--- a/tests/alchemer/test_survey.py
+++ b/tests/alchemer/test_survey.py
@@ -1,6 +1,214 @@
-import pytest
 from uuid import uuid4
+
+import pytest
+import requests
+from click.testing import CliRunner
 from google.cloud import bigquery
+
+from bigquery_etl.alchemer.survey import (
+    construct_data,
+    date_plus_one,
+    format_responses,
+    get_survey_data,
+    insert_to_bq,
+    main,
+    response_schema,
+    utc_date_to_eastern_string,
+)
+
+# https://apihelp.alchemer.com/help/surveyresponse-returned-fields-v5#getobject
+EXAMPLE_RESPONSE = {
+    "result_ok": True,
+    "total_count": 2,
+    "page": 1,
+    "total_pages": 1,
+    "results_per_page": 50,
+    "data": [
+        {
+            "id": "1",
+            "contact_id": "",
+            "status": "Complete",
+            "is_test_data": "0",
+            "date_submitted": "2018-09-27 10:42:26 EDT",
+            "session_id": "1538059336_5bacec4869caa2.27680217",
+            "language": "English",
+            "date_started": "2018-09-27 10:42:16 EDT",
+            "link_id": "7473882",
+            "url_variables": [],
+            "ip_address": "50.232.185.226",
+            "referer": "https://app.alchemer.com/distribute/share/id/4599075",
+            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+            "response_time": 10,
+            "data_quality": [],
+            "longitude": "-105.20369720459",
+            "latitude": "40.050701141357",
+            "country": "United States",
+            "city": "Boulder",
+            "region": "CO",
+            "postal": "80301",
+            "dma": "751",
+            "survey_data": {
+                "2": {
+                    "id": 2,
+                    "type": "RADIO",
+                    "question": "Will you attend the event?",
+                    "section_id": 1,
+                    "original_answer": "Yes",
+                    "answer": "1",
+                    "answer_id": 10001,
+                    "shown": True,
+                },
+                "3": {
+                    "id": 3,
+                    "type": "TEXTBOX",
+                    "question": "How many guests will you bring?",
+                    "section_id": 1,
+                    "answer": "3",
+                    "shown": True,
+                },
+                "4": {
+                    "id": 4,
+                    "type": "TEXTBOX",
+                    "question": "How many guests are under the age of 18?",
+                    "section_id": 1,
+                    "answer": "2",
+                    "shown": True,
+                },
+            },
+        },
+        {
+            "id": "2",
+            "contact_id": "",
+            "status": "Complete",
+            "is_test_data": "0",
+            "date_submitted": "2018-09-27 10:43:11 EDT",
+            "session_id": "1538059381_5bacec751e41f4.51482165",
+            "language": "English",
+            "date_started": "2018-09-27 10:43:01 EDT",
+            "link_id": "7473882",
+            "url_variables": {
+                "__dbget": {"key": "__dbget", "value": "true", "type": "url"}
+            },
+            "ip_address": "50.232.185.226",
+            "referer": "",
+            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+            "response_time": 10,
+            "data_quality": [],
+            "longitude": "-105.20369720459",
+            "latitude": "40.050701141357",
+            "country": "United States",
+            "city": "Boulder",
+            "region": "CO",
+            "postal": "80301",
+            "dma": "751",
+            "survey_data": {
+                "2": {
+                    "id": 2,
+                    "type": "RADIO",
+                    "question": "Will you attend the event?",
+                    "section_id": 1,
+                    "original_answer": "1",
+                    "answer": "1",
+                    "answer_id": 10001,
+                    "shown": True,
+                },
+                "3": {
+                    "id": 3,
+                    "type": "TEXTBOX",
+                    "question": "How many guests will you bring?",
+                    "section_id": 1,
+                    "answer": "2",
+                    "shown": True,
+                },
+                "4": {
+                    "id": 4,
+                    "type": "TEXTBOX",
+                    "question": "How many guests are under the age of 18?",
+                    "section_id": 1,
+                    "answer": "0",
+                    "shown": True,
+                },
+            },
+        },
+    ],
+}
+
+SUBMISSION_DATE = "2021-01-05"
+
+EXAMPLE_RESPONSE_FORMATTED_0 = {
+    "submission_date": SUBMISSION_DATE,
+    "id": "1",
+    "status": "Complete",
+    "session_id": "1538059336_5bacec4869caa2.27680217",
+    "response_time": 10,
+    "survey_data": [
+        {
+            "id": 2,
+            "type": "RADIO",
+            "question": "Will you attend the event?",
+            "section_id": 1,
+            "original_answer": "Yes",
+            "answer": "1",
+            "answer_id": 10001,
+            "shown": True,
+        },
+        {
+            "id": 3,
+            "type": "TEXTBOX",
+            "question": "How many guests will you bring?",
+            "section_id": 1,
+            "answer": "3",
+            "shown": True,
+        },
+        {
+            "id": 4,
+            "type": "TEXTBOX",
+            "question": "How many guests are under the age of 18?",
+            "section_id": 1,
+            "answer": "2",
+            "shown": True,
+        },
+    ],
+}
+
+EXAMPLE_RESPONSE_FORMATTED = [
+    EXAMPLE_RESPONSE_FORMATTED_0,
+    {
+        "submission_date": SUBMISSION_DATE,
+        "id": "2",
+        "status": "Complete",
+        "session_id": "1538059381_5bacec751e41f4.51482165",
+        "response_time": 10,
+        "survey_data": [
+            {
+                "id": 2,
+                "type": "RADIO",
+                "question": "Will you attend the event?",
+                "section_id": 1,
+                "original_answer": "1",
+                "answer": "1",
+                "answer_id": 10001,
+                "shown": True,
+            },
+            {
+                "id": 3,
+                "type": "TEXTBOX",
+                "question": "How many guests will you bring?",
+                "section_id": 1,
+                "answer": "2",
+                "shown": True,
+            },
+            {
+                "id": 4,
+                "type": "TEXTBOX",
+                "question": "How many guests are under the age of 18?",
+                "section_id": 1,
+                "answer": "0",
+                "shown": True,
+            },
+        ],
+    },
+]
 
 
 @pytest.fixture()
@@ -20,38 +228,86 @@ def testing_dataset(testing_client):
 
 
 @pytest.fixture()
-def testing_table(testing_dataset):
+def testing_table_id(testing_dataset):
     table_ref = testing_dataset.table(f"survey_testing_table_{str(uuid4())[:8]}")
-    yield table
+    table_id = f"{table_ref.dataset_id}.{table_ref.table_id}"
+    yield table_id
 
 
 def test_utc_date_to_eastern_time():
-    assert False
+    # UTC-5 during standard time: https://en.wikipedia.org/wiki/Eastern_Time_Zone
+    assert utc_date_to_eastern_string("2021-01-05") == "2021-01-04+19:00:00"
 
 
 def test_date_plus_one():
-    assert False
+    assert date_plus_one("2020-01-05") == "2020-01-06"
 
 
 def test_format_response():
-    assert False
+    submission_date = "2021-01-05"
+    assert (
+        format_responses(EXAMPLE_RESPONSE["data"][0], SUBMISSION_DATE)
+        == EXAMPLE_RESPONSE_FORMATTED_0
+    )
 
 
 def test_construct_data():
-    assert False
+    submission_date = "2021-01-05"
+    assert (
+        construct_data(EXAMPLE_RESPONSE, SUBMISSION_DATE) == EXAMPLE_RESPONSE_FORMATTED
+    )
 
 
-def test_get_survey_data():
-    assert False
+@pytest.fixture()
+def patch_api_requests(monkeypatch):
+    # Note: this does not test iterating over multiple pages
+    class MockResponse:
+        @staticmethod
+        def raise_for_status():
+            pass
+
+        @staticmethod
+        def json():
+            return EXAMPLE_RESPONSE
+
+    def mock_get(*args, **kwargs):
+        return MockResponse()
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+
+def test_get_survey_data(patch_api_requests):
+    assert (
+        get_survey_data("555555", SUBMISSION_DATE, "token", "secret")
+        == EXAMPLE_RESPONSE_FORMATTED
+    )
 
 
 def test_response_schema():
-    assert False
+    # ensure that there aren't any exceptions
+    assert response_schema()
 
 
-def test_insert_to_bq():
-    assert False
+def test_insert_to_bq(testing_table_id):
+    transformed = construct_data(EXAMPLE_RESPONSE, SUBMISSION_DATE)
+    insert_to_bq(transformed, testing_table_id, SUBMISSION_DATE)
 
 
-def test_cli():
-    assert False
+def test_cli(patch_api_requests, testing_table_id):
+    res = CliRunner().invoke(
+        main,
+        [
+            "--date",
+            SUBMISSION_DATE,
+            "--survey_id",
+            "55555",
+            "--api_token",
+            "token",
+            "--api_secret",
+            "secret",
+            "--destination_table",
+            testing_table_id,
+        ],
+        catch_exceptions=False,
+    )
+    assert res.exit_code == 0

--- a/tests/alchemer/test_survey.py
+++ b/tests/alchemer/test_survey.py
@@ -263,11 +263,31 @@ def test_date_plus_one():
 
 
 def test_format_response():
-    submission_date = "2021-01-05"
     assert (
         format_responses(EXAMPLE_RESPONSE["data"][0], SUBMISSION_DATE)
         == EXAMPLE_RESPONSE_FORMATTED_0
     )
+
+
+def test_format_response_nonnumeric_answer_id():
+    base = {
+        "submission_date": SUBMISSION_DATE,
+        "id": "1",
+        "status": "Complete",
+        "session_id": "1538059336_5bacec4869caa2.27680217",
+        "response_time": 10,
+        "survey_data": [
+            {
+                "answer_id": "10001-other",
+            },
+            {
+                "answer_id": "fadfasdf-other",
+            },
+        ],
+    }
+    res = format_response(base, SUBMISSION_DATE)
+    assert res["survey_data"][0]["answer_id"] == 10001
+    assert not res["survey_data"][1].get("answer_id")
 
 
 def test_construct_data():

--- a/tests/alchemer/test_survey.py
+++ b/tests/alchemer/test_survey.py
@@ -38,7 +38,11 @@ EXAMPLE_RESPONSE = {
             "url_variables": [],
             "ip_address": "50.232.185.226",
             "referer": "https://app.alchemer.com/distribute/share/id/4599075",
-            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+            "user_agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/69.0.3497.100 Safari/537.36"
+            ),
             "response_time": 10,
             "data_quality": [],
             "longitude": "-105.20369720459",
@@ -92,7 +96,11 @@ EXAMPLE_RESPONSE = {
             },
             "ip_address": "50.232.185.226",
             "referer": "",
-            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+            "user_agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/69.0.3497.100 Safari/537.36"
+            ),
             "response_time": 10,
             "data_quality": [],
             "longitude": "-105.20369720459",
@@ -291,7 +299,6 @@ def test_format_response_nonnumeric_answer_id():
 
 
 def test_construct_data():
-    submission_date = "2021-01-05"
     assert (
         construct_data(EXAMPLE_RESPONSE, SUBMISSION_DATE) == EXAMPLE_RESPONSE_FORMATTED
     )

--- a/tests/alchemer/test_survey.py
+++ b/tests/alchemer/test_survey.py
@@ -326,86 +326,86 @@ def test_insert_to_bq_options(testing_table_id):
     insert_to_bq(transformed, testing_table_id, SUBMISSION_DATE)
 
 
-# def test_insert_to_bq_subquestions(testing_table_id):
-#     # override survey data
-#     # https://apihelp.alchemer.com/help/surveyresponse-per-question-v5#checkboxgrid
-#     base = EXAMPLE_RESPONSE["data"][0]
-#     base["survey_data"] = {
-#         "30": {
-#             "id": 30,
-#             "type": "parent",
-#             "question": "Checkbox Grid Question Title",
-#             "subquestions": {
-#                 "31": {
-#                     "10062": {
-#                         "id": 10062,
-#                         "type": "CHECKBOX",
-#                         "parent": 30,
-#                         "question": "Row 1 : Column 1",
-#                         "answer": "Column 1",
-#                         "shown": True,
-#                     },
-#                     "10063": {
-#                         "id": 10063,
-#                         "type": "CHECKBOX",
-#                         "parent": 30,
-#                         "question": "Row 1 : Column 2",
-#                         "answer": None,
-#                         "shown": True,
-#                     },
-#                 },
-#                 "32": {
-#                     "10062": {
-#                         "id": 10062,
-#                         "type": "CHECKBOX",
-#                         "parent": 30,
-#                         "question": "Row 2 : Column 1",
-#                         "answer": None,
-#                         "shown": True,
-#                     },
-#                     "10063": {
-#                         "id": 10063,
-#                         "type": "CHECKBOX",
-#                         "parent": 30,
-#                         "question": "Row 2 : Column 2",
-#                         "answer": "Column 2",
-#                         "shown": True,
-#                     },
-#                 },
-#             },
-#             "section_id": 3,
-#             "shown": True,
-#         },
-#         "83": {
-#             "id": 83,
-#             "type": "parent",
-#             "question": "Custom Table Question Title",
-#             "subquestions": {
-#                 "10001": {
-#                     "id": 10001,
-#                     "type": "RADIO",
-#                     "question": "Radio Button Column",
-#                     "section_id": 4,
-#                     "answer": "Option 1",
-#                     "answer_id": 10113,
-#                     "shown": true,
-#                 },
-#                 "10002": {
-#                     "id": 10002,
-#                     "type": "RADIO",
-#                     "question": "Radio Button Column",
-#                     "section_id": 4,
-#                     "answer": "Option 2",
-#                     "answer_id": 10114,
-#                     "shown": true,
-#                 },
-#             },
-#             "section_id": 4,
-#             "shown": true,
-#         },
-#     }
-#     transformed = [format_responses(base, SUBMISSION_DATE)]
-#     insert_to_bq(transformed, testing_table_id, SUBMISSION_DATE)
+def test_insert_to_bq_subquestions(testing_table_id):
+    # Override survey data. Note that the subquestion object is incompatible.
+    # https://apihelp.alchemer.com/help/surveyresponse-per-question-v5#checkboxgrid
+    base = copy.deepcopy(EXAMPLE_RESPONSE["data"][0])
+    base["survey_data"] = {
+        "30": {
+            "id": 30,
+            "type": "parent",
+            "question": "Checkbox Grid Question Title",
+            "subquestions": {
+                "31": {
+                    "10062": {
+                        "id": 10062,
+                        "type": "CHECKBOX",
+                        "parent": 30,
+                        "question": "Row 1 : Column 1",
+                        "answer": "Column 1",
+                        "shown": True,
+                    },
+                    "10063": {
+                        "id": 10063,
+                        "type": "CHECKBOX",
+                        "parent": 30,
+                        "question": "Row 1 : Column 2",
+                        "answer": None,
+                        "shown": True,
+                    },
+                },
+                "32": {
+                    "10062": {
+                        "id": 10062,
+                        "type": "CHECKBOX",
+                        "parent": 30,
+                        "question": "Row 2 : Column 1",
+                        "answer": None,
+                        "shown": True,
+                    },
+                    "10063": {
+                        "id": 10063,
+                        "type": "CHECKBOX",
+                        "parent": 30,
+                        "question": "Row 2 : Column 2",
+                        "answer": "Column 2",
+                        "shown": True,
+                    },
+                },
+            },
+            "section_id": 3,
+            "shown": True,
+        },
+        "83": {
+            "id": 83,
+            "type": "parent",
+            "question": "Custom Table Question Title",
+            "subquestions": {
+                "10001": {
+                    "id": 10001,
+                    "type": "RADIO",
+                    "question": "Radio Button Column",
+                    "section_id": 4,
+                    "answer": "Option 1",
+                    "answer_id": 10113,
+                    "shown": True,
+                },
+                "10002": {
+                    "id": 10002,
+                    "type": "RADIO",
+                    "question": "Radio Button Column",
+                    "section_id": 4,
+                    "answer": "Option 2",
+                    "answer_id": 10114,
+                    "shown": True,
+                },
+            },
+            "section_id": 4,
+            "shown": True,
+        },
+    }
+    transformed = [format_responses(base, SUBMISSION_DATE)]
+    insert_to_bq(transformed, testing_table_id, SUBMISSION_DATE)
 
 
 def test_cli(patch_api_requests, testing_table_id):

--- a/tests/alchemer/test_survey.py
+++ b/tests/alchemer/test_survey.py
@@ -276,16 +276,16 @@ def test_format_response_nonnumeric_answer_id():
         "status": "Complete",
         "session_id": "1538059336_5bacec4869caa2.27680217",
         "response_time": 10,
-        "survey_data": [
-            {
+        "survey_data": {
+            "1": {
                 "answer_id": "10001-other",
             },
-            {
+            "2": {
                 "answer_id": "fadfasdf-other",
             },
-        ],
+        },
     }
-    res = format_response(base, SUBMISSION_DATE)
+    res = format_responses(base, SUBMISSION_DATE)
     assert res["survey_data"][0]["answer_id"] == 10001
     assert not res["survey_data"][1].get("answer_id")
 

--- a/tests/alchemer/test_survey.py
+++ b/tests/alchemer/test_survey.py
@@ -1,0 +1,57 @@
+import pytest
+from uuid import uuid4
+from google.cloud import bigquery
+
+
+@pytest.fixture()
+def testing_client():
+    bq = bigquery.Client()
+    yield bq
+
+
+@pytest.fixture()
+def testing_dataset(testing_client):
+    bq = testing_client
+    dataset_id = f"test_survey_pytest_{str(uuid4())[:8]}"
+    bq.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)
+    dataset = bq.create_dataset(dataset_id)
+    yield dataset
+    bq.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)
+
+
+@pytest.fixture()
+def testing_table(testing_dataset):
+    table_ref = testing_dataset.table(f"survey_testing_table_{str(uuid4())[:8]}")
+    yield table
+
+
+def test_utc_date_to_eastern_time():
+    assert False
+
+
+def test_date_plus_one():
+    assert False
+
+
+def test_format_response():
+    assert False
+
+
+def test_construct_data():
+    assert False
+
+
+def test_get_survey_data():
+    assert False
+
+
+def test_response_schema():
+    assert False
+
+
+def test_insert_to_bq():
+    assert False
+
+
+def test_cli():
+    assert False


### PR DESCRIPTION
This should fix #1647.

This adds a few columns that were originally missing from the schema (`options` and `subquestions`). When handling `subquestions`, the column is stringified into JSON because there are two different schemas for the field depending on the question type. This also adds tests that are based on api documentation examples: https://apihelp.alchemer.com/help/surveyresponse-returned-fields-v5#getobject

I tested this with the current set of surveys:

```
ids=(5572350 5205593 5829956 5187896 5111573)
for id in $ids; do
python3 -m bigquery_etl.alchemer.survey \
	--date 2021-01-05 \
	--survey_id $id  \
	--api_token $ALCHEMER_API_TOKEN \
	--api_secret $ALCHEMER_API_SECRET \
	--destination_table amiyaguchi-dev.analysis.alchemer_vpn_test
done
```

Which works, but with the caveat that one of the surveys returns an answer that breaks the API promise that the `answer_id` is numeric.