### PR TITLE
Bug 1731310 - Added newtab related fields to feature_usage

### DIFF
--- a/bigquery_etl/feature_usage/templates/metadata.yaml
+++ b/bigquery_etl/feature_usage/templates/metadata.yaml
@@ -9,12 +9,13 @@ owners:
   - shong@mozilla.com
   - cdowhygelund@mozilla.com
   - ascholtz@mozilla.com
+  - anicholson@mozilla.com
 labels:
   incremental: true
   application: firefox
   schedule: daily
 scheduling:
-  dag_name: bqetl_main_summary
+  dag_name: bqetl_feature_usage
 bigquery:
   time_partitioning:
     field: submission_date

--- a/bigquery_etl/feature_usage/templating.yaml
+++ b/bigquery_etl/feature_usage/templating.yaml
@@ -254,6 +254,33 @@ sources:
         vetted: true
         min_version: 64
         type: INT64
+      - name: newtabpage_disabled
+        sql: SAFE_CAST(user_pref_browser_newtabpage_enabled AS BOOL)
+        type: BOOL
+      - name: num_topsites_new_tab_impressions_sponsored
+        sql: >
+          (
+            SELECT
+              SUM(
+                IF(SPLIT(key, '_')[SAFE_OFFSET(0)] = 'newtab', value, 0)
+              )
+            FROM
+              UNNEST(contextual_services_topsites_impression_sum)
+          )
+        min_version: 87
+        type: INT64
+      - name: num_new_tab_topsites_clicks_sponsored
+        sql: >
+          (
+            SELECT
+              SUM(
+                IF(SPLIT(key, '_')[SAFE_OFFSET(0)] = 'newtab', value, 0)
+              )
+            FROM
+              UNNEST(contextual_services_topsites_click_sum)
+          )
+        min_version: 87
+        type: INT64
   ### Main ###
   - name: main
     ref: telemetry.main_1pct
@@ -1029,6 +1056,38 @@ sources:
       - name: activitystream_pocket_clicks
         sql: COUNTIF(event = 'CLICK' AND source = 'CARDGRID')
         vetted: false
+      - name: activitystream_sponsored_pocket_clicks
+        sql: >
+              COUNTIF(
+                event = 'CLICK'
+                AND source = 'CARDGRID'
+                AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'spoc'
+              )
+        vetted: false
+      - name: activitystream_sponsored_topsite_clicks
+        sql: >
+              COUNTIF(
+                event = 'CLICK'
+                AND source = 'TOP_SITES'
+                AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'spoc'
+              )
+        vetted: false
+      - name: activitystream_organic_pocket_clicks
+        sql: >
+              COUNTIF(
+                event = 'CLICK'
+                AND source = 'CARDGRID'
+                AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'organic'
+              )
+        vetted: false
+      - name: activitystream_organic_topsite_clicks
+        sql: >
+              COUNTIF(
+                event = 'CLICK'
+                AND source = 'TOP_SITES'
+                AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'organic'
+              )
+        vetted: false
   ### Activity Stream Sessions ###
   - name: activity_stream_sessions
     ref: activity_stream.sessions
@@ -1053,6 +1112,9 @@ sources:
         vetted: false
       - name: activitystream_reported_highlights_off
         sql: MAX(user_prefs & 8 = 0)
+        vetted: false
+      - name: activitystream_reported_sponsored_topstories_off
+        sql: MAX(user_prefs & 32 = 0)
         vetted: false
       - name: activitystream_reported_sponsored_topsites_off
         sql: MAX(user_prefs & 256 = 0)

--- a/dags/bqetl_feature_usage.py
+++ b/dags/bqetl_feature_usage.py
@@ -53,6 +53,7 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="loines@mozilla.com",
         email=[
+            "anicholson@mozilla.com",
             "ascholtz@mozilla.com",
             "cdowhygelund@mozilla.com",
             "loines@mozilla.com",

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/metadata.yaml
@@ -9,6 +9,7 @@ owners:
 - shong@mozilla.com
 - cdowhygelund@mozilla.com
 - ascholtz@mozilla.com
+- anicholson@mozilla.com
 labels:
   incremental: true
   application: firefox

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/schema.yaml
@@ -398,3 +398,49 @@ fields:
 - mode: NULLABLE
   name: activitystream_sessions_both
   type: INTEGER
+- mode: NULLABLE
+  name: newtabpage_disabled
+  type: BOOLEAN
+  description: |-
+    Whether the newtabpage is disabled or not.
+    Based on the browser.newtabpage.enabled pref
+- mode: NULLABLE
+  name: num_topsites_new_tab_impressions_sponsored
+  type: INTEGER
+  description: |-
+    Total number of sponsored topsite impressions on the new tab page.
+- mode: NULLABLE
+  name: num_new_tab_topsites_clicks_sponsored
+  type: INTEGER
+  description: |-
+    Total number of sponsored topsite clicks on the new tab page.
+- mode: NULLABLE
+  name: activitystream_sponsored_pocket_clicks
+  type: INTEGER
+  description: |-
+    Total number of sponsored pocket clicks
+    reported from activity stream events.
+- mode: NULLABLE
+  name: activitystream_sponsored_topsite_clicks
+  type: INTEGER
+  description: |-
+    Total number of sponsored topsite clicks
+    reported from activity stream events.
+- mode: NULLABLE
+  name: activitystream_organic_pocket_clicks
+  type: INTEGER
+  description: |-
+    Total number of organic topsite clicks
+    reported from activity stream events.
+- mode: NULLABLE
+  name: activitystream_organic_topsite_clicks
+  type: INTEGER
+  description: |-
+    Total number of organic topsite clicks
+    reported from activity stream events.
+- mode: NULLABLE
+  name: activitystream_reported_sponsored_topstories_off
+  type: BOOLEAN
+  description: |-
+    Whether or not sponsored topstories is off. Based on the
+    browser.newtabpage.activity-stream.showSponsored pref


### PR DESCRIPTION
RE: https://bugzilla.mozilla.org/show_bug.cgi?id=1731310 - Added newtab related fields to `feature_usage` table

Do this look reasonable? I wasn't able to add:
- The shortcut rows pref because it isn't sent by activity stream at the moment and will probably require a data review
- Pocket impression data because it doesn't have client ids so can't be joined here.

Related probe dictionary link for contextual services - [link](https://probes.telemetry.mozilla.org/?search=contextual.services&view=detail&probeId=scalar%2Fcontextual.services.topsites.click).

Also updated the template DAG  to `bqetl_feature_usage`

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
