### PR TITLE
Revert "Bug 1720938 - Allow ignore on unknown values during stripe import"

### DIFF
--- a/bigquery_etl/stripe/__init__.py
+++ b/bigquery_etl/stripe/__init__.py
@@ -165,7 +165,7 @@ def import_(
             warnings.filterwarnings("ignore", module="google.auth._default")
             job_config = bigquery.LoadJobConfig(
                 clustering_fields=["created"],
-                ignore_unknown_values=True,
+                ignore_unknown_values=False,
                 schema=filtered_schema.filtered,
                 source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
                 time_partitioning=bigquery.TimePartitioning(field="created"),


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#2197

This doesn't seem to have helped in imports. Starting 2021-07-17, jobs started to succeed again.