### PR TITLE
Fix for Bugzilla: 1729084 - Add UDF to remove outliers

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/query.sql
@@ -2,12 +2,33 @@ CREATE TEMP FUNCTION one_index(x ANY TYPE) AS (
   CAST(IF(SAFE_CAST(x AS INT64) < 0, SAFE_CAST(x AS INT64), SAFE_CAST(x AS INT64) + 1) AS STRING)
 );
 
-CREATE TEMP FUNCTION one_index_struct(x STRUCT<k STRING, v INT64>) AS (
-  STRUCT(one_index(x.k) AS key, x.v AS value)
+CREATE TEMP FUNCTION one_index_struct(record STRUCT<k STRING, v INT64>) AS (
+  STRUCT(one_index(record.k) AS key, record.v AS value)
 );
 
-CREATE TEMP FUNCTION one_index_array(x ARRAY<STRUCT<k STRING, v INT64>>) AS (
-  ARRAY(SELECT one_index_struct(e) FROM UNNEST(x) AS e)
+CREATE TEMP FUNCTION one_index_array(map ARRAY<STRUCT<k STRING, v INT64>>) AS (
+  ARRAY(SELECT one_index_struct(record) FROM UNNEST(map) AS record)
+);
+
+CREATE TEMP FUNCTION filter_probe_counts_with_outlier_values(
+  map ARRAY<STRUCT<k STRING, v INT64>>
+) AS (
+  -- Similar to search probes/metrics, count values over 10000 are considered too high
+  ARRAY(
+    SELECT
+      STRUCT(record.k AS key, record.v AS value)
+    FROM
+      UNNEST(map) AS record
+    WHERE
+      record.v <= 10000
+  )
+);
+
+CREATE TEMP FUNCTION transform_scalar_metric_sum_columns(map ARRAY<STRUCT<k STRING, v INT64>>) AS (
+    -- Transforms the sums of probe counts columns from clients_daily by:
+        -- Applying 1-indexing to reflex index -> position (of urlbar choice)
+        -- Replacing outlier sum values above a certain threshold with 0
+  one_index_array(filter_probe_counts_with_outlier_values(map))
 );
 
 WITH combined_urlbar_picked AS (
@@ -28,64 +49,71 @@ WITH combined_urlbar_picked AS (
     [
       STRUCT(
         "autofill" AS type,
-        one_index_array(scalar_parent_urlbar_picked_autofill_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_autofill_sum) AS position
       ),
       STRUCT(
         "bookmark" AS type,
-        one_index_array(scalar_parent_urlbar_picked_bookmark_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_bookmark_sum) AS position
       ),
       STRUCT(
         "dynamic" AS type,
-        one_index_array(scalar_parent_urlbar_picked_dynamic_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_dynamic_sum) AS position
       ),
       STRUCT(
         "extension" AS type,
-        one_index_array(scalar_parent_urlbar_picked_extension_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_extension_sum) AS position
       ),
       STRUCT(
         "formhistory" AS type,
-        one_index_array(scalar_parent_urlbar_picked_formhistory_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_formhistory_sum) AS position
       ),
       STRUCT(
         "history" AS type,
-        one_index_array(scalar_parent_urlbar_picked_history_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_history_sum) AS position
       ),
       STRUCT(
         "keyword" AS type,
-        one_index_array(scalar_parent_urlbar_picked_keyword_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_keyword_sum) AS position
       ),
       STRUCT(
         "remotetab" AS type,
-        one_index_array(scalar_parent_urlbar_picked_remotetab_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_remotetab_sum) AS position
       ),
       STRUCT(
         "searchengine" AS type,
-        one_index_array(scalar_parent_urlbar_picked_searchengine_sum) AS position
+        transform_scalar_metric_sum_columns(
+          scalar_parent_urlbar_picked_searchengine_sum
+        ) AS position
       ),
       STRUCT(
         "searchsuggestion" AS type,
-        one_index_array(scalar_parent_urlbar_picked_searchsuggestion_sum) AS position
+        transform_scalar_metric_sum_columns(
+          scalar_parent_urlbar_picked_searchsuggestion_sum
+        ) AS position
       ),
       STRUCT(
         "switchtab" AS type,
-        one_index_array(scalar_parent_urlbar_picked_switchtab_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_switchtab_sum) AS position
       ),
       STRUCT(
         "tabtosearch" AS type,
-        one_index_array(scalar_parent_urlbar_picked_tabtosearch_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_tabtosearch_sum) AS position
       ),
-      STRUCT("tip" AS type, one_index_array(scalar_parent_urlbar_picked_tip_sum) AS position),
+      STRUCT(
+        "tip" AS type,
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_tip_sum) AS position
+      ),
       STRUCT(
         "topsite" AS type,
-        one_index_array(scalar_parent_urlbar_picked_topsite_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_topsite_sum) AS position
       ),
       STRUCT(
         "unknown" AS type,
-        one_index_array(scalar_parent_urlbar_picked_unknown_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_unknown_sum) AS position
       ),
       STRUCT(
         "visiturl" AS type,
-        one_index_array(scalar_parent_urlbar_picked_visiturl_sum) AS position
+        transform_scalar_metric_sum_columns(scalar_parent_urlbar_picked_visiturl_sum) AS position
       )
     ] AS urlbar_picked_by_type_by_position
   FROM
@@ -100,7 +128,7 @@ count_picked AS (
     COALESCE(SUM(position.value), 0) AS count_picked_total,
     mozfun.map.sum(ARRAY_AGG(STRUCT(type AS key, position.value AS value))) AS count_picked_by_type,
     mozfun.map.sum(
-      ARRAY_AGG(STRUCT(one_index(position.key) AS key, position.value AS value))
+      ARRAY_AGG(STRUCT(position.key AS key, position.value AS value))
     ) AS count_picked_by_position
   FROM
     combined_urlbar_picked

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/test_overactive_filter/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/test_overactive_filter/expect.yaml
@@ -1,0 +1,127 @@
+---
+- &base
+  submission_date: "2021-09-01"
+  client_id: "client_1"
+  default_search_engine: "engine_1"
+  app_version: "one"
+  normalized_channel: "nightly"
+  locale: "en-US"
+  search_region: "US"
+  suggest_enabled: true
+  in_navbar: true
+  suggest_searches: true
+  show_search_suggestions_first: true
+  count_picked_total: 20
+  count_picked_by_type:
+    - key: "autofill"
+      value: 5
+    - key: "bookmark"
+      value: 5
+    - key: "history"
+      value: 5
+    - key: "searchengine"
+      value: 5
+  count_picked_by_position:
+    - key: "1"
+      value: 10
+    - key: "2"
+      value: 10
+  urlbar_picked_by_type_by_position:
+    - type: "autofill"
+      position:
+        - key: "1"
+          value: 5
+    - type: "bookmark"
+      position:
+        - key: "1"
+          value: 5
+    - type: "dynamic"
+      position: []
+    - type: "extension"
+      position: []
+    - type: "formhistory"
+      position: []
+    - type: "history"
+      position:
+        - key: "2"
+          value: 5
+    - type: "keyword"
+      position: []
+    - type: "remotetab"
+      position: []
+    - type: "searchengine"
+      position:
+        - key: "2"
+          value: 5
+    - type: "searchsuggestion"
+      position: []
+    - type: "switchtab"
+      position: []
+    - type: "tabtosearch"
+      position: []
+    - type: "tip"
+      position: []
+    - type: "topsite"
+      position: []
+    - type: "unknown"
+      position: []
+    - type: "visiturl"
+      position: []
+- <<: *base
+  client_id: "client_2"
+  count_picked_total: 21
+  count_picked_by_type:
+    - key: "autofill"
+      value: 6
+    - key: "bookmark"
+      value: 5
+    - key: "history"
+      value: 5
+    - key: "searchengine"
+      value: 5
+  count_picked_by_position:
+    - key: "1"
+      value: 11
+    - key: "2"
+      value: 10
+  urlbar_picked_by_type_by_position:
+    - type: "autofill"
+      position:
+        - key: "1"
+          value: 6
+    - type: "bookmark"
+      position:
+        - key: "1"
+          value: 5
+    - type: "dynamic"
+      position: []
+    - type: "extension"
+      position: []
+    - type: "formhistory"
+      position: []
+    - type: "history"
+      position:
+        - key: "2"
+          value: 5
+    - type: "keyword"
+      position: []
+    - type: "remotetab"
+      position: []
+    - type: "searchengine"
+      position:
+        - key: "2"
+          value: 5
+    - type: "searchsuggestion"
+      position: []
+    - type: "switchtab"
+      position: []
+    - type: "tabtosearch"
+      position: []
+    - type: "tip"
+      position: []
+    - type: "topsite"
+      position: []
+    - type: "unknown"
+      position: []
+    - type: "visiturl"
+      position: []

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/test_overactive_filter/query_params.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/test_overactive_filter/query_params.yaml
@@ -1,0 +1,4 @@
+---
+- name: submission_date
+  type: DATE
+  value: 2021-09-01

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/test_overactive_filter/telemetry.clients_daily.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/test_overactive_filter/telemetry.clients_daily.schema.json
@@ -1,0 +1,329 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "submission_date",
+    "type": "DATE"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "client_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "default_search_engine",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "app_version",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "normalized_channel",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_pref_browser_search_region",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_pref_browser_search_suggest_enabled",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_pref_browser_widget_in_navbar",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_pref_browser_urlbar_suggest_searches",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_pref_browser_urlbar_show_search_suggestions_first",
+    "type": "BOOLEAN"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_autofill_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_bookmark_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_dynamic_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_extension_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_formhistory_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_history_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_keyword_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_remotetab_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_searchengine_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_searchsuggestion_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_switchtab_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_tabtosearch_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_tip_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_topsite_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_unknown_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "scalar_parent_urlbar_picked_visiturl_sum",
+    "type": "RECORD"
+  }
+]

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/test_overactive_filter/telemetry.clients_daily.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/test_overactive_filter/telemetry.clients_daily.yaml
@@ -1,0 +1,44 @@
+---
+- &base
+  submission_date: "2021-09-01"
+  client_id: "client_1"
+  default_search_engine: "engine_1"
+  app_version: "one"
+  normalized_channel: "nightly"
+  locale: "en-US"
+  user_pref_browser_search_region: "US"
+  user_pref_browser_search_suggest_enabled: true
+  user_pref_browser_widget_in_navbar: true
+  user_pref_browser_urlbar_suggest_searches: true
+  user_pref_browser_urlbar_show_search_suggestions_first: true
+  scalar_parent_urlbar_picked_autofill_sum:
+    - key: "0"
+      value: 5
+  scalar_parent_urlbar_picked_bookmark_sum:
+    - key: "0"
+      value: 5
+  scalar_parent_urlbar_picked_dynamic_sum: []
+  scalar_parent_urlbar_picked_extension_sum: []
+  scalar_parent_urlbar_picked_formhistory_sum: []
+  scalar_parent_urlbar_picked_history_sum:
+    - key: "1"
+      value: 5
+  scalar_parent_urlbar_picked_keyword_sum: []
+  scalar_parent_urlbar_picked_remotetab_sum: []
+  scalar_parent_urlbar_picked_searchengine_sum:
+    - key: "1"
+      value: 5
+  scalar_parent_urlbar_picked_searchsuggestion_sum: []
+  scalar_parent_urlbar_picked_switchtab_sum: []
+  scalar_parent_urlbar_picked_tabtosearch_sum: []
+  scalar_parent_urlbar_picked_tip_sum: []
+  scalar_parent_urlbar_picked_topsite_sum: []
+  scalar_parent_urlbar_picked_unknown_sum: []
+  scalar_parent_urlbar_picked_visiturl_sum: []
+- <<: *base
+  client_id: "client_2"
+  scalar_parent_urlbar_picked_autofill_sum:
+    - key: "0"
+      value: 6
+    - key: "1"
+      value: 10001 # 1 over the threshold


### PR DESCRIPTION
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1729084

PR:
- Adds `filter_probe_counts_with_outlier_values` UDF and uses it to remove  metrics/probes in the relevant urlbar keyed scalar metrics if they pass a threshold value. 
This is similar to the approach in [`mobile_search_clients_daily_v1`](https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L632-L633) and we use the same threshold here (10,000).
- Removed double call of `one_index` so position counts are 1-based instead of 2-based 
- Adds tests


Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
~- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.~
~- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated~
