### PR TITLE
Bug 1708264 - Generate dataset metadata

### DIFF
--- a/bigquery_etl/view/generate_stable_views.py
+++ b/bigquery_etl/view/generate_stable_views.py
@@ -132,7 +132,7 @@ def write_dataset_metadata_if_not_exists(
             description=(
                 f"Derived tables related to document namespace"
                 f" {schema.document_namespace},"
-                f"\nnusually populated via queries defined in"
+                f" usually populated via queries defined in"
                 f" https://github.com/mozilla/bigquery-etl"
                 f" and managed by Airflow"
             ),
@@ -150,7 +150,7 @@ def write_dataset_metadata_if_not_exists(
             friendly_name=dataset_name,
             description=(
                 f"User-facing views related to document namespace"
-                f" {schema.document_namespace};\nsee https://github.com/"
+                f" {schema.document_namespace}; see https://github.com/"
                 f"mozilla-services/mozilla-pipeline-schemas/tree/"
                 f"generated-schemas/schemas/{schema.document_namespace}"
             ),

--- a/bigquery_etl/view/generate_stable_views.py
+++ b/bigquery_etl/view/generate_stable_views.py
@@ -110,7 +110,9 @@ class SchemaFile:
         )
 
 
-def write_dataset_metadata_if_not_exists(target_project: str, sql_dir: Path, schema: SchemaFile):
+def write_dataset_metadata_if_not_exists(
+    target_project: str, sql_dir: Path, schema: SchemaFile
+):
     """Write default dataset_metadata.yaml files where none exist."""
     dataset_family = schema.bq_dataset_family
     project_dir = sql_dir / target_project
@@ -123,10 +125,13 @@ def write_dataset_metadata_if_not_exists(target_project: str, sql_dir: Path, sch
         print(f"Creating {target}")
         DatasetMetadata(
             friendly_name=dataset_name,
-            description=(f"Derived tables related to document namespace"
-                         f"{schema.document_namespace}, usually populated via queries"
-                         f" defined in https://github.com/mozilla/bigquery-etl"
-                         " and managed by Airflow"),
+            description=(
+                f"Derived tables related to document namespace"
+                f" {schema.document_namespace},"
+                f"\nnusually populated via queries defined in"
+                f" https://github.com/mozilla/bigquery-etl"
+                f" and managed by Airflow"
+            ),
             dataset_base_acl="derived",
             user_facing=False,
         ).write(target)
@@ -139,10 +144,12 @@ def write_dataset_metadata_if_not_exists(target_project: str, sql_dir: Path, sch
         print(f"Creating {target}")
         DatasetMetadata(
             friendly_name=dataset_name,
-            description=(f"User-facing views related to document namespace"
-                         f" {schema.document_namesspace};\nsee https://github.com/"
-                         f"mozilla-services/mozilla-pipeline-schemas/tree/"
-                         f"generated-schemas/schemas/{schema.document_namespace}"),
+            description=(
+                f"User-facing views related to document namespace"
+                f" {schema.document_namespace};\nsee https://github.com/"
+                f"mozilla-services/mozilla-pipeline-schemas/tree/"
+                f"generated-schemas/schemas/{schema.document_namespace}"
+            ),
             dataset_base_acl="view",
             user_facing=True,
         ).write(target)
@@ -292,8 +299,7 @@ def main():
     schemas = get_stable_table_schemas()
     dataset_families = set([s.bq_dataset_family for s in schemas])
     one_schema_per_dataset = [
-        last
-        for k, (*_, last) in groupby(schemas, lambda t: t.bq_dataset_family)
+        last for k, (*_, last) in groupby(schemas, lambda t: t.bq_dataset_family)
     ]
 
     with ThreadPool(args.parallelism) as pool:

--- a/bigquery_etl/view/generate_stable_views.py
+++ b/bigquery_etl/view/generate_stable_views.py
@@ -128,7 +128,7 @@ def write_dataset_metadata_if_not_exists(
     if not target.exists():
         print(f"Creating {target}")
         DatasetMetadata(
-            friendly_name=dataset_name,
+            friendly_name=f"{schema.document_namespace} Derived",
             description=(
                 f"Derived tables related to document namespace"
                 f" {schema.document_namespace},"
@@ -147,7 +147,7 @@ def write_dataset_metadata_if_not_exists(
     if not target.exists():
         print(f"Creating {target}")
         DatasetMetadata(
-            friendly_name=dataset_name,
+            friendly_name=f"{schema.document_namespace}",
             description=(
                 f"User-facing views related to document namespace"
                 f" {schema.document_namespace}; see https://github.com/"

--- a/bigquery_etl/view/generate_stable_views.py
+++ b/bigquery_etl/view/generate_stable_views.py
@@ -123,7 +123,10 @@ def write_dataset_metadata_if_not_exists(target_project: str, sql_dir: Path, sch
         print(f"Creating {target}")
         DatasetMetadata(
             friendly_name=dataset_name,
-            description=f"Derived tables related to namespace {schema.document_namespace}",
+            description=(f"Derived tables related to document namespace"
+                         f"{schema.document_namespace}, usually populated via queries"
+                         f" defined in https://github.com/mozilla/bigquery-etl"
+                         " and managed by Airflow"),
             dataset_base_acl="derived",
             user_facing=False,
         ).write(target)
@@ -136,7 +139,10 @@ def write_dataset_metadata_if_not_exists(target_project: str, sql_dir: Path, sch
         print(f"Creating {target}")
         DatasetMetadata(
             friendly_name=dataset_name,
-            description=f"Data related to namespace {schema.document_namespace}",
+            description=(f"User-facing views related to document namespace"
+                         f" {schema.document_namesspace};\nsee https://github.com/"
+                         f"mozilla-services/mozilla-pipeline-schemas/tree/"
+                         f"generated-schemas/schemas/{schema.document_namespace}"),
             dataset_base_acl="view",
             user_facing=True,
         ).write(target)

--- a/bigquery_etl/view/generate_stable_views.py
+++ b/bigquery_etl/view/generate_stable_views.py
@@ -113,7 +113,11 @@ class SchemaFile:
 def write_dataset_metadata_if_not_exists(
     target_project: str, sql_dir: Path, schema: SchemaFile
 ):
-    """Write default dataset_metadata.yaml files where none exist."""
+    """Write default dataset_metadata.yaml files where none exist.
+
+    This function expects to be handed one representative `SchemaFile`
+    object representing the dataset.
+    """
     dataset_family = schema.bq_dataset_family
     project_dir = sql_dir / target_project
 
@@ -297,7 +301,6 @@ def main():
         parser.error(f"argument --log-level: {e}")
 
     schemas = get_stable_table_schemas()
-    dataset_families = set([s.bq_dataset_family for s in schemas])
     one_schema_per_dataset = [
         last for k, (*_, last) in groupby(schemas, lambda t: t.bq_dataset_family)
     ]

--- a/sql/moz-fx-data-shared-prod/activity_stream/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream/dataset_metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: Activity Stream
-# yamllint disable-line rule:line-length
+# yamllint disable rule:line-length
 description: |-
   User-facing views related to document namespace activity-stream; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/activity-stream
 dataset_base_acl: view

--- a/sql/moz-fx-data-shared-prod/activity_stream/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream/dataset_metadata.yaml
@@ -1,7 +1,7 @@
 friendly_name: Activity Stream
+# yamllint disable-line rule:line-length
 description: |-
-  Views related to data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
+  User-facing views related to document namespace activity-stream; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/activity-stream
 dataset_base_acl: view
 user_facing: true
 labels: {}

--- a/sql/moz-fx-data-shared-prod/activity_stream_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_derived/dataset_metadata.yaml
@@ -1,7 +1,7 @@
 friendly_name: Activity Stream Derived
+# yamllint disable-line rule:line-length
 description: |-
-  Derived data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
+  Derived tables related to document namespace activity-stream, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
 dataset_base_acl: derived
 user_facing: false
 labels: {}

--- a/sql/moz-fx-data-shared-prod/activity_stream_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_derived/dataset_metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: Activity Stream Derived
-# yamllint disable-line rule:line-length
+# yamllint disable rule:line-length
 description: |-
   Derived tables related to document namespace activity-stream, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
 dataset_base_acl: derived

--- a/sql/moz-fx-data-shared-prod/amo_dev/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_dev/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: AMO Stats Dev
+description: |-
+  Derived data used to power the dev instance of the AMO stats dashboards
+dataset_base_acl: stable
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+  - workgroup:amo/nonprod

--- a/sql/moz-fx-data-shared-prod/amo_prod/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_prod/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: AMO Stats Prod
+description: |-
+  Derived data used to power the AMO stats dashboards
+dataset_base_acl: stable
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+  - workgroup:amo/prod

--- a/sql/moz-fx-data-shared-prod/analysis/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/analysis/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Analysis
+description: |-
+  User-generated tables for analysis
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/blpadi/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/blpadi/dataset_metadata.yaml
@@ -1,0 +1,12 @@
+friendly_name: Blocklist ADI
+description: |-
+  Historical data for Firefox active daily installations.
+
+  See https://wiki.mozilla.org/ADI
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/contextual_services/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services/dataset_metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: contextual-services
-# yamllint disable-line rule:line-length
+# yamllint disable rule:line-length
 description: |-
   User-facing views related to document namespace contextual-services; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/contextual-services
 dataset_base_acl: view

--- a/sql/moz-fx-data-shared-prod/contextual_services/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: contextual_services
+description: |-
+  Derived data related to Contextual Services
+dataset_base_acl: view_restricted
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:contextual-services

--- a/sql/moz-fx-data-shared-prod/contextual_services/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services/dataset_metadata.yaml
@@ -1,7 +1,8 @@
-friendly_name: contextual_services
+friendly_name: contextual-services
+# yamllint disable-line rule:line-length
 description: |-
-  Derived data related to Contextual Services
-dataset_base_acl: view_restricted
+  User-facing views related to document namespace contextual-services; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/contextual-services
+dataset_base_acl: view
 user_facing: true
 labels: {}
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/dataset_metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: contextual-services Derived
-# yamllint disable-line rule:line-length
+# yamllint disable rule:line-length
 description: |-
   Derived tables related to document namespace contextual-services, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
 dataset_base_acl: derived

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/dataset_metadata.yaml
@@ -1,7 +1,8 @@
-friendly_name: contextual_services Derived
+friendly_name: contextual-services Derived
+# yamllint disable-line rule:line-length
 description: |-
-  Derived data related to Contextual Services
-dataset_base_acl: derived_restricted
+  Derived tables related to document namespace contextual-services, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
+dataset_base_acl: derived
 user_facing: false
 labels: {}
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: contextual_services Derived
+description: |-
+  Derived data related to Contextual Services
+dataset_base_acl: derived_restricted
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:contextual-services

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Firefox Accounts
+description: |-
+  Data related to Firefox Accounts
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Firefox Accounts Derived
+description: |-
+  Derived tables for FxA data
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/internet_outages/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/internet_outages/dataset_metadata.yaml
@@ -1,4 +1,5 @@
 friendly_name: Internet Outages
+# yamllint disable rule:line-length
 description: |-
   Derived data useful for detecting regional internet outages,
   shared with some trusted external partners.

--- a/sql/moz-fx-data-shared-prod/internet_outages/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/internet_outages/dataset_metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: Internet Outages
+description: |-
+  Derived data useful for detecting regional internet outages,
+  shared with some trusted external partners.
+
+  See https://docs.google.com/document/d/15HvdPS3UwGhAir6HyWHDLDRaxUFycx4jagJ_ZrHr9D8/edit
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+  - workgroup:internet-outages/external

--- a/sql/moz-fx-data-shared-prod/looker_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/looker_derived/dataset_metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Looker Derived
 description: |-
-  Cache tables populated and used by Looker.
+  Cache tables populated and used by Looker
 dataset_base_acl: derived
 user_facing: false
 labels: {}

--- a/sql/moz-fx-data-shared-prod/looker_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/looker_derived/dataset_metadata.yaml
@@ -1,7 +1,6 @@
-friendly_name: Activity Stream Derived
+friendly_name: Looker Derived
 description: |-
-  Derived data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
+  Cache tables populated and used by Looker.
 dataset_base_acl: derived
 user_facing: false
 labels: {}
@@ -9,3 +8,6 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
+- role: roles/bigquery.dataEditor
+  members:
+  - workgroup:dataops-managed/looker

--- a/sql/moz-fx-data-shared-prod/monitoring/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/dataset_metadata.yaml
@@ -1,7 +1,7 @@
-friendly_name: Activity Stream
+friendly_name: Monitoring
 description: |-
-  Views related to data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
+  User-facing views for pipeline monitoring,
+  including views on `payload_bytes` tables
 dataset_base_acl: view
 user_facing: true
 labels: {}

--- a/sql/moz-fx-data-shared-prod/monitoring/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Activity Stream
+description: |-
+  Views related to data from the activity-stream namespace,
+  capturing activity on the desktop Firefox newtab page.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/dataset_metadata.yaml
@@ -1,7 +1,6 @@
-friendly_name: Activity Stream Derived
+friendly_name: Monitoring Derived
 description: |-
-  Derived data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
+  Derived tables used for various pipeline monitoring purposes.
 dataset_base_acl: derived
 user_facing: false
 labels: {}

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Activity Stream
+description: |-
+  Views related to data from the activity-stream namespace,
+  capturing activity on the desktop Firefox newtab page.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/dataset_metadata.yaml
@@ -1,7 +1,6 @@
-friendly_name: Activity Stream Derived
+friendly_name: Mozilla VPN Derived
 description: |-
-  Derived data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
+  Derived data related to the Mozilla VPN service
 dataset_base_acl: derived
 user_facing: false
 labels: {}

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/dataset_metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: Mozilla VPN External
+description: |-
+  Data extracted from the Mozilla VPN service database.
+dataset_base_acl: restricted
+user_facing: false
+labels: {}
+workgroup_access: []

--- a/sql/moz-fx-data-shared-prod/regrets_reporter/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter/dataset_metadata.yaml
@@ -1,11 +1,10 @@
-friendly_name: Activity Stream
+friendly_name: Regrets Reporter
 description: |-
-  Views related to data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
-dataset_base_acl: view
+  Views related to MoFo's YouTube Regrets campaign
+dataset_base_acl: view_restricted
 user_facing: true
 labels: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
-  - workgroup:mozilla-confidential
+  - workgroup:regrets-reporter

--- a/sql/moz-fx-data-shared-prod/regrets_reporter/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter/dataset_metadata.yaml
@@ -1,7 +1,8 @@
-friendly_name: Regrets Reporter
+friendly_name: regrets-reporter
+# yamllint disable-line rule:line-length
 description: |-
-  Views related to MoFo's YouTube Regrets campaign
-dataset_base_acl: view_restricted
+  User-facing views related to document namespace regrets-reporter; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/regrets-reporter
+dataset_base_acl: view
 user_facing: true
 labels: {}
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/regrets_reporter/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Activity Stream
+description: |-
+  Views related to data from the activity-stream namespace,
+  capturing activity on the desktop Firefox newtab page.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/regrets_reporter/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter/dataset_metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: regrets-reporter
-# yamllint disable-line rule:line-length
+# yamllint disable rule:line-length
 description: |-
   User-facing views related to document namespace regrets-reporter; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/regrets-reporter
 dataset_base_acl: view

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/dataset_metadata.yaml
@@ -1,7 +1,8 @@
-friendly_name: Regrets Reporter Derived
+friendly_name: regrets-reporter Derived
+# yamllint disable-line rule:line-length
 description: |-
-  Derived tables related to MoFo's YouTube Regrets campaign
-dataset_base_acl: derived_restricted
+  Derived tables related to document namespace regrets-reporter, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
+dataset_base_acl: derived
 user_facing: false
 labels: {}
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Regrets Reporter Derived
+description: |-
+  Derived tables related to MoFo's YouTube Regrets campaign
+dataset_base_acl: derived_restricted
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:regrets-reporter

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/dataset_metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: regrets-reporter Derived
-# yamllint disable-line rule:line-length
+# yamllint disable rule:line-length
 description: |-
   Derived tables related to document namespace regrets-reporter, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
 dataset_base_acl: derived

--- a/sql/moz-fx-data-shared-prod/revenue_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/revenue_derived/dataset_metadata.yaml
@@ -1,8 +1,8 @@
-friendly_name: Mozilla VPN
+friendly_name: Revenue Derived
 description: |-
-  Data related to the Mozilla VPN service
-dataset_base_acl: view
-user_facing: true
+  Derived tables related to Mozilla revenue work
+dataset_base_acl: derived
+user_facing: false
 labels: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/search/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Activity Stream
+description: |-
+  Views related to data from the activity-stream namespace,
+  capturing activity on the desktop Firefox newtab page.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/search/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search/dataset_metadata.yaml
@@ -1,7 +1,6 @@
-friendly_name: Activity Stream
+friendly_name: Search
 description: |-
-  Views related to data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
+  Views related to client search counts
 dataset_base_acl: view
 user_facing: true
 labels: {}

--- a/sql/moz-fx-data-shared-prod/search_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/dataset_metadata.yaml
@@ -1,8 +1,8 @@
-friendly_name: Mozilla VPN
+friendly_name: Search Derived
 description: |-
-  Data related to the Mozilla VPN service
-dataset_base_acl: view
-user_facing: true
+  Derived tables related to client search counts
+dataset_base_acl: derived
+user_facing: false
 labels: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/static/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/dataset_metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: Static Data
 description: |-
   Static tables, often useful for data-enriching joins
 dataset_base_acl: udf
-user_facing: false
+user_facing: true
 labels: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/static/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/dataset_metadata.yaml
@@ -1,9 +1,8 @@
-friendly_name: Activity Stream
+friendly_name: Static Data
 description: |-
-  Views related to data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
-dataset_base_acl: view
-user_facing: true
+  Static tables, often useful for data-enriching joins
+dataset_base_acl: udf
+user_facing: false
 labels: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/static/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Activity Stream
+description: |-
+  Views related to data from the activity-stream namespace,
+  capturing activity on the desktop Firefox newtab page.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/stripe/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe/dataset_metadata.yaml
@@ -1,7 +1,6 @@
-friendly_name: Activity Stream
+friendly_name: Stripe
 description: |-
-  Views related to data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
+  Views related to data extracted from payment provider Stripe
 dataset_base_acl: view
 user_facing: true
 labels: {}

--- a/sql/moz-fx-data-shared-prod/stripe/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Activity Stream
+description: |-
+  Views related to data from the activity-stream namespace,
+  capturing activity on the desktop Firefox newtab page.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/stripe_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_derived/dataset_metadata.yaml
@@ -1,7 +1,6 @@
-friendly_name: Activity Stream Derived
+friendly_name: Stripe Derived
 description: |-
-  Derived data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
+  Derived data based on extract from payment provider Stripe
 dataset_base_acl: derived
 user_facing: false
 labels: {}

--- a/sql/moz-fx-data-shared-prod/stripe_external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Stripe External
+description: |-
+  API extracts from Stripe, a payments partner
+dataset_base_acl: restricted
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:stripe
+  - workgroup:data-science/stripe

--- a/sql/moz-fx-data-shared-prod/subscription_platform/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/dataset_metadata.yaml
@@ -1,8 +1,8 @@
-friendly_name: Activity Stream
+friendly_name: Subscription Platform
 description: |-
-  Views related to data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
-dataset_base_acl: view
+  Combined subscription information from multiple products and payment platforms;
+  see bug 1703340
+dataset_base_acl: view_restricted
 user_facing: true
 labels: {}
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/subscription_platform/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/dataset_metadata.yaml
@@ -1,7 +1,7 @@
 friendly_name: Subscription Platform
 description: |-
-  Combined subscription information from multiple products and payment platforms;
-  see bug 1703340
+  Combined subscription information from multiple products
+  and payment platforms; see bug 1703340
 dataset_base_acl: view_restricted
 user_facing: true
 labels: {}

--- a/sql/moz-fx-data-shared-prod/subscription_platform/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Activity Stream
+description: |-
+  Views related to data from the activity-stream namespace,
+  capturing activity on the desktop Firefox newtab page.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/dataset_metadata.yaml
@@ -1,6 +1,7 @@
 friendly_name: Subscription Platform Derived
 description: |-
-  Tables combining subscription information from multiple products and payment platforms
+  Tables combining subscription information from multiple products
+  and payment platforms
 dataset_base_acl: derived
 user_facing: false
 labels: {}

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/dataset_metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: Subscription Platform Derived
 description: |-
   Tables combining subscription information from multiple products
   and payment platforms
-dataset_base_acl: derived
+dataset_base_acl: derived_restricted
 user_facing: false
 labels: {}
 workgroup_access: []

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/dataset_metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: Subscription Platform Derived
+description: |-
+  Tables combining subscription information from multiple products and payment platforms
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+workgroup_access: []

--- a/sql/moz-fx-data-shared-prod/telemetry/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/dataset_metadata.yaml
@@ -1,11 +1,12 @@
-friendly_name: Activity Stream
+friendly_name: Telemetry
 description: |-
-  Views related to data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
+  Views on data from legacy Firefox telemetry, plus many other
+  general-purpose datasets
 dataset_base_acl: view
 user_facing: true
 labels: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
+  - workgroup:dataops-managed/taar
   - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/telemetry/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Activity Stream
+description: |-
+  Views related to data from the activity-stream namespace,
+  capturing activity on the desktop Firefox newtab page.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/dataset_metadata.yaml
@@ -1,7 +1,7 @@
-friendly_name: Activity Stream Derived
+friendly_name: Telemetry Derived
 description: |-
-  Derived data from the activity-stream namespace,
-  capturing activity on the desktop Firefox newtab page.
+  Derived data based on pings from legacy Firefox telemetry, plus many other
+  general-purpose derived tables
 dataset_base_acl: derived
 user_facing: false
 labels: {}

--- a/sql/moz-fx-data-shared-prod/udf/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf/dataset_metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: User-Defined Functions
 description: |-
-  Peristent user-defined functions
+  Persistent user-defined functions
 dataset_base_acl: udf
 user_facing: true
 labels: {}

--- a/sql/moz-fx-data-shared-prod/udf/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: User-Defined Functions
+description: |-
+  Peristent user-defined functions
+dataset_base_acl: udf
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/udf_js/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf_js/dataset_metadata.yaml
@@ -1,6 +1,6 @@
-friendly_name: User-Defined Functions
+friendly_name: User-Defined Functions (Javascript)
 description: |-
-  Peristent user-defined functions
+  Peristent user-defined functions written in Javascript
 dataset_base_acl: udf
 user_facing: true
 labels: {}

--- a/sql/moz-fx-data-shared-prod/udf_js/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf_js/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: User-Defined Functions
+description: |-
+  Peristent user-defined functions
+dataset_base_acl: udf
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/udf_js/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf_js/dataset_metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: User-Defined Functions (Javascript)
 description: |-
-  Peristent user-defined functions written in Javascript
+  Persistent user-defined functions written in Javascript
 dataset_base_acl: udf
 user_facing: true
 labels: {}

--- a/sql/moz-fx-data-shared-prod/udf_legacy/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf_legacy/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: User-Defined Functions
+description: |-
+  Peristent user-defined functions
+dataset_base_acl: udf
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/udf_legacy/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf_legacy/dataset_metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: User-Defined Functions (Legacy)
 description: |-
-  Peristent user-defined functions intended for compatibility with queries
+  Persistent user-defined functions intended for compatibility with queries
   from legacy AWS infrastructure
 dataset_base_acl: udf
 user_facing: true

--- a/sql/moz-fx-data-shared-prod/udf_legacy/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf_legacy/dataset_metadata.yaml
@@ -1,6 +1,7 @@
-friendly_name: User-Defined Functions
+friendly_name: User-Defined Functions (Legacy)
 description: |-
-  Peristent user-defined functions
+  Peristent user-defined functions intended for compatibility with queries
+  from legacy AWS infrastructure
 dataset_base_acl: udf
 user_facing: true
 labels: {}


### PR DESCRIPTION
I haven't completely moved over content from `namespaces.tfvars.json`, but this should give an idea of where this is headed.

In particular, it includes generating additional datasets based on deployed stable table schemas, so that only exceptions have to be specified explicitly in the `main` branch.