### PR TITLE
Bug 1738132 - Added handoff sources to search_clients_daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/query.sql
@@ -25,6 +25,7 @@ WITH combined_access_point AS (
     *,
     ARRAY_CONCAT(
       add_access_point(search_content_urlbar_sum, 'urlbar'),
+      add_access_point(search_content_urlbar_handoff_sum, 'urlbar_handoff'),
       add_access_point(search_content_urlbar_searchmode_sum, 'urlbar_searchmode'),
       add_access_point(search_content_contextmenu_sum, 'contextmenu'),
       add_access_point(search_content_about_home_sum, 'about_home'),
@@ -38,6 +39,7 @@ WITH combined_access_point AS (
     ) AS in_content_with_sap,
     ARRAY_CONCAT(
       add_access_point(search_withads_urlbar_sum, 'urlbar'),
+      add_access_point(search_withads_urlbar_handoff_sum, 'urlbar_handoff'),
       add_access_point(search_withads_urlbar_searchmode_sum, 'urlbar_searchmode'),
       add_access_point(search_withads_contextmenu_sum, 'contextmenu'),
       add_access_point(search_withads_about_home_sum, 'about_home'),
@@ -51,6 +53,7 @@ WITH combined_access_point AS (
     ) AS search_with_ads_with_sap,
     ARRAY_CONCAT(
       add_access_point(search_adclicks_urlbar_sum, 'urlbar'),
+      add_access_point(search_adclicks_urlbar_handoff_sum, 'urlbar_handoff'),
       add_access_point(search_adclicks_urlbar_searchmode_sum, 'urlbar_searchmode'),
       add_access_point(search_adclicks_contextmenu_sum, 'contextmenu'),
       add_access_point(search_adclicks_about_home_sum, 'about_home'),
@@ -87,7 +90,8 @@ augmented AS (
                 'activitystream',
                 'webextension',
                 'alias',
-                'urlbar-searchmode'
+                'urlbar-searchmode',
+                'urlbar-handoff'
               )
               OR element.source IS NULL
             )

--- a/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_access_point_probes/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_access_point_probes/expect.yaml
@@ -98,6 +98,11 @@
   engine: engine5
   source: 'in-content:tagged:code1.unknown'
   tagged_sap: 10
+- <<: *base
+  client_id: b
+  engine: engine5
+  source: 'in-content:tagged:code1.urlbar_handoff'
+  tagged_sap: 11
 # search with ads
 - <<: *base
   client_id: b
@@ -159,6 +164,11 @@
   engine: engine6
   source: 'search-with-ads:tagged.unknown'
   search_with_ads: 21
+- <<: *base
+  client_id: b
+  engine: engine6
+  source: 'search-with-ads:tagged.urlbar_handoff'
+  search_with_ads: 22
 # ad click
 - <<: *base
   client_id: b
@@ -220,3 +230,8 @@
   engine: engine7
   source: 'ad-click:tagged.unknown'
   ad_click: 31
+- <<: *base
+  client_id: b
+  engine: engine7
+  source: 'ad-click:tagged.urlbar_handoff'
+  ad_click: 32

--- a/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_access_point_probes/telemetry.clients_daily.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_access_point_probes/telemetry.clients_daily.schema.json
@@ -546,7 +546,7 @@
     "name": "ad_clicks",
     "type": "RECORD"
   },
-    {
+  {
     "fields": [
       {
         "mode": "NULLABLE",
@@ -561,6 +561,23 @@
     ],
     "mode": "REPEATED",
     "name": "search_content_urlbar_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "search_content_urlbar_handoff_sum",
     "type": "RECORD"
   },
   {
@@ -764,6 +781,23 @@
       }
     ],
     "mode": "REPEATED",
+    "name": "search_withads_urlbar_handoff_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
     "name": "search_withads_urlbar_searchmode_sum",
     "type": "RECORD"
   },
@@ -935,6 +969,23 @@
     ],
     "mode": "REPEATED",
     "name": "search_adclicks_urlbar_sum",
+    "type": "RECORD"
+  },
+    {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "search_adclicks_urlbar_handoff_sum",
     "type": "RECORD"
   },
   {

--- a/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_access_point_probes/telemetry.clients_daily.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_access_point_probes/telemetry.clients_daily.yaml
@@ -80,6 +80,9 @@
   search_content_unknown_sum:
     - key: 'engine5:tagged:code1'
       value: 10
+  search_content_urlbar_handoff_sum:
+    - key: 'engine5:tagged:code1'
+      value: 11
   # search with ads
   search_withads_urlbar_sum:
     - key: 'engine6:tagged'
@@ -116,6 +119,9 @@
   search_withads_unknown_sum:
     - key: 'engine6:tagged'
       value: 21
+  search_withads_urlbar_handoff_sum:
+    - key: 'engine6:tagged'
+      value: 22
   # ad click
   search_adclicks_urlbar_sum:
     - key: 'engine7:tagged'
@@ -152,3 +158,6 @@
   search_adclicks_unknown_sum:
     - key: 'engine7:tagged'
       value: 31
+  search_adclicks_urlbar_handoff_sum:
+    - key: 'engine7:tagged'
+      value: 32

--- a/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_aggregation/telemetry.clients_daily.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_aggregation/telemetry.clients_daily.schema.json
@@ -546,7 +546,7 @@
     "name": "ad_clicks",
     "type": "RECORD"
   },
-    {
+  {
     "fields": [
       {
         "mode": "NULLABLE",
@@ -561,6 +561,23 @@
     ],
     "mode": "REPEATED",
     "name": "search_content_urlbar_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "search_content_urlbar_handoff_sum",
     "type": "RECORD"
   },
   {
@@ -764,6 +781,23 @@
       }
     ],
     "mode": "REPEATED",
+    "name": "search_withads_urlbar_handoff_sum",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
     "name": "search_withads_urlbar_searchmode_sum",
     "type": "RECORD"
   },
@@ -935,6 +969,23 @@
     ],
     "mode": "REPEATED",
     "name": "search_adclicks_urlbar_sum",
+    "type": "RECORD"
+  },
+    {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "search_adclicks_urlbar_handoff_sum",
     "type": "RECORD"
   },
   {


### PR DESCRIPTION
Added handoff-related sources to `search_clients_daily` eg. `urlbar-handoff`, `in-content:tagged:firefox-b-d.urlbar`, etc.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
