### PR TITLE
Fix apple receipt logic for VPN IAP again

### DIFF
--- a/sql/mozfun/iap/derive_apple_subscription_interval/udf.sql
+++ b/sql/mozfun/iap/derive_apple_subscription_interval/udf.sql
@@ -9,10 +9,12 @@ CREATE OR REPLACE FUNCTION iap.derive_apple_subscription_interval(
     "year"
   WHEN
     DATETIME_ADD(purchase_datetime_pst, INTERVAL 1 QUARTER) = expires_datetime_pst
+    OR DATETIME_SUB(expires_datetime_pst, INTERVAL 1 QUARTER) = purchase_datetime_pst
   THEN
     "quarter"
   WHEN
     DATETIME_ADD(purchase_datetime_pst, INTERVAL 1 MONTH) = expires_datetime_pst
+    OR DATETIME_SUB(expires_datetime_pst, INTERVAL 1 MONTH) = purchase_datetime_pst
   THEN
     "month"
   WHEN


### PR DESCRIPTION
`receipt.in_app` and `latest_receipt_info` are both needed to determine subscription periods. `provider_receipt_json` is retreived with [`"exclude-old-transactions": true,`](https://github.com/mozilla-services/guardian-website/blob/60f010b139f292496f00e8586e73daac2e23b906/server/lib/apple.ts#L124), so we use `original_purchase_date` to determine the full life of the subscription, and we assume that no subscriptions have been resurrected after they ended. That assumption is sometimes inaccurate, but it's close enough until we can pull this from a better source of truth (directly from apple, instead of indirectly via guardian)