### PR TITLE
Fix #2068 - Add alternative country names from apple store

### DIFF
--- a/sql/moz-fx-data-shared-prod/static/country_names_alternate.csv
+++ b/sql/moz-fx-data-shared-prod/static/country_names_alternate.csv
@@ -35,3 +35,25 @@ Falkland Islands,FK
 North Korea,KP
 Cocos [Keeling] Islands,CC
 Saint Helena,SH
+Brunei,BN
+Bolivia,BO
+"Congo, Democratic Republic of the",CD
+"Congo, Republic of the",CG
+Cote d'Ivoire,CI
+China mainland,CN
+Micronesia,FM
+St. Kitts and Nevis,KN
+Laos,LA
+St. Lucia,LC
+Moldova,MD
+North Macedonia,MK
+Macau,MO
+Russia,RU
+São Tomé and Príncipe,ST
+Eswatini,SZ
+Taiwan,TW
+Tanzania,TZ
+St. Vincent and the Grenadines,VC
+Venezuela,VE
+British Virgin Islands,VG
+Vietnam,VN

--- a/sql/moz-fx-data-shared-prod/static/country_names_v1/data.csv
+++ b/sql/moz-fx-data-shared-prod/static/country_names_v1/data.csv
@@ -285,3 +285,25 @@ Falkland Islands,FK
 North Korea,KP
 Cocos [Keeling] Islands,CC
 Saint Helena,SH
+Brunei,BN
+Bolivia,BO
+"Congo, Democratic Republic of the",CD
+"Congo, Republic of the",CG
+Cote d'Ivoire,CI
+China mainland,CN
+Micronesia,FM
+St. Kitts and Nevis,KN
+Laos,LA
+St. Lucia,LC
+Moldova,MD
+North Macedonia,MK
+Macau,MO
+Russia,RU
+São Tomé and Príncipe,ST
+Eswatini,SZ
+Taiwan,TW
+Tanzania,TZ
+St. Vincent and the Grenadines,VC
+Venezuela,VE
+British Virgin Islands,VG
+Vietnam,VN


### PR DESCRIPTION
See #2068. Query for generating the list of names is take from https://sql.telemetry.mozilla.org/queries/80165/source

```sql
WITH storefront AS
  (SELECT DISTINCT storefront,
                   CASE
                       WHEN storefront LIKE '%St.%' THEN REPLACE(storefront, 'St.', 'Saint')
                       WHEN storefront = 'China mainland' THEN 'China'
                       WHEN storefront = 'Russia' THEN 'Russian Federation'
                       WHEN storefront = 'Tanzania' THEN 'Tanzania, United Republic of'
                       WHEN storefront = 'North Macedonia' THEN 'Macedonia, the Former Yugoslav Republic of'
                       WHEN storefront = 'São Tomé and Príncipe' THEN 'Sao Tome and Principe'
                       WHEN storefront = 'Micronesia' THEN 'Micronesia, Federated States of'
                       WHEN storefront = 'Moldova' THEN 'Moldova, Republic of'
                       WHEN storefront = 'Venezuela' THEN 'Venezuela, Bolivarian Republic of'
                       WHEN storefront = 'Taiwan' THEN 'Taiwan, Province of China'
                       WHEN storefront = 'British Virgin Islands' THEN 'Virgin Islands, British'
                       WHEN storefront = 'Brunei' THEN 'Brunei Darussalam'
                       WHEN storefront = 'Congo, Democratic Republic of the' THEN 'Congo, the Democratic Republic of the'
                       WHEN storefront = 'Congo, Republic of the' THEN 'Congo'
                       WHEN storefront = 'Bolivia' THEN 'Bolivia, Plurinational State of'
                       WHEN storefront = 'Vietnam' THEN 'Viet Nam'
                       WHEN storefront = "Cote d'Ivoire" THEN "Côte d'Ivoire"
                       ELSE storefront
                   END AS name,
   FROM `moz-fx-data-marketing-prod.apple_app_store.metrics_by_storefront`),
     joined AS
  (SELECT storefront,
          name,
          CASE
              WHEN name = 'Macau' THEN 'MO'
              WHEN name = 'Eswatini' THEN 'SZ'
              WHEN name = 'Laos' THEN 'LA'
              ELSE code
          END AS code
   FROM storefront t
   LEFT JOIN `mozdata.static.country_codes_v1` USING (name)
   WHERE code IS NULL
     OR name <> storefront )
SELECT *
FROM joined
ORDER BY code
```