### PR TITLE
Move generated-sql into place as sql/ in docs deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,9 +219,9 @@ jobs:
       - run:
           name: Build and deploy docs
           command: |
+            rm -r sql/ && cp -r /tmp/generated-sql sql/
             PATH="venv/bin:$PATH" script/generate_docs \
-              --project_dirs /tmp/generated-sql/sql/moz-fx-data-shared-prod \
-              /tmp/generated-sql/sql/mozfun --output_dir=generated_docs/
+              --output_dir=generated_docs/
             cd generated_docs/
             mkdocs gh-deploy \
               -m "[ci skip] Deployed {sha} with MkDocs version: {version}"


### PR DESCRIPTION
This is a quick workaround for the underlying issue with hard-coded paths for dry run skips discussed in https://github.com/mozilla/bigquery-etl/pull/1819

This will get docs publishing working again in the short term while we think about updating the logic to tolerate other paths.