### PR TITLE
DVPN-111 - Allow stripe imports to include customer address

### DIFF
--- a/bigquery_etl/stripe/allowed_fields.yaml
+++ b/bigquery_etl/stripe/allowed_fields.yaml
@@ -120,6 +120,10 @@ event:
       type:
       voided_at:
     customer:
+      address:
+        country:
+        postal_code:
+        state:
       created:
       id:
       metadata:

--- a/tests/stripe/test_allowed_fields.py
+++ b/tests/stripe/test_allowed_fields.py
@@ -11,6 +11,15 @@ from bigquery_etl.stripe.allowed_fields import FilteredSchema
 def test_filter_schema():
     filtered_schema = FilteredSchema(stripe.Customer)
     assert filtered_schema.filtered == (
+        bigquery.SchemaField(
+            name="address",
+            field_type="RECORD",
+            fields=[
+                bigquery.SchemaField(name="country", field_type="STRING"),
+                bigquery.SchemaField(name="postal_code", field_type="STRING"),
+                bigquery.SchemaField(name="state", field_type="STRING"),
+            ],
+        ),
         bigquery.SchemaField(name="created", field_type="TIMESTAMP"),
         bigquery.SchemaField(name="id", field_type="STRING"),
         bigquery.SchemaField(


### PR DESCRIPTION
needed for [DVPN-111](https://mozilla-hub.atlassian.net/browse/DVPN-111)

this will need a manual backfill, but the schema changes will be automatic, and are not exposed to any derived tables with a schema in this repo.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
