### PR TITLE
Remove "preview" warnings from main_1pct and main_nightly

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/metadata.yaml
@@ -1,10 +1,9 @@
 friendly_name: Main 1 percent
 description: >-
-  *Nota bene: This table is in a beta testing phase and may go away!*
-
   A materialized 1 percent sample of main pings intended as a performance
   optimization for exploratory queries. It contains only the most recent
-  six months of data.
+  six months of data. Also see main_nightly for a derived table containing
+  only data where normalized_channel = 'nightly'.
 
   Queries on this table are logically equivalent to queries on top of `main_v4`
   with a filter on `sample_id = 0`, but this table has a few advantages.

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/query.sql
@@ -1,9 +1,7 @@
 SELECT
-  -- subsample_id is an especially experimental field; this table already represents
-  -- a 1% sample, but this field can allow you to efficiently filter down to a 0.01%
-  -- sample, which may or may not be useful in practice. We'll need to get user
-  -- feedback about whether to keep this. The choice of implementation here is not
-  -- yet vetted; it's simply chosen to be a hash that's stable, has a reasonable
+  -- subsample_id can allow you to efficiently filter down to a 0.01% sample.
+  -- The choice of implementation here is not particularly well vetted;
+  -- it's simply chosen to be a hash that's stable, has a reasonable
   -- avalanche effect, and is _different_ from sample_id. We use this same approach
   -- for choosing id_bucket in exact_mau28 tables.
   MOD(ABS(FARM_FINGERPRINT(client_id)), 100) AS subsample_id,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
@@ -1,7 +1,5 @@
 friendly_name: Main Nightly
 description: >-
-  *Nota bene: This table is in a beta testing phase and may go away!*
-
   A materialized subset of main pings intended as a performance
   optimization for exploratory queries. It contains only the most recent
   six months of data for the nightly channel of Firefox.


### PR DESCRIPTION
See https://github.com/mozilla/bigquery-etl/issues/1597