### PR TITLE
Bug 1707921 - Fix missing event property values

### DIFF
--- a/bigquery_etl/events_daily/query_templates/event_types_history_v1/query.sql
+++ b/bigquery_etl/events_daily/query_templates/event_types_history_v1/query.sql
@@ -166,10 +166,12 @@ new_event_property_value_indices AS (
         event_types,
         UNNEST(event_properties) AS existing_event_property,
         UNNEST(value) AS values
-    ) AS event_types
+    ) AS existing_event_type_values
   ON
-    event_property.key = event_types.existing_event_property.key
-    AND event_property.value = event_types.values.key
+    current_events.category = existing_event_type_values.category
+    AND current_events.event = existing_event_type_values.event
+    AND event_property.key = existing_event_type_values.existing_event_property.key
+    AND event_property.value = existing_event_type_values.values.key
   JOIN
     all_event_property_indices
   ON
@@ -177,7 +179,7 @@ new_event_property_value_indices AS (
     AND all_event_property_indices.event = current_events.event
     AND all_event_property_indices.event_property = event_property.key
   WHERE
-    event_types.event IS NULL
+    existing_event_type_values.event IS NULL
   GROUP BY
     category,
     event,

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/event_types_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/event_types_history_v1/query.sql
@@ -157,10 +157,12 @@ new_event_property_value_indices AS (
         event_types,
         UNNEST(event_properties) AS existing_event_property,
         UNNEST(value) AS values
-    ) AS event_types
+    ) AS existing_event_type_values
   ON
-    event_property.key = event_types.existing_event_property.key
-    AND event_property.value = event_types.values.key
+    current_events.category = existing_event_type_values.category
+    AND current_events.event = existing_event_type_values.event
+    AND event_property.key = existing_event_type_values.existing_event_property.key
+    AND event_property.value = existing_event_type_values.values.key
   JOIN
     all_event_property_indices
   ON
@@ -168,7 +170,7 @@ new_event_property_value_indices AS (
     AND all_event_property_indices.event = current_events.event
     AND all_event_property_indices.event_property = event_property.key
   WHERE
-    event_types.event IS NULL
+    existing_event_type_values.event IS NULL
   GROUP BY
     category,
     event,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/event_types_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/event_types_history_v1/query.sql
@@ -163,10 +163,12 @@ new_event_property_value_indices AS (
         event_types,
         UNNEST(event_properties) AS existing_event_property,
         UNNEST(value) AS values
-    ) AS event_types
+    ) AS existing_event_type_values
   ON
-    event_property.key = event_types.existing_event_property.key
-    AND event_property.value = event_types.values.key
+    current_events.category = existing_event_type_values.category
+    AND current_events.event = existing_event_type_values.event
+    AND event_property.key = existing_event_type_values.existing_event_property.key
+    AND event_property.value = existing_event_type_values.values.key
   JOIN
     all_event_property_indices
   ON
@@ -174,7 +176,7 @@ new_event_property_value_indices AS (
     AND all_event_property_indices.event = current_events.event
     AND all_event_property_indices.event_property = event_property.key
   WHERE
-    event_types.event IS NULL
+    existing_event_type_values.event IS NULL
   GROUP BY
     category,
     event,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_history_v1/query.sql
@@ -157,10 +157,12 @@ new_event_property_value_indices AS (
         event_types,
         UNNEST(event_properties) AS existing_event_property,
         UNNEST(value) AS values
-    ) AS event_types
+    ) AS existing_event_type_values
   ON
-    event_property.key = event_types.existing_event_property.key
-    AND event_property.value = event_types.values.key
+    current_events.category = existing_event_type_values.category
+    AND current_events.event = existing_event_type_values.event
+    AND event_property.key = existing_event_type_values.existing_event_property.key
+    AND event_property.value = existing_event_type_values.values.key
   JOIN
     all_event_property_indices
   ON
@@ -168,7 +170,7 @@ new_event_property_value_indices AS (
     AND all_event_property_indices.event = current_events.event
     AND all_event_property_indices.event_property = event_property.key
   WHERE
-    event_types.event IS NULL
+    existing_event_type_values.event IS NULL
   GROUP BY
     category,
     event,

--- a/tests/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/event_types_history_v1/test_new_day/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/event_types_history_v1/test_new_day/expect.yaml
@@ -53,8 +53,14 @@
   numeric_index: 3
   index: "\U00000003"
   event_properties:
-    - key: third_event_prop
+    - key: first_property
       index: 1
+      value:
+        - key: first_property_value_1
+          index: 1
+          value: "\U00000001"
+    - key: third_event_prop
+      index: 2
       value:
         - key: third_event_prop_value_1
           index: 1

--- a/tests/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/event_types_history_v1/test_new_day/org_mozilla_firefox.events.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/event_types_history_v1/test_new_day/org_mozilla_firefox.events.yaml
@@ -18,6 +18,8 @@
       extra:
         - key: third_event_prop
           value: third_event_prop_value_1
+        - key: first_property
+          value: first_property_value_1
     - timestamp: 3000
       name: second_event
       category: second_category


### PR DESCRIPTION
Some event property values were not showing up in the
event_types_history_v1 table. This was because the join
was only on property and value, so when multiple events
shared properties, only one of those events would be
able to use it.

