### PR TITLE
ROAD-86 Process deletions for contextual_services

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -98,7 +98,7 @@ CFR_SRC = DeleteSource(
 )
 CONTEXTUAL_SERVICES_SRC = DeleteSource(
     table="telemetry_stable.deletion_request_v4",
-    field="payload.scalars.parent.deletion_request_context_id"
+    field="payload.scalars.parent.deletion_request_context_id",
 )
 FXA_HMAC_SRC = DeleteSource(
     table="firefox_accounts_derived.fxa_delete_events_v1", field="hmac_user_id"


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/ROAD-86

This is expected to be a no-op since the contextual services tables all have retention periods lower than the shredder frequency, but we are including here as a failsafe.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
