### PR TITLE
DVPN-111 - Wait even longer for stripe report

### DIFF
--- a/bigquery_etl/stripe/__init__.py
+++ b/bigquery_etl/stripe/__init__.py
@@ -68,11 +68,12 @@ def _get_report_rows(
             raise click.ClickException(str(e))
 
         click.echo(f"Waiting on report {run.id!r}", file=sys.stderr)
-        # wait up to ~10 minutes (100 intervals of 6 seconds) for report to finish
-        for _ in range(100):
+        # wait up to 30 minutes for report to finish
+        timeout = datetime.utcnow() + relativedelta(minutes=30)
+        while datetime.utcnow() < timeout:
             if run.status != "pending":
                 break
-            sleep(6)
+            sleep(10)
             run.refresh()
         if run.status != "succeeded":
             raise click.ClickException(

--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -612,7 +612,7 @@ with DAG(
         owner="dthorn@mozilla.com",
         email=["dthorn@mozilla.com", "telemetry-alerts@mozilla.com"],
         retry_delay=datetime.timedelta(seconds=1800),
-        retries=10,
+        retries=47,
         email_on_retry=False,
     )
 

--- a/sql/moz-fx-data-shared-prod/stripe_external/itemized_payout_reconciliation_v5/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/itemized_payout_reconciliation_v5/metadata.yaml
@@ -17,5 +17,5 @@ scheduling:
     - --time-partitioning-field=automatic_payout_effective_at
   # report data isn't generally ready when the dag starts, so retry for a while
   retry_delay: 30m
-  retries: 10
+  retries: 47
   email_on_retry: false


### PR DESCRIPTION
32 retries makes this try until 9:15am PT, so that we can at least see when it comes in before probably moving it to a separate dag.

also wait up to 30 minutes for the report to finish, because the most recent run didn't finish in 10 minutes.