### PR TITLE
Expose an `interval` field on iap subscriptions

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/devices_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/devices_v1/query.sql
@@ -1,4 +1,5 @@
 SELECT
+  id,
   user_id,
   created_at,
   updated_at,

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscriptions_v1/query.sql
@@ -1,4 +1,5 @@
 SELECT
+  id,
   user_id,
   is_active,
   created_at,

--- a/sql/moz-fx-data-shared-prod/stripe_derived/subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/subscriptions_v1/query.sql
@@ -10,6 +10,7 @@ SELECT
   id,
   metadata,
   plan.id AS plan,
+  plan.product,
   start_date,
   status,
   trial_end,

--- a/sql/mozfun/iap/derive_apple_subscription_interval/metadata.yaml
+++ b/sql/mozfun/iap/derive_apple_subscription_interval/metadata.yaml
@@ -1,0 +1,6 @@
+description: >
+  Take output purchase_date and expires_date from mozfun.iap.parse_apple_receipt
+  and return the subscription interval to use for accounting. Values must be
+  DATETIME in America/Los_Angeles to get correct results because of how timezone
+  and daylight savings impact the time of day and the length of a month.
+friendly_name: Derive Apple Subscription Interval from IAP Receipt

--- a/sql/mozfun/iap/derive_apple_subscription_interval/udf.sql
+++ b/sql/mozfun/iap/derive_apple_subscription_interval/udf.sql
@@ -1,0 +1,117 @@
+CREATE OR REPLACE FUNCTION iap.derive_apple_subscription_interval(
+  purchase_datetime_pst DATETIME,
+  expires_datetime_pst DATETIME
+) AS (
+  CASE
+  WHEN
+    DATETIME_ADD(purchase_datetime_pst, INTERVAL 1 YEAR) = expires_datetime_pst
+  THEN
+    "year"
+  WHEN
+    DATETIME_ADD(purchase_datetime_pst, INTERVAL 1 QUARTER) = expires_datetime_pst
+  THEN
+    "quarter"
+  WHEN
+    DATETIME_ADD(purchase_datetime_pst, INTERVAL 1 MONTH) = expires_datetime_pst
+  THEN
+    "month"
+  WHEN
+    DATETIME_ADD(purchase_datetime_pst, INTERVAL 1 WEEK) = expires_datetime_pst
+  THEN
+    "week"
+  WHEN
+    DATETIME_ADD(purchase_datetime_pst, INTERVAL 1 DAY) = expires_datetime_pst
+  THEN
+    "day"
+  ELSE
+    CONCAT(CAST(DATETIME_DIFF(expires_datetime_pst, purchase_datetime_pst, DAY) AS STRING), " day")
+  END
+);
+
+SELECT
+  assert.equals(
+    "year",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2020-03-15 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-03-15 01:00:00 UTC", "America/Los_Angeles")
+    )
+  ),
+  assert.equals(
+    "quarter",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2021-03-15 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-06-15 01:00:00 UTC", "America/Los_Angeles")
+    )
+  ),
+  assert.equals(
+    "month",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2021-03-15 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-04-15 01:00:00 UTC", "America/Los_Angeles")
+    )
+  ),
+  assert.equals(
+    "week",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2021-03-15 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-03-22 01:00:00 UTC", "America/Los_Angeles")
+    )
+  ),
+  assert.equals(
+    "day",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2021-03-15 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-03-16 01:00:00 UTC", "America/Los_Angeles")
+    )
+  ),
+  assert.equals(
+    "2 day",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2021-03-15 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-03-17 01:00:00 UTC", "America/Los_Angeles")
+    )
+  ),
+  -- daylight savings time
+  assert.equals(
+    "quarter",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2021-03-14 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-06-14 00:00:00 UTC", "America/Los_Angeles")
+    )
+  ),
+  assert.equals(
+    "month",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2021-03-14 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-04-14 00:00:00 UTC", "America/Los_Angeles")
+    )
+  ),
+  assert.equals(
+    "week",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2021-03-14 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-03-21 00:00:00 UTC", "America/Los_Angeles")
+    )
+  ),
+  assert.equals(
+    "day",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2021-03-14 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-03-15 00:00:00 UTC", "America/Los_Angeles")
+    )
+  ),
+  assert.equals(
+    "2 day",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2021-03-14 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-03-16 00:00:00 UTC", "America/Los_Angeles")
+    )
+  ),
+  -- february vs march PST
+  assert.equals(
+    "month",
+    iap.derive_apple_subscription_interval(
+      DATETIME(TIMESTAMP "2021-03-01 01:00:00 UTC", "America/Los_Angeles"),
+      DATETIME(TIMESTAMP "2021-03-29 00:00:00 UTC", "America/Los_Angeles")
+    )
+  ),


### PR DESCRIPTION
also expose subscription id and device id for vpn tables, and product id for stripe subscriptions

`interval` maps to `Term` in [Data requirements for Finance](https://docs.google.com/document/d/1na1FlF8frDKF0_8kbc2hUwZXP9ljegYVAVVd1GPIut8/edit), uses naming consistent with Stripe, and correctly returns `"month"` for all the subs we have in prod.

the id fields are all for Looker, where it wants them to ensure it doesn't double count when one_to_many tables are joined in.