### PR TITLE
Move `generated-sql/sql` content to `sql/` for docs deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,9 +235,9 @@ jobs:
       - run:
           name: Build and deploy docs
           command: |
+            rm -r sql/ && cp -r /tmp/generated-sql/sql sql/
             PATH="venv/bin:$PATH" script/generate_docs \
-              --project_dirs /tmp/generated-sql/sql/moz-fx-data-shared-prod \
-              /tmp/generated-sql/sql/mozfun --output_dir=generated_docs/
+               --output_dir=generated_docs/
             cd generated_docs/
             mkdocs gh-deploy \
               -m "[ci skip] Deployed {sha} with MkDocs version: {version}"

--- a/bigquery_etl/docs/derived_datasets/generate_derived_dataset_docs.py
+++ b/bigquery_etl/docs/derived_datasets/generate_derived_dataset_docs.py
@@ -14,7 +14,7 @@ NON_USER_FACING_DATASET_SUFFIXES = (
     "_bi",
     "_restricted",
 )
-SOURCE_URL = "https://github.com/mozilla/bigquery-etl/blob/master"
+SOURCE_URL = "https://github.com/mozilla/bigquery-etl/blob/generated-sql"
 
 
 def generate_derived_dataset_docs(out_dir, project_dir):

--- a/bigquery_etl/docs/generate_docs.py
+++ b/bigquery_etl/docs/generate_docs.py
@@ -18,8 +18,8 @@ METADATA_FILE = "metadata.yaml"
 DOCS_DIR = "docs/"
 INDEX_MD = "index.md"
 SQL_REF_RE = r"@sql\((.+)\)"
-SOURCE_URL = "https://github.com/mozilla/bigquery-etl/blob/master"
-EDIT_URL = "https://github.com/mozilla/bigquery-etl/edit/master/"
+SOURCE_URL = "https://github.com/mozilla/bigquery-etl/blob/generated-sql"
+EDIT_URL = "https://github.com/mozilla/bigquery-etl/edit/generated-sql"
 
 parser = ArgumentParser(description=__doc__)
 parser.add_argument(
@@ -129,9 +129,7 @@ def main():
                         if UDF_FILE in files or PROCEDURE_FILE in files:
                             # UDF-level doc; append to dataset doc
                             dataset_name = os.path.basename(path)
-                            dataset_doc = (
-                                Path(out_dir) / "mozfun" / f"{dataset_name}.md"
-                            )
+                            dataset_doc = out_dir / path.parent / f"{dataset_name}.md"
                             docfile_content = load_with_examples(src)
                             with open(dataset_doc, "a") as dataset_doc_file:
                                 dataset_doc_file.write("\n\n")
@@ -152,7 +150,7 @@ def main():
                                 dataset_doc_file.write(f"{sourced}\n\n")
                         else:
                             # dataset-level doc; create a new doc file
-                            dest = Path(out_dir) / "mozfun" / f"{name}.md"
+                            dest = out_dir / path / f"{name}.md"
                             dest.write_text(load_with_examples(src))
                 else:
                     generate_derived_dataset_docs.generate_derived_dataset_docs(

--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -240,14 +240,10 @@ class DryRun:
 
     def get_referenced_tables(self):
         """Return referenced tables by dry running the SQL file."""
-        # strip file path to 'sql/project/dataset/table/*.sql' format
-        # to be checked against the SKIP list
-        filepath = self.sqlfile[self.sqlfile.find("/sql/") + 1 :]
-
-        if filepath not in SKIP and not self.is_valid():
+        if self.sqlfile not in SKIP and not self.is_valid():
             raise Exception(f"Error when dry running SQL file {self.sqlfile}")
 
-        if filepath in SKIP:
+        if self.sqlfile in SKIP:
             print(f"\t...Ignoring dryrun results for {self.sqlfile}")
 
         if (

--- a/docs/mozfun/.pages
+++ b/docs/mozfun/.pages
@@ -1,3 +1,0 @@
-nav:
-- mozfun.md
-- ...


### PR DESCRIPTION
Resolves #1833 

This is a continuation of the work that was started in #1830: we now move the source content for docs from `tmp/generated-sql/sql/` to `sql/`. I also updated the source URL to point at the `generated-sql` branch.