### PR TITLE
Fix private SQL generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,22 +364,22 @@ jobs:
       - run:
           name: Generate SQL content
           command: |
-            mkdir /tmp/private-generated-sql
-            cp -r sql/ /tmp/private-generated-sql/sql
+            mkdir /tmp/generated-sql
+            cp -r sql/ /tmp/generated-sql/private-sql
             ./bqetl bootstrap
             # Don't depend on dry run for PRs
             PATH="venv/bin:$PATH" ./script/generate_sql \
-              --sql-dir /tmp/private-generated-sql/sql/ \
+              --sql-dir /tmp/generated-sql/private-sql/ \
               --target-project moz-fx-data-shared-prod
       - persist_to_workspace:
-          root: /tmp/private-generated-sql
+          root: /tmp/generated-sql
           paths:
-            - sql
+            - private-sql
   push-private-generated-sql:
     docker: *docker
     steps:
       - attach_workspace:
-          at: /tmp/private-generated-sql
+          at: /tmp/generated-sql
       - add_ssh_keys:
           fingerprints: "cf:d6:25:9a:ee:26:66:39:c8:cc:48:f6:bb:3e:34:68"
       - run:
@@ -394,7 +394,7 @@ jobs:
               private-generated-sql
             cd private-generated-sql/
             rm -rf sql/
-            cp -r /tmp/private-generated-sql/sql sql
+            cp -r /tmp/generated-sql/private-sql sql
             git add .
             git commit -m "Auto-push due to change on main branch [ci skip]" \
               && git push \
@@ -405,12 +405,12 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/private-generated-sql
+          at: /tmp/generated-sql
       - run:
           name: Move generated-sql into place
           command: |
             rm -rf sql/
-            cp -r /tmp/private-generated-sql/sql sql
+            cp -r /tmp/generated-sql/private-sql sql
       - gcp-gcr/gcr-auth
       - gcp-gcr/build-image:
           image: bigquery-etl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ jobs:
       - *restore_mvn_cache
       - *java_deps
       - attach_workspace:
-          at: /tmp/generated-sql
+          at: /tmp/workspace
       - run:
           name: Install dependencies
           command: >
@@ -257,7 +257,7 @@ jobs:
       - run:
           name: Build and deploy docs
           command: |
-            rm -r sql/ && cp -r /tmp/generated-sql/sql sql/
+            rm -r sql/ && cp -r /tmp/workspace/generated-sql/sql sql/
             PATH="venv/bin:$PATH" script/generate_docs \
                --output_dir=generated_docs/
             cd generated_docs/
@@ -274,22 +274,22 @@ jobs:
       - run:
           name: Generate SQL content
           command: |
-            mkdir /tmp/generated-sql
-            cp -r sql/ /tmp/generated-sql/sql
+            mkdir /tmp/workspace/generated-sql
+            cp -r sql/ /tmp/workspace/generated-sql/sql
             ./bqetl bootstrap
             # Don't depend on dry run for PRs
             PATH="venv/bin:$PATH" ./script/generate_sql \
-              --sql-dir /tmp/generated-sql/sql/ \
+              --sql-dir /tmp/workspace/generated-sql/sql/ \
               --target-project moz-fx-data-shared-prod
       - persist_to_workspace:
-          root: /tmp/generated-sql
+          root: /tmp/workspace
           paths:
-            - sql
+            - generated-sql/sql
   push-generated-sql:
     docker: *docker
     steps:
       - attach_workspace:
-          at: /tmp/generated-sql
+          at: /tmp/workspace
       - add_ssh_keys:
           fingerprints: "ab:b5:f7:55:92:0a:72:c4:63:0e:57:be:cd:66:32:53"
       - run:
@@ -303,7 +303,7 @@ jobs:
               generated-sql
             cd generated-sql/
             rm -rf sql/
-            cp -r /tmp/generated-sql/sql sql
+            cp -r /tmp/workspace/generated-sql/sql sql
             git add .
             git commit -m "Auto-push due to change on main branch [ci skip]" \
               && git push \
@@ -317,12 +317,12 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - attach_workspace:
-          at: /tmp/generated-sql
+          at: /tmp/workspace
       - run:
           name: Move generated-sql into place
           command: |
             rm -rf sql/
-            cp -r /tmp/generated-sql/sql sql
+            cp -r /tmp/workspace/generated-sql/sql sql
       - run:
           name: Determine docker image name
           command:
@@ -364,22 +364,22 @@ jobs:
       - run:
           name: Generate SQL content
           command: |
-            mkdir /tmp/private-generated-sql
-            cp -r sql/ /tmp/private-generated-sql/sql
+            mkdir /tmp/workspace/private-generated-sql
+            cp -r sql/ /tmp/workspace/private-generated-sql/sql
             ./bqetl bootstrap
             # Don't depend on dry run for PRs
             PATH="venv/bin:$PATH" ./script/generate_sql \
-              --sql-dir /tmp/private-generated-sql/sql/ \
+              --sql-dir /tmp/workspace/private-generated-sql/sql/ \
               --target-project moz-fx-data-shared-prod
       - persist_to_workspace:
-          root: /tmp/private-generated-sql
+          root: /tmp/workspace
           paths:
-            - sql
+            - private-generated-sql/sql
   push-private-generated-sql:
     docker: *docker
     steps:
       - attach_workspace:
-          at: /tmp/private-generated-sql
+          at: /tmp/workspace
       - add_ssh_keys:
           fingerprints: "cf:d6:25:9a:ee:26:66:39:c8:cc:48:f6:bb:3e:34:68"
       - run:
@@ -394,7 +394,7 @@ jobs:
               private-generated-sql
             cd private-generated-sql/
             rm -rf sql/
-            cp -r /tmp/private-generated-sql/sql sql
+            cp -r /tmp/workspace/private-generated-sql/sql sql
             git add .
             git commit -m "Auto-push due to change on main branch [ci skip]" \
               && git push \
@@ -405,12 +405,12 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/private-generated-sql
+          at: /tmp/workspace
       - run:
           name: Move generated-sql into place
           command: |
             rm -rf sql/
-            cp -r /tmp/private-generated-sql/sql sql
+            cp -r /tmp/workspace/private-generated-sql/sql sql
       - gcp-gcr/gcr-auth
       - gcp-gcr/build-image:
           image: bigquery-etl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
-            - generated-sql/sql
+            - generated-sql
   push-generated-sql:
     docker: *docker
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,22 +364,22 @@ jobs:
       - run:
           name: Generate SQL content
           command: |
-            mkdir /tmp/generated-sql
-            cp -r sql/ /tmp/generated-sql/private-sql
+            mkdir /tmp/private-generated-sql
+            cp -r sql/ /tmp/private-generated-sql/sql
             ./bqetl bootstrap
             # Don't depend on dry run for PRs
             PATH="venv/bin:$PATH" ./script/generate_sql \
-              --sql-dir /tmp/generated-sql/private-sql/ \
+              --sql-dir /tmp/private-generated-sql/sql/ \
               --target-project moz-fx-data-shared-prod
       - persist_to_workspace:
-          root: /tmp/generated-sql
+          root: /tmp/private-generated-sql
           paths:
-            - private-sql
+            - sql
   push-private-generated-sql:
     docker: *docker
     steps:
       - attach_workspace:
-          at: /tmp/generated-sql
+          at: /tmp/private-generated-sql
       - add_ssh_keys:
           fingerprints: "cf:d6:25:9a:ee:26:66:39:c8:cc:48:f6:bb:3e:34:68"
       - run:
@@ -394,7 +394,7 @@ jobs:
               private-generated-sql
             cd private-generated-sql/
             rm -rf sql/
-            cp -r /tmp/generated-sql/private-sql sql
+            cp -r /tmp/private-generated-sql/sql sql
             git add .
             git commit -m "Auto-push due to change on main branch [ci skip]" \
               && git push \
@@ -405,12 +405,12 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/generated-sql
+          at: /tmp/private-generated-sql
       - run:
           name: Move generated-sql into place
           command: |
             rm -rf sql/
-            cp -r /tmp/generated-sql/private-sql sql
+            cp -r /tmp/private-generated-sql/sql sql
       - gcp-gcr/gcr-auth
       - gcp-gcr/build-image:
           image: bigquery-etl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
       - run:
           name: Generate SQL content
           command: |
-            mkdir /tmp/workspace/generated-sql
+            mkdir -p /tmp/workspace/generated-sql
             cp -r sql/ /tmp/workspace/generated-sql/sql
             ./bqetl bootstrap
             # Don't depend on dry run for PRs
@@ -364,7 +364,7 @@ jobs:
       - run:
           name: Generate SQL content
           command: |
-            mkdir /tmp/workspace/private-generated-sql
+            mkdir -p /tmp/workspace/private-generated-sql
             cp -r sql/ /tmp/workspace/private-generated-sql/sql
             ./bqetl bootstrap
             # Don't depend on dry run for PRs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ jobs:
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
-            - private-generated-sql/sql
+            - private-generated-sql
   push-private-generated-sql:
     docker: *docker
     steps:


### PR DESCRIPTION
This fixes CircleCI workflow that is failing[1] because both `generate-sql` and `private-generate-sql` jobs are persisting `sql` directory into the workspace. In order to keep these jobs concurrent, `private-...` branch of the workflow will use `/tmp/generated-sql/private-sql/`.

[1] https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/10084/workflows/a835c08d-7d06-44cc-82a1-31f05795f701/jobs/64214/parallel-runs/0/steps/0-103

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
