### PR TITLE
Remove submission_date field from experiment_search_aggregates_v1

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -162,8 +162,6 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/query.sql",
     "sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/telemetry_derived/asn_aggregates_v1/query.sql",
-    "sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_hourly_v1/query.sql",  # noqa E501
-    "sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_recents_v1/query.sql",  # noqa E501
     # Dataset sql/glam-fenix-dev:glam_etl was not found
     *glob.glob("sql/glam-fenix-dev/glam_etl/**/*.sql", recursive=True),
     # Query templates

--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -49,7 +49,7 @@ class Schema:
         query = f"SELECT * FROM {project}.{dataset}.{table}"
 
         if partitioned_by:
-            query += f" WHERE {partitioned_by} = DATE('2020-01-01')"
+            query += f" WHERE DATE({partitioned_by}) = DATE('2020-01-01')"
 
         # write query to temporary file so it can get dry run
         tmp = NamedTemporaryFile()

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/metadata.yaml
@@ -1,12 +1,20 @@
----
 friendly_name: Experiment Search Aggregates
 description: |-
   Aggregates search metrics for experiments. Used in the
   Grafana Live Monitoring Dashboard.
 owners:
-  - ascholtz@mozilla.com
+- ascholtz@mozilla.com
 labels:
   application: experiments
   schedule: daily
 scheduling:
   dag_name: bqetl_experiments_daily
+bigquery:
+  time_partitioning:
+    field: window_start
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+    - experiment
+    - branch

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql
@@ -105,7 +105,6 @@ all_events AS (
     fenix
 )
 SELECT
-  date(submission_timestamp) AS submission_date,
   experiment,
   branch,
   TIMESTAMP_ADD(
@@ -125,7 +124,6 @@ FROM
 WHERE
   date(submission_timestamp) = @submission_date
 GROUP BY
-  submission_date,
   experiment,
   branch,
   window_start,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/schema.yaml
@@ -1,0 +1,25 @@
+fields:
+- mode: NULLABLE
+  name: experiment
+  type: STRING
+- mode: NULLABLE
+  name: branch
+  type: STRING
+- mode: NULLABLE
+  name: window_start
+  type: TIMESTAMP
+- mode: NULLABLE
+  name: window_end
+  type: TIMESTAMP
+- mode: NULLABLE
+  name: ad_clicks_count
+  type: INTEGER
+- mode: NULLABLE
+  name: search_with_ads_count
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count
+  type: INTEGER
+- mode: NULLABLE
+  name: dataset_id
+  type: STRING


### PR DESCRIPTION
Removes `submission_date` field that was accidentally introduced in https://github.com/mozilla/bigquery-etl/pull/1879 causing the daily runs to fail.