### PR TITLE
Added notes about Rosetta2 and a JDK version for Apple Silicon users

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Quick Start
 
 Ensure Python 3.8+ is available on your machine (see [this guide](https://docs.python-guide.org/starting/install3/osx/) for instructions if you're on a mac and haven't installed anything other than the default system Python.)
 
-For some functionality Java JDK 8+ is also required, and maven is needed for downloading jar dependencies. If you don't already have a JDK and maven installed, consider using [jenv](https://www.jenv.be/) and the `jenv enable-plugin maven` command.
+For some functionality Java JDK 8+ is also required (e.g. [AdoptOpenJDK](https://adoptium.net/?variant=openjdk8)) with `$JAVA_HOME` set, and maven is needed for downloading jar dependencies. If you don't already have a JDK and maven installed, consider using [jenv](https://www.jenv.be/) and the `jenv enable-plugin maven` command.
+The [Rosetta 2 terminal](https://support.apple.com/en-ca/HT211861) is also suggested for installing the above requirements on Apple Silicon (M1).
 
 Install and set up the GCP command line tools:
 


### PR DESCRIPTION
ZetaSQL is only [supported on x86_64/amd64](https://github.com/google/zetasql/blob/master/java/com/google/zetasql/JniChannelProvider.java#L47) at the moment, so Rosetta 2 is suggested. Also added a suggested JDK 

Checklist for reviewer:

~- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)~
~- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.~
~- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated~
