### PR TITLE
Bug 1707571 - Ignore isverified in fxa_auth_events

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -95,6 +95,11 @@ bqetl_fxa_events:
 
     The DAG also provides daily aggregations on top of the raw log data,
     which eventually power high-level reporting about FxA usage.
+
+    Tasks here have occasionally failed due to incompatible schema changes
+    in the tables populated by Cloud Logging.
+    See https://github.com/mozilla/bigquery-etl/issues/1684 for an example
+    mitigation.
   default_args:
     owner: jklukas@mozilla.com
     start_date: "2019-03-01"

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -19,6 +19,11 @@ as part of the import.
 The DAG also provides daily aggregations on top of the raw log data,
 which eventually power high-level reporting about FxA usage.
 
+Tasks here have occasionally failed due to incompatible schema changes
+in the tables populated by Cloud Logging.
+See https://github.com/mozilla/bigquery-etl/issues/1684 for an example
+mitigation.
+
 #### Owner
 
 jklukas@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
@@ -10,7 +10,10 @@ WITH base AS (
           jsonPayload.* REPLACE (
             (
               SELECT AS STRUCT
-                jsonPayload.fields.* EXCEPT (device_id, user_id),
+                jsonPayload.fields.* EXCEPT (device_id, user_id) REPLACE(
+                  -- See https://bugzilla.mozilla.org/show_bug.cgi?id=1707571
+                  CAST(NULL AS FLOAT) AS isverified
+                ),
                 TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id
             ) AS fields
           )


### PR DESCRIPTION
This is hopefully a temporary workaround while we understand the incompatible schema change in the source table.

Very similar to the fix in https://github.com/mozilla/bigquery-etl/pull/1683