### PR TITLE
remove latest_version column for histogram aggregates

### DIFF
--- a/script/glam/run_glam_sql
+++ b/script/glam/run_glam_sql
@@ -167,7 +167,7 @@ function run_desktop_sql {
         run_init "clients_histogram_aggregates_v1"
         run_query "clients_histogram_aggregates_new_v1"
         run_partitioned_query "clients_histogram_aggregates_v1" \
-            true "submission_date" "sample_id,app_version,channel"
+            true 1 "submission_date" "sample_id,app_version,channel"
     fi
 
     run_partitioned_query "clients_histogram_bucket_counts_v1" 10 false
@@ -318,7 +318,7 @@ function main {
     if $reset; then
         bq rm -r -f "$DATASET"
     fi
-    if ! bq ls "${PROJECT}:${DATASET}" &> /dev/null; then
+    if ! bq ls "${DST_PROJECT}:${DATASET}" &> /dev/null; then
         bq mk "$DATASET"
     fi
 

--- a/script/glam/run_glam_sql
+++ b/script/glam/run_glam_sql
@@ -167,7 +167,7 @@ function run_desktop_sql {
         run_init "clients_histogram_aggregates_v1"
         run_query "clients_histogram_aggregates_new_v1"
         run_partitioned_query "clients_histogram_aggregates_v1" \
-            true 1 "submission_date" "sample_id,app_version,channel"
+            1 true "submission_date" "sample_id,app_version,channel"
     fi
 
     run_partitioned_query "clients_histogram_bucket_counts_v1" 10 false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/init.sql
@@ -11,7 +11,6 @@ CREATE TABLE IF NOT EXISTS
       first_bucket INT64,
       last_bucket INT64,
       num_buckets INT64,
-      latest_version INT64,
       metric STRING,
       metric_type STRING,
       key STRING,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/query.sql
@@ -3,7 +3,6 @@ CREATE TEMP FUNCTION udf_merged_user_data(old_aggs ANY TYPE, new_aggs ANY TYPE)
     first_bucket INT64,
     last_bucket INT64,
     num_buckets INT64,
-    latest_version INT64,
     metric STRING,
     metric_type STRING,
     key STRING,
@@ -25,7 +24,6 @@ CREATE TEMP FUNCTION udf_merged_user_data(old_aggs ANY TYPE, new_aggs ANY TYPE)
         first_bucket,
         last_bucket,
         num_buckets,
-        latest_version,
         metric,
         metric_type,
         key,
@@ -37,7 +35,6 @@ CREATE TEMP FUNCTION udf_merged_user_data(old_aggs ANY TYPE, new_aggs ANY TYPE)
         first_bucket,
         last_bucket,
         num_buckets,
-        latest_version,
         metric,
         metric_type,
         key,
@@ -48,7 +45,6 @@ CREATE TEMP FUNCTION udf_merged_user_data(old_aggs ANY TYPE, new_aggs ANY TYPE)
         first_bucket,
         last_bucket,
         num_buckets,
-        latest_version,
         metric,
         metric_type,
         key,
@@ -96,10 +92,23 @@ merged AS
     COALESCE(old_data.app_build_id, new_data.app_build_id) AS app_build_id,
     COALESCE(old_data.channel, new_data.channel) AS channel,
     old_data.histogram_aggregates AS old_aggs,
-    new_data.histogram_aggregates AS new_aggs
+    ARRAY(
+    SELECT AS STRUCT
+       first_bucket ,
+        last_bucket ,
+        num_buckets ,
+        metric ,
+        metric_type ,
+        key ,
+        process ,
+        agg_type ,
+        aggregates
+    FROM
+      UNNEST(new_data.histogram_aggregates)
+    ) AS new_aggs
   FROM clients_histogram_aggregates_old AS old_data
-    FULL OUTER JOIN clients_histogram_aggregates_new AS new_data
-    ON new_data.join_key = old_data.join_key)
+  FULL OUTER JOIN clients_histogram_aggregates_new AS new_data
+  ON new_data.join_key = old_data.join_key)
 
 SELECT
   @submission_date AS submission_date,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/query.sql
@@ -92,20 +92,7 @@ merged AS
     COALESCE(old_data.app_build_id, new_data.app_build_id) AS app_build_id,
     COALESCE(old_data.channel, new_data.channel) AS channel,
     old_data.histogram_aggregates AS old_aggs,
-    ARRAY(
-    SELECT AS STRUCT
-       first_bucket ,
-        last_bucket ,
-        num_buckets ,
-        metric ,
-        metric_type ,
-        key ,
-        process ,
-        agg_type ,
-        aggregates
-    FROM
-      UNNEST(new_data.histogram_aggregates)
-    ) AS new_aggs
+    ARRAYe AS new_aggs
   FROM clients_histogram_aggregates_old AS old_data
   FULL OUTER JOIN clients_histogram_aggregates_new AS new_data
   ON new_data.join_key = old_data.join_key)

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/query.sql
@@ -92,7 +92,19 @@ merged AS
     COALESCE(old_data.app_build_id, new_data.app_build_id) AS app_build_id,
     COALESCE(old_data.channel, new_data.channel) AS channel,
     old_data.histogram_aggregates AS old_aggs,
-    ARRAYe AS new_aggs
+    ARRAY(
+    SELECT AS STRUCT
+      first_bucket,
+      last_bucket,
+      num_buckets,
+      metric,
+      metric_type,
+      key,
+      process,
+      agg_type,
+      aggregates
+    FROM UNNEST(new_data.histogram_aggregates)
+    ) AS new_aggs
   FROM clients_histogram_aggregates_old AS old_data
   FULL OUTER JOIN clients_histogram_aggregates_new AS new_data
   ON new_data.join_key = old_data.join_key)


### PR DESCRIPTION
This will fix the bug [#901](https://github.com/mozilla/bigquery-etl/issues/901)
and also some minor issues found with run_glam_sql 
1.[Missing parameter, num_partitions, that needs to be passed to run_partitioned_query] (https://github.com/mozilla/bigquery-etl/blob/9d8a7d30e6dc7c883523c8d37f274c04b361df51/script/glam/run_glam_sql#L166-L171)
2. Ideally we want the dataset to be created in destination project.[The PROJECT should be DST_PROJECT](https://github.com/mozilla/bigquery-etl/blob/305bcb27d2f54554653d44b2c5798192e3bb1912/script/glam/run_glam_sql#L321-L322)

**Running run_glam_sql for sanity check :**
1. Created a test project and dataset: 
    Project - alekhya-test-1-322715
    Dataset - moz_test_data
2. Created and populated the client_daily_histogram_aggregates_v1 table with minimum viable data for 08-17-2021. 
3. Populated client_histogram_aggregates_v1 with 08-16-2021 and sample_id =3 
3. Manually set the start_stage = 4 within the run_glam_sql script to run code that populates clients_histogram_aggregates_v1
4. Ran the run_glam_sql bash script as follows 
**PROJECT=moz-fx-data-shared-prod DST_PROJECT=alekhya-test-1-322715 PROD_DATASET=telemetry_derived DATASET=moz_test_data SUBMISSION_DATE =2021-08-17 ./run_glam_sql**

**Results :** 
Production data : 
[Script](https://gist.github.com/alekhyamoz/f0cd673a82b455ca35b2e16b339edd0a)
Results: 
![image](https://user-images.githubusercontent.com/88394696/130073063-d2c923ca-0213-45de-b1b9-f8b96a556aa5.png)


Test data : 
[Script](https://gist.github.com/alekhyamoz/4a75bfb6beb61cd1dd4e9d89eb2cb76a)
Resulst:
![image](https://user-images.githubusercontent.com/88394696/130072983-8a762ca7-160f-47d4-97cb-9e00f5e3ce3d.png)

**Steps for migration:** 
1. Create a new table with schema not including the latest_version column using the [init.sql](https://github.com/mozilla/bigquery-etl/blob/remove_latestversion_histogram/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/init.sql)
2. Back-fill the new table with last 2 days worth of data using the [query](https://gist.github.com/alekhyamoz/478a017554e6a5573c938e128e22e7b1)
3. Rename the existing clients_histogram_aggregates_v1 to clients_histogram_aggregates_v1_backup 
`ALTER TABLE `moz-fx-data-shared-prod.telemetry_derived.clients_histogram_aggregates_v1`  RENAME TO `moz-fx-data-shared-prod.telemetry_derived.clients_histogram_aggregates_v1_backup`
4. Rename the existing clients_histogram_aggregates_v2 to `clients_histogram_aggregates_v1`
`ALTER TABLE ```moz-fx-data-shared-prod.telemetry_derived.clients_histogram_aggregates_v2`  RENAME TO `moz-fx-data-shared-prod.telemetry_derived.clients_histogram_aggregates_v1``



