### PR TITLE
Add missing search sources to clients daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
@@ -1079,3 +1079,12 @@ fields:
 - mode: NULLABLE
   name: n_viewed_protection_report
   type: INTEGER
+- mode: NULLABLE
+  name: search_count_webextension
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_alias
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_urlbar_searchmode
+  type: INTEGER

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
@@ -1070,3 +1070,12 @@ fields:
 - mode: NULLABLE
   name: scalar_parent_os_environment_launched_via_other_shortcut
   type: BOOLEAN
+- mode: NULLABLE
+  name: search_count_webextension
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_alias
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_urlbar_searchmode
+  type: INTEGER

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -816,3 +816,12 @@ fields:
 - mode: NULLABLE
   name: scalar_parent_os_environment_launched_via_other
   type: BOOLEAN
+- mode: NULLABLE
+  name: search_count_webextension
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_alias
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_urlbar_searchmode
+  type: INTEGER

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/schema.yaml
@@ -874,3 +874,12 @@ fields:
 - mode: NULLABLE
   name: n_viewed_protection_report
   type: INTEGER
+- mode: NULLABLE
+  name: search_count_webextension
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_alias
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_urlbar_searchmode
+  type: INTEGER

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
@@ -856,3 +856,12 @@ fields:
 - mode: NULLABLE
   name: scalar_parent_os_environment_launched_via_other
   type: BOOLEAN
+- mode: NULLABLE
+  name: search_count_webextension
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_alias
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_urlbar_searchmode
+  type: INTEGER

--- a/sql/moz-fx-data-shared-prod/udf/aggregate_search_counts/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf/aggregate_search_counts/udf.sql
@@ -9,6 +9,9 @@ CREATE OR REPLACE FUNCTION udf.aggregate_search_counts(
       COALESCE(SUM(IF(source = "searchbar", count, 0)), 0) AS search_count_searchbar,
       COALESCE(SUM(IF(source = "system", count, 0)), 0) AS search_count_system,
       COALESCE(SUM(IF(source = "urlbar", count, 0)), 0) AS search_count_urlbar,
+      COALESCE(SUM(IF(source = "webextension", count, 0)), 0) AS search_count_webextension,
+      COALESCE(SUM(IF(source = "alias", count, 0)), 0) AS search_count_alias,
+      COALESCE(SUM(IF(source = "urlbar-searchmode", count, 0)), 0) AS search_count_urlbar_searchmode,
       COALESCE(
         SUM(
           IF(
@@ -65,6 +68,9 @@ SELECT
       0 AS search_count_searchbar,
       0 AS search_count_system,
       0 AS search_count_urlbar,
+      0 AS search_count_webextension,
+      0 AS search_count_alias,
+      0 AS search_count_urlbar_searchmode,
       6 AS search_count_all,
       0 AS search_count_tagged_sap,
       0 AS search_count_tagged_follow_on,
@@ -88,6 +94,9 @@ SELECT
       0 AS search_count_searchbar,
       0 AS search_count_system,
       0 AS search_count_urlbar,
+      0 AS search_count_webextension,
+      0 AS search_count_alias,
+      0 AS search_count_urlbar_searchmode,
       0 AS search_count_tagged_sap,
       0 AS search_count_tagged_follow_on,
       0 AS search_count_organic

--- a/sql/moz-fx-data-shared-prod/udf/aggregate_search_counts/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf/aggregate_search_counts/udf.sql
@@ -11,7 +11,10 @@ CREATE OR REPLACE FUNCTION udf.aggregate_search_counts(
       COALESCE(SUM(IF(source = "urlbar", count, 0)), 0) AS search_count_urlbar,
       COALESCE(SUM(IF(source = "webextension", count, 0)), 0) AS search_count_webextension,
       COALESCE(SUM(IF(source = "alias", count, 0)), 0) AS search_count_alias,
-      COALESCE(SUM(IF(source = "urlbar-searchmode", count, 0)), 0) AS search_count_urlbar_searchmode,
+      COALESCE(
+        SUM(IF(source = "urlbar-searchmode", count, 0)),
+        0
+      ) AS search_count_urlbar_searchmode,
       COALESCE(
         SUM(
           IF(

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/test_aggregation/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/test_aggregation/expect.yaml
@@ -212,7 +212,7 @@
     value: 2
   search_cohort: second
   search_count_abouthome: 2
-  search_count_all: 2
+  search_count_all: 6
   search_count_contextmenu: 0
   search_count_newtab: 0
   search_count_organic: 0
@@ -223,7 +223,7 @@
   search_count_urlbar: 0
   search_count_webextension: 0
   search_count_alias: 0
-  search_count_urlbar_searchmode: 0
+  search_count_urlbar_searchmode: 4
   search_with_ads_count_all: 2
   session_restored_mean: 2
   sessions_started_on_this_day: 1

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/test_aggregation/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/test_aggregation/expect.yaml
@@ -221,6 +221,9 @@
   search_count_tagged_follow_on: 0
   search_count_tagged_sap: 0
   search_count_urlbar: 0
+  search_count_webextension: 0
+  search_count_alias: 0
+  search_count_urlbar_searchmode: 0
   search_with_ads_count_all: 2
   session_restored_mean: 2
   sessions_started_on_this_day: 1

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/test_aggregation/telemetry_stable.main_v4.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/test_aggregation/telemetry_stable.main_v4.yaml
@@ -456,6 +456,8 @@
       search_counts:
       - key: foo.abouthome
         value: '{"sum":1}'
+      - key: foo.urlbar-searchmode
+        value: '{"sum":2}'
       subprocess_abnormal_abort:
       - key: content
         value: '{"sum":1}'


### PR DESCRIPTION
https://jira.mozilla.com/browse/DS-1600

Adds three search sources and updates clients daily schema using [these instructions](https://mozilla.github.io/bigquery-etl/cookbooks/common_workflows/#add-a-new-field-to-clients_daily).  Some weirdness in the steps because the schema is based on undeployed udf changes so I used a temp udf when updating the schema.

Before merge:
- update deployed udf
- validate query
- deploy schema
- validate again