### PR TITLE
Add normalization to operational monitoring views.

### DIFF
--- a/bigquery_etl/operational_monitoring/templates/init.sql
+++ b/bigquery_etl/operational_monitoring/templates/init.sql
@@ -10,15 +10,13 @@ CREATE TABLE IF NOT EXISTS
     metrics ARRAY<
       STRUCT<
         name STRING,
-        histograms ARRAY<
-          STRUCT<
-            bucket_count INT64,
-            sum INT64,
-            histogram_type INT64,
-            `range` ARRAY<INT64>,
-            VALUES
-              ARRAY<STRUCT<key INT64, value INT64>>
-          >
+        histogram STRUCT<
+          bucket_count INT64,
+          sum INT64,
+          histogram_type INT64,
+          `range` ARRAY<INT64>,
+          VALUES
+            ARRAY<STRUCT<key STRING, value INT64>>
         >
       >
     >)
@@ -27,5 +25,5 @@ CLUSTER BY
     build_id
 OPTIONS (
     require_partition_filter = TRUE,
-    partition_expiration_days = 7
+    partition_expiration_days = 5
 )

--- a/bigquery_etl/operational_monitoring/templates/query.sql
+++ b/bigquery_etl/operational_monitoring/templates/query.sql
@@ -35,7 +35,7 @@ WITH merged_probes AS (
   FROM
     `{{source}}`
   WHERE
-    DATE(submission_timestamp) >= DATE_SUB(@submission_date, INTERVAL 30 DAY)
+    DATE(submission_timestamp) >= DATE_SUB(@submission_date, INTERVAL 60 DAY)
   GROUP BY
     submission_date,
     client_id,
@@ -44,48 +44,88 @@ WITH merged_probes AS (
       {{ dimension.name }},
     {% endfor %}
     branch
-)
+),
 
+merged_histograms AS (
+  SELECT
+    submission_date,
+    client_id,
+    build_id,
+    branch,
+    {% for dimension in dimensions %}
+      {{ dimension.name }},
+    {% endfor %}
+    ARRAY_AGG(
+      STRUCT<
+        name STRING,
+        histogram STRUCT<
+          bucket_count INT64,
+          sum INT64,
+          histogram_type INT64,
+          `range` ARRAY<INT64>,
+          values ARRAY<STRUCT<key INT64, value INT64>>
+        >
+      > (
+        metric,
+        CASE
+        WHEN
+          histograms IS NULL
+        THEN
+          NULL
+        ELSE
+          mozfun.hist.merge(histograms)
+        END
+      )
+    ) AS metrics
+  FROM
+    merged_probes
+  CROSS JOIN
+    UNNEST(metrics)
+  WHERE branch IN (
+    {% for branch in branches %}
+      "{{ branch }}"
+      {{ "," if not loop.last else "" }}
+    {% endfor %}
+  )
+  GROUP BY
+    submission_date,
+    client_id,
+    build_id,
+    {% for dimension in dimensions %}
+      {{ dimension.name }},
+    {% endfor %}
+    branch)
+
+
+-- Cast histograms to have string keys so we can use the histogram normalization function
 SELECT
-  submission_date,
-  client_id,
-  build_id,
-  branch,
-  {% for dimension in dimensions %}
-    {{ dimension.name }},
-  {% endfor %}
-  ARRAY_AGG(
-    STRUCT<
-      name STRING,
-      histograms STRUCT<
-        bucket_count INT64,
-        sum INT64,
-        histogram_type INT64,
-        `range` ARRAY<INT64>,
-        values ARRAY<STRUCT<key INT64, value INT64>>
-      >
-    > (
-      metric,
-      CASE
-      WHEN
-        histograms IS NULL
-      THEN
-        NULL
-      ELSE
-        mozfun.hist.merge(histograms)
-      END
-    )
-  ) AS metrics
-FROM
-  merged_probes
-CROSS JOIN
-  UNNEST(metrics)
-WHERE branch IN (
-  {% for branch in branches %}
-    "{{ branch }}"
-    {{ "," if not loop.last else "" }}
-  {% endfor %}
-)
+    submission_date,
+    client_id,
+    build_id,
+    {% for dimension in dimensions %}
+      {{ dimension.name }},
+    {% endfor %}
+    branch,
+    ARRAY_AGG(
+        STRUCT<
+            name STRING,
+            histogram STRUCT<
+                bucket_count INT64,
+                sum INT64,
+                histogram_type INT64,
+                `range` ARRAY<INT64>,
+                VALUES
+                ARRAY<STRUCT<key STRING, value INT64>>
+            >
+        >(name, (histogram.bucket_count,
+            histogram.sum,
+            histogram.histogram_type,
+            histogram.range,
+            ARRAY(SELECT AS STRUCT CAST(keyval.key AS STRING), keyval.value FROM UNNEST(histogram.values) keyval))
+        )
+    ) AS metrics
+FROM merged_histograms
+CROSS JOIN UNNEST(metrics)
 GROUP BY
   submission_date,
   client_id,

--- a/bigquery_etl/operational_monitoring/templates/view.sql
+++ b/bigquery_etl/operational_monitoring/templates/view.sql
@@ -1,0 +1,69 @@
+{{ header }}
+
+CREATE OR REPLACE VIEW
+  `{{gcp_project}}.operational_monitoring.{{slug}}`
+AS
+WITH normalized AS (
+    SELECT
+        client_id,
+        build_id,
+        {% for dimension in dimensions %}
+          {{ dimension.name }},
+        {% endfor %}
+        branch,
+        name AS probe,
+        STRUCT<
+            bucket_count INT64,
+            sum INT64,
+            histogram_type INT64,
+            `range` ARRAY<INT64>,
+            VALUES
+            ARRAY<STRUCT<key STRING, value FLOAT64>>
+        >(
+            ANY_VALUE(histogram.bucket_count),
+            ANY_VALUE(histogram.sum),
+            ANY_VALUE(histogram.histogram_type),
+            ANY_VALUE(histogram.range),
+            mozfun.glam.histogram_normalized_sum(
+                mozfun.hist.merge(ARRAY_AGG(histogram IGNORE NULLS)).values,
+                1.0
+            )
+        ) AS histogram
+        FROM `{{gcp_project}}.{{dataset}}.{{slug}}`
+        CROSS JOIN UNNEST(metrics)
+        WHERE
+            PARSE_DATE('%Y%m%d', CAST(build_id AS STRING)) > DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+            AND DATE(submission_date) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
+        GROUP BY
+        client_id,
+        build_id,
+        {% for dimension in dimensions %}
+          {{ dimension.name }},
+        {% endfor %}
+        branch,
+        probe)
+
+-- Cast histograms to have INT64 keys
+-- so we can use the histogram jackknife percentile function.
+SELECT
+    client_id,
+    build_id,
+    {% for dimension in dimensions %}
+      {{ dimension.name }},
+    {% endfor %}
+    branch,
+    probe,
+    STRUCT<
+        bucket_count INT64,
+        sum INT64,
+        histogram_type INT64,
+        `range` ARRAY<INT64>,
+        VALUES
+        ARRAY<STRUCT<key INT64, value FLOAT64>
+    >>(histogram.bucket_count,
+        histogram.sum,
+        histogram.histogram_type,
+        histogram.range,
+        ARRAY(SELECT AS STRUCT CAST(keyval.key AS INT64), keyval.value FROM UNNEST(histogram.values) keyval)
+    ) AS histogram
+FROM normalized

--- a/sql/moz-fx-data-shared-prod/udf_js/jackknife_percentile_ci/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/jackknife_percentile_ci/udf.sql
@@ -10,7 +10,7 @@ and a histogram struct as the second.
 */
 CREATE OR REPLACE FUNCTION udf_js.jackknife_percentile_ci(
   percentile FLOAT64,
-  histogram STRUCT<values ARRAY<STRUCT<key INT64, value INT64>>>
+  histogram STRUCT<values ARRAY<STRUCT<key INT64, value FLOAT64>>>
 )
 RETURNS STRUCT<low FLOAT64, high FLOAT64, percentile FLOAT64> DETERMINISTIC
 LANGUAGE js
@@ -39,7 +39,7 @@ AS
     if (histogram.length == 0) {
       return null;
     }
-    
+
     return histogram[index].key;
   }
 
@@ -113,7 +113,7 @@ WITH jackknife AS (
       10.0,
       STRUCT(
         [
-          STRUCT(1 AS key, 3 AS value),
+          STRUCT(1 AS key, 3.0 AS value),
           STRUCT(2, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
@@ -125,7 +125,7 @@ WITH jackknife AS (
       20.0,
       STRUCT(
         [
-          STRUCT(1 AS key, 3 AS value),
+          STRUCT(1 AS key, 3.0 AS value),
           STRUCT(2, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
@@ -137,7 +137,7 @@ WITH jackknife AS (
       30.0,
       STRUCT(
         [
-          STRUCT(1 AS key, 3 AS value),
+          STRUCT(1 AS key, 3.0 AS value),
           STRUCT(2, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
@@ -149,7 +149,7 @@ WITH jackknife AS (
       40.0,
       STRUCT(
         [
-          STRUCT(1 AS key, 3 AS value),
+          STRUCT(1 AS key, 3.0 AS value),
           STRUCT(2, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
@@ -161,7 +161,7 @@ WITH jackknife AS (
       50.0,
       STRUCT(
         [
-          STRUCT(1 AS key, 3 AS value),
+          STRUCT(1 AS key, 3.0 AS value),
           STRUCT(2, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
@@ -173,7 +173,7 @@ WITH jackknife AS (
       60.0,
       STRUCT(
         [
-          STRUCT(1 AS key, 3 AS value),
+          STRUCT(1 AS key, 3.0 AS value),
           STRUCT(2, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
@@ -185,7 +185,7 @@ WITH jackknife AS (
       70.0,
       STRUCT(
         [
-          STRUCT(1 AS key, 3 AS value),
+          STRUCT(1 AS key, 3.0 AS value),
           STRUCT(2, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
@@ -197,7 +197,7 @@ WITH jackknife AS (
       80.0,
       STRUCT(
         [
-          STRUCT(1 AS key, 3 AS value),
+          STRUCT(1 AS key, 3.0 AS value),
           STRUCT(2, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
@@ -209,7 +209,7 @@ WITH jackknife AS (
       90.0,
       STRUCT(
         [
-          STRUCT(1 AS key, 3 AS value),
+          STRUCT(1 AS key, 3.0 AS value),
           STRUCT(2, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),


### PR DESCRIPTION
This commit was mainly to add normalization to the histograms in a view so that each client is only counted once for a set of dimensions (their histogram values add up to 1)

However, a few other things came up and there are some other changes I made:
* The normalized histograms have float values that need to be passed into the jackknife percentile function - I needed to update this function to accept floats (couldn’t find a way to make it generic sadly)
* I changed the design of the data processing a bit - I think it didn’t quite make sense before. Now each day the last 60 days of data is aggregated (instead of 30) and there are only 5 (instead of 7) partitions (days) stored. These are mainly for backup but the view will only look at data computed most recently.
* The `init.sql` file was actually incorrect so I updated it
* There were some spots where I updated to use `normalized_slug` as well

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
