### PR TITLE
Ensure dags/ exists on generated-sql and speed up CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,23 +374,20 @@ jobs:
     executor: ubuntu-machine-executor
     steps:
       - checkout
-      - *attach_generated_sql
-      - *copy_generated_sql
       - when:
           condition: &deploy-condition
             or:
               - equal: [main, << pipeline.git.branch >>]
               - << pipeline.git.tag >>
           steps:
+            - *attach_generated_sql
+            - *copy_generated_sql
             - docker/check:
                 docker-password: DOCKER_PASS
                 docker-username: DOCKER_USER
-      - docker/build: &public-image
-          image: ${CIRCLE_PROJECT_USERNAME+$CIRCLE_PROJECT_USERNAME/}${CIRCLE_PROJECT_REPONAME:-bigquery-etl}
-          tag: ${CIRCLE_TAG:-latest}
-      - when:
-          condition: *deploy-condition
-          steps:
+            - docker/build: &public-image
+                image: ${CIRCLE_PROJECT_USERNAME+$CIRCLE_PROJECT_USERNAME/}${CIRCLE_PROJECT_REPONAME:-bigquery-etl}
+                tag: ${CIRCLE_TAG:-latest}
             - docker/push: *public-image
   private-generate-sql:
     docker: *docker
@@ -461,22 +458,19 @@ jobs:
     executor: ubuntu-machine-executor
     steps:
       - checkout
-      - *attach_generated_sql
-      - run:
-          name: Move generated-sql into place
-          command: |
-            rm -rf sql/
-            cp -r /tmp/workspace/private-generated-sql/sql sql
       - when:
           condition: *deploy-condition
           steps:
+            - *attach_generated_sql
+            - run:
+                name: Move generated-sql into place
+                command: |
+                  rm -rf sql/
+                  cp -r /tmp/workspace/private-generated-sql/sql sql
             - gcp-gcr/gcr-auth
-      - gcp-gcr/build-image: &private-image
-          image: bigquery-etl
-          tag: ${CIRCLE_TAG:-latest}
-      - when:
-          condition: *deploy-condition
-          steps:
+            - gcp-gcr/build-image: &private-image
+                image: bigquery-etl
+                tag: ${CIRCLE_TAG:-latest}
             - gcp-gcr/push-image: *private-image
   generate-diff:
     docker: *docker
@@ -507,10 +501,15 @@ jobs:
             ./script/generate_sql \
               --target-project moz-fx-data-shared-prod
 
+            ./script/generate_airflow_dags
+
             cd ..
             diff -bur --no-dereference \
               bigquery-etl-main/sql/ /tmp/workspace/generated-sql/sql/ \
               > /tmp/workspace/generated-sql/sql.diff || true
+            diff -bur --no-dereference \
+              bigquery-etl-main/dags/ /tmp/workspace/generated-sql/dags/ \
+              >> /tmp/workspace/generated-sql/sql.diff || true
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
@@ -594,7 +593,7 @@ workflows:
       - generate-sql
       - generate-diff:
           requires:
-            - generate-sql
+            - generate-dags
           filters:
             branches:
               ignore: main


### PR DESCRIPTION
Okay, I'm trying to solve the mystery around `dags/` not being in `generated-sql` once and for all. I wrote a CI test step to check the files exist in: https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/12979/workflows/3dad7a02-d518-49b7-b5e1-39cd6482ab02/jobs/98704
The problem was that `generate-diff` overwrote the `generated-sql` contents.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
