### PR TITLE
Add main_nightly, similar to main_1pct

### DIFF
--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -134,6 +134,25 @@ with DAG(
         dag=dag,
     )
 
+    telemetry_derived__main_nightly__v1 = bigquery_etl_query(
+        task_id="telemetry_derived__main_nightly__v1",
+        destination_table="main_nightly_v1",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=[
+            "dthorn@mozilla.com",
+            "frank@mozilla.com",
+            "jklukas@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        start_date=datetime.datetime(2020, 7, 1, 0, 0),
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
+        dag=dag,
+    )
+
     telemetry_derived__main_summary__v4 = bigquery_etl_query(
         task_id="telemetry_derived__main_summary__v4",
         destination_table="main_summary_v4",
@@ -191,6 +210,10 @@ with DAG(
     )
 
     telemetry_derived__main_1pct__v1.set_upstream(wait_for_copy_deduplicate_main_ping)
+
+    telemetry_derived__main_nightly__v1.set_upstream(
+        wait_for_copy_deduplicate_main_ping
+    )
 
     telemetry_derived__main_summary__v4.set_upstream(
         wait_for_copy_deduplicate_main_ping

--- a/sql/moz-fx-data-shared-prod/telemetry/main_nightly/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_nightly/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.main_nightly`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.main_nightly_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/init.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.telemetry_derived.main_nightly_v1`
+PARTITION BY
+  DATE(submission_timestamp)
+CLUSTER BY
+  normalized_channel,
+  sample_id
+OPTIONS
+  (require_partition_filter = TRUE, partition_expiration_days = 180)
+AS
+SELECT
+  * REPLACE (
+    mozfun.norm.metadata(metadata) AS metadata,
+    `moz-fx-data-shared-prod.udf.normalize_main_payload`(payload) AS payload
+  )
+FROM
+  telemetry_stable.main_v4
+WHERE
+  FALSE
+  AND normalized_channel = 'nightly'

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
@@ -1,0 +1,35 @@
+friendly_name: Main Nightly
+description: >-
+  *Nota bene: This table is in a beta testing phase and may go away!*
+
+  A materialized subset of main pings intended as a performance
+  optimization for exploratory queries. It contains only the most recent
+  six months of data for the nightly channel of Firefox.
+  Also see main_1pct for a 1% sample that includes all channels.
+
+  Queries on this table are logically equivalent to queries on top of `main_v4`
+  with a filter on `normalized_channel = 'nightly'`, but this table has a few
+  advantages.
+  First, query estimates will be much more accurate; estimates of bytes scanned
+  can't take into account clustering, so we sometimes see valid queries get
+  rejected by Redash due to appearing expensive when they really aren't.
+  Second, simple queries should complete much more quickly on this table
+  compared to `main_v4`; for simple queries on a very wide table like this,
+  the execution time appears to be dominated by BQ simply scanning metadata
+  for all the blocks it might need to touch. Because this table contains
+  only a fraction of main ping data, it is likely to have many fewer blocks to
+  scan through.
+
+  An extra-experimental feature here is the addition of subsample_id, an
+  additional clustering field that allows for queries to efficiently filter
+  down to a 0.01% sample. Like sample_id, it ranges from 0 to 99.
+labels:
+  incremental: true
+owners:
+- jklukas@mozilla.com
+scheduling:
+  dag_name: bqetl_main_summary
+  start_date: '2020-07-01'
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+  referenced_tables: [['moz-fx-data-shared-prod', 'telemetry_stable',
+                       'main_v4']]

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/query.sql
@@ -1,0 +1,14 @@
+SELECT
+  -- We apply field cleaning at the table level rather than the view level because
+  -- the logic here ends up becoming the bottleneck for simple queries on top of
+  -- this table. The limited size and retention policy on this table makes it feasible
+  -- to perform full backfills as needed if this logic changes.
+  * REPLACE (
+    mozfun.norm.metadata(metadata) AS metadata,
+    `moz-fx-data-shared-prod.udf.normalize_main_payload`(payload) AS payload
+  )
+FROM
+  telemetry_stable.main_v4
+WHERE
+  normalized_channel = 'nightly'
+  AND DATE(submission_timestamp) = @submission_date


### PR DESCRIPTION
Should provide a significant performance improvement to queries like https://sql.telemetry.mozilla.org/queries/65380/source and sidestep redash issues with errors due to dry run timeouts.