### PR TITLE
Derived dataset docs generation - refactor and support READMEs

### DIFF
--- a/bigquery_etl/docs/derived_datasets/generate_derived_dataset_docs.py
+++ b/bigquery_etl/docs/derived_datasets/generate_derived_dataset_docs.py
@@ -9,6 +9,7 @@ from bigquery_etl.dependency import extract_table_references
 
 VIEW_FILE = "view.sql"
 METADATA_FILE = "metadata.yaml"
+README_FILE = "README.md"
 NON_USER_FACING_DATASET_SUFFIXES = (
     "_derived",
     "_external",
@@ -28,6 +29,12 @@ def _get_metadata(table_path):
             except yaml.YAMLError as error:
                 print(error)
     return metadata
+
+
+def _get_readme_content(table_path):
+    readme_file = table_path / README_FILE
+    if readme_file.exists():
+        return readme_file.read_text()
 
 
 def _get_referenced_tables_from_view(table_path):
@@ -71,8 +78,11 @@ def _iter_table_markdown(table_paths, template):
                 "Metadata File"
             ] = f"{SOURCE_URL}/{str(table_path / METADATA_FILE)}"
 
+        readme_content = _get_readme_content(table_path)
+
         output = template.render(
             metadata=metadata,
+            readme_content=readme_content,
             table_name=table_path.name,
             source_urls=source_urls,
             referenced_tables=referenced_tables,
@@ -84,7 +94,7 @@ def _iter_table_markdown(table_paths, template):
 
 def generate_derived_dataset_docs(out_dir, project_dir):
     """Generate documentation for derived datasets."""
-    output_path = Path(out_dir) / "datasets"
+    output_path = Path(out_dir) / "mozdata"
     project_path = Path(project_dir)
 
     # get a list of all user-facing datasets

--- a/bigquery_etl/docs/derived_datasets/generate_derived_dataset_docs.py
+++ b/bigquery_etl/docs/derived_datasets/generate_derived_dataset_docs.py
@@ -1,6 +1,5 @@
 """Generate documentation for derived datasets."""
 
-import os
 from pathlib import Path
 
 import yaml
@@ -19,85 +18,99 @@ NON_USER_FACING_DATASET_SUFFIXES = (
 SOURCE_URL = "https://github.com/mozilla/bigquery-etl/blob/generated-sql"
 
 
+def _get_metadata(table_path):
+    metadata = {}
+    metadata_file = table_path / METADATA_FILE
+    if metadata_file.exists():
+        with open(metadata_file) as stream:
+            try:
+                metadata = yaml.safe_load(stream)
+            except yaml.YAMLError as error:
+                print(error)
+    return metadata
+
+
+def _get_referenced_tables_from_view(table_path):
+    referenced_tables = []
+    view_file = table_path / VIEW_FILE
+    if view_file.exists():
+        for referenced_table in extract_table_references(view_file.read_text()):
+            table_split = referenced_table.split(".")
+            if len(table_split) == 2:
+                # missing project ID, retrieve from file path
+                [dataset_id, table_id] = table_split
+                project_id = view_file.parent.parent.parent.name
+            elif len(table_split) == 3:
+                [project_id, dataset_id, table_id] = table_split
+            else:
+                continue
+
+            referenced_tables.append(
+                {
+                    "project_id": project_id,
+                    "dataset_id": dataset_id,
+                    "table_id": table_id,
+                }
+            )
+    return referenced_tables
+
+
+def _iter_table_markdown(table_paths, template):
+    for table_path in table_paths:
+        source_urls = {"Source Directory": f"{SOURCE_URL}/{str(table_path)}"}
+
+        referenced_tables = _get_referenced_tables_from_view(table_path)
+        if referenced_tables:
+            source_urls[
+                "View Definition"
+            ] = f"{SOURCE_URL}/{str(table_path / VIEW_FILE)}"
+
+        metadata = _get_metadata(table_path)
+        if metadata:
+            source_urls[
+                "Metadata File"
+            ] = f"{SOURCE_URL}/{str(table_path / METADATA_FILE)}"
+
+        output = template.render(
+            metadata=metadata,
+            table_name=table_path.name,
+            source_urls=source_urls,
+            referenced_tables=referenced_tables,
+            project_url=f"{SOURCE_URL}/sql",
+        )
+
+        yield output
+
+
 def generate_derived_dataset_docs(out_dir, project_dir):
     """Generate documentation for derived datasets."""
-    project_doc_dir = Path(out_dir) / "mozdata"
+    output_path = Path(out_dir) / "datasets"
+    project_path = Path(project_dir)
 
     # get a list of all user-facing datasets
-    data_sets = [
-        item
-        for item in os.listdir(project_dir)
-        if os.path.isdir(os.path.join(project_dir, item))
-        and all(name not in item for name in NON_USER_FACING_DATASET_SUFFIXES)
-    ]
+    dataset_paths = sorted(
+        [
+            dataset_path
+            for dataset_path in project_path.iterdir()
+            if dataset_path.is_dir()
+            and all(
+                suffix not in str(dataset_path)
+                for suffix in NON_USER_FACING_DATASET_SUFFIXES
+            )
+        ]
+    )
 
-    for table in data_sets:
-        output = []
-        source_urls = {}
-        with open(project_doc_dir / f"{table}.md", "w") as dataset_doc:
+    for dataset_path in dataset_paths:
+        table_paths = sorted([path for path in dataset_path.iterdir() if path.is_dir()])
+
+        file_loader = FileSystemLoader("bigquery_etl/docs/derived_datasets/templates")
+        env = Environment(loader=file_loader)
+        template = env.get_template("table.md")
+
+        with open(output_path / f"{dataset_path.name}.md", "w") as dataset_doc:
             # Manually set title to prevent Mkdocs from removing
             # underscores and capitalizing file names
             # https://github.com/mkdocs/mkdocs/issues/1915#issuecomment-561311801
-            dataset_doc.write(f"---\ntitle: {table}\n---\n\n")
+            dataset_doc.write(f"---\ntitle: {dataset_path.name}\n---\n\n")
 
-            for root, dirs, files in os.walk(Path(project_dir) / table):
-                # show views in an alphabetical order
-                dirs.sort()
-                if dirs:
-                    continue
-                dataset_name = root.split("/")[-1]
-                source_urls["Source Directory"] = f"{SOURCE_URL}/{root}"
-                referenced_tables = []
-
-                metadata = {}
-                if METADATA_FILE in files:
-                    source_urls[
-                        "Metadata File"
-                    ] = f"{SOURCE_URL}/{root}/{METADATA_FILE}"
-                    with open(os.path.join(root, METADATA_FILE)) as stream:
-                        try:
-                            metadata = yaml.safe_load(stream)
-                        except yaml.YAMLError as error:
-                            print(error)
-                if VIEW_FILE in files:
-                    source_urls["View Definition"] = f"{SOURCE_URL}/{root}/{VIEW_FILE}"
-                    view_file = Path(os.path.join(root, VIEW_FILE))
-                    referenced_tables = []
-
-                    for referenced_table in extract_table_references(
-                        view_file.read_text()
-                    ):
-                        table_split = referenced_table.split(".")
-                        if len(table_split) == 2:
-                            # missing project ID, retrieve from file path
-                            [dataset_id, table_id] = table_split
-                            project_id = view_file.parent.parent.parent.name
-                        elif len(table_split) == 3:
-                            [project_id, dataset_id, table_id] = table_split
-                        else:
-                            continue
-
-                        referenced_tables.append(
-                            {
-                                "project_id": project_id,
-                                "dataset_id": dataset_id,
-                                "table_id": table_id,
-                            }
-                        )
-
-                file_loader = FileSystemLoader(
-                    "bigquery_etl/docs/derived_datasets/templates"
-                )
-                # Set up a new template environment
-                env = Environment(loader=file_loader)
-                # Create template with the markdown source text
-                template = env.get_template("table.md")
-
-                output = template.render(
-                    metadata=metadata,
-                    table_name=dataset_name,
-                    source_urls=source_urls,
-                    referenced_tables=referenced_tables,
-                    project_url=f"{SOURCE_URL}/sql",
-                )
-                dataset_doc.write(output)
+            dataset_doc.write("".join(_iter_table_markdown(table_paths, template)))

--- a/bigquery_etl/docs/derived_datasets/templates/table.md
+++ b/bigquery_etl/docs/derived_datasets/templates/table.md
@@ -13,15 +13,19 @@
 {% endif -%}
 
 {% if metadata.owners -%}
-* Owners: 
+* Owners:
 {% for email in metadata.owners -%}
 {% filter indent(width=4) %}
-- [{{email}}](mailto:{{email}}) 
+- [{{email}}](mailto:{{email}})
 {% endfilter %}
 {%- endfor %}
 {% endif %}
 
+{% if readme_content -%}
 
+{{ readme_content }}
+
+{% endif %}
 {% if referenced_tables -%}
 <table>
 <caption>Referenced Tables</caption>
@@ -36,7 +40,7 @@
   		<td><a href={{ project_url + "/" + table.project_id+ "/" + table.dataset_id }}>{{ table.dataset_id }}</a></td>
         <td><a href={{ project_url + "/" + table.project_id + "/" + table.dataset_id + "/" + table.table_id }}>{{ table.table_id }}</a></td>
         </tr>
-{%- endfor %}	
+{%- endfor %}
 </table>
 {% endif %}
 


### PR DESCRIPTION
See title; added some helper functions, switched some references to `Path` objects and supported injecting `README` content. 

Here's a diff of the generated docs before and after the factor + readme support: [Gist](https://gist.github.com/ANich/16ea615c772a6dbac73071236bd42d23). 

The main differences in the diff are:
1. Some View+Metadata links have been removed, they were previously pointing to the wrong files because of some leftover state on iterations. Example L442-443:
```
-[Source Directory](https://github.com/mozilla/bigquery-etl/blob/generated-sql/sql/moz-fx-data-shared-prod/mozilla_vpn/vat_rates)  | [View Definition](https://github.com/mozilla/bigquery-etl/blob/generated-sql/sql/moz-fx-data-shared-prod/mozilla_vpn/vat_rates/view.sql)  | [Metadata File](https://github.com/mozilla/bigquery-etl/blob/generated-sql/sql/moz-fx-data-shared-prod/mozilla_vpn/events_unnested/metadata.yaml) 
+[Source Directory](https://github.com/mozilla/bigquery-etl/blob/generated-sql/sql/moz-fx-data-shared-prod/mozilla_vpn/vat_rates)  | [View Definition](https://github.com/mozilla/bigquery-etl/blob/generated-sql/sql/moz-fx-data-shared-prod/mozilla_vpn/vat_rates/view.sql) 
```
2. Datasets with no views don't have a header or source directory - this is temporary and I'll fix that when I add support for `dataset_metadata.yaml` 
3. Added a README for `search_clients_engines_sources_daily` 🙂

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
