### PR TITLE
Bug 1703362 Purge security.unexpectedload events

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/query.sql
@@ -1,53 +1,60 @@
 -- Creates a backwards-compatible flattened events dataset created from gcp-ingested event pings
 -- Designed to provide continuity for the `events` dataset via a user-facing union view
+WITH base AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    document_id,
+    client_id,
+    normalized_channel,
+    normalized_country_code AS country,
+    environment.settings.locale AS locale,
+    normalized_app_name AS app_name,
+    metadata.uri.app_version AS app_version,
+    normalized_os AS os,
+    normalized_os_version AS os_version,
+    environment.experiments AS experiments,
+    sample_id,
+    payload.session_id AS session_id,
+    SAFE.TIMESTAMP_MILLIS(payload.process_start_timestamp) AS session_start_time,
+    payload.subsession_id AS subsession_id,
+    submission_timestamp AS `timestamp`,
+    udf.deanonymize_event(e).*,
+    event_process,
+    application.build_id,
+    environment.build.architecture AS build_architecture,
+    environment.profile.creation_date AS profile_creation_date,
+    environment.settings.is_default_browser,
+    environment.settings.attribution.source AS attribution_source,
+    environment.system.is_wow64 AS system_is_wow64,
+    environment.system.memory_mb AS system_memory_mb,
+    metadata.geo.city
+  FROM
+    telemetry.event
+  CROSS JOIN
+    UNNEST(
+      [
+        STRUCT("content" AS event_process, payload.events.content AS events),
+        ("dynamic", payload.events.dynamic),
+        ("extension", payload.events.extension),
+        ("gpu", payload.events.gpu),
+        ("parent", payload.events.parent)
+      ]
+    )
+  CROSS JOIN
+    UNNEST(events) AS e
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+)
 SELECT
-  DATE(submission_timestamp) AS submission_date,
-  document_id,
-  client_id,
-  normalized_channel,
-  normalized_country_code AS country,
-  environment.settings.locale AS locale,
-  normalized_app_name AS app_name,
-  metadata.uri.app_version AS app_version,
-  normalized_os AS os,
-  normalized_os_version AS os_version,
-  environment.experiments AS experiments,
-  sample_id,
-  payload.session_id AS session_id,
-  SAFE.TIMESTAMP_MILLIS(payload.process_start_timestamp) AS session_start_time,
-  payload.subsession_id AS subsession_id,
-  submission_timestamp AS `timestamp`,
-  udf.deanonymize_event(e).*,
-  event_process,
-  application.build_id,
-  environment.build.architecture AS build_architecture,
-  environment.profile.creation_date AS profile_creation_date,
-  environment.settings.is_default_browser,
-  environment.settings.attribution.source AS attribution_source,
-  environment.system.is_wow64 AS system_is_wow64,
-  environment.system.memory_mb AS system_memory_mb,
-  metadata.geo.city
+  *
 FROM
-  telemetry.event
-CROSS JOIN
-  UNNEST(
-    [
-      STRUCT("content" AS event_process, payload.events.content AS events),
-      ("dynamic", payload.events.dynamic),
-      ("extension", payload.events.extension),
-      ("gpu", payload.events.gpu),
-      ("parent", payload.events.parent)
-    ]
-  )
-CROSS JOIN
-  UNNEST(events) AS e
+  base
 WHERE
-  DATE(submission_timestamp) = @submission_date
   -- See https://bugzilla.mozilla.org/show_bug.cgi?id=1703362
-  AND NOT (
-    e.f1_ = 'security'
-    AND e.f2_ = 'unexpectedload'
-    AND mozfun.map.get_key(e.f5_, 'contenttype') = 'TYPE_STYLESHEET'
+  NOT (
+    event_category = 'security'
+    AND event_method = 'unexpectedload'
+    AND mozfun.map.get_key(event_map_values, 'contenttype') = 'TYPE_STYLESHEET'
     AND mozfun.norm.truncate_version(app_version, 'major')
     BETWEEN 84
     AND 87

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/query.sql
@@ -42,4 +42,13 @@ CROSS JOIN
 CROSS JOIN
   UNNEST(events) AS e
 WHERE
-  date(submission_timestamp) = @submission_date
+  DATE(submission_timestamp) = @submission_date
+  -- See https://bugzilla.mozilla.org/show_bug.cgi?id=1703362
+  AND NOT (
+    e.f1_ = 'security'
+    AND e.f2_ = 'unexpectedload'
+    AND mozfun.map.get_key(e.f5_, 'contenttype') = 'TYPE_STYLESHEET'
+    AND mozfun.norm.truncate_version(app_version, 'major')
+    BETWEEN 84
+    AND 87
+  )


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1703362

The fix that reduces the quantity of events is scheduled to be included
in Firefox 88, released in late April. From 88 on, the rate of events
is expected to be reasonable, and the filter here will allow them again.

I will run a backfill for this table, starting from 2020-12-15.