### PR TITLE
Firefox desktop date check

### DIFF
--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_beta__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_beta__view_clients_daily_histogram_aggregates_v1.sql
@@ -8,6 +8,7 @@ WITH extracted AS (
     `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_histogram_aggregates_v1
   WHERE
     channel = 'beta'
+    AND SAFE_CAST(app_build_id AS DATE) IS NOT NULL
 )
 SELECT
   * EXCEPT (app_build_id, channel),

--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_beta__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_beta__view_clients_daily_scalar_aggregates_v1.sql
@@ -8,6 +8,7 @@ WITH extracted AS (
     `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_scalar_aggregates_v1
   WHERE
     channel = 'beta'
+    AND SAFE_CAST(app_build_id AS DATE) IS NOT NULL
 )
 SELECT
   * EXCEPT (app_build_id, channel),

--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
@@ -8,6 +8,7 @@ WITH extracted AS (
     `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_histogram_aggregates_v1
   WHERE
     channel = 'nightly'
+    AND SAFE_CAST(app_build_id AS DATE) IS NOT NULL
 )
 SELECT
   * EXCEPT (app_build_id, channel),

--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
@@ -8,6 +8,7 @@ WITH extracted AS (
     `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_scalar_aggregates_v1
   WHERE
     channel = 'nightly'
+    AND SAFE_CAST(app_build_id AS DATE) IS NOT NULL
 )
 SELECT
   * EXCEPT (app_build_id, channel),

--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_release__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_release__view_clients_daily_histogram_aggregates_v1.sql
@@ -8,6 +8,7 @@ WITH extracted AS (
     `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_histogram_aggregates_v1
   WHERE
     channel = 'release'
+    AND SAFE_CAST(app_build_id AS DATE) IS NOT NULL
 )
 SELECT
   * EXCEPT (app_build_id, channel),

--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_release__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_release__view_clients_daily_scalar_aggregates_v1.sql
@@ -8,6 +8,7 @@ WITH extracted AS (
     `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_scalar_aggregates_v1
   WHERE
     channel = 'release'
+    AND SAFE_CAST(app_build_id AS DATE) IS NOT NULL
 )
 SELECT
   * EXCEPT (app_build_id, channel),


### PR DESCRIPTION
This commit has 2 changes:

    The firefox_desktop_glam (glean) failed with the below error :
    Error in query string: Error processing job 'moz-fx-data-glam-prod- fca7:bqjob_r5dc049a3ef61f64b_0000017d7b8d6f6b_1': Failed to parse input string

Link to error
It was decided to filter out pings that provide an app_build that doesn't have a valid date

    Add minimum_client_count filter for firefox_desktop product (value = 10 for time being and should be corrected in the future)
