### PR TITLE
Added schemas to derived dataset docs

### DIFF
--- a/bigquery_etl/docs/derived_datasets/templates/table.md
+++ b/bigquery_etl/docs/derived_datasets/templates/table.md
@@ -26,6 +26,28 @@
 
 {{ readme_content or "" }}
 
+{% if schema -%}
+
+<table>
+<caption>Schema</caption>
+	<tr>
+		<th>Column</th>
+		<th>Description</th>
+		<th>Type</th>
+		<th>Nullable</th>
+ 	</tr>
+{% for field in schema -%}
+ 	<tr>
+        <td>{{ field.name }}</td>
+        <td>{{ field.description or "" }}</td>
+        <td>{{ field.type | capitalize }}</td>
+        <td>{{ 'Yes' if field.mode == 'NULLABLE' else 'No' }}</td>
+    </tr>
+{%- endfor %}
+</table>
+
+{% endif %}
+
 {% if referenced_tables -%}
 <table>
 <caption>Referenced Tables</caption>


### PR DESCRIPTION
Get the schemas for each view from the generated `schema.yaml` file. Currently only works for stable views, will make sure these get generated for non-stable views in a follow up https://github.com/mozilla/bigquery-etl/pull/2614#discussion_r779028390

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
