### PR TITLE
Bug 1757804 - Add new stripe invoice field proration_details

### DIFF
--- a/bigquery_etl/stripe/allowed_fields.yaml
+++ b/bigquery_etl/stripe/allowed_fields.yaml
@@ -289,6 +289,7 @@ event:
           unit_amount:
           unit_amount_decimal:
         proration:
+        proration_details:
         quantity:
         subscription:
         subscription_item:

--- a/bigquery_etl/stripe/event.schema.json
+++ b/bigquery_etl/stripe/event.schema.json
@@ -3220,6 +3220,10 @@
                 "type": "BOOLEAN"
               },
               {
+                "name": "proration_details",
+                "type": "STRING"
+              },
+              {
                 "name": "quantity",
                 "type": "INTEGER"
               },

--- a/bigquery_etl/stripe/invoice.schema.json
+++ b/bigquery_etl/stripe/invoice.schema.json
@@ -787,6 +787,10 @@
         "type": "BOOLEAN"
       },
       {
+        "name": "proration_details",
+        "type": "STRING"
+      },
+      {
         "name": "quantity",
         "type": "INTEGER"
       },


### PR DESCRIPTION
backfill by updating schemas, then in airflow: rerun `stripe_external__events__v1` and `stripe_external__invoices__v1` from march 1st onward. no further downstream tables are impacted.

schema update procedure:

```sh
# allow empty upload in stripe import
sed 's/if not has_rows:/if not has_rows and False:/' -i bigquery_etl/stripe/__init__.py
# update initial invoices schema
script/bqetl stripe import --resource=Invoice --table=moz-fx-data-shared-prod.stripe_external.initial_invoices_v1 --date="$(date -d+1day +%F)" < /dev/null
# update events schema
script/bqetl stripe import --resource=Event --table=moz-fx-data-shared-prod.stripe_external.events_v1 --date="$(date -d+1day +%F)" < /dev/null
# get new invoices schema
bq query --dry_run --format=json --dataset_id=moz-fx-data-shared-prod:stripe_external < sql/moz-fx-data-shared-prod/stripe_external/invoices_v1/init.sql | jq .statistics.query.schema.fields > schema.json
# create empty file for load job
touch empty.ndjson
# update invoices schema with a load job to ensure field order is preserved
bq load --noreplace --source_format=NEWLINE_DELIMITED_JSON --schema_update_option=ALLOW_FIELD_ADDITION moz-fx-data-shared-prod:stripe_external.invoices_v1 empty.ndjson schema.json
# verify by dry running invoices_v1/query.sql
bq query --dry_run --format=json --dataset_id=moz-fx-data-shared-prod:stripe_external < sql/moz-fx-data-shared-prod/stripe_external/invoices_v1/query.sql
```

in the past when i've done the last step with a query in append mode (instead of a load job), the field order was not preserved, which breaks this `UNION ALL`: https://github.com/mozilla/bigquery-etl/blob/249d2789ff569340699e6c246a3a3bd9e33c93c2/sql/moz-fx-data-shared-prod/stripe_external/invoices_v1/query.sql#L18-L33