### PR TITLE
Always update all dates in GA funnel

### DIFF
--- a/dags/bqetl_mozilla_vpn_site_metrics.py
+++ b/dags/bqetl_mozilla_vpn_site_metrics.py
@@ -51,7 +51,7 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="dthorn@mozilla.com",
         email=["dthorn@mozilla.com", "telemetry-alerts@mozilla.com"],
-        date_partition_parameter="date",
+        date_partition_parameter=None,
         depends_on_past=False,
         dag=dag,
     )

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v1/metadata.yaml
@@ -8,4 +8,6 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_mozilla_vpn_site_metrics
-  date_partition_parameter: date
+  # destination is the whole table, not a single partition,
+  # so don't use date_partition_parameter
+  date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v1/query.sql
@@ -48,7 +48,7 @@ website AS (
   FROM
     website_base
   WHERE
-    `date` = @date
+    `date` >= '2020-07-01'
   GROUP BY
     `date`,
     normalized_medium,
@@ -80,7 +80,7 @@ subscriptions AS (
   FROM
     all_subscriptions_v1
   WHERE
-    DATE(subscription_start_date) = @date
+    DATE(subscription_start_date) >= '2020-07-01'
     AND product_name = "Mozilla VPN"
     AND provider LIKE "FxA %"
   GROUP BY


### PR DESCRIPTION
This change causes the query to scan ~125MB, and is needed because subscription attribution may be added after the subscription start date

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
