### PR TITLE
DAG scheduling and docs cleanup

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -27,7 +27,7 @@ bqetl_ssl_ratios:
 bqetl_amo_stats:
   schedule_interval: 0 3 * * *
   # yamllint disable rule:line-length
-  description: >-
+  description: |
     Add-on download and install statistics to power the
     [addons.mozilla.org](https://addons.mozilla.org) (AMO) stats pages.
 
@@ -42,7 +42,7 @@ bqetl_amo_stats:
 
 bqetl_vrbrowser:
   schedule_interval: 0 2 * * *
-  description: >-
+  description: |
     Custom ETL based on Glean pings from Mozilla VR Browser.
   default_args:
     owner: jklukas@mozilla.com
@@ -88,7 +88,7 @@ bqetl_mobile_search:
 
 bqetl_fxa_events:
   schedule_interval: 30 1 * * *
-  description: >-
+  description: |
     Copies data from a Firefox Accounts (FxA) project. Those source tables
     are populated via Cloud Logging (Stackdriver). We hash various fields
     as part of the import.
@@ -103,8 +103,13 @@ bqetl_fxa_events:
     retry_delay: 10m
 
 bqetl_mozilla_vpn:
-  # Depends on bqetl_fxa_events, so run a bit after that one.
   schedule_interval: 45 1 * * *
+  description: |
+    Daily extracts from the Mozilla VPN operational DB to BigQuery
+    as well as derived tables based on that data.
+
+    Depends on `bqetl_fxa_events`, so is scheduled to run a bit
+    after that one.
   default_args:
     owner: dthorn@mozilla.com
     start_date: "2020-10-08"
@@ -126,7 +131,7 @@ bqetl_gud:
 
 bqetl_messaging_system:
   schedule_interval: 0 2 * * *
-  description: >-
+  description: |
     Daily aggregations on top of pings sent for the `messaging_system`
     namespace by desktop Firefox.
   default_args:
@@ -138,7 +143,7 @@ bqetl_messaging_system:
 
 bqetl_activity_stream:
   schedule_interval: 0 2 * * *
-  description: >-
+  description: |
     Daily aggregations on top of pings sent for the `activity_stream`
     namespace by desktop Firefox. These are largely related to activity
     on the newtab page and engagement with Pocket content.
@@ -160,7 +165,11 @@ bqetl_search:
     retry_delay: 30m
 
 bqetl_addons:
-  schedule_interval: 0 3 * * *
+  schedule_interval: 0 4 * * *
+  description: |
+    Daily rollups of addon data from `main` pings.
+
+    Depends on `bqetl_search`, so is scheduled after that DAG.
   default_args:
     owner: bmiroglio@mozilla.com
     start_date: "2018-11-27"
@@ -170,7 +179,7 @@ bqetl_addons:
 
 bqetl_devtools:
   schedule_interval: 0 3 * * *
-  description: >-
+  description: |
     Summarizes usage of the Dev Tools component of desktop Firefox.
   default_args:
     owner: jklukas@mozilla.com
@@ -181,7 +190,7 @@ bqetl_devtools:
 
 bqetl_main_summary:
   schedule_interval: 0 2 * * *
-  description: >-
+  description: |
     General-purpose derived tables for analyzing usage of desktop Firefox.
     This is one of our highest-impact DAGs and should be handled carefully.
   default_args:
@@ -199,7 +208,7 @@ bqetl_main_summary:
 
 bqetl_experiments_daily:
   schedule_interval: 0 3 * * *
-  description: >
+  description: |
     The DAG schedules queries that query experimentation related
     metrics (enrollments, search, ...) from stable tables to finalize
     numbers of experiment monitoring datasets for a specific date.
@@ -232,8 +241,12 @@ bqetl_asn_aggregates:
 # DAG for exporting query data marked as public to GCS
 # queries should not be explicitly assigned to this DAG (done automatically)
 bqetl_public_data_json:
-  schedule_interval: 0 4 * * *
-  description: The DAG exports query data marked as public to GCS
+  schedule_interval: 0 5 * * *
+  description: |
+    Daily exports of query data marked as public to GCS.
+
+    Depends on the results of several upstream DAGs, the latest of which
+    runs at 04:00 UTC.
   default_args:
     owner: ascholtz@mozilla.com
     start_date: "2020-04-14"
@@ -243,7 +256,7 @@ bqetl_public_data_json:
 
 bqetl_internet_outages:
   schedule_interval: 0 3 * * *
-  description: >
+  description: |
     DAG for building the internet outages datasets.
     See [bug 1640204](https://bugzilla.mozilla.org/show_bug.cgi?id=1640204).
   default_args:
@@ -272,7 +285,13 @@ bqetl_fenix_event_rollup:
     retry_delay: 30m
 
 bqetl_stripe:
-  schedule_interval: daily
+  schedule_interval: 30 0 * * *
+  description: |
+    Daily derived tables on top of data imported from Stripe.
+
+    Depends on the `stripe` DAG which starts at midnight UTC;
+    we allow 30 minutes for that DAG to complete before this one
+    is scheduled to start.
   default_args:
     owner: dthorn@mozilla.com
     start_date: "2020-10-05"
@@ -281,6 +300,7 @@ bqetl_stripe:
     retry_delay: 5m
 
 bqetl_org_mozilla_fenix_derived:
+  schedule_interval: 0 2 * * *
   default_args:
     depends_on_past: false
     email:
@@ -292,11 +312,14 @@ bqetl_org_mozilla_fenix_derived:
     retries: 2
     retry_delay: 30m
     start_date: "2020-10-18"
-  schedule_interval: daily
 
 bqetl_google_analytics_derived:
-  # GA export runs at 15:00 UTC so there's an effectively 2-day delay on ETL
   schedule_interval: 0 23 * * *
+  description: |
+    Daily aggregations of data exported from Google Analytics.
+
+    The GA export runs at 15:00 UTC, so there's an effective 2-day delay
+    for user activity to appear in these tables.
   default_args:
     owner: bewu@mozilla.com
     email: ['bewu@mozilla.com']
@@ -306,7 +329,7 @@ bqetl_google_analytics_derived:
 
 bqetl_monitoring:
   schedule_interval: 0 2 * * *
-  description: >
+  description: |
     This DAG schedules queries and scripts for populating datasets
     used for monitoring of the data platform.
   default_args:
@@ -363,7 +386,7 @@ bqetl_desktop_platform:
     retry_delay: 30m
 
 bqetl_internal_tooling:
-  description: >
+  description: |
     This DAG schedules queries for populating queries related to Mozilla's
     internal developer tooling (e.g. mozregression).
   default_args:
@@ -421,7 +444,7 @@ bqetl_adm_engagements_daily:
     retry_delay: 30m
 
 bqetl_desktop_funnel:
-  description: >
+  description: |
     This DAG schedules desktop funnel queries used to power the
     [Numbers that Matter dashboard](https://protosaur.dev/numbers-that-matter/)
   schedule_interval: 0 4 * * *

--- a/dags/bqetl_activity_stream.py
+++ b/dags/bqetl_activity_stream.py
@@ -12,7 +12,10 @@ Built from bigquery-etl repo, [`dags/bqetl_activity_stream.py`](https://github.c
 
 #### Description
 
-Daily aggregations on top of pings sent for the `activity_stream` namespace by desktop Firefox. These are largely related to activity on the newtab page and engagement with Pocket content.
+Daily aggregations on top of pings sent for the `activity_stream`
+namespace by desktop Firefox. These are largely related to activity
+on the newtab page and engagement with Pocket content.
+
 #### Owner
 
 jklukas@mozilla.com

--- a/dags/bqetl_addons.py
+++ b/dags/bqetl_addons.py
@@ -10,6 +10,12 @@ docs = """
 
 Built from bigquery-etl repo, [`dags/bqetl_addons.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_addons.py)
 
+#### Description
+
+Daily rollups of addon data from `main` pings.
+
+Depends on `bqetl_search`, so is scheduled after that DAG.
+
 #### Owner
 
 bmiroglio@mozilla.com
@@ -31,7 +37,7 @@ default_args = {
 with DAG(
     "bqetl_addons",
     default_args=default_args,
-    schedule_interval="0 3 * * *",
+    schedule_interval="0 4 * * *",
     doc_md=docs,
 ) as dag:
 
@@ -88,7 +94,7 @@ with DAG(
         task_id="wait_for_copy_deduplicate_main_ping",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_main_ping",
-        execution_delta=datetime.timedelta(seconds=7200),
+        execution_delta=datetime.timedelta(seconds=10800),
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
@@ -106,6 +112,7 @@ with DAG(
         task_id="wait_for_search_derived__search_clients_daily__v8",
         external_dag_id="bqetl_search",
         external_task_id="search_derived__search_clients_daily__v8",
+        execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
@@ -118,7 +125,7 @@ with DAG(
         task_id="wait_for_telemetry_derived__clients_last_seen__v1",
         external_dag_id="bqetl_main_summary",
         external_task_id="telemetry_derived__clients_last_seen__v1",
-        execution_delta=datetime.timedelta(seconds=3600),
+        execution_delta=datetime.timedelta(seconds=7200),
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",

--- a/dags/bqetl_amo_stats.py
+++ b/dags/bqetl_amo_stats.py
@@ -12,8 +12,11 @@ Built from bigquery-etl repo, [`dags/bqetl_amo_stats.py`](https://github.com/moz
 
 #### Description
 
-Add-on download and install statistics to power the [addons.mozilla.org](https://addons.mozilla.org) (AMO) stats pages.
+Add-on download and install statistics to power the
+[addons.mozilla.org](https://addons.mozilla.org) (AMO) stats pages.
+
 See the [post on the Add-Ons Blog](https://blog.mozilla.org/addons/2020/06/10/improvements-to-statistics-processing-on-amo/).
+
 #### Owner
 
 jklukas@mozilla.com

--- a/dags/bqetl_desktop_funnel.py
+++ b/dags/bqetl_desktop_funnel.py
@@ -12,7 +12,8 @@ Built from bigquery-etl repo, [`dags/bqetl_desktop_funnel.py`](https://github.co
 
 #### Description
 
-This DAG schedules desktop funnel queries used to power the [Numbers that Matter dashboard](https://protosaur.dev/numbers-that-matter/)
+This DAG schedules desktop funnel queries used to power the
+[Numbers that Matter dashboard](https://protosaur.dev/numbers-that-matter/)
 
 #### Owner
 

--- a/dags/bqetl_devtools.py
+++ b/dags/bqetl_devtools.py
@@ -13,6 +13,7 @@ Built from bigquery-etl repo, [`dags/bqetl_devtools.py`](https://github.com/mozi
 #### Description
 
 Summarizes usage of the Dev Tools component of desktop Firefox.
+
 #### Owner
 
 jklukas@mozilla.com

--- a/dags/bqetl_experiments_daily.py
+++ b/dags/bqetl_experiments_daily.py
@@ -12,7 +12,9 @@ Built from bigquery-etl repo, [`dags/bqetl_experiments_daily.py`](https://github
 
 #### Description
 
-The DAG schedules queries that query experimentation related metrics (enrollments, search, ...) from stable tables to finalize numbers of experiment monitoring datasets for a specific date.
+The DAG schedules queries that query experimentation related
+metrics (enrollments, search, ...) from stable tables to finalize
+numbers of experiment monitoring datasets for a specific date.
 
 #### Owner
 

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -12,8 +12,13 @@ Built from bigquery-etl repo, [`dags/bqetl_fxa_events.py`](https://github.com/mo
 
 #### Description
 
-Copies data from a Firefox Accounts (FxA) project. Those source tables are populated via Cloud Logging (Stackdriver). We hash various fields as part of the import.
-The DAG also provides daily aggregations on top of the raw log data, which eventually power high-level reporting about FxA usage.
+Copies data from a Firefox Accounts (FxA) project. Those source tables
+are populated via Cloud Logging (Stackdriver). We hash various fields
+as part of the import.
+
+The DAG also provides daily aggregations on top of the raw log data,
+which eventually power high-level reporting about FxA usage.
+
 #### Owner
 
 jklukas@mozilla.com

--- a/dags/bqetl_google_analytics_derived.py
+++ b/dags/bqetl_google_analytics_derived.py
@@ -10,6 +10,13 @@ docs = """
 
 Built from bigquery-etl repo, [`dags/bqetl_google_analytics_derived.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_google_analytics_derived.py)
 
+#### Description
+
+Daily aggregations of data exported from Google Analytics.
+
+The GA export runs at 15:00 UTC, so there's an effective 2-day delay
+for user activity to appear in these tables.
+
 #### Owner
 
 bewu@mozilla.com

--- a/dags/bqetl_internal_tooling.py
+++ b/dags/bqetl_internal_tooling.py
@@ -12,7 +12,8 @@ Built from bigquery-etl repo, [`dags/bqetl_internal_tooling.py`](https://github.
 
 #### Description
 
-This DAG schedules queries for populating queries related to Mozilla's internal developer tooling (e.g. mozregression).
+This DAG schedules queries for populating queries related to Mozilla's
+internal developer tooling (e.g. mozregression).
 
 #### Owner
 

--- a/dags/bqetl_internet_outages.py
+++ b/dags/bqetl_internet_outages.py
@@ -12,7 +12,8 @@ Built from bigquery-etl repo, [`dags/bqetl_internet_outages.py`](https://github.
 
 #### Description
 
-DAG for building the internet outages datasets. See [bug 1640204](https://bugzilla.mozilla.org/show_bug.cgi?id=1640204).
+DAG for building the internet outages datasets.
+See [bug 1640204](https://bugzilla.mozilla.org/show_bug.cgi?id=1640204).
 
 #### Owner
 

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -12,7 +12,9 @@ Built from bigquery-etl repo, [`dags/bqetl_main_summary.py`](https://github.com/
 
 #### Description
 
-General-purpose derived tables for analyzing usage of desktop Firefox. This is one of our highest-impact DAGs and should be handled carefully.
+General-purpose derived tables for analyzing usage of desktop Firefox.
+This is one of our highest-impact DAGs and should be handled carefully.
+
 #### Owner
 
 dthorn@mozilla.com

--- a/dags/bqetl_messaging_system.py
+++ b/dags/bqetl_messaging_system.py
@@ -12,7 +12,9 @@ Built from bigquery-etl repo, [`dags/bqetl_messaging_system.py`](https://github.
 
 #### Description
 
-Daily aggregations on top of pings sent for the `messaging_system` namespace by desktop Firefox.
+Daily aggregations on top of pings sent for the `messaging_system`
+namespace by desktop Firefox.
+
 #### Owner
 
 najiang@mozilla.com

--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -12,7 +12,8 @@ Built from bigquery-etl repo, [`dags/bqetl_monitoring.py`](https://github.com/mo
 
 #### Description
 
-This DAG schedules queries and scripts for populating datasets used for monitoring of the data platform.
+This DAG schedules queries and scripts for populating datasets
+used for monitoring of the data platform.
 
 #### Owner
 

--- a/dags/bqetl_mozilla_vpn.py
+++ b/dags/bqetl_mozilla_vpn.py
@@ -10,6 +10,14 @@ docs = """
 
 Built from bigquery-etl repo, [`dags/bqetl_mozilla_vpn.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_mozilla_vpn.py)
 
+#### Description
+
+Daily extracts from the Mozilla VPN operational DB to BigQuery
+as well as derived tables based on that data.
+
+Depends on `bqetl_fxa_events`, so is scheduled to run a bit
+after that one.
+
 #### Owner
 
 dthorn@mozilla.com

--- a/dags/bqetl_org_mozilla_fenix_derived.py
+++ b/dags/bqetl_org_mozilla_fenix_derived.py
@@ -31,7 +31,7 @@ default_args = {
 with DAG(
     "bqetl_org_mozilla_fenix_derived",
     default_args=default_args,
-    schedule_interval="@daily",
+    schedule_interval="0 2 * * *",
     doc_md=docs,
 ) as dag:
 
@@ -51,7 +51,7 @@ with DAG(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
-        execution_delta=datetime.timedelta(days=-1, seconds=82800),
+        execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",

--- a/dags/bqetl_public_data_json.py
+++ b/dags/bqetl_public_data_json.py
@@ -13,7 +13,11 @@ Built from bigquery-etl repo, [`dags/bqetl_public_data_json.py`](https://github.
 
 #### Description
 
-The DAG exports query data marked as public to GCS
+Daily exports of query data marked as public to GCS.
+
+Depends on the results of several upstream DAGs, the latest of which
+runs at 04:00 UTC.
+
 #### Owner
 
 ascholtz@mozilla.com
@@ -35,7 +39,7 @@ default_args = {
 with DAG(
     "bqetl_public_data_json",
     default_args=default_args,
-    schedule_interval="0 4 * * *",
+    schedule_interval="0 5 * * *",
     doc_md=docs,
 ) as dag:
     docker_image = "mozilla/bigquery-etl:latest"
@@ -74,6 +78,7 @@ with DAG(
         task_id="wait_for_mozregression_aggregates__v1",
         external_dag_id="bqetl_internal_tooling",
         external_task_id="mozregression_aggregates__v1",
+        execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
@@ -87,7 +92,7 @@ with DAG(
         task_id="wait_for_telemetry_derived__ssl_ratios__v1",
         external_dag_id="bqetl_ssl_ratios",
         external_task_id="telemetry_derived__ssl_ratios__v1",
-        execution_delta=datetime.timedelta(seconds=7200),
+        execution_delta=datetime.timedelta(seconds=10800),
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",

--- a/dags/bqetl_stripe.py
+++ b/dags/bqetl_stripe.py
@@ -10,6 +10,14 @@ docs = """
 
 Built from bigquery-etl repo, [`dags/bqetl_stripe.py`](https://github.com/mozilla/bigquery-etl/blob/master/dags/bqetl_stripe.py)
 
+#### Description
+
+Daily derived tables on top of data imported from Stripe.
+
+Depends on the `stripe` DAG which starts at midnight UTC;
+we allow 30 minutes for that DAG to complete before this one
+is scheduled to start.
+
 #### Owner
 
 dthorn@mozilla.com
@@ -29,7 +37,10 @@ default_args = {
 }
 
 with DAG(
-    "bqetl_stripe", default_args=default_args, schedule_interval="@daily", doc_md=docs
+    "bqetl_stripe",
+    default_args=default_args,
+    schedule_interval="30 0 * * *",
+    doc_md=docs,
 ) as dag:
 
     stripe_derived__customers__v1 = bigquery_etl_query(

--- a/dags/bqetl_stripe.py
+++ b/dags/bqetl_stripe.py
@@ -259,7 +259,7 @@ with DAG(
         task_id="wait_for_stripe_import_events",
         external_dag_id="stripe",
         external_task_id="stripe_import_events",
-        execution_delta=datetime.timedelta(0),
+        execution_delta=datetime.timedelta(seconds=1800),
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",

--- a/dags/bqetl_vrbrowser.py
+++ b/dags/bqetl_vrbrowser.py
@@ -13,6 +13,7 @@ Built from bigquery-etl repo, [`dags/bqetl_vrbrowser.py`](https://github.com/moz
 #### Description
 
 Custom ETL based on Glean pings from Mozilla VR Browser.
+
 #### Owner
 
 jklukas@mozilla.com


### PR DESCRIPTION
This adjusts some DAG schedules in an attempt to minimize the number of
BQSensor rescheduling emails we receive under normal circumstances.

Of note, the `copy_deduplicate` DAG is often taking a little longer than an
hour to complete, meaning that DAGs starting at 02:00 are likely to hit
reschedules. We do not address that problem here in hopes that performance
improvements to copy_deduplicate can bring performance back under 1 hour.

We also make some documentation fixups, including consistently using `|`
rather than `>` or `>-` as our multi-line string indicator. This preserves
whitespace that is relevant for markdown processing.

This should partially alleviate concerns from https://github.com/mozilla/bigquery-etl/pull/1907