### PR TITLE
Fix feature usage table scheduling

### DIFF
--- a/bigquery_etl/feature_usage/templates/metadata.yaml
+++ b/bigquery_etl/feature_usage/templates/metadata.yaml
@@ -15,9 +15,6 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_main_summary
-  date_partition_parameter: null
-  parameters:
-    - submission_date:DATE:{{ds}}
 bigquery:
   time_partitioning:
     field: submission_date

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -259,9 +259,8 @@ with DAG(
             "shong@mozilla.com",
             "telemetry-alerts@mozilla.com",
         ],
-        date_partition_parameter=None,
+        date_partition_parameter="submission_date",
         depends_on_past=False,
-        parameters=["submission_date:DATE:{{ds}}"],
         dag=dag,
     )
 

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/metadata.yaml
@@ -15,9 +15,6 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_main_summary
-  date_partition_parameter: null
-  parameters:
-  - submission_date:DATE:{{ds}}
 bigquery:
   time_partitioning:
     field: submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/query.sql
@@ -1,4 +1,7 @@
 -- Generated via bigquery_etl.feature_usage
+-- Don't edit this file directly.
+-- To add new metrics, please update bigquery_etl/feature_usage/templating.yaml
+-- and run `./bqetl feature_usage generate`.
 WITH user_type AS (
   SELECT
     client_id AS client_id,


### PR DESCRIPTION
The daily Airflow runs of `telemetry_derived.feature_usage_v2` was removing all previous partitions and only updating the latest one. This PR should fix this.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
