### PR TITLE
Fix copy_deduplicate logging

### DIFF
--- a/bigquery_etl/copy_deduplicate.py
+++ b/bigquery_etl/copy_deduplicate.py
@@ -257,7 +257,7 @@ def _run_deduplication_query(client, sql, stable_table, job_config, num_retries)
                 client, sql, stable_table, job_config, num_retries - 1
             )
     logging.info(
-        f"Completed query job for {stable_table.table_id}"
+        f"Completed query job for {stable_table}"
         f" with params: {job_config.query_parameters}"
     )
     return stable_table, query_job


### PR DESCRIPTION
Seeing this in my dry-run of copy-deduplicate on pioneer. It looks like the parameter is already a string by the time it's being logged in this statement.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.8/site-packages/bigquery_etl/copy_deduplicate.py", line 372, in <module>
    main()
  File "/usr/local/lib/python3.8/site-packages/bigquery_etl/copy_deduplicate.py", line 363, in main
    results = pool.starmap(client_q.with_client, query_jobs, chunksize=1)
  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 372, in starmap
    return self._map_async(func, iterable, starmapstar, chunksize).get()
  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 771, in get
    raise self._value
  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 51, in starmapstar
    return list(itertools.starmap(args[0], args[1]))
  File "/usr/local/lib/python3.8/site-packages/bigquery_etl/util/client_queue.py", line 39, in with_client
    return func(client, *args)
  File "/usr/local/lib/python3.8/site-packages/bigquery_etl/copy_deduplicate.py", line 260, in _run_deduplication_query
    f"Completed query job for {stable_table.table_id}"
AttributeError: 'str' object has no attribute 'table_id'
```