### PR TITLE
Airflow DAGs: Don't send alert email on rescheduled sensor retry

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -103,6 +103,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         check_existence=True,
         mode='reschedule',
         pool='DATA_ENG_EXTERNALTASKSENSOR',
+        email_on_retry=False,
     )
     {{ wait_for_seen.append((dependency.dag_name, dependency.task_id)) or "" }}
     {% endif -%}
@@ -124,6 +125,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         check_existence=True,
         mode='reschedule',
         pool='DATA_ENG_EXTERNALTASKSENSOR',
+        email_on_retry=False,
         dag=dag,
     )
     {{ wait_for_seen.append((task_ref.dag_name, task_ref.task_id)) or "" }}

--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -23,11 +23,11 @@ Built from bigquery-etl repo, [`dags/{{ name }}.py`](https://github.com/mozilla/
 """
 
 
-default_args = {{ 
-    default_args.to_dict() | 
+default_args = {{
+    default_args.to_dict() |
     format_attr("start_date", "format_date") |
     format_attr("end_date", "format_date") |
-    format_attr("retry_delay", "format_timedelta") 
+    format_attr("retry_delay", "format_timedelta")
 }}
 
 with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None -%}, schedule_interval={{ schedule_interval | format_timedelta | format_schedule_interval }}{%+ endif -%}, doc_md = docs) as dag:
@@ -64,8 +64,9 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         check_existence=True,
         mode='reschedule',
         pool='DATA_ENG_EXTERNALTASKSENSOR',
+        email_on_retry=False,
     )
-        
+
     {{ task.task_name }}.set_upstream(wait_for_{{ dependency.task_id }})
     {% endif -%}
     {% endfor -%}

--- a/dags/bqetl_activity_stream.py
+++ b/dags/bqetl_activity_stream.py
@@ -74,6 +74,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     activity_stream_bi__impression_stats_flat__v1.set_upstream(

--- a/dags/bqetl_addons.py
+++ b/dags/bqetl_addons.py
@@ -92,6 +92,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__addon_aggregates__v2.set_upstream(
@@ -109,6 +110,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__addons_daily__v1.set_upstream(
@@ -122,6 +124,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__addons_daily__v1.set_upstream(

--- a/dags/bqetl_adm_engagements_daily.py
+++ b/dags/bqetl_adm_engagements_daily.py
@@ -58,6 +58,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__adm_engagements_daily__v1.set_upstream(wait_for_bq_main_events)
@@ -69,6 +70,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__adm_engagements_daily__v1.set_upstream(wait_for_event_events)
@@ -80,6 +82,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__adm_engagements_daily__v1.set_upstream(

--- a/dags/bqetl_amo_stats.py
+++ b/dags/bqetl_amo_stats.py
@@ -129,6 +129,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     amo_prod__amo_stats_installs__v3.set_upstream(wait_for_bq_main_events)
@@ -140,6 +141,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     amo_prod__amo_stats_installs__v3.set_upstream(wait_for_event_events)
@@ -152,6 +154,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     amo_prod__desktop_addons_by_client__v1.set_upstream(
@@ -166,6 +169,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     amo_prod__fenix_addons_by_client__v1.set_upstream(wait_for_copy_deduplicate_all)

--- a/dags/bqetl_asn_aggregates.py
+++ b/dags/bqetl_asn_aggregates.py
@@ -59,6 +59,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__asn_aggregates__v1.set_upstream(wait_for_bq_main_events)

--- a/dags/bqetl_core.py
+++ b/dags/bqetl_core.py
@@ -69,6 +69,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__core_clients_daily__v1.set_upstream(

--- a/dags/bqetl_desktop_funnel.py
+++ b/dags/bqetl_desktop_funnel.py
@@ -83,6 +83,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__desktop_funnel_activation_day_6__v1.set_upstream(
@@ -96,6 +97,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__desktop_funnel_activation_day_6__v1.set_upstream(

--- a/dags/bqetl_desktop_platform.py
+++ b/dags/bqetl_desktop_platform.py
@@ -64,6 +64,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__accessibility_clients__v1.set_upstream(

--- a/dags/bqetl_devtools.py
+++ b/dags/bqetl_devtools.py
@@ -77,6 +77,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__devtools_accessiblility_panel_usage__v1.set_upstream(
@@ -91,6 +92,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__devtools_panel_usage__v1.set_upstream(

--- a/dags/bqetl_event_rollup.py
+++ b/dags/bqetl_event_rollup.py
@@ -121,6 +121,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     messaging_system_derived__event_types_history__v1.set_upstream(

--- a/dags/bqetl_experiments_daily.py
+++ b/dags/bqetl_experiments_daily.py
@@ -115,6 +115,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__experiment_enrollment_aggregates__v1.set_upstream(
@@ -128,6 +129,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__experiment_enrollment_aggregates__v1.set_upstream(
@@ -141,6 +143,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__experiment_enrollment_aggregates__v1.set_upstream(
@@ -158,6 +161,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__experiment_search_aggregates__v1.set_upstream(
@@ -175,6 +179,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__experiments_daily_active_clients__v1.set_upstream(

--- a/dags/bqetl_fenix_event_rollup.py
+++ b/dags/bqetl_fenix_event_rollup.py
@@ -84,6 +84,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     org_mozilla_firefox_derived__event_types_history__v1.set_upstream(

--- a/dags/bqetl_gud.py
+++ b/dags/bqetl_gud.py
@@ -139,6 +139,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__smoot_usage_desktop__v2.set_upstream(
@@ -157,6 +158,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__smoot_usage_fxa__v2.set_upstream(
@@ -191,6 +193,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__smoot_usage_nondesktop__v2.set_upstream(
@@ -204,6 +207,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__smoot_usage_nondesktop__v2.set_upstream(

--- a/dags/bqetl_internal_tooling.py
+++ b/dags/bqetl_internal_tooling.py
@@ -59,6 +59,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     mozregression_aggregates__v1.set_upstream(wait_for_copy_deduplicate_all)

--- a/dags/bqetl_internet_outages.py
+++ b/dags/bqetl_internet_outages.py
@@ -59,6 +59,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     internet_outages__global_outages__v1.set_upstream(wait_for_copy_deduplicate_all)
@@ -70,6 +71,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     internet_outages__global_outages__v1.set_upstream(
@@ -83,6 +85,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     internet_outages__global_outages__v1.set_upstream(

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -322,6 +322,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__clients_daily__v6.set_upstream(
@@ -336,6 +337,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__clients_daily_event__v1.set_upstream(wait_for_bq_main_events)
@@ -347,6 +349,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__clients_daily_event__v1.set_upstream(wait_for_event_events)

--- a/dags/bqetl_messaging_system.py
+++ b/dags/bqetl_messaging_system.py
@@ -158,6 +158,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     messaging_system_derived__cfr_users_daily__v1.set_upstream(

--- a/dags/bqetl_mobile_search.py
+++ b/dags/bqetl_mobile_search.py
@@ -84,6 +84,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     search_derived__mobile_search_clients_daily__v1.set_upstream(

--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -167,6 +167,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     monitoring_derived__average_ping_sizes__v1.set_upstream(
@@ -185,6 +186,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     monitoring_derived__column_size__v1.set_upstream(

--- a/dags/bqetl_mozilla_vpn.py
+++ b/dags/bqetl_mozilla_vpn.py
@@ -326,6 +326,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     mozilla_vpn_derived__login_flows__v1.set_upstream(
@@ -339,6 +340,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     mozilla_vpn_derived__login_flows__v1.set_upstream(

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -91,6 +91,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     firefox_nondesktop_exact_mau28_by_client_count_dimensions.set_upstream(
@@ -105,6 +106,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__firefox_nondesktop_day_2_7_activation__v1.set_upstream(

--- a/dags/bqetl_org_mozilla_fenix_derived.py
+++ b/dags/bqetl_org_mozilla_fenix_derived.py
@@ -55,6 +55,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     org_mozilla_fenix_derived__geckoview_version__v1.set_upstream(

--- a/dags/bqetl_public_data_json.py
+++ b/dags/bqetl_public_data_json.py
@@ -77,6 +77,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     export_public_data_json_mozregression_aggregates__v1.set_upstream(
@@ -91,6 +92,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     export_public_data_json_telemetry_derived__ssl_ratios__v1.set_upstream(

--- a/dags/bqetl_search.py
+++ b/dags/bqetl_search.py
@@ -102,6 +102,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     search_derived__search_clients_daily__v8.set_upstream(

--- a/dags/bqetl_search_dashboard.py
+++ b/dags/bqetl_search_dashboard.py
@@ -84,6 +84,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     search_derived__desktop_search_aggregates_by_userstate__v1.set_upstream(
@@ -98,6 +99,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     search_derived__desktop_search_aggregates_for_searchreport__v1.set_upstream(
@@ -112,6 +114,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     search_derived__mobile_search_aggregates_for_searchreport__v1.set_upstream(

--- a/dags/bqetl_ssl_ratios.py
+++ b/dags/bqetl_ssl_ratios.py
@@ -58,6 +58,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     telemetry_derived__ssl_ratios__v1.set_upstream(wait_for_copy_deduplicate_main_ping)

--- a/dags/bqetl_stripe.py
+++ b/dags/bqetl_stripe.py
@@ -251,6 +251,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 

--- a/dags/bqetl_vrbrowser.py
+++ b/dags/bqetl_vrbrowser.py
@@ -114,6 +114,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     org_mozilla_vrbrowser_derived__baseline_daily__v1.set_upstream(

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -63,6 +63,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -75,6 +75,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     test__query__v1.set_upstream(wait_for_test__external_table__v1)

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -59,6 +59,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     export_public_data_json_test__non_incremental_query__v1.set_upstream(


### PR DESCRIPTION
This updates Airflow DAG template and disables retry emails for rescheduled sensors.

Similar change was pushed to https://github.com/mozilla/telemetry-airflow/pull/1253 last month in order to limit the number of alerting emails a bit.