### PR TITLE
Bug 1683765 - Backfill vpn surveys

### DIFF
--- a/bigquery_etl/cli/__init__.py
+++ b/bigquery_etl/cli/__init__.py
@@ -5,6 +5,7 @@ import warnings
 import click
 
 from .._version import __version__
+from ..cli.alchemer import alchemer
 from ..cli.dag import dag
 from ..cli.dryrun import dryrun
 from ..cli.format import format
@@ -27,6 +28,7 @@ def cli(prog_name=None):
         "stripe": stripe_,
         "glam": glam,
         "view": view,
+        "alchemer": alchemer,
     }
 
     @click.group(commands=commands)

--- a/bigquery_etl/cli/__init__.py
+++ b/bigquery_etl/cli/__init__.py
@@ -5,7 +5,9 @@ import warnings
 import click
 
 from .._version import __version__
-from ..cli.alchemer import alchemer
+
+# We rename the import, otherwise it affects monkeypatching in tests
+from ..cli.alchemer import alchemer as alchemer_
 from ..cli.dag import dag
 from ..cli.dryrun import dryrun
 from ..cli.format import format
@@ -28,7 +30,7 @@ def cli(prog_name=None):
         "stripe": stripe_,
         "glam": glam,
         "view": view,
-        "alchemer": alchemer,
+        "alchemer": alchemer_,
     }
 
     @click.group(commands=commands)

--- a/bigquery_etl/cli/alchemer.py
+++ b/bigquery_etl/cli/alchemer.py
@@ -1,5 +1,5 @@
 """bigquery-etl CLI alchemer command."""
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 import click
 
@@ -29,8 +29,16 @@ def backfill(start_date, end_date, survey_id, api_token, api_secret, destination
     print(
         f"Runing backfill of {survey_id} from {start_date} to {end_date} into {destination_table}"
     )
-    for i in range((end_date - start_date).days + 1):
+    days = (end_date - start_date).days + 1
+    start = datetime.utcnow()
+    for i in range(days):
         current_date = (start_date + timedelta(i)).isoformat()[:10]
         print(f"Running for {current_date}")
         survey_data = get_survey_data(survey_id, current_date, api_token, api_secret)
+        if not survey_data:
+            print("No data, skipping insertion...")
+            continue
         insert_to_bq(survey_data, destination_table, current_date)
+    print(
+        f"Processed {days} days in {int((datetime.utcnow()-start).total_seconds())} seconds"
+    )

--- a/bigquery_etl/cli/alchemer.py
+++ b/bigquery_etl/cli/alchemer.py
@@ -1,0 +1,36 @@
+"""bigquery-etl CLI alchemer command."""
+from datetime import date, timedelta
+
+import click
+
+from ..alchemer.survey import get_survey_data, insert_to_bq
+
+
+@click.group(help="Commands for importing alchemer data.")
+def alchemer():
+    """Create the CLI group for the alchemer command."""
+    pass
+
+
+@alchemer.command()
+@click.option("--start-date", type=click.DateTime(formats=["%Y-%m-%d"]), required=True)
+@click.option(
+    "--end-date", type=click.DateTime(formats=["%Y-%m-%d"]), default=str(date.today())
+)
+@click.option("--survey_id", required=True)
+@click.option("--api_token", required=True)
+@click.option("--api_secret", required=True)
+@click.option("--destination_table", required=True)
+def backfill(start_date, end_date, survey_id, api_token, api_secret, destination_table):
+    """Import data from alchemer (surveygizmo) surveys into BigQuery.
+
+    The date range is inclusive of the start and end values.
+    """
+    print(
+        f"Runing backfill of {survey_id} from {start_date} to {end_date} into {destination_table}"
+    )
+    for i in range((end_date - start_date).days + 1):
+        current_date = (start_date + timedelta(i)).isoformat()[:10]
+        print(f"Running for {current_date}")
+        survey_data = get_survey_data(survey_id, current_date, api_token, api_secret)
+        insert_to_bq(survey_data, destination_table, current_date)

--- a/bigquery_etl/cli/alchemer.py
+++ b/bigquery_etl/cli/alchemer.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timedelta
 
 import click
 
-from ..alchemer.survey import get_survey_data, insert_to_bq
+from bigquery_etl.alchemer.survey import get_survey_data, insert_to_bq
 
 
 @click.group(help="Commands for importing alchemer data.")
@@ -27,7 +27,8 @@ def backfill(start_date, end_date, survey_id, api_token, api_secret, destination
     The date range is inclusive of the start and end values.
     """
     print(
-        f"Runing backfill of {survey_id} from {start_date} to {end_date} into {destination_table}"
+        f"Runing backfill of {survey_id} from {start_date} to {end_date}"
+        " into {destination_table}"
     )
     days = (end_date - start_date).days + 1
     start = datetime.utcnow()

--- a/tests/cli/test_cli_alchemer.py
+++ b/tests/cli/test_cli_alchemer.py
@@ -1,0 +1,37 @@
+from click.testing import CliRunner
+
+from bigquery_etl.cli.alchemer import backfill
+
+
+def test_cli_alchemer_backfill_inclusive_dates(monkeypatch):
+    def nop(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr("bigquery_etl.cli.alchemer.get_survey_data", nop)
+    monkeypatch.setattr("bigquery_etl.cli.alchemer.insert_to_bq", nop)
+
+    result = CliRunner().invoke(
+        backfill,
+        [
+            "--start-date",
+            "2021-01-01",
+            "--end-date",
+            "2021-01-03",
+            "--survey_id",
+            "55555",
+            "--api_token",
+            "token",
+            "--api_secret",
+            "secret",
+            "--destination_table",
+            "testing_dataset.testing_table",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    # parse the output...
+    assert (
+        "2021-01-01" in result.stdout
+        and "2021-01-02" in result.stdout
+        and "2021-01-03" in result.stdout
+    ), result.stdout


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1683765)

This builds on #1634 and completes the historical data import. The script was used for these commands:

```bash
bqetl alchemer backfill \
	--start-date 2020-04-19 \
	--end-date 2021-01-03 \
	--survey_id 5572350  \
	--api_token $ALCHEMER_API_TOKEN \
	--api_secret $ALCHEMER_API_SECRET \
	--destination_table moz-fx-data-shared-prod.mozilla_vpn_external.survey_recommend_v1
# time not taken

bqetl alchemer backfill \
	--start-date 2019-12-09 \
	--end-date 2021-01-03 \
	--survey_id 5187896  \
	--api_token $ALCHEMER_API_TOKEN \
	--api_secret $ALCHEMER_API_SECRET \
	--destination_table moz-fx-data-shared-prod.mozilla_vpn_external.survey_product_quality_v1
# Processed 392 days in 1677 seconds

bqetl alchemer backfill \
	--start-date 2019-12-06 \
	--end-date 2021-01-03 \
	--survey_id 5205593  \
	--api_token $ALCHEMER_API_TOKEN \
	--api_secret $ALCHEMER_API_SECRET \
	--destination_table moz-fx-data-shared-prod.mozilla_vpn_external.survey_market_fit_v1
# Processed 395 days in 1858 seconds

bqetl alchemer backfill \
	--start-date 2020-09-24 \
	--end-date 2021-01-03 \
	--survey_id 5829956  \
	--api_token $ALCHEMER_API_TOKEN \
	--api_secret $ALCHEMER_API_SECRET \
	--destination_table moz-fx-data-shared-prod.mozilla_vpn_external.survey_intercept_q3_v1
# Processed 102 days in 449 seconds

bqetl alchemer backfill \
	--start-date 2019-07-16 \
	--end-date 2021-01-03 \
	--survey_id 5111573  \
	--api_token $ALCHEMER_API_TOKEN \
	--api_secret $ALCHEMER_API_SECRET \
	--destination_table moz-fx-data-shared-prod.mozilla_vpn_external.survey_cancellation_of_service_v1
# Processed 538 days in 1949 seconds
```