### PR TITLE
Bug 1711880 - Add poucave access to clients_daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/clients_daily/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_daily/metadata.yaml
@@ -11,3 +11,7 @@ labels:
   application: firefox
 owners:
   - dthorn@mozilla.com
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:cloudops-managed/poucave

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_daily_v6/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_daily_v6/metadata.yaml
@@ -1,0 +1,5 @@
+---
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:cloudops-managed/poucave

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
@@ -26,3 +26,7 @@ bigquery:
     fields:
     - normalized_channel
     - sample_id
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:cloudops-managed/poucave


### PR DESCRIPTION
I'm not fully acquainted with the generation mechanisms around these tables/views but I hope what's in this PR suffices.

It looks like yamllint enforces stylistic consistency WRT leading spaces on lists within a particular document, so the indentation varies.

https://github.com/mozilla/bigquery-etl/issues/2046 for tooling support for this.