### PR TITLE
Fix ds_format for ts_nodash

### DIFF
--- a/dags/bqetl_experiments_hourly.py
+++ b/dags/bqetl_experiments_hourly.py
@@ -25,7 +25,7 @@ with DAG(
 
     experiment_enrollment_aggregates_hourly = bigquery_etl_query(
         task_id="experiment_enrollment_aggregates_hourly",
-        destination_table='experiment_enrollment_aggregates_hourly_v1${{ macros.ds_format(ts_nodash, "%Y%m%d%H%M%S", "%Y%m%d%H") }}',
+        destination_table='experiment_enrollment_aggregates_hourly_v1${{ macros.ds_format(ts_nodash, "%Y%m%dT%H%M%S", "%Y%m%d%H") }}',
         dataset_id="telemetry_derived",
         project_id="moz-fx-data-shared-prod",
         owner="ascholtz@mozilla.com",
@@ -33,7 +33,7 @@ with DAG(
         date_partition_parameter=None,
         depends_on_past=False,
         parameters=[
-            'submission_timestamp:TIMESTAMP:{{ macros.ds_format(ts_nodash, "%Y%m%d%H%M%S", "%Y-%m-%d %H:00:00") }}'
+            'submission_timestamp:TIMESTAMP:{{ macros.ds_format(ts_nodash, "%Y%m%dT%H%M%S", "%Y-%m-%d %H:00:00") }}'
         ],
         dag=dag,
     )

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_hourly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_hourly_v1/metadata.yaml
@@ -13,11 +13,11 @@ scheduling:
     # This DAG runs 30 minutes after the hour to allow for some latency in 
     # data loading;
     # we truncate ts_nodash so that the query represents the previous full hour.
-    'submission_timestamp:TIMESTAMP:{{ macros.ds_format(ts_nodash, "%Y%m%d%H%M%S", "%Y-%m-%d %H:00:00") }}' # yamllint disable-line rule:line-length
+    'submission_timestamp:TIMESTAMP:{{ macros.ds_format(ts_nodash, "%Y%m%dT%H%M%S", "%Y-%m-%d %H:00:00") }}' # yamllint disable-line rule:line-length
   ]
   referenced_tables: [
     "moz-fx-data-shared-prod", "telemetry_live", "event_v4"
   ]
   destination_table:
-    experiment_enrollment_aggregates_hourly_v1${{ macros.ds_format(ts_nodash, "%Y%m%d%H%M%S", "%Y%m%d%H") }} # yamllint disable-line rule:line-length
+    experiment_enrollment_aggregates_hourly_v1${{ macros.ds_format(ts_nodash, "%Y%m%dT%H%M%S", "%Y%m%d%H") }} # yamllint disable-line rule:line-length
   date_partition_parameter: null


### PR DESCRIPTION
`ts_no_dash` timestamps have format `"%Y%m%dT%H%M%S"` (I missed the `T` before)