### PR TITLE
Revert "Skip dry run for looker forecast cache (#1922)"

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -122,7 +122,6 @@ SKIP = {
     "sql/moz-fx-data-bq-performance/release_criteria/release_criteria_summary_v1/query.sql",
     "sql/moz-fx-data-bq-performance/release_criteria/stale_tests_v1/query.sql",
     "sql/moz-fx-data-bq-performance/release_criteria/release_criteria_v1/query.sql",
-    "sql/moz-fx-data-shared-prod/looker_derived/desktop_forecasts_cache/view.sql",
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",  # noqa E501


### PR DESCRIPTION
This reverts commit 9cbe5b90a9c20247ff9f2d5bd1f804b6d70f15ad.

https://github.com/mozilla-services/cloudops-infra/pull/2987