### PR TITLE
Update pytest-pydocstyle requirement to point to actively developed p…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "google-cloud-storage",
         "Jinja2",
         "pytest-black",
-        "pytest-docstyle",
+        "pytest-pydocstyle",
         "pytest-flake8",
         "pytest-mypy",
         "pytest",


### PR DESCRIPTION
…ackage

Per my Slack thread journey, `pytest-docstyle` was renamed to `pytest-pydocstyle` a while back and our requirements files refer to the new package (while the old package is frozen at a version that does not work with our repo)