### PR TITLE
Bug 1733986 Fix date logic for adm_weekly_aggregates

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/query.sql
@@ -1,5 +1,5 @@
 SELECT
-  DATE(submission_timestamp) AS submission_date,
+  @submission_date AS submission_date,
   LOWER(search_query) AS query,
   block_id,
   COUNT(*) AS impressions,
@@ -11,6 +11,5 @@ WHERE
   BETWEEN DATE_SUB(@submission_date, INTERVAL 6 DAY)
   AND @submission_date
 GROUP BY
-  submission_date,
   query,
   block_id


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1733986

The intention of this query is to each day populate a partition that
windows over the previous 7 days. The GROUP BY should not include
`submission_date` and we need to inject the `@submission_date`
parameter into the query instead.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
