### PR TITLE
Add missing non-versioned telemetry views

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_accounts_exact_mau28_by_dimensions/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_accounts_exact_mau28_by_dimensions/view.sql
@@ -2,15 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.firefox_accounts_exact_mau28_by_dimensions`
 AS
 SELECT
-  raw.* EXCEPT (mau_tier1_inclusive),
-  -- We rename this column here to match the new standard of prefixing _mau
-  -- with the usage criterion; we can refactor to have the correct name in
-  -- the raw table the next time we need to make a change and backfill.
-  mau_tier1_inclusive AS seen_in_tier1_country_mau,
-  COALESCE(cn.code, raw.country) AS country_code
+  *
 FROM
-  `moz-fx-data-shared-prod.firefox_accounts_derived.exact_mau28_v1` AS raw
-LEFT JOIN
-  `moz-fx-data-shared-prod.static.country_names_v1` cn
-ON
-  (raw.country = cn.name)
+  `moz-fx-data-shared-prod.telemetry.firefox_accounts_exact_mau28_by_dimensions_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_accounts_exact_mau28_by_dimensions/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_accounts_exact_mau28_by_dimensions/view.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.firefox_accounts_exact_mau28_by_dimensions`
+AS
+SELECT
+  raw.* EXCEPT (mau_tier1_inclusive),
+  -- We rename this column here to match the new standard of prefixing _mau
+  -- with the usage criterion; we can refactor to have the correct name in
+  -- the raw table the next time we need to make a change and backfill.
+  mau_tier1_inclusive AS seen_in_tier1_country_mau,
+  COALESCE(cn.code, raw.country) AS country_code
+FROM
+  `moz-fx-data-shared-prod.firefox_accounts_derived.exact_mau28_v1` AS raw
+LEFT JOIN
+  `moz-fx-data-shared-prod.static.country_names_v1` cn
+ON
+  (raw.country = cn.name)

--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_desktop_exact_mau28/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_desktop_exact_mau28/view.sql
@@ -1,0 +1,58 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.firefox_desktop_exact_mau28`
+AS
+WITH base AS (
+  SELECT
+    submission_date,
+    SUM(mau) AS mau,
+    SUM(wau) AS wau,
+    SUM(dau) AS dau,
+    sum(IF(country IN ('US', 'GB', 'FR', 'DE', 'CA'), mau, 0)) AS tier1_mau,
+    sum(IF(country IN ('US', 'GB', 'FR', 'DE', 'CA'), wau, 0)) AS tier1_wau,
+    sum(IF(country IN ('US', 'GB', 'FR', 'DE', 'CA'), dau, 0)) AS tier1_dau,
+    SUM(visited_5_uri_mau) AS visited_5_uri_mau,
+    SUM(visited_5_uri_wau) AS visited_5_uri_wau,
+    SUM(visited_5_uri_dau) AS visited_5_uri_dau
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.firefox_desktop_exact_mau28_by_dimensions_v1`
+  GROUP BY
+    submission_date
+),
+  -- We use imputed values for the period after the Armag-add-on deletion event;
+  -- see https://bugzilla.mozilla.org/show_bug.cgi?id=1552558
+imputed_global AS (
+  SELECT
+    `date` AS submission_date,
+    mau
+  FROM
+    `moz-fx-data-shared-prod.static.firefox_desktop_imputed_mau28_v1`
+  WHERE
+    datasource = 'desktop_global'
+),
+    --
+imputed_tier1 AS (
+  SELECT
+    `date` AS submission_date,
+    mau
+  FROM
+    `moz-fx-data-shared-prod.static.firefox_desktop_imputed_mau28_v1`
+  WHERE
+    datasource = 'desktop_tier1'
+)
+SELECT
+  base.* REPLACE (
+    COALESCE(imputed_global.mau, base.mau) AS mau,
+    COALESCE(imputed_tier1.mau, base.tier1_mau) AS tier1_mau
+  )
+FROM
+  base
+FULL JOIN
+  imputed_global
+USING
+  (submission_date)
+FULL JOIN
+  imputed_tier1
+USING
+  (submission_date)
+ORDER BY
+  submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_desktop_exact_mau28/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_desktop_exact_mau28/view.sql
@@ -1,58 +1,7 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.firefox_desktop_exact_mau28`
 AS
-WITH base AS (
-  SELECT
-    submission_date,
-    SUM(mau) AS mau,
-    SUM(wau) AS wau,
-    SUM(dau) AS dau,
-    sum(IF(country IN ('US', 'GB', 'FR', 'DE', 'CA'), mau, 0)) AS tier1_mau,
-    sum(IF(country IN ('US', 'GB', 'FR', 'DE', 'CA'), wau, 0)) AS tier1_wau,
-    sum(IF(country IN ('US', 'GB', 'FR', 'DE', 'CA'), dau, 0)) AS tier1_dau,
-    SUM(visited_5_uri_mau) AS visited_5_uri_mau,
-    SUM(visited_5_uri_wau) AS visited_5_uri_wau,
-    SUM(visited_5_uri_dau) AS visited_5_uri_dau
-  FROM
-    `moz-fx-data-shared-prod.telemetry_derived.firefox_desktop_exact_mau28_by_dimensions_v1`
-  GROUP BY
-    submission_date
-),
-  -- We use imputed values for the period after the Armag-add-on deletion event;
-  -- see https://bugzilla.mozilla.org/show_bug.cgi?id=1552558
-imputed_global AS (
-  SELECT
-    `date` AS submission_date,
-    mau
-  FROM
-    `moz-fx-data-shared-prod.static.firefox_desktop_imputed_mau28_v1`
-  WHERE
-    datasource = 'desktop_global'
-),
-    --
-imputed_tier1 AS (
-  SELECT
-    `date` AS submission_date,
-    mau
-  FROM
-    `moz-fx-data-shared-prod.static.firefox_desktop_imputed_mau28_v1`
-  WHERE
-    datasource = 'desktop_tier1'
-)
 SELECT
-  base.* REPLACE (
-    COALESCE(imputed_global.mau, base.mau) AS mau,
-    COALESCE(imputed_tier1.mau, base.tier1_mau) AS tier1_mau
-  )
+  *
 FROM
-  base
-FULL JOIN
-  imputed_global
-USING
-  (submission_date)
-FULL JOIN
-  imputed_tier1
-USING
-  (submission_date)
-ORDER BY
-  submission_date
+  `moz-fx-data-shared-prod.telemetry.firefox_desktop_exact_mau28_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_desktop_exact_mau28_by_dimensions/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_desktop_exact_mau28_by_dimensions/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.firefox_desktop_exact_mau28_by_dimensions`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.firefox_desktop_exact_mau28_by_dimensions_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_desktop_exact_mau28_by_dimensions/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_desktop_exact_mau28_by_dimensions/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-shared-prod.telemetry_derived.firefox_desktop_exact_mau28_by_dimensions_v1`
+  `moz-fx-data-shared-prod.telemetry.firefox_desktop_exact_mau28_by_dimensions_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28/view.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28`
+AS
+SELECT
+  submission_date,
+  SUM(mau) AS mau,
+  SUM(wau) AS wau,
+  SUM(dau) AS dau,
+  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), mau, 0)) AS tier1_mau,
+  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), wau, 0)) AS tier1_wau,
+  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), dau, 0)) AS tier1_dau
+FROM
+  `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28_by_dimensions_v1`
+GROUP BY
+  submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28/view.sql
@@ -2,14 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28`
 AS
 SELECT
-  submission_date,
-  SUM(mau) AS mau,
-  SUM(wau) AS wau,
-  SUM(dau) AS dau,
-  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), mau, 0)) AS tier1_mau,
-  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), wau, 0)) AS tier1_wau,
-  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), dau, 0)) AS tier1_dau
+  *
 FROM
-  `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28_by_dimensions_v1`
-GROUP BY
-  submission_date
+  `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28_by_dimensions/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28_by_dimensions/view.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28_by_dimensions`
+AS
+SELECT
+  raw.*,
+  COALESCE(cc.name, raw.country) AS country_name
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.firefox_nondesktop_exact_mau28_v1` AS raw
+LEFT JOIN
+  `moz-fx-data-shared-prod.static.country_codes_v1` cc
+ON
+  (raw.country = cc.code)

--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28_by_dimensions/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28_by_dimensions/view.sql
@@ -2,11 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28_by_dimensions`
 AS
 SELECT
-  raw.*,
-  COALESCE(cc.name, raw.country) AS country_name
+  *
 FROM
-  `moz-fx-data-shared-prod.telemetry_derived.firefox_nondesktop_exact_mau28_v1` AS raw
-LEFT JOIN
-  `moz-fx-data-shared-prod.static.country_codes_v1` cc
-ON
-  (raw.country = cc.code)
+  `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28_by_dimensions_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28_by_product/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28_by_product/view.sql
@@ -2,16 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28_by_product`
 AS
 SELECT
-  submission_date,
-  product,
-  SUM(mau) AS mau,
-  SUM(wau) AS wau,
-  SUM(dau) AS dau,
-  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), mau, 0)) AS tier1_mau,
-  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), wau, 0)) AS tier1_wau,
-  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), dau, 0)) AS tier1_dau
+  *
 FROM
-  `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28_by_dimensions_v1`
-GROUP BY
-  submission_date,
-  product
+  `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28_by_product_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28_by_product/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_nondesktop_exact_mau28_by_product/view.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28_by_product`
+AS
+SELECT
+  submission_date,
+  product,
+  SUM(mau) AS mau,
+  SUM(wau) AS wau,
+  SUM(dau) AS dau,
+  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), mau, 0)) AS tier1_mau,
+  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), wau, 0)) AS tier1_wau,
+  SUM(IF(country IN ('US', 'FR', 'DE', 'GB', 'CA'), dau, 0)) AS tier1_dau
+FROM
+  `moz-fx-data-shared-prod.telemetry.firefox_nondesktop_exact_mau28_by_dimensions_v1`
+GROUP BY
+  submission_date,
+  product

--- a/sql/moz-fx-data-shared-prod/telemetry/lockwise_mobile_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/lockwise_mobile_events/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.lockwise_mobile_events`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry.lockwise_mobile_events_v1`


### PR DESCRIPTION
These were found as part of investigating
https://bugzilla.mozilla.org/show_bug.cgi?id=1671933

They are defined in derived-datasets even though they weren't in bigquery-etl
and so there may be user queries that depend on them. These may have been
erroneously deleted in a previous refactor of this repo.

Restoring them here so that they'll be published to the new `mozdata` project.