### PR TITLE
Fix not enough values to unpack for referenced tables

### DIFF
--- a/bigquery_etl/docs/derived_datasets/generate_derived_dataset_docs.py
+++ b/bigquery_etl/docs/derived_datasets/generate_derived_dataset_docs.py
@@ -67,7 +67,16 @@ def generate_derived_dataset_docs(out_dir, project_dir):
                     for referenced_table in extract_table_references(
                         view_file.read_text()
                     ):
-                        [project_id, dataset_id, table_id] = referenced_table.split(".")
+                        table_split = referenced_table.split(".")
+                        if len(table_split) == 2:
+                            # missing project ID, retrieve from file path
+                            [dataset_id, table_id] = table_split
+                            project_id = view_file.parent.parent.parent.name
+                        elif len(table_split) == 3:
+                            [project_id, dataset_id, table_id] = table_split
+                        else:
+                            continue
+
                         referenced_tables.append(
                             {
                                 "project_id": project_id,


### PR DESCRIPTION
This should fix the following error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/root/project/bigquery_etl/docs/generate_docs.py", line 167, in <module>
    main()
  File "/root/project/bigquery_etl/docs/generate_docs.py", line 161, in main
    generate_derived_dataset_docs.generate_derived_dataset_docs(
  File "/root/project/bigquery_etl/docs/derived_datasets/generate_derived_dataset_docs.py", line 70, in generate_derived_dataset_docs
    [project_id, dataset_id, table_id] = referenced_table.split(".")
ValueError: not enough values to unpack (expected 3, got 2)
```

This seems to happen for a couple of queries in `generated-sql`, like in `burnham_derived/baseline_clients_last_seen_v1/query.sql` the referenced table `burnham_derived.baseline_clients_first_seen_v1` gets returned without the project ID. As a workaround, the project ID can be determined from the file path.

cc @whd 