### PR TITLE
Remove virtualenv install from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,6 @@ Install and set up the GCP command line tools:
 * (For Mozilla Employees or Contributors not in Data Engineering) Set up GCP command line tools, [as described on docs.telemetry.mozilla.org](https://docs.telemetry.mozilla.org/cookbooks/bigquery/access.html#using-the-bq-command-line-tool). Note that some functionality (e.g. writing UDFs or backfilling queries) may not be allowed.
 * (For Data Engineering) In addition to setting up the command line tools, you will want to log in to `shared-prod` if making changes to production systems. Run `gcloud auth login --update-adc --project=moz-fx-data-shared-prod` (if you have not run it previously).
 
-Install the [virtualenv](https://virtualenv.pypa.io/en/latest/) Python environment management tool
-```bash
-pip install virtualenv
-```
-
 Clone the repository
 ```bash
 git clone git@github.com:mozilla/bigquery-etl.git


### PR DESCRIPTION
because ./bqetl now uses venv which is part of the python standard library

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
