### PR TITLE
regrets-reporter queries updated to use stable tables

### DIFF
--- a/dags/bqetl_regrets_reporter_summary.py
+++ b/dags/bqetl_regrets_reporter_summary.py
@@ -52,3 +52,15 @@ with DAG(
         depends_on_past=False,
         dag=dag,
     )
+
+    wait_for_copy_deduplicate_all = ExternalTaskCompletedSensor(
+        task_id="wait_for_copy_deduplicate_all",
+        external_dag_id="copy_deduplicate",
+        external_task_id="copy_deduplicate_all",
+        execution_delta=datetime.timedelta(seconds=10800),
+        check_existence=True,
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    regrets_reporter_summary__v1.set_upstream(wait_for_copy_deduplicate_all)

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/init.sql
@@ -20,7 +20,7 @@ WITH base_t AS (
       IF(LOGICAL_OR(e.name = "regret_action"), 1, 0) * 2
     ) + (IF(LOGICAL_OR(e.name = "video_played"), 1, 0) * 4) AS activities,
   FROM
-    `moz-fx-data-shared-prod.regrets_reporter_ucs_live.main_events_v1`,
+    `moz-fx-data-shared-prod.regrets_reporter_ucs_stable.main_events_v1`,
     UNNEST(events) e
   WHERE
     submission_timestamp >= "2021-12-02"
@@ -96,7 +96,7 @@ new_user_base_t AS (
       IF(LOGICAL_OR(e.name = "regret_action"), 1, 0) * 2
     ) + (IF(LOGICAL_OR(e.name = "video_played"), 1, 0) * 4) AS activities,
   FROM
-    `moz-fx-data-shared-prod.regrets_reporter_ucs_live.main_events_v1`,
+    `moz-fx-data-shared-prod.regrets_reporter_ucs_stable.main_events_v1`,
     UNNEST(events) e
   WHERE
     submission_timestamp >= "2021-12-02"

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/query.sql
@@ -10,7 +10,7 @@ WITH base_t AS (
       IF(LOGICAL_OR(e.name = "regret_action"), 1, 0) * 2
     ) + (IF(LOGICAL_OR(e.name = "video_played"), 1, 0) * 4) AS activities,
   FROM
-    `moz-fx-data-shared-prod.regrets_reporter_ucs_live.main_events_v1`,
+    `moz-fx-data-shared-prod.regrets_reporter_ucs_stable.main_events_v1`,
     UNNEST(events) e
   WHERE
     submission_timestamp = @submission_date
@@ -86,7 +86,7 @@ new_user_base_t AS (
       IF(LOGICAL_OR(e.name = "regret_action"), 1, 0) * 2
     ) + (IF(LOGICAL_OR(e.name = "video_played"), 1, 0) * 4) AS activities,
   FROM
-    `moz-fx-data-shared-prod.regrets_reporter_ucs_live.main_events_v1`,
+    `moz-fx-data-shared-prod.regrets_reporter_ucs_stable.main_events_v1`,
     UNNEST(events) e
   WHERE
     submission_timestamp = @submission_date


### PR DESCRIPTION
# regrets-reporter queries updated to use stable tables

- Queries have been updated to use stable tables.
- Since the init.sql was modified and no additional data was appended I'd suggest we drop the old table (or truncate) and re-run the init script to recreate the table depending on this approach we take.


resolves #2635 



---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
