### PR TITLE
DVPN-61 - Detect VPN attribution without guardian user

### DIFF
--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -582,6 +582,10 @@ with DAG(
     )
 
     mozilla_vpn_derived__all_subscriptions__v1.set_upstream(
+        mozilla_vpn_derived__fxa_attribution__v1
+    )
+
+    mozilla_vpn_derived__all_subscriptions__v1.set_upstream(
         mozilla_vpn_derived__subscriptions__v1
     )
 

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/users_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/users_v1/query.sql
@@ -1,25 +1,6 @@
-WITH fxa_attribution AS (
-  SELECT
-    fxa_uid,
-    MIN(flow_started) AS flow_started,
-    ARRAY_AGG(attribution ORDER BY flow_started LIMIT 1)[OFFSET(0)] AS attribution,
-  FROM
-    fxa_attribution_v1
-  CROSS JOIN
-    UNNEST(fxa_uids) AS fxa_uid
-  WHERE
-    attribution IS NOT NULL
-  GROUP BY
-    fxa_uid
-)
 SELECT
-  users_v1.id,
-  users_v1.fxa_uid,
-  users_v1.created_at,
-  fxa_attribution.attribution,
+  id,
+  fxa_uid,
+  created_at,
 FROM
   mozilla_vpn_external.users_v1
-LEFT JOIN
-  fxa_attribution
-ON
-  users_v1.fxa_uid = fxa_attribution.fxa_uid

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/users_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/users_v1/schema.yaml
@@ -8,28 +8,3 @@ fields:
 - mode: NULLABLE
   name: created_at
   type: TIMESTAMP
-- mode: NULLABLE
-  name: attribution
-  type: RECORD
-  fields:
-  - mode: NULLABLE
-    name: entrypoint_experiment
-    type: STRING
-  - mode: NULLABLE
-    name: entrypoint_variation
-    type: STRING
-  - mode: NULLABLE
-    name: utm_campaign
-    type: STRING
-  - mode: NULLABLE
-    name: utm_content
-    type: STRING
-  - mode: NULLABLE
-    name: utm_medium
-    type: STRING
-  - mode: NULLABLE
-    name: utm_source
-    type: STRING
-  - mode: NULLABLE
-    name: utm_term
-    type: STRING


### PR DESCRIPTION
Learned in [DVPN-61](https://mozilla-hub.atlassian.net/browse/DVPN-61) that subscriptions no longer require a guardian user, so we can't depend on the guardian users table to attribute subscriptions.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
