### PR TITLE
Github Action for pushing forks to upstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,16 +372,23 @@ jobs:
       - checkout
       - run:
           name: Manually trigger integration tests for fork
+          # yamllint disable rule:line-length
           command: |
+            apt update
+            apt install jq -y
+
+            CIRCLE_PR_BRANCH=`curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.head.label'`
+
             echo "Integration tests for this fork need to be triggered manually"
             echo "Users with write access to the repository can trigger" \
               " integration tests by visiting: "
             echo "https://github.com/mozilla/bigquery-etl/actions/workflows" \
               "/push-to-upstream.yml".
-            echo "Trigger via 'Run workflow' and provide the " \
-              "<username>:<branch>" of this PR as parameters."
+            echo "Trigger via 'Run workflow' and provide " \
+              '$CIRCLE_PR_BRANCH' as parameter."
 
             exit 1
+          # yamllint enable rule:line-length
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,11 +366,31 @@ jobs:
       - gcp-gcr/push-image:
           image: bigquery-etl
           tag: ${CIRCLE_TAG:-latest}
+  manual-trigger-required-for-fork:
+    docker: *docker
+    steps:
+      - checkout
+      - run:
+          name: Manually trigger integration tests for fork
+          command: |
+            echo "Integration tests for this fork need to be triggered manually"
+            echo "Users with write access to the repository can trigger" \
+              " integration tests by visiting: "
+            echo "https://github.com/mozilla/bigquery-etl/actions/workflows" \
+              "/push-to-upstream.yml".
+            echo "Trigger via 'Run workflow' and provide the " \
+              "<username>:<branch>" of this PR as parameters."
+
+            exit 1
 
 workflows:
   version: 2
   build:
     jobs: &build_jobs
+      - manual-trigger-required-for-fork:
+          filters:
+            branches:
+              only: /^pull\/.*$/
       - build:
           context: data-eng-circleci-tests
       - verify-format-sql

--- a/.github/workflows/push-to-upstream.yml
+++ b/.github/workflows/push-to-upstream.yml
@@ -1,0 +1,37 @@
+# Workflow manually triggered to push fork to upstream
+name: Push to upstream
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Push PR to upstream <username>:<branch>'
+        default: ''
+        required: true
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: webfactory/ssh-agent
+      uses: webfactory/ssh-agent@v0.5.1
+      with:
+          ssh-private-key: ${{ secrets.GH_ACTION_SSH_KEY }}
+    - name: push-upstream
+      run: |
+        ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+        git config --global user.name "Github Action"
+        git config --global user.email "gh-action+bigquery-etl@mozilla.com"
+
+        mkdir bin
+        GPF_INSTALL_LOCATION=bin/git-push-fork-to-upstream-branch
+        GPF_URL=https://raw.githubusercontent.com/jklukas/git-push-fork-to-upstream-branch/master/git-push-fork-to-upstream-branch
+        sudo curl -sL $GPF_URL > $GPF_INSTALL_LOCATION
+        chmod 755 $GPF_INSTALL_LOCATION
+        export GPF_USE_SSH=true
+
+        git clone git@github.com:mozilla/bigquery-etl.git
+        cd gh-actions-test
+
+        ../bin/git-push-fork-to-upstream-branch git@github.com:mozilla/bigquery-etl.git ${{ github.event.inputs.name }}

--- a/.github/workflows/push-to-upstream.yml
+++ b/.github/workflows/push-to-upstream.yml
@@ -17,7 +17,7 @@ jobs:
     - name: webfactory/ssh-agent
       uses: webfactory/ssh-agent@v0.5.1
       with:
-          ssh-private-key: ${{ secrets.GH_ACTION_SSH_KEY }}
+        ssh-private-key: ${{ secrets.GH_ACTION_SSH_KEY }}
     - name: push-upstream
       run: |
         ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
@@ -34,4 +34,6 @@ jobs:
         git clone git@github.com:mozilla/bigquery-etl.git
         cd gh-actions-test
 
-        ../bin/git-push-fork-to-upstream-branch git@github.com:mozilla/bigquery-etl.git ${{ github.event.inputs.name }}
+        ../bin/git-push-fork-to-upstream-branch \
+          git@github.com:mozilla/bigquery-etl.git \
+          ${{ github.event.inputs.name }}


### PR DESCRIPTION
This wraps the [git-push-fork-to-upstream-branch](https://github.com/jklukas/git-push-fork-to-upstream-branch) script into a Github Action. The CircleCI config has been updated to have a failing tasks for forks that will show instructions of how to trigger the Github Actions so that integration tests will get executed for forks.

I successfully tested this approach in this repository: https://github.com/scholtzan/gh-actions-test

The main advantage here is that we don't have to share secrets with forks, however it might be a little unintuitive.

Another option that came to mind that we could try:
* All environment variables (our secrets) get moved into a restricted context
* The setup is essentially the same as described here: https://github.com/mozilla/glean.js/pull/422#issuecomment-863411793
* When sharing secrets also SSH keys are being shared, so we'd need to remove deploy keys from the repository settings and move them to environment variables managed by the restricted context
    * The CircleCI config would need to be rewritten to use the SSH keys from the environment variable

This seems a little less safe since it would require sharing secrets with forks (although if set up correctly it should not pose a security problem). Also not sure how much effort rewriting the CircleCI config would be. 