### PR TITLE
Fix default dataset not found in dry runs

### DIFF
--- a/bigquery_etl/docs/validate_docs.py
+++ b/bigquery_etl/docs/validate_docs.py
@@ -72,7 +72,14 @@ def validate(project_dirs):
                         )
 
                         # store sql in temporary file for dry_run
-                        tmp_dir = Path(tempfile.mkdtemp()) / Path(root)
+                        # DryRun will use tmp_example_file.parent.parent.name as the
+                        # default dataset, which must exist in moz-fx-data-shared-prod
+                        tmp_dir = (
+                            Path(tempfile.mkdtemp())
+                            / "moz-fx-data-shared-prod"
+                            / "tmp"
+                            / "test"
+                        )
                         tmp_dir.mkdir(parents=True, exist_ok=True)
                         tmp_example_file = tmp_dir / file
                         tmp_example_file.write_text(dry_run_sql)

--- a/tests/test_dryrun.py
+++ b/tests/test_dryrun.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from bigquery_etl.dryrun import DryRun, Errors
@@ -7,7 +5,8 @@ from bigquery_etl.dryrun import DryRun, Errors
 
 class TestDryRun:
     def test_dry_run_sql_file(self, tmp_path):
-        query_file = tmp_path / "query.sql"
+        query_file = tmp_path / "tmp" / "test" / "query.sql"
+        query_file.parent.mkdir(parents=True, exist_ok=True)
         query_file.write_text("SELECT 123")
 
         dryrun = DryRun(str(query_file))
@@ -15,7 +14,8 @@ class TestDryRun:
         assert response["valid"]
 
     def test_dry_run_invalid_sql_file(self, tmp_path):
-        query_file = tmp_path / "query.sql"
+        query_file = tmp_path / "tmp" / "test" / "query.sql"
+        query_file.parent.mkdir(parents=True, exist_ok=True)
         query_file.write_text("SELECT INVALID 123")
 
         dryrun = DryRun(str(query_file))
@@ -23,14 +23,16 @@ class TestDryRun:
         assert response["valid"] is False
 
     def test_sql_file_valid(self, tmp_path):
-        query_file = tmp_path / "query.sql"
+        query_file = tmp_path / "tmp" / "test" / "query.sql"
+        query_file.parent.mkdir(parents=True, exist_ok=True)
         query_file.write_text("SELECT 123")
 
         dryrun = DryRun(str(query_file))
         assert dryrun.is_valid()
 
     def test_view_file_valid(self, tmp_path):
-        view_file = tmp_path / "view.sql"
+        view_file = tmp_path / "tmp" / "test" / "view.sql"
+        view_file.parent.mkdir(parents=True, exist_ok=True)
         view_file.write_text(
             """
             SELECT
@@ -46,22 +48,24 @@ class TestDryRun:
         assert dryrun.is_valid()
 
     def test_sql_file_invalid(self, tmp_path):
-        query_file = tmp_path / "query.sql"
+        query_file = tmp_path / "tmp" / "test" / "query.sql"
+        query_file.parent.mkdir(parents=True, exist_ok=True)
         query_file.write_text("SELECT INVALID 123")
 
         dryrun = DryRun(str(query_file))
         assert dryrun.is_valid() is False
 
     def test_get_referenced_tables_empty(self, tmp_path):
-        query_file = tmp_path / "query.sql"
+        query_file = tmp_path / "tmp" / "test" / "query.sql"
+        query_file.parent.mkdir(parents=True, exist_ok=True)
         query_file.write_text("SELECT 123")
 
         dryrun = DryRun(str(query_file))
         assert dryrun.get_referenced_tables() == []
 
     def test_get_sql(self, tmp_path):
-        os.makedirs(tmp_path / "telmetry_derived")
-        query_file = tmp_path / "telmetry_derived" / "query.sql"
+        query_file = tmp_path / "telmetry_derived" / "test" / "query.sql"
+        query_file.parent.mkdir(parents=True, exist_ok=True)
 
         sql_content = "SELECT 123 "
         query_file.write_text(sql_content)
@@ -71,8 +75,8 @@ class TestDryRun:
             DryRun(sqlfile="invalid path").get_sql()
 
     def test_get_referenced_tables(self, tmp_path):
-        os.makedirs(tmp_path / "telmetry_derived")
-        query_file = tmp_path / "telmetry_derived" / "query.sql"
+        query_file = tmp_path / "telmetry_derived" / "test" / "query.sql"
+        query_file.parent.mkdir(parents=True, exist_ok=True)
         query_file.write_text(
             "SELECT * FROM telemetry_derived.clients_daily_v6 "
             "WHERE submission_date = '2020-01-01'"
@@ -83,7 +87,8 @@ class TestDryRun:
         assert query_dryrun[0]["datasetId"] == "telemetry_derived"
         assert query_dryrun[0]["tableId"] == "clients_daily_v6"
 
-        view_file = tmp_path / "telmetry_derived" / "view.sql"
+        view_file = tmp_path / "telmetry_derived" / "clients_daily" / "view.sql"
+        view_file.parent.mkdir(parents=True, exist_ok=True)
         view_file.write_text(
             """
             CREATE OR REPLACE VIEW
@@ -122,8 +127,8 @@ class TestDryRun:
         assert multiple_tables[1]["tableId"] == "baseline_v1"
 
     def test_get_error(self, tmp_path):
-        os.makedirs(tmp_path / "telemetry")
-        view_file = tmp_path / "telemetry" / "view.sql"
+        view_file = tmp_path / "telemetry" / "clients_daily" / "view.sql"
+        view_file.parent.mkdir(parents=True, exist_ok=True)
 
         view_file.write_text(
             """


### PR DESCRIPTION
Over the weekend bigquery started returning errors if the default dataset does not exist for a dry run.