### PR TITLE
Fix 'NoneType' error when generating SQL content

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -334,7 +334,7 @@ class DryRun:
     def errors(self):
         """Dry run the provided SQL file and return errors."""
         if self.dry_run_result is None:
-            return None
+            return []
         return self.dry_run_result.get("errors", [])
 
     def get_error(self):


### PR DESCRIPTION
#1811 failed "Generate SQL content" in CircleCI because of the below error:

![CleanShot 2021-02-16 at 14 07 04@2x](https://user-images.githubusercontent.com/28797553/108127621-5e86dc80-7060-11eb-90ba-1304b9502226.png)

I believe this is due to `errors()` returning None when there's no result, which can't be iterated over when used here:
https://github.com/mozilla/bigquery-etl/blob/28f15e16e5168aa26540448e621265af04136644/bigquery_etl/view/generate_stable_views.py#L174

I changed the output to an empty list to fix this bug.