### PR TITLE
Fix vpn retention table to correctly handle periods other than 1 month

### DIFF
--- a/dags/bqetl_mozilla_vpn.py
+++ b/dags/bqetl_mozilla_vpn.py
@@ -543,9 +543,6 @@ with DAG(
     mozilla_vpn_derived__retention_by_subscription__v1.set_upstream(
         mozilla_vpn_derived__all_subscriptions__v1
     )
-    mozilla_vpn_derived__retention_by_subscription__v1.set_upstream(
-        wait_for_stripe_external__invoices__v1
-    )
 
     mozilla_vpn_derived__subscriptions__v1.set_upstream(
         mozilla_vpn_external__subscriptions__v1

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/query.sql
@@ -234,7 +234,7 @@ apple_iap_subscriptions AS (
     CAST(NULL AS TIMESTAMP) AS canceled_at,
     CAST(NULL AS TIMESTAMP) AS cancel_at,
     CAST(NULL AS BOOL) AS cancel_at_period_end,
-    IF(end_time < CURRENT_DATE, end_time, NULL) AS ended_at,
+    IF(end_time < TIMESTAMP(CURRENT_DATE), end_time, NULL) AS ended_at,
     LEAST(end_time, TIMESTAMP(CURRENT_DATE)) AS end_date,
     fxa_uid,
     CAST(NULL AS STRING) AS country,

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/retention_by_subscription_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/retention_by_subscription_v1/query.sql
@@ -1,86 +1,20 @@
-WITH invoices AS (
-  SELECT
-    lines.subscription AS subscription_id,
-    DATE(TIMESTAMP_SECONDS(lines.period.start)) AS period_start_date,
-    invoices.billing_reason,
-    invoices.status_transitions,
-  FROM
-    `moz-fx-data-shared-prod`.stripe_external.invoices_v1 AS invoices
-  CROSS JOIN
-    UNNEST(lines) AS lines
-  WHERE
-    status IN ("paid", "open")
-),
-cohort AS (
-  SELECT DISTINCT
-    subscription_id,
-    DATE_TRUNC(MIN(period_start_date), MONTH) AS cohort_month,
-  FROM
-    invoices
-  GROUP BY
-    subscription_id
-  HAVING
-    cohort_month >= "2020-07-01"
-),
-attribution AS (
-  SELECT
-    subscription_id,
-    product_name,
-    plan_amount,
-    plan_currency,
-    plan_id,
-    plan_interval,
-    plan_interval_count,
-    pricing_plan,
-    provider,
-    country,
-    country_name,
-    coarse_attribution_category,
-    attribution_category,
-    utm_source,
-    utm_medium,
-    utm_content,
-    utm_campaign,
-    normalized_medium,
-    normalized_source,
-    normalized_campaign,
-    normalized_content,
-    normalized_acquisition_channel,
-    website_channel_group,
-  FROM
-    all_subscriptions_v1
-),
-cohorts_expanded AS (
+WITH base AS (
   SELECT
     *,
-    DATE_DIFF(activity_month, cohort_month, MONTH) AS renewal_period,
+    DATE_TRUNC(subscription_start_date, MONTH) AS cohort_month,
+    mozfun.norm.subscription_months_renewed(
+      -- month is timezone sensitive, so use localized datetime to calculate monthly retention
+      DATETIME(subscription_start_date, plan_interval_timezone),
+      DATETIME(end_date, plan_interval_timezone),
+      2 -- grace period in days
+    ) AS months_renewed,
   FROM
-    cohort
-  -- inner join to only include valid vpn subscriptions as defined by all_subscriptions_v1
-  JOIN
-    attribution
-  USING
-    (subscription_id)
-  CROSS JOIN
-    UNNEST(GENERATE_DATE_ARRAY(cohort_month, CURRENT_DATE, INTERVAL 1 MONTH)) AS activity_month
-),
-renewals AS (
-  SELECT DISTINCT
-    subscription_id,
-    DATE_TRUNC(period_start_date, MONTH) AS activity_month,
-  FROM
-    invoices
-  WHERE
-    billing_reason IN ("subscription_create", "subscription_cycle")
-    AND status_transitions.paid_at IS NOT NULL
+    all_subscriptions_v1
 )
 SELECT
   *,
-  renewals.subscription_id AS renewal_subscription_id,
-  renewals.activity_month AS activity_period_month,
 FROM
-  cohorts_expanded
-LEFT JOIN
-  renewals
-USING
-  (subscription_id, activity_month)
+  base
+CROSS JOIN
+  UNNEST(GENERATE_DATE_ARRAY(cohort_month, CURRENT_DATE, INTERVAL 1 MONTH)) AS activity_month
+  WITH OFFSET AS renewal_period

--- a/sql/mozfun/norm/subscription_months_renewed/udf.sql
+++ b/sql/mozfun/norm/subscription_months_renewed/udf.sql
@@ -1,0 +1,74 @@
+CREATE OR REPLACE FUNCTION norm.subscription_months_renewed(
+  start DATETIME,
+  `end` DATETIME,
+  grace_days INT64
+) AS (
+  (
+    SELECT
+      IFNULL(MAX(months_renewed), 0)
+    FROM
+      UNNEST([DATETIME_DIFF(`end`, start, MONTH)]) AS total_months,
+      UNNEST(GENERATE_ARRAY(total_months - 2, total_months)) AS months_renewed
+    WHERE
+      -- only return 0 via fallback
+      months_renewed > 0
+      -- don't count renewals that end within the grace period for payment
+      AND DATETIME_ADD(
+        DATETIME_ADD(start, INTERVAL months_renewed MONTH),
+        INTERVAL grace_days DAY
+      ) < `end`
+      AND start < DATETIME_SUB(
+        DATETIME_SUB(`end`, INTERVAL months_renewed MONTH),
+        INTERVAL grace_days DAY
+      )
+  )
+);
+
+-- Tests
+SELECT
+  assert.equals(expected, norm.subscription_months_renewed(start, `end`, 2))
+FROM
+  UNNEST(
+    ARRAY<STRUCT<start DATETIME, `end` DATETIME, expected INT64>>[
+      -- start at middle of month
+      (DATETIME "2021-01-15", DATETIME "2021-03-18", 2),
+      (DATETIME "2021-01-15", DATETIME "2021-03-17", 1),
+      (DATETIME "2021-01-15", DATETIME "2021-03-16", 1),
+      (DATETIME "2021-01-15", DATETIME "2021-03-15", 1),
+      (DATETIME "2021-01-15", DATETIME "2021-02-18", 1),
+      (DATETIME "2021-01-15", DATETIME "2021-02-17", 0),
+      (DATETIME "2021-01-15", DATETIME "2021-02-16", 0),
+      (DATETIME "2021-01-15", DATETIME "2021-02-15", 0),
+      -- grace period does not cause negative result
+      (DATETIME "2021-01-15", DATETIME "2021-01-18", 0),
+      (DATETIME "2021-01-15", DATETIME "2021-01-17", 0),
+      (DATETIME "2021-01-15", DATETIME "2021-01-16", 0),
+      -- start at end of short month
+      (DATETIME "2021-02-28", DATETIME "2021-06-03", 3),
+      (DATETIME "2021-02-28", DATETIME "2021-06-02", 2),
+      (DATETIME "2021-02-28", DATETIME "2021-06-01", 2),
+      (DATETIME "2021-02-28", DATETIME "2021-05-31", 2),
+      (DATETIME "2021-02-28", DATETIME "2021-05-30", 2),
+      (DATETIME "2021-02-28", DATETIME "2021-05-29", 2),
+      (DATETIME "2021-02-28", DATETIME "2021-05-28", 2),
+      -- start at end of long month
+      (DATETIME "2021-01-31", DATETIME "2021-05-03", 3),
+      (DATETIME "2021-01-31", DATETIME "2021-05-02", 2),
+      (DATETIME "2021-01-31", DATETIME "2021-05-01", 2),
+      (DATETIME "2021-01-31", DATETIME "2021-04-30", 2),
+      -- end near end of short month
+      (DATETIME "2021-01-30", DATETIME "2021-04-02", 2),
+      (DATETIME "2021-01-30", DATETIME "2021-04-01", 1),
+      (DATETIME "2021-01-30", DATETIME "2021-03-31", 1),
+      (DATETIME "2021-01-30", DATETIME "2021-03-30", 1),
+      (DATETIME "2021-01-30", DATETIME "2021-03-03", 1),
+      (DATETIME "2021-01-30", DATETIME "2021-03-02", 0),
+      -- end near end of shortest month
+      (DATETIME "2021-01-28", DATETIME "2021-03-31", 2),
+      (DATETIME "2021-01-28", DATETIME "2021-03-30", 1),
+      (DATETIME "2021-01-28", DATETIME "2021-03-03", 1),
+      (DATETIME "2021-01-28", DATETIME "2021-03-02", 0),
+      (DATETIME "2021-01-28", DATETIME "2021-03-01", 0),
+      (DATETIME "2021-01-28", DATETIME "2021-02-28", 0)
+    ]
+  )


### PR DESCRIPTION
previous definition of retention required an invoice to be paid in each month to count as renewed. This definition was insufficient because invoices aren't available for IAP subs, "month" is a timezone sensitive concept and IAP subs use `America/Los_Angeles`, and for non-monthly subscriptions (e.g. 6 month and 1 year subs) we don't have an invoice for each month.

New definition is based on localized start/end datetime and grace period in days, and is defined in a UDF for ease of testing.