### PR TITLE
bug: explicitly casting dates in where clause to date

### DIFF
--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/query.sql
@@ -13,7 +13,7 @@ WITH base_t AS (
     `moz-fx-data-shared-prod.regrets_reporter_ucs_stable.main_events_v1`,
     UNNEST(events) e
   WHERE
-    submission_timestamp = @submission_date
+    DATE(submission_timestamp) = DATE(@submission_date)
   GROUP BY
     metrics.string.metadata_installation_id,
     DATE(submission_timestamp)
@@ -89,7 +89,7 @@ new_user_base_t AS (
     `moz-fx-data-shared-prod.regrets_reporter_ucs_stable.main_events_v1`,
     UNNEST(events) e
   WHERE
-    submission_timestamp = @submission_date
+    DATE(submission_timestamp) = DATE(@submission_date)
   GROUP BY
     installation_id
 ),


### PR DESCRIPTION
DAG `bqetl_regrets_reporter` failed (https://workflow.telemetry.mozilla.org/log?dag_id=bqetl_regrets_reporter_summary&task_id=regrets_reporter_summary__v1&execution_date=2022-01-09T04%3A00%3A00%2B00%3A00) with the following error:

```shell
[2022-01-10 22:31:20,925] {{pod_launcher.py:149}} INFO - Error in query string: Error processing job 'moz-fx-data-shared-
[2022-01-10 22:31:20,926] {{pod_launcher.py:149}} INFO - prod:bqjob_r20704d803590cdda_0000017e461e041b_1': No matching signature for
[2022-01-10 22:31:20,926] {{pod_launcher.py:149}} INFO - operator = for argument types: TIMESTAMP, DATE. Supported signature: ANY = ANY
```

This should address this error.


---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
