### PR TITLE
Require downloading Java dependencies as part of setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd bigquery-etl
 venv/bin/pre-commit install
 ```
 
-4. Optionally, download java dependencies
+4. Download java dependencies
 ```bash
 mvn dependency:copy-dependencies
 venv/bin/pip-sync requirements.txt java-requirements.txt


### PR DESCRIPTION
Downloading JAVA is now required in many places in our repo, such as generating docs, running dry-run, etc. I think it's time that we remove the "optionally" part from this step instruction.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated
