### PR TITLE
changes to extract probes counts to include total_sample column

### DIFF
--- a/bigquery_etl/glam/templates/extract_probe_counts_v1.sql
+++ b/bigquery_etl/glam/templates/extract_probe_counts_v1.sql
@@ -1,6 +1,6 @@
 {{ header }}
 
-SELECT
+WITH final_probe_extract AS ( SELECT
     channel,
     app_version as version,
     ping_type,
@@ -31,3 +31,71 @@ GROUP BY
     metric_type,
     key,
     client_agg_type
+),
+-- to populate total_sample for agg_type other than 'count'
+glam_sample_counts AS (
+  SELECT fsc1.os,
+    fsc1.app_version,
+    fsc1.app_build_id,
+    fsc1.metric,
+    fsc1.key,
+    fsc1.ping_type,
+    fsc1.agg_type,
+    CASE WHEN fsc1.agg_type in ('max','min','sum','avg') AND fsc2.agg_type = 'count' THEN fsc2.total_sample ELSE fsc1.total_sample END as total_sample
+  FROM `{{ dataset }}.{{ prefix }}__view_sample_counts_v1`  fsc1
+  INNER JOIN `{{ dataset }}.{{ prefix }}__view_sample_counts_v1`  fsc2
+  ON fsc1.os = fsc2.os
+    AND fsc1.app_build_id = fsc2.app_build_id
+    AND fsc1.app_version = fsc2.app_version
+    AND fsc1.metric = fsc2.metric
+    AND fsc1.key = fsc2.key
+    AND fsc1.ping_type = fsc2.ping_type
+WHERE fsc2.agg_type = 'count'
+),
+-- get all the rcords from view_probe_counts and the matching from view_sample_counts
+ranked_data AS (SELECT
+  cp.channel,
+  cp.version,
+  cp.os,
+  cp.ping_type,
+  cp.build_id,
+  cp.build_date,
+  cp.metric,
+  cp.metric_key,
+  cp.client_agg_type,
+  cp.metric_type,
+  total_users,
+  histogram,
+  percentiles,
+  CASE WHEN client_agg_type = '' THEN 0 ELSE total_sample END AS total_sample,
+  ROW_NUMBER() OVER (PARTITION BY cp.version, cp.os, cp.build_id,cp.ping_type, cp.metric, cp.metric_key, cp.client_agg_type,cp.metric_type,histogram, percentiles
+                    ORDER BY total_users, total_sample DESC) as rnk
+FROM
+  final_probe_extract cp
+LEFT JOIN glam_sample_counts sc
+  ON
+    sc.os = cp.os
+    AND sc.app_build_id = cp.build_id
+    AND sc.app_version = cp.version
+    AND sc.metric = cp.metric
+    AND sc.key = cp.metric_key
+    AND total_sample IS NOT NULL
+    AND (sc.agg_type = cp.client_agg_type OR cp.client_agg_type='')
+)
+--remove duplicates
+SELECT channel,
+  version,
+  ping_type,
+  os,
+  build_id,
+  build_date,
+  metric,
+  metric_type,
+  metric_key,
+  client_agg_type,
+  total_users,
+  histogram,
+  percentiles,
+  CAST(total_sample as INT) total_sample
+FROM ranked_data
+WHERE rnk = 1

--- a/bigquery_etl/glam/templates/view_sample_counts_v1.sql
+++ b/bigquery_etl/glam/templates/view_sample_counts_v1.sql
@@ -9,35 +9,56 @@ AS
 WITH histogram_data AS (
   SELECT
     client_id,
-    {{ attributes }}, 
+    ping_type,
+    os,
+    app_version,
+    app_build_id,
+    channel,
     h1.metric,
     h1.key, 
     h1.value
   FROM
     `{{ project }}.{{ dataset }}.{{ prefix }}__clients_histogram_aggregates_v1`, UNNEST(histogram_aggregates) h1
-    ),
-all_clients AS (SELECT
+),
+scalars_histogram_data AS (
+  SELECT
     client_id,
-    {{ attributes }}, 
+    ping_type,
+    os,
+    app_version,
+    app_build_id,
+    channel,
     s1.metric,
     s1.key,
     s1.value
   FROM
     `{{ project }}.{{ dataset }}.{{ prefix }}__clients_scalar_aggregates_v1`, UNNEST(scalar_aggregates) s1
-    WHERE s1.agg_type in ('count', 'false', 'true')
-  UNION ALL
+
+  UNION ALL 
+
   SELECT
     client_id,
-    {{ attributes }}, 
+    ping_type,
+    os,
+    app_version,
+    app_build_id,
+    channel,
     metric,
     v1.key,
     v1.value
   FROM
-    histogram_data, UNNEST(value) v1
+    histogram_data,
+    UNNEST(value) v1
 ),
+<<<<<<< HEAD
+=======
+
+
+
+>>>>>>> 492749c63 (changes to extract probes counts to include total_sample column)
 {{
     enumerate_table_combinations(
-        "all_clients",
+        "scalars_histogram_data",
         "all_combos",
         cubed_attributes,
         attribute_combinations

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql
@@ -1,4 +1,4 @@
-SELECT
+WITH final_probe_extract AS (SELECT
   app_version,
   COALESCE(os, "*") AS os,
   COALESCE(app_build_id, "*") AS app_build_id,
@@ -30,3 +30,62 @@ GROUP BY
   process,
   client_agg_type,
   total_users
+), 
+glam_sample_counts AS (
+    SELECT fsc1.os, 
+    fsc1.app_version,
+    fsc1.app_build_id,
+    fsc1.metric,
+    fsc1.key,
+    fsc1.process,
+    fsc1.agg_type, 
+    CASE WHEN fsc1.agg_type in ('max','min','sum','avg') AND fsc2.agg_type = 'count' THEN fsc2.total_sample ELSE fsc1.total_sample END as total_sample
+   FROM `moz-fx-data-shared-prod.telemetry_derived.glam_sample_counts_v1` fsc1
+  INNER JOIN `moz-fx-data-shared-prod.telemetry_derived.glam_sample_counts_v1` fsc2
+  ON fsc1.os = fsc2.os
+    AND fsc1.app_build_id = fsc2.app_build_id
+    AND fsc1.app_version = fsc2.app_version
+    AND fsc1.metric = fsc2.metric
+    AND fsc1.key = fsc2.key
+    AND fsc1.channel = fsc2.channel
+    AND fsc1.process = fsc2.process 
+  WHERE fsc1.channel = @channel
+)
+
+SELECT
+  cp.app_version,
+  cp.os,
+  cp.app_build_id,
+  cp.process,
+  cp.metric,
+  cp.key,
+  cp.client_agg_type,
+  cp.metric_type,
+  total_users,
+  histogram,
+  percentiles,
+  CASE WHEN client_agg_type = '' THEN 0 ELSE total_sample END AS total_sample
+FROM
+  final_probe_extract cp
+LEFT JOIN glam_sample_counts sc
+  ON
+    sc.os = cp.os
+    AND sc.app_build_id = cp.app_build_id
+    AND sc.app_version = cp.app_version
+    AND sc.metric = cp.metric
+    AND sc.key = cp.key
+    AND sc.process = cp.process
+    AND total_sample IS NOT NULL
+    AND (sc.agg_type = cp.client_agg_type OR cp.client_agg_type='')
+GROUP BY  cp.app_version,
+  cp.os,
+  cp.app_build_id,
+  cp.process,
+  cp.metric,
+  cp.key,
+  cp.client_agg_type,
+  cp.metric_type,
+  total_users,
+  total_sample,
+  histogram,
+  percentiles


### PR DESCRIPTION

This is related to adding total_sample to the extract_probes tables for both glean products and desktop. 
The PR will be merged once the backend (postgres ) db migration has completed to include the new column.

