### PR TITLE
Add glean_usage ETL generation to generate_all_views

### DIFF
--- a/bigquery_etl/glean_usage/baseline_clients_daily.py
+++ b/bigquery_etl/glean_usage/baseline_clients_daily.py
@@ -36,6 +36,15 @@ parser.add_argument(
     "--output-dir",
     help="Also write the query text underneath the given sql dir",
 )
+parser.add_argument(
+    "--views_only",
+    "--views-only",
+    action="store_true",
+    help=(
+        "If set, we write out only view queries to --output-dir and we skip"
+        " running the queries; intended for stable use by Jenkins"
+    ),
+)
 standard_args.add_parallelism(parser)
 standard_args.add_dry_run(parser, debug_log_queries=False)
 standard_args.add_log_level(parser)
@@ -77,9 +86,12 @@ def main():
                 date=args.date,
                 dry_run=True,
                 output_dir=args.output_dir,
+                views_only=args.views_only,
             ),
             baseline_tables,
         )
+        if args.views_only:
+            return
         logging.info(
             f"Dry runs successful for {len(baseline_tables)}"
             " baseline_clients_daily table(s)"
@@ -92,7 +104,7 @@ def main():
             )
 
 
-def run_query(client, baseline_table, date, dry_run, output_dir=None):
+def run_query(client, baseline_table, date, dry_run, output_dir=None, views_only=False):
     """Process a single table, potentially also writing out the generated queries."""
     tables = table_names_from_baseline(baseline_table)
 
@@ -102,23 +114,26 @@ def run_query(client, baseline_table, date, dry_run, output_dir=None):
     render_kwargs.update(tables)
     job_kwargs = dict(use_legacy_sql=False, dry_run=dry_run)
 
-    sql = render(QUERY_FILENAME, **render_kwargs)
+    query_sql = render(QUERY_FILENAME, **render_kwargs)
     init_sql = render(QUERY_FILENAME, init=True, **render_kwargs)
     view_sql = render(VIEW_FILENAME, **render_kwargs)
-    if output_dir:
-        write_sql(output_dir, daily_table, "query.sql", sql)
-        write_sql(output_dir, daily_table, "init.sql", init_sql)
-        write_sql(output_dir, daily_view, "view.sql", view_sql)
+    sql = query_sql
 
     try:
         client.get_table(daily_table)
     except NotFound:
-        if dry_run:
+        if views_only:
+            logging.info(f"Skipping view for table which doesn't exist: {daily_table}")
+            return
+        elif dry_run:
             logging.info(f"Table does not yet exist: {daily_table}")
         else:
             logging.info(f"Creating table: {daily_table}")
         sql = init_sql
     else:
+        if views_only:
+            write_sql(output_dir, daily_view, "view.sql", view_sql)
+            return
         # Table exists, so we will run the incremental query.
         job_kwargs.update(
             destination=f"{daily_table}${date.strftime('%Y%m%d')}",
@@ -127,6 +142,12 @@ def run_query(client, baseline_table, date, dry_run, output_dir=None):
         )
         if not dry_run:
             logging.info(f"Running query for: {daily_table}")
+
+    if output_dir:
+        write_sql(output_dir, daily_view, "view.sql", view_sql)
+        write_sql(output_dir, daily_table, "query.sql", query_sql)
+        write_sql(output_dir, daily_table, "init.sql", init_sql)
+
     job_config = bigquery.QueryJobConfig(**job_kwargs)
     job = client.query(sql, job_config)
     if not dry_run:

--- a/script/generate_all_views
+++ b/script/generate_all_views
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script should call all routines that generate views.
+# It is called by Jenkins as the source of truth for what views should be published.
+
+set -e
+
+: "${TARGET_PROJECT:=moz-fx-data-shar-nonprod-efed}"
+: "${SQL_DIR:=sql}"
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --target-project)
+    TARGET_PROJECT="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    --sql-dir)
+    SQL_DIR="$2"
+    shift # past argument
+    shift # past value
+    ;;
+esac
+done
+
+# Fill in any missing view definitions in the moz-fx-data-shared-prod/ folder
+./script/generate_views "${TARGET_PROJECT}:*_stable.*" --sql-dir "${SQL_DIR}"
+
+# Fill in views for generated Glean ETL
+PLACEHOLDER_DATE="2000-01-01"
+./script/run_glean_baseline_clients_daily --project-id "${TARGET_PROJECT}" --output-dir "${SQL_DIR}/${TARGET_PROJECT}" --views-only --date="${PLACEHOLDER_DATE}"
+./script/run_glean_baseline_clients_last_seen --project-id "${TARGET_PROJECT}" --output-dir "${SQL_DIR}/${TARGET_PROJECT}" --views-only --date="${PLACEHOLDER_DATE}"

--- a/script/generate_and_publish_views
+++ b/script/generate_and_publish_views
@@ -28,6 +28,6 @@ done
 
 # We additionally make sure we have identical view definitions in moz-fx-data-derived-datasets and mozdata
 if [[ "$TARGET_PROJECT" == "moz-fx-data-shared-prod" ]]; then
-    ./script/publish_views --target-project moz-fx-data-derived-datasets "${SQL_DIR}"
-    ./script/publish_views --target-project mozdata "${SQL_DIR}"
+    ./script/publish_views --user-facing-only --target-project moz-fx-data-derived-datasets "${SQL_DIR}"
+    ./script/publish_views --user-facing-only --target-project mozdata "${SQL_DIR}"
 fi

--- a/script/generate_and_publish_views
+++ b/script/generate_and_publish_views
@@ -2,11 +2,32 @@
 
 set -e
 
-# Fill in any missing view definitions in the moz-fx-data-shared-prod/ folder
-./script/generate_views 'moz-fx-data-shared-prod:*_stable.*'
+: "${TARGET_PROJECT:=moz-fx-data-shar-nonprod-efed}"
+: "${SQL_DIR:=sql/}"
 
-# All view definitions target moz-fx-data-shared-prod by default
-./script/publish_views sql/
+while [[ $# -gt 0 ]]
+do
+key="$1"
 
-# We additionally make sure we have identical view definitions in moz-fx-data-derived-datasets
-./script/publish_views --target-project moz-fx-data-derived-datasets sql/
+case $key in
+    --target-project)
+    TARGET_PROJECT="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    --sql-dir)
+    SQL_DIR="$2"
+    shift # past argument
+    shift # past value
+    ;;
+esac
+done
+
+./script/generate_all_views --target-project "${TARGET_PROJECT}" --sql-dir "${SQL_DIR}"
+./script/publish_views --target-project "${TARGET_PROJECT}" "${SQL_DIR}"
+
+# We additionally make sure we have identical view definitions in moz-fx-data-derived-datasets and mozdata
+if [[ "$TARGET_PROJECT" == "moz-fx-data-shared-prod" ]]; then
+    ./script/publish_views --target-project moz-fx-data-derived-datasets "${SQL_DIR}"
+    ./script/publish_views --target-project mozdata "${SQL_DIR}"
+fi


### PR DESCRIPTION
The new `generate_all_views` script is intended to replace `generate_views`
as the entrypoint for Jenkins. Its usage is demonstrated in the
`generate_and_publish_views` script.

This supports the move to user queries in the `mozdata` project.