### PR TITLE
[Bug 1643735] Use dedicated queue for bqetl_public_data_json

### DIFF
--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -45,6 +45,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         + ["--parameter={{ task.date_partition_parameter }}:DATE:{% raw %}{{ds}}{% endraw -%}"]
         {%- endif -%},
         image=docker_image,
+        queue="dedicated",
         dag=dag
     )
 {% endfor -%}
@@ -75,6 +76,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         task_id="public_data_gcs_metadata",
         command=["script/publish_public_data_gcs_metadata"],
         docker_image=docker_image,
+        queue="dedicated",
         dag=dag
     )
 

--- a/dags/bqetl_public_data_json.py
+++ b/dags/bqetl_public_data_json.py
@@ -56,6 +56,7 @@ with DAG(
         + ["--project_id=moz-fx-data-shared-prod"]
         + ["--parameter=submission_date:DATE:{{ds}}"],
         image=docker_image,
+        queue="dedicated",
         dag=dag,
     )
 
@@ -71,6 +72,7 @@ with DAG(
         + ["--project_id=moz-fx-data-shared-prod"]
         + ["--parameter=submission_date:DATE:{{ds}}"],
         image=docker_image,
+        queue="dedicated",
         dag=dag,
     )
 
@@ -106,6 +108,7 @@ with DAG(
         task_id="public_data_gcs_metadata",
         command=["script/publish_public_data_gcs_metadata"],
         docker_image=docker_image,
+        queue="dedicated",
         dag=dag,
     )
 

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -49,6 +49,7 @@ with DAG(
         + ["--project_id=moz-fx-data-test-project"]
         + ["--parameter=submission_date:DATE:{{ds}}"],
         image=docker_image,
+        queue="dedicated",
         dag=dag,
     )
 
@@ -69,6 +70,7 @@ with DAG(
         task_id="public_data_gcs_metadata",
         command=["script/publish_public_data_gcs_metadata"],
         docker_image=docker_image,
+        queue="dedicated",
         dag=dag,
     )
 


### PR DESCRIPTION
Changing the `bqetl_public_data_json` DAG to use the new `'dedicated'` queue.