### PR TITLE
Changed cli.format calls in other cli commands

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -5,7 +5,6 @@ import re
 import string
 import sys
 from datetime import date, timedelta
-
 from functools import partial
 from multiprocessing.pool import Pool
 from pathlib import Path
@@ -19,11 +18,11 @@ from ..cli.format import format
 from ..cli.utils import (
     is_authenticated,
     is_valid_project,
-    sql_dir_option,
-    use_cloud_function_option,
     paths_matching_name_pattern,
     project_id_option,
     respect_dryrun_skip_option,
+    sql_dir_option,
+    use_cloud_function_option,
 )
 from ..dependency import get_dependency_graph
 from ..dryrun import SKIP, DryRun
@@ -650,7 +649,7 @@ def validate(
     dataset_dirs = set()
     for query in query_files:
         project = query.parent.parent.parent.name
-        ctx.invoke(format, path=str(query))
+        ctx.invoke(format, paths=[str(query)])
         ctx.invoke(
             dryrun,
             paths=[str(query)],

--- a/bigquery_etl/cli/routine.py
+++ b/bigquery_etl/cli/routine.py
@@ -1,5 +1,6 @@
 """bigquery-etl CLI UDF command."""
 
+import copy
 import os
 import re
 import shutil
@@ -9,7 +10,6 @@ from fnmatch import fnmatchcase
 from pathlib import Path
 
 import click
-import copy
 import pytest
 import yaml
 
@@ -365,7 +365,7 @@ def validate(ctx, name, sql_dir, project_id):
 
     validate_docs.validate(project_dirs(project_id))
     for routine_file in routine_files:
-        ctx.invoke(format, path=str(routine_file.parent))
+        ctx.invoke(format, paths=[str(routine_file.parent)])
         pytest.main([str(routine_file.parent)])
 
 


### PR DESCRIPTION
Follow up to https://github.com/mozilla/bigquery-etl/pull/2348 - updates `bqetl query validate` and `bqetl routine validate` after changed signature. 

(plus auto-file formatting)

Checklist for reviewer:

~- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)~
~- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
~- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated~
