### PR TITLE
Added sql_generators script to create (derived dataset) schema.yaml files

### DIFF
--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -131,6 +131,7 @@ class Metadata:
     bigquery: Optional[BigQueryMetadata] = attr.ib(None)
     schema: Optional[SchemaMetadata] = attr.ib(None)
     workgroup_access: Optional[List[WorkgroupAccessMetadata]] = attr.ib(None)
+    references: Dict = attr.ib({})
 
     @owners.validator
     def validate_owners(self, attribute, value):
@@ -203,6 +204,7 @@ class Metadata:
         bigquery = None
         schema = None
         workgroup_access = None
+        references = {}
 
         with open(metadata_file, "r") as yaml_stream:
             try:
@@ -247,6 +249,9 @@ class Metadata:
                         metadata["workgroup_access"], List[WorkgroupAccessMetadata]
                     )
 
+                if "references" in metadata:
+                    references = metadata["references"]
+
                 return cls(
                     friendly_name,
                     description,
@@ -256,6 +261,7 @@ class Metadata:
                     bigquery,
                     schema,
                     workgroup_access,
+                    references,
                 )
             except yaml.YAMLError as e:
                 raise e

--- a/script/generate_sql
+++ b/script/generate_sql
@@ -45,3 +45,8 @@ set -x
 
 # Record dependencies in yaml files
 ./script/bqetl dependency record --skip-existing "${SQL_DIR}"
+
+# Create the derived view schemas for the specified project
+./script/bqetl generate derived_view_schemas \
+    --target-project "${TARGET_PROJECT}" \
+    --sql-dir "${SQL_DIR}" \

--- a/sql_generators/derived_view_schemas/__init__.py
+++ b/sql_generators/derived_view_schemas/__init__.py
@@ -1,0 +1,182 @@
+"""Generate and record schemas for user-facing derived dataset views."""
+
+from functools import partial
+from pathlib import Path
+
+import click
+from pathos.multiprocessing import ProcessingPool
+
+NON_USER_FACING_DATASET_SUFFIXES = (
+    "_derived",
+    "_external",
+    "_bi",
+    "_restricted",
+)
+
+
+def _generate_view_schema(sql_dir, view_directory):
+    import logging
+
+    from bigquery_etl.metadata.parse_metadata import Metadata
+    from bigquery_etl.schema import Schema
+
+    logging.basicConfig(format="%(levelname)s (%(filename)s:%(lineno)d) - %(message)s")
+
+    VIEW_FILE = "view.sql"
+    METADATA_FILE = "metadata.yaml"
+    SCHEMA_FILE = "schema.yaml"
+
+    # If the view references only one table, we can:
+    # 1. Get the reference table partition key if it exists.
+    #   (to dry run views to partitioned tables).
+    # 2. Get the reference table schema and use it to enrich the
+    #   view schema we get from dry-running.
+    # Note this works because dependencies (references) are recorded
+    #   as a part of sql-generation.
+    def _get_reference_dir_path(view_dir):
+        try:
+            metadata = Metadata.from_file(view_dir / METADATA_FILE)
+        except Exception as metadata_exception:
+            logging.warning(f"Unable to get view metadata: {metadata_exception}")
+            return
+
+        view_references = metadata.references.get(VIEW_FILE, [])
+        if len(view_references) == 1:
+            target_reference = view_references[0]
+        else:
+            return
+
+        target_project = view_dir.parent.parent.name
+        target_dataset = view_dir.parent.name
+
+        parts = target_reference.split(".")
+        if len(parts) == 3:
+            reference_project_id, reference_dataset_id, reference_table_id = parts
+        # Fully qualify the reference:
+        elif len(parts) == 2:
+            reference_project_id = target_project
+            reference_dataset_id, reference_table_id = parts
+        elif len(parts) == 1:
+            reference_project_id = target_project
+            reference_dataset_id = target_dataset
+            reference_table_id = parts[0]
+        else:
+            return
+
+        return (
+            sql_dir / reference_project_id / reference_dataset_id / reference_table_id
+        )
+
+    def _get_reference_partition_key(ref_path):
+        if ref_path is None:
+            logging.debug("No table reference, skipping partition key.")
+            return
+
+        try:
+            reference_metadata = Metadata.from_file(ref_path / METADATA_FILE)
+        except Exception as metadata_exception:
+            logging.warning(f"Unable to get reference metadata: {metadata_exception}")
+            return
+
+        bigquery_metadata = reference_metadata.bigquery
+        if bigquery_metadata is None:
+            logging.warning(
+                f"No bigquery metadata at {ref_path}, unable to get partition key."
+            )
+            return
+
+        partition_metadata = bigquery_metadata.time_partitioning
+        if partition_metadata is None:
+            logging.warning(
+                f"No partition metadata at {ref_path}, unable to get partition key."
+            )
+            return
+
+        return partition_metadata.field
+
+    reference_path = _get_reference_dir_path(view_directory)
+
+    # Optionally get the upstream partition key
+    reference_partition_key = _get_reference_partition_key(reference_path)
+    if reference_partition_key is None:
+        logging.debug("No reference partition key, dry running without one.")
+
+    project_id = view_directory.parent.parent.name
+    dataset_id = view_directory.parent.name
+    view_id = view_directory.name
+
+    schema = Schema.for_table(
+        project_id, dataset_id, view_id, partitioned_by=reference_partition_key
+    )
+    if len(schema.schema.get("fields")) == 0:
+        logging.warning(
+            "Got empty schema potentially due to dry-run error. Won't write yaml."
+        )
+        return
+
+    # Optionally enrich the view schema if we have a valid table reference
+    if reference_path:
+        try:
+            reference_schema = Schema.from_schema_file(reference_path / SCHEMA_FILE)
+            schema.merge(reference_schema, add_missing_fields=False)
+        except Exception as e:
+            logging.info(
+                f"Unable to open reference schema; unable to enrich schema: {e}"
+            )
+
+    schema.to_yaml_file(view_directory / SCHEMA_FILE)
+
+
+@click.command("generate")
+@click.option(
+    "--target_project",
+    "--target-project",
+    help="Which project the views should be written to.",
+    default="moz-fx-data-shared-prod",
+)
+@click.option(
+    "--output-dir",
+    "--output_dir",
+    "--sql-dir",
+    "--sql_dir",
+    help="The location to write to. Defaults to sql/.",
+    default=Path("sql"),
+    type=click.Path(file_okay=False),
+)
+@click.option(
+    "--parallelism",
+    "-P",
+    help="Maximum number of tasks to execute concurrently",
+    default=20,
+    type=int,
+)
+def generate(target_project, output_dir, parallelism):
+    """
+    Generate schema yaml files for views in output_dir/target_project.
+
+    We dry-run to get the schema data and where possible we enrich the
+    view schemas with underlying table descriptions.
+    """
+    project_path = Path(f"{output_dir}/{target_project}")
+
+    dataset_paths = [
+        dataset_path
+        for dataset_path in project_path.iterdir()
+        if dataset_path.is_dir()
+        and all(
+            suffix not in str(dataset_path)
+            for suffix in NON_USER_FACING_DATASET_SUFFIXES
+        )
+    ]
+
+    for dataset_path in dataset_paths:
+        view_directories = [path for path in dataset_path.iterdir() if path.is_dir()]
+
+        with ProcessingPool(parallelism) as pool:
+            pool.map(
+                partial(
+                    _generate_view_schema,
+                    Path(output_dir),
+                ),
+                view_directories,
+            )

--- a/tests/data/metadata.yaml
+++ b/tests/data/metadata.yaml
@@ -13,3 +13,6 @@ labels:
   number_value: 1234234
   number_string: 1234abcde
   123-432: valid
+references:
+  query.sql:
+    - project.dataset_derived.table_v1

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -85,6 +85,8 @@ class TestParseMetadata(object):
         assert metadata.labels["number_string"] == "1234abcde"
         assert "123-432" in metadata.labels
         assert metadata.owners == ["test1@mozilla.com", "test2@example.com"]
+        assert "query.sql" in metadata.references
+        assert metadata.references["query.sql"] == ["project.dataset_derived.table_v1"]
 
     def test_non_existing_file(self):
         metadata_file = TEST_DIR / "nonexisting_dir" / "metadata.yaml"


### PR DESCRIPTION
Specifically for views in user-facing derived datasets. Along with some metadata updates to support `references`

More context: https://bugzilla.mozilla.org/show_bug.cgi?id=1713623#c3 and https://github.com/mozilla/bigquery-etl/pull/2614#discussion_r779028390 

Along with https://github.com/mozilla/bigquery-etl/pull/2118, this should close https://github.com/mozilla/bigquery-etl/issues/1685.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
