### PR TITLE
Add ios support to experiment aggregates queries

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_fennec_derived/experiment_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_fennec_derived/experiment_events_live_v1/init.sql
@@ -1,0 +1,76 @@
+-- This and the following materialized view need to be kept in sync:
+-- - org_mozilla_firefox_beta_derived.experiment_events_live_v1
+-- - org_mozilla_ios_derived.experiment_events_live_v1
+-- - org_mozilla_firefox_derived.experiment_events_live_v1
+-- - org_mozilla_ios_firefox_derived.experiment_events_live_v1
+-- - org_mozilla_ios_firefoxbeta_derived.experiment_events_live_v1
+-- - org_mozilla_ios_fennec_derived.experiment_events_live_v1
+CREATE MATERIALIZED VIEW
+IF
+  NOT EXISTS org_mozilla_ios_fennec_derived.experiment_events_live_v1
+  OPTIONS
+    (enable_refresh = TRUE, refresh_interval_minutes = 5)
+  AS
+  WITH ios_all_events AS (
+    SELECT
+      submission_timestamp,
+      events
+    FROM
+      `moz-fx-data-shared-prod.org_mozilla_ios_fennec_live.events_v1`
+  ),
+  ios AS (
+    SELECT
+      submission_timestamp AS `timestamp`,
+      event.category AS `type`,
+      CAST(event.extra[safe_offset(i)].value AS STRING) AS branch,
+      CAST(event.extra[safe_offset(j)].value AS STRING) AS experiment,
+      event.name AS event_method
+    FROM
+      ios_all_events,
+      UNNEST(events) AS event,
+            -- Workaround for https://issuetracker.google.com/issues/182829918
+      -- To prevent having the branch name set to the experiment slug,
+      -- the number of generated array indices needs to be different.
+      UNNEST(GENERATE_ARRAY(0, 50)) AS i,
+      UNNEST(GENERATE_ARRAY(0, 51)) AS j
+    WHERE
+      event.category = 'nimbus_events'
+      AND CAST(event.extra[safe_offset(i)].key AS STRING) = 'branch'
+      AND CAST(event.extra[safe_offset(j)].key AS STRING) = 'experiment'
+  )
+  SELECT
+    date(`timestamp`) AS submission_date,
+    `type`,
+    experiment,
+    branch,
+    TIMESTAMP_ADD(
+      TIMESTAMP_TRUNC(`timestamp`, HOUR),
+    -- Aggregates event counts over 5-minute intervals
+      INTERVAL(DIV(EXTRACT(MINUTE FROM `timestamp`), 5) * 5) MINUTE
+    ) AS window_start,
+    TIMESTAMP_ADD(
+      TIMESTAMP_TRUNC(`timestamp`, HOUR),
+      INTERVAL((DIV(EXTRACT(MINUTE FROM `timestamp`), 5) + 1) * 5) MINUTE
+    ) AS window_end,
+    COUNTIF(event_method = 'enroll' OR event_method = 'enrollment') AS enroll_count,
+    COUNTIF(event_method = 'unenroll' OR event_method = 'unenrollment') AS unenroll_count,
+    COUNTIF(event_method = 'graduate') AS graduate_count,
+    COUNTIF(event_method = 'update') AS update_count,
+    COUNTIF(event_method = 'enrollFailed') AS enroll_failed_count,
+    COUNTIF(event_method = 'unenrollFailed') AS unenroll_failed_count,
+    COUNTIF(event_method = 'updateFailed') AS update_failed_count,
+    COUNTIF(event_method = 'disqualification') AS disqualification_count,
+    COUNTIF(event_method = 'expose' OR event_method = 'exposure') AS exposure_count
+  FROM
+    ios
+  WHERE
+    -- Limit the amount of data the materialized view is going to backfill when created.
+    -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
+    timestamp > TIMESTAMP('2021-06-15')
+  GROUP BY
+    submission_date,
+    `type`,
+    experiment,
+    branch,
+    window_start,
+    window_end

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_fennec_derived/experiment_events_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_fennec_derived/experiment_events_live_v1/metadata.yaml
@@ -1,0 +1,8 @@
+friendly_name: Experiment Events Live
+description: |-
+  Materialized view of experimentation related events
+  coming from Firefox for iOS clients.
+owners:
+- ascholtz@mozilla.com
+labels:
+  materialized_view: true

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_fennec_derived/experiment_search_events_live_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_fennec_derived/experiment_search_events_live_v1/init.sql
@@ -1,0 +1,54 @@
+-- This and the following materialized view need to be kept in sync:
+-- - org_mozilla_fenix_derived.experiment_search_events_live_v1
+-- - org_mozilla_firefox_beta_derived.experiment_search_events_live_v1
+-- - org_mozilla_firefox_derived.experiment_search_events_live_v1
+-- - org_mozilla_ios_firefox_derived.experiment_search_events_live_v1
+-- - org_mozilla_ios_firefoxbeta_derived.experiment_search_events_live_v1
+-- - org_mozilla_ios_fennec_derived.experiment_search_events_live_v1
+CREATE MATERIALIZED VIEW
+IF
+  NOT EXISTS `moz-fx-data-shared-prod.org_mozilla_ios_fennec_derived.experiment_search_events_live_v1`
+  OPTIONS
+    (enable_refresh = TRUE, refresh_interval_minutes = 5)
+  AS
+  SELECT
+    date(submission_timestamp) AS submission_date,
+    experiment.key AS experiment,
+    experiment.value.branch AS branch,
+    TIMESTAMP_ADD(
+      TIMESTAMP_TRUNC(submission_timestamp, HOUR),
+        -- Aggregates event counts over 5-minute intervals
+      INTERVAL(DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) * 5) MINUTE
+    ) AS window_start,
+    TIMESTAMP_ADD(
+      TIMESTAMP_TRUNC(submission_timestamp, HOUR),
+      INTERVAL((DIV(EXTRACT(MINUTE FROM submission_timestamp), 5) + 1) * 5) MINUTE
+    ) AS window_end,
+    SUM(0) AS ad_clicks_count,
+    SUM(0) AS search_with_ads_count,
+    -- Concatenating an element with value = 0 ensures that the count values are not null even if the array is empty
+    -- Materialized views don't support COALESCE or IFNULL
+    SUM(
+      CAST(
+        ARRAY_CONCAT(metrics.labeled_counter.search_counts, [('', 0)])[
+          SAFE_OFFSET(i)
+        ].value AS INT64
+      )
+    ) AS search_count
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_fennec_live.metrics_v1`
+  LEFT JOIN
+    UNNEST(ping_info.experiments) AS experiment
+  CROSS JOIN
+    -- Max. number of entries is around 10
+    UNNEST(GENERATE_ARRAY(0, 50)) AS i
+  WHERE
+      -- Limit the amount of data the materialized view is going to backfill when created.
+      -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
+    DATE(submission_timestamp) > '2021-06-15'
+  GROUP BY
+    submission_date,
+    experiment,
+    branch,
+    window_start,
+    window_end

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_fennec_derived/experiment_search_events_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_fennec_derived/experiment_search_events_live_v1/metadata.yaml
@@ -1,0 +1,8 @@
+friendly_name: Experiment Search Events Live
+description: |-
+  Materialized view of experimentation related search events
+  coming from Firefox for iOS clients.
+owners:
+- ascholtz@mozilla.com
+labels:
+  materialized_view: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_live_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_live_v1/view.sql
@@ -137,6 +137,26 @@ SELECT
   disqualification_count,
   exposure_count
 FROM
+  `moz-fx-data-shared-prod.org_mozilla_ios_fennec_derived.experiment_events_live_v1`
+WHERE
+  window_start > TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
+UNION ALL
+SELECT
+  type,
+  experiment,
+  branch,
+  window_start,
+  window_end,
+  enroll_count,
+  unenroll_count,
+  graduate_count,
+  update_count,
+  enroll_failed_count,
+  unenroll_failed_count,
+  update_failed_count,
+  disqualification_count,
+  exposure_count
+FROM
   `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_v1`
 WHERE
   window_start <= TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_v1/query.sql
@@ -64,6 +64,12 @@ ios_all_events AS (
     events
   FROM
     `moz-fx-data-shared-prod.org_mozilla_ios_firefoxbeta.events`
+  UNION ALL
+  SELECT
+    submission_timestamp,
+    events
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_fennec.events`
 ),
 fenix AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/view.sql
@@ -63,6 +63,45 @@ WITH all_searches AS (
     search_with_ads_count,
     search_count
   FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.experiment_search_events_live_v1`
+  WHERE
+    window_start > TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
+  UNION ALL
+  SELECT
+    branch,
+    experiment,
+    window_start,
+    window_end,
+    ad_clicks_count,
+    search_with_ads_count,
+    search_count
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_firefoxbeta_derived.experiment_search_events_live_v1`
+  WHERE
+    window_start > TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
+  UNION ALL
+  SELECT
+    branch,
+    experiment,
+    window_start,
+    window_end,
+    ad_clicks_count,
+    search_with_ads_count,
+    search_count
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_fennec_derived.experiment_search_events_live_v1`
+  WHERE
+    window_start > TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
+  UNION ALL
+  SELECT
+    branch,
+    experiment,
+    window_start,
+    window_end,
+    ad_clicks_count,
+    search_with_ads_count,
+    search_count
+  FROM
     `moz-fx-data-shared-prod.telemetry_derived.experiment_search_aggregates_v1`
   WHERE
     window_start <= TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql
@@ -135,6 +135,43 @@ fenix AS (
     experiment,
     branch
 ),
+ios AS (
+  SELECT
+    submission_timestamp,
+    experiment.key AS experiment,
+    experiment.value.branch AS branch,
+    SUM(0) AS ad_clicks_count,
+    SUM(0) AS search_with_ads_count,
+    SUM(
+      (SELECT SUM(value.value) FROM UNNEST(metrics.labeled_counter.search_counts) AS value)
+    ) AS search_count,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_firefox_stable.metrics_v1`
+  LEFT JOIN
+    UNNEST(ping_info.experiments) AS experiment
+  GROUP BY
+    submission_timestamp,
+    experiment,
+    branch
+  UNION ALL
+  SELECT
+    submission_timestamp,
+    experiment.key AS experiment,
+    experiment.value.branch AS branch,
+    SUM(0) AS ad_clicks_count,
+    SUM(0) AS search_with_ads_count,
+    SUM(
+      (SELECT SUM(value.value) FROM UNNEST(metrics.labeled_counter.search_counts) AS value)
+    ) AS search_count,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_firefoxbeta_stable.metrics_v1`
+  LEFT JOIN
+    UNNEST(ping_info.experiments) AS experiment
+  GROUP BY
+    submission_timestamp,
+    experiment,
+    branch
+),
 all_events AS (
   SELECT
     *
@@ -145,6 +182,11 @@ all_events AS (
     *
   FROM
     fenix
+  UNION ALL
+  SELECT
+    *
+  FROM
+    ios
 )
 SELECT
   experiment,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql
@@ -171,6 +171,24 @@ ios AS (
     submission_timestamp,
     experiment,
     branch
+  UNION ALL
+  SELECT
+    submission_timestamp,
+    experiment.key AS experiment,
+    experiment.value.branch AS branch,
+    SUM(0) AS ad_clicks_count,
+    SUM(0) AS search_with_ads_count,
+    SUM(
+      (SELECT SUM(value.value) FROM UNNEST(metrics.labeled_counter.search_counts) AS value)
+    ) AS search_count,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_fennec_stable.metrics_v1`
+  LEFT JOIN
+    UNNEST(ping_info.experiments) AS experiment
+  GROUP BY
+    submission_timestamp,
+    experiment,
+    branch
 ),
 all_events AS (
   SELECT


### PR DESCRIPTION
Missed to add ios support to the aggregates queries. This data needs to be backfilled to 2021-06-07