### PR TITLE
Bug 1720767 - Adjust apple app store connect to 20:00 UTC

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -544,7 +544,7 @@ bqetl_ctxsvc_derived:
   schedule_interval: 0 3 * * *
 
 bqetl_app_store_connect:
-  schedule_interval: 0 13 * * *
+  schedule_interval: 0 20 * * *
   description: |
     Reports from Apple's App Store Connect API.
 
@@ -552,9 +552,13 @@ bqetl_app_store_connect:
     transactions that happened from 12:00 a.m. to 11:59 p.m. PST.
     https://help.apple.com/app-store-connect/#/dev061699fdb
 
-    Daily reports for the Americas are available by 5 am Pacific Time, which
-    can be either 12:00 or 13:00 UTC, depending on Daylight Savings Time, so
-    this dag runs at 13:00 UTC.
+    Daily reports for the Americas are available by 5 am Pacific Time, which can
+    be either 12:00 or 13:00 UTC, depending on Daylight Savings Time. Daily
+    reports for Japan, Australia, and New Zealand by 5 am Japan Standard Time;
+    and 5 am Central European Time for all other territories.
+
+    Based on [bug 1720767](https://bugzilla.mozilla.org/show_bug.cgi?id=1720767)
+    imports have been adjusted to 20:00 UTC.
   default_args:
     owner: dthorn@mozilla.com
     start_date: "2021-01-15"

--- a/dags/bqetl_app_store_connect.py
+++ b/dags/bqetl_app_store_connect.py
@@ -18,9 +18,13 @@ Reports are based on Pacific Standard Time (PST). A day includes
 transactions that happened from 12:00 a.m. to 11:59 p.m. PST.
 https://help.apple.com/app-store-connect/#/dev061699fdb
 
-Daily reports for the Americas are available by 5 am Pacific Time, which
-can be either 12:00 or 13:00 UTC, depending on Daylight Savings Time, so
-this dag runs at 13:00 UTC.
+Daily reports for the Americas are available by 5 am Pacific Time, which can
+be either 12:00 or 13:00 UTC, depending on Daylight Savings Time. Daily
+reports for Japan, Australia, and New Zealand by 5 am Japan Standard Time;
+and 5 am Central European Time for all other territories.
+
+Based on [bug 1720767](https://bugzilla.mozilla.org/show_bug.cgi?id=1720767)
+imports have been adjusted to 20:00 UTC.
 
 #### Owner
 
@@ -43,7 +47,7 @@ default_args = {
 with DAG(
     "bqetl_app_store_connect",
     default_args=default_args,
-    schedule_interval="0 13 * * *",
+    schedule_interval="0 20 * * *",
     doc_md=docs,
 ) as dag:
 


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1720767)

This DAG has been failing since run 2021-07-13. I've manually run this later in the day, and it seems to work. The time may have to be adjusted.

From the bug:

> On run 2021-07-13, the report was ready between 2021-07-14 17:03:10,121 and 2021-07-14 23:56:17,966. On run 2021-07-14, the report was ready between 2021-07-15 14:02:24,875 and 2021-07-15 21:06:53,772.
> 
> According to the error message, "Japan, Australia, and New Zealand by 5 am Japan Standard Time; and 5 am Central European Time for all other territories." 5AM JST is 20:00 UTC and 5AM CEST is 03:00 UTC. The time on the report looks most consistent with 5AM JST.

If the job fails one more time (tomorrow morning), I think we should go ahead and adjust import time.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
