### PR TITLE
Bug 1727081 Add link to Data Access Workgroups docs

### DIFF
--- a/docs/cookbooks/common_workflows.md
+++ b/docs/cookbooks/common_workflows.md
@@ -160,6 +160,9 @@ To provision a new BigQuery dataset for holding tables, you'll need to
 create a `dataset_metadata.yaml` which will cause the dataset to be
 automatically deployed a few hours after merging. Changes to existing
 datasets may trigger manual operator approval (such as changing access policies).
+For more on access controls, see
+[Data Access Workgroups](https://mana.mozilla.org/wiki/display/DOPS/Data+Access+Workgroups)
+in Mana.
 
 The `bqetl query create` command will automatically generate a skeleton
 `dataset_metadata.yaml` file if the query name contains a dataset that
@@ -183,9 +186,9 @@ dataset_base_acl: derived
 # and in mozdata; this should be false for all `_derived` datasets
 user_facing: false
 
-# Most datasets can have mozilla-confidential access like below,
-# but some datasets will be defined with more restricted access
-# or with additional access for services.
+# Most datasets can have mozilla-confidential access like below, but some
+# datasets will be defined with more restricted access or with additional
+# access for services; see "Data Access Workgroups" link above.
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1727081

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
