### PR TITLE
Bug 1738132 - Added aggregations for new urlbar handoff probes to clients_daily (and downstreams)

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
@@ -753,6 +753,9 @@ fields:
   mode: NULLABLE
   name: search_count_organic
   type: INTEGER
+- mode: NULLABLE
+  name: search_count_urlbar_handoff
+  type: INTEGER
 - description: null
   mode: NULLABLE
   name: session_restored_mean
@@ -1327,6 +1330,16 @@ fields:
     name: value
     type: INTEGER
   mode: REPEATED
+  name: search_content_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
   name: search_content_urlbar_searchmode_sum
   type: RECORD
 - fields:
@@ -1437,6 +1450,16 @@ fields:
     name: value
     type: INTEGER
   mode: REPEATED
+  name: search_withads_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
   name: search_withads_urlbar_searchmode_sum
   type: RECORD
 - fields:
@@ -1538,6 +1561,16 @@ fields:
     type: INTEGER
   mode: REPEATED
   name: search_adclicks_urlbar_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_urlbar_handoff_sum
   type: RECORD
 - fields:
   - mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
@@ -413,6 +413,9 @@ clients_summary AS (
     payload.processes.parent.keyed_scalars.browser_search_adclicks_tabhistory,
     payload.processes.parent.keyed_scalars.browser_search_adclicks_reload,
     payload.processes.parent.keyed_scalars.browser_search_adclicks_unknown,
+    payload.processes.parent.keyed_scalars.browser_search_content_urlbar_handoff,
+    payload.processes.parent.keyed_scalars.browser_search_withads_urlbar_handoff,
+    payload.processes.parent.keyed_scalars.browser_search_adclicks_urlbar_handoff,
     count_histograms[OFFSET(0)].histogram AS histogram_parent_devtools_aboutdebugging_opened_count,
     count_histograms[
       OFFSET(1)
@@ -997,7 +1000,8 @@ aggregates AS (
                 browser_search_adclicks_webextension,
                 browser_search_adclicks_tabhistory,
                 browser_search_adclicks_reload,
-                browser_search_adclicks_unknown
+                browser_search_adclicks_unknown,
+                browser_search_adclicks_urlbar_handoff
               )
             )
         )
@@ -1022,7 +1026,8 @@ aggregates AS (
                 browser_search_withads_webextension,
                 browser_search_withads_tabhistory,
                 browser_search_withads_reload,
-                browser_search_withads_unknown
+                browser_search_withads_unknown,
+                browser_search_withads_urlbar_handoff
               )
             )
         )
@@ -1096,7 +1101,10 @@ aggregates AS (
       STRUCT(ARRAY_CONCAT_AGG(browser_search_adclicks_webextension)),
       STRUCT(ARRAY_CONCAT_AGG(browser_search_adclicks_tabhistory)),
       STRUCT(ARRAY_CONCAT_AGG(browser_search_adclicks_reload)),
-      STRUCT(ARRAY_CONCAT_AGG(browser_search_adclicks_unknown))
+      STRUCT(ARRAY_CONCAT_AGG(browser_search_adclicks_unknown)),
+      STRUCT(ARRAY_CONCAT_AGG(browser_search_content_urlbar_handoff)),
+      STRUCT(ARRAY_CONCAT_AGG(browser_search_withads_urlbar_handoff)),
+      STRUCT(ARRAY_CONCAT_AGG(browser_search_adclicks_urlbar_handoff))
     ] AS map_sum_aggregates,
     udf.search_counts_map_sum(ARRAY_CONCAT_AGG(search_counts)) AS search_counts,
     mozfun.stats.mode_last(
@@ -1223,5 +1231,8 @@ SELECT
   map_sum_aggregates[OFFSET(64)].map AS search_adclicks_tabhistory_sum,
   map_sum_aggregates[OFFSET(65)].map AS search_adclicks_reload_sum,
   map_sum_aggregates[OFFSET(66)].map AS search_adclicks_unknown_sum,
+  map_sum_aggregates[OFFSET(67)].map AS search_content_urlbar_handoff_sum,
+  map_sum_aggregates[OFFSET(68)].map AS search_withads_urlbar_handoff_sum,
+  map_sum_aggregates[OFFSET(69)].map AS search_adclicks_urlbar_handoff_sum,
 FROM
   udf_aggregates

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
@@ -753,6 +753,9 @@ fields:
   mode: NULLABLE
   name: search_count_organic
   type: INTEGER
+- mode: NULLABLE
+  name: search_count_urlbar_handoff
+  type: INTEGER
 - description: null
   mode: NULLABLE
   name: session_restored_mean
@@ -1318,6 +1321,16 @@ fields:
     name: value
     type: INTEGER
   mode: REPEATED
+  name: search_content_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
   name: search_content_urlbar_searchmode_sum
   type: RECORD
 - fields:
@@ -1428,6 +1441,16 @@ fields:
     name: value
     type: INTEGER
   mode: REPEATED
+  name: search_withads_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
   name: search_withads_urlbar_searchmode_sum
   type: RECORD
 - fields:
@@ -1529,6 +1552,16 @@ fields:
     type: INTEGER
   mode: REPEATED
   name: search_adclicks_urlbar_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_urlbar_handoff_sum
   type: RECORD
 - fields:
   - mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -571,6 +571,9 @@ fields:
   name: search_count_organic
   type: INTEGER
 - mode: NULLABLE
+  name: search_count_urlbar_handoff
+  type: INTEGER
+- mode: NULLABLE
   name: session_restored_mean
   type: FLOAT
 - mode: NULLABLE
@@ -1064,6 +1067,16 @@ fields:
     name: value
     type: INTEGER
   mode: REPEATED
+  name: search_content_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
   name: search_content_urlbar_searchmode_sum
   type: RECORD
 - fields:
@@ -1174,6 +1187,16 @@ fields:
     name: value
     type: INTEGER
   mode: REPEATED
+  name: search_withads_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
   name: search_withads_urlbar_searchmode_sum
   type: RECORD
 - fields:
@@ -1275,6 +1298,16 @@ fields:
     type: INTEGER
   mode: REPEATED
   name: search_adclicks_urlbar_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_urlbar_handoff_sum
   type: RECORD
 - fields:
   - mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/schema.yaml
@@ -611,6 +611,9 @@ fields:
   name: search_count_organic
   type: INTEGER
 - mode: NULLABLE
+  name: search_count_urlbar_handoff
+  type: INTEGER
+- mode: NULLABLE
   name: session_restored_mean
   type: FLOAT
 - mode: NULLABLE
@@ -1122,6 +1125,16 @@ fields:
     name: value
     type: INTEGER
   mode: REPEATED
+  name: search_content_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
   name: search_content_urlbar_searchmode_sum
   type: RECORD
 - fields:
@@ -1232,6 +1245,16 @@ fields:
     name: value
     type: INTEGER
   mode: REPEATED
+  name: search_withads_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
   name: search_withads_urlbar_searchmode_sum
   type: RECORD
 - fields:
@@ -1333,6 +1356,16 @@ fields:
     type: INTEGER
   mode: REPEATED
   name: search_adclicks_urlbar_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_urlbar_handoff_sum
   type: RECORD
 - fields:
   - mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
@@ -611,6 +611,9 @@ fields:
   name: search_count_organic
   type: INTEGER
 - mode: NULLABLE
+  name: search_count_urlbar_handoff
+  type: INTEGER
+- mode: NULLABLE
   name: session_restored_mean
   type: FLOAT
 - mode: NULLABLE
@@ -1104,6 +1107,16 @@ fields:
     name: value
     type: INTEGER
   mode: REPEATED
+  name: search_content_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
   name: search_content_urlbar_searchmode_sum
   type: RECORD
 - fields:
@@ -1214,6 +1227,16 @@ fields:
     name: value
     type: INTEGER
   mode: REPEATED
+  name: search_withads_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
   name: search_withads_urlbar_searchmode_sum
   type: RECORD
 - fields:
@@ -1315,6 +1338,16 @@ fields:
     type: INTEGER
   mode: REPEATED
   name: search_adclicks_urlbar_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_urlbar_handoff_sum
   type: RECORD
 - fields:
   - mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/udf/aggregate_search_counts/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf/aggregate_search_counts/udf.sql
@@ -9,6 +9,7 @@ CREATE OR REPLACE FUNCTION udf.aggregate_search_counts(
       COALESCE(SUM(IF(source = "searchbar", count, 0)), 0) AS search_count_searchbar,
       COALESCE(SUM(IF(source = "system", count, 0)), 0) AS search_count_system,
       COALESCE(SUM(IF(source = "urlbar", count, 0)), 0) AS search_count_urlbar,
+      COALESCE(SUM(IF(source = "urlbar-handoff", count, 0)), 0) AS search_count_urlbar_handoff,
       COALESCE(SUM(IF(source = "webextension", count, 0)), 0) AS search_count_webextension,
       COALESCE(SUM(IF(source = "alias", count, 0)), 0) AS search_count_alias,
       COALESCE(
@@ -21,6 +22,7 @@ CREATE OR REPLACE FUNCTION udf.aggregate_search_counts(
             source IN (
               'searchbar',
               'urlbar',
+              'urlbar-handoff',
               'abouthome',
               'newtab',
               'contextmenu',
@@ -71,10 +73,11 @@ SELECT
       0 AS search_count_searchbar,
       0 AS search_count_system,
       0 AS search_count_urlbar,
+      3 AS search_count_urlbar_handoff,
       0 AS search_count_webextension,
       0 AS search_count_alias,
       0 AS search_count_urlbar_searchmode,
-      6 AS search_count_all,
+      9 AS search_count_all,
       0 AS search_count_tagged_sap,
       0 AS search_count_tagged_follow_on,
       0 AS search_count_organic
@@ -84,7 +87,8 @@ SELECT
         STRUCT('foo' AS engine, 'abouthome' AS source, 3 AS count),
         STRUCT('foo' AS engine, 'abouthome' AS source, 2 AS count),
         STRUCT('foo' AS engine, 'contextmenu' AS source, 1 AS count),
-        STRUCT('foo' AS engine, 'contextmenu' AS source, NULL AS count)
+        STRUCT('foo' AS engine, 'contextmenu' AS source, NULL AS count),
+        STRUCT('foo' AS engine, 'urlbar-handoff' AS source, 3 AS count)
       ]
     )
   ),
@@ -97,6 +101,7 @@ SELECT
       0 AS search_count_searchbar,
       0 AS search_count_system,
       0 AS search_count_urlbar,
+      0 AS search_count_urlbar_handoff,
       0 AS search_count_webextension,
       0 AS search_count_alias,
       0 AS search_count_urlbar_searchmode,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1738132

1. Account for new urlbar handoff related histogram values in the udf that reads [`SEARCH_COUNTS`](https://probes.telemetry.mozilla.org/?search=search_counts&view=detail&probeId=histogram%2FSEARCH_COUNTS). 
2. Add aggregates for sap, adclicks and withads probes

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
