### PR TITLE
ROAD-163 Add live views for contextual-services pings

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services/quicksuggest_click_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services/quicksuggest_click_live/metadata.yaml
@@ -1,0 +1,9 @@
+---
+# yamllint disable rule:line-length
+friendly_name: Live Pings for `contextual-services/quicksuggest-click`
+description: |-
+  A live view of pings sent for the
+  `contextual-services/quicksuggest-click`
+  document type.
+
+  Clustering fields: `submission_timestamp`

--- a/sql/moz-fx-data-shared-prod/contextual_services/quicksuggest_click_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services/quicksuggest_click_live/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.contextual_services.quicksuggest_click_live`
+AS
+SELECT
+  * REPLACE (mozfun.norm.metadata(metadata) AS metadata)
+FROM
+  `moz-fx-data-shared-prod.contextual_services_live.quicksuggest_click_v1`

--- a/sql/moz-fx-data-shared-prod/contextual_services/quicksuggest_impression_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services/quicksuggest_impression_live/metadata.yaml
@@ -1,0 +1,15 @@
+---
+# yamllint disable rule:line-length
+friendly_name: Live Pings for `contextual-services/quicksuggest-impression`
+description: |-
+  A live view of pings sent for the
+  `contextual-services/quicksuggest-impression`
+  document type, but with search terms fields excluded.
+
+  Clustering fields: `submission_timestamp`
+labels:
+  authorized: true
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:contextual-services

--- a/sql/moz-fx-data-shared-prod/contextual_services/quicksuggest_impression_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services/quicksuggest_impression_live/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.contextual_services.quicksuggest_impression_live`
+AS
+SELECT
+  * EXCEPT (search_query, matched_keywords) REPLACE(mozfun.norm.metadata(metadata) AS metadata)
+FROM
+  `moz-fx-data-shared-prod.contextual_services_live.quicksuggest_impression_v1`

--- a/sql/moz-fx-data-shared-prod/contextual_services/topsites_click_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services/topsites_click_live/metadata.yaml
@@ -1,0 +1,9 @@
+---
+# yamllint disable rule:line-length
+friendly_name: Live Pings for `contextual-services/topsites-click`
+description: |-
+  A live view of pings sent for the
+  `contextual-services/topsites-click`
+  document type.
+
+  Clustering fields: `submission_timestamp`

--- a/sql/moz-fx-data-shared-prod/contextual_services/topsites_click_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services/topsites_click_live/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.contextual_services.topsites_click_live`
+AS
+SELECT
+  * REPLACE (mozfun.norm.metadata(metadata) AS metadata)
+FROM
+  `moz-fx-data-shared-prod.contextual_services_live.topsites_click_v1`

--- a/sql/moz-fx-data-shared-prod/contextual_services/topsites_impression_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services/topsites_impression_live/metadata.yaml
@@ -1,0 +1,9 @@
+---
+# yamllint disable rule:line-length
+friendly_name: Live Pings for `contextual-services/topsites-impression`
+description: |-
+  A live view of pings sent for the
+  `contextual-services/topsites-impression`
+  document type.
+
+  Clustering fields: `submission_timestamp`

--- a/sql/moz-fx-data-shared-prod/contextual_services/topsites_impression_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services/topsites_impression_live/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.contextual_services.topsites_impression_live`
+AS
+SELECT
+  * REPLACE (mozfun.norm.metadata(metadata) AS metadata)
+FROM
+  `moz-fx-data-shared-prod.contextual_services_live.topsites_impression_v1`


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/ROAD-163

All of the underlying live tables are already accessible to the
`contextual-services` except for quicksuggest impressions, so only one of these
views is defined with authorization.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
