### PR TITLE
Update google-api-core to 1.31.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ click==8.0.1
 gcsfs==2021.6.1
 gcloud==0.18.3
 gitpython==3.1.18
-google-api-core==1.30.0  # transitive dep that needs dependabot updates
+google-api-core==1.31.0  # transitive dep that needs dependabot updates
 google-cloud-bigquery==2.20.0
 google-cloud-storage==1.40.0
 googleapis-common-protos==1.53.0  # transitive dep that needs dependabot updates

--- a/requirements.txt
+++ b/requirements.txt
@@ -207,9 +207,9 @@ gitpython==3.1.18 \
     # via
     #   -r requirements.in
     #   mozilla-schema-generator
-google-api-core[grpc]==1.30.0 \
-    --hash=sha256:0724d354d394b3d763bc10dfee05807813c5210f0bd9b8e2ddf6b6925603411c \
-    --hash=sha256:92cd9e9f366e84bfcf2524e34d2dc244906c645e731962617ba620da1620a1e0
+google-api-core[grpc]==1.31.0 \
+    --hash=sha256:7c8ba88e2b893ef4f67d67e229aade51a2db5053023b73b1394a5ee3dcdb561c \
+    --hash=sha256:a9f979b5c6a9cad31a4120ca6be712df76adc32336a7bf4bc2f4331a1b527fe7
     # via
     #   -r requirements.in
     #   google-cloud-bigquery


### PR DESCRIPTION
fixes docker builds
dependabot isn't posting an update for this because `No update possible`:

```
updater | INFO <job_170750073> Checking if google-api-core 1.30.0 needs updating
  proxy | 2021/07/12 18:07:57 [236] GET https://pypi.org:443/simple/google-api-core/
  proxy | 2021/07/12 18:07:57 [236] 200 https://pypi.org:443/simple/google-api-core/
updater | INFO <job_170750073> Latest version is 1.31.0
  proxy | 2021/07/12 18:08:04 [238] GET https://pypi.org:443/simple/pip/
  proxy | 2021/07/12 18:08:04 [238] 200 https://pypi.org:443/simple/pip/
  proxy | 2021/07/12 18:08:06 [240] GET https://pypi.org:443/simple/google-api-core/
  proxy | 2021/07/12 18:08:06 [240] 304 https://pypi.org:443/simple/google-api-core/
  proxy | 2021/07/12 18:08:07 [242] GET https://files.pythonhosted.org:443/packages/aa/51/629a31d4e7db2bbc0b0b789ac4034108c68647bea9cf5b54c8366df47b8e/google_api_core-1.31.0-py2.py3-none-any.whl
  proxy | 2021/07/12 18:08:07 [242] 200 https://files.pythonhosted.org:443/packages/aa/51/629a31d4e7db2bbc0b0b789ac4034108c68647bea9cf5b54c8366df47b8e/google_api_core-1.31.0-py2.py3-none-any.whl
updater | INFO <job_170750073> Requirements to unlock update_not_possible
updater | INFO <job_170750073> Requirements update strategy bump_versions
updater | INFO <job_170750073> No update possible for google-api-core 1.30.0
```