### PR TITLE
Disambiguate ad_clicks in addons_daily query

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -63,12 +63,6 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_last_seen_v1/query.sql",  # noqa E501
-    "sql/moz-fx-data-shared-prod/telemetry_derived/addons_daily_v1/query.sql",
-    "sql/moz-fx-data-shared-prod/search_derived/search_clients_last_seen_v1/init.sql",
-    "sql/moz-fx-data-shared-prod/search_derived/search_clients_last_seen_v1/query.sql",
-    "sql/moz-fx-data-shared-prod/search/search_rfm/view.sql",
-    "sql/moz-fx-data-shared-prod/search/search_clients_last_seen_v1/view.sql",
-    "sql/moz-fx-data-shared-prod/search/search_clients_last_seen/view.sql",
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_export_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_user_ids_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_user_ids_v1/init.sql",  # noqa E501

--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_last_seen_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_last_seen_v1/init.sql
@@ -1,4 +1,4 @@
-CREATE TABLE
+CREATE TABLE IF NOT EXISTS
   search_clients_last_seen_v1
 PARTITION BY
   submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/addons_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/addons_daily_v1/query.sql
@@ -97,7 +97,7 @@ client_meta AS (
     tagged_follow_on,
     organic,
     searches_with_ads,
-    ad_clicks,
+    client_searches.ad_clicks,
     active_addons
   FROM
     `moz-fx-data-shared-prod.telemetry_derived.clients_last_seen_v1`


### PR DESCRIPTION
The addons_daily_v1 query failed last night with an error about `ad_clicks`
being an ambiguous field name. See
[Airflow logs](https://workflow.telemetry.mozilla.org/log?execution_date=2021-06-23T04%3A00%3A00%2B00%3A00&task_id=telemetry_derived__addons_daily__v1&dag_id=bqetl_addons).

This is due to https://github.com/mozilla/bigquery-etl/pull/2151 which added
a field called ad_clicks to clients_daily and downstream tables. That new field
is present in a join.

This PR disambiguates the reference by specifying which table to pull it from.