### PR TITLE
Add Markdown description to Airflow DAGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Scheduling Queries in Airflow
   ```yaml
   bqetl_ssl_ratios:   # name of the DAG; must start with bqetl_
     schedule_interval: 0 2 * * *    # query schedule
+    description: The DAG schedules SSL ratios queries.
     default_args:
       owner: example@mozilla.com
       start_date: '2020-04-05'  # YYYY-MM-DD

--- a/bigquery_etl/query_scheduling/dag.py
+++ b/bigquery_etl/query_scheduling/dag.py
@@ -116,6 +116,7 @@ class Dag:
     schedule_interval: str = attr.ib()
     default_args: DagDefaultArgs
     tasks: List[Task] = attr.ib([])
+    description: str = attr.ib("")
 
     @name.validator
     def validate_dag_name(self, attribute, value):

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -5,6 +5,23 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### {{ name }}
+
+Built from bigquery-etl repo, [`dags/{{ name }}.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/{{ name }}.py)
+
+{% if description != "" -%}
+#### Description
+
+{{ description }}
+{% endif -%}
+
+#### Owner
+
+{{ default_args.owner }}
+"""
+
+
 default_args = {{ 
     default_args.to_dict() | 
     format_attr("start_date", "format_date") |
@@ -12,7 +29,7 @@ default_args = {{
     format_attr("retry_delay", "format_timedelta") 
 }}
 
-with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None -%}, schedule_interval={{ schedule_interval | format_timedelta | format_schedule_interval }}{%+ endif -%}) as dag:
+with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None -%}, schedule_interval={{ schedule_interval | format_timedelta | format_schedule_interval }}{%+ endif -%}, doc_md = docs) as dag:
 {% for task in tasks | sort(attribute='task_name') %}
     {% if task.is_python_script -%}
         {{ task.task_name }} = gke_command(

--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -6,6 +6,23 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.gcp import gke_command
 
+docs = """
+### {{ name }}
+
+Built from bigquery-etl repo, [`dags/{{ name }}.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/{{ name }}.py)
+
+{% if description != "" -%}
+#### Description
+
+{{ description }}
+{% endif -%}
+
+#### Owner
+
+{{ default_args.owner }}
+"""
+
+
 default_args = {{ 
     default_args.to_dict() | 
     format_attr("start_date", "format_date") |
@@ -13,7 +30,7 @@ default_args = {{
     format_attr("retry_delay", "format_timedelta") 
 }}
 
-with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None -%}, schedule_interval={{ schedule_interval | format_timedelta | format_schedule_interval }}{%+ endif -%}) as dag:
+with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None -%}, schedule_interval={{ schedule_interval | format_timedelta | format_schedule_interval }}{%+ endif -%}, doc_md = docs) as dag:
     docker_image = "mozilla/bigquery-etl:latest"
 {% for task in tasks | sort(attribute='task_name') %}
     {{ task.task_name }} = GKEPodOperator(

--- a/dags.yaml
+++ b/dags.yaml
@@ -169,9 +169,10 @@ bqetl_experiments_daily:
 bqetl_experiments_hourly:
   schedule_interval: 30 * * * *
   description: >
-    The DAG schedules queries every hour that materialize experimentation related
-    metrics (enrollment, search, ...) used for monitoring. Tasks are
-    generally scheduled with some lag to account for BigQuery sink delays.
+    The DAG schedules queries every hour that materialize experimentation
+    related metrics (enrollment, search, ...) used for monitoring. Tasks
+    are generally scheduled with some lag to account for BigQuery sink
+    delays.
   default_args:
     owner: ascholtz@mozilla.com
     start_date: "2021-01-10"
@@ -202,6 +203,7 @@ bqetl_asn_aggregates:
 # queries should not be explicitly assigned to this DAG (done automatically)
 bqetl_public_data_json:
   schedule_interval: 0 4 * * *
+  description: The DAG exports query data marked as public to GCS
   default_args:
     owner: ascholtz@mozilla.com
     start_date: "2020-04-14"
@@ -209,9 +211,11 @@ bqetl_public_data_json:
     retries: 2
     retry_delay: 30m
 
-# DAG for building the internet outages datasets. See bug 1640204.
 bqetl_internet_outages:
   schedule_interval: 0 3 * * *
+  description: > 
+    DAG for building the internet outages datasets.
+    See [bug 1640204](https://bugzilla.mozilla.org/show_bug.cgi?id=1640204).
   default_args:
     owner: aplacitelli@mozilla.com
     start_date: "2020-01-01"
@@ -290,6 +294,9 @@ bqetl_google_analytics_derived:
 
 bqetl_monitoring:
   schedule_interval: 0 2 * * *
+  description: >
+    This DAG schedules queries and scripts for populating datasets
+    used for monitoring of the data platform.
   default_args:
     owner: ascholtz@mozilla.com
     email: ['ascholtz@mozilla.com']

--- a/dags.yaml
+++ b/dags.yaml
@@ -16,6 +16,7 @@ bqetl_error_aggregates:
 
 bqetl_ssl_ratios:
   schedule_interval: 0 2 * * *
+  description: The DAG schedules SSL ratios queries.
   default_args:
     owner: chutten@mozilla.com
     start_date: "2019-07-20"
@@ -154,6 +155,10 @@ bqetl_main_summary:
 
 bqetl_experiments_daily:
   schedule_interval: 0 3 * * *
+  description: >
+    The DAG schedules queries that query experimentation related
+    metrics (enrollments, search, ...) from stable tables to finalize
+    numbers of experiment monitoring datasets for a specific date.
   default_args:
     owner: ascholtz@mozilla.com
     start_date: "2018-11-27"
@@ -163,6 +168,10 @@ bqetl_experiments_daily:
 
 bqetl_experiments_hourly:
   schedule_interval: 30 * * * *
+  description: >
+    The DAG schedules queries every hour that materialize experimentation related
+    metrics (enrollment, search, ...) used for monitoring. Tasks are
+    generally scheduled with some lag to account for BigQuery sink delays.
   default_args:
     owner: ascholtz@mozilla.com
     start_date: "2021-01-10"
@@ -181,6 +190,7 @@ bqetl_document_sample:
 
 bqetl_asn_aggregates:
   schedule_interval: 0 2 * * *
+  description: The DAG schedules ASN aggregates queries.
   default_args:
     owner: ascholtz@mozilla.com
     start_date: "2020-04-05"

--- a/dags/bqetl_account_ecosystem.py
+++ b/dags/bqetl_account_ecosystem.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_account_ecosystem
+
+Built from bigquery-etl repo, [`dags/bqetl_account_ecosystem.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_account_ecosystem.py)
+
+#### Owner
+
+jklukas@mozilla.com
+"""
+
+
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2020, 9, 17, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_account_ecosystem", default_args=default_args, schedule_interval="0 2 * * *"
+    "bqetl_account_ecosystem",
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    doc_md=docs,
 ) as dag:
 
     account_ecosystem_derived__desktop_clients_daily__v1 = bigquery_etl_query(

--- a/dags/bqetl_activity_stream.py
+++ b/dags/bqetl_activity_stream.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_activity_stream
+
+Built from bigquery-etl repo, [`dags/bqetl_activity_stream.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_activity_stream.py)
+
+#### Owner
+
+jklukas@mozilla.com
+"""
+
+
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_activity_stream", default_args=default_args, schedule_interval="0 2 * * *"
+    "bqetl_activity_stream",
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    doc_md=docs,
 ) as dag:
 
     activity_stream_bi__impression_stats_by_experiment__v1 = bigquery_etl_query(

--- a/dags/bqetl_addons.py
+++ b/dags/bqetl_addons.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_addons
+
+Built from bigquery-etl repo, [`dags/bqetl_addons.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_addons.py)
+
+### Owner
+
+bmiroglio@mozilla.com
+"""
+
+
 default_args = {
     "owner": "bmiroglio@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 27, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_addons", default_args=default_args, schedule_interval="0 3 * * *"
+    "bqetl_addons",
+    default_args=default_args,
+    schedule_interval="0 3 * * *",
+    doc_md=docs,
 ) as dag:
 
     telemetry_derived__addon_aggregates__v2 = bigquery_etl_query(

--- a/dags/bqetl_addons.py
+++ b/dags/bqetl_addons.py
@@ -10,7 +10,7 @@ docs = """
 
 Built from bigquery-etl repo, [`dags/bqetl_addons.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_addons.py)
 
-### Owner
+#### Owner
 
 bmiroglio@mozilla.com
 """

--- a/dags/bqetl_amo_stats.py
+++ b/dags/bqetl_amo_stats.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_amo_stats
+
+Built from bigquery-etl repo, [`dags/bqetl_amo_stats.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_amo_stats.py)
+
+#### Owner
+
+jklukas@mozilla.com
+"""
+
+
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2020, 6, 1, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_amo_stats", default_args=default_args, schedule_interval="0 3 * * *"
+    "bqetl_amo_stats",
+    default_args=default_args,
+    schedule_interval="0 3 * * *",
+    doc_md=docs,
 ) as dag:
 
     amo_dev__amo_stats_dau__v2 = bigquery_etl_query(

--- a/dags/bqetl_asn_aggregates.py
+++ b/dags/bqetl_asn_aggregates.py
@@ -5,6 +5,20 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_asn_aggregates
+
+Built from bigquery-etl repo, [`dags/bqetl_asn_aggregates.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_asn_aggregates.py)
+
+#### Description
+
+The DAG schedules ASN aggregates queries.
+#### Owner
+
+ascholtz@mozilla.com
+"""
+
+
 default_args = {
     "owner": "ascholtz@mozilla.com",
     "start_date": datetime.datetime(2020, 4, 5, 0, 0),
@@ -18,7 +32,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_asn_aggregates", default_args=default_args, schedule_interval="0 2 * * *"
+    "bqetl_asn_aggregates",
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    doc_md=docs,
 ) as dag:
 
     telemetry_derived__asn_aggregates__v1 = bigquery_etl_query(

--- a/dags/bqetl_core.py
+++ b/dags/bqetl_core.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_core
+
+Built from bigquery-etl repo, [`dags/bqetl_core.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_core.py)
+
+#### Owner
+
+jklukas@mozilla.com
+"""
+
+
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
@@ -17,7 +28,9 @@ default_args = {
     "retries": 1,
 }
 
-with DAG("bqetl_core", default_args=default_args, schedule_interval="0 2 * * *") as dag:
+with DAG(
+    "bqetl_core", default_args=default_args, schedule_interval="0 2 * * *", doc_md=docs
+) as dag:
 
     telemetry_derived__core_clients_daily__v1 = bigquery_etl_query(
         task_id="telemetry_derived__core_clients_daily__v1",

--- a/dags/bqetl_deletion_request_volume.py
+++ b/dags/bqetl_deletion_request_volume.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_deletion_request_volume
+
+Built from bigquery-etl repo, [`dags/bqetl_deletion_request_volume.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_deletion_request_volume.py)
+
+#### Owner
+
+dthorn@mozilla.com
+"""
+
+
 default_args = {
     "owner": "dthorn@mozilla.com",
     "start_date": datetime.datetime(2020, 6, 29, 0, 0),
@@ -21,6 +32,7 @@ with DAG(
     "bqetl_deletion_request_volume",
     default_args=default_args,
     schedule_interval="0 1 * * *",
+    doc_md=docs,
 ) as dag:
 
     monitoring_derived__deletion_request_volume__v1 = bigquery_etl_query(

--- a/dags/bqetl_desktop_platform.py
+++ b/dags/bqetl_desktop_platform.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_desktop_platform
+
+Built from bigquery-etl repo, [`dags/bqetl_desktop_platform.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_desktop_platform.py)
+
+#### Owner
+
+jklukas@mozilla.com
+"""
+
+
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 1, 0, 0),
@@ -22,7 +33,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_desktop_platform", default_args=default_args, schedule_interval="0 3 * * *"
+    "bqetl_desktop_platform",
+    default_args=default_args,
+    schedule_interval="0 3 * * *",
+    doc_md=docs,
 ) as dag:
 
     telemetry_derived__accessibility_clients__v1 = bigquery_etl_query(

--- a/dags/bqetl_devtools.py
+++ b/dags/bqetl_devtools.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_devtools
+
+Built from bigquery-etl repo, [`dags/bqetl_devtools.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_devtools.py)
+
+#### Owner
+
+jklukas@mozilla.com
+"""
+
+
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 27, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_devtools", default_args=default_args, schedule_interval="0 3 * * *"
+    "bqetl_devtools",
+    default_args=default_args,
+    schedule_interval="0 3 * * *",
+    doc_md=docs,
 ) as dag:
 
     telemetry_derived__devtools_accessiblility_panel_usage__v1 = bigquery_etl_query(

--- a/dags/bqetl_document_sample.py
+++ b/dags/bqetl_document_sample.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_document_sample
+
+Built from bigquery-etl repo, [`dags/bqetl_document_sample.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_document_sample.py)
+
+#### Owner
+
+amiyaguchi@mozilla.com
+"""
+
+
 default_args = {
     "owner": "amiyaguchi@mozilla.com",
     "start_date": datetime.datetime(2020, 2, 17, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_document_sample", default_args=default_args, schedule_interval="@daily"
+    "bqetl_document_sample",
+    default_args=default_args,
+    schedule_interval="@daily",
+    doc_md=docs,
 ) as dag:
 
     monitoring_derived__document_sample_nonprod__v1 = bigquery_etl_query(

--- a/dags/bqetl_error_aggregates.py
+++ b/dags/bqetl_error_aggregates.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_error_aggregates
+
+Built from bigquery-etl repo, [`dags/bqetl_error_aggregates.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_error_aggregates.py)
+
+#### Owner
+
+bewu@mozilla.com
+"""
+
+
 default_args = {
     "owner": "bewu@mozilla.com",
     "start_date": datetime.datetime(2019, 11, 1, 0, 0),
@@ -25,6 +36,7 @@ with DAG(
     "bqetl_error_aggregates",
     default_args=default_args,
     schedule_interval=datetime.timedelta(seconds=10800),
+    doc_md=docs,
 ) as dag:
 
     telemetry_derived__error_aggregates__v1 = bigquery_etl_query(

--- a/dags/bqetl_experiments_daily.py
+++ b/dags/bqetl_experiments_daily.py
@@ -10,11 +10,11 @@ docs = """
 
 Built from bigquery-etl repo, [`dags/bqetl_experiments_daily.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_experiments_daily.py)
 
-### Description
+#### Description
 
 The DAG schedules queries that query experimentation related metrics (enrollments, search, ...) from stable tables to finalize numbers of experiment monitoring datasets for a specific date.
 
-### Owner
+#### Owner
 
 ascholtz@mozilla.com
 """

--- a/dags/bqetl_experiments_daily.py
+++ b/dags/bqetl_experiments_daily.py
@@ -5,6 +5,21 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_experiments_daily
+
+Built from bigquery-etl repo, [`dags/bqetl_experiments_daily.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_experiments_daily.py)
+
+### Description
+
+The DAG schedules queries that query experimentation related metrics (enrollments, search, ...) from stable tables to finalize numbers of experiment monitoring datasets for a specific date.
+
+### Owner
+
+ascholtz@mozilla.com
+"""
+
+
 default_args = {
     "owner": "ascholtz@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 27, 0, 0),
@@ -18,7 +33,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_experiments_daily", default_args=default_args, schedule_interval="0 3 * * *"
+    "bqetl_experiments_daily",
+    default_args=default_args,
+    schedule_interval="0 3 * * *",
+    doc_md=docs,
 ) as dag:
 
     experiment_enrollment_daily_active_population = bigquery_etl_query(

--- a/dags/bqetl_experiments_hourly.py
+++ b/dags/bqetl_experiments_hourly.py
@@ -5,6 +5,21 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_experiments_hourly
+
+Built from bigquery-etl repo, [`dags/bqetl_experiments_hourly.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_experiments_hourly.py)
+
+#### Description
+
+The DAG schedules queries every hour that materialize experimentation related metrics (enrollment, search, ...) used for monitoring. Tasks are generally scheduled with some lag to account for BigQuery sink delays.
+
+#### Owner
+
+ascholtz@mozilla.com
+"""
+
+
 default_args = {
     "owner": "ascholtz@mozilla.com",
     "start_date": datetime.datetime(2021, 1, 10, 0, 0),
@@ -21,6 +36,7 @@ with DAG(
     "bqetl_experiments_hourly",
     default_args=default_args,
     schedule_interval="30 * * * *",
+    doc_md=docs,
 ) as dag:
 
     experiment_enrollment_aggregates_hourly = bigquery_etl_query(

--- a/dags/bqetl_fenix_event_rollup.py
+++ b/dags/bqetl_fenix_event_rollup.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_fenix_event_rollup
+
+Built from bigquery-etl repo, [`dags/bqetl_fenix_event_rollup.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_fenix_event_rollup.py)
+
+#### Owner
+
+frank@mozilla.com
+"""
+
+
 default_args = {
     "owner": "frank@mozilla.com",
     "start_date": datetime.datetime(2020, 9, 9, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_fenix_event_rollup", default_args=default_args, schedule_interval="0 2 * * *"
+    "bqetl_fenix_event_rollup",
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    doc_md=docs,
 ) as dag:
 
     org_mozilla_firefox_derived__events_daily__v1 = bigquery_etl_query(

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_fxa_events
+
+Built from bigquery-etl repo, [`dags/bqetl_fxa_events.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_fxa_events.py)
+
+#### Owner
+
+jklukas@mozilla.com
+"""
+
+
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 3, 1, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_fxa_events", default_args=default_args, schedule_interval="30 1 * * *"
+    "bqetl_fxa_events",
+    default_args=default_args,
+    schedule_interval="30 1 * * *",
+    doc_md=docs,
 ) as dag:
 
     firefox_accounts_derived__exact_mau28__v1 = bigquery_etl_query(

--- a/dags/bqetl_google_analytics_derived.py
+++ b/dags/bqetl_google_analytics_derived.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_google_analytics_derived
+
+Built from bigquery-etl repo, [`dags/bqetl_google_analytics_derived.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_google_analytics_derived.py)
+
+#### Owner
+
+bewu@mozilla.com
+"""
+
+
 default_args = {
     "owner": "bewu@mozilla.com",
     "start_date": datetime.datetime(2020, 10, 31, 0, 0),
@@ -21,6 +32,7 @@ with DAG(
     "bqetl_google_analytics_derived",
     default_args=default_args,
     schedule_interval="0 23 * * *",
+    doc_md=docs,
 ) as dag:
 
     ga_derived__blogs_daily_summary__v1 = bigquery_etl_query(

--- a/dags/bqetl_gud.py
+++ b/dags/bqetl_gud.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_gud
+
+Built from bigquery-etl repo, [`dags/bqetl_gud.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_gud.py)
+
+#### Owner
+
+jklukas@mozilla.com
+"""
+
+
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
@@ -17,7 +28,9 @@ default_args = {
     "retries": 1,
 }
 
-with DAG("bqetl_gud", default_args=default_args, schedule_interval="0 3 * * *") as dag:
+with DAG(
+    "bqetl_gud", default_args=default_args, schedule_interval="0 3 * * *", doc_md=docs
+) as dag:
 
     telemetry_derived__smoot_usage_desktop__v2 = bigquery_etl_query(
         task_id="telemetry_derived__smoot_usage_desktop__v2",

--- a/dags/bqetl_internet_outages.py
+++ b/dags/bqetl_internet_outages.py
@@ -5,6 +5,21 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_internet_outages
+
+Built from bigquery-etl repo, [`dags/bqetl_internet_outages.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_internet_outages.py)
+
+#### Description
+
+DAG for building the internet outages datasets. See [bug 1640204](https://bugzilla.mozilla.org/show_bug.cgi?id=1640204).
+
+#### Owner
+
+aplacitelli@mozilla.com
+"""
+
+
 default_args = {
     "owner": "aplacitelli@mozilla.com",
     "start_date": datetime.datetime(2020, 1, 1, 0, 0),
@@ -18,7 +33,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_internet_outages", default_args=default_args, schedule_interval="0 3 * * *"
+    "bqetl_internet_outages",
+    default_args=default_args,
+    schedule_interval="0 3 * * *",
+    doc_md=docs,
 ) as dag:
 
     internet_outages__global_outages__v1 = bigquery_etl_query(

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_main_summary
+
+Built from bigquery-etl repo, [`dags/bqetl_main_summary.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_main_summary.py)
+
+#### Owner
+
+dthorn@mozilla.com
+"""
+
+
 default_args = {
     "owner": "dthorn@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 27, 0, 0),
@@ -23,7 +34,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_main_summary", default_args=default_args, schedule_interval="0 2 * * *"
+    "bqetl_main_summary",
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    doc_md=docs,
 ) as dag:
 
     firefox_desktop_exact_mau28_by_client_count_dimensions = bigquery_etl_query(

--- a/dags/bqetl_marketing_fetch.py
+++ b/dags/bqetl_marketing_fetch.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_marketing_fetch
+
+Built from bigquery-etl repo, [`dags/bqetl_marketing_fetch.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_marketing_fetch.py)
+
+#### Owner
+
+bewu@mozilla.com
+"""
+
+
 default_args = {
     "owner": "bewu@mozilla.com",
     "start_date": datetime.datetime(2020, 11, 30, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_marketing_fetch", default_args=default_args, schedule_interval="0 1 * * 1"
+    "bqetl_marketing_fetch",
+    default_args=default_args,
+    schedule_interval="0 1 * * 1",
+    doc_md=docs,
 ) as dag:
 
     fetch__spend_alignment_by_campaign__v1 = bigquery_etl_query(

--- a/dags/bqetl_messaging_system.py
+++ b/dags/bqetl_messaging_system.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_messaging_system
+
+Built from bigquery-etl repo, [`dags/bqetl_messaging_system.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_messaging_system.py)
+
+#### Owner
+
+najiang@mozilla.com
+"""
+
+
 default_args = {
     "owner": "najiang@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_messaging_system", default_args=default_args, schedule_interval="0 2 * * *"
+    "bqetl_messaging_system",
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    doc_md=docs,
 ) as dag:
 
     messaging_system_derived__cfr_exact_mau28_by_dimensions__v1 = bigquery_etl_query(

--- a/dags/bqetl_mobile_search.py
+++ b/dags/bqetl_mobile_search.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_mobile_search
+
+Built from bigquery-etl repo, [`dags/bqetl_mobile_search.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_mobile_search.py)
+
+#### Owner
+
+bewu@mozilla.com
+"""
+
+
 default_args = {
     "owner": "bewu@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_mobile_search", default_args=default_args, schedule_interval="0 2 * * *"
+    "bqetl_mobile_search",
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    doc_md=docs,
 ) as dag:
 
     search_derived__mobile_search_aggregates__v1 = bigquery_etl_query(

--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -5,6 +5,21 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_monitoring
+
+Built from bigquery-etl repo, [`dags/bqetl_monitoring.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_monitoring.py)
+
+#### Description
+
+This DAG schedules queries and scripts for populating datasets used for monitoring of the data platform.
+
+#### Owner
+
+ascholtz@mozilla.com
+"""
+
+
 default_args = {
     "owner": "ascholtz@mozilla.com",
     "start_date": datetime.datetime(2018, 10, 30, 0, 0),
@@ -18,7 +33,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_monitoring", default_args=default_args, schedule_interval="0 2 * * *"
+    "bqetl_monitoring",
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    doc_md=docs,
 ) as dag:
 
     monitoring_derived__average_ping_sizes__v1 = gke_command(

--- a/dags/bqetl_mozilla_vpn.py
+++ b/dags/bqetl_mozilla_vpn.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_mozilla_vpn
+
+Built from bigquery-etl repo, [`dags/bqetl_mozilla_vpn.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_mozilla_vpn.py)
+
+#### Owner
+
+dthorn@mozilla.com
+"""
+
+
 default_args = {
     "owner": "dthorn@mozilla.com",
     "start_date": datetime.datetime(2020, 10, 8, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_mozilla_vpn", default_args=default_args, schedule_interval="@daily"
+    "bqetl_mozilla_vpn",
+    default_args=default_args,
+    schedule_interval="@daily",
+    doc_md=docs,
 ) as dag:
 
     mozilla_vpn_derived__add_device_events__v1 = bigquery_etl_query(

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_nondesktop
+
+Built from bigquery-etl repo, [`dags/bqetl_nondesktop.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_nondesktop.py)
+
+#### Owner
+
+jklukas@mozilla.com
+"""
+
+
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_nondesktop", default_args=default_args, schedule_interval="0 3 * * *"
+    "bqetl_nondesktop",
+    default_args=default_args,
+    schedule_interval="0 3 * * *",
+    doc_md=docs,
 ) as dag:
 
     firefox_nondesktop_exact_mau28_by_client_count_dimensions = bigquery_etl_query(

--- a/dags/bqetl_org_mozilla_fenix_derived.py
+++ b/dags/bqetl_org_mozilla_fenix_derived.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_org_mozilla_fenix_derived
+
+Built from bigquery-etl repo, [`dags/bqetl_org_mozilla_fenix_derived.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_org_mozilla_fenix_derived.py)
+
+#### Owner
+
+amiyaguchi@mozilla.com
+"""
+
+
 default_args = {
     "owner": "amiyaguchi@mozilla.com",
     "start_date": datetime.datetime(2020, 10, 18, 0, 0),
@@ -21,6 +32,7 @@ with DAG(
     "bqetl_org_mozilla_fenix_derived",
     default_args=default_args,
     schedule_interval="@daily",
+    doc_md=docs,
 ) as dag:
 
     org_mozilla_fenix_derived__geckoview_version__v1 = bigquery_etl_query(

--- a/dags/bqetl_public_data_json.py
+++ b/dags/bqetl_public_data_json.py
@@ -6,6 +6,20 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.gcp import gke_command
 
+docs = """
+### bqetl_public_data_json
+
+Built from bigquery-etl repo, [`dags/bqetl_public_data_json.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_public_data_json.py)
+
+#### Description
+
+The DAG exports query data marked as public to GCS
+#### Owner
+
+ascholtz@mozilla.com
+"""
+
+
 default_args = {
     "owner": "ascholtz@mozilla.com",
     "start_date": datetime.datetime(2020, 4, 14, 0, 0),
@@ -19,7 +33,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_public_data_json", default_args=default_args, schedule_interval="0 4 * * *"
+    "bqetl_public_data_json",
+    default_args=default_args,
+    schedule_interval="0 4 * * *",
+    doc_md=docs,
 ) as dag:
     docker_image = "mozilla/bigquery-etl:latest"
 

--- a/dags/bqetl_search.py
+++ b/dags/bqetl_search.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_search
+
+Built from bigquery-etl repo, [`dags/bqetl_search.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_search.py)
+
+#### Owner
+
+bewu@mozilla.com
+"""
+
+
 default_args = {
     "owner": "bewu@mozilla.com",
     "start_date": datetime.datetime(2018, 11, 27, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_search", default_args=default_args, schedule_interval="0 3 * * *"
+    "bqetl_search",
+    default_args=default_args,
+    schedule_interval="0 3 * * *",
+    doc_md=docs,
 ) as dag:
 
     search_derived__search_aggregates__v8 = bigquery_etl_query(

--- a/dags/bqetl_search_dashboard.py
+++ b/dags/bqetl_search_dashboard.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_search_dashboard
+
+Built from bigquery-etl repo, [`dags/bqetl_search_dashboard.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_search_dashboard.py)
+
+#### Owner
+
+ssuh@mozilla.com
+"""
+
+
 default_args = {
     "owner": "ssuh@mozilla.com",
     "start_date": datetime.datetime(2020, 12, 14, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_search_dashboard", default_args=default_args, schedule_interval="0 4 * * *"
+    "bqetl_search_dashboard",
+    default_args=default_args,
+    schedule_interval="0 4 * * *",
+    doc_md=docs,
 ) as dag:
 
     search_derived__desktop_search_aggregates_by_userstate__v1 = bigquery_etl_query(

--- a/dags/bqetl_ssl_ratios.py
+++ b/dags/bqetl_ssl_ratios.py
@@ -5,6 +5,20 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_ssl_ratios
+
+Built from bigquery-etl repo, [`dags/bqetl_ssl_ratios.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_ssl_ratios.py)
+
+#### Description
+
+The DAG schedules SSL ratios queries.
+#### Owner
+
+chutten@mozilla.com
+"""
+
+
 default_args = {
     "owner": "chutten@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 20, 0, 0),
@@ -18,7 +32,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_ssl_ratios", default_args=default_args, schedule_interval="0 2 * * *"
+    "bqetl_ssl_ratios",
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    doc_md=docs,
 ) as dag:
 
     telemetry_derived__ssl_ratios__v1 = bigquery_etl_query(

--- a/dags/bqetl_stripe.py
+++ b/dags/bqetl_stripe.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_stripe
+
+Built from bigquery-etl repo, [`dags/bqetl_stripe.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_stripe.py)
+
+#### Owner
+
+dthorn@mozilla.com
+"""
+
+
 default_args = {
     "owner": "dthorn@mozilla.com",
     "start_date": datetime.datetime(2020, 10, 5, 0, 0),
@@ -17,7 +28,9 @@ default_args = {
     "retries": 2,
 }
 
-with DAG("bqetl_stripe", default_args=default_args, schedule_interval="@daily") as dag:
+with DAG(
+    "bqetl_stripe", default_args=default_args, schedule_interval="@daily", doc_md=docs
+) as dag:
 
     stripe_derived__customers__v1 = bigquery_etl_query(
         task_id="stripe_derived__customers__v1",

--- a/dags/bqetl_vrbrowser.py
+++ b/dags/bqetl_vrbrowser.py
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_vrbrowser
+
+Built from bigquery-etl repo, [`dags/bqetl_vrbrowser.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_vrbrowser.py)
+
+#### Owner
+
+jklukas@mozilla.com
+"""
+
+
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
@@ -22,7 +33,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_vrbrowser", default_args=default_args, schedule_interval="0 2 * * *"
+    "bqetl_vrbrowser",
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    doc_md=docs,
 ) as dag:
 
     org_mozilla_vrbrowser_derived__baseline_daily__v1 = bigquery_etl_query(

--- a/tests/data/dags/python_script_test_dag
+++ b/tests/data/dags/python_script_test_dag
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_test_dag
+
+Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_test_dag.py)
+
+#### Owner
+
+test@example.org
+"""
+
+
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 1, 1, 0, 0),
@@ -18,7 +29,7 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_test_dag", default_args=default_args, schedule_interval="@daily"
+    "bqetl_test_dag", default_args=default_args, schedule_interval="@daily", doc_md=docs
 ) as dag:
 
     test__python_script_query__v1 = gke_command(

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_test_dag
+
+Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_test_dag.py)
+
+#### Owner
+
+test@example.org
+"""
+
+
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 1, 1, 0, 0),
@@ -18,7 +29,7 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_test_dag", default_args=default_args, schedule_interval="@daily"
+    "bqetl_test_dag", default_args=default_args, schedule_interval="@daily", doc_md=docs
 ) as dag:
 
     test__non_incremental_query__v1 = bigquery_etl_query(

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_test_dag
+
+Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_test_dag.py)
+
+#### Owner
+
+test@example.org
+"""
+
+
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 1, 1, 0, 0),
@@ -18,7 +29,7 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_test_dag", default_args=default_args, schedule_interval="@daily"
+    "bqetl_test_dag", default_args=default_args, schedule_interval="@daily", doc_md=docs
 ) as dag:
 
     test__no_metadata_query__v1 = bigquery_etl_query(

--- a/tests/data/dags/test_dag_external_dependency
+++ b/tests/data/dags/test_dag_external_dependency
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_external_test_dag
+
+Built from bigquery-etl repo, [`dags/bqetl_external_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_external_test_dag.py)
+
+#### Owner
+
+test@example.org
+"""
+
+
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 5, 25, 0, 0),
@@ -18,7 +29,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_external_test_dag", default_args=default_args, schedule_interval="@daily"
+    "bqetl_external_test_dag",
+    default_args=default_args,
+    schedule_interval="@daily",
+    doc_md=docs,
 ) as dag:
 
     {{ temporary_dataset }}__external_table__v1 = bigquery_etl_query(

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -5,6 +5,17 @@ from airflow.operators.sensors import ExternalTaskSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
+docs = """
+### bqetl_test_dag
+
+Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_test_dag.py)
+
+#### Owner
+
+test@example.org
+"""
+
+
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 5, 25, 0, 0),
@@ -18,7 +29,7 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_test_dag", default_args=default_args, schedule_interval="@daily"
+    "bqetl_test_dag", default_args=default_args, schedule_interval="@daily", doc_md=docs
 ) as dag:
 
     {{ temporary_dataset }}__query__v1 = bigquery_etl_query(

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -6,6 +6,17 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.gcp import gke_command
 
+docs = """
+### bqetl_public_data_json
+
+Built from bigquery-etl repo, [`dags/bqetl_public_data_json.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_public_data_json.py)
+
+#### Owner
+
+test@example.org
+"""
+
+
 default_args = {
     "owner": "test@example.org",
     "start_date": datetime.datetime(2020, 1, 1, 0, 0),
@@ -19,7 +30,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_public_data_json", default_args=default_args, schedule_interval="@daily"
+    "bqetl_public_data_json",
+    default_args=default_args,
+    schedule_interval="@daily",
+    doc_md=docs,
 ) as dag:
     docker_image = "mozilla/bigquery-etl:latest"
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/1534

This adds support for defining a `description` for DAGs in `dags.yaml` which gets added as a Markdown description to the generated Airflow DAGs.