### PR TITLE
DO-500 Rename search_clients_daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/search/mobile_search_clients_engines_sources_daily/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search/mobile_search_clients_engines_sources_daily/metadata.yaml
@@ -1,14 +1,8 @@
 ---
-friendly_name: Mobile Search Clients Daily
+friendly_name: Mobile Search Clients Engines Sources Daily
 description: |
   A daily aggregate of baseline and metrics pings that have
   searches from each (client_id, engine, source) combination,
   partitioned by day.
-
-  Exposed to users as `search.mobile_search_clients_engines_sources_daily`.
 owners:
   - bewu@mozilla.com
-labels:
-  schedule: daily
-scheduling:
-  dag_name: bqetl_mobile_search

--- a/sql/moz-fx-data-shared-prod/search/mobile_search_clients_engines_sources_daily/view.sql
+++ b/sql/moz-fx-data-shared-prod/search/mobile_search_clients_engines_sources_daily/view.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.search.mobile_search_clients_engines_sources_daily`
+AS
+SELECT
+  * EXCEPT (normalized_engine),
+  `moz-fx-data-shared-prod`.udf.normalize_search_engine(engine) AS normalized_engine,
+  search_count AS sap,
+FROM
+  `moz-fx-data-shared-prod.search_derived.mobile_search_clients_daily_v1`

--- a/sql/moz-fx-data-shared-prod/search/mobile_search_clients_engines_sources_last_seen/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search/mobile_search_clients_engines_sources_last_seen/metadata.yaml
@@ -1,0 +1,7 @@
+---
+friendly_name: Mobile Search Clients Engines Sources Last Seen
+description: |
+  Captures search activity of each (client_id, engine, source) combination
+  for mobile clients in the past 365 days for each submission date.
+owners:
+  - bewu@mozilla.com

--- a/sql/moz-fx-data-shared-prod/search/mobile_search_clients_engines_sources_last_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/search/mobile_search_clients_engines_sources_last_seen/view.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.search.mobile_search_clients_engines_sources_last_seen`
+AS
+SELECT
+  * EXCEPT (engine_searches, total_searches),
+  `moz-fx-data-shared-prod`.udf.normalize_monthly_searches(engine_searches) AS engine_searches,
+FROM
+  `moz-fx-data-shared-prod.search_derived.mobile_search_clients_last_seen_v1`

--- a/sql/moz-fx-data-shared-prod/search/search_clients_engines_sources_daily/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search/search_clients_engines_sources_daily/metadata.yaml
@@ -1,0 +1,6 @@
+---
+friendly_name: Search Clients Engines Sources Daily
+description: |
+  A daily aggregate of desktop searches per (client_id, engine, source).
+owners:
+  - bewu@mozilla.com

--- a/sql/moz-fx-data-shared-prod/search/search_clients_engines_sources_daily/view.sql
+++ b/sql/moz-fx-data-shared-prod/search/search_clients_engines_sources_daily/view.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.search.search_clients_engines_sources_daily`
+AS
+SELECT
+  submission_date AS submission_date_s3,
+  * EXCEPT (normalized_engine),
+  `moz-fx-data-shared-prod`.udf.normalize_search_engine(engine) AS normalized_engine,
+FROM
+  `moz-fx-data-shared-prod.search_derived.search_clients_daily_v8`

--- a/sql/moz-fx-data-shared-prod/search/search_clients_engines_sources_last_seen/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search/search_clients_engines_sources_last_seen/metadata.yaml
@@ -1,0 +1,7 @@
+---
+friendly_name: Search Clients Engines Sources Last Seen
+description: |
+  Captures search history of each desktop (client_id, engine, source)
+  combination in 28 day windows for each submission date.
+owners:
+  - frank@mozilla.com

--- a/sql/moz-fx-data-shared-prod/search/search_clients_engines_sources_last_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/search/search_clients_engines_sources_last_seen/view.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.search.search_clients_engines_sources_last_seen`
+AS
+SELECT
+  * EXCEPT (total_searches),
+  `moz-fx-data-shared-prod`.udf.bits_to_days_since_seen(days_seen_bytes) AS days_since_seen,
+  `moz-fx-data-shared-prod`.udf.bits_to_days_since_seen(days_searched_bytes) AS days_since_searched,
+  `moz-fx-data-shared-prod`.udf.bits_to_days_since_seen(
+    days_tagged_searched_bytes
+  ) AS days_since_tagged_searched,
+  `moz-fx-data-shared-prod`.udf.bits_to_days_since_seen(
+    days_searched_with_ads_bytes
+  ) AS days_since_searched_with_ads,
+  `moz-fx-data-shared-prod`.udf.bits_to_days_since_seen(
+    days_clicked_ads_bytes
+  ) AS days_since_clicked_ad,
+  `moz-fx-data-shared-prod`.udf.bits_to_days_since_first_seen(
+    days_created_profile_bytes
+  ) AS days_since_created_profile
+FROM
+  `moz-fx-data-shared-prod.search_derived.search_clients_last_seen_v1`

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_last_seen_v1/metadata.yaml
@@ -1,8 +1,10 @@
 ---
 friendly_name: Mobile Search Clients Last Seen
-description: |-
-  Captures search activity of a single mobile client in the past 365 days
-  for each submission date.
+description: |
+  Captures search activity of each (client_id, engine, source) combination
+  for mobile clients in the past 365 days for each submission date.
+
+  Exposed to users as `search.mobile_search_clients_engines_sources_last_seen`.
 owners:
   - bewu@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/metadata.yaml
@@ -1,6 +1,9 @@
 ---
 friendly_name: Search Clients Daily
-description: A daily aggregate of search clients, partitioned by day
+description: |
+  A daily aggregate of desktop searches per (client_id, engine, source).
+
+  Exposed to users as view `search.search_clients_engines_sources_daily`.
 owners:
   - bewu@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_last_seen_v1/metadata.yaml
@@ -1,8 +1,10 @@
 ---
 friendly_name: Search Clients Last Seen
-description: |-
-  Captures history of activity of each search client in 28 day
-  windows for each submission date.
+description: |
+  Captures search history of each (client_id, engine, source) combination
+  in 28 day windows for each submission date.
+
+  Exposed to users as view `search.search_clients_engines_sources_last_seen`.
 owners:
   - frank@mozilla.com
 labels:


### PR DESCRIPTION
See https://jira.mozilla.com/projects/DO/issues/DO-500

`search_clients_daily` becomes `search_clients_engines_sources_daily`
which more accurately represents the data model. We also rename the mobile
equivalent and the related `last_seen` views.

The old views stick around for now. We will need to announce deprecation of the
old views and a timeline for turning them off.

The underlying tables are unchanged. This effort is only about changing the
user interface.