### PR TITLE
Run vat_rates_v1 query in default project

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/vat_rates_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/vat_rates_v1/query.py
@@ -22,16 +22,17 @@ job_config = bigquery.QueryJobConfig(
 )
 
 # Use credentials that include a google drive scope
-credentials, _ = google.auth.default(
+credentials, project = google.auth.default(
     scopes=[
         "https://www.googleapis.com/auth/drive",
         "https://www.googleapis.com/auth/bigquery",
     ]
 )
-client = bigquery.Client(credentials=credentials, project="moz-fx-data-shared-prod")
+client = bigquery.Client(credentials=credentials, project=project)
 
 query = client.query(
-    """CREATE OR REPLACE TABLE mozilla_vpn_external.vat_rates_v1
+    """CREATE OR REPLACE TABLE
+  `moz-fx-data-shared-prod`.mozilla_vpn_external.vat_rates_v1
 AS
 SELECT
   * REPLACE (


### PR DESCRIPTION
update from #2357 to fix `Access Denied: Project moz-fx-data-shared-prod: User does not have bigquery.jobs.create permission in project moz-fx-data-shared-prod`

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
