### PR TITLE
Bug 1757804 - Fix schema for proration_details

### DIFF
--- a/bigquery_etl/stripe/allowed_fields.yaml
+++ b/bigquery_etl/stripe/allowed_fields.yaml
@@ -290,6 +290,9 @@ event:
           unit_amount_decimal:
         proration:
         proration_details:
+          credited_items:
+            invoice:
+            invoice_line_items:
         quantity:
         subscription:
         subscription_item:

--- a/bigquery_etl/stripe/event.schema.json
+++ b/bigquery_etl/stripe/event.schema.json
@@ -3221,7 +3221,24 @@
               },
               {
                 "name": "proration_details",
-                "type": "STRING"
+                "type": "RECORD",
+                "fields": [
+                  {
+                    "name": "credited_items",
+                    "type": "RECORD",
+                    "fields": [
+                      {
+                        "name": "invoice",
+                        "type": "STRING"
+                      },
+                      {
+                        "name": "invoice_line_items",
+                        "type": "STRING",
+                        "mode": "REPEATED"
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "name": "quantity",

--- a/bigquery_etl/stripe/invoice.schema.json
+++ b/bigquery_etl/stripe/invoice.schema.json
@@ -788,7 +788,24 @@
       },
       {
         "name": "proration_details",
-        "type": "STRING"
+        "type": "RECORD",
+        "fields": [
+          {
+            "name": "credited_items",
+            "type": "RECORD",
+            "fields": [
+              {
+                "name": "invoice",
+                "type": "STRING"
+              },
+              {
+                "name": "invoice_line_items",
+                "type": "STRING",
+                "mode": "REPEATED"
+              }
+            ]
+          }
+        ]
       },
       {
         "name": "quantity",


### PR DESCRIPTION
I forgot to verify that the schema was actually correct in #2776, and `proration_details` is a `RECORD` not a `STRING`.

documentation for the field: https://stripe.com/docs/api/invoices/line_item#invoice_line_item_object-proration_details

incorrect schema was rolled back via:

```sh
# restore to pre-schema-update timestamp to revert schema change
bq cp moz-fx-data-shared-prod:stripe_external.initial_invoices_v1{@1646431146000,}
bq cp moz-fx-data-shared-prod:stripe_external.events_v1{@1646431146000,}
bq cp moz-fx-data-shared-prod:stripe_external.invoices_v1{@1646431146000,}
```

same schema deploy strategy as for #2776:

```sh
# allow empty upload in stripe import
sed 's/if not has_rows:/if not has_rows and False:/' -i bigquery_etl/stripe/__init__.py
# update initial invoices schema
script/bqetl stripe import --resource=Invoice --table=moz-fx-data-shared-prod.stripe_external.initial_invoices_v1 --date="$(date -d+1day +%F)" < /dev/null
# update events schema
script/bqetl stripe import --resource=Event --table=moz-fx-data-shared-prod.stripe_external.events_v1 --date="$(date -d+1day +%F)" < /dev/null
# get new invoices schema
bq query --dry_run --format=json --dataset_id=moz-fx-data-shared-prod:stripe_external < sql/moz-fx-data-shared-prod/stripe_external/invoices_v1/init.sql | jq .statistics.query.schema.fields > schema.json
# create empty file for load job
touch empty.ndjson
# update invoices schema with a load job to ensure field order is preserved
bq load --noreplace --source_format=NEWLINE_DELIMITED_JSON --schema_update_option=ALLOW_FIELD_ADDITION moz-fx-data-shared-prod:stripe_external.invoices_v1 empty.ndjson schema.json
# verify by dry running invoices_v1/query.sql
bq query --dry_run --format=json --dataset_id=moz-fx-data-shared-prod:stripe_external < sql/moz-fx-data-shared-prod/stripe_external/invoices_v1/query.sql
```
