### PR TITLE
ROAD-167 Update aggregates to use suggest_impression_sanitized_v2

### DIFF
--- a/dags/bqetl_search_terms_daily.py
+++ b/dags/bqetl_search_terms_daily.py
@@ -56,6 +56,7 @@ with DAG(
         ],
         date_partition_parameter="submission_date",
         depends_on_past=False,
+        arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
         dag=dag,
     )
 
@@ -109,6 +110,14 @@ with DAG(
         dag=dag,
     )
 
+    search_terms_derived__adm_weekly_aggregates__v1.set_upstream(
+        search_terms_derived__suggest_impression_sanitized__v2
+    )
+
+    search_terms_derived__aggregated_search_terms_daily__v1.set_upstream(
+        search_terms_derived__suggest_impression_sanitized__v2
+    )
+
     wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
@@ -117,14 +126,6 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
-    )
-
-    search_terms_derived__adm_weekly_aggregates__v1.set_upstream(
-        wait_for_copy_deduplicate_all
-    )
-
-    search_terms_derived__aggregated_search_terms_daily__v1.set_upstream(
-        wait_for_copy_deduplicate_all
     )
 
     search_terms_derived__suggest_impression_sanitized__v1.set_upstream(

--- a/sql/moz-fx-data-shared-prod/search_terms/suggest_impression_sanitized/view.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms/suggest_impression_sanitized/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   * REPLACE (mozfun.norm.metadata(metadata) AS metadata)
 FROM
-  `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v1`
+  `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v2`

--- a/sql/moz-fx-data-shared-prod/search_terms/suggest_impression_sanitized/view.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms/suggest_impression_sanitized/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   * REPLACE (mozfun.norm.metadata(metadata) AS metadata)
 FROM
-  `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v2`
+  `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v1`

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/metadata.yaml
@@ -19,5 +19,4 @@ bigquery:
     type: day
 scheduling:
   dag_name: bqetl_search_terms_daily
-  referenced_tables: [['moz-fx-data-shared-prod', 'contextual_services_stable',
-                       'quicksuggest_impression_v1']]
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_weekly_aggregates_v1/query.sql
@@ -1,16 +1,17 @@
 SELECT
+  DATE_SUB(@submission_date, INTERVAL 6 DAY) AS start_date,
   @submission_date AS submission_date,
-  LOWER(search_query) AS query,
+  sanitized_query AS query,
   block_id,
   COUNT(*) AS impressions,
   COUNTIF(is_clicked) AS clicks,
 FROM
-  search_terms.suggest_impression_sanitized
+  search_terms_derived.suggest_impression_sanitized_v2
 WHERE
   DATE(submission_timestamp)
   BETWEEN DATE_SUB(@submission_date, INTERVAL 6 DAY)
   AND @submission_date
-  AND LENGTH(search_query) > 0
+  AND LENGTH(sanitized_query) > 0
   AND normalized_channel = 'release'
 GROUP BY
   query,

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/aggregated_search_terms_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/aggregated_search_terms_daily_v1/query.sql
@@ -1,11 +1,11 @@
 SELECT
   DATE(submission_timestamp) AS submission_date,
-  LOWER(search_query) AS search_terms,
+  sanitized_query AS search_terms,
   COUNT(*) AS impressions,
   COUNTIF(is_clicked) AS clicks,
   COUNT(DISTINCT context_id) AS client_days
 FROM
-  `moz-fx-data-shared-prod.contextual_services_stable.quicksuggest_impression_v1`
+  search_terms_derived.suggest_impression_sanitized_v2
 WHERE
   DATE(submission_timestamp) = @submission_date
 GROUP BY


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/ROAD-167

The Jira ticket discusses just updating the `adm_weekly_aggregates` to include
queries sent through Merino, but the scope of this PR is a bit wider, also
updating the list of top daily queries to include Merino.

Note that suggest_impression_sanitized_v2 pulls in both search terms sent
through telemetry and through the Merino pathway, so this should be safe to
merge next week even though we do not have queries flowing through Merino in
release at this point.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
