### PR TITLE
execution_date to to_datetime_string in experiment_enrollment_aggregates_hourly scheduling

### DIFF
--- a/dags/bqetl_experiments_hourly.py
+++ b/dags/bqetl_experiments_hourly.py
@@ -25,7 +25,7 @@ with DAG(
 
     experiment_enrollment_aggregates_hourly = bigquery_etl_query(
         task_id="experiment_enrollment_aggregates_hourly",
-        destination_table='experiment_enrollment_aggregates_hourly_v1${{ macros.ds_format(execution_date + macros.timedelta(hours=-1), "%Y-%m-%d %H:%M:%S", "%Y%m%d%H") }}',
+        destination_table='experiment_enrollment_aggregates_hourly_v1${{ macros.ds_format((execution_date + macros.timedelta(hours=-1)).to_datetime_string(), "%Y-%m-%d %H:%M:%S", "%Y%m%d%H") }}',
         dataset_id="telemetry_derived",
         project_id="moz-fx-data-shared-prod",
         owner="ascholtz@mozilla.com",

--- a/script/experiments/export_experiment_monitoring_data.py
+++ b/script/experiments/export_experiment_monitoring_data.py
@@ -33,7 +33,6 @@ parser.add_argument(
 )
 parser.add_argument(
     "--datasets",
-    required=True,
     help="Experiment monitoring datasets to be exported",
     nargs="*",
     default=[

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_hourly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_hourly_v1/metadata.yaml
@@ -19,6 +19,6 @@ scheduling:
     "moz-fx-data-shared-prod", "telemetry_live", "event_v4"
   ]
   destination_table:
-    experiment_enrollment_aggregates_hourly_v1${{ macros.ds_format(execution_date + macros.timedelta(hours=-1), "%Y-%m-%d %H:%M:%S", "%Y%m%d%H") }} # yamllint disable-line rule:line-length
+    experiment_enrollment_aggregates_hourly_v1${{ macros.ds_format((execution_date + macros.timedelta(hours=-1)).to_datetime_string(), "%Y-%m-%d %H:%M:%S", "%Y%m%d%H") }} # yamllint disable-line rule:line-length
   query_file_path: 'sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_hourly_v1/query.sql' # yamllint disable-line rule:line-length
   date_partition_parameter: null


### PR DESCRIPTION
I set up a local Airflow instance to test this. For a `2021-01-13T00:00:00Z` run timestamp the partition date part got rendered into `2021011223`

Before it was failing with ` ERROR - strptime() argument 1 must be str, not Pendulum`