### PR TITLE
Temporarily remove glean ios from mobile search

### DIFF
--- a/bigquery_etl/search/templates/mobile_search_clients_daily.template.sql
+++ b/bigquery_etl/search/templates/mobile_search_clients_daily.template.sql
@@ -127,11 +127,6 @@ glean_metrics AS (
     *
   FROM
     fenix_metrics_with_locale
-  UNION ALL
-  SELECT
-    *
-  FROM
-    ios_metrics
 ),
 glean_combined_searches AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql
@@ -421,11 +421,6 @@ glean_metrics AS (
     *
   FROM
     fenix_metrics_with_locale
-  UNION ALL
-  SELECT
-    *
-  FROM
-    ios_metrics
 ),
 glean_combined_searches AS (
   SELECT

--- a/tests/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/test_aggregation/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/test_aggregation/expect.yaml
@@ -230,38 +230,38 @@
   experiments:
   - key: test_experiment
     value: test_branch
-- &ios_base
-  <<: *base
-  client_id: release_ios
-  os: iOS
-  os_version: "13.0"
-  app_version: "31.0"
-  app_name: Firefox iOS
-  normalized_app_name: Firefox iOS
-  channel: release
-  country: US
-  locale: en-US
-  profile_creation_date: 18201
-  profile_age_in_days: 30
-- <<: *ios_base
-  default_search_engine: engine2
-  engine: engine2
-  source: actionbar
-  search_count: 1
-- <<: *ios_base
-  default_search_engine: engine2
-  engine: engine2
-  source: suggestion
-  search_count: 2
-- <<: *ios_base
-  client_id: beta_ios
-  channel: beta
-  engine: engine2
-  source: in-content.sap.code
-  tagged_sap: 2
-- <<: *ios_base
-  client_id: nightly_ios
-  channel: nightly
-  engine: engine2
-  source: in-content.sap-follow-on.code
-  tagged_follow_on: 1
+#- &ios_base
+#  <<: *base
+#  client_id: release_ios
+#  os: iOS
+#  os_version: "13.0"
+#  app_version: "31.0"
+#  app_name: Firefox iOS
+#  normalized_app_name: Firefox iOS
+#  channel: release
+#  country: US
+#  locale: en-US
+#  profile_creation_date: 18201
+#  profile_age_in_days: 30
+#- <<: *ios_base
+#  default_search_engine: engine2
+#  engine: engine2
+#  source: actionbar
+#  search_count: 1
+#- <<: *ios_base
+#  default_search_engine: engine2
+#  engine: engine2
+#  source: suggestion
+#  search_count: 2
+#- <<: *ios_base
+#  client_id: beta_ios
+#  channel: beta
+#  engine: engine2
+#  source: in-content.sap.code
+#  tagged_sap: 2
+#- <<: *ios_base
+#  client_id: nightly_ios
+#  channel: nightly
+#  engine: engine2
+#  source: in-content.sap-follow-on.code
+#  tagged_follow_on: 1

--- a/tests/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/test_namespace_union/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/test_namespace_union/expect.yaml
@@ -33,27 +33,27 @@
   app_name: Fenix
   normalized_app_name: Fenix
   channel: release
-- <<: *base
-  os: iOS
-  os_version: "13.0"
-  client_id: b
-  app_version: "31.0"
-  app_name: Firefox iOS
-  normalized_app_name: Firefox iOS
-  channel: release
-- <<: *base
-  os: iOS
-  os_version: "13.0"
-  client_id: b
-  app_version: "31.0"
-  app_name: Firefox iOS
-  normalized_app_name: Firefox iOS
-  channel: beta
-- <<: *base
-  os: iOS
-  os_version: "13.0"
-  client_id: b
-  app_version: "31.0"
-  app_name: Firefox iOS
-  normalized_app_name: Firefox iOS
-  channel: nightly
+#- <<: *base
+#  os: iOS
+#  os_version: "13.0"
+#  client_id: b
+#  app_version: "31.0"
+#  app_name: Firefox iOS
+#  normalized_app_name: Firefox iOS
+#  channel: release
+#- <<: *base
+#  os: iOS
+#  os_version: "13.0"
+#  client_id: b
+#  app_version: "31.0"
+#  app_name: Firefox iOS
+#  normalized_app_name: Firefox iOS
+#  channel: beta
+#- <<: *base
+#  os: iOS
+#  os_version: "13.0"
+#  client_id: b
+#  app_version: "31.0"
+#  app_name: Firefox iOS
+#  normalized_app_name: Firefox iOS
+#  channel: nightly


### PR DESCRIPTION
See point 3 in this comment https://bugzilla.mozilla.org/show_bug.cgi?id=1673976#c7

Core pings are still reporting search_counts so we're double counting sap and clients.  I'll backfill the last week to fix this