### PR TITLE
[Bug 1706394] Internet outages dataset query from telemetry_stable.main_v4

### DIFF
--- a/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/query.sql
@@ -229,7 +229,7 @@ histogram_data_sample AS (
       payload.processes.content.histograms.http_page_tls_handshake
     ).values AS tls_handshake,
   FROM
-    telemetry.main
+    telemetry_stable.main_v4
   WHERE
     DATE(submission_timestamp) = @submission_date
     -- Restrict to Firefox.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1706394

Directly querying from `telemetry_stable.main_v4` fixes the `Resources exceeded during query execution` error.

cc @Dexterp37 