### PR TITLE
Add regrets-reporter-ucs dataset and ACL metadata

### DIFF
--- a/sql/moz-fx-data-shared-prod/regrets_reporter_ucs/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_ucs/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: regrets-reporter-ucs
+# yamllint disable rule:line-length
+description: |-
+  User-facing views related to document namespace regrets-reporter-ucs; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/regrets-reporter-ucs
+dataset_base_acl: view_restricted
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:regrets-reporter

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_ucs_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_ucs_derived/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: regrets-reporter-ucs Derived
+# yamllint disable rule:line-length
+description: |-
+  Derived tables related to document namespace regrets-reporter-ucs, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
+dataset_base_acl: derived_restricted
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:regrets-reporter


### PR DESCRIPTION
https://github.com/mozilla-services/cloudops-infra/pull/3546 was sufficient to allow these schemas to be deployed, but once bqetl automation started to generate metadata as well we wound up in an inconsistent generated state.

This seems like a reasonable place to mention https://bugzilla.mozilla.org/show_bug.cgi?id=1740483#c5 / https://bugzilla.mozilla.org/show_bug.cgi?id=1654078#c45. I didn't include views here as I'm primarily concerned with unblocking the schemas pipeline, but maybe that should be considered.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
