### PR TITLE
Prevent schema update downstream from dry running views

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -823,7 +823,9 @@ def update(
                 dependencies = [
                     p
                     for k, refs in dependency_graph.items()
-                    for p in paths_matching_name_pattern(k, sql_dir, project_id)
+                    for p in paths_matching_name_pattern(
+                        k, sql_dir, project_id, files=("query.sql",)
+                    )
                     if identifier in refs
                 ]
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/2278

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
