### PR TITLE
Add user-agent to experimenter request

### DIFF
--- a/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
@@ -145,9 +145,9 @@ class ExperimentV6:
         converter = cattr.Converter()
         converter.register_structure_hook(
             datetime.datetime,
-            lambda num, _: pytz.utc.localize(
-                datetime.datetime.fromisoformat(num.replace("Z", "+00:00"))
-            ),
+            lambda num, _: datetime.datetime.fromisoformat(
+                num.replace("Z", "+00:00")
+            ).astimezone(pytz.utc),
         )
         return converter.structure(d, cls)
 


### PR DESCRIPTION
See https://github.com/mozilla/jetstream/issues/972

It's easier for the Experimenter folks to debug issues if they can see where requests from the API are coming from.

cc @jaredlockhart


