### PR TITLE
Avoid error messages in generate_stable_views

### DIFF
--- a/bigquery_etl/view/generate_stable_views.py
+++ b/bigquery_etl/view/generate_stable_views.py
@@ -259,6 +259,12 @@ def get_stable_table_schemas() -> List[SchemaFile]:
                 schema = json.load(tar.extractfile(tarinfo.name))  # type: ignore
                 bq_schema = {}
 
+                # Schemas without pipeline metadata (like glean/glean)
+                # do not have corresponding BQ tables, so we skip them here.
+                pipeline_meta = schema.get("mozPipelineMetadata", None)
+                if pipeline_meta is None:
+                    continue
+
                 try:
                     bq_schema_file = tar.extractfile(
                         tarinfo.name.replace(".schema.json", ".bq")
@@ -267,9 +273,6 @@ def get_stable_table_schemas() -> List[SchemaFile]:
                 except KeyError as e:
                     print(f"Cannot get Bigquery schema for {tarinfo.name}: {e}")
 
-                pipeline_meta = schema.get("mozPipelineMetadata", None)
-                if pipeline_meta is None:
-                    continue
                 schemas.append(
                     SchemaFile(
                         schema=bq_schema,


### PR DESCRIPTION
As of https://github.com/mozilla/bigquery-etl/pull/2118 we see error messages
from any `bqetl` command that calls `generate_stable_views` like:

```
Cannot get Bigquery schema for mozilla-pipeline-schemas-9e81d822064c5a8336d3f2e61cc67cdf58d4a010/schemas/glean/glean/glean.1.schema.json: "filename 'mozilla-pipeline-schemas-9e81d822064c5a8336d3f2e61cc67cdf58d4a010/schemas/glean/glean/glean.1.bq' not found"
Cannot get Bigquery schema for mozilla-pipeline-schemas-9e81d822064c5a8336d3f2e61cc67cdf58d4a010/schemas/metadata/credentials/credentials.1.schema.json: "filename 'mozilla-pipeline-schemas-9e81d822064c5a8336d3f2e61cc67cdf58d4a010/schemas/metadata/credentials/credentials.1.bq' not found"
...
```

These correspond to schema "fragments" that have no concrete BQ tables.
We need to check for the existence of `mozPipelineMetadata` _before_
trying to access a relevant BQ schema in order to avoid these.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
