### PR TITLE
Less logging for schema update

### DIFF
--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -193,9 +193,6 @@ class Schema:
                         if update:
                             # add field attributes if not exists in schema
                             nodes[node_name][node_attr_key] = node_attr_value
-                            print(
-                                f"Attribute {node_attr_key} added to {prefix}.{field_path}"
-                            )
                         else:
                             if node_attr_key == "description":
                                 print(


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/2610

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
