### PR TITLE
Speed up generate_sql

### DIFF
--- a/bigquery_etl/cli/glean_usage.py
+++ b/bigquery_etl/cli/glean_usage.py
@@ -128,13 +128,14 @@ def generate(project_id, output_dir, parallelism, exclude, only, app_name):
         for table in GLEAN_TABLES
     ]
 
-    # Parameters to generate per-app_id datasets consist of the function to be called
+    # Parameters to generate per-app datasets consist of the function to be called
     # and app_info
     generate_per_app = [
         (
             partial(table.generate_per_app, project_id, output_dir=output_dir),
-            app_info[0],
+            info,
         )
+        for info in app_info
         for table in GLEAN_TABLES
     ]
 

--- a/bigquery_etl/view/generate_stable_views.py
+++ b/bigquery_etl/view/generate_stable_views.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from functools import partial
 from io import BytesIO
 from itertools import groupby
-from multiprocessing.pool import ThreadPool
+from multiprocessing.pool import Pool
 from pathlib import Path
 import re
 
@@ -345,7 +345,7 @@ def main():
         last for k, (*_, last) in groupby(schemas, lambda t: t.bq_dataset_family)
     ]
 
-    with ThreadPool(args.parallelism) as pool:
+    with Pool(args.parallelism) as pool:
         pool.map(
             partial(
                 write_view_if_not_exists,
@@ -353,7 +353,6 @@ def main():
                 Path(args.sql_dir),
             ),
             schemas,
-            chunksize=1,
         )
         pool.map(
             partial(
@@ -362,7 +361,6 @@ def main():
                 Path(args.sql_dir),
             ),
             one_schema_per_dataset,
-            chunksize=1,
         )
 
 


### PR DESCRIPTION
This is one piece for working towards https://github.com/mozilla/bigquery-etl/issues/2313 for which I started drafting a proposal.

How do we feel about reducing the time for running `generate_sql` by 3x 😉 
The task now takes about 2.30m vs 8.30m


