### PR TITLE
Remove jsonPayload.fields.id from fxa_auth query

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
@@ -10,7 +10,11 @@ WITH base AS (
           jsonPayload.* REPLACE (
             (
               SELECT AS STRUCT
-                jsonPayload.fields.* EXCEPT (device_id, user_id),
+                jsonPayload.fields.* EXCEPT (device_id, user_id)
+                -- Type changed from STRING to FLOAT64 in source table,
+                -- so we cannot access this field in a wildcard query
+                -- without raising errors.
+                REPLACE(CAST(NULL AS STRING) AS id),
                 TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id
             ) AS fields
           )


### PR DESCRIPTION
This query failed on the 2021-01-18 run with:

> jsonPayload.fields.id has changed type from STRING to FLOAT

Attempts to run this query in the BQ console show errors because the wildcard
query picks up only the most recent schema, which is incompatible with
historical days. We replace the field with null for now and can investigate
with FxA folks what might have caused this schema change.