### PR TITLE
Create a stable table for Fx Suggest's impression clicks

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -42,6 +42,8 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/monitoring_derived/deletion_request_volume_v1/query.sql",
     "sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v1/view.sql",
     "sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/query.sql",
+    "sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/init.sql",
+    "sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/query.sql",
     "sql/moz-fx-data-shared-prod/monitoring/schema_error_counts_v1/view.sql",
     "sql/moz-fx-data-shared-prod/monitoring_derived/structured_error_counts_v1/view.sql",
     "sql/moz-fx-data-shared-prod/monitoring/structured_error_counts/view.sql",

--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -136,6 +136,18 @@ with DAG(
         email=["amiyaguchi@mozilla.com", "ascholtz@mozilla.com"],
     )
 
+    monitoring_derived__suggest_impression_rate__v1 = bigquery_etl_query(
+        task_id="monitoring_derived__suggest_impression_rate__v1",
+        destination_table="suggest_impression_rate_v1",
+        dataset_id="monitoring_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="aplacitelli@mozilla.com",
+        email=["aplacitelli@mozilla.com", "ascholtz@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
     monitoring_derived__telemetry_distinct_docids__v1 = bigquery_etl_query(
         task_id="monitoring_derived__telemetry_distinct_docids__v1",
         destination_table="telemetry_distinct_docids_v1",
@@ -207,6 +219,10 @@ with DAG(
     )
 
     monitoring_derived__structured_missing_columns__v1.set_upstream(
+        wait_for_copy_deduplicate_all
+    )
+
+    monitoring_derived__suggest_impression_rate__v1.set_upstream(
         wait_for_copy_deduplicate_all
     )
 

--- a/sql/moz-fx-data-shared-prod/monitoring/suggest_impression_rate_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/suggest_impression_rate_live/view.sql
@@ -5,3 +5,12 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.suggest_impression_rate_live_v1`
+WHERE
+  DATE(submission_minute) >= DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
+UNION ALL
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.monitoring_derived.suggest_impression_rate_v1`
+WHERE
+  DATE(submission_minute) < DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/init.sql
@@ -1,7 +1,15 @@
 CREATE TABLE IF NOT EXISTS
-  `moz-fx-data-shared-prod.monitoring_derived.suggest_impression_rate_v1`(
-    submission_minute TIESTAMP,
-    n INT64
-  )
+  `moz-fx-data-shared-prod.monitoring_derived.suggest_impression_rate_v1`
 PARTITION BY
-  submission_minute
+  DATE(submission_minute) AS
+SELECT
+  TIMESTAMP_TRUNC(submission_timestamp, minute) AS submission_minute,
+  COUNT(*) AS n,
+FROM
+  -- For this initialization query, we select from the sanitized table, which contains
+  -- 15 days of history rather than just 2.
+  `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v1`
+WHERE
+  DATE(submission_timestamp) >= '2021-10-27'
+GROUP BY
+  1

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/init.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.monitoring_derived.suggest_impression_rate_v1`(
+    submission_minute TIESTAMP,
+    n INT64
+  )
+PARTITION BY
+  submission_minute

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/init.sql
@@ -1,7 +1,8 @@
 CREATE TABLE IF NOT EXISTS
   `moz-fx-data-shared-prod.monitoring_derived.suggest_impression_rate_v1`
 PARTITION BY
-  DATE(submission_minute) AS
+  DATE(submission_minute)
+AS
 SELECT
   TIMESTAMP_TRUNC(submission_timestamp, minute) AS submission_minute,
   COUNT(*) AS n,

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Suggest Impression Rate Stable
+description: |-
+  Used to visualize telemetry rates in Grafana as a cross check for
+  operational monitoring of the Merino service.
+owners:
+  - aplacitelli@mozilla.com
+labels:
+  authorized: true
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_monitoring
+  referenced_tables:
+    - ['moz-fx-data-shared-prod',
+       'contextual_services_stable',
+       'quicksuggest_impression_v1']
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/metadata.yaml
@@ -5,7 +5,6 @@ description: |-
 owners:
   - aplacitelli@mozilla.com
 labels:
-  authorized: true
   incremental: true
   schedule: daily
 scheduling:

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_v1/query.sql
@@ -1,0 +1,9 @@
+SELECT
+  TIMESTAMP_TRUNC(submission_timestamp, minute) AS submission_minute,
+  COUNT(*) AS n,
+FROM
+  `moz-fx-data-shared-prod.contextual_services_stable.quicksuggest_impression_v1`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+GROUP BY
+  1


### PR DESCRIPTION
And merge the historical data with the live data in the `suggest_impression_rate_live` materialized view.

This is needed for the Merino operational dashboard.

This fixes [the following JIRA ticket](https://mozilla-hub.atlassian.net/browse/ROAD-133).

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
