### PR TITLE
Filter out skipped apps when creating baseline queries and views

### DIFF
--- a/bigquery_etl/cli/glean_usage.py
+++ b/bigquery_etl/cli/glean_usage.py
@@ -94,6 +94,13 @@ def generate(project_id, output_dir, parallelism, exclude, only, app_name):
         only_tables=[only] if only else None,
         table_filter=table_filter,
     )
+    # filter out skipped apps
+    baseline_tables = [
+        baseline_table
+        for baseline_table in baseline_tables
+        if baseline_table.split(".")[1]
+        not in [f"{skipped_app}_stable" for skipped_app in SKIP_APPS]
+    ]
 
     output_dir = Path(output_dir) / project_id
 


### PR DESCRIPTION
This errors just started happening:

```
google.api_core.exceptions.NotFound: 404 Not found: Table moz-fx-data-shared-prod:mlhackweek_search_derived.baseline_clients_daily_v1 was not found in location US

(job ID: 4a7f3dd2-efda-4a77-acb5-9e19e52aa62f)

                          -----Query Job SQL Follows-----                           

    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |
   1:-- Generated via bigquery_etl.glean_usage
   2:CREATE OR REPLACE VIEW
   3:  `moz-fx-data-shared-prod.mlhackweek_search.baseline_clients_daily`
   4:AS
   5:SELECT
   6:  *
   7:FROM
   8:  `moz-fx-data-shared-prod.mlhackweek_search_derived.baseline_clients_daily_v1`
```

It looks like `mlhackweek_search` is not ignored when generating baseline related views and queries.