### PR TITLE
Bug 1708111 - Trim whitespace from addon_id in amo_prod queries

### DIFF
--- a/sql/moz-fx-data-shared-prod/amo_prod/desktop_addons_by_client_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/amo_prod/desktop_addons_by_client_v1/query.sql
@@ -27,10 +27,10 @@ WITH per_client AS (
       -- Previous logic in https://github.com/mozilla/bigquery-etl/blob/55a429924beee3c31aca4fee0063d655f1d527f2/sql/amo_prod/desktop_addons_by_client_v1/query.sql
       ARRAY(
         SELECT AS STRUCT
-          decode_uri_component(REGEXP_EXTRACT(addon, "(.+):")) AS id,
-          REGEXP_EXTRACT(addon, ":(.+)") AS version
+          decode_uri_component(REGEXP_EXTRACT(TRIM(addon), "(.+):")) AS id,
+          REGEXP_EXTRACT(TRIM(addon), ":(.+)") AS version
         FROM
-          UNNEST(SPLIT(payload.info.addons)) AS addon
+          UNNEST(SPLIT(payload.info.addons, ",")) AS addon
       )
       ORDER BY
         submission_timestamp

--- a/sql/moz-fx-data-shared-prod/amo_prod/fenix_addons_by_client_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/amo_prod/fenix_addons_by_client_v1/query.sql
@@ -85,7 +85,7 @@ SELECT
   * EXCEPT (addons),
   ARRAY(
     SELECT AS STRUCT
-      addon,
+      TRIM(addon) AS addon,
       -- As of 2020-07-01, the metrics ping from Fenix contains no data about
       -- the version of installed addons, so we inject null and replace with
       -- an appropriate placeholder value when we get to the app-facing view.
@@ -93,7 +93,7 @@ SELECT
     FROM
       UNNEST(addons) AS addon
     GROUP BY
-      addon
+      TRIM(addon)
   ) AS addons
 FROM
   per_client


### PR DESCRIPTION
There was a change in the formatting logic in Fenix that introduced spaces.
See https://github.com/mozilla-mobile/fenix/pull/18529#discussion_r621903980

We also add TRIM logic to the desktop query for similar protection.

cc @willdurand 