### PR TITLE
Fix pickling error in schema validate command (and Posixpath formatting error)

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -344,7 +344,7 @@ class DryRun:
                     ),
                 }
         except Exception as e:
-            print(f"{self.sqlfile:59} ERROR\n", e)
+            print(f"{self.sqlfile!s:59} ERROR\n", e)
             return None
 
     def get_referenced_tables(self):
@@ -459,20 +459,20 @@ class DryRun:
             return False
 
         if self.dry_run_result["valid"]:
-            print(f"{self.sqlfile:59} OK")
+            print(f"{self.sqlfile!s:59} OK")
         elif self.get_error() == Errors.READ_ONLY:
             # We want the dryrun service to only have read permissions, so
             # we expect CREATE VIEW and CREATE TABLE to throw specific
             # exceptions.
-            print(f"{self.sqlfile:59} OK")
+            print(f"{self.sqlfile!s:59} OK")
         elif self.get_error() == Errors.DATE_FILTER_NEEDED and self.strip_dml:
             # With strip_dml flag, some queries require a partition filter
             # (submission_date, submission_timestamp, etc.) to run
             # We mark these requests as valid and add a date filter
             # in get_referenced_table()
-            print(f"{self.sqlfile:59} OK but DATE FILTER NEEDED")
+            print(f"{self.sqlfile!s:59} OK but DATE FILTER NEEDED")
         else:
-            print(f"{self.sqlfile:59} ERROR\n", self.dry_run_result["errors"])
+            print(f"{self.sqlfile!s:59} ERROR\n", self.dry_run_result["errors"])
             return False
 
         return True


### PR DESCRIPTION
`$ bqetl query schema validate {table}` raises  `AttributeError: Can't pickle local object 'validate_schema.<locals>._validate_schema'` since nested functions can't be serialized. 

Kept the name definition in scope by extracting the function and using a partial. 

There was also a `TypeError: unsupported format string passed to PosixPath.__format__` since [path objects don't support formatting directly](https://bugs.python.org/issue38222). Used the suggested fix of casting in the f-string. 

Checklist for reviewer:

~- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)~
~- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.~
~- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated~
