### PR TITLE
DVPN-118 - Remove unintentional column from vpn aggregates views

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/active_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/active_subscriptions/view.sql
@@ -8,7 +8,7 @@ WITH max_agg_date AS (
     `moz-fx-data-shared-prod`.mozilla_vpn_derived.active_subscriptions_v1
 )
 SELECT
-  *
+  active_subscriptions_live.*
 FROM
   `moz-fx-data-shared-prod`.mozilla_vpn_derived.active_subscriptions_live
 CROSS JOIN

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/subscription_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/subscription_events/view.sql
@@ -8,7 +8,7 @@ WITH max_agg_date AS (
     `moz-fx-data-shared-prod`.mozilla_vpn_derived.subscription_events_v1
 )
 SELECT
-  *
+  subscription_events_live.*
 FROM
   `moz-fx-data-shared-prod`.mozilla_vpn_derived.subscription_events_live
 CROSS JOIN


### PR DESCRIPTION
fixes view deploy error introduced by #2782: `Queries in UNION ALL have mismatched column count; query 1 has 32 columns, query 2 has 31 columns at [19:1]`