### PR TITLE
Support clients_daily and search_clients_daily sanitization

### DIFF
--- a/bigquery_etl/shredder/bug1751979.py
+++ b/bigquery_etl/shredder/bug1751979.py
@@ -480,7 +480,7 @@ CREATE TEMP FUNCTION sanitize_engine_source(
               -- Add a hash of code to avoid multiple rows ending up with the same
               -- (client_id, sanitized_engine, sanitized_source) value, violating
               -- the table's contract.
-              SUBSTR(TO_HEX(SHA256(code)), 1, 4))
+              LEFT(TO_HEX(SHA256(code)), 8))
           ) AS key
       FROM
         parsed

--- a/bigquery_etl/shredder/bug1751979.py
+++ b/bigquery_etl/shredder/bug1751979.py
@@ -474,7 +474,13 @@ CREATE TEMP FUNCTION sanitize_engine_source(
               "monline_7_dg"
             ),
             key,
-            CONCAT(prefix, "other.scrubbed")
+            CONCAT(
+              prefix,
+              "other.scrubbed.",
+              -- Add a hash of code to avoid multiple rows ending up with the same
+              -- (client_id, sanitized_engine, sanitized_source) value, violating
+              -- the table's contract.
+              SUBSTR(TO_HEX(SHA256(code)), 1, 4))
           ) AS key
       FROM
         parsed

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -22,10 +22,13 @@ from ..util.bigquery_id import FULL_JOB_ID_RE, full_job_id, sql_table_id
 from ..util.client_queue import ClientQueue
 from ..util.exceptions import BigQueryInsertError
 from .bug1751979 import (
+    BUG_1751979_CLIENTS_DAILY_V6_REPLACE_CLAUSE,
     BUG_1751979_MAIN_SUMMARY_V4_REPLACE_CLAUSE,
     BUG_1751979_MAIN_SUMMARY_V4_UDFS,
     BUG_1751979_MAIN_V4_REPLACE_CLAUSE,
     BUG_1751979_MAIN_V4_UDFS,
+    BUG_1751979_SEARCH_CLIENTS_DAILY_V8_REPLACE_CLAUSE,
+    BUG_1751979_SEARCH_CLIENTS_DAILY_V8_UDFS,
 )
 from .config import (
     DELETE_TARGETS,
@@ -274,6 +277,24 @@ def delete_from_partition(
             ):
                 replace_clause = BUG_1751979_MAIN_SUMMARY_V4_REPLACE_CLAUSE
                 temporary_udfs = BUG_1751979_MAIN_SUMMARY_V4_UDFS
+            # And corresponding changes for clients_daily-derived tables.
+            elif sql_table_id(target) in [
+                "moz-fx-data-shared-prod.telemetry_derived.clients_daily_v6",
+                "moz-fx-data-shared-prod.telemetry_derived.clients_daily_joined_v1",
+                "moz-fx-data-shared-prod.telemetry_derived.clients_last_seen_v6",
+                "moz-fx-data-shared-prod.telemetry_derived.clients_last_seen_joined_v1",
+            ]:
+                replace_clause = BUG_1751979_CLIENTS_DAILY_V6_REPLACE_CLAUSE
+                temporary_udfs = (
+                    BUG_1751979_MAIN_SUMMARY_V4_UDFS + BUG_1751979_MAIN_V4_UDFS
+                )
+            # And corresponding changes for search_clients_daily-derived tables.
+            elif (
+                sql_table_id(target)
+                == "moz-fx-data-shared-prod.telemetry_derived.search_clients_daily_v8"
+            ):
+                replace_clause = BUG_1751979_SEARCH_CLIENTS_DAILY_V8_REPLACE_CLAUSE
+                temporary_udfs = BUG_1751979_SEARCH_CLIENTS_DAILY_V8_UDFS
 
             query = reformat(
                 f"""


### PR DESCRIPTION
See discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1751979#c13

This should be the final set of tables we need to support in shredder for sanitization. And this will only be applied to the partitions earlier than 2019-11-22.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [x] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [x] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
