### PR TITLE
Make `truncate_version` return NUMERIC

### DIFF
--- a/sql/mozfun/norm/truncate_version/metadata.yaml
+++ b/sql/mozfun/norm/truncate_version/metadata.yaml
@@ -1,12 +1,16 @@
 friendly_name: Truncate Version
 description: |
   Truncates a version string like "<major>.<minor>.<patch>" to
-  either the major or minor version. For example, "5.1.0" would be
-  truncated to "5.1" if the parameter is "minor" or "5" if the parameter
-  is major.
+  either the major or minor version. The return value is NUMERIC,
+  which means that you can sort the results without fear (e.g. 100
+  will be categorized as greater than 80, which isn't the case when
+  sorting lexigraphically).
+
+  For example, "5.1.0" would be translated to 5.1 if the parameter is
+  "minor" or 5 if the parameter is major.
 
   If the version is only a major and/or minor version, then it will be left
-  unchanged (for example "10" would stay as "10" when run through this
+  unchanged (for example "10" would stay as 10 when run through this
   function, no matter what the arguments).
 
   This is useful for grouping Linux and Mac operating system versions inside

--- a/sql/mozfun/norm/truncate_version/udf.sql
+++ b/sql/mozfun/norm/truncate_version/udf.sql
@@ -1,14 +1,14 @@
 CREATE OR REPLACE FUNCTION norm.truncate_version(os_version STRING, truncation_level STRING)
-RETURNS STRING AS (
+RETURNS NUMERIC AS (
   CASE
   WHEN
     truncation_level = "minor"
   THEN
-    REGEXP_EXTRACT(os_version, r"^([0-9]+[.]?[0-9]+).*")
+    CAST(REGEXP_EXTRACT(os_version, r"^([0-9]+[.]?[0-9]+).*") AS NUMERIC)
   WHEN
     truncation_level = "major"
   THEN
-    REGEXP_EXTRACT(os_version, r"^([0-9]+).*")
+    CAST(REGEXP_EXTRACT(os_version, r"^([0-9]+).*") AS NUMERIC)
   ELSE
     NULL
   END
@@ -16,9 +16,10 @@ RETURNS STRING AS (
 
 -- Tests
 SELECT
-  assert.equals("16.1", norm.truncate_version("16.1.1", "minor")),
-  assert.equals("16", norm.truncate_version("16.1.1", "major")),
-  assert.equals("10", norm.truncate_version("10", "minor")),
-  assert.equals("5.1", norm.truncate_version("5.1.5-ubuntu-foobar", "minor")),
-  assert.equals(CAST(NULL AS STRING), norm.truncate_version("5.1.5-ubuntu-foobar", "patch")),
-  assert.equals(CAST(NULL AS STRING), norm.truncate_version("foo-bar", "minor"))
+  assert.equals(16.1, norm.truncate_version("16.1.1", "minor")),
+  assert.equals(16.03, norm.truncate_version("16.03.1", "minor")),
+  assert.equals(16, norm.truncate_version("16.1.1", "major")),
+  assert.equals(10, norm.truncate_version("10", "minor")),
+  assert.equals(5.1, norm.truncate_version("5.1.5-ubuntu-foobar", "minor")),
+  assert.equals(CAST(NULL AS NUMERIC), norm.truncate_version("5.1.5-ubuntu-foobar", "patch")),
+  assert.equals(CAST(NULL AS NUMERIC), norm.truncate_version("foo-bar", "minor"))


### PR DESCRIPTION
This should work reliably for all the cases we care about and
allows doing things like sorting by versions reliably (since one
can't assume lexicographical ordering).

Using NUMERIC should protect us from weird floating point edge cases:

https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types

See also #1770