### PR TITLE
Revert "adding 2m sleep to the export task for allowing it to complete"

### DIFF
--- a/script/glam/export_csv
+++ b/script/glam/export_csv
@@ -25,5 +25,4 @@ bq extract --destination_format CSV --noprint_header \
 bq extract --destination_format CSV --noprint_header \
     "${src_project}:${dataset}.${product}__extract_sample_counts_v1" \
     "$bucket/glam-extract-${product}-sample-counts.csv"
-
-sleep 120
+    


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#2609. The sleep timer is no longer required and the issue has been resolved by adding a dummy task to the airflow dag.
<img width="354" alt="Screen Shot 2022-01-14 at 12 23 23 PM" src="https://user-images.githubusercontent.com/88394696/149558097-71891133-a2f0-46c0-8de7-23f6aabfb638.png">
 