### PR TITLE
Use ExternalTaskCompletedSensor in generated Airflow DAGs

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -99,7 +99,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
     {% endif -%}
     {% else -%}
     {% if (dependency.dag_name, dependency.task_id) not in wait_for_seen -%}
-    wait_for_{{ dependency.task_id }} = ExternalTaskSensor(
+    wait_for_{{ dependency.task_id }} = ExternalTaskCompletedSensor(
         task_id='wait_for_{{ dependency.task_id }}',
         external_dag_id='{{ dependency.dag_name }}',
         external_task_id='{{ dependency.task_id }}',
@@ -120,7 +120,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
 
     {% for task_ref in task.depends_on | sort(attribute='task_id') -%}
     {% if (task_ref.dag_name, task_ref.task_id) not in wait_for_seen -%}
-    wait_for_{{ task_ref.dag_name }}_{{ task_ref.task_id }} = ExternalTaskSensor(
+    wait_for_{{ task_ref.dag_name }}_{{ task_ref.task_id }} = ExternalTaskCompletedSensor(
         task_id="wait_for_{{ task_ref.dag_name }}_{{ task_ref.task_id }}",
         external_dag_id="{{ task_ref.dag_name }}",
         external_task_id="{{ task_ref.task_id }}",

--- a/dags/bqetl_activity_stream.py
+++ b/dags/bqetl_activity_stream.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -69,7 +69,7 @@ with DAG(
         activity_stream_bi__impression_stats_flat__v1
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",

--- a/dags/bqetl_addons.py
+++ b/dags/bqetl_addons.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -90,7 +90,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_main_ping = ExternalTaskSensor(
+    wait_for_copy_deduplicate_main_ping = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_main_ping",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_main_ping",
@@ -108,7 +108,7 @@ with DAG(
 
     telemetry_derived__addons__v2.set_upstream(wait_for_copy_deduplicate_main_ping)
 
-    wait_for_search_derived__search_clients_daily__v8 = ExternalTaskSensor(
+    wait_for_search_derived__search_clients_daily__v8 = ExternalTaskCompletedSensor(
         task_id="wait_for_search_derived__search_clients_daily__v8",
         external_dag_id="bqetl_search",
         external_task_id="search_derived__search_clients_daily__v8",
@@ -121,7 +121,7 @@ with DAG(
     telemetry_derived__addons_daily__v1.set_upstream(
         wait_for_search_derived__search_clients_daily__v8
     )
-    wait_for_telemetry_derived__clients_last_seen__v1 = ExternalTaskSensor(
+    wait_for_telemetry_derived__clients_last_seen__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_telemetry_derived__clients_last_seen__v1",
         external_dag_id="bqetl_main_summary",
         external_task_id="telemetry_derived__clients_last_seen__v1",

--- a/dags/bqetl_adm_engagements_daily.py
+++ b/dags/bqetl_adm_engagements_daily.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -50,7 +50,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_bq_main_events = ExternalTaskSensor(
+    wait_for_bq_main_events = ExternalTaskCompletedSensor(
         task_id="wait_for_bq_main_events",
         external_dag_id="copy_deduplicate",
         external_task_id="bq_main_events",
@@ -61,7 +61,7 @@ with DAG(
     )
 
     telemetry_derived__adm_engagements_daily__v1.set_upstream(wait_for_bq_main_events)
-    wait_for_event_events = ExternalTaskSensor(
+    wait_for_event_events = ExternalTaskCompletedSensor(
         task_id="wait_for_event_events",
         external_dag_id="copy_deduplicate",
         external_task_id="event_events",
@@ -72,7 +72,7 @@ with DAG(
     )
 
     telemetry_derived__adm_engagements_daily__v1.set_upstream(wait_for_event_events)
-    wait_for_search_derived__search_clients_daily__v8 = ExternalTaskSensor(
+    wait_for_search_derived__search_clients_daily__v8 = ExternalTaskCompletedSensor(
         task_id="wait_for_search_derived__search_clients_daily__v8",
         external_dag_id="bqetl_search",
         external_task_id="search_derived__search_clients_daily__v8",

--- a/dags/bqetl_amo_stats.py
+++ b/dags/bqetl_amo_stats.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -124,7 +124,7 @@ with DAG(
 
     amo_prod__amo_stats_dau__v2.set_upstream(amo_prod__fenix_addons_by_client__v1)
 
-    wait_for_bq_main_events = ExternalTaskSensor(
+    wait_for_bq_main_events = ExternalTaskCompletedSensor(
         task_id="wait_for_bq_main_events",
         external_dag_id="copy_deduplicate",
         external_task_id="bq_main_events",
@@ -135,7 +135,7 @@ with DAG(
     )
 
     amo_prod__amo_stats_installs__v3.set_upstream(wait_for_bq_main_events)
-    wait_for_event_events = ExternalTaskSensor(
+    wait_for_event_events = ExternalTaskCompletedSensor(
         task_id="wait_for_event_events",
         external_dag_id="copy_deduplicate",
         external_task_id="event_events",
@@ -147,7 +147,7 @@ with DAG(
 
     amo_prod__amo_stats_installs__v3.set_upstream(wait_for_event_events)
 
-    wait_for_copy_deduplicate_main_ping = ExternalTaskSensor(
+    wait_for_copy_deduplicate_main_ping = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_main_ping",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_main_ping",
@@ -161,7 +161,7 @@ with DAG(
         wait_for_copy_deduplicate_main_ping
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",

--- a/dags/bqetl_app_store_connect.py
+++ b/dags/bqetl_app_store_connect.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/dags/bqetl_asn_aggregates.py
+++ b/dags/bqetl_asn_aggregates.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -51,7 +51,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_bq_main_events = ExternalTaskSensor(
+    wait_for_bq_main_events = ExternalTaskCompletedSensor(
         task_id="wait_for_bq_main_events",
         external_dag_id="copy_deduplicate",
         external_task_id="bq_main_events",

--- a/dags/bqetl_core.py
+++ b/dags/bqetl_core.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -61,7 +61,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
@@ -74,14 +74,16 @@ with DAG(
     telemetry_derived__core_clients_daily__v1.set_upstream(
         wait_for_copy_deduplicate_all
     )
-    wait_for_telemetry_derived__core_clients_first_seen__v1 = ExternalTaskSensor(
-        task_id="wait_for_telemetry_derived__core_clients_first_seen__v1",
-        external_dag_id="copy_deduplicate",
-        external_task_id="telemetry_derived__core_clients_first_seen__v1",
-        execution_delta=datetime.timedelta(seconds=3600),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    wait_for_telemetry_derived__core_clients_first_seen__v1 = (
+        ExternalTaskCompletedSensor(
+            task_id="wait_for_telemetry_derived__core_clients_first_seen__v1",
+            external_dag_id="copy_deduplicate",
+            external_task_id="telemetry_derived__core_clients_first_seen__v1",
+            execution_delta=datetime.timedelta(seconds=3600),
+            check_existence=True,
+            mode="reschedule",
+            pool="DATA_ENG_EXTERNALTASKSENSOR",
+        )
     )
 
     telemetry_derived__core_clients_daily__v1.set_upstream(

--- a/dags/bqetl_ctxsvc_derived.py
+++ b/dags/bqetl_ctxsvc_derived.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -50,7 +50,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",

--- a/dags/bqetl_deletion_request_volume.py
+++ b/dags/bqetl_deletion_request_volume.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/dags/bqetl_desktop_funnel.py
+++ b/dags/bqetl_desktop_funnel.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -76,7 +76,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
@@ -89,7 +89,7 @@ with DAG(
     telemetry_derived__desktop_funnel_activation_day_6__v1.set_upstream(
         wait_for_copy_deduplicate_all
     )
-    wait_for_telemetry_derived__clients_last_seen__v1 = ExternalTaskSensor(
+    wait_for_telemetry_derived__clients_last_seen__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_telemetry_derived__clients_last_seen__v1",
         external_dag_id="bqetl_main_summary",
         external_task_id="telemetry_derived__clients_last_seen__v1",

--- a/dags/bqetl_desktop_platform.py
+++ b/dags/bqetl_desktop_platform.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -56,7 +56,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_main_ping = ExternalTaskSensor(
+    wait_for_copy_deduplicate_main_ping = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_main_ping",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_main_ping",

--- a/dags/bqetl_devtools.py
+++ b/dags/bqetl_devtools.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -70,7 +70,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_main_ping = ExternalTaskSensor(
+    wait_for_copy_deduplicate_main_ping = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_main_ping",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_main_ping",
@@ -84,7 +84,7 @@ with DAG(
         wait_for_copy_deduplicate_main_ping
     )
 
-    wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskSensor(
+    wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskCompletedSensor(
         task_id="wait_for_telemetry_derived__clients_daily__v6",
         external_dag_id="bqetl_main_summary",
         external_task_id="telemetry_derived__clients_daily__v6",

--- a/dags/bqetl_document_sample.py
+++ b/dags/bqetl_document_sample.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/dags/bqetl_error_aggregates.py
+++ b/dags/bqetl_error_aggregates.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/dags/bqetl_event_rollup.py
+++ b/dags/bqetl_event_rollup.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -170,27 +170,31 @@ with DAG(
         firefox_accounts_derived__event_types__v1
     )
 
-    wait_for_firefox_accounts_derived__fxa_auth_events__v1 = ExternalTaskSensor(
-        task_id="wait_for_firefox_accounts_derived__fxa_auth_events__v1",
-        external_dag_id="bqetl_fxa_events",
-        external_task_id="firefox_accounts_derived__fxa_auth_events__v1",
-        execution_delta=datetime.timedelta(seconds=5400),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    wait_for_firefox_accounts_derived__fxa_auth_events__v1 = (
+        ExternalTaskCompletedSensor(
+            task_id="wait_for_firefox_accounts_derived__fxa_auth_events__v1",
+            external_dag_id="bqetl_fxa_events",
+            external_task_id="firefox_accounts_derived__fxa_auth_events__v1",
+            execution_delta=datetime.timedelta(seconds=5400),
+            check_existence=True,
+            mode="reschedule",
+            pool="DATA_ENG_EXTERNALTASKSENSOR",
+        )
     )
 
     funnel_events_source__v1.set_upstream(
         wait_for_firefox_accounts_derived__fxa_auth_events__v1
     )
-    wait_for_firefox_accounts_derived__fxa_content_events__v1 = ExternalTaskSensor(
-        task_id="wait_for_firefox_accounts_derived__fxa_content_events__v1",
-        external_dag_id="bqetl_fxa_events",
-        external_task_id="firefox_accounts_derived__fxa_content_events__v1",
-        execution_delta=datetime.timedelta(seconds=5400),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    wait_for_firefox_accounts_derived__fxa_content_events__v1 = (
+        ExternalTaskCompletedSensor(
+            task_id="wait_for_firefox_accounts_derived__fxa_content_events__v1",
+            external_dag_id="bqetl_fxa_events",
+            external_task_id="firefox_accounts_derived__fxa_content_events__v1",
+            execution_delta=datetime.timedelta(seconds=5400),
+            check_existence=True,
+            mode="reschedule",
+            pool="DATA_ENG_EXTERNALTASKSENSOR",
+        )
     )
 
     funnel_events_source__v1.set_upstream(
@@ -201,7 +205,7 @@ with DAG(
         messaging_system_derived__event_types_history__v1
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",

--- a/dags/bqetl_experiments_daily.py
+++ b/dags/bqetl_experiments_daily.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -109,7 +109,7 @@ with DAG(
         telemetry_derived__experiments_daily_active_clients__v1
     )
 
-    wait_for_bq_main_events = ExternalTaskSensor(
+    wait_for_bq_main_events = ExternalTaskCompletedSensor(
         task_id="wait_for_bq_main_events",
         external_dag_id="copy_deduplicate",
         external_task_id="bq_main_events",
@@ -122,7 +122,7 @@ with DAG(
     telemetry_derived__experiment_enrollment_aggregates__v1.set_upstream(
         wait_for_bq_main_events
     )
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
@@ -135,7 +135,7 @@ with DAG(
     telemetry_derived__experiment_enrollment_aggregates__v1.set_upstream(
         wait_for_copy_deduplicate_all
     )
-    wait_for_event_events = ExternalTaskSensor(
+    wait_for_event_events = ExternalTaskCompletedSensor(
         task_id="wait_for_event_events",
         external_dag_id="copy_deduplicate",
         external_task_id="event_events",
@@ -152,7 +152,7 @@ with DAG(
     telemetry_derived__experiment_search_aggregates__v1.set_upstream(
         wait_for_copy_deduplicate_all
     )
-    wait_for_copy_deduplicate_main_ping = ExternalTaskSensor(
+    wait_for_copy_deduplicate_main_ping = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_main_ping",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_main_ping",
@@ -169,7 +169,7 @@ with DAG(
     telemetry_derived__experiments_daily_active_clients__v1.set_upstream(
         wait_for_copy_deduplicate_all
     )
-    wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskSensor(
+    wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskCompletedSensor(
         task_id="wait_for_telemetry_derived__clients_daily__v6",
         external_dag_id="bqetl_main_summary",
         external_task_id="telemetry_derived__clients_daily__v6",

--- a/dags/bqetl_fenix_event_rollup.py
+++ b/dags/bqetl_fenix_event_rollup.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -76,7 +76,7 @@ with DAG(
         org_mozilla_firefox_derived__event_types_history__v1
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",

--- a/dags/bqetl_firefox_ios.py
+++ b/dags/bqetl_firefox_ios.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/dags/bqetl_google_analytics_derived.py
+++ b/dags/bqetl_google_analytics_derived.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/dags/bqetl_gud.py
+++ b/dags/bqetl_gud.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -131,7 +131,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_telemetry_derived__clients_last_seen__v1 = ExternalTaskSensor(
+    wait_for_telemetry_derived__clients_last_seen__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_telemetry_derived__clients_last_seen__v1",
         external_dag_id="bqetl_main_summary",
         external_task_id="telemetry_derived__clients_last_seen__v1",
@@ -149,14 +149,16 @@ with DAG(
         telemetry_derived__smoot_usage_desktop__v2
     )
 
-    wait_for_firefox_accounts_derived__fxa_users_last_seen__v1 = ExternalTaskSensor(
-        task_id="wait_for_firefox_accounts_derived__fxa_users_last_seen__v1",
-        external_dag_id="bqetl_fxa_events",
-        external_task_id="firefox_accounts_derived__fxa_users_last_seen__v1",
-        execution_delta=datetime.timedelta(seconds=5400),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    wait_for_firefox_accounts_derived__fxa_users_last_seen__v1 = (
+        ExternalTaskCompletedSensor(
+            task_id="wait_for_firefox_accounts_derived__fxa_users_last_seen__v1",
+            external_dag_id="bqetl_fxa_events",
+            external_task_id="firefox_accounts_derived__fxa_users_last_seen__v1",
+            execution_delta=datetime.timedelta(seconds=5400),
+            check_existence=True,
+            mode="reschedule",
+            pool="DATA_ENG_EXTERNALTASKSENSOR",
+        )
     )
 
     telemetry_derived__smoot_usage_fxa__v2.set_upstream(
@@ -183,7 +185,7 @@ with DAG(
         telemetry_derived__smoot_usage_new_profiles__v2
     )
 
-    wait_for_baseline_clients_last_seen = ExternalTaskSensor(
+    wait_for_baseline_clients_last_seen = ExternalTaskCompletedSensor(
         task_id="wait_for_baseline_clients_last_seen",
         external_dag_id="copy_deduplicate",
         external_task_id="baseline_clients_last_seen",
@@ -196,14 +198,16 @@ with DAG(
     telemetry_derived__smoot_usage_nondesktop__v2.set_upstream(
         wait_for_baseline_clients_last_seen
     )
-    wait_for_telemetry_derived__core_clients_last_seen__v1 = ExternalTaskSensor(
-        task_id="wait_for_telemetry_derived__core_clients_last_seen__v1",
-        external_dag_id="bqetl_core",
-        external_task_id="telemetry_derived__core_clients_last_seen__v1",
-        execution_delta=datetime.timedelta(seconds=3600),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    wait_for_telemetry_derived__core_clients_last_seen__v1 = (
+        ExternalTaskCompletedSensor(
+            task_id="wait_for_telemetry_derived__core_clients_last_seen__v1",
+            external_dag_id="bqetl_core",
+            external_task_id="telemetry_derived__core_clients_last_seen__v1",
+            execution_delta=datetime.timedelta(seconds=3600),
+            check_existence=True,
+            mode="reschedule",
+            pool="DATA_ENG_EXTERNALTASKSENSOR",
+        )
     )
 
     telemetry_derived__smoot_usage_nondesktop__v2.set_upstream(

--- a/dags/bqetl_internal_tooling.py
+++ b/dags/bqetl_internal_tooling.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -52,7 +52,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",

--- a/dags/bqetl_internet_outages.py
+++ b/dags/bqetl_internet_outages.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -52,7 +52,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
@@ -63,7 +63,7 @@ with DAG(
     )
 
     internet_outages__global_outages__v1.set_upstream(wait_for_copy_deduplicate_all)
-    wait_for_copy_deduplicate_main_ping = ExternalTaskSensor(
+    wait_for_copy_deduplicate_main_ping = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_main_ping",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_main_ping",
@@ -76,7 +76,7 @@ with DAG(
     internet_outages__global_outages__v1.set_upstream(
         wait_for_copy_deduplicate_main_ping
     )
-    wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskSensor(
+    wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskCompletedSensor(
         task_id="wait_for_telemetry_derived__clients_daily__v6",
         external_dag_id="bqetl_main_summary",
         external_task_id="telemetry_derived__clients_daily__v6",

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -331,7 +331,7 @@ with DAG(
         telemetry_derived__clients_last_seen__v1
     )
 
-    wait_for_copy_deduplicate_main_ping = ExternalTaskSensor(
+    wait_for_copy_deduplicate_main_ping = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_main_ping",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_main_ping",
@@ -345,7 +345,7 @@ with DAG(
         wait_for_copy_deduplicate_main_ping
     )
 
-    wait_for_bq_main_events = ExternalTaskSensor(
+    wait_for_bq_main_events = ExternalTaskCompletedSensor(
         task_id="wait_for_bq_main_events",
         external_dag_id="copy_deduplicate",
         external_task_id="bq_main_events",
@@ -356,7 +356,7 @@ with DAG(
     )
 
     telemetry_derived__clients_daily_event__v1.set_upstream(wait_for_bq_main_events)
-    wait_for_event_events = ExternalTaskSensor(
+    wait_for_event_events = ExternalTaskCompletedSensor(
         task_id="wait_for_event_events",
         external_dag_id="copy_deduplicate",
         external_task_id="event_events",

--- a/dags/bqetl_marketing_fetch.py
+++ b/dags/bqetl_marketing_fetch.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/dags/bqetl_messaging_system.py
+++ b/dags/bqetl_messaging_system.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -152,7 +152,7 @@ with DAG(
         messaging_system_derived__cfr_users_last_seen__v1
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",

--- a/dags/bqetl_mobile_search.py
+++ b/dags/bqetl_mobile_search.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -75,7 +75,7 @@ with DAG(
         search_derived__mobile_search_clients_daily__v1
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",

--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -160,7 +160,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
@@ -178,7 +178,7 @@ with DAG(
         monitoring_derived__stable_table_sizes__v1
     )
 
-    wait_for_copy_deduplicate_main_ping = ExternalTaskSensor(
+    wait_for_copy_deduplicate_main_ping = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_main_ping",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_main_ping",

--- a/dags/bqetl_mozilla_vpn.py
+++ b/dags/bqetl_mozilla_vpn.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -395,7 +395,7 @@ with DAG(
     mozilla_vpn_derived__all_subscriptions__v1.set_upstream(
         mozilla_vpn_derived__users__v1
     )
-    wait_for_stripe_derived__customers__v1 = ExternalTaskSensor(
+    wait_for_stripe_derived__customers__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_stripe_derived__customers__v1",
         external_dag_id="bqetl_stripe",
         external_task_id="stripe_derived__customers__v1",
@@ -408,7 +408,7 @@ with DAG(
     mozilla_vpn_derived__all_subscriptions__v1.set_upstream(
         wait_for_stripe_derived__customers__v1
     )
-    wait_for_stripe_derived__plans__v1 = ExternalTaskSensor(
+    wait_for_stripe_derived__plans__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_stripe_derived__plans__v1",
         external_dag_id="bqetl_stripe",
         external_task_id="stripe_derived__plans__v1",
@@ -421,7 +421,7 @@ with DAG(
     mozilla_vpn_derived__all_subscriptions__v1.set_upstream(
         wait_for_stripe_derived__plans__v1
     )
-    wait_for_stripe_derived__products__v1 = ExternalTaskSensor(
+    wait_for_stripe_derived__products__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_stripe_derived__products__v1",
         external_dag_id="bqetl_stripe",
         external_task_id="stripe_derived__products__v1",
@@ -434,7 +434,7 @@ with DAG(
     mozilla_vpn_derived__all_subscriptions__v1.set_upstream(
         wait_for_stripe_derived__products__v1
     )
-    wait_for_stripe_derived__subscriptions__v1 = ExternalTaskSensor(
+    wait_for_stripe_derived__subscriptions__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_stripe_derived__subscriptions__v1",
         external_dag_id="bqetl_stripe",
         external_task_id="stripe_derived__subscriptions__v1",
@@ -447,7 +447,7 @@ with DAG(
     mozilla_vpn_derived__all_subscriptions__v1.set_upstream(
         wait_for_stripe_derived__subscriptions__v1
     )
-    wait_for_stripe_external__charges__v1 = ExternalTaskSensor(
+    wait_for_stripe_external__charges__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_stripe_external__charges__v1",
         external_dag_id="bqetl_stripe",
         external_task_id="stripe_external__charges__v1",
@@ -460,7 +460,7 @@ with DAG(
     mozilla_vpn_derived__all_subscriptions__v1.set_upstream(
         wait_for_stripe_external__charges__v1
     )
-    wait_for_stripe_external__fxa_pay_setup_complete__v1 = ExternalTaskSensor(
+    wait_for_stripe_external__fxa_pay_setup_complete__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_stripe_external__fxa_pay_setup_complete__v1",
         external_dag_id="bqetl_stripe",
         external_task_id="stripe_external__fxa_pay_setup_complete__v1",
@@ -473,7 +473,7 @@ with DAG(
     mozilla_vpn_derived__all_subscriptions__v1.set_upstream(
         wait_for_stripe_external__fxa_pay_setup_complete__v1
     )
-    wait_for_stripe_external__invoices__v1 = ExternalTaskSensor(
+    wait_for_stripe_external__invoices__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_stripe_external__invoices__v1",
         external_dag_id="bqetl_stripe",
         external_task_id="stripe_external__invoices__v1",
@@ -509,27 +509,31 @@ with DAG(
         mozilla_vpn_derived__users__v1
     )
 
-    wait_for_firefox_accounts_derived__fxa_auth_events__v1 = ExternalTaskSensor(
-        task_id="wait_for_firefox_accounts_derived__fxa_auth_events__v1",
-        external_dag_id="bqetl_fxa_events",
-        external_task_id="firefox_accounts_derived__fxa_auth_events__v1",
-        execution_delta=datetime.timedelta(seconds=900),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    wait_for_firefox_accounts_derived__fxa_auth_events__v1 = (
+        ExternalTaskCompletedSensor(
+            task_id="wait_for_firefox_accounts_derived__fxa_auth_events__v1",
+            external_dag_id="bqetl_fxa_events",
+            external_task_id="firefox_accounts_derived__fxa_auth_events__v1",
+            execution_delta=datetime.timedelta(seconds=900),
+            check_existence=True,
+            mode="reschedule",
+            pool="DATA_ENG_EXTERNALTASKSENSOR",
+        )
     )
 
     mozilla_vpn_derived__login_flows__v1.set_upstream(
         wait_for_firefox_accounts_derived__fxa_auth_events__v1
     )
-    wait_for_firefox_accounts_derived__fxa_content_events__v1 = ExternalTaskSensor(
-        task_id="wait_for_firefox_accounts_derived__fxa_content_events__v1",
-        external_dag_id="bqetl_fxa_events",
-        external_task_id="firefox_accounts_derived__fxa_content_events__v1",
-        execution_delta=datetime.timedelta(seconds=900),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    wait_for_firefox_accounts_derived__fxa_content_events__v1 = (
+        ExternalTaskCompletedSensor(
+            task_id="wait_for_firefox_accounts_derived__fxa_content_events__v1",
+            external_dag_id="bqetl_fxa_events",
+            external_task_id="firefox_accounts_derived__fxa_content_events__v1",
+            execution_delta=datetime.timedelta(seconds=900),
+            check_existence=True,
+            mode="reschedule",
+            pool="DATA_ENG_EXTERNALTASKSENSOR",
+        )
     )
 
     mozilla_vpn_derived__login_flows__v1.set_upstream(

--- a/dags/bqetl_mozilla_vpn_site_metrics.py
+++ b/dags/bqetl_mozilla_vpn_site_metrics.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -85,7 +85,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_mozilla_vpn_derived__all_subscriptions__v1 = ExternalTaskSensor(
+    wait_for_mozilla_vpn_derived__all_subscriptions__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_mozilla_vpn_derived__all_subscriptions__v1",
         external_dag_id="bqetl_mozilla_vpn",
         external_task_id="mozilla_vpn_derived__all_subscriptions__v1",

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -83,21 +83,23 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_telemetry_derived__core_clients_last_seen__v1 = ExternalTaskSensor(
-        task_id="wait_for_telemetry_derived__core_clients_last_seen__v1",
-        external_dag_id="bqetl_core",
-        external_task_id="telemetry_derived__core_clients_last_seen__v1",
-        execution_delta=datetime.timedelta(seconds=3600),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    wait_for_telemetry_derived__core_clients_last_seen__v1 = (
+        ExternalTaskCompletedSensor(
+            task_id="wait_for_telemetry_derived__core_clients_last_seen__v1",
+            external_dag_id="bqetl_core",
+            external_task_id="telemetry_derived__core_clients_last_seen__v1",
+            execution_delta=datetime.timedelta(seconds=3600),
+            check_existence=True,
+            mode="reschedule",
+            pool="DATA_ENG_EXTERNALTASKSENSOR",
+        )
     )
 
     firefox_nondesktop_exact_mau28_by_client_count_dimensions.set_upstream(
         wait_for_telemetry_derived__core_clients_last_seen__v1
     )
 
-    wait_for_baseline_clients_last_seen = ExternalTaskSensor(
+    wait_for_baseline_clients_last_seen = ExternalTaskCompletedSensor(
         task_id="wait_for_baseline_clients_last_seen",
         external_dag_id="copy_deduplicate",
         external_task_id="baseline_clients_last_seen",

--- a/dags/bqetl_org_mozilla_fenix_derived.py
+++ b/dags/bqetl_org_mozilla_fenix_derived.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -47,7 +47,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",

--- a/dags/bqetl_pocket.py
+++ b/dags/bqetl_pocket.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/dags/bqetl_release_criteria.py
+++ b/dags/bqetl_release_criteria.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/dags/bqetl_releases.py
+++ b/dags/bqetl_releases.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/dags/bqetl_search.py
+++ b/dags/bqetl_search.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -92,7 +92,7 @@ with DAG(
         search_derived__search_clients_daily__v8
     )
 
-    wait_for_telemetry_derived__main_summary__v4 = ExternalTaskSensor(
+    wait_for_telemetry_derived__main_summary__v4 = ExternalTaskCompletedSensor(
         task_id="wait_for_telemetry_derived__main_summary__v4",
         external_dag_id="bqetl_main_summary",
         external_task_id="telemetry_derived__main_summary__v4",

--- a/dags/bqetl_search_dashboard.py
+++ b/dags/bqetl_search_dashboard.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -76,7 +76,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_telemetry_derived__clients_last_seen__v1 = ExternalTaskSensor(
+    wait_for_telemetry_derived__clients_last_seen__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_telemetry_derived__clients_last_seen__v1",
         external_dag_id="bqetl_main_summary",
         external_task_id="telemetry_derived__clients_last_seen__v1",
@@ -90,7 +90,7 @@ with DAG(
         wait_for_telemetry_derived__clients_last_seen__v1
     )
 
-    wait_for_search_derived__search_aggregates__v8 = ExternalTaskSensor(
+    wait_for_search_derived__search_aggregates__v8 = ExternalTaskCompletedSensor(
         task_id="wait_for_search_derived__search_aggregates__v8",
         external_dag_id="bqetl_search",
         external_task_id="search_derived__search_aggregates__v8",
@@ -104,14 +104,16 @@ with DAG(
         wait_for_search_derived__search_aggregates__v8
     )
 
-    wait_for_search_derived__mobile_search_clients_daily__v1 = ExternalTaskSensor(
-        task_id="wait_for_search_derived__mobile_search_clients_daily__v1",
-        external_dag_id="bqetl_mobile_search",
-        external_task_id="search_derived__mobile_search_clients_daily__v1",
-        execution_delta=datetime.timedelta(seconds=7200),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    wait_for_search_derived__mobile_search_clients_daily__v1 = (
+        ExternalTaskCompletedSensor(
+            task_id="wait_for_search_derived__mobile_search_clients_daily__v1",
+            external_dag_id="bqetl_mobile_search",
+            external_task_id="search_derived__mobile_search_clients_daily__v1",
+            execution_delta=datetime.timedelta(seconds=7200),
+            check_existence=True,
+            mode="reschedule",
+            pool="DATA_ENG_EXTERNALTASKSENSOR",
+        )
     )
 
     search_derived__mobile_search_aggregates_for_searchreport__v1.set_upstream(

--- a/dags/bqetl_ssl_ratios.py
+++ b/dags/bqetl_ssl_ratios.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -50,7 +50,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_main_ping = ExternalTaskSensor(
+    wait_for_copy_deduplicate_main_ping = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_main_ping",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_main_ping",

--- a/dags/bqetl_stripe.py
+++ b/dags/bqetl_stripe.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -267,7 +267,7 @@ with DAG(
 
     stripe_derived__subscriptions__v1.set_upstream(stripe_external__subscriptions__v1)
 
-    wait_for_stripe_import_events = ExternalTaskSensor(
+    wait_for_stripe_import_events = ExternalTaskCompletedSensor(
         task_id="wait_for_stripe_import_events",
         external_dag_id="stripe",
         external_task_id="stripe_import_events",

--- a/dags/bqetl_vrbrowser.py
+++ b/dags/bqetl_vrbrowser.py
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -107,7 +107,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",

--- a/tests/data/dags/python_script_test_dag
+++ b/tests/data/dags/python_script_test_dag
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -56,7 +56,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_external_task1 = ExternalTaskSensor(
+    wait_for_external_task1 = ExternalTaskCompletedSensor(
         task_id="wait_for_external_task1",
         external_dag_id="external",
         external_task_id="task1",

--- a/tests/data/dags/test_dag_external_dependency
+++ b/tests/data/dags/test_dag_external_dependency
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -1,7 +1,7 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
-from airflow.operators.sensors import ExternalTaskSensor
+from operators.task_sensor import ExternalTaskCompletedSensor
 import datetime
 from utils.gcp import bigquery_etl_query, gke_command
 
@@ -68,7 +68,7 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_test__external_table__v1 = ExternalTaskSensor(
+    wait_for_test__external_table__v1 = ExternalTaskCompletedSensor(
         task_id="wait_for_test__external_table__v1",
         external_dag_id="bqetl_external_test_dag",
         external_task_id="test__external_table__v1",


### PR DESCRIPTION
`ExternalTaskCompletedSensor`s have been running without any issue in `bqetl_public_data_json`. So I think it's time to use it for the other generated DAGs as well.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
