### PR TITLE
Bug 1752787 ID field type change in fxa_auth_events

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
@@ -10,7 +10,9 @@ WITH base AS (
           jsonPayload.* REPLACE (
             (
               SELECT AS STRUCT
-                jsonPayload.fields.* EXCEPT (device_id, user_id) REPLACE(
+                  jsonPayload.fields.* EXCEPT (device_id, user_id) REPLACE(
+                  -- See https://bugzilla.mozilla.org/show_bug.cgi?id=1752787
+                  CAST(id AS STRING) AS id,
                   -- See https://bugzilla.mozilla.org/show_bug.cgi?id=1707571
                   CAST(NULL AS FLOAT64) AS emailverified,
                   CAST(NULL AS FLOAT64) AS isprimary,


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1752787

The source field `jsonPayload.fields.id` changed from STRING to FLOAT64.
This change allows us to handle either case and consistently produce a STRING.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
