### PR TITLE
Add mvn setup for circleci doc generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,8 @@ jobs:
       - *skip_forked_pr
       - *restore_venv_cache
       - *build
+      - *restore_mvn_cache
+      - *java_deps
       - attach_workspace:
           at: /tmp/generated-sql
       - run:


### PR DESCRIPTION
The `docs` step is currently failing with: `subprocess.CalledProcessError: Command '['which', 'javac']' returned non-zero exit status 1.`