### PR TITLE
adding the date check for glean products

### DIFF
--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -186,18 +186,21 @@ def main():
             "filter_version": True,
             "num_versions_to_keep": 3,
             "total_users": 10,
+            "minimum_client_count": 10,
         },
         "firefox_desktop_glam_beta": {
             "build_date_udf": "mozfun.glam.build_hour_to_datetime",
             "filter_version": True,
             "num_versions_to_keep": 3,
             "total_users": 10,
+            "minimum_client_count": 10,
         },
         "firefox_desktop_glam_release": {
             "build_date_udf": "mozfun.glam.build_hour_to_datetime",
             "filter_version": True,
             "num_versions_to_keep": 3,
             "total_users": 10,
+            "minimum_client_count": 10,
         },
     }
     validate(instance=config, schema=config_schema)

--- a/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
@@ -17,6 +17,7 @@ WITH extracted AS (
   WHERE
     DATE(submission_timestamp) = {{ submission_date }}
     AND client_info.client_id IS NOT NULL
+    AND SAFE_CAST(client_info.app_build AS DATE) IS NOT NULL
 ),
 histograms AS (
   SELECT

--- a/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
@@ -18,6 +18,7 @@ WITH extracted AS (
   WHERE
     DATE(submission_timestamp) = {{ submission_date }}
     AND client_info.client_id IS NOT NULL
+    AND SAFE_CAST(client_info.app_build AS DATE) IS NOT NULL
 ),
 unlabeled_metrics AS (
   SELECT

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_histogram_aggregates_metrics_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_histogram_aggregates_metrics_v1/query.sql
@@ -17,6 +17,7 @@ WITH extracted AS (
   WHERE
     DATE(submission_timestamp) = @submission_date
     AND client_info.client_id IS NOT NULL
+    AND SAFE_CAST(client_info.app_build AS DATE) IS NOT NULL
 ),
 histograms AS (
   SELECT

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_baseline_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_baseline_v1/query.sql
@@ -17,6 +17,7 @@ WITH extracted AS (
   WHERE
     DATE(submission_timestamp) = @submission_date
     AND client_info.client_id IS NOT NULL
+    AND SAFE_CAST(client_info.app_build AS DATE) IS NOT NULL
 ),
 unlabeled_metrics AS (
   SELECT
@@ -28,6 +29,76 @@ unlabeled_metrics AS (
     app_build_id,
     channel,
     ARRAY<STRUCT<metric STRING, metric_type STRING, key STRING, agg_type STRING, value FLOAT64>>[
+      (
+        'browser_engagement_active_ticks',
+        'counter',
+        '',
+        'avg',
+        avg(CAST(metrics.counter.browser_engagement_active_ticks AS INT64))
+      ),
+      (
+        'browser_engagement_active_ticks',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.browser_engagement_active_ticks) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'browser_engagement_active_ticks',
+        'counter',
+        '',
+        'max',
+        max(CAST(metrics.counter.browser_engagement_active_ticks AS INT64))
+      ),
+      (
+        'browser_engagement_active_ticks',
+        'counter',
+        '',
+        'min',
+        min(CAST(metrics.counter.browser_engagement_active_ticks AS INT64))
+      ),
+      (
+        'browser_engagement_active_ticks',
+        'counter',
+        '',
+        'sum',
+        sum(CAST(metrics.counter.browser_engagement_active_ticks AS INT64))
+      ),
+      (
+        'browser_engagement_uri_count',
+        'counter',
+        '',
+        'avg',
+        avg(CAST(metrics.counter.browser_engagement_uri_count AS INT64))
+      ),
+      (
+        'browser_engagement_uri_count',
+        'counter',
+        '',
+        'count',
+        IF(MIN(metrics.counter.browser_engagement_uri_count) IS NULL, NULL, COUNT(*))
+      ),
+      (
+        'browser_engagement_uri_count',
+        'counter',
+        '',
+        'max',
+        max(CAST(metrics.counter.browser_engagement_uri_count AS INT64))
+      ),
+      (
+        'browser_engagement_uri_count',
+        'counter',
+        '',
+        'min',
+        min(CAST(metrics.counter.browser_engagement_uri_count AS INT64))
+      ),
+      (
+        'browser_engagement_uri_count',
+        'counter',
+        '',
+        'sum',
+        sum(CAST(metrics.counter.browser_engagement_uri_count AS INT64))
+      ),
       (
         'glean_baseline_duration',
         'timespan',

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_deletion_request_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_deletion_request_v1/query.sql
@@ -17,6 +17,7 @@ WITH extracted AS (
   WHERE
     DATE(submission_timestamp) = @submission_date
     AND client_info.client_id IS NOT NULL
+    AND SAFE_CAST(client_info.app_build AS DATE) IS NOT NULL
 ),
 unlabeled_metrics AS (
   SELECT

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_events_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_events_v1/query.sql
@@ -17,6 +17,7 @@ WITH extracted AS (
   WHERE
     DATE(submission_timestamp) = @submission_date
     AND client_info.client_id IS NOT NULL
+    AND SAFE_CAST(client_info.app_build AS DATE) IS NOT NULL
 ),
 unlabeled_metrics AS (
   SELECT

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_fog_validation_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_fog_validation_v1/query.sql
@@ -17,6 +17,7 @@ WITH extracted AS (
   WHERE
     DATE(submission_timestamp) = @submission_date
     AND client_info.client_id IS NOT NULL
+    AND SAFE_CAST(client_info.app_build AS DATE) IS NOT NULL
 ),
 unlabeled_metrics AS (
   SELECT

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_metrics_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_metrics_v1/query.sql
@@ -17,6 +17,7 @@ WITH extracted AS (
   WHERE
     DATE(submission_timestamp) = @submission_date
     AND client_info.client_id IS NOT NULL
+    AND SAFE_CAST(client_info.app_build AS DATE) IS NOT NULL
 ),
 unlabeled_metrics AS (
   SELECT

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_bucket_counts_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_bucket_counts_v1/query.sql
@@ -33,6 +33,18 @@ all_combos AS (
   CROSS JOIN
     static_combos combo
 ),
+build_ids AS (
+  SELECT
+    app_build_id,
+    channel,
+  FROM
+    all_combos
+  GROUP BY
+    1,
+    2
+  HAVING
+    COUNT(DISTINCT client_id) > 10
+),
 normalized_histograms AS (
   SELECT
     ping_type,
@@ -70,6 +82,10 @@ unnested AS (
     normalized_histograms,
     UNNEST(histogram_aggregates) AS histogram_aggregates,
     UNNEST(aggregates) AS aggregates
+  INNER JOIN
+    build_ids
+  USING
+    (app_build_id, channel)
 ),
 -- Find information that can be used to construct the bucket range. Most of the
 -- distributions follow a bucketing rule of 8*log2(n). This doesn't apply to the
@@ -82,6 +98,14 @@ distribution_metadata AS (
   FROM
     UNNEST(
       [
+        STRUCT(
+          "custom_distribution" AS metric_type,
+          "search_terms_group_size_distribution" AS metric,
+          1 AS range_min,
+          4 AS range_max,
+          5 AS bucket_count,
+          "linear" AS histogram_type
+        ),
         STRUCT(
           "custom_distribution" AS metric_type,
           "geckoview_document_site_origins" AS metric,

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_bucket_counts_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_bucket_counts_v1/query.sql
@@ -138,6 +138,18 @@ bucketed_booleans AS (
   FROM
     all_combos
 ),
+build_ids AS (
+  SELECT
+    app_build_id,
+    channel,
+  FROM
+    all_combos
+  GROUP BY
+    1,
+    2
+  HAVING
+    COUNT(DISTINCT client_id) > 10
+),
 log_min_max AS (
   SELECT
     metric,
@@ -237,6 +249,16 @@ booleans_and_scalars AS (
     bucket
   FROM
     bucketed_scalars
+),
+valid_booleans_scalars AS (
+  SELECT
+    *
+  FROM
+    booleans_and_scalars
+  INNER JOIN
+    build_ids
+  USING
+    (app_build_id, channel)
 )
 SELECT
   ping_type,
@@ -256,7 +278,7 @@ SELECT
   -- we could rely on count(*) because there is one row per client and bucket
   COUNT(DISTINCT client_id) AS count
 FROM
-  booleans_and_scalars
+  valid_booleans_scalars
 GROUP BY
   ping_type,
   os,


### PR DESCRIPTION
This commit has 2 changes: 
1. The firefox_desktop_glam (glean) failed with the below error : 
Error in query string: Error processing job 'moz-fx-data-glam-prod- fca7:bqjob_r5dc049a3ef61f64b_0000017d7b8d6f6b_1': Failed to parse input string

[Link to error ](https://workflow.telemetry.mozilla.org/log?dag_id=glam_firefox_desktop&task_id=query_firefox_desktop_glam_release__clients_scalar_aggregates_v1&execution_date=2021-12-01T02%3A00%3A00%2B00%3A00
)
It was decided to filter out pings that provide an app_build that doesn't have a valid date 


2. Add minimum_client_count filter for firefox_desktop product (value = 10 for time being and should be corrected in the future)
