### PR TITLE
Optimize enrollment_other_events_overall

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_other_events_overall_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_other_events_overall_v1/view.sql
@@ -20,11 +20,12 @@ SELECT
   window_start AS `time`,
   experiment,
   branch,
-  event.event AS event,
-  SUM(event.count) AS value
+  e.event AS event,
+  SUM(e.count) AS value
 FROM
-  pivot,
-  UNNEST(events) AS event
+  pivot
+CROSS JOIN
+  UNNEST(events) AS e
 GROUP BY
   1,
   2,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_other_events_overall_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_other_events_overall_v1/view.sql
@@ -6,44 +6,13 @@ WITH pivot AS (
     window_start,
     experiment,
     branch,
-    "graduated" AS event,
-    graduate_count AS count
-  FROM
-    `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v1`
-  UNION ALL
-  SELECT
-    window_start,
-    experiment,
-    branch,
-    "enroll_failed" AS event,
-    enroll_failed_count AS count
-  FROM
-    `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v1`
-  UNION ALL
-  SELECT
-    window_start,
-    experiment,
-    branch,
-    "unenroll_failed" AS event,
-    unenroll_failed_count AS count
-  FROM
-    `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v1`
-  UNION ALL
-  SELECT
-    window_start,
-    experiment,
-    branch,
-    "updated" AS event,
-    update_count AS count
-  FROM
-    `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v1`
-  UNION ALL
-  SELECT
-    window_start,
-    experiment,
-    branch,
-    "update_failed" AS event,
-    update_failed_count AS count
+    [
+      STRUCT("graduated" AS event, graduate_count AS count),
+      STRUCT("enroll_failed" AS event, enroll_failed_count AS count),
+      STRUCT("unenroll_failed" AS event, unenroll_failed_count AS count),
+      STRUCT("updated" AS event, update_count AS count),
+      STRUCT("update_failed" AS event, update_failed_count AS count)
+    ] AS events
   FROM
     `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v1`
 )
@@ -51,10 +20,11 @@ SELECT
   window_start AS `time`,
   experiment,
   branch,
-  event,
-  SUM(`count`) AS value
+  event.event AS event,
+  SUM(event.count) AS value
 FROM
-  pivot
+  pivot,
+  UNNEST(events) AS event
 GROUP BY
   1,
   2,


### PR DESCRIPTION
Querying `telemetry.experiment_enrollment_other_events_overall` outside of shared-prod is not possible anymore due to the query exceeding complexity limitations. Rewriting the query fixed the problem.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
