### PR TITLE
Rewrite experiment_search_events_live_v1 materialized views without TO_JSON_STRING

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/experiment_search_events_live_v1/init.sql
@@ -29,21 +29,21 @@ IF
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_ad_clicks, [('', 0)])[
           SAFE_OFFSET(i)
-        ].value AS int64
+        ].value AS INT64
       )
     ) AS ad_clicks_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_with_ads, [('', 0)])[
           SAFE_OFFSET(i)
-        ].value AS int64
+        ].value AS INT64
       )
     ) AS search_with_ads_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.metrics_search_count, [('', 0)])[
           SAFE_OFFSET(i)
-        ].value AS int64
+        ].value AS INT64
       )
     ) AS search_count
   FROM

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/experiment_search_events_live_v1/init.sql
@@ -10,113 +10,52 @@ IF
   OPTIONS
     (enable_refresh = TRUE, refresh_interval_minutes = 5)
   AS
-  -- Materialized views do not support sub-queries for UNNESTing fields.
-  -- This limitation prevents summing up individual nested counters.
-  -- As a workaround the nested counters are converted into arrays of counts. The
-  -- conversion is done by a combination of dumping the fields as JSON
-  -- strings, applying regexes and concatenating extracted strings.
-  --
-  -- (1) Dump the nested counter field as JSON string, for example:
-  --     [{"key":"duckduckgo","value":7}, {"key":"google","value":4}]
-  -- (2) Using a regex, extract all values and dump the result array as
-  --     JSON string: ["7", "4"]
-  -- (3) Using regex replace, transform the count numbers in the array
-  --     to an array where the position of the element determines the
-  --     count type [search_ad_clicks, search_with_ads, search_count]:
-  --     "[[7, 0, 0], [4, 0, 0]]"
-  -- (4) Convert the nested array string to an array and concatenate
-  --     nested arrays of ping to a single array and dump as JSON string,
-  --     for example: "[[7, 0, 0], [4, 0, 0], [0, 1, 0], [0, 0, 3]]"
-  --
-  -- (5) Convert the nested array string into an array, unnest and sum
-  --     individual counts based on their array index:
-  --        ad_clicks_count = 11
-  --        search_with_ads_count = 1
-  --        search_count = 3
-  WITH aggregated_arrays AS (
-    SELECT
-      submission_timestamp,
-      experiment.key AS experiment,
-      experiment.value.branch AS branch,
-      -- (4)
-      TO_JSON_STRING(
-        ARRAY_CONCAT(
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              TO_JSON_STRING(
-                REGEXP_EXTRACT_ALL(
-                  -- (1)
-                  TO_JSON_STRING(metrics.labeled_counter.browser_search_ad_clicks),
-                  '"value":([^,}]+)'
-                )
-              ),
-              r'"([^"]+)"',
-              r'[\1, 0, 0]'
-            )
-          ),
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              TO_JSON_STRING(
-                REGEXP_EXTRACT_ALL(
-                  -- (1)
-                  TO_JSON_STRING(metrics.labeled_counter.browser_search_with_ads),
-                  '"value":([^,}]+)'
-                )
-              ),
-              r'"([^"]+)"',
-              r'[0, \1, 0]'
-            )
-          ),
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              TO_JSON_STRING(
-                REGEXP_EXTRACT_ALL(
-                  -- (1)
-                  TO_JSON_STRING(metrics.labeled_counter.metrics_search_count),
-                  '"value":([^,}]+)'
-                )
-              ),
-              r'"([^"]+)"',
-              r'[0, 0, \1]'
-            )
-          )
-        )
-      ) AS nested_counts
-    FROM
-      `moz-fx-data-shared-prod.org_mozilla_fenix_live.metrics_v1`
-    LEFT JOIN
-      UNNEST(ping_info.experiments) AS experiment
-    WHERE
-    -- Limit the amount of data the materialized view is going to backfill when created.
-    -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-      DATE(submission_timestamp) > '2021-03-12'
-  )
   SELECT
     date(submission_timestamp) AS submission_date,
-    experiment,
-    branch,
+    experiment.key AS experiment,
+    experiment.value.branch AS branch,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
-    -- Aggregates event counts over 5-minute intervals
+        -- Aggregates event counts over 5-minute intervals
       INTERVAL(DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) * 5) MINUTE
     ) AS window_start,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
       INTERVAL((DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) + 1) * 5) MINUTE
     ) AS window_end,
-    -- (5)
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(0)] AS INT64)) AS ad_clicks_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(1)] AS INT64)) AS search_with_ads_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(2)] AS INT64)) AS search_count,
+        -- Concatenating an element with value = 0 ensures that the count values are not null even if the array is empty
+        -- Materialized views don't support COALESCE or IFNULL
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.browser_search_ad_clicks, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS ad_clicks_count,
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.browser_search_with_ads, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS search_with_ads_count,
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.metrics_search_count, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS search_count
   FROM
-    aggregated_arrays,
-    UNNEST(JSON_EXTRACT_ARRAY(REPLACE(nested_counts, '"', ""))) AS counts
+    `moz-fx-data-shared-prod.org_mozilla_fenix_live.metrics_v1`
+  LEFT JOIN
+    UNNEST(ping_info.experiments) AS experiment,
+    -- Max. number of entries is around 10
+    UNNEST(GENERATE_ARRAY(0, 50)) AS i
+  WHERE
+      -- Limit the amount of data the materialized view is going to backfill when created.
+      -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
+    DATE(submission_timestamp) > '2021-04-20'
   GROUP BY
     submission_date,
     experiment,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/experiment_search_events_live_v1/init.sql
@@ -28,34 +28,35 @@ IF
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_ad_clicks, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS ad_clicks_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_with_ads, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS search_with_ads_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.metrics_search_count, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS search_count
   FROM
     `moz-fx-data-shared-prod.org_mozilla_fenix_live.metrics_v1`
   LEFT JOIN
-    UNNEST(ping_info.experiments) AS experiment,
+    UNNEST(ping_info.experiments) AS experiment
+  CROSS JOIN
     -- Max. number of entries is around 10
     UNNEST(GENERATE_ARRAY(0, 50)) AS i
   WHERE
       -- Limit the amount of data the materialized view is going to backfill when created.
       -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-    DATE(submission_timestamp) > '2021-04-20'
+    DATE(submission_timestamp) > '2021-04-25'
   GROUP BY
     submission_date,
     experiment,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/experiment_search_events_live_v1/init.sql
@@ -29,21 +29,21 @@ IF
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_ad_clicks, [('', 0)])[
           SAFE_OFFSET(i)
-        ].value AS int64
+        ].value AS INT64
       )
     ) AS ad_clicks_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_with_ads, [('', 0)])[
           SAFE_OFFSET(i)
-        ].value AS int64
+        ].value AS INT64
       )
     ) AS search_with_ads_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.metrics_search_count, [('', 0)])[
           SAFE_OFFSET(i)
-        ].value AS int64
+        ].value AS INT64
       )
     ) AS search_count
   FROM

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/experiment_search_events_live_v1/init.sql
@@ -10,113 +10,52 @@ IF
   OPTIONS
     (enable_refresh = TRUE, refresh_interval_minutes = 5)
   AS
-  -- Materialized views do not support sub-queries for UNNESTing fields.
-  -- This limitation prevents summing up individual nested counters.
-  -- As a workaround the nested counters are converted into arrays of counts. The
-  -- conversion is done by a combination of dumping the fields as JSON
-  -- strings, applying regexes and concatenating extracted strings.
-  --
-  -- (1) Dump the nested counter field as JSON string, for example:
-  --     [{"key":"duckduckgo","value":7}, {"key":"google","value":4}]
-  -- (2) Using a regex, extract all values and dump the result array as
-  --     JSON string: ["7", "4"]
-  -- (3) Using regex replace, transform the count numbers in the array
-  --     to an array where the position of the element determines the
-  --     count type [search_ad_clicks, search_with_ads, search_count]:
-  --     "[[7, 0, 0], [4, 0, 0]]"
-  -- (4) Convert the nested array string to an array and concatenate
-  --     nested arrays of ping to a single array and dump as JSON string,
-  --     for example: "[[7, 0, 0], [4, 0, 0], [0, 1, 0], [0, 0, 3]]"
-  --
-  -- (5) Convert the nested array string into an array, unnest and sum
-  --     individual counts based on their array index:
-  --        ad_clicks_count = 11
-  --        search_with_ads_count = 1
-  --        search_count = 3
-  WITH aggregated_arrays AS (
-    SELECT
-      submission_timestamp,
-      experiment.key AS experiment,
-      experiment.value.branch AS branch,
-      -- (4)
-      TO_JSON_STRING(
-        ARRAY_CONCAT(
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              TO_JSON_STRING(
-                REGEXP_EXTRACT_ALL(
-                  -- (1)
-                  TO_JSON_STRING(metrics.labeled_counter.browser_search_ad_clicks),
-                  '"value":([^,}]+)'
-                )
-              ),
-              r'"([^"]+)"',
-              r'[\1, 0, 0]'
-            )
-          ),
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              TO_JSON_STRING(
-                REGEXP_EXTRACT_ALL(
-                  -- (1)
-                  TO_JSON_STRING(metrics.labeled_counter.browser_search_with_ads),
-                  '"value":([^,}]+)'
-                )
-              ),
-              r'"([^"]+)"',
-              r'[0, \1, 0]'
-            )
-          ),
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              TO_JSON_STRING(
-                REGEXP_EXTRACT_ALL(
-                  -- (1)
-                  TO_JSON_STRING(metrics.labeled_counter.metrics_search_count),
-                  '"value":([^,}]+)'
-                )
-              ),
-              r'"([^"]+)"',
-              r'[0, 0, \1]'
-            )
-          )
-        )
-      ) AS nested_counts
-    FROM
-      `moz-fx-data-shared-prod.org_mozilla_firefox_beta_live.metrics_v1`
-    LEFT JOIN
-      UNNEST(ping_info.experiments) AS experiment
-    WHERE
-    -- Limit the amount of data the materialized view is going to backfill when created.
-    -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-      DATE(submission_timestamp) > '2021-03-12'
-  )
   SELECT
     date(submission_timestamp) AS submission_date,
-    experiment,
-    branch,
+    experiment.key AS experiment,
+    experiment.value.branch AS branch,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
-    -- Aggregates event counts over 5-minute intervals
+        -- Aggregates event counts over 5-minute intervals
       INTERVAL(DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) * 5) MINUTE
     ) AS window_start,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
       INTERVAL((DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) + 1) * 5) MINUTE
     ) AS window_end,
-    -- (5)
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(0)] AS INT64)) AS ad_clicks_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(1)] AS INT64)) AS search_with_ads_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(2)] AS INT64)) AS search_count,
+        -- Concatenating an element with value = 0 ensures that the count values are not null even if the array is empty
+        -- Materialized views don't support COALESCE or IFNULL
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.browser_search_ad_clicks, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS ad_clicks_count,
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.browser_search_with_ads, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS search_with_ads_count,
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.metrics_search_count, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS search_count
   FROM
-    aggregated_arrays,
-    UNNEST(JSON_EXTRACT_ARRAY(REPLACE(nested_counts, '"', ""))) AS counts
+    `moz-fx-data-shared-prod.org_mozilla_firefox_beta_live.metrics_v1`
+  LEFT JOIN
+    UNNEST(ping_info.experiments) AS experiment,
+    -- Max. number of entries is around 10
+    UNNEST(GENERATE_ARRAY(0, 50)) AS i
+  WHERE
+      -- Limit the amount of data the materialized view is going to backfill when created.
+      -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
+    DATE(submission_timestamp) > '2021-04-20'
   GROUP BY
     submission_date,
     experiment,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/experiment_search_events_live_v1/init.sql
@@ -28,34 +28,35 @@ IF
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_ad_clicks, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS ad_clicks_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_with_ads, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS search_with_ads_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.metrics_search_count, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS search_count
   FROM
     `moz-fx-data-shared-prod.org_mozilla_firefox_beta_live.metrics_v1`
   LEFT JOIN
-    UNNEST(ping_info.experiments) AS experiment,
+    UNNEST(ping_info.experiments) AS experiment
+  CROSS JOIN
     -- Max. number of entries is around 10
     UNNEST(GENERATE_ARRAY(0, 50)) AS i
   WHERE
       -- Limit the amount of data the materialized view is going to backfill when created.
       -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-    DATE(submission_timestamp) > '2021-04-20'
+    DATE(submission_timestamp) > '2021-04-25'
   GROUP BY
     submission_date,
     experiment,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/experiment_search_events_live_v1/init.sql
@@ -29,21 +29,21 @@ IF
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_ad_clicks, [('', 0)])[
           SAFE_OFFSET(i)
-        ].value AS int64
+        ].value AS INT64
       )
     ) AS ad_clicks_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_with_ads, [('', 0)])[
           SAFE_OFFSET(i)
-        ].value AS int64
+        ].value AS INT64
       )
     ) AS search_with_ads_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.metrics_search_count, [('', 0)])[
           SAFE_OFFSET(i)
-        ].value AS int64
+        ].value AS INT64
       )
     ) AS search_count
   FROM

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/experiment_search_events_live_v1/init.sql
@@ -28,34 +28,35 @@ IF
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_ad_clicks, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS ad_clicks_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.browser_search_with_ads, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS search_with_ads_count,
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.metrics_search_count, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS search_count
   FROM
     `moz-fx-data-shared-prod.org_mozilla_firefox_live.metrics_v1`
   LEFT JOIN
-    UNNEST(ping_info.experiments) AS experiment,
+    UNNEST(ping_info.experiments) AS experiment
+  CROSS JOIN
     -- Max. number of entries is around 10
     UNNEST(GENERATE_ARRAY(0, 50)) AS i
   WHERE
       -- Limit the amount of data the materialized view is going to backfill when created.
       -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-    DATE(submission_timestamp) > '2021-04-20'
+    DATE(submission_timestamp) > '2021-04-25'
   GROUP BY
     submission_date,
     experiment,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/experiment_search_events_live_v1/init.sql
@@ -10,113 +10,52 @@ IF
   OPTIONS
     (enable_refresh = TRUE, refresh_interval_minutes = 5)
   AS
-  -- Materialized views do not support sub-queries for UNNESTing fields.
-  -- This limitation prevents summing up individual nested counters.
-  -- As a workaround the nested counters are converted into arrays of counts. The
-  -- conversion is done by a combination of dumping the fields as JSON
-  -- strings, applying regexes and concatenating extracted strings.
-  --
-  -- (1) Dump the nested counter field as JSON string, for example:
-  --     [{"key":"duckduckgo","value":7}, {"key":"google","value":4}]
-  -- (2) Using a regex, extract all values and dump the result array as
-  --     JSON string: ["7", "4"]
-  -- (3) Using regex replace, transform the count numbers in the array
-  --     to an array where the position of the element determines the
-  --     count type [search_ad_clicks, search_with_ads, search_count]:
-  --     "[[7, 0, 0], [4, 0, 0]]"
-  -- (4) Convert the nested array string to an array and concatenate
-  --     nested arrays of ping to a single array and dump as JSON string,
-  --     for example: "[[7, 0, 0], [4, 0, 0], [0, 1, 0], [0, 0, 3]]"
-  --
-  -- (5) Convert the nested array string into an array, unnest and sum
-  --     individual counts based on their array index:
-  --        ad_clicks_count = 11
-  --        search_with_ads_count = 1
-  --        search_count = 3
-  WITH aggregated_arrays AS (
-    SELECT
-      submission_timestamp,
-      experiment.key AS experiment,
-      experiment.value.branch AS branch,
-      -- (4)
-      TO_JSON_STRING(
-        ARRAY_CONCAT(
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              TO_JSON_STRING(
-                REGEXP_EXTRACT_ALL(
-                  -- (1)
-                  TO_JSON_STRING(metrics.labeled_counter.browser_search_ad_clicks),
-                  '"value":([^,}]+)'
-                )
-              ),
-              r'"([^"]+)"',
-              r'[\1, 0, 0]'
-            )
-          ),
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              TO_JSON_STRING(
-                REGEXP_EXTRACT_ALL(
-                  -- (1)
-                  TO_JSON_STRING(metrics.labeled_counter.browser_search_with_ads),
-                  '"value":([^,}]+)'
-                )
-              ),
-              r'"([^"]+)"',
-              r'[0, \1, 0]'
-            )
-          ),
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              TO_JSON_STRING(
-                REGEXP_EXTRACT_ALL(
-                  -- (1)
-                  TO_JSON_STRING(metrics.labeled_counter.metrics_search_count),
-                  '"value":([^,}]+)'
-                )
-              ),
-              r'"([^"]+)"',
-              r'[0, 0, \1]'
-            )
-          )
-        )
-      ) AS nested_counts
-    FROM
-      `moz-fx-data-shared-prod.org_mozilla_firefox_live.metrics_v1`
-    LEFT JOIN
-      UNNEST(ping_info.experiments) AS experiment
-    WHERE
-    -- Limit the amount of data the materialized view is going to backfill when created.
-    -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-      DATE(submission_timestamp) > '2021-03-12'
-  )
   SELECT
     date(submission_timestamp) AS submission_date,
-    experiment,
-    branch,
+    experiment.key AS experiment,
+    experiment.value.branch AS branch,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
-    -- Aggregates event counts over 5-minute intervals
+        -- Aggregates event counts over 5-minute intervals
       INTERVAL(DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) * 5) MINUTE
     ) AS window_start,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
       INTERVAL((DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) + 1) * 5) MINUTE
     ) AS window_end,
-    -- (5)
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(0)] AS INT64)) AS ad_clicks_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(1)] AS INT64)) AS search_with_ads_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(2)] AS INT64)) AS search_count,
+        -- Concatenating an element with value = 0 ensures that the count values are not null even if the array is empty
+        -- Materialized views don't support COALESCE or IFNULL
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.browser_search_ad_clicks, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS ad_clicks_count,
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.browser_search_with_ads, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS search_with_ads_count,
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.metrics_search_count, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS search_count
   FROM
-    aggregated_arrays,
-    UNNEST(JSON_EXTRACT_ARRAY(REPLACE(nested_counts, '"', ""))) AS counts
+    `moz-fx-data-shared-prod.org_mozilla_firefox_live.metrics_v1`
+  LEFT JOIN
+    UNNEST(ping_info.experiments) AS experiment,
+    -- Max. number of entries is around 10
+    UNNEST(GENERATE_ARRAY(0, 50)) AS i
+  WHERE
+      -- Limit the amount of data the materialized view is going to backfill when created.
+      -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
+    DATE(submission_timestamp) > '2021-04-20'
   GROUP BY
     submission_date,
     experiment,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/experiment_search_events_live_v1/init.sql
@@ -10,81 +10,40 @@ IF
   OPTIONS
     (enable_refresh = TRUE, refresh_interval_minutes = 5)
   AS
-  -- Materialized views do not support sub-queries for UNNESTing fields.
-  -- This limitation prevents summing up individual nested counters.
-  -- As a workaround the nested counters are converted into arrays of counts. The
-  -- conversion is done by a combination of dumping the fields as JSON
-  -- strings, applying regexes and concatenating extracted strings.
-  --
-  -- (1) Dump the nested counter field as JSON string, for example:
-  --     [{"key":"duckduckgo","value":7}, {"key":"google","value":4}]
-  -- (2) Using a regex, extract all values and dump the result array as
-  --     JSON string: ["7", "4"]
-  -- (3) Using regex replace, transform the count numbers in the array
-  --     to an array where the position of the element determines the
-  --     count type [search_ad_clicks, search_with_ads, search_count]:
-  --     "[[7, 0, 0], [4, 0, 0]]"
-  -- (4) Convert the nested array string to an array and concatenate
-  --     nested arrays of ping to a single array and dump as JSON string,
-  --     for example: "[[7, 0, 0], [4, 0, 0], [0, 1, 0], [0, 0, 3]]"
-  --
-  -- (5) Convert the nested array string into an array, unnest and sum
-  --     individual counts based on their array index:
-  --        ad_clicks_count = 11
-  --        search_with_ads_count = 1
-  --        search_count = 3
-  WITH aggregated_arrays AS (
-    SELECT
-      submission_timestamp,
-      experiment.key AS experiment,
-      experiment.value.branch AS branch,
-      -- (4)
-      TO_JSON_STRING(
-        JSON_EXTRACT_ARRAY(
-          -- (3)
-          REGEXP_REPLACE(
-            -- (2)
-            TO_JSON_STRING(
-              REGEXP_EXTRACT_ALL(
-                -- (1)
-                TO_JSON_STRING(metrics.labeled_counter.search_counts),
-                '"value":([^,}]+)'
-              )
-            ),
-            r'"([^"]+)"',
-            r'[0, 0, \1]'
-          )
-        )
-      ) AS nested_counts
-    FROM
-      `moz-fx-data-shared-prod.org_mozilla_ios_firefox_live.metrics_v1`
-    LEFT JOIN
-      UNNEST(ping_info.experiments) AS experiment
-    WHERE
-    -- Limit the amount of data the materialized view is going to backfill when created.
-    -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-      DATE(submission_timestamp) > '2021-04-01'
-  )
   SELECT
     date(submission_timestamp) AS submission_date,
-    experiment,
-    branch,
+    experiment.key AS experiment,
+    experiment.value.branch AS branch,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
-    -- Aggregates event counts over 5-minute intervals
+        -- Aggregates event counts over 5-minute intervals
       INTERVAL(DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) * 5) MINUTE
     ) AS window_start,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
       INTERVAL((DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) + 1) * 5) MINUTE
     ) AS window_end,
-    -- (5)
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(0)] AS INT64)) AS ad_clicks_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(1)] AS INT64)) AS search_with_ads_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(2)] AS INT64)) AS search_count,
+    SUM(0) AS ad_clicks_count,
+    SUM(0) AS search_with_ads_count,
+    -- Concatenating an element with value = 0 ensures that the count values are not null even if the array is empty
+    -- Materialized views don't support COALESCE or IFNULL
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.search_counts, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS search_count
   FROM
-    aggregated_arrays,
-    UNNEST(JSON_EXTRACT_ARRAY(REPLACE(nested_counts, '"', ""))) AS counts
+    `moz-fx-data-shared-prod.org_mozilla_ios_firefox_live.metrics_v1`
+  LEFT JOIN
+    UNNEST(ping_info.experiments) AS experiment,
+    -- Max. number of entries is around 10
+    UNNEST(GENERATE_ARRAY(0, 50)) AS i
+  WHERE
+      -- Limit the amount of data the materialized view is going to backfill when created.
+      -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
+    DATE(submission_timestamp) > '2021-04-20'
   GROUP BY
     submission_date,
     experiment,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/experiment_search_events_live_v1/init.sql
@@ -31,7 +31,7 @@ IF
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.search_counts, [('', 0)])[
           SAFE_OFFSET(i)
-        ].value AS int64
+        ].value AS INT64
       )
     ) AS search_count
   FROM

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/experiment_search_events_live_v1/init.sql
@@ -30,20 +30,21 @@ IF
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.search_counts, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS search_count
   FROM
     `moz-fx-data-shared-prod.org_mozilla_ios_firefox_live.metrics_v1`
   LEFT JOIN
-    UNNEST(ping_info.experiments) AS experiment,
+    UNNEST(ping_info.experiments) AS experiment
+  CROSS JOIN
     -- Max. number of entries is around 10
     UNNEST(GENERATE_ARRAY(0, 50)) AS i
   WHERE
       -- Limit the amount of data the materialized view is going to backfill when created.
       -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-    DATE(submission_timestamp) > '2021-04-20'
+    DATE(submission_timestamp) > '2021-04-25'
   GROUP BY
     submission_date,
     experiment,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/experiment_search_events_live_v1/init.sql
@@ -30,20 +30,21 @@ IF
     SUM(
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.search_counts, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS search_count
   FROM
     `moz-fx-data-shared-prod.org_mozilla_ios_firefoxbeta_live.metrics_v1`
   LEFT JOIN
-    UNNEST(ping_info.experiments) AS experiment,
+    UNNEST(ping_info.experiments) AS experiment
+  CROSS JOIN
     -- Max. number of entries is around 10
     UNNEST(GENERATE_ARRAY(0, 50)) AS i
   WHERE
       -- Limit the amount of data the materialized view is going to backfill when created.
       -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-    DATE(submission_timestamp) > '2021-04-20'
+    DATE(submission_timestamp) > '2021-04-25'
   GROUP BY
     submission_date,
     experiment,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/experiment_search_events_live_v1/init.sql
@@ -31,7 +31,7 @@ IF
       CAST(
         ARRAY_CONCAT(metrics.labeled_counter.search_counts, [('', 0)])[
           SAFE_OFFSET(i)
-        ].value AS int64
+        ].value AS INT64
       )
     ) AS search_count
   FROM

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/experiment_search_events_live_v1/init.sql
@@ -10,81 +10,40 @@ IF
   OPTIONS
     (enable_refresh = TRUE, refresh_interval_minutes = 5)
   AS
-  -- Materialized views do not support sub-queries for UNNESTing fields.
-  -- This limitation prevents summing up individual nested counters.
-  -- As a workaround the nested counters are converted into arrays of counts. The
-  -- conversion is done by a combination of dumping the fields as JSON
-  -- strings, applying regexes and concatenating extracted strings.
-  --
-  -- (1) Dump the nested counter field as JSON string, for example:
-  --     [{"key":"duckduckgo","value":7}, {"key":"google","value":4}]
-  -- (2) Using a regex, extract all values and dump the result array as
-  --     JSON string: ["7", "4"]
-  -- (3) Using regex replace, transform the count numbers in the array
-  --     to an array where the position of the element determines the
-  --     count type [search_ad_clicks, search_with_ads, search_count]:
-  --     "[[7, 0, 0], [4, 0, 0]]"
-  -- (4) Convert the nested array string to an array and concatenate
-  --     nested arrays of ping to a single array and dump as JSON string,
-  --     for example: "[[7, 0, 0], [4, 0, 0], [0, 1, 0], [0, 0, 3]]"
-  --
-  -- (5) Convert the nested array string into an array, unnest and sum
-  --     individual counts based on their array index:
-  --        ad_clicks_count = 11
-  --        search_with_ads_count = 1
-  --        search_count = 3
-  WITH aggregated_arrays AS (
-    SELECT
-      submission_timestamp,
-      experiment.key AS experiment,
-      experiment.value.branch AS branch,
-      -- (4)
-      TO_JSON_STRING(
-        JSON_EXTRACT_ARRAY(
-          -- (3)
-          REGEXP_REPLACE(
-            -- (2)
-            TO_JSON_STRING(
-              REGEXP_EXTRACT_ALL(
-                -- (1)
-                TO_JSON_STRING(metrics.labeled_counter.search_counts),
-                '"value":([^,}]+)'
-              )
-            ),
-            r'"([^"]+)"',
-            r'[0, 0, \1]'
-          )
-        )
-      ) AS nested_counts
-    FROM
-      `moz-fx-data-shared-prod.org_mozilla_ios_firefoxbeta_live.metrics_v1`
-    LEFT JOIN
-      UNNEST(ping_info.experiments) AS experiment
-    WHERE
-    -- Limit the amount of data the materialized view is going to backfill when created.
-    -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-      DATE(submission_timestamp) > '2021-04-15'
-  )
   SELECT
     date(submission_timestamp) AS submission_date,
-    experiment,
-    branch,
+    experiment.key AS experiment,
+    experiment.value.branch AS branch,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
-    -- Aggregates event counts over 5-minute intervals
+        -- Aggregates event counts over 5-minute intervals
       INTERVAL(DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) * 5) MINUTE
     ) AS window_start,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
       INTERVAL((DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) + 1) * 5) MINUTE
     ) AS window_end,
-    -- (5)
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(0)] AS INT64)) AS ad_clicks_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(1)] AS INT64)) AS search_with_ads_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(2)] AS INT64)) AS search_count,
+    SUM(0) AS ad_clicks_count,
+    SUM(0) AS search_with_ads_count,
+    -- Concatenating an element with value = 0 ensures that the count values are not null even if the array is empty
+    -- Materialized views don't support COALESCE or IFNULL
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.search_counts, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS search_count
   FROM
-    aggregated_arrays,
-    UNNEST(JSON_EXTRACT_ARRAY(REPLACE(nested_counts, '"', ""))) AS counts
+    `moz-fx-data-shared-prod.org_mozilla_ios_firefoxbeta_live.metrics_v1`
+  LEFT JOIN
+    UNNEST(ping_info.experiments) AS experiment,
+    -- Max. number of entries is around 10
+    UNNEST(GENERATE_ARRAY(0, 50)) AS i
+  WHERE
+      -- Limit the amount of data the materialized view is going to backfill when created.
+      -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
+    DATE(submission_timestamp) > '2021-04-20'
   GROUP BY
     submission_date,
     experiment,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_events_live_v1/init.sql
@@ -4,134 +4,75 @@ IF
   OPTIONS
     (enable_refresh = TRUE, refresh_interval_minutes = 5)
   AS
-    -- Materialized views do not support sub-queries for UNNESTing fields.
-  -- This limitation prevents summing up individual nested counters.
-  -- As a workaround the nested counters are converted into arrays of counts. The
-  -- conversion is done by a combination of dumping the fields as JSON
-  -- strings, applying regexes and concatenating extracted strings.
-  --
-  -- (1) Dump the nested counter field as JSON string, for example:
-  --     [{"key":"duckduckgo","value":7}, {"key":"google","value":4}]
-  -- (2) Using a regex, extract all values and dump the result array as
-  --     JSON string: ["7", "4"]
-  -- (3) Using regex replace, transform the count numbers in the array
-  --     to an array where the position of the element determines the
-  --     count type [search_ad_clicks, search_with_ads, search_count]:
-  --     "[[7, 0, 0], [4, 0, 0]]"
-  -- (4) Convert the nested array string to an array and concatenate
-  --     nested arrays of ping to a single array and dump as JSON string,
-  --     for example: "[[7, 0, 0], [4, 0, 0], [0, 1, 0], [0, 0, 3]]"
-  --
-  -- (5) Convert the nested array string into an array, unnest and sum
-  --     individual counts based on their array index:
-  --        ad_clicks_count = 11
-  --        search_with_ads_count = 1
-  --        search_count = 3
-  WITH aggregated_arrays AS (
-    SELECT
-      submission_timestamp,
-      experiment.key AS experiment,
-      experiment.value.branch AS branch,
-      -- (4)
-      TO_JSON_STRING(
-        ARRAY_CONCAT(
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              TO_JSON_STRING(
-                REGEXP_EXTRACT_ALL(
-                  -- (1)
-                  TO_JSON_STRING(payload.processes.parent.keyed_scalars.browser_search_ad_clicks),
-                  '"value":([^,}]+)'
-                )
-              ),
-              r'"([^"]+)"',
-              r'[\1, 0, 0]'
-            )
-          ),
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              TO_JSON_STRING(
-                REGEXP_EXTRACT_ALL(
-                  -- (1)
-                  TO_JSON_STRING(payload.processes.parent.keyed_scalars.browser_search_with_ads),
-                  '"value":([^,}]+)'
-                )
-              ),
-              r'"([^"]+)"',
-              r'[0, \1, 0]'
-            )
-          ),
-          JSON_EXTRACT_ARRAY(
-            -- (3)
-            REGEXP_REPLACE(
-              -- (2)
-              CONCAT(
-                TO_JSON_STRING(
-                  ARRAY_CONCAT(
-                    -- extract sum from histogram
-                    -- acount for compact and JSON histograms
-                    REGEXP_EXTRACT_ALL(
-                      -- (1)
-                      TO_JSON_STRING(payload.keyed_histograms.search_counts),
-                      r'\\"sum\\":([^},]+)'
-                    ),
-                    REGEXP_EXTRACT_ALL(
-                      -- (1)
-                      TO_JSON_STRING(payload.keyed_histograms.search_counts),
-                      r'"value":"(\d+)"'
-                    ),
-                    REGEXP_EXTRACT_ALL(
-                      -- (1)
-                      TO_JSON_STRING(payload.keyed_histograms.search_counts),
-                      r'"value":"\d+;(\d+);'
-                    ),
-                    REGEXP_EXTRACT_ALL(
-                      -- (1)
-                      TO_JSON_STRING(payload.keyed_histograms.search_counts),
-                      r'"value":"(\d+),\d+"'
-                    )
-                  )
-                )
-              ),
-              r'"([^"]+)"',
-              r'[0, 0, \1]'
-            )
-          )
-        )
-      ) AS nested_counts
-    FROM
-      `moz-fx-data-shared-prod.telemetry_live.main_v4`
-    LEFT JOIN
-      UNNEST(environment.experiments) AS experiment
-    WHERE
-    -- Limit the amount of data the materialized view is going to backfill when created.
-    -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-      DATE(submission_timestamp) > '2021-03-12'
-  )
   SELECT
     date(submission_timestamp) AS submission_date,
-    experiment,
-    branch,
+    experiment.key AS experiment,
+    experiment.value.branch AS branch,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
-    -- Aggregates event counts over 5-minute intervals
+        -- Aggregates event counts over 5-minute intervals
       INTERVAL(DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) * 5) MINUTE
     ) AS window_start,
     TIMESTAMP_ADD(
       TIMESTAMP_TRUNC(submission_timestamp, HOUR),
       INTERVAL((DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) + 1) * 5) MINUTE
     ) AS window_end,
-    -- (5)
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(0)] AS INT64)) AS ad_clicks_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(1)] AS INT64)) AS search_with_ads_count,
-    SUM(CAST(JSON_EXTRACT_ARRAY(counts)[OFFSET(2)] AS INT64)) AS search_count,
+        -- Concatenating an element with value = 0 ensures that the count values are not null even if the array is empty
+        -- Materialized views don't support COALESCE or IFNULL
+    SUM(
+      CAST(
+        ARRAY_CONCAT(payload.processes.parent.keyed_scalars.browser_search_ad_clicks, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS ad_clicks_count,
+    SUM(
+      CAST(
+        ARRAY_CONCAT(payload.processes.parent.keyed_scalars.browser_search_with_ads, [('', 0)])[
+          safe_offset(i)
+        ].value AS int64
+      )
+    ) AS search_with_ads_count,
+    SUM(
+      [
+        CAST(
+          REGEXP_EXTRACT(
+            payload.keyed_histograms.search_counts[safe_offset(i)].value,
+            r'"sum":([^},]+)'
+          ) AS int64
+        ),
+        CAST(
+          REGEXP_EXTRACT(
+            payload.keyed_histograms.search_counts[safe_offset(i)].value,
+            r'^"(\d+)"$'
+          ) AS int64
+        ),
+        CAST(
+          REGEXP_EXTRACT(
+            payload.keyed_histograms.search_counts[safe_offset(i)].value,
+            r'^"\d+;(\d+);'
+          ) AS int64
+        ),
+        CAST(
+          REGEXP_EXTRACT(
+            payload.keyed_histograms.search_counts[safe_offset(i)].value,
+            r'^"(\d+),\d+"'
+          ) AS int64
+        ),
+        0
+      ][SAFE_OFFSET(j)]
+    ) AS search_count
   FROM
-    aggregated_arrays,
-    UNNEST(JSON_EXTRACT_ARRAY(REPLACE(nested_counts, '"', ""))) AS counts
+    `moz-fx-data-shared-prod.telemetry_live.main_v4`
+  LEFT JOIN
+    UNNEST(environment.experiments) AS experiment,
+    -- Max. number of entries is around 10
+    UNNEST(GENERATE_ARRAY(0, 50)) AS i,
+    UNNEST(GENERATE_ARRAY(0, 5)) AS j
+  WHERE
+      -- Limit the amount of data the materialized view is going to backfill when created.
+      -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
+    DATE(submission_timestamp) > '2021-04-20'
   GROUP BY
     submission_date,
     experiment,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_events_live_v1/init.sql
@@ -22,14 +22,14 @@ IF
     SUM(
       CAST(
         ARRAY_CONCAT(payload.processes.parent.keyed_scalars.browser_search_ad_clicks, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS ad_clicks_count,
     SUM(
       CAST(
         ARRAY_CONCAT(payload.processes.parent.keyed_scalars.browser_search_with_ads, [('', 0)])[
-          safe_offset(i)
+          SAFE_OFFSET(i)
         ].value AS int64
       )
     ) AS search_with_ads_count,
@@ -37,25 +37,25 @@ IF
       [
         CAST(
           REGEXP_EXTRACT(
-            payload.keyed_histograms.search_counts[safe_offset(i)].value,
+            payload.keyed_histograms.search_counts[SAFE_OFFSET(i)].value,
             r'"sum":([^},]+)'
           ) AS int64
         ),
         CAST(
           REGEXP_EXTRACT(
-            payload.keyed_histograms.search_counts[safe_offset(i)].value,
+            payload.keyed_histograms.search_counts[SAFE_OFFSET(i)].value,
             r'^"(\d+)"$'
           ) AS int64
         ),
         CAST(
           REGEXP_EXTRACT(
-            payload.keyed_histograms.search_counts[safe_offset(i)].value,
+            payload.keyed_histograms.search_counts[SAFE_OFFSET(i)].value,
             r'^"\d+;(\d+);'
           ) AS int64
         ),
         CAST(
           REGEXP_EXTRACT(
-            payload.keyed_histograms.search_counts[safe_offset(i)].value,
+            payload.keyed_histograms.search_counts[SAFE_OFFSET(i)].value,
             r'^"(\d+),\d+"'
           ) AS int64
         ),
@@ -65,14 +65,16 @@ IF
   FROM
     `moz-fx-data-shared-prod.telemetry_live.main_v4`
   LEFT JOIN
-    UNNEST(environment.experiments) AS experiment,
+    UNNEST(environment.experiments) AS experiment
+  CROSS JOIN
     -- Max. number of entries is around 10
-    UNNEST(GENERATE_ARRAY(0, 50)) AS i,
+    UNNEST(GENERATE_ARRAY(0, 50)) AS i
+  CROSS JOIN
     UNNEST(GENERATE_ARRAY(0, 5)) AS j
   WHERE
       -- Limit the amount of data the materialized view is going to backfill when created.
       -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
-    DATE(submission_timestamp) > '2021-04-20'
+    DATE(submission_timestamp) > '2021-04-25'
   GROUP BY
     submission_date,
     experiment,


### PR DESCRIPTION
Using the workaround for `TO_JSON_STRING` of generating an array of indices works well for our `experiment_search_events_live_v1` materialized views. If I do the same for the `experiment_events_live_v1` materialized views I still run into the issue where `branch` is set to the `experiment` slug. So for now we have to keep using `TO_JSON_STRING` there.

For reference, this is basically the query I tried (shortened here) that returned the incorrect result:
```sql
CREATE MATERIALIZED VIEW
  AS
  SELECT
      submission_timestamp AS `timestamp`,
      event.category AS `type`,
      CAST(event.extra[safe_offset(i)].value as STRING) AS branch,  -- still set to the experiment slug
      CAST(event.extra[safe_offset(j)].value as STRING) AS experiment,
      event.name AS event_method
    FROM
      fenix_all_events,
      UNNEST(events) AS event,
      UNNEST(GENERATE_ARRAY(0, 100)) as i,
      UNNEST(GENERATE_ARRAY(0, 100)) as j
    WHERE
      event.category = 'nimbus_events' AND
      CAST(event.extra[safe_offset(i)].key as STRING) = 'branch' AND
      CAST(event.extra[safe_offset(j)].key as STRING) = 'experiment'
```