### PR TITLE
Skip dry run for looker forecast cache

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -122,6 +122,7 @@ SKIP = {
     "sql/moz-fx-data-bq-performance/release_criteria/release_criteria_summary_v1/query.sql",
     "sql/moz-fx-data-bq-performance/release_criteria/stale_tests_v1/query.sql",
     "sql/moz-fx-data-bq-performance/release_criteria/release_criteria_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/looker_derived/desktop_forecasts_cache/view.sql",
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",  # noqa E501


### PR DESCRIPTION
We're getting Permission Denied, causing CI on the default branch to show failure.