### PR TITLE
Bug 1707395 Don't publish views when running glean_usage

### DIFF
--- a/bigquery_etl/glean_usage/baseline_clients_daily.py
+++ b/bigquery_etl/glean_usage/baseline_clients_daily.py
@@ -79,8 +79,6 @@ def run_query(
     job = client.query(sql, job_config)
     if not dry_run:
         job.result()
-        logging.info(f"Recreating view {daily_view}")
-        client.query(view_sql, bigquery.QueryJobConfig(use_legacy_sql=False)).result()
 
 
 if __name__ == "__main__":

--- a/bigquery_etl/glean_usage/baseline_clients_first_seen.py
+++ b/bigquery_etl/glean_usage/baseline_clients_first_seen.py
@@ -93,8 +93,6 @@ def run_query(
     job = client.query(sql, job_config)
     if not dry_run:
         job.result()
-        logging.info(f"Recreating view {view_id}")
-        client.query(view_sql, bigquery.QueryJobConfig(use_legacy_sql=False)).result()
 
 
 if __name__ == "__main__":

--- a/bigquery_etl/glean_usage/baseline_clients_last_seen.py
+++ b/bigquery_etl/glean_usage/baseline_clients_last_seen.py
@@ -85,8 +85,6 @@ def run_query(
     job = client.query(sql, job_config)
     if not dry_run:
         job.result()
-        logging.info(f"Recreating view {last_seen_view}")
-        client.query(view_sql, bigquery.QueryJobConfig(use_legacy_sql=False)).result()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Originally, the only way views got published for `baseline_clients_*` tables
was as part of the query runs, but we have since implemented the `output-only`
option and integrated that into `script/generate-sql`, so these views will
get created and updated with normal view publishing runs.

Thus, we no longer need to publish the views along with the queries, which
removes a circular dependency problem we have right now between clients_daily
and clients_first_seen when we first create a new Glean app.