### PR TITLE
[Bug 1748716] Add scheduled query for stable table column count monitoring

### DIFF
--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -103,6 +103,19 @@ with DAG(
         dag=dag,
     )
 
+    monitoring_derived__stable_table_column_counts__v1 = bigquery_etl_query(
+        task_id="monitoring_derived__stable_table_column_counts__v1",
+        destination_table=None,
+        dataset_id="monitoring_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="ascholtz@mozilla.com",
+        email=["ascholtz@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        sql_file_path="sql/moz-fx-data-shared-prod/monitoring_derived/stable_table_column_counts_v1/script.sql",
+        dag=dag,
+    )
+
     monitoring_derived__stable_table_sizes__v1 = gke_command(
         task_id="monitoring_derived__stable_table_sizes__v1",
         command=[
@@ -204,6 +217,13 @@ with DAG(
     )
 
     monitoring_derived__column_size__v1.set_upstream(
+        wait_for_copy_deduplicate_main_ping
+    )
+
+    monitoring_derived__stable_table_column_counts__v1.set_upstream(
+        wait_for_copy_deduplicate_all
+    )
+    monitoring_derived__stable_table_column_counts__v1.set_upstream(
         wait_for_copy_deduplicate_main_ping
     )
 

--- a/sql/moz-fx-data-shared-prod/monitoring/stable_table_column_counts/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/stable_table_column_counts/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.monitoring.stable_table_column_counts`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.monitoring_derived.stable_table_column_counts_v1`

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_table_column_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_table_column_counts_v1/metadata.yaml
@@ -1,0 +1,18 @@
+friendly_name: Stable Table Column Counts
+description: |-
+  Number of columns in stable table schemas, partitioned by day
+owners:
+- ascholtz@mozilla.com
+labels:
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_monitoring
+  referenced_tables:
+  - ['moz-fx-data-shared-prod', '*_stable', '*']
+  - ['moz-fx-data-shared-prod', 'telemetry_stable', 'main_v4']
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_table_column_counts_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_table_column_counts_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+- mode: NULLABLE
+  name: dataset
+  type: STRING
+- mode: NULLABLE
+  name: table_name
+  type: STRING
+- mode: NULLABLE
+  name: total_columns
+  type: INTEGER

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_table_column_counts_v1/script.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_table_column_counts_v1/script.sql
@@ -1,0 +1,53 @@
+DECLARE datasets ARRAY<STRING>;
+
+DECLARE i INT64 DEFAULT 0;
+
+SET datasets = (
+  SELECT
+    ARRAY_AGG(schema_name)
+  FROM
+    `moz-fx-data-shared-prod.INFORMATION_SCHEMA.SCHEMATA`
+  WHERE
+    schema_name LIKE '%_stable%'
+);
+
+CREATE TEMP TABLE
+  columns(dataset STRING, table STRING, total_columns INT64);
+
+LOOP
+  SET i = i + 1;
+
+  IF
+    i > ARRAY_LENGTH(datasets)
+  THEN
+    LEAVE;
+  END IF;
+
+  EXECUTE IMMEDIATE '''
+    INSERT columns
+    SELECT "''' || datasets[
+    ORDINAL(i)
+  ] || '''" AS dataset, 
+      table_name, 
+      COUNT(DISTINCT(field_path)) AS total_columns 
+    FROM `moz-fx-data-shared-prod`.''' || datasets[
+    ORDINAL(i)
+  ] || '''.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS
+    WHERE
+      data_type NOT LIKE "%STRUCT%"
+      AND data_type NOT LIKE "%ARRAY%"
+    GROUP BY
+      table_name  
+    ''';
+END LOOP;
+
+-- Insert into target table
+INSERT INTO
+  monitoring_derived.stable_table_column_counts_v1
+SELECT
+  DATE(@submission_date) AS submission_date,
+  dataset,
+  table_name,
+  total_columns
+FROM
+  columns


### PR DESCRIPTION
The query has been migrated from https://sql.telemetry.mozilla.org/queries/76766/source

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
