### PR TITLE
Add option to generate stable views without dry run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,9 +224,11 @@ jobs:
           command: |
             mkdir /tmp/generated-sql
             cp -r sql/ /tmp/generated-sql/sql
+            # Don't depend on dry run for PRs
             PATH="venv/bin:$PATH" ./script/generate_sql \
               --sql-dir /tmp/generated-sql/sql/ \
-              --target-project moz-fx-data-shared-prod
+              --target-project moz-fx-data-shared-prod \
+              $(test "${CIRCLE_BRANCH}" = master || echo --no-dry-run)
       - persist_to_workspace:
           root: /tmp/generated-sql
           paths:

--- a/script/generate_sql
+++ b/script/generate_sql
@@ -9,6 +9,7 @@ set -e
 
 : "${TARGET_PROJECT:=moz-fx-data-shar-nonprod-efed}"
 : "${SQL_DIR:=sql}"
+NO_DRY_RUN=( )
 
 while [[ $# -gt 0 ]]
 do
@@ -25,6 +26,10 @@ case $key in
     shift # past argument
     shift # past value
     ;;
+    --no-dry-run)
+    NO_DRY_RUN=( "$1" )
+    shift # past argument
+    ;;
     *)    # unknown option
     echo "ERROR: Unknown option: $1" >&2
     exit 1
@@ -32,8 +37,14 @@ case $key in
 esac
 done
 
-# Fill in any missing view definitions in the moz-fx-data-shared-prod/ folder
-python -m bigquery_etl.view.generate_stable_views --sql-dir "${SQL_DIR}" --parallelism=20
+set -x
+
+# Fill in any missing view definitions in the target project folder
+time python -m bigquery_etl.view.generate_stable_views \
+    --target-project "${TARGET_PROJECT}" \
+    --sql-dir "${SQL_DIR}" \
+    "${NO_DRY_RUN[@]}" \
+    --parallelism=20
 
 # Fill in definitions for generated Glean ETL
 PLACEHOLDER_DATE="2000-01-01"


### PR DESCRIPTION
generate-sql is currently the slowest CI job on this repo, usually taking 4-5min to run. This should speed that up by about 2-3 minutes.

~This is in draft because it needs data ops to set up permissions (or a cloud function) so that circleci can list stable tables in prod.~ edit: permissions no longer needed