### PR TITLE
Monitoring data export fixes

### DIFF
--- a/script/experiments/export_experiment_monitoring_data.py
+++ b/script/experiments/export_experiment_monitoring_data.py
@@ -223,7 +223,9 @@ def export_dataset(
             source_project,
             destination_project,
         )
-        p.map(_experiment_data_export, active_experiments)
+        p.map_async(_experiment_data_export, active_experiments).get(
+            600
+        )  # timeout after 10 minutes
 
 
 def _convert_ndjson_to_json(

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_live/view.sql
@@ -11,9 +11,9 @@ SELECT
 FROM
   `moz-fx-data-shared-prod.telemetry.experiment_enrollment_aggregates_hourly`
 WHERE
-  DATE(timestamp) > (
+  timestamp > (
     SELECT
-      DATE(MAX(window_end))
+      MAX(window_end)
     FROM
       `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_v1`
   )

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_base/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_base/view.sql
@@ -15,7 +15,7 @@ WITH live_and_stable AS (
     `moz-fx-data-shared-prod.telemetry_live.main_v4`
 )
 SELECT
-  submission_timestamp AS `timestamp`,
+  date(submission_timestamp) AS submission_date,
   dataset_id,
   unnested_experiments.key AS experiment,
   unnested_experiments.value AS branch,
@@ -53,7 +53,7 @@ FROM
     )
   ) AS unnested_search_counts
 GROUP BY
-  timestamp,
+  submission_date,
   dataset_id,
   experiment,
   branch,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_hourly_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_hourly_v1/init.sql
@@ -1,6 +1,5 @@
 CREATE TABLE IF NOT EXISTS
   `moz-fx-data-shared-prod.telemetry_derived.experiment_search_aggregates_hourly_v1`(
-    timestamp TIMESTAMP,
     dataset_id STRING,
     branch STRING,
     experiment STRING,
@@ -11,6 +10,6 @@ CREATE TABLE IF NOT EXISTS
     search_count INT64
   )
 PARTITION BY
-  TIMESTAMP_TRUNC(timestamp, HOUR)
+  TIMESTAMP_TRUNC(window_start, HOUR)
 CLUSTER BY
   experiment

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_hourly_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_hourly_v1/query.sql
@@ -1,7 +1,8 @@
 SELECT
-  *
+  * EXCEPT (submission_date)
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.experiment_search_aggregates_base`
 WHERE
-  timestamp >= TIMESTAMP_SUB(@submission_timestamp, INTERVAL 1 HOUR)
-  AND timestamp < @submission_timestamp
+  window_start >= TIMESTAMP_SUB(@submission_timestamp, INTERVAL 1 HOUR)
+  AND window_start < @submission_timestamp
+  AND submission_date > DATE(TIMESTAMP_SUB(@submission_timestamp, INTERVAL 2 HOUR))

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/view.sql
@@ -20,9 +20,9 @@ WITH all_searches AS (
   FROM
     `moz-fx-data-shared-prod.telemetry.experiment_search_aggregates_hourly`
   WHERE
-    DATE(timestamp) > (
+    timestamp > (
       SELECT
-        DATE(MAX(window_end))
+        MAX(window_end)
       FROM
         `moz-fx-data-shared-prod.telemetry_derived.experiment_search_aggregates_v1`
     )

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/view.sql
@@ -3,7 +3,6 @@ CREATE OR REPLACE VIEW
 AS
 WITH all_searches AS (
   SELECT
-    `timestamp`,
     dataset_id,
     branch,
     experiment,
@@ -20,7 +19,7 @@ WITH all_searches AS (
   FROM
     `moz-fx-data-shared-prod.telemetry.experiment_search_aggregates_hourly`
   WHERE
-    timestamp > (
+    window_start > (
       SELECT
         MAX(window_end)
       FROM

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_recents_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_recents_v1/init.sql
@@ -1,6 +1,5 @@
 CREATE TABLE IF NOT EXISTS
   `moz-fx-data-shared-prod.telemetry_derived.experiment_search_aggregates_recents_v1`(
-    timestamp TIMESTAMP,
     dataset_id STRING,
     branch STRING,
     experiment STRING,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_recents_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_recents_v1/query.sql
@@ -1,14 +1,15 @@
 SELECT
-  *
+  * EXCEPT (submission_date)
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.experiment_search_aggregates_base`
 WHERE
   -- limit the range that is queries from the main live table to up to max 2 hours
   -- search aggregates hourly gets updated every 1 hour with a 30 minute delay
-  timestamp > TIMESTAMP_SUB(@submission_timestamp, INTERVAL 2 HOUR)
-  AND timestamp > (
+  window_start > TIMESTAMP_SUB(@submission_timestamp, INTERVAL 2 HOUR)
+  AND window_start > (
     SELECT
-      MAX(timestamp)
+      MAX(window_start)
     FROM
       `moz-fx-data-shared-prod.telemetry.experiment_search_aggregates_hourly`
   )
+  AND submission_date > DATE(TIMESTAMP_SUB(@submission_timestamp, INTERVAL 2 HOUR))

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/init.sql
@@ -1,6 +1,5 @@
 CREATE TABLE IF NOT EXISTS
   `moz-fx-data-shared-prod.telemetry_derived.experiment_search_aggregates_v1`(
-    timestamp TIMESTAMP,
     dataset_id STRING,
     experiment STRING,
     branch STRING,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql
@@ -1,7 +1,7 @@
 SELECT
-  *
+  * EXCEPT (submission_date)
 FROM
   experiment_search_aggregates_base
 WHERE
-  date(`timestamp`) = @submission_date
+  submission_date = @submission_date
   AND dataset_id = 'telemetry_stable'


### PR DESCRIPTION
The monitoring data export got stuck a few times with the following error:

```
[2021-01-28 05:49:09,586] {pod_launcher.py:156} INFO - b'Exception in thread Thread-3:\n'
[2021-01-28 05:49:09,586] {pod_launcher.py:156} INFO - b'Traceback (most recent call last):\n'
[2021-01-28 05:49:09,586] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner\n'
[2021-01-28 05:49:09,586] {pod_launcher.py:156} INFO - b'    self.run()\n'
[2021-01-28 05:49:09,586] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/threading.py", line 870, in run\n'
[2021-01-28 05:49:09,587] {pod_launcher.py:156} INFO - b'    self._target(*self._args, **self._kwargs)\n'
[2021-01-28 05:49:09,587] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 576, in _handle_results\n'
[2021-01-28 05:49:09,588] {pod_launcher.py:156} INFO - b'    task = get()\n'
[2021-01-28 05:49:09,588] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/multiprocessing/connection.py", line 251, in recv\n'
[2021-01-28 05:49:09,588] {pod_launcher.py:156} INFO - b'    return _ForkingPickler.loads(buf.getbuffer())\n'
[2021-01-28 05:49:09,588] {pod_launcher.py:156} INFO - b"TypeError: __init__() missing 2 required positional arguments: 'status_code' and 'text'\n"
```

The Airflow task just kept running but never finished. The following PR has a fix for this.
