### PR TITLE
python38 required again

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,5 +16,5 @@ command = """
     ./script/generate_docs --output_dir=generated_docs/
     cd generated_docs && mkdocs build
 """
-environment = { PYTHON_VERSION = "3.7" }
+environment = { PYTHON_VERSION = "3.8" }
 publish = "generated_docs/site"

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,5 @@
 attrs==21.2.0
 authlib==0.15.4
-backports.cached-property==1.0.1  # python 3.7 backwards compat
 cattrs==1.7.1
 click==8.0.1
 gcsfs==2021.7.0
@@ -10,7 +9,6 @@ google-api-core==1.31.0  # transitive dep that needs dependabot updates
 google-cloud-bigquery==2.24.0
 google-cloud-storage==1.41.1
 googleapis-common-protos==1.53.0  # transitive dep that needs dependabot updates
-importlib-metadata==4.6.3  # python 3.7 backwards compat
 Jinja2==3.0.1
 jsonschema==3.2.0
 mozilla-schema-generator==0.4.0
@@ -32,4 +30,3 @@ stripe==2.60.0
 typing==3.7.4.3
 ujson==4.0.2
 yamllint==1.26.2
-zipp==3.5.0  # python 3.7 backwards compat

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,10 +71,6 @@ authlib==0.15.4 \
     --hash=sha256:37df3a2554bc6fe0da3cc6848c44fac2ae40634a7f8fc72543947f4330b26464 \
     --hash=sha256:d9fe5edb59801b16583faa86f88d798d99d952979b9616d5c735b9170b41ae2c
     # via -r requirements.in
-backports.cached-property==1.0.1 \
-    --hash=sha256:1a5ef1e750f8bc7d0204c807aae8e0f450c655be0cf4b30407a35fd4bb27186c \
-    --hash=sha256:687b5fe14be40aadcf547cae91337a1fdb84026046a39370274e54d3fe4fb4f9
-    # via -r requirements.in
 black==21.4b2 \
     --hash=sha256:bff7067d8bc25eb21dcfdbc8c72f2baafd9ec6de4663241a52fb904b304d391f \
     --hash=sha256:fc9bcf3b482b05c1f35f6a882c079dc01b9c7795827532f4cc43c0ec88067bbc
@@ -356,10 +352,6 @@ idna==2.10 \
     # via
     #   requests
     #   yarl
-importlib-metadata==4.6.3 \
-    --hash=sha256:0645585859e9a6689c523927a5032f2ba5919f1f7d0e84bd4533312320de1ff9 \
-    --hash=sha256:51c6635429c77cf1ae634c997ff9e53ca3438b495f10a55ba28594dd69764a8b
-    # via -r requirements.in
 iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
@@ -998,12 +990,6 @@ yarl==1.6.3 \
     --hash=sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a \
     --hash=sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71
     # via aiohttp
-zipp==3.5.0 \
-    --hash=sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3 \
-    --hash=sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4
-    # via
-    #   -r requirements.in
-    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.1 \

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     extras_require={"java": ["pyjnius"]},
     long_description="Tooling for building derived datasets in BigQuery",
     long_description_content_type="text/markdown",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     entry_points="""
         [console_scripts]
         bqetl=bigquery_etl.cli:cli


### PR DESCRIPTION
Now that we're using Netlify's 20.04 image (which has Python 3.8), we can remove this backwards compatibility code.
