### PR TITLE
Allow to specify partition expiration in metadata

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -957,6 +957,7 @@ def _update_query_schema(
                 field=table.time_partitioning.field,
                 partition_type=table.time_partitioning.type_.lower(),
                 required=table.time_partitioning.require_partition_filter,
+                expiration=table.time_partitioning.expiration_ms,
             )
             click.echo(f"Partitioning metadata added to {metadata_file_path}")
 
@@ -1108,6 +1109,7 @@ def deploy(
                         require_partition_filter=(
                             metadata.bigquery.time_partitioning.require_partition_filter
                         ),
+                        expiration_ms=metadata.bigquery.time_partitioning.expiration_ms,
                     )
 
                 if metadata.bigquery and metadata.bigquery.clustering:

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -28,7 +28,15 @@ from ..dependency import get_dependency_graph
 from ..dryrun import SKIP, DryRun
 from ..format_sql.formatter import reformat
 from ..metadata import validate_metadata
-from ..metadata.parse_metadata import METADATA_FILE, DatasetMetadata, Metadata
+from ..metadata.parse_metadata import (
+    METADATA_FILE,
+    DatasetMetadata,
+    Metadata,
+    BigQueryMetadata,
+    PartitionMetadata,
+    ClusteringMetadata,
+    PartitionType,
+)
 from ..query_scheduling.dag_collection import DagCollection
 from ..query_scheduling.generate_airflow_dags import get_dags
 from ..run_query import run
@@ -163,6 +171,10 @@ def create(name, sql_dir, project_id, owner, init):
         description="Please provide a description for the query",
         owners=[owner],
         labels={"incremental": True},
+        bigquery=BigQueryMetadata(
+            time_partitioning=PartitionMetadata(field="", type=PartitionType.DAY),
+            clustering=ClusteringMetadata(fields=[]),
+        ),
     )
     metadata.write(metadata_file)
 

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -59,7 +59,8 @@ class PartitionMetadata:
 
     field: str
     type: PartitionType
-    require_partition_filter: bool = attr.ib(False)
+    require_partition_filter: bool = attr.ib(True)
+    expiration_ms: Optional[int] = attr.ib(None)
 
 
 @attr.s(auto_attribs=True)
@@ -310,7 +311,9 @@ class Metadata:
         """Return the bug ID of the data review bug in bugzilla."""
         return self.labels.get("review_bugs", None)
 
-    def set_bigquery_partitioning(self, field, partition_type, required):
+    def set_bigquery_partitioning(
+        self, field, partition_type, required, expiration=None
+    ):
         """Update the BigQuery partitioning metadata."""
         clustering = None
         if self.bigquery and self.bigquery.clustering:
@@ -321,6 +324,7 @@ class Metadata:
                 field=field,
                 type=PartitionType(partition_type),
                 require_partition_filter=required,
+                expiration_ms=expiration,
             ),
             clustering=clustering,
         )


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/2536 and https://github.com/mozilla/bigquery-etl/issues/2537

This adds support for `expiration_ms` to the metadata. We can already specify `require_partition_filter` (see https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_installs_v1/metadata.yaml#L15). When running `schema deploy` this partitioning information will also be updated in the source table.



Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
