### PR TITLE
Add templates to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     package_data={
         "bigquery_etl": [
             "query_scheduling/templates/*.j2",
+            "glean_usage/templates/*",
             "alchemer/*.json",
             "stripe/*.json",
             "stripe/*.yaml",


### PR DESCRIPTION
Some Airflow tasks have been failing due to

```
b"FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.8/site-packages/bigquery_etl/glean_usage/templates/metrics_templating.yaml'\n"
```

This should add the missing file to the package

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
