### PR TITLE
Backfill explicit project

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -596,7 +596,7 @@ def backfill(
                 f"following dates will be excluded from the backfill: {exclude}"
             )
 
-        client = bigquery.Client()
+        client = bigquery.Client(project=project_id)
         try:
             project, dataset, table = extract_from_query_path(query_file_path)
             client.get_table(f"{project}.{dataset}.{table}")


### PR DESCRIPTION
For baseline it will try to use `derived-datasets` by default