### PR TITLE
Remove old experiment search aggregates views

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_search_aggregates_hourly/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_search_aggregates_hourly/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.telemetry.experiment_search_aggregates_hourly`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.telemetry_derived.experiment_search_aggregates_hourly_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_search_aggregates_recents/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_search_aggregates_recents/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.telemetry.experiment_search_aggregates_recents`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.telemetry_derived.experiment_search_aggregates_recents_v1`


### PR DESCRIPTION
I removed the tables these views reference earlier today since we now use materialized views. 

Dry run is failing due to https://github.com/mozilla/bigquery-etl/issues/1874