### PR TITLE
Ignore comments when verifying compiled requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,8 @@ jobs:
             pip-compile --quiet --allow-unsafe --generate-hashes
             pip-compile --quiet --allow-unsafe --generate-hashes \
               java-requirements.in
-            git diff --exit-code requirements.txt java-requirements.txt
+            git diff --exit-code -G '^ *[^# ]' -- requirements.txt \
+              java-requirements.txt
   test-sql:
     docker: *docker
     steps:


### PR DESCRIPTION
[Dependabot is resolving dependencies with python 3.9+](https://github.com/mozilla/bigquery-etl/pull/2539/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552), and this will allow that to pass CI so long as the actual dependencies are the same for python 3.8