### PR TITLE
Expose vpn subscription updated_at to redash

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscriptions_v1/query.sql
@@ -3,6 +3,7 @@ SELECT
   is_active,
   created_at,
   ended_at,
+  updated_at,
   type,
   provider,
 FROM


### PR DESCRIPTION
turns out `ended_at` isn't useful right now, but between `is_active` and `updated_at` we can get close