### PR TITLE
add glam_etl to non user facing view

### DIFF
--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -50,6 +50,7 @@ NON_USER_FACING_DATASET_SUFFIXES = (
     "_external",
     "_bi",
     "_restricted",
+    "glam_etl",
 )
 
 


### PR DESCRIPTION
Removing the multitude of tables in mozdata.glam_etl which are interim/raw tables that we would not want analysts to find/use.
