### PR TITLE
Add missing probes

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_content_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_content_v1/query.sql
@@ -16443,6 +16443,13 @@ histograms AS (
         (1, 100, 50)
       ),
       (
+        'video_dropped_frames_proportion_exponential',
+        'histogram-exponential',
+        'content',
+        payload.processes.content.histograms.video_dropped_frames_proportion_exponential,
+        (1, 10000, 100)
+      ),
+      (
         'video_eme_play_success',
         'histogram-boolean',
         'content',


### PR DESCRIPTION
This is related to the discussion of missing probe https://mozilla.slack.com/archives/CB1EQ437S/p1643899307478819
The probe video_dropped_frames_proportion_exponential is not seen in glam UI. 
The table `telemetry_derived.clients_daily_histogram_aggregates_v1` does not show the probe either
I have run the query based on https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_content_v1/query.sql however including the missing probe. 
[Here is the sample query](https://gist.github.com/alekhyamoz/0c3a252f1d8b601beec39b1ccee82e5b) which outputs the missing probe related data 
This PR updates the sql by including the missing probe
