### PR TITLE
Remove generated-sql for glam

### DIFF
--- a/script/generate_sql
+++ b/script/generate_sql
@@ -43,22 +43,5 @@ python -m bigquery_etl.view.generate_stable_views \
 # Fill in definitions for generated Glean ETL
 ./script/bqetl glean_usage generate --project-id "${TARGET_PROJECT}" --output-dir "${SQL_DIR}"
 
-# Generate all of the relevant incremental SQL for GLAM. This completely ignores
-# the TARGET_PROJECT variable, which is not useful in this scope.
-products="
-    org_mozilla_fenix_glam_nightly
-    org_mozilla_fenix_glam_beta
-    org_mozilla_fenix_glam_release
-"
-
-for product in $products; do
-    PATH="venv/bin:$PATH" \
-    SQL_DIR="${SQL_DIR}" \
-    STAGE="incremental" \
-    DST_PROJECT="moz-fx-data-glam-prod-fca7" \
-    PRODUCT="$product" \
-    ./script/glam/generate_glean_sql
-done
-
 # Record dependencies in yaml files
 ./script/bqetl dependency record --skip-existing "${SQL_DIR}"


### PR DESCRIPTION
Removing generating sql for the glam queries because of operational issues, most recently #2214. The job requires use of MSG, which caches results in a folder in the current working directory. I'm not going to be around tomorrow to debug issues, so punting this until next week by removing the relevant code.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
