### PR TITLE
Fix #2212 - Write glam sql to directory specified by SQL_DIR

### DIFF
--- a/script/generate_sql
+++ b/script/generate_sql
@@ -53,6 +53,7 @@ products="
 
 for product in $products; do
     PATH="venv/bin:$PATH" \
+    SQL_DIR="${SQL_DIR}" \
     STAGE="incremental" \
     DST_PROJECT="moz-fx-data-glam-prod-fca7" \
     PRODUCT="$product" \

--- a/script/glam/generate_glean_sql
+++ b/script/glam/generate_glean_sql
@@ -7,7 +7,8 @@ function write_scalars {
     local dataset=$2
     local table=$3
     local dst_project=$4
-    local directory="sql/${dst_project}/glam_etl/${product}__clients_daily_scalar_aggregates_${table}"
+    local sql_dir=$5
+    local directory="${sql_dir}/${dst_project}/glam_etl/${product}__clients_daily_scalar_aggregates_${table}"
     mkdir -p "$directory"
     if ! python3 -m bigquery_etl.glam.clients_daily_scalar_aggregates \
         --source-table "$dataset.$table" \
@@ -24,7 +25,8 @@ function write_histograms {
     local dataset=$2
     local table=$3
     local dst_project=$4
-    local directory="sql/${dst_project}/glam_etl/${product}__clients_daily_histogram_aggregates_${table}"
+    local sql_dir=$5
+    local directory="${sql_dir}/${dst_project}/glam_etl/${product}__clients_daily_histogram_aggregates_${table}"
     mkdir -p "$directory"
     if ! python3 -m bigquery_etl.glam.clients_daily_histogram_aggregates \
         --source-table "$dataset.$table" \
@@ -40,6 +42,7 @@ function write_clients_daily_aggregates {
     local product=$1
     local src_project=$2
     local dst_project=$3
+    local sql_dir=$4
 
     local dataset="${product}_stable"
     local qualified="$src_project:$dataset"
@@ -62,8 +65,8 @@ function write_clients_daily_aggregates {
     )
     # generate all of the schemas in parallel
     for table in $tables; do
-        write_scalars "$product" "$dataset" "$table" "$dst_project" &
-        write_histograms "$product" "$dataset" "$table" "$dst_project" &
+        write_scalars "$product" "$dataset" "$table" "$dst_project" "$sql_dir" &
+        write_histograms "$product" "$dataset" "$table" "$dst_project" "$sql_dir" &
     done
 
     # wait for all of the processes before continuing
@@ -77,20 +80,34 @@ src_project=${SRC_PROJECT:-moz-fx-data-shared-prod}
 # We may also define the PROJECT as the destination project for backwards
 # compatibility.
 dst_project=${DST_PROJECT:-${PROJECT:-glam-fenix-dev}}
+sql_dir=${SQL_DIR:-sql}
+# also remove trailing slash
+sql_dir=${sql_dir%/}
+
 product=${PRODUCT?PRODUCT must be defined}
 stage=${STAGE?$error}
 
 # ensure the sql directory exists
-mkdir -p sql/$dst_project/glam_etl
+mkdir -p $sql_dir/$dst_project/glam_etl
 
 if [[ $stage == "daily" ]]; then
-    write_clients_daily_aggregates "$product" "$src_project" "$dst_project"
-    python3 -m bigquery_etl.glam.generate --project "$dst_project" --prefix "${product}" --daily-view-only
+    write_clients_daily_aggregates "$product" "$src_project" "$dst_project" "$sql_dir"
+    python3 -m bigquery_etl.glam.generate \
+        --sql-root "$sql_dir" \
+        --project "$dst_project" \
+        --prefix "${product}" \
+        --daily-view-only
 elif [[ $stage == "incremental" ]]; then
-    python3 -m bigquery_etl.glam.generate --project "$dst_project" --prefix "${product}"
+    python3 -m bigquery_etl.glam.generate \
+        --sql-root "$sql_dir" \
+        --project "$dst_project" \
+        --prefix "${product}"
 elif [[ $stage == "all" ]]; then
-    write_clients_daily_aggregates "$product" "$src_project" "$dst_project"
-    python3 -m bigquery_etl.glam.generate --project "$dst_project" --prefix "${product}"
+    write_clients_daily_aggregates "$product" "$src_project" "$dst_project" "$sql_dir"
+    python3 -m bigquery_etl.glam.generate \
+        --sql-root "$sql_dir" \
+        --project "$dst_project" \
+        --prefix "${product}"
 else
     echo "$error"
     exit 1


### PR DESCRIPTION
This should fix #2212, which is an issue that occurs when the SQL_DIR is set to something that is not sql/

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
