### PR TITLE
Bug 1708264 - Add initial support for dataset_metadata.yaml

### DIFF
--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -335,15 +335,10 @@ class DatasetMetadata:
 
     @classmethod
     def from_file(cls, metadata_file):
-        """Parse dataset metadata from the provided file and create a new
-        DatasetMetadata instance."""
-        friendly_name = None
-        description = None
-        owners = []
-        labels = {}
-        scheduling = {}
-        bigquery = None
+        """Parse dataset metadata from the provided file.
 
+        Returns a new DatasetMetadata instance.
+        """
         with open(metadata_file, "r") as yaml_stream:
             try:
                 metadata = yaml.safe_load(yaml_stream)

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 
 from ..util import standard_args
 from ..util.common import project_dirs
-from .parse_metadata import Metadata
+from .parse_metadata import Metadata, DatasetMetadata
 
 parser = ArgumentParser(description=__doc__)
 
@@ -35,7 +35,7 @@ def validate(target):
         for root, dirs, files in os.walk(target):
             for file in files:
                 if Metadata.is_metadata_file(file):
-                    path = os.path.join(root, *dirs, file)
+                    path = os.path.join(root, file)
                     metadata = Metadata.from_file(path)
 
                     if not validate_public_data(metadata, path):
@@ -43,6 +43,25 @@ def validate(target):
 
                     # todo more validation
                     # e.g. https://github.com/mozilla/bigquery-etl/issues/924
+
+    else:
+        logging.error(f"Invalid target: {target}, target must be a directory.")
+        sys.exit(1)
+
+    if failed:
+        sys.exit(1)
+
+
+def validate_datasets(target):
+    """Validate dataset metadata files."""
+    failed = False
+
+    if os.path.isdir(target):
+        for root, dirs, files in os.walk(target):
+            for file in files:
+                if DatasetMetadata.is_dataset_metadata_file(file):
+                    path = os.path.join(root, file)
+                    dataset_metadata = DatasetMetadata.from_file(path)
     else:
         logging.error(f"Invalid target: {target}, target must be a directory.")
         sys.exit(1)

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -61,7 +61,7 @@ def validate_datasets(target):
             for file in files:
                 if DatasetMetadata.is_dataset_metadata_file(file):
                     path = os.path.join(root, file)
-                    dataset_metadata = DatasetMetadata.from_file(path)
+                    _ = DatasetMetadata.from_file(path)
     else:
         logging.error(f"Invalid target: {target}, target must be a directory.")
         sys.exit(1)

--- a/sql/moz-fx-data-shared-prod/activity_stream/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Activity Stream
+description: |-
+  Views related to data from the activity-stream namespace,
+  capturing activity on the desktop Firefox newtab page.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/dataset_metadata.yaml
@@ -3,7 +3,7 @@ description: |-
   Derived data from the activity-stream namespace,
   made available for Pocket's BI tools.
 dataset_base_acl: stable
-user_facing: true
+user_facing: false
 labels: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/dataset_metadata.yaml
@@ -1,0 +1,12 @@
+friendly_name: Activity Stream BI
+description: |-
+  Derived data from the activity-stream namespace,
+  made available for Pocket's BI tools.
+dataset_base_acl: stable
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+  - workgroup:pocket/external

--- a/sql/moz-fx-data-shared-prod/activity_stream_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_derived/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Activity Stream
+description: |-
+  Derived data from the activity-stream namespace,
+  capturing activity on the desktop Firefox newtab page.
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/tests/cli/test_cli_query.py
+++ b/tests/cli/test_cli_query.py
@@ -35,7 +35,7 @@ class TestQuery:
             result = runner.invoke(create, ["test.test_query"])
             assert result.exit_code == 0
             assert os.listdir("sql/moz-fx-data-shared-prod") == ["test"]
-            assert os.listdir("sql/moz-fx-data-shared-prod/test") == [
+            assert sorted(os.listdir("sql/moz-fx-data-shared-prod/test")) == [
                 "dataset_metadata.yaml",
                 "test_query_v1",
             ]
@@ -51,7 +51,7 @@ class TestQuery:
             os.makedirs("sql/moz-fx-data-shared-prod")
             result = runner.invoke(create, ["test.test_query_v4"])
             assert result.exit_code == 0
-            assert os.listdir("sql/moz-fx-data-shared-prod/test") == [
+            assert sorted(os.listdir("sql/moz-fx-data-shared-prod/test")) == [
                 "dataset_metadata.yaml",
                 "test_query_v4",
             ]
@@ -63,11 +63,11 @@ class TestQuery:
             assert result.exit_code == 0
             assert "test_derived" in os.listdir("sql/moz-fx-data-shared-prod")
             assert "test" in os.listdir("sql/moz-fx-data-shared-prod")
-            assert os.listdir("sql/moz-fx-data-shared-prod/test_derived") == [
+            assert sorted(os.listdir("sql/moz-fx-data-shared-prod/test_derived")) == [
                 "dataset_metadata.yaml",
-                "test_query_v1"
+                "test_query_v1",
             ]
-            assert os.listdir("sql/moz-fx-data-shared-prod/test") == [
+            assert sorted(os.listdir("sql/moz-fx-data-shared-prod/test")) == [
                 "dataset_metadata.yaml",
                 "test_query",
             ]
@@ -84,11 +84,11 @@ class TestQuery:
             assert result.exit_code == 0
             assert "test_derived" in os.listdir("sql/moz-fx-data-shared-prod")
             assert "test" in os.listdir("sql/moz-fx-data-shared-prod")
-            assert os.listdir("sql/moz-fx-data-shared-prod/test_derived") == [
+            assert sorted(os.listdir("sql/moz-fx-data-shared-prod/test_derived")) == [
                 "dataset_metadata.yaml",
                 "test_query_v1",
             ]
-            assert os.listdir("sql/moz-fx-data-shared-prod/test") == [
+            assert sorted(os.listdir("sql/moz-fx-data-shared-prod/test")) == [
                 "dataset_metadata.yaml",
                 "test_query",
             ]
@@ -101,7 +101,7 @@ class TestQuery:
             os.makedirs("sql/moz-fx-data-shared-prod")
             result = runner.invoke(create, ["test.test_query", "--init"])
             assert result.exit_code == 0
-            assert os.listdir("sql/moz-fx-data-shared-prod/test") == [
+            assert sorted(os.listdir("sql/moz-fx-data-shared-prod/test")) == [
                 "dataset_metadata.yaml",
                 "test_query_v1",
             ]

--- a/tests/cli/test_cli_query.py
+++ b/tests/cli/test_cli_query.py
@@ -35,7 +35,10 @@ class TestQuery:
             result = runner.invoke(create, ["test.test_query"])
             assert result.exit_code == 0
             assert os.listdir("sql/moz-fx-data-shared-prod") == ["test"]
-            assert os.listdir("sql/moz-fx-data-shared-prod/test") == ["test_query_v1"]
+            assert os.listdir("sql/moz-fx-data-shared-prod/test") == [
+                "dataset_metadata.yaml",
+                "test_query_v1",
+            ]
             assert "query.sql" in os.listdir(
                 "sql/moz-fx-data-shared-prod/test/test_query_v1"
             )
@@ -48,7 +51,10 @@ class TestQuery:
             os.makedirs("sql/moz-fx-data-shared-prod")
             result = runner.invoke(create, ["test.test_query_v4"])
             assert result.exit_code == 0
-            assert os.listdir("sql/moz-fx-data-shared-prod/test") == ["test_query_v4"]
+            assert os.listdir("sql/moz-fx-data-shared-prod/test") == [
+                "dataset_metadata.yaml",
+                "test_query_v4",
+            ]
 
     def test_create_derived_query_with_view(self, runner):
         with runner.isolated_filesystem():
@@ -58,9 +64,13 @@ class TestQuery:
             assert "test_derived" in os.listdir("sql/moz-fx-data-shared-prod")
             assert "test" in os.listdir("sql/moz-fx-data-shared-prod")
             assert os.listdir("sql/moz-fx-data-shared-prod/test_derived") == [
+                "dataset_metadata.yaml",
                 "test_query_v1"
             ]
-            assert os.listdir("sql/moz-fx-data-shared-prod/test") == ["test_query"]
+            assert os.listdir("sql/moz-fx-data-shared-prod/test") == [
+                "dataset_metadata.yaml",
+                "test_query",
+            ]
             assert os.listdir("sql/moz-fx-data-shared-prod/test/test_query") == [
                 "view.sql"
             ]
@@ -75,9 +85,13 @@ class TestQuery:
             assert "test_derived" in os.listdir("sql/moz-fx-data-shared-prod")
             assert "test" in os.listdir("sql/moz-fx-data-shared-prod")
             assert os.listdir("sql/moz-fx-data-shared-prod/test_derived") == [
-                "test_query_v1"
+                "dataset_metadata.yaml",
+                "test_query_v1",
             ]
-            assert os.listdir("sql/moz-fx-data-shared-prod/test") == ["test_query"]
+            assert os.listdir("sql/moz-fx-data-shared-prod/test") == [
+                "dataset_metadata.yaml",
+                "test_query",
+            ]
             assert os.listdir("sql/moz-fx-data-shared-prod/test/test_query") == [
                 "view.sql"
             ]
@@ -87,7 +101,10 @@ class TestQuery:
             os.makedirs("sql/moz-fx-data-shared-prod")
             result = runner.invoke(create, ["test.test_query", "--init"])
             assert result.exit_code == 0
-            assert os.listdir("sql/moz-fx-data-shared-prod/test") == ["test_query_v1"]
+            assert os.listdir("sql/moz-fx-data-shared-prod/test") == [
+                "dataset_metadata.yaml",
+                "test_query_v1",
+            ]
             assert "query.sql" in os.listdir(
                 "sql/moz-fx-data-shared-prod/test/test_query_v1"
             )


### PR DESCRIPTION
This adds the machinery to create `dataset_metadata.yaml` as part of
`bqetl query create` and to validate that these files are valid, but these
are not yet actually used for anything.

The next step will be to fill out `dataset_metadata.yaml` for all
existing derived and user-facing datasets.