### PR TITLE
Doc fixes for truncate_version

### DIFF
--- a/sql/mozfun/norm/truncate_version/metadata.yaml
+++ b/sql/mozfun/norm/truncate_version/metadata.yaml
@@ -1,16 +1,16 @@
 friendly_name: Truncate Version
 description: |
-  Truncates a version string like "<major>.<minor>.<patch>" to
-  either the major or minor version. The return value is NUMERIC,
+  Truncates a version string like `<major>.<minor>.<patch>` to
+  either the major or minor version. The return value is `NUMERIC`,
   which means that you can sort the results without fear (e.g. 100
   will be categorized as greater than 80, which isn't the case when
   sorting lexigraphically).
 
-  For example, "5.1.0" would be translated to 5.1 if the parameter is
-  "minor" or 5 if the parameter is major.
+  For example, "5.1.0" would be translated to `5.1` if the parameter is
+  "minor" or `5` if the parameter is major.
 
   If the version is only a major and/or minor version, then it will be left
-  unchanged (for example "10" would stay as 10 when run through this
+  unchanged (for example "10" would stay as `10` when run through this
   function, no matter what the arguments).
 
   This is useful for grouping Linux and Mac operating system versions inside


### PR DESCRIPTION
It looks like angle brackets get parsed as HTML tags and disappear in the rendered docs. Generally adding some backticks where it will help readability.