### PR TITLE
Updated owner of DAGs as per tags google sheet

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2,11 +2,11 @@
 bqetl_error_aggregates:
   schedule_interval: 3h
   default_args:
-    owner: wlachance@mozilla.com
+    owner: wkahngreene@mozilla.com
     email:
       [
         "telemetry-alerts@mozilla.com",
-        "wlachance@mozilla.com",
+        "wkahngreene@mozilla.com",
       ]
     start_date: "2019-11-01"
     retries: 1
@@ -80,9 +80,13 @@ bqetl_core:
 bqetl_nondesktop:
   schedule_interval: 0 3 * * *
   default_args:
-    owner: jklukas@mozilla.com
+    owner: mgorlick@mozilla.com
     start_date: "2019-07-25"
-    email: ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"]
+    email: [
+      "telemetry-alerts@mozilla.com",
+      "jklukas@mozilla.com",
+      "mgorlick@mozilla.com"
+    ]
     retries: 1
     retry_delay: 5m
   tags:

--- a/dags/bqetl_error_aggregates.py
+++ b/dags/bqetl_error_aggregates.py
@@ -12,15 +12,15 @@ Built from bigquery-etl repo, [`dags/bqetl_error_aggregates.py`](https://github.
 
 #### Owner
 
-wlachance@mozilla.com
+wkahngreene@mozilla.com
 """
 
 
 default_args = {
-    "owner": "wlachance@mozilla.com",
+    "owner": "wkahngreene@mozilla.com",
     "start_date": datetime.datetime(2019, 11, 1, 0, 0),
     "end_date": None,
-    "email": ["telemetry-alerts@mozilla.com", "wlachance@mozilla.com"],
+    "email": ["telemetry-alerts@mozilla.com", "wkahngreene@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1200),
     "email_on_failure": True,
@@ -44,7 +44,11 @@ with DAG(
         dataset_id="telemetry_derived",
         project_id="moz-fx-data-shared-prod",
         owner="wlachance@mozilla.com",
-        email=["telemetry-alerts@mozilla.com", "wlachance@mozilla.com"],
+        email=[
+            "telemetry-alerts@mozilla.com",
+            "wkahngreene@mozilla.com",
+            "wlachance@mozilla.com",
+        ],
         date_partition_parameter="submission_date",
         depends_on_past=False,
         dag=dag,

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -12,15 +12,19 @@ Built from bigquery-etl repo, [`dags/bqetl_nondesktop.py`](https://github.com/mo
 
 #### Owner
 
-jklukas@mozilla.com
+mgorlick@mozilla.com
 """
 
 
 default_args = {
-    "owner": "jklukas@mozilla.com",
+    "owner": "mgorlick@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25, 0, 0),
     "end_date": None,
-    "email": ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
+    "email": [
+        "telemetry-alerts@mozilla.com",
+        "jklukas@mozilla.com",
+        "mgorlick@mozilla.com",
+    ],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=300),
     "email_on_failure": True,
@@ -44,7 +48,11 @@ with DAG(
         dataset_id="telemetry_derived",
         project_id="moz-fx-data-shared-prod",
         owner="jklukas@mozilla.com",
-        email=["jklukas@mozilla.com", "telemetry-alerts@mozilla.com"],
+        email=[
+            "jklukas@mozilla.com",
+            "mgorlick@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
         date_partition_parameter="submission_date",
         depends_on_past=False,
         dag=dag,
@@ -68,7 +76,11 @@ with DAG(
         dataset_id="telemetry_derived",
         project_id="moz-fx-data-shared-prod",
         owner="jklukas@mozilla.com",
-        email=["jklukas@mozilla.com", "telemetry-alerts@mozilla.com"],
+        email=[
+            "jklukas@mozilla.com",
+            "mgorlick@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
         date_partition_parameter="submission_date",
         depends_on_past=False,
         dag=dag,
@@ -80,7 +92,11 @@ with DAG(
         dataset_id="telemetry_derived",
         project_id="moz-fx-data-shared-prod",
         owner="jklukas@mozilla.com",
-        email=["jklukas@mozilla.com", "telemetry-alerts@mozilla.com"],
+        email=[
+            "jklukas@mozilla.com",
+            "mgorlick@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
         date_partition_parameter=None,
         depends_on_past=False,
         dag=dag,


### PR DESCRIPTION
# Updated owner of DAGs as per tags google sheet

When collecting a list of Airflow tags we identified that some DAG owners were no longer at Mozilla. This PR updates out of date owners.

Airflow Tags Google Sheet: https://docs.google.com/spreadsheets/d/1WXo5_d8j_KfGzT07ay3gC2zAfnhRHzxoZDlwcThNvf0/edit#gid=0