### PR TITLE
Update google-api-core

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ cattrs==1.7.1
 click==8.0.1
 gcloud==0.18.3
 gitpython==3.1.17
-google-api-core==1.29.0  # transitive dep that needs dependabot updates
+google-api-core==1.30.0  # transitive dep that needs dependabot updates
 google-cloud-bigquery==2.20.0
 google-cloud-storage==1.38.0
 googleapis-common-protos==1.53.0  # transitive dep that needs dependabot updates

--- a/requirements.txt
+++ b/requirements.txt
@@ -129,9 +129,9 @@ gitpython==3.1.17 \
     # via
     #   -r requirements.in
     #   mozilla-schema-generator
-google-api-core[grpc]==1.29.0 \
-    --hash=sha256:dbe885011111a9afd9ea9a347db6a9c608e82e5c7648c1f7fabf2b4079a579b5 \
-    --hash=sha256:f83118319d2a28806ec3399671cbe4af5351bd0dac54c40a0395da6162ebe324
+google-api-core[grpc]==1.30.0 \
+    --hash=sha256:0724d354d394b3d763bc10dfee05807813c5210f0bd9b8e2ddf6b6925603411c \
+    --hash=sha256:92cd9e9f366e84bfcf2524e34d2dc244906c645e731962617ba620da1620a1e0
     # via
     #   -r requirements.in
     #   google-cloud-bigquery


### PR DESCRIPTION
Should fix the CircleCI failures due to:

```
Collecting google-api-core<2.0.0dev,>=1.21.0
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    google-api-core<2.0.0dev,>=1.21.0 from https://files.pythonhosted.org/packages/f6/72/6dc3c3c4576fedc409fd825bf71e22d0f448bd68143c79cdbd6216744282/google_api_core-1.30.0-py2.py3-none-any.whl#sha256=92cd9e9f366e84bfcf2524e34d2dc244906c645e731962617ba620da1620a1e0 (from google-cloud-core==1.6.0->-r requirements.txt (line 150))
The command '/bin/sh -c pip install -r requirements.txt' returned a non-zero code: 1

Exited with code exit status 1


```