### PR TITLE
Ensure diff has maximum length

### DIFF
--- a/.circleci/post-diff.js
+++ b/.circleci/post-diff.js
@@ -6,14 +6,22 @@
 
 const fs = require("fs");
 const bot = require("circle-github-bot").create();
+// Github comments can have a maximum length of 65536 characters
+const max_content_length = 65000;
 
 function diff() {
     let root = "/tmp/workspace/generated-sql/";
     let diff_file = "sql.diff";
     let diff_content = fs.readFileSync(root + "/" + diff_file, "utf8");
 
-    var body = "No content detected."
+    var body = "No content detected.";
+    var warnings = "";
+
     if (diff_content) {
+        if (diff_content.length > max_content_length) {
+            diff_content = diff_content.substring(0, max_content_length);
+            warnings = "⚠️ Only part of the diff is displayed."
+        }
         body = `<details>
 <summary>Click to expand!</summary>
 
@@ -26,6 +34,7 @@ ${diff_content}
     }
     var content = `#### \`${diff_file}\`
 ${body}
+${warnings}
 `;
     return content;
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/2620

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
