### PR TITLE
Allow stripe events import to succeed when schema changes

### DIFF
--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -536,6 +536,25 @@ with DAG(
         retry_delay=datetime.timedelta(seconds=300),
     )
 
+    stripe_external__events_schema_check__v1 = gke_command(
+        task_id="stripe_external__events_schema_check__v1",
+        command=[
+            "python",
+            "sql/moz-fx-data-shared-prod/stripe_external/events_schema_check_v1/query.py",
+        ]
+        + [
+            "--date={{ ds }}",
+            "--api-key={{ var.value.stripe_api_key }}",
+            "--format-resources",
+            "--strict-schema",
+            "--quiet",
+        ],
+        docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
+        owner="dthorn@mozilla.com",
+        email=["dthorn@mozilla.com", "telemetry-alerts@mozilla.com"],
+        retry_delay=datetime.timedelta(seconds=300),
+    )
+
     stripe_external__invoices__v1 = bigquery_etl_query(
         task_id="stripe_external__invoices__v1",
         destination_table="invoices_v1",

--- a/sql/moz-fx-data-shared-prod/stripe_external/events_schema_check_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/events_schema_check_v1/metadata.yaml
@@ -1,0 +1,18 @@
+---
+friendly_name: Stripe Events Schema Check
+description: >
+  Check for unexpected fields in events from the Stripe API.
+owners:
+  - dthorn@mozilla.com
+labels:
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_subplat
+  retry_delay: 5m
+  arguments:
+    - --date={{ ds }}
+    - --api-key={{ var.value.stripe_api_key }}
+    - --format-resources
+    - --strict-schema
+    - --quiet

--- a/sql/moz-fx-data-shared-prod/stripe_external/events_schema_check_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/stripe_external/events_schema_check_v1/query.py
@@ -1,0 +1,6 @@
+"""Import Stripe events from the Stripe API."""
+
+from bigquery_etl.stripe import stripe_import
+
+if __name__ == "__main__":
+    stripe_import()


### PR DESCRIPTION
fixes #2205

this splits out the part where stripe throws an error on new fields into a separate job. It doesn't re-use the data from the stripe API because we don't want to preserve new fields anywhere unless they have been approved, lest they contain private information.