### PR TITLE
Remove time_partitioning_type from bqetl backfill

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -530,7 +530,6 @@ def backfill(
                 arguments = (
                     [
                         "query",
-                        "--time_partitioning_type=DAY",
                         f"--parameter=submission_date:DATE:{backfill_date}",
                         "--use_legacy_sql=false",
                         "--replace",


### PR DESCRIPTION
With `--time_partitioning_type=DAY` being set the `bqetl query backfill` fails with:
```
Incompatible table partitioning specification. Expects partitioning specification interval(type:day,field:date), but input partitioning specification is interval(type:day)
```

Simply removing it solved the problem