### PR TITLE
Bug 1729970 Add firefox suggest prefs to clients_daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
@@ -1654,3 +1654,9 @@ fields:
 - mode: NULLABLE
   name: user_pref_browser_urlbar_show_search_suggestions_first
   type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest_sponsored
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
@@ -1645,3 +1645,9 @@ fields:
 - mode: NULLABLE
   name: user_pref_browser_urlbar_show_search_suggestions_first
   type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest_sponsored
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -1391,3 +1391,9 @@ fields:
 - mode: NULLABLE
   name: user_pref_browser_urlbar_show_search_suggestions_first
   type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest_sponsored
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/schema.yaml
@@ -1449,3 +1449,9 @@ fields:
 - mode: NULLABLE
   name: user_pref_browser_urlbar_show_search_suggestions_first
   type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest_sponsored
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
@@ -1431,3 +1431,9 @@ fields:
 - mode: NULLABLE
   name: user_pref_browser_urlbar_show_search_suggestions_first
   type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest_sponsored
+  type: STRING


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1729970

Also refactors `mozfun.map.get_key` calls to a single `UNNEST` query with multiple aggregations.

I'll add these fields to `urlbar_clients_daily` in a separate PR.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
