### PR TITLE
Quick fix for null metadata descriptions

### DIFF
--- a/bigquery_etl/docs/derived_datasets/templates/table.md
+++ b/bigquery_etl/docs/derived_datasets/templates/table.md
@@ -7,7 +7,7 @@
 
 `{{ qualified_table_name }}`
 
-{{ metadata.description | e }}
+{{ metadata.description or "" | e }}
 
 {% if metadata.labels -%}
 {% if metadata.labels.schedule -%}


### PR DESCRIPTION
Fill absent metadata with empty string. Somehow didn't show up in my local instance on an earlier PR

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
