### PR TITLE
Add date clause to search terms aggregates

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/query.sql
@@ -1,4 +1,5 @@
 SELECT
+  DATE(submission_timestamp) AS submission_date,
   search_query AS query,
   block_id,
   COUNT(*) AS impressions,
@@ -10,6 +11,7 @@ WHERE
   BETWEEN @submission_date
   AND DATE_SUB(@submission_date, INTERVAL 6 DAY)
 GROUP BY
+  submission_date,
   query,
   block_id
 HAVING

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/aggregated_search_terms_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/aggregated_search_terms_daily_v1/query.sql
@@ -6,6 +6,8 @@ SELECT
   COUNT(DISTINCT context_id) AS client_days
 FROM
   `moz-fx-data-shared-prod.contextual_services_stable.quicksuggest_impression_v1`
+WHERE
+  DATE(submission_timestamp) = @submission_date
 GROUP BY
   submission_date,
   search_query


### PR DESCRIPTION
Fixes recent [Airflow error](https://workflow.telemetry.mozilla.org/log?task_id=search_terms_derived__aggregated_search_terms_daily__v1&dag_id=bqetl_search_terms_daily&execution_date=2021-09-26T03%3A00%3A00%2B00%3A00)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
