### PR TITLE
tweaked comment in validate-dags to mention that tags are also validated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,10 @@ jobs:
             # now take ownership of the folder
             sudo chown -R 10001:10001 .
       - run:
-          name: Test if dag scripts can be parsed
+          name: |
+            Test if dag scripts can be parsed by Airflow
+            and tags have set correctly
+          # Valid tags defined in `telemetry-airflow/bin/test-dag-tags.py`
           command: |
             cd telemetry-airflow
             bash bin/test-parse


### PR DESCRIPTION
# tweaked comment in validate-dags to mention that tags are also validated

If I understand the pipeline definition correctly there are no actual logic tweaks required for the dag tag validation to work in CircleCi, as soon as it's added to telemetry-airflow main branch it should also be used here.

telemetry-airflow PR for adding Airflow tags validation: https://github.com/mozilla/telemetry-airflow/pull/1446

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
