### PR TITLE
Handle job.num_dml_affected_rows is None in shredder delete summary

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -545,7 +545,7 @@ def main():
         if args.dry_run:
             logging.info(f"Would scan {table_bytes_processed} bytes from {table_id}")
         else:
-            table_rows_deleted = sum(job.num_dml_affected_rows for job in jobs)
+            table_rows_deleted = sum(job.num_dml_affected_rows or 0 for job in jobs)
             rows_deleted += table_rows_deleted
             logging.info(
                 f"Scanned {table_bytes_processed} bytes and "


### PR DESCRIPTION
this is currently blocking shredder deletes from completing successfully in airflow

see also: #1908 which is the same thing for a different field