### PR TITLE
Update jackknife_percentile_ci() for use with scalar float buckets

### DIFF
--- a/bigquery_etl/operational_monitoring/templates/histogram_view.sql
+++ b/bigquery_etl/operational_monitoring/templates/histogram_view.sql
@@ -43,7 +43,7 @@ WITH normalized AS (
         branch,
         probe)
 
--- Cast histograms to have INT64 keys
+-- Cast histograms to have FLOAT64 keys
 -- so we can use the histogram jackknife percentile function.
 SELECT
     client_id,
@@ -59,11 +59,11 @@ SELECT
         histogram_type INT64,
         `range` ARRAY<INT64>,
         VALUES
-        ARRAY<STRUCT<key INT64, value FLOAT64>
+        ARRAY<STRUCT<key FLOAT64, value FLOAT64>
     >>(histogram.bucket_count,
         histogram.sum,
         histogram.histogram_type,
         histogram.range,
-        ARRAY(SELECT AS STRUCT CAST(keyval.key AS INT64), keyval.value FROM UNNEST(histogram.values) keyval)
+        ARRAY(SELECT AS STRUCT CAST(keyval.key AS FLOAT64), keyval.value FROM UNNEST(histogram.values) keyval)
     ) AS histogram
 FROM normalized

--- a/bigquery_etl/operational_monitoring/templates/scalar_init.sql
+++ b/bigquery_etl/operational_monitoring/templates/scalar_init.sql
@@ -7,13 +7,10 @@ CREATE TABLE IF NOT EXISTS
     {% for dimension in dimensions %}
       {{ dimension.name }} STRING,
     {% endfor %}
-    metrics ARRAY<
-      STRUCT<
-        name STRING,
-        agg_type STRING,
-        value INT64
-      >
-    >)
+    name STRING,
+    agg_type STRING,
+    value FLOAT64
+  )
 PARTITION BY submission_date
 CLUSTER BY
     build_id

--- a/bigquery_etl/operational_monitoring/templates/scalar_query.sql
+++ b/bigquery_etl/operational_monitoring/templates/scalar_query.sql
@@ -57,19 +57,53 @@ WITH merged_scalars AS (
           {{ dimension.name }},
         {% endfor %}
         branch
-)
+),
 
-SELECT *
-FROM merged_scalars
-WHERE branch IN (
-    -- If branches are not defined, assume it's a rollout
-    -- and fall back to branches labeled as enabled/disabled
-    {% if branches %}
-    {% for branch in branches %}
-      "{{ branch }}"
-      {{ "," if not loop.last else "" }}
-    {% endfor %}
-    {% else %}
-    "enabled", "disabled"
-    {% endif %}
-)
+flattened_scalars AS (
+    SELECT *
+    FROM merged_scalars
+    CROSS JOIN UNNEST(metrics)
+    WHERE branch IN (
+        -- If branches are not defined, assume it's a rollout
+        -- and fall back to branches labeled as enabled/disabled
+        {% if branches %}
+        {% for branch in branches %}
+          "{{ branch }}"
+          {{ "," if not loop.last else "" }}
+        {% endfor %}
+        {% else %}
+        "enabled", "disabled"
+        {% endif %}
+    )
+),
+
+log_min_max AS (
+  SELECT
+    name,
+    LOG(IF(MIN(value) <= 0, 1, MIN(value)), 2) log_min,
+    LOG(IF(MAX(value) <= 0, 1, MAX(value)), 2) log_max
+  FROM
+    flattened_scalars
+  GROUP BY 1),
+
+buckets_by_metric AS (
+  SELECT name, ARRAY(SELECT FORMAT("%.*f", 2, bucket) FROM UNNEST(
+    mozfun.glam.histogram_generate_scalar_buckets(log_min, log_max, 100)
+  ) AS bucket ORDER BY bucket) AS buckets
+  FROM log_min_max)
+
+SELECT
+    submission_date,
+    client_id,
+    build_id,
+    cores_count,
+    os,
+    branch,
+    name,
+    agg_type,
+    -- Replace value with its bucket value
+    SAFE_CAST(FORMAT("%.*f", 2, COALESCE(mozfun.glam.histogram_bucket_from_value(buckets, SAFE_CAST(value AS FLOAT64)), 0) + 0.0001) AS FLOAT64) AS value
+FROM
+    flattened_scalars
+LEFT JOIN buckets_by_metric USING(name)
+

--- a/bigquery_etl/operational_monitoring/templates/scalar_view.sql
+++ b/bigquery_etl/operational_monitoring/templates/scalar_view.sql
@@ -16,8 +16,6 @@ SELECT
     ELSE SUM(value)
   END AS value
 FROM `{{gcp_project}}.{{dataset}}.{{slug}}_scalar`
-CROSS JOIN
-  UNNEST(metrics)
 WHERE
   PARSE_DATE('%Y%m%d', CAST(build_id AS STRING)) > DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
   AND DATE(submission_date) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)

--- a/sql/moz-fx-data-shared-prod/udf_js/jackknife_percentile_ci/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/jackknife_percentile_ci/udf.sql
@@ -10,7 +10,7 @@ and a histogram struct as the second.
 */
 CREATE OR REPLACE FUNCTION udf_js.jackknife_percentile_ci(
   percentile FLOAT64,
-  histogram STRUCT<values ARRAY<STRUCT<key INT64, value FLOAT64>>>
+  histogram STRUCT<values ARRAY<STRUCT<key FLOAT64, value FLOAT64>>>
 )
 RETURNS STRUCT<low FLOAT64, high FLOAT64, percentile FLOAT64> DETERMINISTIC
 LANGUAGE js
@@ -114,7 +114,7 @@ WITH jackknife AS (
       STRUCT(
         [
           STRUCT(1 AS key, 3.0 AS value),
-          STRUCT(2, 2),
+          STRUCT(2.0, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
           STRUCT(6, 2)
@@ -126,7 +126,7 @@ WITH jackknife AS (
       STRUCT(
         [
           STRUCT(1 AS key, 3.0 AS value),
-          STRUCT(2, 2),
+          STRUCT(2.0, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
           STRUCT(6, 2)
@@ -138,7 +138,7 @@ WITH jackknife AS (
       STRUCT(
         [
           STRUCT(1 AS key, 3.0 AS value),
-          STRUCT(2, 2),
+          STRUCT(2.0, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
           STRUCT(6, 2)
@@ -150,7 +150,7 @@ WITH jackknife AS (
       STRUCT(
         [
           STRUCT(1 AS key, 3.0 AS value),
-          STRUCT(2, 2),
+          STRUCT(2.0, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
           STRUCT(6, 2)
@@ -162,7 +162,7 @@ WITH jackknife AS (
       STRUCT(
         [
           STRUCT(1 AS key, 3.0 AS value),
-          STRUCT(2, 2),
+          STRUCT(2.0, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
           STRUCT(6, 2)
@@ -174,7 +174,7 @@ WITH jackknife AS (
       STRUCT(
         [
           STRUCT(1 AS key, 3.0 AS value),
-          STRUCT(2, 2),
+          STRUCT(2.0, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
           STRUCT(6, 2)
@@ -186,7 +186,7 @@ WITH jackknife AS (
       STRUCT(
         [
           STRUCT(1 AS key, 3.0 AS value),
-          STRUCT(2, 2),
+          STRUCT(2.0, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
           STRUCT(6, 2)
@@ -198,7 +198,7 @@ WITH jackknife AS (
       STRUCT(
         [
           STRUCT(1 AS key, 3.0 AS value),
-          STRUCT(2, 2),
+          STRUCT(2.0, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
           STRUCT(6, 2)
@@ -210,7 +210,7 @@ WITH jackknife AS (
       STRUCT(
         [
           STRUCT(1 AS key, 3.0 AS value),
-          STRUCT(2, 2),
+          STRUCT(2.0, 2),
           STRUCT(4, 1),
           STRUCT(5, 1),
           STRUCT(6, 2)


### PR DESCRIPTION
For some background/context:

The motivation of this PR is that the `jackknife_percentile_ci()` function can get really slow when it's applied to very long lists of numbers since it produces more subsamples with larger amounts of data and computes percentiles for each subsample.

A list of scalars with a wide variety of numbers was taking a long time (3min+) to compute these percentiles. By bucketing the scalars, a histogram with fewer numbers takes less time to compute percentiles on.

I used the same [scalar bucketing strategy used in glam](https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/query.sql#L69-L86) which allows for buckets that are more appropriate per metric. However, the buckets are more precise so they are floats. So I updated the `jackknife_percentile_ci()` function to accept floats.

This PR also moves the flattening of scalars (i.e. `unnest(metrics)`) out of the scalar view and into the scalar query since it needs to be unnested to compute the buckets. This required a schema change so I'll be migrating into the new table when this PR merges.