### PR TITLE
Bug 1732293 Fix incorrect field ref in distinct_doc_ids query

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/structured_distinct_docids_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/structured_distinct_docids_v1/query.py
@@ -13,19 +13,21 @@ WITH decoded AS (
   SELECT
     * EXCEPT (metadata),  -- Some tables have different field order in metadata
     metadata.header.x_source_tags,
+    metadata.document_namespace,
   FROM
     `moz-fx-data-shared-prod.monitoring.payload_bytes_decoded_structured`
   UNION ALL
   SELECT
     * EXCEPT (metadata),
     metadata.header.x_source_tags,
+    metadata.document_namespace,
   FROM
     `moz-fx-data-shared-prod.monitoring.payload_bytes_decoded_stub_installer`
 )
 SELECT
   DATE(submission_timestamp) AS submission_date,
   -- We sub '-' for '_' for historical continuity
-  REPLACE(namespace, '-', '_') AS namespace,
+  REPLACE(document_namespace, '-', '_') AS namespace,
   doc_type,
   COUNT(DISTINCT(document_id)) AS docid_count,
 FROM


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1732293

Fixes regression from https://github.com/mozilla/bigquery-etl/pull/2367

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
