### PR TITLE
Show only available urls in source

### DIFF
--- a/bigquery_etl/docs/derived_datasets/generate_derived_dataset_docs.py
+++ b/bigquery_etl/docs/derived_datasets/generate_derived_dataset_docs.py
@@ -43,18 +43,20 @@ def generate_derived_dataset_docs(out_dir, project_dir):
                 if dirs:
                     continue
                 dataset_name = root.split("/")[-1]
-                source_urls["Source"] = f"{SOURCE_URL}/{root}"
+                source_urls["Source Directory"] = f"{SOURCE_URL}/{root}"
 
                 metadata = {}
                 if METADATA_FILE in files:
-                    source_urls["Metadata"] = f"{SOURCE_URL}/{root}/{METADATA_FILE}"
+                    source_urls[
+                        "Metadata File"
+                    ] = f"{SOURCE_URL}/{root}/{METADATA_FILE}"
                     with open(os.path.join(root, METADATA_FILE)) as stream:
                         try:
                             metadata = yaml.safe_load(stream)
                         except yaml.YAMLError as error:
                             print(error)
                 if VIEW_FILE in files:
-                    source_urls["View"] = f"{SOURCE_URL}/{root}/{VIEW_FILE}"
+                    source_urls["View Definition"] = f"{SOURCE_URL}/{root}/{VIEW_FILE}"
 
                 file_loader = FileSystemLoader(
                     "bigquery_etl/docs/derived_datasets/templates"

--- a/bigquery_etl/docs/derived_datasets/templates/table.md
+++ b/bigquery_etl/docs/derived_datasets/templates/table.md
@@ -21,8 +21,9 @@
 {%- endfor %}
 {% endif %}
 
-
-[Source Directory]({{ source_urls["Source"] }}) | [Metadata File]({{ source_urls["Metadata"] }}) | [View Definition]({{ source_urls["View"] }}) 
+{% for key, value in source_urls.items() -%}
+[{{key}}]({{ value }}) {{ " | " if not loop.last else "" }}
+{%- endfor %} 
 
 ---
 


### PR DESCRIPTION
This PR fixes a bug: right now we're showing links to metadata and view files at the bottom of every entry, which is not right because some tables don't have metadata or view files. For example, this data set does not have any metadata files: https://mozilla.github.io/bigquery-etl/mozdata/default_browser_agent/