### PR TITLE
Fix vpn subscriptions and devices imports

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/devices_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/devices_v1/query.sql
@@ -1,5 +1,5 @@
 SELECT
-  COALESCE(_update, devices_v1).*
+  IF(_update.id IS NOT NULL, _update, devices_v1).*
 FROM
   EXTERNAL_QUERY(
     "moz-fx-guardian-prod-bfc7.us.guardian-sql-prod",

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/subscriptions_v1/query.sql
@@ -1,5 +1,5 @@
 SELECT
-  COALESCE(_update, subscriptions_v1).*
+  IF(_update.id IS NOT NULL, _update, subscriptions_v1).*
 FROM
   EXTERNAL_QUERY(
     "moz-fx-guardian-prod-bfc7.us.guardian-sql-prod",


### PR DESCRIPTION
`COALESCE` can't be used because table refs in a join are never actually `NULL`