### PR TITLE
feat: updated ubuntu image 2014 being depracted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   ubuntu-machine-executor:
     machine:
-      image: ubuntu-2004:202111-02
+      image: cimg/base:2022.03
 
 jobs:
   build:
@@ -220,7 +220,7 @@ jobs:
     # based on
     # https://github.com/mozilla/telemetry-airflow/blob/main/.circleci/config.yml
     machine:
-      image: ubuntu-2004:202111-01
+      image: cimg/base:2022.03
       docker_layer_caching: true
     steps:
       - checkout


### PR DESCRIPTION
As far as I understand the docs:

`cimg/base:version` is the new pattern used for tagging ubuntu images by circleci:
https://circleci.com/developer/images/image/cimg/base

This is a follow up to email I received from CircleCi with deprecation notice for old Ubuntu images:
https://circleci.com/blog/ubuntu-14-16-image-deprecation/