### PR TITLE
Update publish_static script for mozdata

### DIFF
--- a/bigquery_etl/publish_static.py
+++ b/bigquery_etl/publish_static.py
@@ -75,7 +75,10 @@ def _load_table(
 def main():
     """Publish csv files as BigQuery tables."""
     args = _parse_args()
-    projects = project_dirs(args.project_id)
+
+    # This machinery is only compatible with
+    # the sql/moz-fx-data-shared-prod/static directory.
+    projects = project_dirs('moz-fx-data-shared-prod')
 
     for data_dir in projects:
         for root, dirs, files in os.walk(data_dir):

--- a/bigquery_etl/publish_static.py
+++ b/bigquery_etl/publish_static.py
@@ -78,7 +78,7 @@ def main():
 
     # This machinery is only compatible with
     # the sql/moz-fx-data-shared-prod/static directory.
-    projects = project_dirs('moz-fx-data-shared-prod')
+    projects = project_dirs("moz-fx-data-shared-prod")
 
     for data_dir in projects:
         for root, dirs, files in os.walk(data_dir):

--- a/sql/moz-fx-data-shared-prod/static/README.md
+++ b/sql/moz-fx-data-shared-prod/static/README.md
@@ -8,3 +8,12 @@ the `publish_static` script.  An optional `schema.json` and `description.txt`
 can be defined in the same directory.  If `schema.json` is not defined, column
 names are inferred from the first line of the CSV and are assumed to be strings.
 `description.txt` defines the table description in BigQuery.
+
+These should be published to all active projects used for production
+ETL and analysis:
+
+```
+./script/publish_static --project-id mozdata
+./script/publish_static --project-id moz-fx-data-shared-prod
+./script/publish_static --project-id moz-fx-data-derived-datasets
+```


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1671933

It appears that the current behavior is broken for publishing to any project other than shared-prod.