### PR TITLE
Add a11y_theme fields to clients daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
@@ -1764,3 +1764,19 @@ fields:
 - mode: NULLABLE
   name: user_pref_browser_urlbar_quicksuggest_data_collection_enabled
   type: STRING
+- mode: NULLABLE
+  name: scalar_a11y_hcm_foreground
+  type: INTEGER
+- mode: NULLABLE
+  name: scalar_a11y_hcm_background
+  type: INTEGER
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: BOOLEAN
+  mode: REPEATED
+  name: a11y_theme
+  type: RECORD

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
@@ -375,6 +375,8 @@ clients_summary AS (
     payload.processes.content.scalars.webrtc_nicer_turn_401s AS scalar_content_webrtc_nicer_turn_401s,
     payload.processes.content.scalars.webrtc_nicer_turn_403s AS scalar_content_webrtc_nicer_turn_403s,
     payload.processes.content.scalars.webrtc_nicer_turn_438s AS scalar_content_webrtc_nicer_turn_438s,
+    payload.processes.parent.scalars.a11y_hcm_foreground AS scalar_a11y_hcm_foreground,
+    payload.processes.parent.scalars.a11y_hcm_background AS scalar_a11y_hcm_background,
     payload.processes.parent.keyed_scalars.browser_search_ad_clicks AS scalar_parent_browser_search_ad_clicks,
     payload.processes.parent.keyed_scalars.browser_search_with_ads AS scalar_parent_browser_search_with_ads,
     payload.processes.parent.keyed_scalars.devtools_accessibility_select_accessible_for_node AS scalar_parent_devtools_accessibility_select_accessible_for_node,
@@ -421,6 +423,7 @@ clients_summary AS (
     payload.processes.parent.keyed_scalars.contextual_services_quicksuggest_help,
     payload.processes.parent.keyed_scalars.contextual_services_topsites_click,
     payload.processes.parent.keyed_scalars.contextual_services_topsites_impression,
+    payload.processes.parent.keyed_scalars.a11y_theme,
     count_histograms[OFFSET(0)].histogram AS histogram_parent_devtools_aboutdebugging_opened_count,
     count_histograms[
       OFFSET(1)
@@ -869,6 +872,13 @@ aggregates AS (
     mozfun.stats.mode_last(
       ARRAY_AGG(scalar_parent_aushelper_websense_reg_version ORDER BY submission_timestamp)
     ) AS scalar_parent_aushelper_websense_reg_version,
+    mozfun.stats.mode_last(
+      ARRAY_AGG(scalar_a11y_hcm_foreground ORDER BY submission_timestamp)
+    ) AS scalar_a11y_hcm_foreground,
+    mozfun.stats.mode_last(
+      ARRAY_AGG(scalar_a11y_hcm_background ORDER BY submission_timestamp)
+    ) AS scalar_a11y_hcm_background,
+    mozfun.map.mode_last(ARRAY_CONCAT_AGG(a11y_theme ORDER BY submission_timestamp)) AS a11y_theme,
     MAX(
       scalar_parent_browser_engagement_max_concurrent_tab_count
     ) AS scalar_parent_browser_engagement_max_concurrent_tab_count_max,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
@@ -1749,3 +1749,19 @@ fields:
 - mode: NULLABLE
   name: user_pref_browser_urlbar_quicksuggest_data_collection_enabled
   type: STRING
+- mode: NULLABLE
+  name: scalar_a11y_hcm_foreground
+  type: INTEGER
+- mode: NULLABLE
+  name: scalar_a11y_hcm_background
+  type: INTEGER
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: BOOLEAN
+  mode: REPEATED
+  name: a11y_theme
+  type: RECORD

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -1495,3 +1495,19 @@ fields:
 - mode: NULLABLE
   name: user_pref_browser_urlbar_quicksuggest_data_collection_enabled
   type: STRING
+- mode: NULLABLE
+  name: scalar_a11y_hcm_foreground
+  type: INTEGER
+- mode: NULLABLE
+  name: scalar_a11y_hcm_background
+  type: INTEGER
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: BOOLEAN
+  mode: REPEATED
+  name: a11y_theme
+  type: RECORD

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/schema.yaml
@@ -1553,3 +1553,19 @@ fields:
 - mode: NULLABLE
   name: user_pref_browser_urlbar_quicksuggest_data_collection_enabled
   type: STRING
+- mode: NULLABLE
+  name: scalar_a11y_hcm_foreground
+  type: INTEGER
+- mode: NULLABLE
+  name: scalar_a11y_hcm_background
+  type: INTEGER
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: BOOLEAN
+  mode: REPEATED
+  name: a11y_theme
+  type: RECORD

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
@@ -1535,3 +1535,19 @@ fields:
 - mode: NULLABLE
   name: user_pref_browser_urlbar_quicksuggest_data_collection_enabled
   type: STRING
+- mode: NULLABLE
+  name: scalar_a11y_hcm_foreground
+  type: INTEGER
+- mode: NULLABLE
+  name: scalar_a11y_hcm_background
+  type: INTEGER
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: BOOLEAN
+  mode: REPEATED
+  name: a11y_theme
+  type: RECORD


### PR DESCRIPTION
For migrating accessibility dashboards to Looker: https://mozilla-hub.atlassian.net/browse/DENG-52

Making the fields `a11y_theme`, `a11y_hcm_foreground` and `a11y_hcm_background` available in clients_daily