### PR TITLE
Make restricted access datasets view_restricted

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services/dataset_metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: contextual-services
 # yamllint disable rule:line-length
 description: |-
   User-facing views related to document namespace contextual-services; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/contextual-services
-dataset_base_acl: view
+dataset_base_acl: view_restricted
 user_facing: true
 labels: {}
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/dataset_metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: contextual-services Derived
 # yamllint disable rule:line-length
 description: |-
   Derived tables related to document namespace contextual-services, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
-dataset_base_acl: derived
+dataset_base_acl: derived_restricted
 user_facing: false
 labels: {}
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/regrets_reporter/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter/dataset_metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: regrets-reporter
 # yamllint disable rule:line-length
 description: |-
   User-facing views related to document namespace regrets-reporter; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/regrets-reporter
-dataset_base_acl: view
+dataset_base_acl: view_restricted
 user_facing: true
 labels: {}
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/dataset_metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: regrets-reporter Derived
 # yamllint disable rule:line-length
 description: |-
   Derived tables related to document namespace regrets-reporter, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
-dataset_base_acl: derived
+dataset_base_acl: derived_restricted
 user_facing: false
 labels: {}
 workgroup_access:


### PR DESCRIPTION
This removes the default `projectReaders` access. We set this correctly on `subscription_platform` but not these two datasets.