### PR TITLE
Exclude probes that cause error on GLAM from ETL (#2792)

### DIFF
--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 from jinja2 import Environment, PackageLoader
 
 from bigquery_etl.format_sql.formatter import reformat
+from bigquery_etl.util.probe_filters import get_etl_excluded_probes_quickfix
 
 from .utils import get_schema, ping_type_from_table
 
@@ -42,6 +43,7 @@ def get_distribution_metrics(schema: Dict) -> Dict[str, List[str]]:
         "custom_distribution",
     }
     metrics: Dict[str, List[str]] = {metric_type: [] for metric_type in metric_type_set}
+    excluded_metrics = get_etl_excluded_probes_quickfix()
 
     # Iterate over every element in the schema under the metrics section and
     # collect a list of metric names.
@@ -53,7 +55,8 @@ def get_distribution_metrics(schema: Dict) -> Dict[str, List[str]]:
             if metric_type not in metric_type_set:
                 continue
             for field in metric_field["fields"]:
-                metrics[metric_type].append(field["name"])
+                if field["name"] not in excluded_metrics:
+                    metrics[metric_type].append(field["name"])
     return metrics
 
 

--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -43,7 +43,7 @@ def get_distribution_metrics(schema: Dict) -> Dict[str, List[str]]:
         "custom_distribution",
     }
     metrics: Dict[str, List[str]] = {metric_type: [] for metric_type in metric_type_set}
-    excluded_metrics = get_etl_excluded_probes_quickfix()
+    excluded_metrics = get_etl_excluded_probes_quickfix("fenix")
 
     # Iterate over every element in the schema under the metrics section and
     # collect a list of metric names.

--- a/bigquery_etl/glam/clients_daily_scalar_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_scalar_aggregates.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 from jinja2 import Environment, PackageLoader
 
 from bigquery_etl.format_sql.formatter import reformat
+from bigquery_etl.util.probe_filters import get_etl_excluded_probes_quickfix
 
 from .utils import get_schema, ping_type_from_table
 
@@ -99,6 +100,7 @@ def get_scalar_metrics(schema: Dict, scalar_type: str) -> Dict[str, List[str]]:
     scalars: Dict[str, List[str]] = {
         metric_type: [] for metric_type in metric_type_set[scalar_type]
     }
+    excluded_metrics = get_etl_excluded_probes_quickfix()
 
     # Iterate over every element in the schema under the metrics section and
     # collect a list of metric names.
@@ -110,7 +112,8 @@ def get_scalar_metrics(schema: Dict, scalar_type: str) -> Dict[str, List[str]]:
             if metric_type not in metric_type_set[scalar_type]:
                 continue
             for field in metric_field["fields"]:
-                scalars[metric_type].append(field["name"])
+                if field["name"] not in excluded_metrics:
+                    scalars[metric_type].append(field["name"])
     return scalars
 
 

--- a/bigquery_etl/glam/clients_daily_scalar_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_scalar_aggregates.py
@@ -100,7 +100,7 @@ def get_scalar_metrics(schema: Dict, scalar_type: str) -> Dict[str, List[str]]:
     scalars: Dict[str, List[str]] = {
         metric_type: [] for metric_type in metric_type_set[scalar_type]
     }
-    excluded_metrics = get_etl_excluded_probes_quickfix()
+    excluded_metrics = get_etl_excluded_probes_quickfix("fenix")
 
     # Iterate over every element in the schema under the metrics section and
     # collect a list of metric names.

--- a/bigquery_etl/util/probe_filters.py
+++ b/bigquery_etl/util/probe_filters.py
@@ -1,0 +1,12 @@
+"""Functions that retrieve allow or block lists of probes."""
+
+
+def get_etl_excluded_probes_quickfix():
+    """Provide a static list of probes that must be excluded from aggregation.
+
+    TODO: Change the function name and doc when final implementation is done.
+    When so, this function will prob be turned into something like 'get_allowed_probes'
+    and retrieve the list from an api call.
+    """
+    # See https://github.com/mozilla/glam/issues/1865
+    return {"sqlite_store_open", "sqlite_store_query"}

--- a/bigquery_etl/util/probe_filters.py
+++ b/bigquery_etl/util/probe_filters.py
@@ -1,7 +1,7 @@
 """Functions that retrieve allow or block lists of probes."""
 
 
-def get_etl_excluded_probes_quickfix():
+def get_etl_excluded_probes_quickfix(product):
     """Provide a static list of probes that must be excluded from aggregation.
 
     TODO: Change the function name and doc when final implementation is done.
@@ -9,4 +9,8 @@ def get_etl_excluded_probes_quickfix():
     and retrieve the list from an api call.
     """
     # See https://github.com/mozilla/glam/issues/1865
-    return {"sqlite_store_open", "sqlite_store_query"}
+    forbidden_probes_by_product = {
+        "fenix": {},
+        "desktop": {"sqlite_store_open", "sqlite_store_query"},
+    }
+    return forbidden_probes_by_product[product]

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_v1.sql.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from time import sleep
 
 from google.cloud import bigquery
+from bigquery_etl.util import probe_filters
 
 sys.path.append(str(Path(__file__).parent.parent.parent.resolve()))
 from bigquery_etl.format_sql.formatter import reformat
@@ -455,6 +456,7 @@ def get_histogram_probes_and_buckets(histogram_type, processes_to_output):
 
     with urllib.request.urlopen(PROBE_INFO_SERVICE) as url:
         data = json.loads(gzip.decompress(url.read()).decode())
+        excluded_probes = probe_filters.get_etl_excluded_probes_quickfix()
         histogram_probes = {
             x.replace("histogram/", "").replace(".", "_").lower()
             for x in data.keys()
@@ -465,7 +467,7 @@ def get_histogram_probes_and_buckets(histogram_type, processes_to_output):
         relevant_probes = {
             histogram: {"processes": process}
             for histogram, process in main_summary_histograms.items()
-            if histogram in histogram_probes
+            if histogram in histogram_probes and histogram not in excluded_probes
         }
         for key in data.keys():
             if not key.startswith("histogram/"):

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_v1.sql.py
@@ -456,7 +456,7 @@ def get_histogram_probes_and_buckets(histogram_type, processes_to_output):
 
     with urllib.request.urlopen(PROBE_INFO_SERVICE) as url:
         data = json.loads(gzip.decompress(url.read()).decode())
-        excluded_probes = probe_filters.get_etl_excluded_probes_quickfix()
+        excluded_probes = probe_filters.get_etl_excluded_probes_quickfix("desktop")
         histogram_probes = {
             x.replace("histogram/", "").replace(".", "_").lower()
             for x in data.keys()

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
@@ -446,7 +446,7 @@ def get_scalar_probes(scalar_type):
     # and those that exist in main summary
     with urllib.request.urlopen(PROBE_INFO_SERVICE) as url:
         data = json.loads(gzip.decompress(url.read()).decode())
-        excluded_probes = probe_filters.get_etl_excluded_probes_quickfix()
+        excluded_probes = probe_filters.get_etl_excluded_probes_quickfix("desktop")
         scalar_probes = set(
             [
                 snake_case(x.replace("scalar/", ""))

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
@@ -10,6 +10,8 @@ import urllib.request
 from pathlib import Path
 from time import sleep
 
+from bigquery_etl.util import probe_filters
+
 sys.path.append(str(Path(__file__).parent.parent.parent.resolve()))
 from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.util.common import snake_case
@@ -444,13 +446,14 @@ def get_scalar_probes(scalar_type):
     # and those that exist in main summary
     with urllib.request.urlopen(PROBE_INFO_SERVICE) as url:
         data = json.loads(gzip.decompress(url.read()).decode())
+        excluded_probes = probe_filters.get_etl_excluded_probes_quickfix()
         scalar_probes = set(
             [
                 snake_case(x.replace("scalar/", ""))
                 for x in data.keys()
                 if x.startswith("scalar/")
             ]
-        )
+        ) - excluded_probes
 
         return {
             "scalars": filter_scalars_dict(main_summary_scalars, scalar_probes),


### PR DESCRIPTION
Fixes #2792

This implements a quick-fix to stop probes that cause error on GLAM from being aggregated.
There's upcoming work fixing [another issue](https://github.com/mozilla/glam/issues/1847) that will also allow us to replace the probe names hardcoded in this PR with api calls that will return them.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
