### PR TITLE
Bug 1720938 - Allow ignore on unknown values during stripe import

### DIFF
--- a/bigquery_etl/stripe/__init__.py
+++ b/bigquery_etl/stripe/__init__.py
@@ -165,7 +165,7 @@ def import_(
             warnings.filterwarnings("ignore", module="google.auth._default")
             job_config = bigquery.LoadJobConfig(
                 clustering_fields=["created"],
-                ignore_unknown_values=False,
+                ignore_unknown_values=True,
                 schema=filtered_schema.filtered,
                 source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
                 time_partitioning=bigquery.TimePartitioning(field="created"),


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1720938)

The schemas are already populated, so this would be the easiest way to ignore new fields and have the job running over the weekend. This needs to be followed up to determine whether to add the new fields.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
