### PR TITLE
Update glean_usage generate parameter in scripts

### DIFF
--- a/script/generate_sql
+++ b/script/generate_sql
@@ -41,7 +41,7 @@ set -x
     --parallelism=20
 
 # Fill in definitions for generated Glean ETL
-./script/bqetl generate glean_usage --project-id "${TARGET_PROJECT}" --output-dir "${SQL_DIR}"
+./script/bqetl generate glean_usage --target-project "${TARGET_PROJECT}" --output-dir "${SQL_DIR}"
 
 # Record dependencies in yaml files
 ./script/bqetl dependency record --skip-existing "${SQL_DIR}"

--- a/script/update_example_glean_usage
+++ b/script/update_example_glean_usage
@@ -8,10 +8,10 @@ cd "$(dirname "$0")/.."
 
 ./bqetl bootstrap
 ./bqetl generate glean_usage --only 'org_mozilla_fenix_stable.baseline_v1' \
-    --project-id moz-fx-data-shared-prod
+    --target-project moz-fx-data-shared-prod
 
 ./bqetl generate glean_usage --only 'org_mozilla_ios_firefox_stable.baseline_v1' \
-    --project-id moz-fx-data-shared-prod
+    --target-project moz-fx-data-shared-prod
 
 wait
 trap - EXIT


### PR DESCRIPTION
Fixes:

```
+ ./script/generate_all_views --target-project moz-fx-data-shared-prod --sql-dir /tmp/sql
+ ./script/bqetl generate stable_views --target-project moz-fx-data-shared-prod --sql-dir /tmp/sql --parallelism=20
telemetry_derived/foo/query.sql                             OK
+ ./script/bqetl generate glean_usage --project-id moz-fx-data-shared-prod --output-dir /tmp/sql
Usage: ./script/bqetl generate glean_usage [OPTIONS]
Try './script/bqetl generate glean_usage --help' for help
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
