### PR TITLE
Bug 1720752 - Fix stripe import for custom_field array

### DIFF
--- a/tests/stripe/test_allowed_fields.py
+++ b/tests/stripe/test_allowed_fields.py
@@ -64,6 +64,21 @@ def test_format_row():
     }
     assert filtered_schema.format_row(dispute) == dispute
 
+    filtered_schema = FilteredSchema(stripe.Invoice)
+    invoice = {
+        "amount_due": 5,
+        "custom_fields": [
+            {"name": "userid", "value": "raw_user_id"},
+        ],
+    }
+    expect = {
+        "amount_due": 5,
+        "custom_fields": [
+            {"name": "fxa_uid", "value": sha256(b"raw_user_id").hexdigest()}
+        ],
+    }
+    assert filtered_schema.format_row(invoice) == expect
+
 
 @pytest.mark.parametrize(
     "row,message",


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1720752)

This is causing import errors as of 2021-07-14. The `custom_field` in the invoices schema is being treated like the `metadata` object, but is actually shaped differently. 

:relud is out sick, but it would be nice to resolve the airflow failures earlier since it seems to be propagating weird to the vpn dashboard.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
