### PR TITLE
Remove references to moz-fx-data-derived-datasets

### DIFF
--- a/script/generate_and_publish_views
+++ b/script/generate_and_publish_views
@@ -26,8 +26,7 @@ done
 ./script/generate_all_views --target-project "${TARGET_PROJECT}" --sql-dir "${SQL_DIR}"
 ./script/publish_views --target-project "${TARGET_PROJECT}" "${SQL_DIR}"
 
-# We additionally make sure we have identical view definitions in moz-fx-data-derived-datasets and mozdata
+# We additionally make sure we have identical view definitions in mozdata
 if [[ "$TARGET_PROJECT" == "moz-fx-data-shared-prod" ]]; then
-    ./script/publish_views --user-facing-only --target-project moz-fx-data-derived-datasets "${SQL_DIR}"
     ./script/publish_views --user-facing-only --target-project mozdata "${SQL_DIR}"
 fi

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_scheduled_query_usage_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_scheduled_query_usage_v1/query.py
@@ -9,7 +9,6 @@ from google.cloud import bigquery
 
 DEFAULT_PROJECTS = [
     "moz-fx-data-shared-prod",
-    "moz-fx-data-derived-datasets",
     "moz-fx-data-experiments",
 ]
 

--- a/sql/moz-fx-data-shared-prod/static/README.md
+++ b/sql/moz-fx-data-shared-prod/static/README.md
@@ -15,5 +15,4 @@ ETL and analysis:
 ```
 ./script/publish_static --project-id mozdata
 ./script/publish_static --project-id moz-fx-data-shared-prod
-./script/publish_static --project-id moz-fx-data-derived-datasets
 ```


### PR DESCRIPTION
My editor auto `chmod +x`'d the query.py file since it has magic at the top.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
