### PR TITLE
Allow customer_address fields on invoices

### DIFF
--- a/bigquery_etl/stripe/allowed_fields.yaml
+++ b/bigquery_etl/stripe/allowed_fields.yaml
@@ -176,6 +176,10 @@ event:
         name:
         value:
       customer:
+      customer_address:
+        country:
+        postal_code:
+        state:
       customer_tax_exempt:
       customer_tax_ids:
         type:

--- a/sql/moz-fx-data-shared-prod/stripe_external/invoices_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/invoices_v1/init.sql
@@ -1,3 +1,19 @@
+-- Invoices frequently get multiple events with the same timestamp, so define a status order based
+-- on https://stripe.com/docs/invoicing/overview#workflow-overview
+CREATE TEMP FUNCTION status_order(status STRING) AS (
+  -- format:off
+  CASE LOWER(status)
+  WHEN "draft" THEN 1
+  WHEN "deleted" THEN 2
+  WHEN "open" THEN 3
+  WHEN "uncollectible" THEN 4
+  WHEN "void" THEN 5
+  WHEN "paid" THEN 6
+  ELSE 0
+  END
+  -- format:on
+);
+
 CREATE OR REPLACE TABLE
   `moz-fx-data-shared-prod`.stripe_external.invoices_v1
 PARTITION BY
@@ -9,6 +25,7 @@ WITH events AS (
   SELECT
     created AS event_timestamp,
     `data`.invoice.*,
+    TRUE AS _from_events,
   FROM
     events_v1
   WHERE
@@ -17,13 +34,36 @@ WITH events AS (
   SELECT
     created AS event_timestamp,
     *,
+    FALSE AS _from_events,
   FROM
     initial_invoices_v1
+),
+ranked_events AS (
+  SELECT
+    * EXCEPT (_from_events),
+    DENSE_RANK() OVER (
+      PARTITION BY
+        id
+      ORDER BY
+        event_timestamp DESC,
+        status_order(status) DESC,
+        -- when previous results would otherwise match rank with events, only
+        -- aggregate the events to ensure idempotent mode-last calculation
+        _from_events DESC
+    ) AS _rank,
+  FROM
+    events
 )
 SELECT
   id,
-  ARRAY_AGG(events ORDER BY event_timestamp DESC LIMIT 1)[OFFSET(0)].* EXCEPT (id),
+  ANY_VALUE(ranked_events).* EXCEPT (id, _rank) REPLACE(
+    -- collect mode-last metadata values, because there is no accurate
+    -- deterministic ordering for events with the same rank
+    mozfun.map.mode_last(ARRAY_CONCAT_AGG(metadata)) AS metadata
+  ),
 FROM
-  events
+  ranked_events
+WHERE
+  _rank = 1
 GROUP BY
   id

--- a/sql/moz-fx-data-shared-prod/stripe_external/invoices_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/invoices_v1/query.sql
@@ -1,8 +1,25 @@
+-- Invoices frequently get multiple events with the same timestamp, so define a status order based
+-- on https://stripe.com/docs/invoicing/overview#workflow-overview
+CREATE TEMP FUNCTION status_order(status STRING) AS (
+  -- format:off
+  CASE LOWER(status)
+  WHEN "draft" THEN 1
+  WHEN "deleted" THEN 2
+  WHEN "open" THEN 3
+  WHEN "uncollectible" THEN 4
+  WHEN "void" THEN 5
+  WHEN "paid" THEN 6
+  ELSE 0
+  END
+  -- format:on
+);
+
 WITH events AS (
   SELECT
     `data`.invoice.id,
     created AS event_timestamp,
     `data`.invoice.* EXCEPT (id),
+    TRUE AS _from_events,
   FROM
     events_v1
   WHERE
@@ -11,13 +28,36 @@ WITH events AS (
   UNION ALL
   SELECT
     *,
+    FALSE AS _from_events,
   FROM
     invoices_v1
+),
+ranked_events AS (
+  SELECT
+    * EXCEPT (_from_events),
+    DENSE_RANK() OVER (
+      PARTITION BY
+        id
+      ORDER BY
+        event_timestamp DESC,
+        status_order(status) DESC,
+        -- when previous results would otherwise match rank with events, only
+        -- aggregate the events to ensure idempotent mode-last calculation
+        _from_events DESC
+    ) AS _rank,
+  FROM
+    events
 )
 SELECT
   id,
-  ARRAY_AGG(events ORDER BY event_timestamp DESC LIMIT 1)[OFFSET(0)].* EXCEPT (id),
+  ANY_VALUE(ranked_events).* EXCEPT (id, _rank) REPLACE(
+    -- collect mode-last metadata values, because there is no accurate
+    -- deterministic ordering for events with the same rank
+    mozfun.map.mode_last(ARRAY_CONCAT_AGG(metadata)) AS metadata
+  ),
 FROM
-  events
+  ranked_events
+WHERE
+  _rank = 1
 GROUP BY
   id


### PR DESCRIPTION
because that is where FxA is putting billing address values from the paypal billing agreement.

also use more-correct invoice aggregation (fixes issue where "paypalTransactionId" is missing from BigQuery invoice metadata but present in Stripe)

I will need to backfill customer_address for invoices, and after that I will file a separate PR to update all_subscriptions_v1 to use it for determining subscription country for paypal customers.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
