### PR TITLE
Add derived table and view for fxa stdout events

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -71,6 +71,7 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_export_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_user_ids_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_user_ids_v1/init.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/regrets_reporter/regrets_reporter_update/view.sql",
     "sql/moz-fx-data-shared-prod/revenue_derived/client_ltv_v1/query.sql",
     "sql/moz-fx-data-shared-prod/monitoring/payload_bytes_decoded_structured/view.sql",

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -135,6 +135,19 @@ with DAG(
         dag=dag,
     )
 
+    firefox_accounts_derived__fxa_stdout_events__v1 = bigquery_etl_query(
+        task_id="firefox_accounts_derived__fxa_stdout_events__v1",
+        destination_table="fxa_stdout_events_v1",
+        dataset_id="firefox_accounts_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=["jklukas@mozilla.com", "telemetry-alerts@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
+        dag=dag,
+    )
+
     firefox_accounts_derived__fxa_users_daily__v1 = bigquery_etl_query(
         task_id="firefox_accounts_derived__fxa_users_daily__v1",
         destination_table="fxa_users_daily_v1",

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
@@ -1,0 +1,124 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_accounts.fxa_content_auth_stdout_events`
+AS
+  --
+WITH content AS (
+  SELECT
+    jsonPayload.logger,
+    jsonPayload.fields.event_type,
+    jsonPayload.fields.app_version,
+    jsonPayload.fields.os_name,
+    jsonPayload.fields.os_version,
+    jsonPayload.fields.country,
+    jsonPayload.fields.language,
+    jsonPayload.fields.user_id,
+    jsonPayload.fields.user_properties,
+    jsonPayload.fields.event_properties,
+    `timestamp`,
+    receiveTimestamp
+  FROM
+    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_content_events_v1`
+),
+  --
+auth AS (
+  SELECT
+    jsonPayload.logger,
+    jsonPayload.fields.event_type,
+    jsonPayload.fields.app_version,
+    jsonPayload.fields.os_name,
+    jsonPayload.fields.os_version,
+    jsonPayload.fields.country,
+    jsonPayload.fields.language,
+    jsonPayload.fields.user_id,
+    jsonPayload.fields.user_properties,
+    jsonPayload.fields.event_properties,
+    `timestamp`,
+    receiveTimestamp
+  FROM
+    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_auth_events_v1`
+),
+  --
+stdout AS (
+  SELECT
+    jsonPayload.logger,
+    jsonPayload.fields.event_type,
+    jsonPayload.fields.app_version,
+    jsonPayload.fields.os_name,
+    jsonPayload.fields.os_version,
+    CAST(NULL AS STRING) AS country,
+    jsonPayload.fields.language,
+    jsonPayload.fields.user_id,
+    jsonPayload.fields.user_properties,
+    jsonPayload.fields.event_properties,
+    `timestamp`,
+    receiveTimestamp
+  FROM
+    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_stdout_events_v1`
+),
+  --
+unioned AS (
+  SELECT
+    *
+  FROM
+    auth
+  UNION ALL
+  SELECT
+    *
+  FROM
+    content
+  UNION ALL
+  SELECT
+    *
+  FROM
+    stdout
+)
+  --
+SELECT
+  * EXCEPT (user_properties, event_properties),
+  REPLACE(JSON_EXTRACT(user_properties, '$.utm_term'), "\"", "") AS utm_term,
+  REPLACE(JSON_EXTRACT(user_properties, '$.utm_source'), "\"", "") AS utm_source,
+  REPLACE(JSON_EXTRACT(user_properties, '$.utm_medium'), "\"", "") AS utm_medium,
+  REPLACE(JSON_EXTRACT(user_properties, '$.utm_campaign'), "\"", "") AS utm_campaign,
+  REPLACE(JSON_EXTRACT(user_properties, '$.utm_content'), "\"", "") AS utm_content,
+  REPLACE(JSON_EXTRACT(user_properties, '$.ua_version'), "\"", "") AS ua_version,
+  REPLACE(JSON_EXTRACT(user_properties, '$.ua_browser'), "\"", "") AS ua_browser,
+  REPLACE(JSON_EXTRACT(user_properties, '$.entrypoint'), "\"", "") AS entrypoint,
+  REPLACE(
+    JSON_EXTRACT(user_properties, '$.entrypoint_experiment'),
+    "\"",
+    ""
+  ) AS entrypoint_experiment,
+  REPLACE(
+    JSON_EXTRACT(user_properties, '$.entrypoint_variation'),
+    "\"",
+    ""
+  ) AS entrypoint_variation,
+  REPLACE(JSON_EXTRACT(user_properties, '$.flow_id'), "\"", "") AS flow_id,
+  REPLACE(JSON_EXTRACT(event_properties, '$.service'), "\"", "") AS service,
+  REPLACE(JSON_EXTRACT(event_properties, '$.email_type'), "\"", "") AS email_type,
+  REPLACE(JSON_EXTRACT(event_properties, '$.email_provider'), "\"", "") AS email_provider,
+  REPLACE(JSON_EXTRACT(event_properties, '$.oauth_client_id'), "\"", "") AS oauth_client_id,
+  REPLACE(JSON_EXTRACT(event_properties, '$.connect_device_flow'), "\"", "") AS connect_device_flow,
+  REPLACE(JSON_EXTRACT(event_properties, '$.connect_device_os'), "\"", "") AS connect_device_os,
+  REPLACE(JSON_EXTRACT(user_properties, '$.sync_device_count'), "\"", "") AS sync_device_count,
+  REPLACE(
+    JSON_EXTRACT(user_properties, '$.sync_active_devices_day'),
+    "\"",
+    ""
+  ) AS sync_active_devices_day,
+  REPLACE(
+    JSON_EXTRACT(user_properties, '$.sync_active_devices_week'),
+    "\"",
+    ""
+  ) AS sync_active_devices_week,
+  REPLACE(
+    JSON_EXTRACT(user_properties, '$.sync_active_devices_month'),
+    "\"",
+    ""
+  ) AS sync_active_devices_month,
+  REPLACE(JSON_EXTRACT(event_properties, '$.email_sender'), "\"", "") AS email_sender,
+  REPLACE(JSON_EXTRACT(event_properties, '$.email_service'), "\"", "") AS email_service,
+  REPLACE(JSON_EXTRACT(event_properties, '$.email_template'), "\"", "") AS email_template,
+  REPLACE(JSON_EXTRACT(event_properties, '$.email_version'), "\"", "") AS email_version
+FROM
+  unioned

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
@@ -1,0 +1,12 @@
+---
+friendly_name: FxA Stdout Events
+description: Selected Amplitude events extracted from FxA server stdout logs
+owners:
+  - jklukas@mozilla.com
+labels:
+  application: fxa
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_fxa_events
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/query.sql
@@ -1,0 +1,19 @@
+SELECT
+  * REPLACE (
+    (
+      SELECT AS STRUCT
+        jsonPayload.* REPLACE (
+          (
+            SELECT AS STRUCT
+              jsonPayload.fields.* EXCEPT (device_id, user_id),
+              TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id
+          ) AS fields
+        )
+    ) AS jsonPayload
+  )
+FROM
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.stdout_20*`
+WHERE
+  jsonPayload.type = 'amplitudeEvent'
+  AND jsonPayload.fields.event_type IS NOT NULL
+  AND _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)


### PR DESCRIPTION
so that mozilla vpn funnel analysis can use events like `fxa_pay_setup - *` that only appear in the stdout tables.
