### PR TITLE
Fix suggestions for daily, weekly, ... scheduling options

### DIFF
--- a/bigquery_etl/cli/dag.py
+++ b/bigquery_etl/cli/dag.py
@@ -93,7 +93,7 @@ def info(name, dags_config, with_tasks):
     help=(
         "Schedule interval of the new DAG. "
         "Schedule intervals can be either in CRON format or one of: "
-        "@once, @hourly, @daily, @weekly, @monthly, @yearly or a timedelta []d[]h[]m"
+        "once, hourly, daily, weekly, monthly, yearly or a timedelta []d[]h[]m"
     ),
     required=True,
 )

--- a/bigquery_etl/query_scheduling/dag.py
+++ b/bigquery_etl/query_scheduling/dag.py
@@ -140,13 +140,7 @@ class Dag:
 
     @schedule_interval.validator
     def validate_schedule_interval(self, attribute, value):
-        """
-        Validate the schedule_interval format.
-
-        Schedule intervals can be either in CRON format or one of:
-        @once, @hourly, @daily, @weekly, @monthly, @yearly
-        or a timedelta []d[]h[]m
-        """
+        """Validate the schedule_interval format."""
         if not is_schedule_interval(value):
             raise ValueError(f"Invalid schedule_interval {value}.")
 

--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -80,13 +80,7 @@ class TaskRef:
 
     @schedule_interval.validator
     def validate_schedule_interval(self, attribute, value):
-        """
-        Validate the schedule_interval format.
-
-        Schedule intervals can be either in CRON format or one of:
-        @once, @hourly, @daily, @weekly, @monthly, @yearly
-        or a timedelta []d[]h[]m
-        """
+        """Validate the schedule_interval format."""
         if value is not None and not is_schedule_interval(value):
             raise ValueError(f"Invalid schedule_interval {value}.")
 

--- a/bigquery_etl/query_scheduling/utils.py
+++ b/bigquery_etl/query_scheduling/utils.py
@@ -49,10 +49,6 @@ SCHEDULE_INTERVAL_RE = re.compile(
 def is_schedule_interval(interval):
     """
     Check whether the provided string is a valid schedule interval.
-
-    Schedule intervals can be either in CRON format or one of:
-    @once, @hourly, @daily, @weekly, @monthly, @yearly
-    or a timedelta []d[]h[]m
     """
     return SCHEDULE_INTERVAL_RE.match(interval)
 

--- a/bigquery_etl/query_scheduling/utils.py
+++ b/bigquery_etl/query_scheduling/utils.py
@@ -47,9 +47,7 @@ SCHEDULE_INTERVAL_RE = re.compile(
 
 
 def is_schedule_interval(interval):
-    """
-    Check whether the provided string is a valid schedule interval.
-    """
+    """Check whether the provided string is a valid schedule interval."""
     return SCHEDULE_INTERVAL_RE.match(interval)
 
 


### PR DESCRIPTION
The comment (and help text) falsely implied you should prefix
them with an `@` symbol.