### PR TITLE
Delay VPN dag

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -82,6 +82,16 @@ bqetl_fxa_events:
     retries: 1
     retry_delay: 10m
 
+bqetl_mozilla_vpn:
+  # Depends on bqetl_fxa_events, so run a bit after that one.
+  schedule_interval: 45 1 * * *
+  default_args:
+    owner: dthorn@mozilla.com
+    start_date: "2020-10-08"
+    email: ["telemetry-alerts@mozilla.com", "dthorn@mozilla.com"]
+    retries: 2
+    retry_delay: 30m
+
 bqetl_gud:
   schedule_interval: 0 3 * * *
   default_args:
@@ -244,15 +254,6 @@ bqetl_stripe:
     email: ["telemetry-alerts@mozilla.com", "dthorn@mozilla.com"]
     retries: 2
     retry_delay: 5m
-
-bqetl_mozilla_vpn:
-  schedule_interval: daily
-  default_args:
-    owner: dthorn@mozilla.com
-    start_date: "2020-10-08"
-    email: ["telemetry-alerts@mozilla.com", "dthorn@mozilla.com"]
-    retries: 2
-    retry_delay: 30m
 
 bqetl_org_mozilla_fenix_derived:
   default_args:

--- a/dags/bqetl_mozilla_vpn.py
+++ b/dags/bqetl_mozilla_vpn.py
@@ -18,7 +18,7 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_mozilla_vpn", default_args=default_args, schedule_interval="@daily"
+    "bqetl_mozilla_vpn", default_args=default_args, schedule_interval="45 1 * * *"
 ) as dag:
 
     mozilla_vpn_derived__add_device_events__v1 = bigquery_etl_query(
@@ -282,7 +282,7 @@ with DAG(
         task_id="wait_for_firefox_accounts_derived__fxa_auth_events__v1",
         external_dag_id="bqetl_fxa_events",
         external_task_id="firefox_accounts_derived__fxa_auth_events__v1",
-        execution_delta=datetime.timedelta(days=-1, seconds=81000),
+        execution_delta=datetime.timedelta(seconds=900),
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
@@ -295,7 +295,7 @@ with DAG(
         task_id="wait_for_firefox_accounts_derived__fxa_content_events__v1",
         external_dag_id="bqetl_fxa_events",
         external_task_id="firefox_accounts_derived__fxa_content_events__v1",
-        execution_delta=datetime.timedelta(days=-1, seconds=81000),
+        execution_delta=datetime.timedelta(seconds=900),
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",


### PR DESCRIPTION
We get alert emails every day about the wait_for_firefox_accounts_derived
task, since this DAG starts at midnight and the upstream DAG doesn't start
until 1:30. This reschedules the VPN DAG to occur 15 minutes after the upstream
DAG to avoid these alerts.

@relud - I'm relying on you to determine whether there would be any ill effects of delaying these queries, or if the logic relies on the timestamp rather than just the date.