### PR TITLE
Add start_date filter and aggregation by submission_date.

### DIFF
--- a/bigquery_etl/operational_monitoring/README.md
+++ b/bigquery_etl/operational_monitoring/README.md
@@ -1,0 +1,93 @@
+Operational Monitoring
+===
+
+Operational Monitoring is a general term that refers to monitoring the health of software.
+
+For the purpose of this project, there will be a couple of specific monitoring use cases that are supported:
+1. Monitoring build over build. This is typically for Nightly where one build may contain changes that a previous build doesn't and we want to see if those changes affected certain metrics.
+2. Monitoring by submission date over time. This is helpful for a rollout in Release for example, where we want to make sure there are no performance or stability regressions over time as a new build rolls out.
+
+Although the ETL for both cases shares a common set of templates, the data is a stored/represented slightly differently.
+* For case 1, submission date is used as the partition but previous submission dates are only there for backup. The most recent submission date is the only one of interest as it will include all relevant builds to be graphed.
+* For case 2, submission date is also used as the partition, but they are not backups. The previous submission dates will include dates that need to be graphed.
+
+#### Project Definition Files
+A project is defined using in a JSON file in combination with 2 other JSON files. Examples of each file can be found below:
+
+##### dimensions.json
+```
+{
+  "cores_count": {
+    "source": ["mozdata.telemetry.main_nightly"],
+    "sql": "environment.system.cpu.cores"
+  },
+  "os": {
+    "source": ["mozdata.telemetry.main_nightly", "mozdata.telemetry.crash"],
+    "sql": "normalized_os"
+  }
+  ...
+}
+```
+
+##### probes.json
+```
+{
+  "CONTENT_SHUTDOWN_CRASHES": {
+    "source": "mozdata.telemetry.crash",
+    "category": "stability",
+    "type": "scalar",
+    "sql": "IF(REGEXP_CONTAINS(payload.process_type, 'content') AND REGEXP_CONTAINS(payload.metadata.ipc_channel_error, 'ShutDownKill'), 1, 0)"
+  },
+  "CONTENT_PROCESS_COUNT": {
+    "source": "mozdata.telemetry.main_nightly",
+    "category": "performance",
+    "type": "histogram",
+    "sql": "payload.histograms.content_process_count"
+  },
+ ...
+}
+```
+
+##### <project_name>.json
+
+```
+{
+  "name": "Fission Release Rollout",
+  "slug": "bug-1732206-rollout-fission-release-rollout-release-94-95",
+  "channel": "release",
+  "boolean_pref": "environment.settings.fission_enabled",
+  "xaxis": "submission_date",
+  "start_date": "2021-11-09",
+  "analysis": [{
+  	"source": "mozdata.telemetry.main_1pct",
+  	"dimensions": ["cores_count", "os"],
+  	"probes": [
+  		"CONTENT_PROCESS_COUNT",
+    ]
+	}, {
+    "source": "mozdata.telemetry.crash",
+    "dimensions": ["cores_count", "os"],
+    "probes": [
+      "CONTENT_SHUTDOWN_CRASHES",
+    ]
+  }]
+}
+```
+
+Below is the description of each field in the project definition and its allowable values:
+* `name`: Name that will be used as the generated Looker dashboard title
+* `slug`: The slug associated with the rollout that is being monitored
+* `channel`: `release`, `beta`, or `nightly`. The channel the rollout is running in
+* `boolean_pref`: A sql snippet that results in a boolean representing whether a user is included in the rollout or not (note: this will soon be deprecated in favour of using the slug directly to check)
+* `xaxis`: `submission_date` or `build_id`. specifies the type of monitoring desired as described above.
+* `start_date`: `yyyy-mm-dd`, specifies the oldest submission date or build id to be processed (where build id is cast to date). If not set, defaults to the previous 30 days.
+* `analysis`: An array of objects with the fields `source`, `dimensions`, and `probes` where each object represents data that will be pulled out from a different sourc.
+    * `source`: The BigQuery table name to be queried
+    * `dimensions`: The dimensions of interest, referenced from `dimensions.json`
+    * `probes`: The probes of interest, referenced from `probes.json`
+
+
+
+
+
+

--- a/bigquery_etl/operational_monitoring/templates/histogram_init.sql
+++ b/bigquery_etl/operational_monitoring/templates/histogram_init.sql
@@ -23,7 +23,11 @@ CREATE TABLE IF NOT EXISTS
 PARTITION BY submission_date
 CLUSTER BY
     build_id
-OPTIONS (
-    require_partition_filter = TRUE,
+OPTIONS
+  (require_partition_filter = TRUE,
+    {% if xaxis == "submission_date" %}
+    partition_expiration_days = NULL
+    {% else %}
     partition_expiration_days = 5
-)
+    {% endif %}
+  )

--- a/bigquery_etl/operational_monitoring/templates/histogram_query.sql
+++ b/bigquery_etl/operational_monitoring/templates/histogram_query.sql
@@ -2,7 +2,11 @@
 
 WITH merged_probes AS (
   SELECT
+    {% if xaxis == "submission_date" %}
+    DATE(submission_timestamp) AS submission_date,
+    {% else %}
     @submission_date AS submission_date,
+    {% endif %}
     client_id,
     SAFE.SUBSTR(application.build_id, 0, 8) AS build_id,
     {% for dimension in dimensions %}

--- a/bigquery_etl/operational_monitoring/templates/histogram_view.sql
+++ b/bigquery_etl/operational_monitoring/templates/histogram_view.sql
@@ -6,7 +6,11 @@ AS
 WITH normalized AS (
     SELECT
         client_id,
+        {% if xaxis == "submission_date" %}
+        submission_date,
+        {% else %}
         build_id,
+        {% endif %}
         {% for dimension in dimensions %}
           {{ dimension.name }},
         {% endfor %}
@@ -32,11 +36,27 @@ WITH normalized AS (
         FROM `{{gcp_project}}.{{dataset}}.{{slug}}_histogram`
         CROSS JOIN UNNEST(metrics)
         WHERE
-            PARSE_DATE('%Y%m%d', CAST(build_id AS STRING)) > DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+          {% if xaxis == "submission_date" %}
+            {% if start_date %}
+            DATE(submission_date) >= "{{start_date}}"
+            {% else %}
+            DATE(submission_date) > DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+            {% endif %}
+          {% else %}
+            {% if start_date %}
+            PARSE_DATE('%Y%m%d', CAST(build_id AS STRING)) >= "{{start_date}}"
+            {% else %}
+            PARSE_DATE('%Y%m%d', CAST(build_id AS STRING)) > DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+            {% endif %}
             AND DATE(submission_date) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
+          {% endif %}
         GROUP BY
         client_id,
+        {% if xaxis == "submission_date" %}
+        submission_date,
+        {% else %}
         build_id,
+        {% endif %}
         {% for dimension in dimensions %}
           {{ dimension.name }},
         {% endfor %}
@@ -47,7 +67,11 @@ WITH normalized AS (
 -- so we can use the histogram jackknife percentile function.
 SELECT
     client_id,
+    {% if xaxis == "submission_date" %}
+    submission_date,
+    {% else %}
     build_id,
+    {% endif %}
     {% for dimension in dimensions %}
       {{ dimension.name }},
     {% endfor %}

--- a/bigquery_etl/operational_monitoring/templates/scalar_init.sql
+++ b/bigquery_etl/operational_monitoring/templates/scalar_init.sql
@@ -14,7 +14,11 @@ CREATE TABLE IF NOT EXISTS
 PARTITION BY submission_date
 CLUSTER BY
     build_id
-OPTIONS (
-    require_partition_filter = TRUE,
+OPTIONS
+  (require_partition_filter = TRUE,
+    {% if xaxis == "submission_date" %}
+    partition_expiration_days = NULL
+    {% else %}
     partition_expiration_days = 5
-)
+    {% endif %}
+  )

--- a/bigquery_etl/operational_monitoring/templates/scalar_query.sql
+++ b/bigquery_etl/operational_monitoring/templates/scalar_query.sql
@@ -2,7 +2,11 @@
 
 WITH merged_scalars AS (
     SELECT
+        {% if xaxis == "submission_date" %}
+        DATE(submission_timestamp) AS submission_date,
+        {% else %}
         @submission_date AS submission_date,
+        {% endif %}
         client_id,
         SAFE.SUBSTR(application.build_id, 0, 8) AS build_id,
         {% for dimension in dimensions %}


### PR DESCRIPTION
I've made some changes to support monitoring a rollout in release where we want to look at data by submission date rather than build ID. I've also added a readme to provide context/explanation on how this works