### PR TITLE
Include fxa stdout events in mozilla vpn attribution

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -92,6 +92,7 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/devices_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/protected_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/site_metrics_empty_check_v1/query.sql",  # noqa E501

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/init.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS
     flow_started TIMESTAMP,
     fxa_uids ARRAY<STRING>,
     attribution STRUCT<
+      `timestamp` TIMESTAMP,
       entrypoint_experiment STRING,
       entrypoint_variation STRING,
       utm_campaign STRING,

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/query.sql
@@ -1,4 +1,53 @@
-WITH base AS (
+WITH fxa_stdout_events AS (
+  SELECT
+    PARSE_DATE('%y%m%d', _TABLE_SUFFIX) AS partition_date,
+    `timestamp`,
+    jsonPayload.fields.event_properties,
+    jsonPayload.fields.event_type,
+    TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id,
+    jsonPayload.fields.user_properties,
+  FROM
+    `moz-fx-fxa-prod-0712.fxa_prod_logs.stdout_20*`
+  WHERE
+    jsonPayload.type = 'amplitudeEvent'
+    AND jsonPayload.fields.event_type IS NOT NULL
+),
+fxa_content_auth_stdout_events AS (
+  SELECT
+    DATE(`timestamp`) AS partition_date,
+    `timestamp`,
+    service,
+    event_type,
+    flow_id,
+    user_id,
+    entrypoint_experiment,
+    entrypoint_variation,
+    utm_campaign,
+    utm_content,
+    utm_medium,
+    utm_source,
+    utm_term,
+  FROM
+    mozdata.firefox_accounts.fxa_content_auth_events
+  UNION ALL
+  SELECT
+    partition_date,
+    `timestamp`,
+    JSON_VALUE(event_properties, '$.service') AS service,
+    event_type,
+    JSON_VALUE(user_properties, '$.flow_id') AS flow_id,
+    user_id,
+    JSON_VALUE(user_properties, '$.entrypoint_experiment') AS entrypoint_experiment,
+    JSON_VALUE(user_properties, '$.entrypoint_variation') AS entrypoint_variation,
+    JSON_VALUE(user_properties, '$.utm_campaign') AS utm_campaign,
+    JSON_VALUE(user_properties, '$.utm_content') AS utm_content,
+    JSON_VALUE(user_properties, '$.utm_medium') AS utm_medium,
+    JSON_VALUE(user_properties, '$.utm_source') AS utm_source,
+    JSON_VALUE(user_properties, '$.utm_term') AS utm_term,
+  FROM
+    fxa_stdout_events
+),
+flows AS (
   SELECT
     flow_id,
     MIN(`timestamp`) AS flow_started,
@@ -13,6 +62,7 @@ WITH base AS (
         OR utm_source IS NOT NULL
         OR utm_term IS NOT NULL,
         STRUCT(
+          `timestamp`,
           entrypoint_experiment,
           entrypoint_variation,
           utm_campaign,
@@ -29,10 +79,15 @@ WITH base AS (
         1
     )[SAFE_OFFSET(0)] AS attribution,
   FROM
-    firefox_accounts.fxa_content_auth_events
+    fxa_content_auth_stdout_events
   WHERE
-    IF(@date IS NULL, DATE(`timestamp`) < CURRENT_DATE, DATE(`timestamp`) = @date)
-    AND service = "guardian-vpn"
+    IF(@date IS NULL, partition_date < CURRENT_DATE, partition_date = @date)
+    -- cannot filter service because
+    AND (
+      service = "guardian-vpn"
+      -- service is missing for these event types
+      OR (service IS NULL AND (event_type = "fxa_rp_button - view" OR event_type LIKE "fxa_pay_%"))
+    )
     AND flow_id IS NOT NULL
   GROUP BY
     flow_id
@@ -47,9 +102,11 @@ SELECT
   MIN(flow_started) AS flow_started,
   ARRAY_AGG(DISTINCT fxa_uid IGNORE NULLS) AS fxa_uids,
   -- preserve earliest non-null attribution
-  ARRAY_AGG(attribution IGNORE NULLS ORDER BY flow_started LIMIT 1)[SAFE_OFFSET(0)] AS attribution,
+  ARRAY_AGG(attribution IGNORE NULLS ORDER BY attribution.timestamp LIMIT 1)[
+    SAFE_OFFSET(0)
+  ] AS attribution,
 FROM
-  base
+  flows
 LEFT JOIN
   UNNEST(fxa_uids) AS fxa_uid
 GROUP BY

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/schema.yaml
@@ -14,6 +14,9 @@ fields:
   type: RECORD
   fields:
   - mode: NULLABLE
+    name: timestamp
+    type: TIMESTAMP
+  - mode: NULLABLE
     name: entrypoint_experiment
     type: STRING
   - mode: NULLABLE


### PR DESCRIPTION
This a separate issue that came up while investigating [FXA-3965](https://mozilla-hub.atlassian.net/browse/FXA-3965)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
