### PR TITLE
Include FxA events with "undefined_oauth" service for attribution

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/query.sql
@@ -86,7 +86,10 @@ flows AS (
     AND (
       service = "guardian-vpn"
       -- service is missing for these event types
-      OR (service IS NULL AND (event_type = "fxa_rp_button - view" OR event_type LIKE "fxa_pay_%"))
+      OR (
+        (service IS NULL OR service = "undefined_oauth")
+        AND (event_type = "fxa_rp_button - view" OR event_type LIKE "fxa_pay_%")
+      )
     )
     AND flow_id IS NOT NULL
   GROUP BY


### PR DESCRIPTION
Starting 2021-12-08 a proportion of FxA events with UTM attribution data began showing up with the `service` value "undefined_oauth" instead of null.

- [Slack thread](https://mozilla.slack.com/archives/C018SNLQP6C/p1641498560007200)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
