### PR TITLE
DVPN-118 - Fix jinja filter for delaying vpn aggregates

### DIFF
--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -47,7 +47,7 @@ with DAG(
 
     mozilla_vpn_derived__active_subscriptions__v1 = bigquery_etl_query(
         task_id="mozilla_vpn_derived__active_subscriptions__v1",
-        destination_table="active_subscriptions_v1${{macros.ds_add(ds, -7)|ds_nodash}}",
+        destination_table='active_subscriptions_v1${{ macros.ds_format(macros.ds_add(ds, -7), "%Y-%m-%d", "%Y%m%d") }}',
         dataset_id="mozilla_vpn_derived",
         project_id="moz-fx-data-shared-prod",
         owner="dthorn@mozilla.com",
@@ -203,7 +203,7 @@ with DAG(
 
     mozilla_vpn_derived__subscription_events__v1 = bigquery_etl_query(
         task_id="mozilla_vpn_derived__subscription_events__v1",
-        destination_table="subscription_events_v1${{macros.ds_add(ds, -7)|ds_nodash}}",
+        destination_table='subscription_events_v1${{ macros.ds_format(macros.ds_add(ds, -7), "%Y-%m-%d", "%Y%m%d") }}',
         dataset_id="mozilla_vpn_derived",
         project_id="moz-fx-data-shared-prod",
         owner="dthorn@mozilla.com",

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_v1/metadata.yaml
@@ -11,6 +11,11 @@ scheduling:
   # delay aggregates by 7 days, to ensure data is complete
   date_partition_parameter: null
   destination_table:
-    "active_subscriptions_v1${{macros.ds_add(ds, -7)|ds_nodash}}"
+    # TODO when airflow is updated to 2.2+ use ds_nodash filter:
+    # "active_subscriptions_v1${{macros.ds_add(ds, -7)|ds_nodash}}"
+    >-
+    active_subscriptions_v1${{
+    macros.ds_format(macros.ds_add(ds, -7), "%Y-%m-%d", "%Y%m%d")
+    }}
   parameters:
     - "date:DATE:{{macros.ds_add(ds, -7)}}"

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscription_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscription_events_v1/metadata.yaml
@@ -11,6 +11,11 @@ scheduling:
   # delay aggregates by 7 days, to ensure data is complete
   date_partition_parameter: null
   destination_table:
-    "subscription_events_v1${{macros.ds_add(ds, -7)|ds_nodash}}"
+    # TODO when airflow is updated to 2.2+ use ds_nodash filter:
+    # "subscription_events_v1${{macros.ds_add(ds, -7)|ds_nodash}}"
+    >-
+    subscription_events_v1${{
+    macros.ds_format(macros.ds_add(ds, -7), "%Y-%m-%d", "%Y%m%d")
+    }}
   parameters:
     - "date:DATE:{{macros.ds_add(ds, -7)}}"


### PR DESCRIPTION
`|ds_nodash` isn't available until airflow 2.2, we are on 2.1.4 so per https://airflow.apache.org/docs/apache-airflow/2.1.4/macros-ref.html we have to use `macros.ds_format(ds, input_format, output_format)` 