### PR TITLE
Airflow task SLA and execution_timeout

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -160,6 +160,8 @@ class Task:
     retry_delay: Optional[str] = attr.ib(None)
     retries: Optional[int] = attr.ib(None)
     email_on_retry: Optional[bool] = attr.ib(None)
+    sla: Optional[str] = attr.ib(None)  # todo: set to 3h
+    execution_timeout: Optional[str] = attr.ib(None)  # todo: set to 24h
 
     @owner.validator
     def validate_owner(self, attribute, value):
@@ -204,6 +206,24 @@ class Task:
     @retry_delay.validator
     def validate_retry_delay(self, attribute, value):
         """Check that retry_delay is in a valid timedelta format."""
+        if value is not None and not is_timedelta_string(value):
+            raise ValueError(
+                f"Invalid timedelta definition for {attribute}: {value}."
+                "Timedeltas should be specified like: 1h, 30m, 1h15m, 1d4h45m, ..."
+            )
+
+    @sla.validator
+    def validate_sla(self, attribute, value):
+        """Check that sla is in a valid timedelta format."""
+        if value is not None and not is_timedelta_string(value):
+            raise ValueError(
+                f"Invalid timedelta definition for {attribute}: {value}."
+                "Timedeltas should be specified like: 1h, 30m, 1h15m, 1d4h45m, ..."
+            )
+
+    @execution_timeout.validator
+    def validate_execution_timeout(self, attribute, value):
+        """Check that execution_timeout is in a valid timedelta format."""
         if value is not None and not is_timedelta_string(value):
             raise ValueError(
                 f"Invalid timedelta definition for {attribute}: {value}."

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -29,7 +29,7 @@ default_args = {{
     format_attr("retry_delay", "format_timedelta")
 }}
 
-with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None -%}, schedule_interval={{ schedule_interval | format_timedelta | format_schedule_interval }}{%+ endif -%}, doc_md = docs) as dag:
+with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval is not none -%}, schedule_interval={{ schedule_interval | format_timedelta | format_schedule_interval }}{%+ endif -%}, doc_md = docs) as dag:
 {% for task in tasks | sort(attribute='task_name') %}
     {% if task.is_python_script -%}
         {{ task.task_name }} = gke_command(
@@ -41,10 +41,10 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             docker_image='gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest',
             owner='{{ task.owner }}',
             email={{ task.email | sort }},
-            {%+ if task.sla != None -%}
+            {%+ if task.sla is not none -%}
             sla={{ task.sla }},
             {%+ endif -%}
-            {%+ if task.execution_timeout != None -%}
+            {%+ if task.execution_timeout is not none -%}
             execution_timeout={{ task.execution_timeout }},
             {%+ endif -%}
         )
@@ -82,19 +82,19 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             {%+ if task.priority -%}
             priority_weight={{ task.priority }},
             {%+ endif -%}
-            {%+ if task.retry_delay != None -%}
+            {%+ if task.retry_delay is not none -%}
             retry_delay={{ task.retry_delay | format_timedelta | format_repr }},
             {%+ endif -%}
-            {%+ if task.retries != None -%}
+            {%+ if task.retries is not none -%}
             retries={{ task.retries }},
             {%+ endif -%}
-            {%+ if task.email_on_retry != None -%}
+            {%+ if task.email_on_retry is not none -%}
             email_on_retry={{ task.email_on_retry }},
             {%+ endif -%}
-            {%+ if task.sla != None -%}
+            {%+ if task.sla is not none -%}
             sla={{ task.sla }},
             {%+ endif -%}
-            {%+ if task.execution_timeout != None -%}
+            {%+ if task.execution_timeout is not none -%}
             execution_timeout={{ task.execution_timeout }},
             {%+ endif -%}
             dag=dag,
@@ -121,10 +121,10 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         check_existence=True,
         mode='reschedule',
         pool='DATA_ENG_EXTERNALTASKSENSOR',
-        {%+ if task.sla != None -%}
+        {%+ if task.sla is not none -%}
         sla={{ task.sla }},
         {%+ endif -%}
-        {%+ if task.execution_timeout != None -%}
+        {%+ if task.execution_timeout is not none -%}
         execution_timeout={{ task.execution_timeout }},
         {%+ endif -%}
     )
@@ -149,10 +149,10 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         mode='reschedule',
         pool='DATA_ENG_EXTERNALTASKSENSOR',
         dag=dag,
-        {%+ if task.sla != None -%}
+        {%+ if task.sla is not none -%}
         sla={{ task.sla }},
         {%+ endif -%}
-        {%+ if task.execution_timeout != None -%}
+        {%+ if task.execution_timeout is not none -%}
         execution_timeout={{ task.execution_timeout }},
         {%+ endif -%}
     )

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -41,6 +41,12 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             docker_image='gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest',
             owner='{{ task.owner }}',
             email={{ task.email | sort }},
+            {%+ if task.sla != None -%}
+            sla={{ task.sla }},
+            {%+ endif -%}
+            {%+ if task.execution_timeout != None -%}
+            execution_timeout={{ task.execution_timeout }},
+            {%+ endif -%}
         )
     {%+ else -%}
         {{ task.task_name }} = bigquery_etl_query(
@@ -85,6 +91,12 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             {%+ if task.email_on_retry != None -%}
             email_on_retry={{ task.email_on_retry }},
             {%+ endif -%}
+            {%+ if task.sla != None -%}
+            sla={{ task.sla }},
+            {%+ endif -%}
+            {%+ if task.execution_timeout != None -%}
+            execution_timeout={{ task.execution_timeout }},
+            {%+ endif -%}
             dag=dag,
         )
     {% endif -%}
@@ -109,6 +121,12 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         check_existence=True,
         mode='reschedule',
         pool='DATA_ENG_EXTERNALTASKSENSOR',
+        {%+ if task.sla != None -%}
+        sla={{ task.sla }},
+        {%+ endif -%}
+        {%+ if task.execution_timeout != None -%}
+        execution_timeout={{ task.execution_timeout }},
+        {%+ endif -%}
     )
     {{ wait_for_seen.append((dependency.dag_name, dependency.task_id)) or "" }}
     {% endif -%}
@@ -131,6 +149,12 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         mode='reschedule',
         pool='DATA_ENG_EXTERNALTASKSENSOR',
         dag=dag,
+        {%+ if task.sla != None -%}
+        sla={{ task.sla }},
+        {%+ endif -%}
+        {%+ if task.execution_timeout != None -%}
+        execution_timeout={{ task.execution_timeout }},
+        {%+ endif -%}
     )
     {{ wait_for_seen.append((task_ref.dag_name, task_ref.task_id)) or "" }}
     {%+ endif -%}

--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -30,7 +30,7 @@ default_args = {{
     format_attr("retry_delay", "format_timedelta")
 }}
 
-with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None -%}, schedule_interval={{ schedule_interval | format_timedelta | format_schedule_interval }}{%+ endif -%}, doc_md = docs) as dag:
+with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval is not none -%}, schedule_interval={{ schedule_interval | format_timedelta | format_schedule_interval }}{%+ endif -%}, doc_md = docs) as dag:
     docker_image = "gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest"
 {% for task in tasks | sort(attribute='task_name') %}
     {{ task.task_name }} = GKEPodOperator(
@@ -45,6 +45,9 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         + ["--parameter={{ task.date_partition_parameter }}:DATE:{% raw %}{{ds}}{% endraw -%}"]
         {%- endif -%},
         image=docker_image,
+        sla=datetime.timedelta(minutes=5),
+        execution_timeout=datetime.timedelta(minutes=10),
+        email_on_retry=False,
         dag=dag
     )
 {% endfor -%}
@@ -64,7 +67,9 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         check_existence=True,
         mode='reschedule',
         pool='DATA_ENG_EXTERNALTASKSENSOR',
-        sla=datetime.timedelta(hours=3)
+        sla=datetime.timedelta(minutes=5),
+        execution_timeout=datetime.timedelta(minutes=10),
+        email_on_retry=False,
     )
 
     {{ task.task_name }}.set_upstream(wait_for_{{ dependency.task_id }})

--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -64,6 +64,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         check_existence=True,
         mode='reschedule',
         pool='DATA_ENG_EXTERNALTASKSENSOR',
+        sla=datetime.timedelta(hours=3)
     )
 
     {{ task.task_name }}.set_upstream(wait_for_{{ dependency.task_id }})

--- a/dags/bqetl_public_data_json.py
+++ b/dags/bqetl_public_data_json.py
@@ -56,6 +56,9 @@ with DAG(
         + ["--project_id=moz-fx-data-shared-prod"]
         + ["--parameter=submission_date:DATE:{{ds}}"],
         image=docker_image,
+        sla=datetime.timedelta(minutes=5),
+        execution_timeout=datetime.timedelta(minutes=10),
+        email_on_retry=False,
         dag=dag,
     )
 
@@ -71,6 +74,9 @@ with DAG(
         + ["--project_id=moz-fx-data-shared-prod"]
         + ["--parameter=submission_date:DATE:{{ds}}"],
         image=docker_image,
+        sla=datetime.timedelta(minutes=5),
+        execution_timeout=datetime.timedelta(minutes=10),
+        email_on_retry=False,
         dag=dag,
     )
 
@@ -82,6 +88,9 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        sla=datetime.timedelta(minutes=5),
+        execution_timeout=datetime.timedelta(minutes=10),
+        email_on_retry=False,
     )
 
     export_public_data_json_mozregression_aggregates__v1.set_upstream(
@@ -96,6 +105,9 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        sla=datetime.timedelta(minutes=5),
+        execution_timeout=datetime.timedelta(minutes=10),
+        email_on_retry=False,
     )
 
     export_public_data_json_telemetry_derived__ssl_ratios__v1.set_upstream(

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -49,6 +49,8 @@ with DAG(
         + ["--project_id=moz-fx-data-test-project"]
         + ["--parameter=submission_date:DATE:{{ds}}"],
         image=docker_image,
+        sla=datetime.timedelta(minutes=5),
+        execution_timeout=datetime.timedelta(minutes=10),
         dag=dag,
     )
 
@@ -59,6 +61,8 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        sla=datetime.timedelta(minutes=5),
+        execution_timeout=datetime.timedelta(minutes=10),
     )
 
     export_public_data_json_test__non_incremental_query__v1.set_upstream(

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -51,6 +51,7 @@ with DAG(
         image=docker_image,
         sla=datetime.timedelta(minutes=5),
         execution_timeout=datetime.timedelta(minutes=10),
+        email_on_retry=False,
         dag=dag,
     )
 
@@ -63,6 +64,7 @@ with DAG(
         pool="DATA_ENG_EXTERNALTASKSENSOR",
         sla=datetime.timedelta(minutes=5),
         execution_timeout=datetime.timedelta(minutes=10),
+        email_on_retry=False,
     )
 
     export_public_data_json_test__non_incremental_query__v1.set_upstream(


### PR DESCRIPTION
Based on proposal https://docs.google.com/document/d/1V8FwVH_oZonh-SLKRbghkzglofRlec7S51QwIIsLZbQ/edit#

I think it makes sense to set an `sla` for tasks but also ensure they time out after a while, otherwise we might end up with a lot of tasks retrying taking up all the slots if not detected during triage.