### PR TITLE
Remove allow_field_addition_on_date from clients_daily

### DIFF
--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -111,7 +111,6 @@ with DAG(
         start_date=datetime.datetime(2019, 11, 5, 0, 0),
         date_partition_parameter="submission_date",
         depends_on_past=False,
-        allow_field_addition_on_date="2021-04-19",
         dag=dag,
     )
 

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
@@ -15,7 +15,6 @@ labels:
   application: firefox
   schedule: daily
 scheduling:
-  allow_field_addition_on_date: '2021-04-19'
   dag_name: bqetl_main_summary
   start_date: '2019-11-05'
 bigquery:


### PR DESCRIPTION
`allow_field_addition_on_date` in clients_daily changes the order of fields in the destination table schema based on how they appear in the query. This causes the schema of `clients_first_seen` and `clients_last_seen` to be different from `clients_daily` after adding new fields.