### PR TITLE
Add ACL metadata for taar access to clients_last_seen table

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
@@ -25,3 +25,9 @@ scheduling:
   allow_field_addition_on_date: '2020-10-20'
   email: ['dthorn@mozilla.com', 'jklukas@mozilla.com']
   depends_on_past: true
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      # managed at the dataset-level
+      # - workgroup:mozilla-confidential
+      - workgroup:dataops-managed/taar


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1704675#c2 since the taar dataflow job requires read access to telemetry.clients_last_seen which requires access to telemetry_derived.clients_last_seen_v1.

Permissions for the user-facing views have already been granted via PR https://github.com/mozilla-services/cloudops-infra/pull/3014 

r?