### PR TITLE
remove error aggregates dependency

### DIFF
--- a/dags/bqetl_error_aggregates.py
+++ b/dags/bqetl_error_aggregates.py
@@ -46,28 +46,3 @@ with DAG(
         depends_on_past=False,
         dag=dag,
     )
-
-    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
-        task_id="wait_for_copy_deduplicate_all",
-        external_dag_id="copy_deduplicate",
-        external_task_id="copy_deduplicate_all",
-        execution_delta=datetime.timedelta(days=1),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
-    )
-
-    telemetry_derived__error_aggregates__v1.set_upstream(wait_for_copy_deduplicate_all)
-    wait_for_copy_deduplicate_main_ping = ExternalTaskCompletedSensor(
-        task_id="wait_for_copy_deduplicate_main_ping",
-        external_dag_id="copy_deduplicate",
-        external_task_id="copy_deduplicate_main_ping",
-        execution_delta=datetime.timedelta(days=1),
-        check_existence=True,
-        mode="reschedule",
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
-    )
-
-    telemetry_derived__error_aggregates__v1.set_upstream(
-        wait_for_copy_deduplicate_main_ping
-    )

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/error_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/error_aggregates_v1/metadata.yaml
@@ -9,12 +9,6 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_error_aggregates
-  # manually depend on previous day's stable tables, because live tables are
-  # used instead of the current day's stable table partitions
-  depends_on:
-    - dag_name: copy_deduplicate
-      task_id: copy_deduplicate_all
-      execution_delta: 24h
-    - dag_name: copy_deduplicate
-      task_id: copy_deduplicate_main_ping
-      execution_delta: 24h
+  # This dag runs more frequently than upstream tables, so it can't depend on
+  # them directly, which is fine because it also queries live tables.
+  referenced_tables: []


### PR DESCRIPTION
I did not previously notice that this dag runs every three hours, so it can't depend on stable tables at all.

This fixes a regression introduced in #2330

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
