### PR TITLE
Update minimum JDK to 11 and update install recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Quick Start
 
 Ensure Python 3.8+ is available on your machine (see [this guide](https://docs.python-guide.org/starting/install3/osx/) for instructions if you're on a mac and haven't installed anything other than the default system Python.)
 
-For some functionality Java JDK 8+ is also required (e.g. [AdoptOpenJDK](https://adoptium.net/?variant=openjdk8)) with `$JAVA_HOME` set, and maven is needed for downloading jar dependencies. If you don't already have a JDK and maven installed, consider using [jenv](https://www.jenv.be/) and the `jenv enable-plugin maven` command.
+For some functionality Java JDK 11+ is also required (e.g. [AdoptOpenJDK](https://adoptium.net/?variant=openjdk11)) with `$JAVA_HOME` set, and maven is needed for downloading jar dependencies.
+Maven is available from your package manager in most Linux distributions and from [homebrew](https://brew.sh/) on mac, or you can install yourself by [downloading a binary](https://maven.apache.org/download.cgi) and following maven's [install instructions](https://maven.apache.org/install.html).
 The [Rosetta 2 terminal](https://support.apple.com/en-ca/HT211861) is also suggested for installing the above requirements on Apple Silicon (M1).
 
 Install and set up the GCP command line tools:


### PR DESCRIPTION
there were two `jenv` tools, and we were linked to the wrong one, and the correct one is gone now.

@ANich can you check that JDK 11 works on M1?

The last public update to Oracle JDK 8 was in 2019, and active support ends in 5 months (31 Mar 2022) per https://endoflife.date/java.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
