### PR TITLE
Update stripe subscription schema

### DIFF
--- a/bigquery_etl/stripe/event.schema.json
+++ b/bigquery_etl/stripe/event.schema.json
@@ -9274,6 +9274,12 @@
             ]
           },
           {
+            "name": "payment_settings",
+            "type": "RECORD",
+            "fields": [
+            ]
+          },
+          {
             "name": "pending_invoice_item_interval",
             "type": "RECORD",
             "fields": [

--- a/bigquery_etl/stripe/subscription.schema.json
+++ b/bigquery_etl/stripe/subscription.schema.json
@@ -761,6 +761,12 @@
     ]
   },
   {
+    "name": "payment_settings",
+    "type": "RECORD",
+    "fields": [
+    ]
+  },
+  {
     "name": "pending_invoice_item_interval",
     "type": "RECORD",
     "fields": [


### PR DESCRIPTION
new field is not being added to `allow_fields.yaml`, so final schemas won't change.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
