### PR TITLE
Fix GH action for pushing to upstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,11 +381,9 @@ jobs:
 
             echo "Integration tests for this fork need to be triggered manually"
             echo "Users with write access to the repository can trigger" \
-              " integration tests by visiting: "
-            echo "https://github.com/mozilla/bigquery-etl/actions/workflows" \
-              "/push-to-upstream.yml".
-            echo "Trigger via 'Run workflow' and provide " \
-              '$CIRCLE_PR_BRANCH' as parameter."
+              "integration tests by visiting: "
+            echo "https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml".
+            echo "Trigger via 'Run workflow' and provide '$CIRCLE_PR_BRANCH' as parameter."
 
             exit 1
           # yamllint enable rule:line-length

--- a/.github/workflows/push-to-upstream.yml
+++ b/.github/workflows/push-to-upstream.yml
@@ -14,13 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: webfactory/ssh-agent
-      uses: webfactory/ssh-agent@v0.5.1
-      with:
-        ssh-private-key: ${{ secrets.GH_ACTION_SSH_KEY }}
     - name: push-upstream
       run: |
-        ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+        eval "$(ssh-agent -s)"
+        ssh-add - <<< "${{ secrets.GH_ACTION_SSH_KEY }}"
+
         git config --global user.name "Github Action"
         git config --global user.email "gh-action+bigquery-etl@mozilla.com"
 


### PR DESCRIPTION
Fixes the following error

```
webfactory/ssh-agent@v0.5.1 is not allowed to be used in mozilla/bigquery-etl. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub or match the following: !/mozilla/**, !mozilla/**, ./**, aws-actions/*, docker/*, pypa/gh-action-pypi-publish@release/v1.4.2.
```