### PR TITLE
Simplify experiment_enrollment_cumulative_population_estimate query

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -155,6 +155,8 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/experiment_events_live_v1/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/experiment_search_events_live_v1/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/experiment_events_live_v1/init.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_cumulative_population_estimate_v1/view.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/telemetry/experiment_enrollment_cumulative_population_estimate/view.sql",  # noqa E501
     # Already exists (and lacks an "OR REPLACE" clause)
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_first_seen_v1/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/clients_last_seen_v1/init.sql",  # noqa E501

--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -29,6 +29,8 @@ SKIP_VALIDATION = {
     "sql/moz-fx-data-shared-prod/telemetry/clients_probe_processes/view.sql",
     # tests
     "sql/moz-fx-data-test-project/test/simple_view/view.sql",
+    # Access Denied
+    "sql/moz-fx-data-shared-prod/telemetry/experiment_enrollment_cumulative_population_estimate/view.sql",  # noqa E501
 }
 
 # skip publishing these views


### PR DESCRIPTION
Fixes https://github.com/mozilla/jetstream/issues/924

We've been running into `Resources exceeded during query execution: Not enough resources for query planning - too many subqueries or query is too complex.` errors when querying from `mozdata.telemetry.experiment_enrollment_cumulative_population_estimate`. This change fixes the issue. I already manually deployed the view to do some testing