### PR TITLE
Add option to limit max rows during backfill

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -425,6 +425,13 @@ def info(name, sql_dir, project_id, cost, last_updated):
     "--allow-field-addition/--no-allow-field-addition",
     help="Allow schema additions during query time",
 )
+@click.option(
+    "--max_rows",
+    "-n",
+    type=int,
+    default=100,
+    help="How many rows to return in the result",
+)
 @click.pass_context
 def backfill(
     ctx,
@@ -436,6 +443,7 @@ def backfill(
     exclude,
     dry_run,
     allow_field_addition,
+    max_rows,
 ):
     """Run a backfill."""
     if not is_authenticated():
@@ -470,6 +478,7 @@ def backfill(
                         f"--parameter=submission_date:DATE:{backfill_date}",
                         "--use_legacy_sql=false",
                         "--replace",
+                        f"--max_rows={max_rows}"
                     ]
                     + (
                         ["--schema_update_option=ALLOW_FIELD_ADDITION"]

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -478,7 +478,7 @@ def backfill(
                         f"--parameter=submission_date:DATE:{backfill_date}",
                         "--use_legacy_sql=false",
                         "--replace",
-                        f"--max_rows={max_rows}"
+                        f"--max_rows={max_rows}",
                     ]
                     + (
                         ["--schema_update_option=ALLOW_FIELD_ADDITION"]


### PR DESCRIPTION
I've been backfilling a table manually from my desktop and am passing through the `-n` option to the backfill command so its not as noisy. The results look something like this using `-n 0`:

```bash
Waiting on bqjob_r5cb295690726aab3_0000017842a32d80_1 ... (34s) Current status: DONE   
Run backfill for moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.legacy_mobile_core_v2$20201017 with @submission_date=2020-10-17
Waiting on bqjob_r17681e93c9b58343_0000017842a3bf38_1 ... (34s) Current status: DONE   
Run backfill for moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.legacy_mobile_core_v2$20201018 with @submission_date=2020-10-18
Waiting on bqjob_r62e1b06a2e57e4cf_0000017842a450bb_1 ... (23s) Current status: DONE   
Run backfill for moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.legacy_mobile_core_v2$20201019 with @submission_date=2020-10-19
Waiting on bqjob_r77cb4aa027fe7b6_0000017842a4b73c_1 ... (21s) Current status: RUNNING
```