### PR TITLE
Move feature_usage_v2 to separate DAG

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -562,3 +562,20 @@ bqetl_experimenter_experiments_import:
     retries: 0
     email:
       - ascholtz@mozilla.com
+
+bqetl_feature_usage:
+  schedule_interval: 0 5 * * *
+  description: |
+    Daily aggregation of browser features usages from `main` pings,
+    `event` pings and addon data.
+
+    Depends on `bqetl_addons` and `bqetl_main_summary`, so is scheduled after.
+  default_args:
+    owner: ascholtz@mozilla.com
+    start_date: "2021-01-01"
+    email:
+      - "telemetry-alerts@mozilla.com"
+      - "ascholtz@mozilla.com"
+      - "loines@mozilla.com"
+    retries: 2
+    retry_delay: 30m

--- a/dags/bqetl_feature_usage.py
+++ b/dags/bqetl_feature_usage.py
@@ -1,0 +1,138 @@
+# Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
+
+from airflow import DAG
+from operators.task_sensor import ExternalTaskCompletedSensor
+import datetime
+from utils.gcp import bigquery_etl_query, gke_command
+
+docs = """
+### bqetl_feature_usage
+
+Built from bigquery-etl repo, [`dags/bqetl_feature_usage.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/bqetl_feature_usage.py)
+
+#### Description
+
+Daily aggregation of browser features usages from `main` pings,
+`event` pings and addon data.
+
+Depends on `bqetl_addons` and `bqetl_main_summary`, so is scheduled after.
+
+#### Owner
+
+ascholtz@mozilla.com
+"""
+
+
+default_args = {
+    "owner": "ascholtz@mozilla.com",
+    "start_date": datetime.datetime(2021, 1, 1, 0, 0),
+    "end_date": None,
+    "email": [
+        "telemetry-alerts@mozilla.com",
+        "ascholtz@mozilla.com",
+        "loines@mozilla.com",
+    ],
+    "depends_on_past": False,
+    "retry_delay": datetime.timedelta(seconds=1800),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 2,
+}
+
+with DAG(
+    "bqetl_feature_usage",
+    default_args=default_args,
+    schedule_interval="0 5 * * *",
+    doc_md=docs,
+) as dag:
+
+    telemetry_derived__feature_usage__v2 = bigquery_etl_query(
+        task_id="telemetry_derived__feature_usage__v2",
+        destination_table="feature_usage_v2",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="loines@mozilla.com",
+        email=[
+            "ascholtz@mozilla.com",
+            "cdowhygelund@mozilla.com",
+            "loines@mozilla.com",
+            "shong@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    wait_for_bq_main_events = ExternalTaskCompletedSensor(
+        task_id="wait_for_bq_main_events",
+        external_dag_id="copy_deduplicate",
+        external_task_id="bq_main_events",
+        execution_delta=datetime.timedelta(seconds=14400),
+        check_existence=True,
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    telemetry_derived__feature_usage__v2.set_upstream(wait_for_bq_main_events)
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
+        task_id="wait_for_copy_deduplicate_all",
+        external_dag_id="copy_deduplicate",
+        external_task_id="copy_deduplicate_all",
+        execution_delta=datetime.timedelta(seconds=14400),
+        check_existence=True,
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    telemetry_derived__feature_usage__v2.set_upstream(wait_for_copy_deduplicate_all)
+    wait_for_event_events = ExternalTaskCompletedSensor(
+        task_id="wait_for_event_events",
+        external_dag_id="copy_deduplicate",
+        external_task_id="event_events",
+        execution_delta=datetime.timedelta(seconds=14400),
+        check_existence=True,
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    telemetry_derived__feature_usage__v2.set_upstream(wait_for_event_events)
+    wait_for_telemetry_derived__addons__v2 = ExternalTaskCompletedSensor(
+        task_id="wait_for_telemetry_derived__addons__v2",
+        external_dag_id="bqetl_addons",
+        external_task_id="telemetry_derived__addons__v2",
+        execution_delta=datetime.timedelta(seconds=3600),
+        check_existence=True,
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    telemetry_derived__feature_usage__v2.set_upstream(
+        wait_for_telemetry_derived__addons__v2
+    )
+    wait_for_telemetry_derived__clients_last_seen__v1 = ExternalTaskCompletedSensor(
+        task_id="wait_for_telemetry_derived__clients_last_seen__v1",
+        external_dag_id="bqetl_main_summary",
+        external_task_id="telemetry_derived__clients_last_seen__v1",
+        execution_delta=datetime.timedelta(seconds=10800),
+        check_existence=True,
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    telemetry_derived__feature_usage__v2.set_upstream(
+        wait_for_telemetry_derived__clients_last_seen__v1
+    )
+    wait_for_telemetry_derived__main_1pct__v1 = ExternalTaskCompletedSensor(
+        task_id="wait_for_telemetry_derived__main_1pct__v1",
+        external_dag_id="bqetl_main_summary",
+        external_task_id="telemetry_derived__main_1pct__v1",
+        execution_delta=datetime.timedelta(seconds=10800),
+        check_existence=True,
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    telemetry_derived__feature_usage__v2.set_upstream(
+        wait_for_telemetry_derived__main_1pct__v1
+    )

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -243,27 +243,6 @@ with DAG(
         dag=dag,
     )
 
-    telemetry_derived__feature_usage__v2 = bigquery_etl_query(
-        task_id="telemetry_derived__feature_usage__v2",
-        destination_table="feature_usage_v2",
-        dataset_id="telemetry_derived",
-        project_id="moz-fx-data-shared-prod",
-        owner="loines@mozilla.com",
-        email=[
-            "ascholtz@mozilla.com",
-            "cdowhygelund@mozilla.com",
-            "dthorn@mozilla.com",
-            "frank@mozilla.com",
-            "jklukas@mozilla.com",
-            "loines@mozilla.com",
-            "shong@mozilla.com",
-            "telemetry-alerts@mozilla.com",
-        ],
-        date_partition_parameter="submission_date",
-        depends_on_past=False,
-        dag=dag,
-    )
-
     telemetry_derived__firefox_desktop_usage__v1 = bigquery_etl_query(
         task_id="telemetry_derived__firefox_desktop_usage__v1",
         destination_table="firefox_desktop_usage_v1",
@@ -423,39 +402,6 @@ with DAG(
 
     telemetry_derived__events_1pct__v1.set_upstream(wait_for_bq_main_events)
     telemetry_derived__events_1pct__v1.set_upstream(wait_for_event_events)
-
-    telemetry_derived__feature_usage__v2.set_upstream(wait_for_bq_main_events)
-    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
-        task_id="wait_for_copy_deduplicate_all",
-        external_dag_id="copy_deduplicate",
-        external_task_id="copy_deduplicate_all",
-        execution_delta=datetime.timedelta(seconds=3600),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
-    )
-
-    telemetry_derived__feature_usage__v2.set_upstream(wait_for_copy_deduplicate_all)
-    telemetry_derived__feature_usage__v2.set_upstream(wait_for_event_events)
-    wait_for_telemetry_derived__addons__v2 = ExternalTaskCompletedSensor(
-        task_id="wait_for_telemetry_derived__addons__v2",
-        external_dag_id="bqetl_addons",
-        external_task_id="telemetry_derived__addons__v2",
-        execution_delta=datetime.timedelta(days=-1, seconds=79200),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
-    )
-
-    telemetry_derived__feature_usage__v2.set_upstream(
-        wait_for_telemetry_derived__addons__v2
-    )
-
-    telemetry_derived__feature_usage__v2.set_upstream(
-        telemetry_derived__clients_last_seen__v1
-    )
-
-    telemetry_derived__feature_usage__v2.set_upstream(telemetry_derived__main_1pct__v1)
 
     telemetry_derived__firefox_desktop_usage__v1.set_upstream(
         firefox_desktop_exact_mau28_by_dimensions_v2

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/metadata.yaml
@@ -14,7 +14,7 @@ labels:
   application: firefox
   schedule: daily
 scheduling:
-  dag_name: bqetl_main_summary
+  dag_name: bqetl_feature_usage
 bigquery:
   time_partitioning:
     field: submission_date


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/2230

The `feature_usage_v2` task is scheduled as part to the `bqetl_main_summary` DAG. The task depends on some tasks in the `bqetl_addons` DAG. `bqetl_addons` has some tasks that depend on `bqetl_main_summary`. To resolve this circular dependency I've moved the feature usage query into a separate DAG

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
