### PR TITLE
Show generated SQL diff in PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
     steps:
       - checkout
       - *restore_venv_cache
+      - *build
       - run:
           name: Verify that SQL is correctly formatted
           command: |
@@ -446,6 +447,55 @@ jobs:
           condition: *deploy-condition
           steps:
             - gcp-gcr/push-image: *private-image
+  generate-diff:
+    docker: *docker
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - *restore_venv_cache
+      - *build
+      - *restore_mvn_cache
+      - *java_deps
+      - run:
+          name: Generate SQL content diff
+          command: |
+            # compare a branch against the main branch,
+            # or skip if we're already on the main branch
+            if [[ "$CIRCLE_BRANCH" == "main" ]]; then
+              circleci-agent step halt
+            fi
+            git clone --single-branch --branch main \
+              git@github.com:mozilla/bigquery-etl \
+              bigquery-etl-main
+
+            cd bigquery-etl-main
+            pip install -r requirements.txt
+            pip install -r java-requirements.txt
+            mvn dependency:copy-dependencies
+            ./script/generate_sql \
+              --target-project moz-fx-data-shared-prod
+
+            cd ..
+            diff -bur --no-dereference \
+              bigquery-etl-main/sql/ /tmp/workspace/generated-sql/sql/ \
+              > /tmp/workspace/generated-sql/sql.diff || true
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - generated-sql
+  post-diff:
+    docker:
+      - image: circleci/node:8.10.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: npm i circle-github-bot
+      - run: .circleci/post-diff.js
+      - store_artifacts:
+          path: /tmp/integration
+          destination: /app/integration
   manual-trigger-required-for-fork:
     docker: *docker
     steps:
@@ -497,6 +547,12 @@ workflows:
       - validate-docs
       - validate-views
       - generate-sql
+      - generate-diff:
+          requires:
+            - generate-sql
+      - post-diff:
+          requires:
+            - generate-diff
       - docs:
           requires:
             - generate-sql

--- a/.circleci/post-diff.js
+++ b/.circleci/post-diff.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// A script for posting the generated-sql diff to Github from CircleCI. 
+// This requires GH_AUTH_TOKEN to be set up, along-side CircleCI specific 
+// variables. See the source at [1] for more details.
+// https://github.com/themadcreator/circle-github-bot/blob/master/src/index.ts
+
+const fs = require("fs");
+const bot = require("circle-github-bot").create();
+
+function diff() {
+    let root = "/tmp/workspace/generated-sql/";
+    let diff_file = "sql.diff";
+    let diff_content = fs.readFileSync(root + "/" + diff_file, "utf8");
+
+    var body = "No content detected."
+    if (diff_content) {
+        body = `<details>
+<summary>Click to expand!</summary>
+
+\`\`\`diff
+${diff_content}
+\`\`\`
+
+</details>
+`
+    }
+    var content = `#### \`${diff_file}\`
+${body}
+`;
+    return content;
+}
+
+bot.comment(process.env.GH_AUTH_TOKEN, `
+### Integration report for "${bot.env.commitMessage}"
+${diff()}
+`);


### PR DESCRIPTION
For https://github.com/mozilla/bigquery-etl/issues/2313

This adds a bot to the CI that will compare generated and static SQL to the `main` branch of this repository whenever a PR is opened. This hopefully makes it easier for reviewers to reason about changes made to generated SQL.

An example of what the diff looks like is shown below.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
