### PR TITLE
Specify query file path for experiment enrollment aggregates hourly scheduling

### DIFF
--- a/dags/bqetl_experiments_hourly.py
+++ b/dags/bqetl_experiments_hourly.py
@@ -35,5 +35,6 @@ with DAG(
         parameters=[
             'submission_timestamp:TIMESTAMP:{{ macros.ds_format(ts_nodash, "%Y%m%dT%H%M%S", "%Y-%m-%d %H:00:00") }}'
         ],
+        sql_file_path="sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_hourly_v1/query.sql",
         dag=dag,
     )

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_hourly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_hourly_v1/metadata.yaml
@@ -20,4 +20,5 @@ scheduling:
   ]
   destination_table:
     experiment_enrollment_aggregates_hourly_v1${{ macros.ds_format(ts_nodash, "%Y%m%dT%H%M%S", "%Y%m%d%H") }} # yamllint disable-line rule:line-length
+  query_file_path: 'sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_hourly_v1/query.sql' # yamllint disable-line rule:line-length
   date_partition_parameter: null


### PR DESCRIPTION
Currently failing on `No such file or directory: 'sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_hourly_v1$2021011320/query.sql'\n"`