### PR TITLE
Add ACL metadata for poucave access to live events view

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_live/metadata.yaml
@@ -1,0 +1,6 @@
+---
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential
+      - workgroup:cloudops-managed/poucave

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_live/metadata.yaml
@@ -2,5 +2,5 @@
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
-      - workgroup:mozilla-confidential
+      # - workgroup:mozilla-confidential
       - workgroup:cloudops-managed/poucave


### PR DESCRIPTION
Requires https://github.com/mozilla-services/cloudops-infra/pull/3008 
For https://bugzilla.mozilla.org/show_bug.cgi?id=1682343
