### PR TITLE
Fix skipping publishing and validation of views

### DIFF
--- a/bigquery_etl/cli/view.py
+++ b/bigquery_etl/cli/view.py
@@ -6,7 +6,7 @@ import re
 import string
 import sys
 
-from multiprocessing.pool import Pool
+from multiprocessing.pool import Pool, ThreadPool
 
 from ..view import View
 from .dryrun import dryrun
@@ -197,9 +197,10 @@ def publish(
     views = [View.from_file(f) for f in view_files]
     views = [v for v in views if not user_facing_only or v.is_user_facing]
 
-    with Pool(parallelism) as p:
+    with ThreadPool(parallelism) as p:
         publish_view = functools.partial(_publish_view, target_project, dry_run)
         result = p.map(publish_view, views, chunksize=1)
+
     if not all(result):
         sys.exit(1)
 
@@ -207,4 +208,4 @@ def publish(
 
 
 def _publish_view(target_project, dry_run, view):
-    view.publish(target_project, dry_run)
+    return view.publish(target_project, dry_run)

--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -128,7 +128,7 @@ class View:
 
     def is_valid(self):
         """Validate the SQL view definition."""
-        if self.path in SKIP_VALIDATION:
+        if any(str(self.path).endswith(p) for p in SKIP_VALIDATION):
             print(f"Skipped validation for {self.path}")
             return True
         return self._valid_fully_qualified_references() and self._valid_view_naming()
@@ -188,7 +188,7 @@ class View:
 
         If `target_project` is set, it will replace the project ID in the view definition.
         """
-        if self.path in SKIP_PUBLISHING:
+        if any(str(self.path).endswith(p) for p in SKIP_PUBLISHING):
             print(f"Skipping {self.path}")
             return True
 

--- a/tests/view/test_view.py
+++ b/tests/view/test_view.py
@@ -62,16 +62,16 @@ class TestView:
     @pytest.mark.java
     def test_view_valid(self, runner):
         with runner.isolated_filesystem():
-            view = View.create("moz-fx-data-test-project", "test", "simple_view", "sql")
+            view = View.create("moz-fx-data-test-project", "test", "view", "sql")
             assert view.is_valid()
 
     @pytest.mark.java
     def test_view_invalid(self, runner):
         with runner.isolated_filesystem():
-            view = View.create("moz-fx-data-test-project", "test", "simple_view", "sql")
+            view = View.create("moz-fx-data-test-project", "test", "view", "sql")
             assert view.is_valid()
 
-            view.path.write_text("CREATE OR REPLACE VIEW test.simple_view AS SELECT 1")
+            view.path.write_text("CREATE OR REPLACE VIEW test.view AS SELECT 1")
             assert view.is_valid() is False
 
             view.path.write_text("SELECT 1")
@@ -85,7 +85,7 @@ class TestView:
     @pytest.mark.java
     def test_view_do_not_publish_invalid(self, runner):
         with runner.isolated_filesystem():
-            view = View.create("moz-fx-data-test-project", "test", "simple_view", "sql")
+            view = View.create("moz-fx-data-test-project", "test", "view", "sql")
             assert view.is_valid()
             view.path.write_text("SELECT 1")
             assert view.is_valid() is False


### PR DESCRIPTION
We've been running into the following error

```
Error publishing /tmp/sql/moz-fx-data-shared-prod/telemetry/clients_probe_processes/view.sql. Invalid view definition.
```

The view should be skipped by wasn't because the current logic assumed it would be stored in `sql/moz-fx-data-shared-prod/` rather than `/tmp/sql/moz-fx-data-shared-prod/`

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
