### PR TITLE
modified regrets reporter summary query to run query against all data

### DIFF
--- a/dags/bqetl_regrets_reporter_summary.py
+++ b/dags/bqetl_regrets_reporter_summary.py
@@ -48,8 +48,9 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="kignasiak@mozilla.com",
         email=["kignasiak@mozilla.com", "telemetry-alerts@mozilla.com"],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        parameters=["submission_date:DATE:{{ds}}"],
         dag=dag,
     )
 

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/init.sql
@@ -23,7 +23,7 @@ WITH base_t AS (
     `moz-fx-data-shared-prod.regrets_reporter_ucs_stable.main_events_v1`,
     UNNEST(events) e
   WHERE
-    submission_timestamp >= "2021-12-02"
+    DATE(submission_timestamp) >= DATE("2021-12-02")
   GROUP BY
     metrics.string.metadata_installation_id,
     DATE(submission_timestamp)
@@ -99,7 +99,7 @@ new_user_base_t AS (
     `moz-fx-data-shared-prod.regrets_reporter_ucs_stable.main_events_v1`,
     UNNEST(events) e
   WHERE
-    submission_timestamp >= "2021-12-02"
+    DATE(submission_timestamp) >= DATE("2021-12-02")
   GROUP BY
     installation_id
 ),

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/metadata.yaml
@@ -14,12 +14,13 @@ labels:
 scheduling:
   dag_name: bqetl_regrets_reporter_summary
   task_name: regrets_reporter_summary__v1
+  schedule: daily
+  date_partition_parameter: null
+  parameters: ["submission_date:DATE:{{ds}}"]
+  referenced_tables: [['moz-fx-data-shared-prod',
+                       'regrets_reporter_ucs_stable',
+                       'main_events_v1']]
 bigquery:
-  time_partitioning:
-    field: date
-    type: day
-    require_partition_filter: true
-    expiration_days: null
   clustering:
     fields:
     - country

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/metadata.yaml
@@ -5,7 +5,10 @@ description: |
 owners:
 - kignasiak@mozilla.com
 labels:
-  incremental: true
+  # has to be full load, otherwise the query logic does not work
+  # see Github issue for more info:
+  # https://github.com/mozilla/bigquery-etl/issues/2634
+  incremental: false
   public_bigquery: false
   public_json: false
 scheduling:

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/query.sql
@@ -1,13 +1,3 @@
-CREATE OR REPLACE TABLE
-  `moz-fx-data-shared-prod`.regrets_reporter_derived.regrets_reporter_summary_v1
-PARTITION BY
-  date
-CLUSTER BY
-  country,
-  browser
-OPTIONS
-  (require_partition_filter = TRUE)
-AS
 WITH base_t AS (
   SELECT
     metrics.string.metadata_installation_id AS installation_id,

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/query.sql
@@ -1,3 +1,13 @@
+CREATE OR REPLACE TABLE
+  `moz-fx-data-shared-prod`.regrets_reporter_derived.regrets_reporter_summary_v1
+PARTITION BY
+  date
+CLUSTER BY
+  country,
+  browser
+OPTIONS
+  (require_partition_filter = TRUE)
+AS
 WITH base_t AS (
   SELECT
     metrics.string.metadata_installation_id AS installation_id,
@@ -13,7 +23,7 @@ WITH base_t AS (
     `moz-fx-data-shared-prod.regrets_reporter_ucs_stable.main_events_v1`,
     UNNEST(events) e
   WHERE
-    DATE(submission_timestamp) = DATE(@submission_date)
+    DATE(submission_timestamp) >= DATE("2021-12-02")
   GROUP BY
     metrics.string.metadata_installation_id,
     DATE(submission_timestamp)
@@ -89,7 +99,7 @@ new_user_base_t AS (
     `moz-fx-data-shared-prod.regrets_reporter_ucs_stable.main_events_v1`,
     UNNEST(events) e
   WHERE
-    DATE(submission_timestamp) = DATE(@submission_date)
+    DATE(submission_timestamp) >= DATE("2021-12-02")
   GROUP BY
     installation_id
 ),


### PR DESCRIPTION
modified regrets reporter summary query to run query against all data

The job is no longer "incremental", but full table reload occurs. This is because of the logic. Currently, Jesse says the query is 2.2Gib of processing to execute. He also said that this will increase a bit once this bug is resolved: https://bugzilla.mozilla.org/show_bug.cgi?id=1748284

After a quick investigation and a chat with Jesse it became apparent that the previous approach would not work for getting the data we need due to the query logic. We could see that also all the results appended by the incremental job were wrong. See comments in this issue for more information: https://github.com/mozilla/bigquery-etl/issues/2634



Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
