### PR TITLE
Add Windows 10/11 21H2 update to aggregates

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/windows_10_aggregate/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/windows_10_aggregate/view.sql
@@ -8,19 +8,17 @@ WITH
     windows_build_number AS build_number,
     CAST(windows_ubr AS STRING) AS ubr,
     CASE
-    WHEN windows_build_number <= 10240 THEN '1507'
-    WHEN windows_build_number <= 10586 THEN '1511'
-    WHEN windows_build_number <= 14393 THEN '1607'
-    WHEN windows_build_number <= 15063 THEN '1703'
-    WHEN windows_build_number <= 16299 THEN '1709'
-    WHEN windows_build_number <= 17134 THEN '1803'
-    WHEN windows_build_number <= 17763 THEN '1809'
-    WHEN windows_build_number <= 18362 THEN '1903'
-    WHEN windows_build_number <= 18363 THEN '1909'
-    WHEN windows_build_number <= 19041 THEN '2004'
-    WHEN windows_build_number <= 19042 THEN '20H2'
-    WHEN windows_build_number <= 19043 THEN '21H1'
-    WHEN windows_build_number > 19043 THEN 'Insider'
+    WHEN windows_build_number <= 17134 THEN 'Win10 <1809'
+    WHEN windows_build_number <= 17763 THEN 'Win10 1809'
+    WHEN windows_build_number <= 18362 THEN 'Win10 1903'
+    WHEN windows_build_number <= 18363 THEN 'Win10 1909'
+    WHEN windows_build_number <= 19041 THEN 'Win10 2004'
+    WHEN windows_build_number <= 19042 THEN 'Win10 20H2'
+    WHEN windows_build_number <= 19043 THEN 'Win10 21H1'
+    WHEN windows_build_number <= 19044 THEN 'Win10 21H2'
+    WHEN windows_build_number < 22000 THEN 'Win10 Insider'
+    WHEN windows_build_number = 22000 THEN 'Win11 21H2'
+    WHEN windows_build_number > 22000 THEN 'Win11 Insider'
     ELSE NULL
     END AS build_group,
     SPLIT(app_version, ".")[OFFSET(0)] AS ff_build_version,


### PR DESCRIPTION
Windows 11 still has os_version = 10 like Windows 10, so the only way to differentiate is by the build number. Might as well keep them on the same dashboard. This also cleans up older versions which currently combine to ~5% of overall Win10 user share into one grouping to cut down on some of the clutter as the number of releases increases over time.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
