### PR TITLE
Fix #1729 - Add timespan to metrics for GLAM ETL queries for Glean

### DIFF
--- a/bigquery_etl/glam/clients_daily_scalar_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_scalar_aggregates.py
@@ -90,7 +90,7 @@ def get_scalar_metrics(schema: Dict, scalar_type: str) -> Dict[str, List[str]]:
     """
     assert scalar_type in ("unlabeled", "labeled")
     metric_type_set = {
-        "unlabeled": ["boolean", "counter", "quantity"],
+        "unlabeled": ["boolean", "counter", "quantity", "timespan"],
         "labeled": ["labeled_counter"],
     }
     scalars: Dict[str, List[str]] = {

--- a/bigquery_etl/glam/clients_daily_scalar_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_scalar_aggregates.py
@@ -64,17 +64,20 @@ def get_unlabeled_metrics_sql(probes: Dict[str, List[str]]) -> str:
         )
 
     for metric_type, _probes in probes.items():
+        # timespans are nested within an object that also carries the unit of
+        # of time associated with the value
+        suffix = ".value" if metric_type == "timespan" else ""
         for probe in _probes:
             for agg_func in ["max", "avg", "min", "sum"]:
                 probe_structs.append(
                     (
                         f"('{probe}', '{metric_type}', '', '{agg_func}', "
-                        f"{agg_func}(CAST(metrics.{metric_type}.{probe} AS INT64)))"
+                        f"{agg_func}(CAST(metrics.{metric_type}.{probe}{suffix} AS INT64)))"
                     )
                 )
             probe_structs.append(
                 f"('{probe}', '{metric_type}', '', 'count', "
-                f"IF(MIN(metrics.{metric_type}.{probe}) IS NULL, NULL, COUNT(*)))"
+                f"IF(MIN(metrics.{metric_type}.{probe}{suffix}) IS NULL, NULL, COUNT(*)))"
             )
 
     probe_structs.sort()

--- a/bigquery_etl/glam/models.py
+++ b/bigquery_etl/glam/models.py
@@ -78,7 +78,7 @@ def scalar_bucket_counts(**kwargs):
             "counter",
             "quantity",
             "labeled_counter",
-            "timespan",
+            "timespan"
         """,
         boolean_metric_types="""
             "boolean"
@@ -140,7 +140,7 @@ def probe_counts(**kwargs):
             "counter",
             "quantity",
             "labeled_counter",
-            "timespan
+            "timespan"
         """,
         boolean_metric_types="""
             "boolean"

--- a/bigquery_etl/glam/models.py
+++ b/bigquery_etl/glam/models.py
@@ -77,7 +77,8 @@ def scalar_bucket_counts(**kwargs):
         scalar_metric_types="""
             "counter",
             "quantity",
-            "labeled_counter"
+            "labeled_counter",
+            "timespan",
         """,
         boolean_metric_types="""
             "boolean"
@@ -138,7 +139,8 @@ def probe_counts(**kwargs):
         scalar_metric_types="""
             "counter",
             "quantity",
-            "labeled_counter"
+            "labeled_counter",
+            "timespan
         """,
         boolean_metric_types="""
             "boolean"

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_baseline_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_baseline_v1/query.sql
@@ -64,6 +64,41 @@ unlabeled_metrics AS (
         sum(CAST(metrics.counter.events_total_uri_count AS INT64))
       ),
       (
+        'glean_baseline_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.glean_baseline_duration.value AS INT64))
+      ),
+      (
+        'glean_baseline_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.glean_baseline_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'glean_baseline_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.glean_baseline_duration.value AS INT64))
+      ),
+      (
+        'glean_baseline_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.glean_baseline_duration.value AS INT64))
+      ),
+      (
+        'glean_baseline_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.glean_baseline_duration.value AS INT64))
+      ),
+      (
         'glean_validation_metrics_ping_count',
         'counter',
         '',

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_metrics_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_metrics_v1/query.sql
@@ -127,6 +127,20 @@ unlabeled_metrics AS (
         sum(CAST(metrics.quantity.avif_dav1d_decode_error AS INT64))
       ),
       (
+        'contextual_menu_long_press_tapped',
+        'boolean',
+        '',
+        'false',
+        SUM(CAST(NOT metrics.boolean.contextual_menu_long_press_tapped AS INT64))
+      ),
+      (
+        'contextual_menu_long_press_tapped',
+        'boolean',
+        '',
+        'true',
+        SUM(CAST(metrics.boolean.contextual_menu_long_press_tapped AS INT64))
+      ),
+      (
         'events_total_uri_count',
         'counter',
         '',
@@ -329,6 +343,17 @@ unlabeled_metrics AS (
         'true',
         SUM(CAST(metrics.boolean.glean_core_migration_successful AS INT64))
       ),
+      ('glean_error_io', 'counter', '', 'avg', avg(CAST(metrics.counter.glean_error_io AS INT64))),
+      (
+        'glean_error_io',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.glean_error_io) IS NULL, NULL, COUNT(*))
+      ),
+      ('glean_error_io', 'counter', '', 'max', max(CAST(metrics.counter.glean_error_io AS INT64))),
+      ('glean_error_io', 'counter', '', 'min', min(CAST(metrics.counter.glean_error_io AS INT64))),
+      ('glean_error_io', 'counter', '', 'sum', sum(CAST(metrics.counter.glean_error_io AS INT64))),
       (
         'glean_error_preinit_tasks_overflow',
         'counter',
@@ -519,6 +544,41 @@ unlabeled_metrics AS (
         sum(CAST(metrics.counter.glean_validation_baseline_ping_count AS INT64))
       ),
       (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'avg',
+        avg(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.glean_validation_foreground_count) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'max',
+        max(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'min',
+        min(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'sum',
+        sum(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
         'logins_store_read_query_count',
         'counter',
         '',
@@ -638,6 +698,69 @@ unlabeled_metrics AS (
         SUM(CAST(metrics.boolean.metrics_default_browser AS INT64))
       ),
       (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'avg',
+        avg(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.metrics_desktop_bookmarks_count) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'max',
+        max(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'min',
+        min(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'sum',
+        sum(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_has_desktop_bookmarks',
+        'boolean',
+        '',
+        'false',
+        SUM(CAST(NOT metrics.boolean.metrics_has_desktop_bookmarks AS INT64))
+      ),
+      (
+        'metrics_has_desktop_bookmarks',
+        'boolean',
+        '',
+        'true',
+        SUM(CAST(metrics.boolean.metrics_has_desktop_bookmarks AS INT64))
+      ),
+      (
+        'metrics_has_mobile_bookmarks',
+        'boolean',
+        '',
+        'false',
+        SUM(CAST(NOT metrics.boolean.metrics_has_mobile_bookmarks AS INT64))
+      ),
+      (
+        'metrics_has_mobile_bookmarks',
+        'boolean',
+        '',
+        'true',
+        SUM(CAST(metrics.boolean.metrics_has_mobile_bookmarks AS INT64))
+      ),
+      (
         'metrics_has_open_tabs',
         'boolean',
         '',
@@ -678,6 +801,41 @@ unlabeled_metrics AS (
         '',
         'true',
         SUM(CAST(metrics.boolean.metrics_has_top_sites AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'avg',
+        avg(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.metrics_mobile_bookmarks_count) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'max',
+        max(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'min',
+        min(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'sum',
+        sum(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
       ),
       (
         'metrics_recently_used_pwa_count',

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_migration_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_migration_v1/query.sql
@@ -183,6 +183,41 @@ unlabeled_metrics AS (
         sum(CAST(metrics.counter.migration_addons_success_reason AS INT64))
       ),
       (
+        'migration_addons_total_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_addons_total_duration.value AS INT64))
+      ),
+      (
+        'migration_addons_total_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.migration_addons_total_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'migration_addons_total_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_addons_total_duration.value AS INT64))
+      ),
+      (
+        'migration_addons_total_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_addons_total_duration.value AS INT64))
+      ),
+      (
+        'migration_addons_total_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_addons_total_duration.value AS INT64))
+      ),
+      (
         'migration_bookmarks_any_failures',
         'boolean',
         '',
@@ -230,6 +265,41 @@ unlabeled_metrics AS (
         '',
         'sum',
         sum(CAST(metrics.counter.migration_bookmarks_detected AS INT64))
+      ),
+      (
+        'migration_bookmarks_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_bookmarks_duration.value AS INT64))
+      ),
+      (
+        'migration_bookmarks_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.migration_bookmarks_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'migration_bookmarks_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_bookmarks_duration.value AS INT64))
+      ),
+      (
+        'migration_bookmarks_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_bookmarks_duration.value AS INT64))
+      ),
+      (
+        'migration_bookmarks_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_bookmarks_duration.value AS INT64))
       ),
       (
         'migration_bookmarks_failure_reason',
@@ -300,6 +370,41 @@ unlabeled_metrics AS (
         '',
         'sum',
         sum(CAST(metrics.counter.migration_bookmarks_success_reason AS INT64))
+      ),
+      (
+        'migration_bookmarks_total_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_bookmarks_total_duration.value AS INT64))
+      ),
+      (
+        'migration_bookmarks_total_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.migration_bookmarks_total_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'migration_bookmarks_total_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_bookmarks_total_duration.value AS INT64))
+      ),
+      (
+        'migration_bookmarks_total_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_bookmarks_total_duration.value AS INT64))
+      ),
+      (
+        'migration_bookmarks_total_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_bookmarks_total_duration.value AS INT64))
       ),
       (
         'migration_fxa_any_failures',
@@ -414,6 +519,41 @@ unlabeled_metrics AS (
         sum(CAST(metrics.counter.migration_fxa_success_reason AS INT64))
       ),
       (
+        'migration_fxa_total_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_fxa_total_duration.value AS INT64))
+      ),
+      (
+        'migration_fxa_total_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.migration_fxa_total_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'migration_fxa_total_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_fxa_total_duration.value AS INT64))
+      ),
+      (
+        'migration_fxa_total_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_fxa_total_duration.value AS INT64))
+      ),
+      (
+        'migration_fxa_total_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_fxa_total_duration.value AS INT64))
+      ),
+      (
         'migration_gecko_any_failures',
         'boolean',
         '',
@@ -498,6 +638,41 @@ unlabeled_metrics AS (
         sum(CAST(metrics.counter.migration_gecko_success_reason AS INT64))
       ),
       (
+        'migration_gecko_total_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_gecko_total_duration.value AS INT64))
+      ),
+      (
+        'migration_gecko_total_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.migration_gecko_total_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'migration_gecko_total_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_gecko_total_duration.value AS INT64))
+      ),
+      (
+        'migration_gecko_total_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_gecko_total_duration.value AS INT64))
+      ),
+      (
+        'migration_gecko_total_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_gecko_total_duration.value AS INT64))
+      ),
+      (
         'migration_history_any_failures',
         'boolean',
         '',
@@ -545,6 +720,41 @@ unlabeled_metrics AS (
         '',
         'sum',
         sum(CAST(metrics.counter.migration_history_detected AS INT64))
+      ),
+      (
+        'migration_history_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_history_duration.value AS INT64))
+      ),
+      (
+        'migration_history_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.migration_history_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'migration_history_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_history_duration.value AS INT64))
+      ),
+      (
+        'migration_history_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_history_duration.value AS INT64))
+      ),
+      (
+        'migration_history_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_history_duration.value AS INT64))
       ),
       (
         'migration_history_failure_reason',
@@ -615,6 +825,41 @@ unlabeled_metrics AS (
         '',
         'sum',
         sum(CAST(metrics.counter.migration_history_success_reason AS INT64))
+      ),
+      (
+        'migration_history_total_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_history_total_duration.value AS INT64))
+      ),
+      (
+        'migration_history_total_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.migration_history_total_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'migration_history_total_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_history_total_duration.value AS INT64))
+      ),
+      (
+        'migration_history_total_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_history_total_duration.value AS INT64))
+      ),
+      (
+        'migration_history_total_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_history_total_duration.value AS INT64))
       ),
       (
         'migration_logins_any_failures',
@@ -734,6 +979,41 @@ unlabeled_metrics AS (
         '',
         'sum',
         sum(CAST(metrics.counter.migration_logins_success_reason AS INT64))
+      ),
+      (
+        'migration_logins_total_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_logins_total_duration.value AS INT64))
+      ),
+      (
+        'migration_logins_total_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.migration_logins_total_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'migration_logins_total_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_logins_total_duration.value AS INT64))
+      ),
+      (
+        'migration_logins_total_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_logins_total_duration.value AS INT64))
+      ),
+      (
+        'migration_logins_total_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_logins_total_duration.value AS INT64))
       ),
       (
         'migration_logins_unsupported_db_version',
@@ -925,6 +1205,41 @@ unlabeled_metrics AS (
         sum(CAST(metrics.counter.migration_open_tabs_success_reason AS INT64))
       ),
       (
+        'migration_open_tabs_total_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_open_tabs_total_duration.value AS INT64))
+      ),
+      (
+        'migration_open_tabs_total_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.migration_open_tabs_total_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'migration_open_tabs_total_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_open_tabs_total_duration.value AS INT64))
+      ),
+      (
+        'migration_open_tabs_total_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_open_tabs_total_duration.value AS INT64))
+      ),
+      (
+        'migration_open_tabs_total_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_open_tabs_total_duration.value AS INT64))
+      ),
+      (
         'migration_pinned_sites_any_failures',
         'boolean',
         '',
@@ -1087,6 +1402,45 @@ unlabeled_metrics AS (
         sum(CAST(metrics.counter.migration_pinned_sites_success_reason AS INT64))
       ),
       (
+        'migration_pinned_sites_total_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_pinned_sites_total_duration.value AS INT64))
+      ),
+      (
+        'migration_pinned_sites_total_duration',
+        'timespan',
+        '',
+        'count',
+        IF(
+          MIN(metrics.timespan.migration_pinned_sites_total_duration.value) IS NULL,
+          NULL,
+          COUNT(*)
+        )
+      ),
+      (
+        'migration_pinned_sites_total_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_pinned_sites_total_duration.value AS INT64))
+      ),
+      (
+        'migration_pinned_sites_total_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_pinned_sites_total_duration.value AS INT64))
+      ),
+      (
+        'migration_pinned_sites_total_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_pinned_sites_total_duration.value AS INT64))
+      ),
+      (
         'migration_search_any_failures',
         'boolean',
         '',
@@ -1169,6 +1523,41 @@ unlabeled_metrics AS (
         '',
         'sum',
         sum(CAST(metrics.counter.migration_search_success_reason AS INT64))
+      ),
+      (
+        'migration_search_total_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_search_total_duration.value AS INT64))
+      ),
+      (
+        'migration_search_total_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.migration_search_total_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'migration_search_total_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_search_total_duration.value AS INT64))
+      ),
+      (
+        'migration_search_total_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_search_total_duration.value AS INT64))
+      ),
+      (
+        'migration_search_total_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_search_total_duration.value AS INT64))
       ),
       (
         'migration_settings_any_failures',
@@ -1269,6 +1658,41 @@ unlabeled_metrics AS (
         SUM(CAST(metrics.boolean.migration_settings_telemetry_enabled AS INT64))
       ),
       (
+        'migration_settings_total_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_settings_total_duration.value AS INT64))
+      ),
+      (
+        'migration_settings_total_duration',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.migration_settings_total_duration.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'migration_settings_total_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_settings_total_duration.value AS INT64))
+      ),
+      (
+        'migration_settings_total_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_settings_total_duration.value AS INT64))
+      ),
+      (
+        'migration_settings_total_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_settings_total_duration.value AS INT64))
+      ),
+      (
         'migration_telemetry_identifiers_any_failures',
         'boolean',
         '',
@@ -1359,6 +1783,45 @@ unlabeled_metrics AS (
         '',
         'sum',
         sum(CAST(metrics.counter.migration_telemetry_identifiers_success_reason AS INT64))
+      ),
+      (
+        'migration_telemetry_identifiers_total_duration',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.migration_telemetry_identifiers_total_duration.value AS INT64))
+      ),
+      (
+        'migration_telemetry_identifiers_total_duration',
+        'timespan',
+        '',
+        'count',
+        IF(
+          MIN(metrics.timespan.migration_telemetry_identifiers_total_duration.value) IS NULL,
+          NULL,
+          COUNT(*)
+        )
+      ),
+      (
+        'migration_telemetry_identifiers_total_duration',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.migration_telemetry_identifiers_total_duration.value AS INT64))
+      ),
+      (
+        'migration_telemetry_identifiers_total_duration',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.migration_telemetry_identifiers_total_duration.value AS INT64))
+      ),
+      (
+        'migration_telemetry_identifiers_total_duration',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.migration_telemetry_identifiers_total_duration.value AS INT64))
       )
     ] AS scalar_aggregates
   FROM

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_startup_timeline_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_startup_timeline_v1/query.sql
@@ -64,6 +64,41 @@ unlabeled_metrics AS (
         sum(CAST(metrics.counter.startup_timeline_clock_ticks_per_second AS INT64))
       ),
       (
+        'startup_timeline_framework_start',
+        'timespan',
+        '',
+        'avg',
+        avg(CAST(metrics.timespan.startup_timeline_framework_start.value AS INT64))
+      ),
+      (
+        'startup_timeline_framework_start',
+        'timespan',
+        '',
+        'count',
+        IF(MIN(metrics.timespan.startup_timeline_framework_start.value) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'startup_timeline_framework_start',
+        'timespan',
+        '',
+        'max',
+        max(CAST(metrics.timespan.startup_timeline_framework_start.value AS INT64))
+      ),
+      (
+        'startup_timeline_framework_start',
+        'timespan',
+        '',
+        'min',
+        min(CAST(metrics.timespan.startup_timeline_framework_start.value AS INT64))
+      ),
+      (
+        'startup_timeline_framework_start',
+        'timespan',
+        '',
+        'sum',
+        sum(CAST(metrics.timespan.startup_timeline_framework_start.value AS INT64))
+      ),
+      (
         'startup_timeline_framework_start_error',
         'boolean',
         '',

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_bucket_counts_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_bucket_counts_v1/query.sql
@@ -197,7 +197,7 @@ bucketed_scalars AS (
   USING
     (metric, key)
   WHERE
-    metric_type IN ("counter", "quantity", "labeled_counter")
+    metric_type IN ("counter", "quantity", "labeled_counter", "timespan")
 ),
 booleans_and_scalars AS (
   SELECT

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_probe_counts_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_probe_counts_v1/query.sql
@@ -15,7 +15,7 @@ SELECT
     mozfun.map.sum(ARRAY_AGG(STRUCT<key STRING, value FLOAT64>(bucket, count))),
     CASE
     WHEN
-      metric_type IN ("counter", "quantity", "labeled_counter")
+      metric_type IN ("counter", "quantity", "labeled_counter", "timespan")
     THEN
       ARRAY(
         SELECT

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_scalar_aggregates_metrics_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_scalar_aggregates_metrics_v1/query.sql
@@ -127,6 +127,20 @@ unlabeled_metrics AS (
         sum(CAST(metrics.quantity.avif_dav1d_decode_error AS INT64))
       ),
       (
+        'contextual_menu_long_press_tapped',
+        'boolean',
+        '',
+        'false',
+        SUM(CAST(NOT metrics.boolean.contextual_menu_long_press_tapped AS INT64))
+      ),
+      (
+        'contextual_menu_long_press_tapped',
+        'boolean',
+        '',
+        'true',
+        SUM(CAST(metrics.boolean.contextual_menu_long_press_tapped AS INT64))
+      ),
+      (
         'events_total_uri_count',
         'counter',
         '',
@@ -329,6 +343,17 @@ unlabeled_metrics AS (
         'true',
         SUM(CAST(metrics.boolean.glean_core_migration_successful AS INT64))
       ),
+      ('glean_error_io', 'counter', '', 'avg', avg(CAST(metrics.counter.glean_error_io AS INT64))),
+      (
+        'glean_error_io',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.glean_error_io) IS NULL, NULL, COUNT(*))
+      ),
+      ('glean_error_io', 'counter', '', 'max', max(CAST(metrics.counter.glean_error_io AS INT64))),
+      ('glean_error_io', 'counter', '', 'min', min(CAST(metrics.counter.glean_error_io AS INT64))),
+      ('glean_error_io', 'counter', '', 'sum', sum(CAST(metrics.counter.glean_error_io AS INT64))),
       (
         'glean_error_preinit_tasks_overflow',
         'counter',
@@ -519,6 +544,41 @@ unlabeled_metrics AS (
         sum(CAST(metrics.counter.glean_validation_baseline_ping_count AS INT64))
       ),
       (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'avg',
+        avg(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.glean_validation_foreground_count) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'max',
+        max(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'min',
+        min(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'sum',
+        sum(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
         'logins_store_read_query_count',
         'counter',
         '',
@@ -638,6 +698,69 @@ unlabeled_metrics AS (
         SUM(CAST(metrics.boolean.metrics_default_browser AS INT64))
       ),
       (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'avg',
+        avg(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.metrics_desktop_bookmarks_count) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'max',
+        max(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'min',
+        min(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'sum',
+        sum(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_has_desktop_bookmarks',
+        'boolean',
+        '',
+        'false',
+        SUM(CAST(NOT metrics.boolean.metrics_has_desktop_bookmarks AS INT64))
+      ),
+      (
+        'metrics_has_desktop_bookmarks',
+        'boolean',
+        '',
+        'true',
+        SUM(CAST(metrics.boolean.metrics_has_desktop_bookmarks AS INT64))
+      ),
+      (
+        'metrics_has_mobile_bookmarks',
+        'boolean',
+        '',
+        'false',
+        SUM(CAST(NOT metrics.boolean.metrics_has_mobile_bookmarks AS INT64))
+      ),
+      (
+        'metrics_has_mobile_bookmarks',
+        'boolean',
+        '',
+        'true',
+        SUM(CAST(metrics.boolean.metrics_has_mobile_bookmarks AS INT64))
+      ),
+      (
         'metrics_has_open_tabs',
         'boolean',
         '',
@@ -678,6 +801,41 @@ unlabeled_metrics AS (
         '',
         'true',
         SUM(CAST(metrics.boolean.metrics_has_top_sites AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'avg',
+        avg(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.metrics_mobile_bookmarks_count) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'max',
+        max(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'min',
+        min(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'sum',
+        sum(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
       ),
       (
         'metrics_recently_used_pwa_count',

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fennec_aurora__clients_daily_scalar_aggregates_metrics_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fennec_aurora__clients_daily_scalar_aggregates_metrics_v1/query.sql
@@ -127,6 +127,20 @@ unlabeled_metrics AS (
         sum(CAST(metrics.quantity.avif_dav1d_decode_error AS INT64))
       ),
       (
+        'contextual_menu_long_press_tapped',
+        'boolean',
+        '',
+        'false',
+        SUM(CAST(NOT metrics.boolean.contextual_menu_long_press_tapped AS INT64))
+      ),
+      (
+        'contextual_menu_long_press_tapped',
+        'boolean',
+        '',
+        'true',
+        SUM(CAST(metrics.boolean.contextual_menu_long_press_tapped AS INT64))
+      ),
+      (
         'events_total_uri_count',
         'counter',
         '',
@@ -329,6 +343,17 @@ unlabeled_metrics AS (
         'true',
         SUM(CAST(metrics.boolean.glean_core_migration_successful AS INT64))
       ),
+      ('glean_error_io', 'counter', '', 'avg', avg(CAST(metrics.counter.glean_error_io AS INT64))),
+      (
+        'glean_error_io',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.glean_error_io) IS NULL, NULL, COUNT(*))
+      ),
+      ('glean_error_io', 'counter', '', 'max', max(CAST(metrics.counter.glean_error_io AS INT64))),
+      ('glean_error_io', 'counter', '', 'min', min(CAST(metrics.counter.glean_error_io AS INT64))),
+      ('glean_error_io', 'counter', '', 'sum', sum(CAST(metrics.counter.glean_error_io AS INT64))),
       (
         'glean_error_preinit_tasks_overflow',
         'counter',
@@ -519,6 +544,41 @@ unlabeled_metrics AS (
         sum(CAST(metrics.counter.glean_validation_baseline_ping_count AS INT64))
       ),
       (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'avg',
+        avg(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.glean_validation_foreground_count) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'max',
+        max(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'min',
+        min(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
+        'glean_validation_foreground_count',
+        'counter',
+        '',
+        'sum',
+        sum(CAST(metrics.counter.glean_validation_foreground_count AS INT64))
+      ),
+      (
         'logins_store_read_query_count',
         'counter',
         '',
@@ -638,6 +698,69 @@ unlabeled_metrics AS (
         SUM(CAST(metrics.boolean.metrics_default_browser AS INT64))
       ),
       (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'avg',
+        avg(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.metrics_desktop_bookmarks_count) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'max',
+        max(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'min',
+        min(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_desktop_bookmarks_count',
+        'counter',
+        '',
+        'sum',
+        sum(CAST(metrics.counter.metrics_desktop_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_has_desktop_bookmarks',
+        'boolean',
+        '',
+        'false',
+        SUM(CAST(NOT metrics.boolean.metrics_has_desktop_bookmarks AS INT64))
+      ),
+      (
+        'metrics_has_desktop_bookmarks',
+        'boolean',
+        '',
+        'true',
+        SUM(CAST(metrics.boolean.metrics_has_desktop_bookmarks AS INT64))
+      ),
+      (
+        'metrics_has_mobile_bookmarks',
+        'boolean',
+        '',
+        'false',
+        SUM(CAST(NOT metrics.boolean.metrics_has_mobile_bookmarks AS INT64))
+      ),
+      (
+        'metrics_has_mobile_bookmarks',
+        'boolean',
+        '',
+        'true',
+        SUM(CAST(metrics.boolean.metrics_has_mobile_bookmarks AS INT64))
+      ),
+      (
         'metrics_has_open_tabs',
         'boolean',
         '',
@@ -678,6 +801,41 @@ unlabeled_metrics AS (
         '',
         'true',
         SUM(CAST(metrics.boolean.metrics_has_top_sites AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'avg',
+        avg(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.metrics_mobile_bookmarks_count) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'max',
+        max(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'min',
+        min(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
+      ),
+      (
+        'metrics_mobile_bookmarks_count',
+        'counter',
+        '',
+        'sum',
+        sum(CAST(metrics.counter.metrics_mobile_bookmarks_count AS INT64))
       ),
       (
         'metrics_recently_used_pwa_count',


### PR DESCRIPTION
Fixes #1729 by adding timespans to the set of metrics. It turns out that it's not as simple as adding it to the set of unlabeled metrics due to the structure:


```sql
select metrics.timespan.startup_timeline_framework_start
from mozdata.org_mozilla_fenix.startup_timeline
where date(submission_timestamp) = "2021-01-30"
```

```json
[
  {
    "startup_timeline_framework_start": {
      "time_unit": "nanosecond",
      "value": "370000000"
    }
  },
  {
    "startup_timeline_framework_start": {
      "time_unit": "nanosecond",
      "value": "740000000"
    }
  },
...
]
```