### PR TITLE
Lowercase and trim in suggest_impressions_sanitized_v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/query.sql
@@ -17,7 +17,9 @@ WITH impressions AS (
     -- but we reapply truncation to be explicit about granularity.
     TIMESTAMP_TRUNC(submission_timestamp, SECOND) AS submission_timestamp,
     request_id,
-    search_query AS telemetry_query,
+    -- Firefox allows casing and whitespace differences when matching to the
+    -- list of suggestions in RemoteSettings.
+    LTRIM(LOWER(search_query)) AS telemetry_query,
     advertiser,
     block_id,
     context_id,
@@ -43,7 +45,7 @@ merino_logs AS (
   SELECT
     TIMESTAMP_TRUNC(timestamp, SECOND) AS merino_timestamp,
     jsonPayload.fields.rid AS request_id,
-    jsonPayload.fields.query,
+    LTRIM(LOWER(jsonPayload.fields.query)) AS query,
     -- Merino currently injects 'none' for missing geo fields.
     NULLIF(jsonPayload.fields.country, 'none') AS merino_country,
     NULLIF(jsonPayload.fields.region, 'none') AS merino_region,

--- a/tests/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/test_single_day/moz-fx-data-shared-prod.contextual_services_stable.quicksuggest_impression_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/test_single_day/moz-fx-data-shared-prod.contextual_services_stable.quicksuggest_impression_v1.yaml
@@ -20,7 +20,7 @@
   version: "94.0.2"
 - submission_timestamp: "2021-01-01 12:03:00"
   request_id: null
-  search_query: "new gui"
+  search_query: " NEW GUI"
   advertiser: awesome guitar store
   block_id: bid2
   context_id: cid2

--- a/tests/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/test_single_day/suggest-searches-prod-a30f.logs.stdout.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/test_single_day/suggest-searches-prod-a30f.logs.stdout.yaml
@@ -3,7 +3,7 @@
     type: web.suggest.request
     fields:
       rid: rid1
-      query: "shoes for "
+      query: " Shoes for "
       country: US
       region: none
       dma: none


### PR DESCRIPTION
This better matches the current client behavior for matching.
We're currently getting `<disallowed>` in results from Merino and mixed case in results from telemetry.
I don't think preserving the casing or leading whitespace has analytical value, and it makes the results harder to work with.

Note that we'll need to also make these changes in cloudops-infra to have them take effect.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
