### PR TITLE
Bug 1719188 - Add filter for large scalars in aggregates

### DIFF
--- a/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
@@ -71,6 +71,9 @@ scalar_aggregates_new AS (
     --format:on
   FROM
     version_filtered_new
+  WHERE
+    -- avoid overflows from very large numbers that are typically anomalies
+    value <= POW(2, 40)
   GROUP BY
     {{ attributes }},
     {{ user_data_attributes }},

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1/query.sql
@@ -169,6 +169,9 @@ scalar_aggregates_new AS (
     --format:on
   FROM
     version_filtered_new
+  WHERE
+    -- avoid overflows from very large numbers that are typically anomalies
+    value <= POW(2, 40)
   GROUP BY
     client_id,
     ping_type,

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_histogram_aggregates_metrics_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_histogram_aggregates_metrics_v1/query.sql
@@ -435,6 +435,21 @@ histograms AS (
         metrics.timing_distribution.perf_startup_home_fragment_on_view_created.values
       ),
       (
+        "performance_clone_deserialize_items",
+        "custom_distribution",
+        metrics.custom_distribution.performance_clone_deserialize_items.values
+      ),
+      (
+        "performance_clone_deserialize_size",
+        "memory_distribution",
+        metrics.memory_distribution.performance_clone_deserialize_size.values
+      ),
+      (
+        "performance_clone_deserialize_time",
+        "timing_distribution",
+        metrics.timing_distribution.performance_clone_deserialize_time.values
+      ),
+      (
         "performance_interaction_keypress_present_latency",
         "timing_distribution",
         metrics.timing_distribution.performance_interaction_keypress_present_latency.values


### PR DESCRIPTION
#2173 only fixed things half way. I'm not sure if this will fix things all the way, since the job fails in the next stage during the bucket counts.

See the [bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1719188) for some details on the failure. 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
