### PR TITLE
Support analysis for rollouts in opmon (by treating a boolean pref as a branch)

### DIFF
--- a/bigquery_etl/operational_monitoring/__init__.py
+++ b/bigquery_etl/operational_monitoring/__init__.py
@@ -72,14 +72,16 @@ def _query_up_to_date(dataset, slug, basename, project_last_modified):
 
 
 def _write_sql_for_data_type(
-    query, project, dataset, slug, render_kwargs, probes, data_type
+    query, project, dataset, om_project, render_kwargs, probes, data_type
 ):
-    normalized_slug = _bq_normalize_name(slug)
+    normalized_slug = _bq_normalize_name(om_project["slug"])
     render_kwargs.update(
         {
             "source": query["source"],
             "probes": _get_name_and_sql(query, probes, "probes", data_type),
-            "slug": slug,
+            "slug": om_project["slug"],
+            "channel": om_project["channel"],
+            "pref": om_project.get("boolean_pref"),
         }
     )
     _write_sql(
@@ -134,7 +136,7 @@ def _generate_sql(project, dataset):
             project, bucket, blob.name
         )
         normalized_slug = _bq_normalize_name(om_project["slug"])
-        render_kwargs.update({"branches": om_project["branches"]})
+        render_kwargs.update({"branches": om_project.get("branches", [])})
         if _query_up_to_date(
             dataset, normalized_slug, INIT_FILENAME, project_last_modified
         ):
@@ -153,7 +155,7 @@ def _generate_sql(project, dataset):
                     query,
                     project,
                     dataset,
-                    om_project["slug"],
+                    om_project,
                     render_kwargs,
                     probes,
                     data_type,

--- a/bigquery_etl/operational_monitoring/templates/histogram_query.sql
+++ b/bigquery_etl/operational_monitoring/templates/histogram_query.sql
@@ -8,6 +8,9 @@ WITH merged_probes AS (
     {% for dimension in dimensions %}
       CAST({{ dimension.sql }} AS STRING) AS {{ dimension.name }},
     {% endfor %}
+
+    -- If a pref is defined, treat it as a rollout with an enabled and disabled branch
+    -- otherwise use the branches from the experiment based on the slug
     {% if pref %}
     CASE
       WHEN SAFE_CAST({{pref}} as BOOLEAN) THEN 'enabled'
@@ -91,6 +94,8 @@ merged_histograms AS (
   CROSS JOIN
     UNNEST(metrics)
   WHERE branch IN (
+    -- If branches are not defined, assume it's a rollout
+    -- and fall back to branches labeled as enabled/disabled
     {% if branches %}
     {% for branch in branches %}
       "{{ branch }}"

--- a/bigquery_etl/operational_monitoring/templates/histogram_query.sql
+++ b/bigquery_etl/operational_monitoring/templates/histogram_query.sql
@@ -8,10 +8,18 @@ WITH merged_probes AS (
     {% for dimension in dimensions %}
       CAST({{ dimension.sql }} AS STRING) AS {{ dimension.name }},
     {% endfor %}
+    {% if pref %}
+    CASE
+      WHEN SAFE_CAST({{pref}} as BOOLEAN) THEN 'enabled'
+      WHEN NOT SAFE_CAST({{pref}} as BOOLEAN) THEN 'disabled'
+    END
+    AS branch,
+    {% else %}
     mozfun.map.get_key(
       environment.experiments,
       "{{slug}}"
     ).branch AS branch,
+    {% endif %}
     ARRAY<
       STRUCT<
         metric STRING,
@@ -36,6 +44,7 @@ WITH merged_probes AS (
     `{{source}}`
   WHERE
     DATE(submission_timestamp) >= DATE_SUB(@submission_date, INTERVAL 60 DAY)
+  AND normalized_channel = '{{channel}}'
   GROUP BY
     submission_date,
     client_id,
@@ -82,10 +91,14 @@ merged_histograms AS (
   CROSS JOIN
     UNNEST(metrics)
   WHERE branch IN (
+    {% if branches %}
     {% for branch in branches %}
       "{{ branch }}"
       {{ "," if not loop.last else "" }}
     {% endfor %}
+    {% else %}
+    "enabled", "disabled"
+    {% endif %}
   )
   GROUP BY
     submission_date,

--- a/bigquery_etl/operational_monitoring/templates/scalar_query.sql
+++ b/bigquery_etl/operational_monitoring/templates/scalar_query.sql
@@ -8,6 +8,9 @@ WITH merged_scalars AS (
         {% for dimension in dimensions %}
           CAST({{ dimension.sql }} AS STRING) AS {{ dimension.name }},
         {% endfor %}
+
+        -- If a pref is defined, treat it as a rollout with an enabled and disabled branch
+        -- otherwise use the branches from the experiment based on the slug
         {% if pref %}
         CASE
           WHEN SAFE_CAST({{pref}} as BOOLEAN) THEN 'enabled'
@@ -59,6 +62,8 @@ WITH merged_scalars AS (
 SELECT *
 FROM merged_scalars
 WHERE branch IN (
+    -- If branches are not defined, assume it's a rollout
+    -- and fall back to branches labeled as enabled/disabled
     {% if branches %}
     {% for branch in branches %}
       "{{ branch }}"

--- a/bigquery_etl/operational_monitoring/templates/scalar_query.sql
+++ b/bigquery_etl/operational_monitoring/templates/scalar_query.sql
@@ -1,46 +1,70 @@
 {{ header }}
 
-SELECT
-    @submission_date AS submission_date,
-    client_id,
-    SAFE.SUBSTR(application.build_id, 0, 8) AS build_id,
-    {% for dimension in dimensions %}
-      CAST({{ dimension.sql }} AS STRING) AS {{ dimension.name }},
+WITH merged_scalars AS (
+    SELECT
+        @submission_date AS submission_date,
+        client_id,
+        SAFE.SUBSTR(application.build_id, 0, 8) AS build_id,
+        {% for dimension in dimensions %}
+          CAST({{ dimension.sql }} AS STRING) AS {{ dimension.name }},
+        {% endfor %}
+        {% if pref %}
+        CASE
+          WHEN SAFE_CAST({{pref}} as BOOLEAN) THEN 'enabled'
+          WHEN NOT SAFE_CAST({{pref}} as BOOLEAN) THEN 'disabled'
+        END
+        AS branch,
+        {% else %}
+        mozfun.map.get_key(
+          environment.experiments,
+          "{{slug}}"
+        ).branch AS branch,
+        {% endif %}
+        ARRAY<
+            STRUCT<
+                name STRING,
+                agg_type STRING,
+                value INT64
+            >
+        >[
+          {% for probe in probes %}
+            (
+                "{{ probe.name }}",
+                "MAX",
+                MAX(CAST({{ probe.sql }} AS INT64))
+            ),
+            (
+                "{{ probe.name }}",
+                "SUM",
+                SUM(CAST({{ probe.sql }} AS INT64))
+            )
+            {{ "," if not loop.last else "" }}
+          {% endfor %}
+        ] AS metrics,
+    FROM
+        `{{source}}`
+    WHERE
+        DATE(submission_timestamp) >= DATE_SUB(@submission_date, INTERVAL 60 DAY)
+    AND normalized_channel = '{{channel}}'
+    GROUP BY
+        submission_date,
+        client_id,
+        build_id,
+        {% for dimension in dimensions %}
+          {{ dimension.name }},
+        {% endfor %}
+        branch
+)
+
+SELECT *
+FROM merged_scalars
+WHERE branch IN (
+    {% if branches %}
+    {% for branch in branches %}
+      "{{ branch }}"
+      {{ "," if not loop.last else "" }}
     {% endfor %}
-    mozfun.map.get_key(
-      environment.experiments,
-      "{{slug}}"
-    ).branch AS branch,
-    ARRAY<
-        STRUCT<
-            name STRING,
-            agg_type STRING,
-            value INT64
-        >
-    >[
-      {% for probe in probes %}
-        (
-            "{{ probe.name }}",
-            "MAX",
-            MAX(CAST({{ probe.sql }} AS INT64))
-        ),
-        (
-            "{{ probe.name }}",
-            "SUM",
-            SUM(CAST({{ probe.sql }} AS INT64))
-        )
-        {{ "," if not loop.last else "" }}
-      {% endfor %}
-    ] AS metrics,
-FROM
-    `{{source}}`
-WHERE
-    DATE(submission_timestamp) >= DATE_SUB(@submission_date, INTERVAL 60 DAY)
-GROUP BY
-    submission_date,
-    client_id,
-    build_id,
-    {% for dimension in dimensions %}
-      {{ dimension.name }},
-    {% endfor %}
-    branch
+    {% else %}
+    "enabled", "disabled"
+    {% endif %}
+)


### PR DESCRIPTION
This PR adds the ability to specify in an opmon project config file that a certain boolean pref will be used instead of regular experiment branches for doing the comparative analysis.

TODO:
- [x] Use the pref in the sql templates that comes from the config

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
