### PR TITLE
Ignore materialized view dry runs

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -130,6 +130,13 @@ SKIP = {
     "sql/moz-fx-data-bq-performance/release_criteria/release_criteria_v1/query.sql",
     # Materialized views
     "sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_events_live_v1/init.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/telemetry_derived/experiment_events_live_v1/init.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/experiment_search_events_live_v1/init.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/experiment_events_live_v1/init.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/experiment_search_events_live_v1/init.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/experiment_events_live_v1/init.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/experiment_search_events_live_v1/init.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/experiment_events_live_v1/init.sql",  # noqa E501
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",  # noqa E501


### PR DESCRIPTION
The new BigQuery release introduced some change which disallows using `TO_JSON_STRING` with `STRUCT` input in materialized view: "Materialized views may not use the TO_JSON_STRING function with a STRUCT input". Unfortunately, our current strategy depends on using `TO_JSON_STRING` with `STRUCT` inputs. Materialized view that have been deployed in the past are still working, for now.

To reduce CI failure noise, this will skip dry runs for materialized views