### PR TITLE
Added JDK install to python-deps stage for pyjnius build on M1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,11 @@ orbs:
   gcp-gcr: circleci/gcp-gcr@0.13.0
   docker: circleci/docker@1.5
 
+executors:
+  custom-ubuntu-executor:
+    machine:
+      image: ubuntu-2004:202111-02
+
 jobs:
   build:
     docker: &docker
@@ -361,11 +366,9 @@ jobs:
               || echo "Skipping push since it looks like there were no changes"
 
   deploy:
-    executor: docker/docker
+    executor: custom-ubuntu-executor
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - *attach_generated_sql
       - *copy_generated_sql
       - when:
@@ -450,7 +453,7 @@ jobs:
               || echo "Skipping push since it looks like there were no changes"
           # yamllint enable rule:line-length
   deploy-to-private-gcr:
-    executor: gcp-gcr/default
+    executor: custom-ubuntu-executor
     steps:
       - checkout
       - *attach_generated_sql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
   docker: circleci/docker@1.5
 
 executors:
-  custom-ubuntu-executor:
+  ubuntu-machine-executor:
     machine:
       image: ubuntu-2004:202111-02
 
@@ -366,7 +366,7 @@ jobs:
               || echo "Skipping push since it looks like there were no changes"
 
   deploy:
-    executor: custom-ubuntu-executor
+    executor: ubuntu-machine-executor
     steps:
       - checkout
       - *attach_generated_sql
@@ -453,7 +453,7 @@ jobs:
               || echo "Skipping push since it looks like there were no changes"
           # yamllint enable rule:line-length
   deploy-to-private-gcr:
-    executor: custom-ubuntu-executor
+    executor: ubuntu-machine-executor
     steps:
       - checkout
       - *attach_generated_sql

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG PYTHON_VERSION=3.8
 # has updated coreutils that require a newer linux kernel than provided by CircleCI, per
 # https://forums.docker.com/t/multiple-projects-stopped-building-on-docker-hub-operation-not-permitted/92570/6
 # and https://forums.docker.com/t/multiple-projects-stopped-building-on-docker-hub-operation-not-permitted/92570/11
-# --platform=linux/amd64 added for Apple Silicon support
+# --platform=linux/amd64 added to prevent pulling ARM images when run on Apple Silicon
 FROM --platform=linux/amd64 python:${PYTHON_VERSION}-slim-buster AS base
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ARG PYTHON_VERSION=3.8
 # has updated coreutils that require a newer linux kernel than provided by CircleCI, per
 # https://forums.docker.com/t/multiple-projects-stopped-building-on-docker-hub-operation-not-permitted/92570/6
 # and https://forums.docker.com/t/multiple-projects-stopped-building-on-docker-hub-operation-not-permitted/92570/11
-FROM python:${PYTHON_VERSION}-slim-buster AS base
+# --platform=linux/amd64 added for Apple Silicon support
+FROM --platform=linux/amd64 python:${PYTHON_VERSION}-slim-buster AS base
 WORKDIR /app
 
 # build typed-ast in separate stage because it requires gcc and libc-dev


### PR DESCRIPTION
On Apple Silicon docker build isn't locating java when building pyjnius

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
