### PR TITLE
Update google-api-core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -129,9 +129,9 @@ gitpython==3.1.17 \
     # via
     #   -r requirements.in
     #   mozilla-schema-generator
-google-api-core[grpc]==1.27.0 \
-    --hash=sha256:407e3e52435a44f6d59d4fef7b5e115bed7b20d77cbdab79e00232bfff7bf912 \
-    --hash=sha256:edfca00d76081f359bed7b2efa2dc3a057309e55bf0a91628a0639730e31c357
+google-api-core[grpc]==1.28.0 \
+    --hash=sha256:02646803bd728e12dd1f45ee1dcc31c12614c9a1ac451b9a1ce26aa65df9b957 \
+    --hash=sha256:a658a4e367511a444c7daf2c58855ff6fd7f7d138c154e5b17186c1f8154c8cb
     # via
     #   google-cloud-bigquery
     #   google-cloud-core


### PR DESCRIPTION
Similar to https://github.com/mozilla/bigquery-etl/pull/2036

Docker build is currently failing.