### PR TITLE
added 99 and 99.9 to scalar and histogram- desktop

### DIFF
--- a/script/glam/run_glam_sql
+++ b/script/glam/run_glam_sql
@@ -284,14 +284,10 @@ function run_glean_sql {
         pids+=($!)
         run_view "${product}__view_user_counts_v1" &
         pids+=($!)
-        run_view "${product}__view_sample_counts_v1" &
-        pids+=($!)
         wait_pids "${pids[@]}"
 
         pids=()
         run_query "${product}__extract_user_counts_v1" &
-        pids+=($!)
-        run_query "${product}__extract_sample_counts_v1" &
         pids+=($!)
         run_query "${product}__extract_probe_counts_v1" &
         pids+=($!)

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/histogram_percentiles_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/histogram_percentiles_v1/query.sql
@@ -5,7 +5,9 @@ SELECT
     ('25', mozfun.glam.percentile(25, aggregates, metric_type)),
     ('50', mozfun.glam.percentile(50, aggregates, metric_type)),
     ('75', mozfun.glam.percentile(75, aggregates, metric_type)),
-    ('95', mozfun.glam.percentile(95, aggregates, metric_type))
+    ('95', mozfun.glam.percentile(95, aggregates, metric_type)),
+    ('99', mozfun.glam.percentile(99, aggregates, metric_type)),
+    ('99.9', mozfun.glam.percentile(99.9, aggregates, metric_type))
   ] AS aggregates
 FROM
   clients_histogram_probe_counts_v1

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/query.sql
@@ -66,7 +66,7 @@ percentiles AS (
     agg_type AS client_agg_type,
     'percentiles' AS agg_type,
     SUM(user_count) AS total_users,
-    APPROX_QUANTILES(value, 100)  AS aggregates
+    APPROX_QUANTILES(value, 1000)  AS aggregates
   FROM
     user_aggregates
   CROSS JOIN UNNEST(scalar_aggregates)
@@ -82,8 +82,8 @@ percentiles AS (
     client_agg_type)
 
 SELECT *
-REPLACE(mozfun.glam.map_from_array_offsets(
-  [5.0, 25.0, 50.0, 75.0, 95.0],
+REPLACE(mozfun.glam.map_from_array_offsets_v2(
+  [50, 250, 500, 750, 950, 990, 999],
   aggregates
 ) AS aggregates)
 FROM percentiles

--- a/sql/mozfun/glam/map_from_array_offsets_v2/metadata.yaml
+++ b/sql/mozfun/glam/map_from_array_offsets_v2/metadata.yaml
@@ -1,0 +1,3 @@
+description: ""
+friendly_name: Map from array offsets for 1000 quantiles
+

--- a/sql/mozfun/glam/map_from_array_offsets_v2/udf.sql
+++ b/sql/mozfun/glam/map_from_array_offsets_v2/udf.sql
@@ -1,0 +1,13 @@
+(
+    SELECT
+      ARRAY_AGG(
+        STRUCT<key STRING, value FLOAT64>(
+          CAST(ROUND((key/10),1) AS STRING),
+          `values`[OFFSET(SAFE_CAST(key AS INT64))]
+        )
+        ORDER BY
+          key
+      )
+    FROM
+      UNNEST(required) AS key
+  )


### PR DESCRIPTION

This is to resolve [issue(https://github.com/mozilla/glam/issues/1576)

The 99 and 99.9 percentiles will be added to the glam desktop ETL. 
A new udf `mozfun.glam.map_from_array_offsets_v2` to get the appropriate percentage values since we are using `APPROX_QUANTILES(value, 1000)` instead of `APPROX_QUANTILES(value, 100)` 

Below is the data from test run :
Scalar:
<img width="771" alt="Screen Shot 2021-09-27 at 1 40 53 PM" src="https://user-images.githubusercontent.com/88394696/134958421-7ff59995-ba9b-44e4-8650-def7227e5970.png">

Histogram:

<img width="1225" alt="Screen Shot 2021-09-27 at 1 42 40 PM" src="https://user-images.githubusercontent.com/88394696/134958629-e9fb63a6-1dd0-4956-be0b-636159ab46db.png">

