### PR TITLE
Fix clients first seen matching org_mozilla_firefoxreality

### DIFF
--- a/bigquery_etl/glean_usage/baseline_clients_first_seen.py
+++ b/bigquery_etl/glean_usage/baseline_clients_first_seen.py
@@ -35,8 +35,9 @@ def run_query(
     view_id = tables["first_seen_view"]
     render_kwargs = dict(
         header="-- Generated via bigquery_etl.glean_usage\n",
+        # do not match on org_mozilla_firefoxreality
         fennec_id=any(
-            (app_id in baseline_table)
+            (f"{app_id}_stable" in baseline_table)
             for app_id in [
                 "org_mozilla_firefox",
                 "org_mozilla_fenix_nightly",


### PR DESCRIPTION
Follow up for #1934. See https://workflow.telemetry.mozilla.org/log?task_id=baseline_clients_first_seen&dag_id=copy_deduplicate&execution_date=2021-04-05T01%3A00%3A00%2B00%3A00

<details>
<summary>click here for airflow error</summary>

```
[2021-04-06 02:06:35,615] {pod_launcher.py:156} INFO - b'INFO Table does not yet exist: moz-fx-data-shared-prod.org_mozilla_vrbrowser_derived.baseline_clients_first_seen_v1\n'
[2021-04-06 02:06:36,214] {pod_launcher.py:156} INFO - b'Traceback (most recent call last):\n'
[2021-04-06 02:06:36,214] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/runpy.py", line 194, in _run_module_as_main\n'
[2021-04-06 02:06:36,214] {pod_launcher.py:156} INFO - b'    return _run_code(code, main_globals, None,\n'
[2021-04-06 02:06:36,214] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/runpy.py", line 87, in _run_code\n'
[2021-04-06 02:06:36,214] {pod_launcher.py:156} INFO - b'    exec(code, run_globals)\n'
[2021-04-06 02:06:36,215] {pod_launcher.py:156} INFO - b'  File "/app/bigquery_etl/glean_usage/baseline_clients_first_seen.py", line 183, in <module>\n'
[2021-04-06 02:06:36,215] {pod_launcher.py:156} INFO - b'    main()\n'
[2021-04-06 02:06:36,215] {pod_launcher.py:156} INFO - b'  File "/app/bigquery_etl/glean_usage/baseline_clients_first_seen.py", line 83, in main\n'
[2021-04-06 02:06:36,215] {pod_launcher.py:156} INFO - b'    pool.map(\n'
[2021-04-06 02:06:36,215] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 364, in map\n'
[2021-04-06 02:06:36,215] {pod_launcher.py:156} INFO - b'    return self._map_async(func, iterable, mapstar, chunksize).get()\n'
[2021-04-06 02:06:36,215] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 771, in get\n'
[2021-04-06 02:06:36,215] {pod_launcher.py:156} INFO - b'    raise self._value\n'
[2021-04-06 02:06:36,215] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 125, in worker\n'
[2021-04-06 02:06:36,215] {pod_launcher.py:156} INFO - b'    result = (True, func(*args, **kwds))\n'
[2021-04-06 02:06:36,216] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 48, in mapstar\n'
[2021-04-06 02:06:36,216] {pod_launcher.py:156} INFO - b'    return list(map(*args))\n'
[2021-04-06 02:06:36,216] {pod_launcher.py:156} INFO - b'  File "/app/bigquery_etl/glean_usage/baseline_clients_first_seen.py", line 175, in run_query\n'
[2021-04-06 02:06:36,216] {pod_launcher.py:156} INFO - b'    job = client.query(sql, job_config)\n'
[2021-04-06 02:06:36,216] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/google/cloud/bigquery/client.py", line 2931, in query\n'
[2021-04-06 02:06:36,216] {pod_launcher.py:156} INFO - b'    query_job._begin(retry=retry, timeout=timeout)\n'
[2021-04-06 02:06:36,216] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/google/cloud/bigquery/job/query.py", line 1069, in _begin\n'
[2021-04-06 02:06:36,216] {pod_launcher.py:156} INFO - b'    super(QueryJob, self)._begin(client=client, retry=retry, timeout=timeout)\n'
[2021-04-06 02:06:36,216] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/google/cloud/bigquery/job/base.py", line 430, in _begin\n'
[2021-04-06 02:06:36,216] {pod_launcher.py:156} INFO - b'    api_response = client._call_api(\n'
[2021-04-06 02:06:36,217] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/google/cloud/bigquery/client.py", line 640, in _call_api\n'
[2021-04-06 02:06:36,217] {pod_launcher.py:156} INFO - b'    return call()\n'
[2021-04-06 02:06:36,217] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/google/api_core/retry.py", line 281, in retry_wrapped_func\n'
[2021-04-06 02:06:36,217] {pod_launcher.py:156} INFO - b'    return retry_target(\n'
[2021-04-06 02:06:36,217] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/google/api_core/retry.py", line 184, in retry_target\n'
[2021-04-06 02:06:36,217] {pod_launcher.py:156} INFO - b'    return target()\n'
[2021-04-06 02:06:36,217] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/google/cloud/_http.py", line 483, in api_request\n'
[2021-04-06 02:06:36,217] {pod_launcher.py:156} INFO - b'telemetry_derived/foo/query.sql                             OK\n'
[2021-04-06 02:06:36,217] {pod_launcher.py:156} INFO - b'    raise exceptions.from_http_response(response)\n'
[2021-04-06 02:06:36,217] {pod_launcher.py:156} INFO - b'google.api_core.exceptions.NotFound: 404 POST https://bigquery.googleapis.com/bigquery/v2/projects/moz-fx-data-shared-prod/jobs?prettyPrint=false: Not found: Table moz-fx-data-shared-prod:org_mozilla_firefoxreality_stable.migration_v1 was not found in location US\n'
[2021-04-06 02:06:36,217] {pod_launcher.py:156} INFO - b'\n'
[2021-04-06 02:06:36,218] {pod_launcher.py:156} INFO - b'(job ID: c5976362-601f-4f17-8437-1078542eb984)\n'
[2021-04-06 02:06:36,218] {pod_launcher.py:156} INFO - b'\n'
[2021-04-06 02:06:36,218] {pod_launcher.py:156} INFO - b'                                -----Query Job SQL Follows-----                                \n'
[2021-04-06 02:06:36,218] {pod_launcher.py:156} INFO - b'\n'
[2021-04-06 02:06:36,218] {pod_launcher.py:156} INFO - b'    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |\n'
[2021-04-06 02:06:36,218] {pod_launcher.py:156} INFO - b'   1:-- Generated via bigquery_etl.glean_usage\n'
[2021-04-06 02:06:36,218] {pod_launcher.py:156} INFO - b'   2:CREATE TABLE IF NOT EXISTS\n'
[2021-04-06 02:06:36,218] {pod_launcher.py:156} INFO - b'   3:  `org_mozilla_firefoxreality_derived.baseline_clients_first_seen_v1`\n'
[2021-04-06 02:06:36,218] {pod_launcher.py:156} INFO - b'   4:PARTITION BY\n'
[2021-04-06 02:06:36,219] {pod_launcher.py:156} INFO - b'   5:  first_seen_date\n'
[2021-04-06 02:06:36,219] {pod_launcher.py:156} INFO - b'   6:CLUSTER BY\n'
[2021-04-06 02:06:36,219] {pod_launcher.py:156} INFO - b'   7:  sample_id,\n'
[2021-04-06 02:06:36,219] {pod_launcher.py:156} INFO - b'   8:  submission_date\n'
[2021-04-06 02:06:36,219] {pod_launcher.py:156} INFO - b'   9:OPTIONS\n'
[2021-04-06 02:06:36,219] {pod_launcher.py:156} INFO - b'  10:  (require_partition_filter = FALSE)\n'
[2021-04-06 02:06:36,219] {pod_launcher.py:156} INFO - b'  11:AS\n'
[2021-04-06 02:06:36,219] {pod_launcher.py:156} INFO - b'  12:WITH baseline AS (\n'
[2021-04-06 02:06:36,219] {pod_launcher.py:156} INFO - b'  13:  SELECT\n'
[2021-04-06 02:06:36,219] {pod_launcher.py:156} INFO - b'  14:    client_info.client_id,\n'
[2021-04-06 02:06:36,219] {pod_launcher.py:156} INFO - b'  15:    sample_id,\n'
[2021-04-06 02:06:36,220] {pod_launcher.py:156} INFO - b'  16:    DATE(MIN(submission_timestamp)) AS submission_date,\n'
[2021-04-06 02:06:36,220] {pod_launcher.py:156} INFO - b'  17:    DATE(MIN(submission_timestamp)) AS first_seen_date,\n'
[2021-04-06 02:06:36,220] {pod_launcher.py:156} INFO - b'  18:  FROM\n'
[2021-04-06 02:06:36,220] {pod_launcher.py:156} INFO - b'  19:    `org_mozilla_firefoxreality_stable.baseline_v1`\n'
[2021-04-06 02:06:36,220] {pod_launcher.py:156} INFO - b'  20:    -- initialize by looking over all of history\n'
[2021-04-06 02:06:36,220] {pod_launcher.py:156} INFO - b'  21:  WHERE\n'
[2021-04-06 02:06:36,220] {pod_launcher.py:156} INFO - b'  22:    DATE(submission_timestamp) > "2010-01-01"\n'
[2021-04-06 02:06:36,220] {pod_launcher.py:156} INFO - b'  23:  GROUP BY\n'
[2021-04-06 02:06:36,220] {pod_launcher.py:156} INFO - b'  24:    client_id,\n'
[2021-04-06 02:06:36,220] {pod_launcher.py:156} INFO - b'  25:    sample_id\n'
[2021-04-06 02:06:36,220] {pod_launcher.py:156} INFO - b'  26:),\n'
[2021-04-06 02:06:36,221] {pod_launcher.py:156} INFO - b'  27:-- this lookup is ~13GB on release (org_mozilla_firefox) as of 2021-03-31\n'
[2021-04-06 02:06:36,221] {pod_launcher.py:156} INFO - b'  28:_fennec_id_lookup AS (\n'
[2021-04-06 02:06:36,246] {pod_launcher.py:156} INFO - b'  29:  SELECT\n'
[2021-04-06 02:06:36,246] {pod_launcher.py:156} INFO - b'  30:    client_info.client_id,\n'
[2021-04-06 02:06:36,247] {pod_launcher.py:156} INFO - b'  31:    MIN(metrics.uuid.migration_telemetry_identifiers_fennec_client_id) AS fennec_client_id\n'
[2021-04-06 02:06:36,247] {pod_launcher.py:156} INFO - b'  32:  FROM\n'
[2021-04-06 02:06:36,247] {pod_launcher.py:156} INFO - b'  33:    `org_mozilla_firefoxreality_stable.migration_v1`\n'
[2021-04-06 02:06:36,247] {pod_launcher.py:156} INFO - b'  34:  WHERE\n'
[2021-04-06 02:06:36,247] {pod_launcher.py:156} INFO - b'  35:    DATE(submission_timestamp) > "2010-01-01"\n'
[2021-04-06 02:06:36,247] {pod_launcher.py:156} INFO - b'  36:    AND client_info.client_id IS NOT NULL\n'
[2021-04-06 02:06:36,247] {pod_launcher.py:156} INFO - b'  37:    AND metrics.uuid.migration_telemetry_identifiers_fennec_client_id IS NOT NULL\n'
[2021-04-06 02:06:36,247] {pod_launcher.py:156} INFO - b'  38:  GROUP BY\n'
[2021-04-06 02:06:36,247] {pod_launcher.py:156} INFO - b'  39:    1\n'
[2021-04-06 02:06:36,248] {pod_launcher.py:156} INFO - b'  40:),\n'
[2021-04-06 02:06:36,248] {pod_launcher.py:156} INFO - b'  41:_core AS (\n'
[2021-04-06 02:06:36,248] {pod_launcher.py:156} INFO - b'  42:  SELECT\n'
[2021-04-06 02:06:36,248] {pod_launcher.py:156} INFO - b'  43:    *\n'
[2021-04-06 02:06:36,248] {pod_launcher.py:156} INFO - b'  44:  FROM\n'
[2021-04-06 02:06:36,248] {pod_launcher.py:156} INFO - b'  45:    `telemetry_derived.core_clients_first_seen_v1`\n'
[2021-04-06 02:06:36,248] {pod_launcher.py:156} INFO - b'  46:  WHERE\n'
[2021-04-06 02:06:36,248] {pod_launcher.py:156} INFO - b'  47:    first_seen_date > "2010-01-01"\n'
[2021-04-06 02:06:36,248] {pod_launcher.py:156} INFO - b'  48:),\n'
[2021-04-06 02:06:36,248] {pod_launcher.py:156} INFO - b'  49:-- scanning this table is ~25GB\n'
[2021-04-06 02:06:36,248] {pod_launcher.py:156} INFO - b'  50:_core_clients_first_seen AS (\n'
[2021-04-06 02:06:36,249] {pod_launcher.py:156} INFO - b'  51:  SELECT\n'
[2021-04-06 02:06:36,249] {pod_launcher.py:156} INFO - b'  52:    _fennec_id_lookup.client_id,\n'
[2021-04-06 02:06:36,249] {pod_launcher.py:156} INFO - b'  53:    first_seen_date\n'
[2021-04-06 02:06:36,249] {pod_launcher.py:156} INFO - b'  54:  FROM\n'
[2021-04-06 02:06:36,249] {pod_launcher.py:156} INFO - b'  55:    _fennec_id_lookup\n'
[2021-04-06 02:06:36,249] {pod_launcher.py:156} INFO - b'  56:  JOIN\n'
[2021-04-06 02:06:36,249] {pod_launcher.py:156} INFO - b'  57:    _core\n'
[2021-04-06 02:06:36,249] {pod_launcher.py:156} INFO - b'  58:  ON\n'
[2021-04-06 02:06:36,249] {pod_launcher.py:156} INFO - b'  59:    _fennec_id_lookup.fennec_client_id = _core.client_id\n'
[2021-04-06 02:06:36,249] {pod_launcher.py:156} INFO - b'  60:)\n'
[2021-04-06 02:06:36,250] {pod_launcher.py:156} INFO - b'  61:SELECT\n'
[2021-04-06 02:06:36,250] {pod_launcher.py:156} INFO - b'  62:  client_id,\n'
[2021-04-06 02:06:36,250] {pod_launcher.py:156} INFO - b'  63:  submission_date,\n'
[2021-04-06 02:06:36,250] {pod_launcher.py:156} INFO - b'  64:  COALESCE(core.first_seen_date, baseline.first_seen_date) AS first_seen_date,\n'
[2021-04-06 02:06:36,250] {pod_launcher.py:156} INFO - b'  65:  sample_id\n'
[2021-04-06 02:06:36,250] {pod_launcher.py:156} INFO - b'  66:FROM\n'
[2021-04-06 02:06:36,250] {pod_launcher.py:156} INFO - b'  67:  baseline\n'
[2021-04-06 02:06:36,250] {pod_launcher.py:156} INFO - b'  68:LEFT JOIN\n'
[2021-04-06 02:06:36,250] {pod_launcher.py:156} INFO - b'  69:  _core_clients_first_seen core\n'
[2021-04-06 02:06:36,250] {pod_launcher.py:156} INFO - b'  70:USING\n'
[2021-04-06 02:06:36,251] {pod_launcher.py:156} INFO - b'  71:  (client_id)\n'
[2021-04-06 02:06:36,251] {pod_launcher.py:156} INFO - b'    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |\n'
[2021-04-06 02:06:37,272] {pod_launcher.py:173} INFO - Event: baseline-clients-first-seen-138a4fa2952a4266bb5945a5b898daa3 had an event of type Running
[2021-04-06 02:06:37,272] {pod_launcher.py:166} INFO - Pod baseline-clients-first-seen-138a4fa2952a4266bb5945a5b898daa3 has state running
[2021-04-06 02:06:39,312] {pod_launcher.py:173} INFO - Event: baseline-clients-first-seen-138a4fa2952a4266bb5945a5b898daa3 had an event of type Failed
[2021-04-06 02:06:39,313] {pod_launcher.py:284} INFO - Event with job id baseline-clients-first-seen-138a4fa2952a4266bb5945a5b898daa3 Failed
[2021-04-06 02:06:39,352] {pod_launcher.py:173} INFO - Event: baseline-clients-first-seen-138a4fa2952a4266bb5945a5b898daa3 had an event of type Failed
[2021-04-06 02:06:39,352] {pod_launcher.py:284} INFO - Event with job id baseline-clients-first-seen-138a4fa2952a4266bb5945a5b898daa3 Failed
[2021-04-06 02:06:39,363] {taskinstance.py:1150} ERROR - Pod Launching failed: Pod returned a failure: failed
```

</details>