### PR TITLE
Clean up shredder whitespace and unneeded DISTINCT

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -206,12 +206,12 @@ def delete_from_partition(
         if use_dml:
             field_condition = " OR ".join(
                 f"""
-                 {field} IN (
-                   SELECT
-                     {source.field}
-                   FROM
-                     `{sql_table_id(source)}`
-                   WHERE
+                {field} IN (
+                  SELECT
+                    {source.field}
+                  FROM
+                    `{sql_table_id(source)}`
+                  WHERE
                 """
                 + " AND ".join((source_condition, *source.conditions))
                 + ")"
@@ -229,17 +229,19 @@ def delete_from_partition(
         else:
             field_joins = "".join(
                 f"""
-                 LEFT JOIN (
-                   SELECT DISTINCT
-                     {source.field} AS _source_{index}
-                   FROM
-                     `{sql_table_id(source)}`
-                   WHERE
+                LEFT JOIN
+                  (
+                    SELECT
+                      {source.field} AS _source_{index}
+                    FROM
+                      `{sql_table_id(source)}`
+                    WHERE
                 """
                 + " AND ".join((source_condition, *source.conditions))
                 + f"""
-                )
-                ON {field} = _source_{index}
+                  )
+                ON
+                  {field} = _source_{index}
                 """
                 for index, (field, source) in enumerate(zip(target.fields, sources))
             )
@@ -248,7 +250,9 @@ def delete_from_partition(
             )
             query = reformat(
                 f"""
-                SELECT _target.* FROM
+                SELECT
+                  _target.*
+                FROM
                   `{sql_table_id(target)}` AS _target
                 {field_joins}
                 WHERE


### PR DESCRIPTION
addresses https://github.com/mozilla/bigquery-etl/pull/2711#pullrequestreview-878074033

draft because I want to run tests to verify speed without the `DISTINCT` clause