### PR TITLE
Resolves #2462 - SELECT NULL for columns that we can't manually drop

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/query.sql
@@ -14,6 +14,9 @@ SELECT
   os_version,
   is_default_browser,
   channel,
+  CAST(
+    NULL AS STRING
+  ) AS normalized_engine, -- See https://github.com/mozilla/bigquery-etl/issues/2462
   COUNT(*) AS client_count,
   SUM(organic) AS organic,
   SUM(tagged_sap) AS tagged_sap,

--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/query.sql
@@ -246,6 +246,9 @@ counted AS (
     scalar_parent_urlbar_searchmode_touchbar_sum,
     scalar_parent_urlbar_searchmode_typed_sum,
     profile_age_in_days,
+    CAST(
+      NULL AS STRING
+    ) AS normalized_engine, -- https://github.com/mozilla/bigquery-etl/issues/2462
     SUM(IF(type = 'organic', count, 0)) OVER w1 AS organic,
     SUM(IF(type = 'tagged-sap', count, 0)) OVER w1 AS tagged_sap,
     SUM(IF(type = 'tagged-follow-on', count, 0)) OVER w1 AS tagged_follow_on,


### PR DESCRIPTION
We can't drop the column ([see docs](https://cloud.google.com/bigquery/docs/managing-table-schemas#deleting_columns_from_a_tables_schema_definition)) due to BigQuery's size constraints for dropping columns: 
![image](https://user-images.githubusercontent.com/8276642/138890130-232edb29-19c9-426d-a106-8c2e877f4ac2.png)
so we can add a SELECT NULL to the `query.sql` files with a note.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
~- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up~
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
~- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been ~updated
