### PR TITLE
added queries for sample counts

### DIFF
--- a/script/glam/run_glam_sql
+++ b/script/glam/run_glam_sql
@@ -33,6 +33,7 @@ function replace_dataset {
     sed "s/$PROD_DATASET/$DATASET/g" < "$sql_path"
 }
 
+
 function run_query {
     local destination_table=$1
     local time_partition=${2:-false}
@@ -175,6 +176,8 @@ function run_desktop_sql {
 
     run_query "histogram_percentiles_v1"
     run_query "glam_user_counts_v1"
+    run_query "glam_sample_counts_v1"
+    run_query "glam_sample_counts_extract_v1"
 }
 
 function wait_pids {

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_sample_counts_extract_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_sample_counts_extract_v1/query.sql
@@ -1,0 +1,41 @@
+WITH deduped AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        os,
+        app_version,
+        app_build_id,
+        channel
+      ORDER BY
+        total_sample DESC
+    ) AS rank
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.glam_sample_counts_v1`
+)
+SELECT
+  CASE
+  WHEN
+    channel = "nightly"
+  THEN
+    1
+  WHEN
+    channel = "beta"
+  THEN
+    2
+  WHEN
+    channel = "release"
+  THEN
+    3
+  END
+  AS channel,
+  app_version,
+  COALESCE(app_build_id, "*") AS app_build_id,
+  COALESCE(os, "*") AS os,
+  metric,
+  key,
+  total_sample
+FROM
+  deduped
+WHERE
+  rank = 1;

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_sample_counts_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_sample_counts_v1/query.sql
@@ -1,0 +1,184 @@
+WITH all_samples AS (
+  SELECT
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    metric,
+    key,
+    h1.aggregates
+  FROM
+    clients_histogram_aggregates_v1,
+    UNNEST(histogram_aggregates) h1
+  WHERE
+    submission_date = @submission_date
+)
+SELECT
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  metric,
+  all_samples.key,
+  SUM(v1.value) AS total_sample
+FROM
+  all_samples,
+  UNNEST(aggregates) v1
+GROUP BY
+  os,
+  app_version,
+  app_build_id,
+  channel,
+  metric,
+  key
+UNION ALL
+SELECT
+  CAST(NULL AS STRING) AS os,
+  app_version,
+  app_build_id,
+  channel,
+  metric,
+  all_samples.key,
+  SUM(v1.value) AS total_sample
+FROM
+  all_samples,
+  UNNEST(aggregates) v1
+GROUP BY
+  app_version,
+  app_build_id,
+  channel,
+  metric,
+  key
+UNION ALL
+SELECT
+  os,
+  CAST(NULL AS INT64) AS app_version,
+  app_build_id,
+  channel,
+  metric,
+  all_samples.key,
+  SUM(v1.value) AS total_sample
+FROM
+  all_samples,
+  UNNEST(aggregates) v1
+GROUP BY
+  os,
+  app_build_id,
+  channel,
+  metric,
+  key
+UNION ALL
+SELECT
+  os,
+  app_version,
+  CAST(NULL AS STRING) AS app_build_id,
+  channel,
+  metric,
+  all_samples.key,
+  SUM(v1.value) AS total_sample
+FROM
+  all_samples,
+  UNNEST(aggregates) v1
+GROUP BY
+  os,
+  app_version,
+  channel,
+  metric,
+  key
+UNION ALL
+SELECT
+  os,
+  CAST(NULL AS INT64) AS app_version,
+  CAST(NULL AS STRING) AS app_build_id,
+  channel,
+  metric,
+  all_samples.key,
+  SUM(v1.value) AS total_sample
+FROM
+  all_samples,
+  UNNEST(aggregates) v1
+GROUP BY
+  os,
+  channel,
+  metric,
+  key
+UNION ALL
+SELECT
+  CAST(NULL AS STRING) AS os,
+  app_version,
+  CAST(NULL AS STRING) AS app_build_id,
+  channel,
+  metric,
+  all_samples.key,
+  SUM(v1.value) AS total_sample
+FROM
+  all_samples,
+  UNNEST(aggregates) v1
+GROUP BY
+  app_version,
+  channel,
+  metric,
+  key
+UNION ALL
+SELECT
+  CAST(NULL AS STRING) AS os,
+  app_version,
+  CAST(NULL AS STRING) AS app_build_id,
+  CAST(NULL AS STRING) AS channel,
+  metric,
+  all_samples.key,
+  SUM(v1.value) AS total_sample
+FROM
+  all_samples,
+  UNNEST(aggregates) v1
+GROUP BY
+  app_version,
+  metric,
+  key
+UNION ALL
+SELECT
+  os,
+  CAST(NULL AS INT64) AS app_version,
+  CAST(NULL AS STRING) AS app_build_id,
+  CAST(NULL AS STRING) AS channel,
+  metric,
+  all_samples.key,
+  SUM(v1.value) AS total_sample
+FROM
+  all_samples,
+  UNNEST(aggregates) v1
+GROUP BY
+  os,
+  metric,
+  key
+UNION ALL
+SELECT
+  CAST(NULL AS STRING) AS os,
+  CAST(NULL AS INT64) AS app_version,
+  CAST(NULL AS STRING) AS app_build_id,
+  channel,
+  metric,
+  all_samples.key,
+  SUM(v1.value) AS total_sample
+FROM
+  all_samples,
+  UNNEST(aggregates) v1
+GROUP BY
+  channel,
+  metric,
+  key
+UNION ALL
+SELECT
+  CAST(NULL AS STRING) AS os,
+  CAST(NULL AS INT64) AS app_version,
+  CAST(NULL AS STRING) AS app_build_id,
+  CAST(NULL AS STRING) AS channel,
+  metric,
+  all_samples.key,
+  SUM(v1.value) AS total_sample
+FROM
+  all_samples,
+  UNNEST(aggregates) v1
+GROUP BY
+  metric,
+  key


### PR DESCRIPTION
The PR is to resolve the issue [#1240](https://github.com/mozilla/glam/issues/1240). 
As part of the change, I have added two sql queries 
1. To pull the counts from `clients_histogram_aggregates` table [query1](https://gist.github.com/alekhyamoz/031fd954469acd6020d844202c5f8ce4)
2. To dedup in case of duplicates [query 2](https://gist.github.com/alekhyamoz/c8a668430e37b32083818fb70fd1c2aa)

Testing process:
Used run_glam_sql to test the process 
1. Get sample data from `moz-fx-data-shared-prod.telemetry_derived.clients_histogram_aggregates` to `alekhya-test-1-322715.moz_test_data.clients_histogram_aggregates` [query](https://gist.github.com/alekhyamoz/e5e452185cdfe04096f03f37ff8260ff)
2. PROJECT=moz-fx-data-shared-prod DST_PROJECT=alekhya-test-1-322715 PROD_DATASET=telemetry_derived DATASET=moz_test_data SUBMISSION_DATE=2021-09-01 ./run_glam_sql

Validation: 
Production query [link](https://gist.github.com/alekhyamoz/8cf1b1b716146f7de458e9c524839629)
The results
<img width="719" alt="Screen Shot 2021-09-02 at 12 22 34 PM" src="https://user-images.githubusercontent.com/88394696/131880944-4081aad1-4815-41d3-b049-954b5530d237.png">

Testing 
<img width="629" alt="Screen Shot 2021-09-02 at 12 23 13 PM" src="https://user-images.githubusercontent.com/88394696/131881035-ab58586a-9da2-4a50-9692-e04344d0ea86.png">






