### PR TITLE
Copy generated-sql content into docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,6 +324,13 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
+      - attach_workspace:
+          at: /tmp/generated-sql
+      - run:
+          name: Move generated-sql into place
+          command:
+            rm -rf sql/
+            cp -r /tmp/generated-sql/sql sql
       - run:
           name: Determine docker image name
           command:
@@ -342,7 +349,7 @@ jobs:
 workflows:
   version: 2
   build:
-    jobs:
+    jobs: &build_jobs
       - build:
           context: data-eng-circleci-tests
       - verify-format-sql
@@ -372,6 +379,7 @@ workflows:
       - deploy:
           context: data-eng-bigquery-etl-dockerhub
           requires:
+            - generate-sql
             # can't run in parallel because CIRCLE_BUILD_NUM is same
             - build
           filters:
@@ -379,3 +387,16 @@ workflows:
               only: main
             tags:
               only: /.*/
+  nightly:
+    jobs: *build_jobs
+    triggers:
+      - schedule:
+          # Scheduled queries start running at 01:00 UTC; we push a new build
+          # at midnight UTC to ensure the generated content in the container
+          # reflects any changes to deployed tables in production since the
+          # last code change pushed to this repository.
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main


### PR DESCRIPTION
This also adds a scheduled build at midnight UTC to ensure that the generated
content is updated shortly before nightly ETL starts.

This should allow us to relieve some awkwardness like in various contexts
where we need to run `script/generate_sql` before invoking an endpoint in the
container. In particular, it will allow us to revert
https://github.com/mozilla/telemetry-airflow/pull/1312
and may allow us to remove [generation when publishing views in Jenkins](https://github.com/mozilla-services/cloudops-infra/blob/de1f9e61e2a2236904449d8c482aa238cd7bffa2/projects/data-shared/Jenkinsfile.bigquery.prod#L139).