### PR TITLE
Use clients_daily_joined_v1 for telemetry.clients_daily

### DIFF
--- a/dags/bqetl_devtools.py
+++ b/dags/bqetl_devtools.py
@@ -84,10 +84,10 @@ with DAG(
         wait_for_copy_deduplicate_main_ping
     )
 
-    wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskCompletedSensor(
-        task_id="wait_for_telemetry_derived__clients_daily__v6",
+    wait_for_telemetry_derived__clients_daily_joined__v1 = ExternalTaskCompletedSensor(
+        task_id="wait_for_telemetry_derived__clients_daily_joined__v1",
         external_dag_id="bqetl_main_summary",
-        external_task_id="telemetry_derived__clients_daily__v6",
+        external_task_id="telemetry_derived__clients_daily_joined__v1",
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
@@ -95,5 +95,5 @@ with DAG(
     )
 
     telemetry_derived__devtools_panel_usage__v1.set_upstream(
-        wait_for_telemetry_derived__clients_daily__v6
+        wait_for_telemetry_derived__clients_daily_joined__v1
     )

--- a/dags/bqetl_experiments_daily.py
+++ b/dags/bqetl_experiments_daily.py
@@ -165,10 +165,10 @@ with DAG(
     telemetry_derived__experiments_daily_active_clients__v1.set_upstream(
         wait_for_copy_deduplicate_all
     )
-    wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskCompletedSensor(
-        task_id="wait_for_telemetry_derived__clients_daily__v6",
+    wait_for_telemetry_derived__clients_daily_joined__v1 = ExternalTaskCompletedSensor(
+        task_id="wait_for_telemetry_derived__clients_daily_joined__v1",
         external_dag_id="bqetl_main_summary",
-        external_task_id="telemetry_derived__clients_daily__v6",
+        external_task_id="telemetry_derived__clients_daily_joined__v1",
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
@@ -176,5 +176,5 @@ with DAG(
     )
 
     telemetry_derived__experiments_daily_active_clients__v1.set_upstream(
-        wait_for_telemetry_derived__clients_daily__v6
+        wait_for_telemetry_derived__clients_daily_joined__v1
     )

--- a/dags/bqetl_search.py
+++ b/dags/bqetl_search.py
@@ -91,10 +91,10 @@ with DAG(
         search_derived__search_clients_daily__v8
     )
 
-    wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskCompletedSensor(
-        task_id="wait_for_telemetry_derived__clients_daily__v6",
+    wait_for_telemetry_derived__clients_daily_joined__v1 = ExternalTaskCompletedSensor(
+        task_id="wait_for_telemetry_derived__clients_daily_joined__v1",
         external_dag_id="bqetl_main_summary",
-        external_task_id="telemetry_derived__clients_daily__v6",
+        external_task_id="telemetry_derived__clients_daily_joined__v1",
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
@@ -102,7 +102,7 @@ with DAG(
     )
 
     search_derived__search_clients_daily__v8.set_upstream(
-        wait_for_telemetry_derived__clients_daily__v6
+        wait_for_telemetry_derived__clients_daily_joined__v1
     )
 
     search_derived__search_clients_last_seen__v1.set_upstream(

--- a/dags/bqetl_urlbar.py
+++ b/dags/bqetl_urlbar.py
@@ -59,10 +59,10 @@ with DAG(
         dag=dag,
     )
 
-    wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskCompletedSensor(
-        task_id="wait_for_telemetry_derived__clients_daily__v6",
+    wait_for_telemetry_derived__clients_daily_joined__v1 = ExternalTaskCompletedSensor(
+        task_id="wait_for_telemetry_derived__clients_daily_joined__v1",
         external_dag_id="bqetl_main_summary",
-        external_task_id="telemetry_derived__clients_daily__v6",
+        external_task_id="telemetry_derived__clients_daily_joined__v1",
         execution_delta=datetime.timedelta(seconds=3600),
         check_existence=True,
         mode="reschedule",
@@ -70,5 +70,5 @@ with DAG(
     )
 
     telemetry_derived__urlbar_clients_daily__v1.set_upstream(
-        wait_for_telemetry_derived__clients_daily__v6
+        wait_for_telemetry_derived__clients_daily_joined__v1
     )

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_daily_v6/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_daily_v6/view.sql
@@ -16,4 +16,4 @@ SELECT
     IFNULL(geo_subdivision2, '??') AS geo_subdivision2
   )
 FROM
-  `moz-fx-data-shared-prod.telemetry_derived.clients_daily_v6`
+  `moz-fx-data-shared-prod.telemetry_derived.clients_daily_joined_v1`


### PR DESCRIPTION
All the data has been backfilled (https://bugzilla.mozilla.org/show_bug.cgi?id=1732155) so there shouldn't be anything blocking us from using `telemetry_derived.clients_daily_joined_v1` as basis for `telemetry.clients_daily`.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
