### PR TITLE
adding 2m sleep to the export task for allowing it to complete

### DIFF
--- a/script/glam/export_csv
+++ b/script/glam/export_csv
@@ -25,4 +25,5 @@ bq extract --destination_format CSV --noprint_header \
 bq extract --destination_format CSV --noprint_header \
     "${src_project}:${dataset}.${product}__extract_sample_counts_v1" \
     "$bucket/glam-extract-${product}-sample-counts.csv"
-    
+
+sleep 120


### PR DESCRIPTION
The glam fenix imports are failing with error 'Dependencies not met'

https://workflow.telemetry.mozilla.org/log?dag_id=glam_fenix&task_id=glam_fenix_import_glean_counts&execution_date=2021-12-10T02%3A00%3A00%2B00%3A00

The error is complaining about the upstream task 'export_org_mozilla_fenix_glam_beta'

Example:
The task starts at time 2021-12-11 02:18:35,380,

But the dependent task finishes afterward: at the time [2021-12-11 02:19:24,249]