### PR TITLE
Add app_name to mozfun.norm.product_info output

### DIFF
--- a/sql/mozfun/norm/product_info/README.md
+++ b/sql/mozfun/norm/product_info/README.md
@@ -1,6 +1,6 @@
 The mappings are as follows:
 
-app_name         | normalized_os | looker_app_name  | product          | canonical_app_name              | 2019  | 2020  | 2021
+legacy_app_name  | normalized_os | app_name         | product          | canonical_app_name              | 2019  | 2020  | 2021
 ---------------- | ------------- | ---------------- | ---------------- | ------------------------------- | ----- | ----  | ----
 Firefox          | *             | firefox_desktop  | Firefox          | Firefox for Desktop             | true  | true  | true
 Fenix            | Android       | fenix            | Fenix            | Firefox for Android (Fenix)     | true  | true  | true

--- a/sql/mozfun/norm/product_info/README.md
+++ b/sql/mozfun/norm/product_info/README.md
@@ -5,7 +5,7 @@ app_name         | normalized_os | looker_app_name  | product          | canonic
 Firefox          | *             | firefox_desktop  | Firefox          | Firefox for Desktop             | true  | true  | true
 Fenix            | Android       | fenix            | Fenix            | Firefox for Android (Fenix)     | true  | true  | true
 Fennec           | Android       | fennec           | Fennec           | Firefox for Android (Fennec)    | true  | true  | true
-Firefox Preview  | Android       | firefox_preview  | Firefox Preview  | Firefox Preview for Android     | true  | true  | false
+Firefox Preview  | Android       | firefox_preview  | Firefox Preview  | Firefox Preview for Android     | true  | true  | true
 Fennec           | iOS           | firefox_ios      | Firefox iOS      | Firefox for iOS                 | true  | true  | true
 FirefoxForFireTV | Android       | firefox_fire_tv  | Firefox Fire TV  | Firefox for Fire TV             | false | false | false
 FirefoxConnect   | Android       | firefox_connect  | Firefox Echo     | Firefox for Echo Show           | true  | true  | true

--- a/sql/mozfun/norm/product_info/README.md
+++ b/sql/mozfun/norm/product_info/README.md
@@ -1,20 +1,20 @@
 The mappings are as follows:
 
-app_name         | normalized_os | product          | canonical_name              | 2019  | 2020
----------------- | ------------- | ---------------- | --------------------------- | ----- | ----
-Firefox          | *             | Firefox          | Firefox for Desktop         | true  | true
-Fenix            | Android       | Fenix            | Firefox for Android (Fenix) | true  | true
-Fennec           | Android       | Fennec           | Firefox for Android (Fennec)| true  | true
-Firefox Preview  | Android       | Firefox Preview  | Firefox Preview for Android | true  | true
-Fennec           | iOS           | Firefox iOS      | Firefox for iOS             | true  | true
-FirefoxForFireTV | Android       | Firefox Fire TV  | Firefox for Fire TV         | false | false
-FirefoxConnect   | Android       | Firefox Echo     | Firefox for Echo Show       | true  | true
-Zerda            | Android       | Firefox Lite     | Firefox Lite                | true  | true
-Zerda_cn         | Android       | Firefox Lite CN  | Firefox Lite (China)        | false | false
-Focus            | Android       | Focus Android    | Firefox Focus for Android   | true  | true
-Focus            | iOS           | Focus iOS        | Firefox Focus for iOS       | true  | true
-Klar             | Android       | Klar Android     | Firefox Klar for Android    | false | false
-Klar             | iOS           | Klar iOS         | Firefox Klar for iOS        | false | false
-Lockbox          | Android       | Lockwise Android | Lockwise for Android        | true  | true
-Lockbox          | iOS           | Lockwise iOS     | Lockwise for iOS            | true  | true
-FirefoxReality*  | Android       | Firefox Reality  | Firefox Reality             | false | false
+app_name         | normalized_os | looker_app_name  | product          | canonical_app_name              | 2019  | 2020  | 2021
+---------------- | ------------- | ---------------- | ---------------- | ------------------------------- | ----- | ----  | ----
+Firefox          | *             | firefox_desktop  | Firefox          | Firefox for Desktop             | true  | true  | true
+Fenix            | Android       | fenix            | Fenix            | Firefox for Android (Fenix)     | true  | true  | true
+Fennec           | Android       | fennec           | Fennec           | Firefox for Android (Fennec)    | true  | true  | true
+Firefox Preview  | Android       | firefox_preview  | Firefox Preview  | Firefox Preview for Android     | true  | true  | false
+Fennec           | iOS           | firefox_ios      | Firefox iOS      | Firefox for iOS                 | true  | true  | true
+FirefoxForFireTV | Android       | firefox_fire_tv  | Firefox Fire TV  | Firefox for Fire TV             | false | false | false
+FirefoxConnect   | Android       | firefox_connect  | Firefox Echo     | Firefox for Echo Show           | true  | true  | true
+Zerda            | Android       | firefox_lite     | Firefox Lite     | Firefox Lite                    | true  | true  | true
+Zerda_cn         | Android       | firefox_lite_cn  | Firefox Lite CN  | Firefox Lite (China)            | false | false | false
+Focus            | Android       | focus_android    | Focus Android    | Firefox Focus for Android       | true  | true  | true
+Focus            | iOS           | focus_ios        | Focus iOS        | Firefox Focus for iOS           | true  | true  | true
+Klar             | Android       | klar_android     | Klar Android     | Firefox Klar for Android        | false | false | false
+Klar             | iOS           | klar_ios         | Klar iOS         | Firefox Klar for iOS            | false | false | false
+Lockbox          | Android       | lockwise_android | Lockwise Android | Lockwise for Android            | true  | true  | true
+Lockbox          | iOS           | lockwise_ios     | Lockwise iOS     | Lockwise for iOS                | true  | true  | true
+FirefoxReality*  | Android       | firefox_reality  | Firefox Reality  | Firefox Reality                 | false | false | false

--- a/sql/mozfun/norm/product_info/generate_body.sql
+++ b/sql/mozfun/norm/product_info/generate_body.sql
@@ -13,16 +13,18 @@ lines AS (
     UNNEST(SPLIT(input, '\n')) AS line
   WHERE
     line NOT LIKE '%-----%'
-    AND line NOT LIKE '%canonical_name%'
+    AND line NOT LIKE '%canonical_app_name%'
 ),
 structured AS (
   SELECT AS STRUCT
     fields[OFFSET(0)] AS app_name,
     fields[OFFSET(1)] AS normalized_os,
-    fields[OFFSET(2)] AS product,
-    fields[OFFSET(3)] AS canonical_name,
-    fields[OFFSET(4)] AS contributes_to_2019_kpi,
-    fields[OFFSET(5)] AS contributes_to_2020_kpi,
+    fields[OFFSET(2)] AS looker_app_name,
+    fields[OFFSET(3)] AS product,
+    fields[OFFSET(4)] AS canonical_app_name,
+    fields[OFFSET(5)] AS contributes_to_2019_kpi,
+    fields[OFFSET(6)] AS contributes_to_2020_kpi,
+    fields[OFFSET(7)] AS contributes_to_2021_kpi,
   FROM
     lines
   WHERE
@@ -48,19 +50,26 @@ formatted AS (
     *,
     CONCAT(
       FORMAT(
-        "WHEN app_name LIKE %T AND normalized_os LIKE %T THEN STRUCT(%T AS product, %T AS canonical_name, %s AS contributes_to_2019_kpi, %s AS contributes_to_2020_kpi)",
+        "WHEN app_name LIKE %T AND normalized_os LIKE %T THEN STRUCT(%T AS looker_app_name, %T AS product, %T AS canonical_app_name, %T AS canonical_name, %s AS contributes_to_2019_kpi, %s AS contributes_to_2020_kpi, %s AS contributes_to_2021_kpi)",
         app_name,
         normalized_os,
+        looker_app_name,
         product,
-        canonical_name,
+        canonical_app_name,
+        canonical_app_name,
         contributes_to_2019_kpi,
-        contributes_to_2020_kpi
+        contributes_to_2020_kpi,
+        contributes_to_2021_kpi
       )
     ) AS case_stmt,
   FROM
     unioned
 )
 SELECT
-  CONCAT("CASE\n", STRING_AGG(case_stmt, "\n"), "\nELSE ('Other', 'Other', false, false) END")
+  CONCAT(
+    "CASE\n",
+    STRING_AGG(case_stmt, "\n"),
+    "\nELSE ('other', 'Other', 'Other', 'Other', FALSE, FALSE, FALSE) END"
+  )
 FROM
   formatted

--- a/sql/mozfun/norm/product_info/generate_body.sql
+++ b/sql/mozfun/norm/product_info/generate_body.sql
@@ -17,9 +17,9 @@ lines AS (
 ),
 structured AS (
   SELECT AS STRUCT
-    fields[OFFSET(0)] AS app_name,
+    fields[OFFSET(0)] AS legacy_app_name,
     fields[OFFSET(1)] AS normalized_os,
-    fields[OFFSET(2)] AS looker_app_name,
+    fields[OFFSET(2)] AS app_name,
     fields[OFFSET(3)] AS product,
     fields[OFFSET(4)] AS canonical_app_name,
     fields[OFFSET(5)] AS contributes_to_2019_kpi,
@@ -39,21 +39,21 @@ unioned AS (
   -- so we duplicate some rows.
   UNION ALL
   SELECT
-    * REPLACE (product AS app_name)
+    * REPLACE (product AS legacy_app_name)
   FROM
     structured
   WHERE
-    product NOT IN (SELECT app_name FROM structured)
+    product NOT IN (SELECT legacy_app_name FROM structured)
 ),
 formatted AS (
   SELECT
     *,
     CONCAT(
       FORMAT(
-        "WHEN app_name LIKE %T AND normalized_os LIKE %T THEN STRUCT(%T AS looker_app_name, %T AS product, %T AS canonical_app_name, %T AS canonical_name, %s AS contributes_to_2019_kpi, %s AS contributes_to_2020_kpi, %s AS contributes_to_2021_kpi)",
-        app_name,
+        "WHEN legacy_app_name LIKE %T AND normalized_os LIKE %T THEN STRUCT(%T AS app_name, %T AS product, %T AS canonical_app_name, %T AS canonical_name, %s AS contributes_to_2019_kpi, %s AS contributes_to_2020_kpi, %s AS contributes_to_2021_kpi)",
+        legacy_app_name,
         normalized_os,
-        looker_app_name,
+        app_name,
         product,
         canonical_app_name,
         canonical_app_name,

--- a/sql/mozfun/norm/product_info/metadata.yaml
+++ b/sql/mozfun/norm/product_info/metadata.yaml
@@ -32,7 +32,8 @@ description: |
   `product` is deprecated
   and is provided for continuity with some existing tables. Going forward,
   use `looker_app_name` which maps to the `app_name` returned by the `probeinfo`
-  API for Glean apps.
+  API for Glean apps. We are using these values consistently as we build
+  reporting functionality in Looker.
 
   The returned `canonical_app_name` is more verbose and is suited for displaying
   in visualizations. `canonical_name` is a synonym that we provide for

--- a/sql/mozfun/norm/product_info/metadata.yaml
+++ b/sql/mozfun/norm/product_info/metadata.yaml
@@ -6,14 +6,14 @@ description: |
   appear in (legacy) pings.
 
   As of 2021, most Mozilla products are sending telemetry via the Glean SDK,
-  with Glean telemetry in active development for desktop Firefox. The
+  with Glean telemetry in active development for desktop Firefox as well. The
   `probeinfo` API is the single source of truth for metadata about applications
   sending Glean telemetry, and the values here should match fields included in
   [the v2 Glean app listings endpoint
   ](https://mozilla.github.io/probe-scraper/#operation/getAppListings)
   as much as possible.
   That said, this function is oriented towards handling the transitional
-  period where legacy pings are still important for reporting.
+  period where legacy pings are still important for some reporting.
 
   For legacy telemetry pings like `main` ping for desktop and `core` ping for
   mobile products, the `app_name` give as input to this function
@@ -22,15 +22,17 @@ description: |
 
   For Glean pings, the concept of an `app_name` doesn't exist, since pings
   from different applications are routed to different BigQuery datasets.
-  Instead, the `app_name` send in for Glean pings should be the same value as
+  Instead, the `app_name` sent in for Glean pings should be the same value as
   what's expected for `product`. So, a view on top of pings from Fenix should
   pass in "Fenix" for `app_name`.
 
   The returned `product` name and `looker_app_name` values are intended to be
-  readable and unambiguous, but short and easy to type. `product` is deprecated
+  readable and unambiguous, but short and easy to type.
+  They are suitable for use as a key in derived tables.
+  `product` is deprecated
   and is provided for continuity with some existing tables. Going forward,
   use `looker_app_name` which maps to the `app_name` returned by the `probeinfo`
-  API for Glean apps. This value is suitable for use as a key in derived tables.
+  API for Glean apps.
 
   The returned `canonical_app_name` is more verbose and is suited for displaying
   in visualizations. `canonical_name` is a synonym that we provide for

--- a/sql/mozfun/norm/product_info/metadata.yaml
+++ b/sql/mozfun/norm/product_info/metadata.yaml
@@ -1,27 +1,23 @@
 ---
 friendly_name: Normalize Product Info
 description: |
-  Returns a normalized `product` name and a `canonical_name` for a product
-  based on the raw `app_name` and `normalized_os` values that appear in pings.
+  Returns a normalized `looker_app_name`, `product` name, and `canonical_name`
+  for a product based on the raw `app_name` and `normalized_os` values that
+  appear in (legacy) pings.
 
-  The returned `product` name is intended to be readable and unambiguous, but
-  short and easy to type. This value is suitable for use as a key in derived
-  tables.
-
-  The returned `canonical_name` is more verbose and is suited for displaying
-  in visualizations.
-
-  The returned struct also contains boolean `contributes_to_2020_kpi` as the
-  canonical reference for whether the given application is included in KPI
-  reporting. Additional fields may be added for future years.
-
-  The `normalized_os` value that's passed in should be the top-level
-  `normalized_os` value present in any ping table or you may want
-  to wrap a raw value in `mozfun.norm.os`
-  like `mozfun.norm.product_info(app_name, mozfun.norm.os(os))`.
+  As of 2021, most Mozilla products are sending telemetry via the Glean SDK,
+  with Glean telemetry in active development for desktop Firefox. The
+  `probeinfo` API is the single source of truth for metadata about applications
+  sending Glean telemetry, and the values here should match fields included in
+  [the v2 Glean app listings endpoint
+  ](https://mozilla.github.io/probe-scraper/#operation/getAppListings)
+  as much as possible.
+  That said, this function is oriented towards handling the transitional
+  period where legacy pings are still important for reporting.
 
   For legacy telemetry pings like `main` ping for desktop and `core` ping for
-  mobile products, `app_name` should come from the submission URI (stored as
+  mobile products, the `app_name` give as input to this function
+  should come from the submission URI (stored as
   `metadata.uri.app_name` in BigQuery ping tables).
 
   For Glean pings, the concept of an `app_name` doesn't exist, since pings
@@ -29,6 +25,26 @@ description: |
   Instead, the `app_name` send in for Glean pings should be the same value as
   what's expected for `product`. So, a view on top of pings from Fenix should
   pass in "Fenix" for `app_name`.
+
+  The returned `product` name and `looker_app_name` values are intended to be
+  readable and unambiguous, but short and easy to type. `product` is deprecated
+  and is provided for continuity with some existing tables. Going forward,
+  use `looker_app_name` which maps to the `app_name` returned by the `probeinfo`
+  API for Glean apps. This value is suitable for use as a key in derived tables.
+
+  The returned `canonical_app_name` is more verbose and is suited for displaying
+  in visualizations. `canonical_name` is a synonym that we provide for
+  historical compatibility, but `canonical_app_name` is the preferred
+  "end-to-end" term for this identifier.
+
+  The returned struct also contains boolean `contributes_to_2021_kpi` as the
+  canonical reference for whether the given application is included in KPI
+  reporting. Additional fields may be added for future years.
+
+  The `normalized_os` value that's passed in should be the top-level
+  `normalized_os` value present in any ping table or you may want
+  to wrap a raw value in `mozfun.norm.os`
+  like `mozfun.norm.product_info(app_name, mozfun.norm.os(os))`.
 
   This function also tolerates passing in a `product` value as `app_name` so
   that this function is still useful for derived tables which have thrown away

--- a/sql/mozfun/norm/product_info/metadata.yaml
+++ b/sql/mozfun/norm/product_info/metadata.yaml
@@ -1,44 +1,37 @@
 ---
 friendly_name: Normalize Product Info
 description: |
-  Returns a normalized `looker_app_name`, `product` name, and `canonical_name`
-  for a product based on the raw `app_name` and `normalized_os` values that
-  appear in (legacy) pings.
+  Returns a normalized `app_name` and `canonical_app_name`
+  for a product based on `legacy_app_name` and `normalized_os` values.
+  Thus, this function serves as a bridge to get from legacy application
+  identifiers to the consistent identifiers we are using for reporting in 2021.
 
   As of 2021, most Mozilla products are sending telemetry via the Glean SDK,
   with Glean telemetry in active development for desktop Firefox as well. The
   `probeinfo` API is the single source of truth for metadata about applications
-  sending Glean telemetry, and the values here should match fields included in
+  sending Glean telemetry; the values for `app_name` and
+  `canonical_app_name` returned here correspond to the "end-to-end identifier"
+  values documented in
   [the v2 Glean app listings endpoint
-  ](https://mozilla.github.io/probe-scraper/#operation/getAppListings)
-  as much as possible.
-  That said, this function is oriented towards handling the transitional
-  period where legacy pings are still important for some reporting.
+  ](https://mozilla.github.io/probe-scraper/#operation/getAppListings).
+  For non-Glean telemetry, we provide values in the same style to provide
+  continuity as we continue the migration to Glean.
 
   For legacy telemetry pings like `main` ping for desktop and `core` ping for
-  mobile products, the `app_name` give as input to this function
+  mobile products, the `legacy_app_name` given as input to this function
   should come from the submission URI (stored as
   `metadata.uri.app_name` in BigQuery ping tables).
+  For Glean pings, we have invented `product` values that can be passed
+  in to this function as the `legacy_app_name` parameter.
 
-  For Glean pings, the concept of an `app_name` doesn't exist, since pings
-  from different applications are routed to different BigQuery datasets.
-  Instead, the `app_name` sent in for Glean pings should be the same value as
-  what's expected for `product`. So, a view on top of pings from Fenix should
-  pass in "Fenix" for `app_name`.
-
-  The returned `product` name and `looker_app_name` values are intended to be
+  The returned `app_name` values are intended to be
   readable and unambiguous, but short and easy to type.
   They are suitable for use as a key in derived tables.
-  `product` is deprecated
-  and is provided for continuity with some existing tables. Going forward,
-  use `looker_app_name` which maps to the `app_name` returned by the `probeinfo`
-  API for Glean apps. We are using these values consistently as we build
-  reporting functionality in Looker.
+  `product` is a deprecated field that was similar in intent.
 
   The returned `canonical_app_name` is more verbose and is suited for displaying
   in visualizations. `canonical_name` is a synonym that we provide for
-  historical compatibility, but `canonical_app_name` is the preferred
-  "end-to-end" term for this identifier.
+  historical compatibility with previous versions of this function.
 
   The returned struct also contains boolean `contributes_to_2021_kpi` as the
   canonical reference for whether the given application is included in KPI
@@ -49,6 +42,6 @@ description: |
   to wrap a raw value in `mozfun.norm.os`
   like `mozfun.norm.product_info(app_name, mozfun.norm.os(os))`.
 
-  This function also tolerates passing in a `product` value as `app_name` so
-  that this function is still useful for derived tables which have thrown away
-  the raw `app_name` value.
+  This function also tolerates passing in a `product` value as
+  `legacy_app_name` so that this function is still useful for derived tables
+  which have thrown away the raw `app_name` value from legacy pings.

--- a/sql/mozfun/norm/product_info/udf.sql
+++ b/sql/mozfun/norm/product_info/udf.sql
@@ -390,21 +390,11 @@ WITH b AS (
     norm.product_info('Firefox', 'Windows')
 )
 SELECT
-  assert.equals(
-    STRUCT(
-      'firefox_desktop',
-      'Firefox',
-      'Firefox for Desktop',
-      'Firefox for Desktop',
-      TRUE,
-      TRUE,
-      TRUE
-    ),
-    b
-  ),
   assert.equals('firefox_desktop', b.looker_app_name),
   assert.equals('Firefox', b.product),
   assert.equals('Firefox for Desktop', b.canonical_app_name),
+  assert.equals('Firefox for Desktop', b.canonical_name),
+  assert.true(b.contributes_to_2020_kpi),
   assert.true(b.contributes_to_2021_kpi),
 FROM
   b;
@@ -417,6 +407,7 @@ SELECT
   assert.equals('firefox_ios', b.looker_app_name),
   assert.equals('Firefox iOS', b.product),
   assert.equals('Firefox for iOS', b.canonical_app_name),
+  assert.true(b.contributes_to_2020_kpi),
   assert.true(b.contributes_to_2021_kpi),
 FROM
   b;
@@ -430,6 +421,7 @@ SELECT
   assert.equals('Lockwise iOS', b.product),
   assert.equals('Lockwise for iOS', b.canonical_name),
   assert.equals('Lockwise for iOS', b.canonical_app_name),
+  assert.true(b.contributes_to_2020_kpi),
   assert.true(b.contributes_to_2021_kpi),
 FROM
   b;
@@ -443,6 +435,7 @@ SELECT
   assert.equals('Klar iOS', b.product),
   assert.equals('Firefox Klar for iOS', b.canonical_name),
   assert.equals('Firefox Klar for iOS', b.canonical_app_name),
+  assert.false(b.contributes_to_2020_kpi),
   assert.false(b.contributes_to_2021_kpi),
 FROM
   b;
@@ -457,5 +450,18 @@ SELECT
   assert.equals('Firefox for Android (Fenix)', b.canonical_app_name),
   assert.true(b.contributes_to_2020_kpi),
   assert.true(b.contributes_to_2021_kpi),
+FROM
+  b;
+
+WITH b AS (
+  SELECT AS VALUE
+    norm.product_info('foo', 'bar')
+)
+SELECT
+  assert.equals('other', b.looker_app_name),
+  assert.equals('Other', b.product),
+  assert.equals('Other', b.canonical_app_name),
+  assert.false(b.contributes_to_2020_kpi),
+  assert.false(b.contributes_to_2021_kpi),
 FROM
   b;

--- a/sql/mozfun/norm/product_info/udf.sql
+++ b/sql/mozfun/norm/product_info/udf.sql
@@ -4,9 +4,9 @@ The case statement below can be generated based on the markdown table
 in metadata.yaml via the query in generate_body.sql
 
 */
-CREATE OR REPLACE FUNCTION norm.product_info(app_name STRING, normalized_os STRING)
+CREATE OR REPLACE FUNCTION norm.product_info(legacy_app_name STRING, normalized_os STRING)
 RETURNS STRUCT<
-  looker_app_name STRING,
+  app_name STRING,
   product STRING,
   canonical_app_name STRING,
   canonical_name STRING,
@@ -16,11 +16,11 @@ RETURNS STRUCT<
 > AS (
   CASE
   WHEN
-    app_name LIKE "Firefox"
+    legacy_app_name LIKE "Firefox"
     AND normalized_os LIKE "%"
   THEN
     STRUCT(
-      "firefox_desktop" AS looker_app_name,
+      "firefox_desktop" AS app_name,
       "Firefox" AS product,
       "Firefox for Desktop" AS canonical_app_name,
       "Firefox for Desktop" AS canonical_name,
@@ -29,11 +29,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Fenix"
+    legacy_app_name LIKE "Fenix"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "fenix" AS looker_app_name,
+      "fenix" AS app_name,
       "Fenix" AS product,
       "Firefox for Android (Fenix)" AS canonical_app_name,
       "Firefox for Android (Fenix)" AS canonical_name,
@@ -42,11 +42,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Fennec"
+    legacy_app_name LIKE "Fennec"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "fennec" AS looker_app_name,
+      "fennec" AS app_name,
       "Fennec" AS product,
       "Firefox for Android (Fennec)" AS canonical_app_name,
       "Firefox for Android (Fennec)" AS canonical_name,
@@ -55,24 +55,24 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Firefox Preview"
+    legacy_app_name LIKE "Firefox Preview"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "firefox_preview" AS looker_app_name,
+      "firefox_preview" AS app_name,
       "Firefox Preview" AS product,
       "Firefox Preview for Android" AS canonical_app_name,
       "Firefox Preview for Android" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
       TRUE AS contributes_to_2020_kpi,
-      FALSE AS contributes_to_2021_kpi
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Fennec"
+    legacy_app_name LIKE "Fennec"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
-      "firefox_ios" AS looker_app_name,
+      "firefox_ios" AS app_name,
       "Firefox iOS" AS product,
       "Firefox for iOS" AS canonical_app_name,
       "Firefox for iOS" AS canonical_name,
@@ -81,11 +81,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "FirefoxForFireTV"
+    legacy_app_name LIKE "FirefoxForFireTV"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "firefox_fire_tv" AS looker_app_name,
+      "firefox_fire_tv" AS app_name,
       "Firefox Fire TV" AS product,
       "Firefox for Fire TV" AS canonical_app_name,
       "Firefox for Fire TV" AS canonical_name,
@@ -94,11 +94,11 @@ RETURNS STRUCT<
       FALSE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "FirefoxConnect"
+    legacy_app_name LIKE "FirefoxConnect"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "firefox_connect" AS looker_app_name,
+      "firefox_connect" AS app_name,
       "Firefox Echo" AS product,
       "Firefox for Echo Show" AS canonical_app_name,
       "Firefox for Echo Show" AS canonical_name,
@@ -107,11 +107,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Zerda"
+    legacy_app_name LIKE "Zerda"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "firefox_lite" AS looker_app_name,
+      "firefox_lite" AS app_name,
       "Firefox Lite" AS product,
       "Firefox Lite" AS canonical_app_name,
       "Firefox Lite" AS canonical_name,
@@ -120,11 +120,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Zerda_cn"
+    legacy_app_name LIKE "Zerda_cn"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "firefox_lite_cn" AS looker_app_name,
+      "firefox_lite_cn" AS app_name,
       "Firefox Lite CN" AS product,
       "Firefox Lite (China)" AS canonical_app_name,
       "Firefox Lite (China)" AS canonical_name,
@@ -133,11 +133,11 @@ RETURNS STRUCT<
       FALSE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Focus"
+    legacy_app_name LIKE "Focus"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "focus_android" AS looker_app_name,
+      "focus_android" AS app_name,
       "Focus Android" AS product,
       "Firefox Focus for Android" AS canonical_app_name,
       "Firefox Focus for Android" AS canonical_name,
@@ -146,11 +146,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Focus"
+    legacy_app_name LIKE "Focus"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
-      "focus_ios" AS looker_app_name,
+      "focus_ios" AS app_name,
       "Focus iOS" AS product,
       "Firefox Focus for iOS" AS canonical_app_name,
       "Firefox Focus for iOS" AS canonical_name,
@@ -159,11 +159,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Klar"
+    legacy_app_name LIKE "Klar"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "klar_android" AS looker_app_name,
+      "klar_android" AS app_name,
       "Klar Android" AS product,
       "Firefox Klar for Android" AS canonical_app_name,
       "Firefox Klar for Android" AS canonical_name,
@@ -172,11 +172,11 @@ RETURNS STRUCT<
       FALSE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Klar"
+    legacy_app_name LIKE "Klar"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
-      "klar_ios" AS looker_app_name,
+      "klar_ios" AS app_name,
       "Klar iOS" AS product,
       "Firefox Klar for iOS" AS canonical_app_name,
       "Firefox Klar for iOS" AS canonical_name,
@@ -185,11 +185,11 @@ RETURNS STRUCT<
       FALSE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Lockbox"
+    legacy_app_name LIKE "Lockbox"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "lockwise_android" AS looker_app_name,
+      "lockwise_android" AS app_name,
       "Lockwise Android" AS product,
       "Lockwise for Android" AS canonical_app_name,
       "Lockwise for Android" AS canonical_name,
@@ -198,11 +198,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Lockbox"
+    legacy_app_name LIKE "Lockbox"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
-      "lockwise_ios" AS looker_app_name,
+      "lockwise_ios" AS app_name,
       "Lockwise iOS" AS product,
       "Lockwise for iOS" AS canonical_app_name,
       "Lockwise for iOS" AS canonical_name,
@@ -211,11 +211,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "FirefoxReality%"
+    legacy_app_name LIKE "FirefoxReality%"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "firefox_reality" AS looker_app_name,
+      "firefox_reality" AS app_name,
       "Firefox Reality" AS product,
       "Firefox Reality" AS canonical_app_name,
       "Firefox Reality" AS canonical_name,
@@ -224,11 +224,11 @@ RETURNS STRUCT<
       FALSE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Firefox iOS"
+    legacy_app_name LIKE "Firefox iOS"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
-      "firefox_ios" AS looker_app_name,
+      "firefox_ios" AS app_name,
       "Firefox iOS" AS product,
       "Firefox for iOS" AS canonical_app_name,
       "Firefox for iOS" AS canonical_name,
@@ -237,11 +237,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Firefox Fire TV"
+    legacy_app_name LIKE "Firefox Fire TV"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "firefox_fire_tv" AS looker_app_name,
+      "firefox_fire_tv" AS app_name,
       "Firefox Fire TV" AS product,
       "Firefox for Fire TV" AS canonical_app_name,
       "Firefox for Fire TV" AS canonical_name,
@@ -250,11 +250,11 @@ RETURNS STRUCT<
       FALSE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Firefox Echo"
+    legacy_app_name LIKE "Firefox Echo"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "firefox_connect" AS looker_app_name,
+      "firefox_connect" AS app_name,
       "Firefox Echo" AS product,
       "Firefox for Echo Show" AS canonical_app_name,
       "Firefox for Echo Show" AS canonical_name,
@@ -263,11 +263,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Firefox Lite"
+    legacy_app_name LIKE "Firefox Lite"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "firefox_lite" AS looker_app_name,
+      "firefox_lite" AS app_name,
       "Firefox Lite" AS product,
       "Firefox Lite" AS canonical_app_name,
       "Firefox Lite" AS canonical_name,
@@ -276,11 +276,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Firefox Lite CN"
+    legacy_app_name LIKE "Firefox Lite CN"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "firefox_lite_cn" AS looker_app_name,
+      "firefox_lite_cn" AS app_name,
       "Firefox Lite CN" AS product,
       "Firefox Lite (China)" AS canonical_app_name,
       "Firefox Lite (China)" AS canonical_name,
@@ -289,11 +289,11 @@ RETURNS STRUCT<
       FALSE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Focus Android"
+    legacy_app_name LIKE "Focus Android"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "focus_android" AS looker_app_name,
+      "focus_android" AS app_name,
       "Focus Android" AS product,
       "Firefox Focus for Android" AS canonical_app_name,
       "Firefox Focus for Android" AS canonical_name,
@@ -302,11 +302,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Focus iOS"
+    legacy_app_name LIKE "Focus iOS"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
-      "focus_ios" AS looker_app_name,
+      "focus_ios" AS app_name,
       "Focus iOS" AS product,
       "Firefox Focus for iOS" AS canonical_app_name,
       "Firefox Focus for iOS" AS canonical_name,
@@ -315,11 +315,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Klar Android"
+    legacy_app_name LIKE "Klar Android"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "klar_android" AS looker_app_name,
+      "klar_android" AS app_name,
       "Klar Android" AS product,
       "Firefox Klar for Android" AS canonical_app_name,
       "Firefox Klar for Android" AS canonical_name,
@@ -328,11 +328,11 @@ RETURNS STRUCT<
       FALSE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Klar iOS"
+    legacy_app_name LIKE "Klar iOS"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
-      "klar_ios" AS looker_app_name,
+      "klar_ios" AS app_name,
       "Klar iOS" AS product,
       "Firefox Klar for iOS" AS canonical_app_name,
       "Firefox Klar for iOS" AS canonical_name,
@@ -341,11 +341,11 @@ RETURNS STRUCT<
       FALSE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Lockwise Android"
+    legacy_app_name LIKE "Lockwise Android"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "lockwise_android" AS looker_app_name,
+      "lockwise_android" AS app_name,
       "Lockwise Android" AS product,
       "Lockwise for Android" AS canonical_app_name,
       "Lockwise for Android" AS canonical_name,
@@ -354,11 +354,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Lockwise iOS"
+    legacy_app_name LIKE "Lockwise iOS"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
-      "lockwise_ios" AS looker_app_name,
+      "lockwise_ios" AS app_name,
       "Lockwise iOS" AS product,
       "Lockwise for iOS" AS canonical_app_name,
       "Lockwise for iOS" AS canonical_name,
@@ -367,11 +367,11 @@ RETURNS STRUCT<
       TRUE AS contributes_to_2021_kpi
     )
   WHEN
-    app_name LIKE "Firefox Reality"
+    legacy_app_name LIKE "Firefox Reality"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
-      "firefox_reality" AS looker_app_name,
+      "firefox_reality" AS app_name,
       "Firefox Reality" AS product,
       "Firefox Reality" AS canonical_app_name,
       "Firefox Reality" AS canonical_name,
@@ -390,7 +390,7 @@ WITH b AS (
     norm.product_info('Firefox', 'Windows')
 )
 SELECT
-  assert.equals('firefox_desktop', b.looker_app_name),
+  assert.equals('firefox_desktop', b.app_name),
   assert.equals('Firefox', b.product),
   assert.equals('Firefox for Desktop', b.canonical_app_name),
   assert.equals('Firefox for Desktop', b.canonical_name),
@@ -404,7 +404,7 @@ WITH b AS (
     norm.product_info('Firefox iOS', 'iOS')
 )
 SELECT
-  assert.equals('firefox_ios', b.looker_app_name),
+  assert.equals('firefox_ios', b.app_name),
   assert.equals('Firefox iOS', b.product),
   assert.equals('Firefox for iOS', b.canonical_app_name),
   assert.true(b.contributes_to_2020_kpi),
@@ -417,7 +417,7 @@ WITH b AS (
     norm.product_info('Lockbox', 'iOS')
 )
 SELECT
-  assert.equals('lockwise_ios', b.looker_app_name),
+  assert.equals('lockwise_ios', b.app_name),
   assert.equals('Lockwise iOS', b.product),
   assert.equals('Lockwise for iOS', b.canonical_name),
   assert.equals('Lockwise for iOS', b.canonical_app_name),
@@ -431,7 +431,7 @@ WITH b AS (
     norm.product_info('Klar', 'iOS')
 )
 SELECT
-  assert.equals('klar_ios', b.looker_app_name),
+  assert.equals('klar_ios', b.app_name),
   assert.equals('Klar iOS', b.product),
   assert.equals('Firefox Klar for iOS', b.canonical_name),
   assert.equals('Firefox Klar for iOS', b.canonical_app_name),
@@ -445,7 +445,7 @@ WITH b AS (
     norm.product_info('Fenix', 'Android')
 )
 SELECT
-  assert.equals('fenix', b.looker_app_name),
+  assert.equals('fenix', b.app_name),
   assert.equals('Fenix', b.product),
   assert.equals('Firefox for Android (Fenix)', b.canonical_app_name),
   assert.true(b.contributes_to_2020_kpi),
@@ -458,7 +458,7 @@ WITH b AS (
     norm.product_info('foo', 'bar')
 )
 SELECT
-  assert.equals('other', b.looker_app_name),
+  assert.equals('other', b.app_name),
   assert.equals('Other', b.product),
   assert.equals('Other', b.canonical_app_name),
   assert.false(b.contributes_to_2020_kpi),

--- a/sql/mozfun/norm/product_info/udf.sql
+++ b/sql/mozfun/norm/product_info/udf.sql
@@ -6,10 +6,13 @@ in metadata.yaml via the query in generate_body.sql
 */
 CREATE OR REPLACE FUNCTION norm.product_info(app_name STRING, normalized_os STRING)
 RETURNS STRUCT<
+  looker_app_name STRING,
   product STRING,
+  canonical_app_name STRING,
   canonical_name STRING,
   contributes_to_2019_kpi BOOLEAN,
-  contributes_to_2020_kpi BOOLEAN
+  contributes_to_2020_kpi BOOLEAN,
+  contributes_to_2021_kpi BOOLEAN
 > AS (
   CASE
   WHEN
@@ -17,307 +20,442 @@ RETURNS STRUCT<
     AND normalized_os LIKE "%"
   THEN
     STRUCT(
+      "firefox_desktop" AS looker_app_name,
       "Firefox" AS product,
+      "Firefox for Desktop" AS canonical_app_name,
       "Firefox for Desktop" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Fenix"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "fenix" AS looker_app_name,
       "Fenix" AS product,
+      "Firefox for Android (Fenix)" AS canonical_app_name,
       "Firefox for Android (Fenix)" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Fennec"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "fennec" AS looker_app_name,
       "Fennec" AS product,
+      "Firefox for Android (Fennec)" AS canonical_app_name,
       "Firefox for Android (Fennec)" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Firefox Preview"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "firefox_preview" AS looker_app_name,
       "Firefox Preview" AS product,
+      "Firefox Preview for Android" AS canonical_app_name,
       "Firefox Preview for Android" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      FALSE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Fennec"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
+      "firefox_ios" AS looker_app_name,
       "Firefox iOS" AS product,
+      "Firefox for iOS" AS canonical_app_name,
       "Firefox for iOS" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "FirefoxForFireTV"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "firefox_fire_tv" AS looker_app_name,
       "Firefox Fire TV" AS product,
+      "Firefox for Fire TV" AS canonical_app_name,
       "Firefox for Fire TV" AS canonical_name,
       FALSE AS contributes_to_2019_kpi,
-      FALSE AS contributes_to_2020_kpi
+      FALSE AS contributes_to_2020_kpi,
+      FALSE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "FirefoxConnect"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "firefox_connect" AS looker_app_name,
       "Firefox Echo" AS product,
+      "Firefox for Echo Show" AS canonical_app_name,
       "Firefox for Echo Show" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Zerda"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "firefox_lite" AS looker_app_name,
       "Firefox Lite" AS product,
+      "Firefox Lite" AS canonical_app_name,
       "Firefox Lite" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Zerda_cn"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "firefox_lite_cn" AS looker_app_name,
       "Firefox Lite CN" AS product,
+      "Firefox Lite (China)" AS canonical_app_name,
       "Firefox Lite (China)" AS canonical_name,
       FALSE AS contributes_to_2019_kpi,
-      FALSE AS contributes_to_2020_kpi
+      FALSE AS contributes_to_2020_kpi,
+      FALSE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Focus"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "focus_android" AS looker_app_name,
       "Focus Android" AS product,
+      "Firefox Focus for Android" AS canonical_app_name,
       "Firefox Focus for Android" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Focus"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
+      "focus_ios" AS looker_app_name,
       "Focus iOS" AS product,
+      "Firefox Focus for iOS" AS canonical_app_name,
       "Firefox Focus for iOS" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Klar"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "klar_android" AS looker_app_name,
       "Klar Android" AS product,
+      "Firefox Klar for Android" AS canonical_app_name,
       "Firefox Klar for Android" AS canonical_name,
       FALSE AS contributes_to_2019_kpi,
-      FALSE AS contributes_to_2020_kpi
+      FALSE AS contributes_to_2020_kpi,
+      FALSE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Klar"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
+      "klar_ios" AS looker_app_name,
       "Klar iOS" AS product,
+      "Firefox Klar for iOS" AS canonical_app_name,
       "Firefox Klar for iOS" AS canonical_name,
       FALSE AS contributes_to_2019_kpi,
-      FALSE AS contributes_to_2020_kpi
+      FALSE AS contributes_to_2020_kpi,
+      FALSE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Lockbox"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "lockwise_android" AS looker_app_name,
       "Lockwise Android" AS product,
+      "Lockwise for Android" AS canonical_app_name,
       "Lockwise for Android" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Lockbox"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
+      "lockwise_ios" AS looker_app_name,
       "Lockwise iOS" AS product,
+      "Lockwise for iOS" AS canonical_app_name,
       "Lockwise for iOS" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "FirefoxReality%"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "firefox_reality" AS looker_app_name,
       "Firefox Reality" AS product,
+      "Firefox Reality" AS canonical_app_name,
       "Firefox Reality" AS canonical_name,
       FALSE AS contributes_to_2019_kpi,
-      FALSE AS contributes_to_2020_kpi
+      FALSE AS contributes_to_2020_kpi,
+      FALSE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Firefox iOS"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
+      "firefox_ios" AS looker_app_name,
       "Firefox iOS" AS product,
+      "Firefox for iOS" AS canonical_app_name,
       "Firefox for iOS" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Firefox Fire TV"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "firefox_fire_tv" AS looker_app_name,
       "Firefox Fire TV" AS product,
+      "Firefox for Fire TV" AS canonical_app_name,
       "Firefox for Fire TV" AS canonical_name,
       FALSE AS contributes_to_2019_kpi,
-      FALSE AS contributes_to_2020_kpi
+      FALSE AS contributes_to_2020_kpi,
+      FALSE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Firefox Echo"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "firefox_connect" AS looker_app_name,
       "Firefox Echo" AS product,
+      "Firefox for Echo Show" AS canonical_app_name,
       "Firefox for Echo Show" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Firefox Lite"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "firefox_lite" AS looker_app_name,
       "Firefox Lite" AS product,
+      "Firefox Lite" AS canonical_app_name,
       "Firefox Lite" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Firefox Lite CN"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "firefox_lite_cn" AS looker_app_name,
       "Firefox Lite CN" AS product,
+      "Firefox Lite (China)" AS canonical_app_name,
       "Firefox Lite (China)" AS canonical_name,
       FALSE AS contributes_to_2019_kpi,
-      FALSE AS contributes_to_2020_kpi
+      FALSE AS contributes_to_2020_kpi,
+      FALSE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Focus Android"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "focus_android" AS looker_app_name,
       "Focus Android" AS product,
+      "Firefox Focus for Android" AS canonical_app_name,
       "Firefox Focus for Android" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Focus iOS"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
+      "focus_ios" AS looker_app_name,
       "Focus iOS" AS product,
+      "Firefox Focus for iOS" AS canonical_app_name,
       "Firefox Focus for iOS" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Klar Android"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "klar_android" AS looker_app_name,
       "Klar Android" AS product,
+      "Firefox Klar for Android" AS canonical_app_name,
       "Firefox Klar for Android" AS canonical_name,
       FALSE AS contributes_to_2019_kpi,
-      FALSE AS contributes_to_2020_kpi
+      FALSE AS contributes_to_2020_kpi,
+      FALSE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Klar iOS"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
+      "klar_ios" AS looker_app_name,
       "Klar iOS" AS product,
+      "Firefox Klar for iOS" AS canonical_app_name,
       "Firefox Klar for iOS" AS canonical_name,
       FALSE AS contributes_to_2019_kpi,
-      FALSE AS contributes_to_2020_kpi
+      FALSE AS contributes_to_2020_kpi,
+      FALSE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Lockwise Android"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "lockwise_android" AS looker_app_name,
       "Lockwise Android" AS product,
+      "Lockwise for Android" AS canonical_app_name,
       "Lockwise for Android" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Lockwise iOS"
     AND normalized_os LIKE "iOS"
   THEN
     STRUCT(
+      "lockwise_ios" AS looker_app_name,
       "Lockwise iOS" AS product,
+      "Lockwise for iOS" AS canonical_app_name,
       "Lockwise for iOS" AS canonical_name,
       TRUE AS contributes_to_2019_kpi,
-      TRUE AS contributes_to_2020_kpi
+      TRUE AS contributes_to_2020_kpi,
+      TRUE AS contributes_to_2021_kpi
     )
   WHEN
     app_name LIKE "Firefox Reality"
     AND normalized_os LIKE "Android"
   THEN
     STRUCT(
+      "firefox_reality" AS looker_app_name,
       "Firefox Reality" AS product,
+      "Firefox Reality" AS canonical_app_name,
       "Firefox Reality" AS canonical_name,
       FALSE AS contributes_to_2019_kpi,
-      FALSE AS contributes_to_2020_kpi
+      FALSE AS contributes_to_2020_kpi,
+      FALSE AS contributes_to_2021_kpi
     )
   ELSE
-    ('Other', 'Other', FALSE, FALSE)
+    ('other', 'Other', 'Other', 'Other', FALSE, FALSE, FALSE)
   END
 );
 
 -- Tests
+WITH b AS (
+  SELECT AS VALUE
+    norm.product_info('Firefox', 'Windows')
+)
 SELECT
   assert.equals(
-    STRUCT('Firefox', 'Firefox for Desktop', TRUE, TRUE),
-    norm.product_info('Firefox', 'Windows')
+    STRUCT(
+      'firefox_desktop',
+      'Firefox',
+      'Firefox for Desktop',
+      'Firefox for Desktop',
+      TRUE,
+      TRUE,
+      TRUE
+    ),
+    b
   ),
-  assert.equals(
-    STRUCT('Fenix', 'Firefox for Android (Fenix)', TRUE, TRUE),
-    norm.product_info('Fenix', 'Android')
-  ),
-  assert.equals(STRUCT('Other', 'Other', FALSE, FALSE), norm.product_info('Fenix', 'iOS')),
-  assert.equals(
-    STRUCT('Klar iOS', 'Firefox Klar for iOS', FALSE, FALSE),
-    norm.product_info('Klar', 'iOS')
-  ),
-  assert.equals(
-    STRUCT('Lockwise iOS', 'Lockwise for iOS', TRUE, TRUE),
-    norm.product_info('Lockbox', 'iOS')
-  ),
-  -- Make sure we can pass in product values for app_name.
-  assert.equals(
-    STRUCT('Firefox iOS', 'Firefox for iOS', TRUE, TRUE),
+  assert.equals('firefox_desktop', b.looker_app_name),
+  assert.equals('Firefox', b.product),
+  assert.equals('Firefox for Desktop', b.canonical_app_name),
+  assert.true(b.contributes_to_2021_kpi),
+FROM
+  b;
+
+WITH b AS (
+  SELECT AS VALUE
     norm.product_info('Firefox iOS', 'iOS')
-  );
+)
+SELECT
+  assert.equals('firefox_ios', b.looker_app_name),
+  assert.equals('Firefox iOS', b.product),
+  assert.equals('Firefox for iOS', b.canonical_app_name),
+  assert.true(b.contributes_to_2021_kpi),
+FROM
+  b;
+
+WITH b AS (
+  SELECT AS VALUE
+    norm.product_info('Lockbox', 'iOS')
+)
+SELECT
+  assert.equals('lockwise_ios', b.looker_app_name),
+  assert.equals('Lockwise iOS', b.product),
+  assert.equals('Lockwise for iOS', b.canonical_name),
+  assert.equals('Lockwise for iOS', b.canonical_app_name),
+  assert.true(b.contributes_to_2021_kpi),
+FROM
+  b;
+
+WITH b AS (
+  SELECT AS VALUE
+    norm.product_info('Klar', 'iOS')
+)
+SELECT
+  assert.equals('klar_ios', b.looker_app_name),
+  assert.equals('Klar iOS', b.product),
+  assert.equals('Firefox Klar for iOS', b.canonical_name),
+  assert.equals('Firefox Klar for iOS', b.canonical_app_name),
+  assert.false(b.contributes_to_2021_kpi),
+FROM
+  b;
+
+WITH b AS (
+  SELECT AS VALUE
+    norm.product_info('Fenix', 'Android')
+)
+SELECT
+  assert.equals('fenix', b.looker_app_name),
+  assert.equals('Fenix', b.product),
+  assert.equals('Firefox for Android (Fenix)', b.canonical_app_name),
+  assert.true(b.contributes_to_2020_kpi),
+  assert.true(b.contributes_to_2021_kpi),
+FROM
+  b;


### PR DESCRIPTION
See the new documentation in `product_info/metadata.yaml` for full context.

I want to use this when creating derived tables for serving 2021 KPI info for mobile products in https://github.com/mozilla/bigquery-etl/pull/1824