### PR TITLE
Fixups for search terms aggregate tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/query.sql
@@ -1,6 +1,6 @@
 SELECT
   DATE(submission_timestamp) AS submission_date,
-  search_query AS query,
+  LOWER(search_query) AS query,
   block_id,
   COUNT(*) AS impressions,
   COUNTIF(is_clicked) AS clicks,

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/query.sql
@@ -8,13 +8,9 @@ FROM
   search_terms.suggest_impression_sanitized
 WHERE
   DATE(submission_timestamp)
-  BETWEEN @submission_date
-  AND DATE_SUB(@submission_date, INTERVAL 6 DAY)
+  BETWEEN DATE_SUB(@submission_date, INTERVAL 6 DAY)
+  AND @submission_date
 GROUP BY
   submission_date,
   query,
   block_id
-HAVING
-  -- This filter matches aggregated_search_terms_daily, but may change; see
-  -- https://bugzilla.mozilla.org/show_bug.cgi?id=1729524
-  COUNT(DISTINCT context_id) > 30000

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/aggregated_search_terms_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/aggregated_search_terms_daily_v1/query.sql
@@ -1,6 +1,6 @@
 SELECT
   DATE(submission_timestamp) AS submission_date,
-  search_query AS search_terms,
+  LOWER(search_query) AS search_terms,
   COUNT(*) AS impressions,
   COUNTIF(is_clicked) AS clicks,
   COUNT(DISTINCT context_id) AS client_days
@@ -10,6 +10,6 @@ WHERE
   DATE(submission_timestamp) = @submission_date
 GROUP BY
   submission_date,
-  search_query
+  search_terms
 HAVING
   client_days > 30000


### PR DESCRIPTION
The adm weekly query was running, but always producing null results due to the inverted date range.

Also, removing the low volume filter per https://bugzilla.mozilla.org/show_bug.cgi?id=1729524#c4

Also, forcing all terms to lowercase before grouping, as I'm observing that the client does pass through terms with casing differences.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
