### PR TITLE
Remove allow_field_addition_on_date in clients_first_seen_v1 metadata

### DIFF
--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -170,7 +170,6 @@ with DAG(
         depends_on_past=True,
         parameters=["submission_date:DATE:{{ds}}"],
         priority_weight=80,
-        allow_field_addition_on_date="2021-04-19",
         dag=dag,
     )
 

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/metadata.yaml
@@ -15,7 +15,6 @@ labels:
 scheduling:
   dag_name: bqetl_main_summary
   start_date: '2020-05-05'
-  allow_field_addition_on_date: '2021-04-19'
   priority: 80
   depends_on_past: true
   # This query updates the entire existing table every day rather than appending


### PR DESCRIPTION
Airflow is failing due to

```
[2021-04-20 03:23:12,457] {pod_launcher.py:156} INFO - b"BigQuery error in query operation: Error processing job 'moz-fx-data-shared-\n"
[2021-04-20 03:23:12,458] {pod_launcher.py:156} INFO - b"prod:bqjob_r7a908a819004b2fe_00000178ed4da52e_1': Schema update options should\n"
[2021-04-20 03:23:12,458] {pod_launcher.py:156} INFO - b'only be specified with WRITE_APPEND disposition, or with WRITE_TRUNCATE\n'
[2021-04-20 03:23:12,458] {pod_launcher.py:156} INFO - b'disposition on a table partition.\n'
```