### PR TITLE
Fix broken opmon dag.

### DIFF
--- a/bigquery_etl/operational_monitoring/__init__.py
+++ b/bigquery_etl/operational_monitoring/__init__.py
@@ -14,6 +14,8 @@ from google.cloud import bigquery, storage
 
 from bigquery_etl.util.common import render, write_sql
 
+PATH = Path(os.path.dirname(__file__))
+
 QUERY_FILENAME = "{}_query{}.sql"
 INIT_FILENAME = "{}_init.sql"
 VIEW_FILENAME = "{}_view.sql"
@@ -56,7 +58,7 @@ def _write_sql(
         output_filename,
         render(
             template_filename,
-            template_folder="operational_monitoring",
+            template_folder=PATH,
             **kwargs,
             init=init,
         ),


### PR DESCRIPTION
After this commit https://github.com/mozilla/bigquery-etl/commit/3f0b5373ce23734c3bc9cf7487107685f8c19fa2, the way that `render()` would be called has changed a tad and is currently causing failures in the operational monitoring airflow.

These changes should address the failures