### PR TITLE
Add gcloud config set step for running tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -24,7 +24,8 @@ mvn dependency:copy-dependencies
 
 # run integration tests with 4 workers in parallel
 gcloud auth application-default login # or set GOOGLE_APPLICATION_CREDENTIALS
-export GOOGLE_PROJECT_ID="bigquery-etl-integration-test"
+export GOOGLE_PROJECT_ID=bigquery-etl-integration-test
+gcloud config set project $GOOGLE_PROJECT_ID
 ./venv/bin/pytest -m integration -n 4
 ```
 


### PR DESCRIPTION
(via @ANich) It feels slightly wrong to have to set this value twice (once via environment variable and once via gcloud).

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
