### PR TITLE
DVPN-118 - Delay channel_group_proportions_v1

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -91,6 +91,7 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/query.sql",
+    "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/devices_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/query.sql",
     "sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql",  # noqa E501

--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -85,13 +85,15 @@ with DAG(
 
     mozilla_vpn_derived__channel_group_proportions__v1 = bigquery_etl_query(
         task_id="mozilla_vpn_derived__channel_group_proportions__v1",
-        destination_table="channel_group_proportions_v1",
+        destination_table='channel_group_proportions_v1${{ macros.ds_format(macros.ds_add(ds, -7), "%Y-%m-%d", "%Y%m%d") }}',
         dataset_id="mozilla_vpn_derived",
         project_id="moz-fx-data-shared-prod",
         owner="dthorn@mozilla.com",
         email=["dthorn@mozilla.com", "telemetry-alerts@mozilla.com"],
-        date_partition_parameter="date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        parameters=["date:DATE:{{macros.ds_add(ds, -7)}}"],
+        sql_file_path="sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/query.sql",
         dag=dag,
     )
 
@@ -943,6 +945,10 @@ with DAG(
 
     mozilla_vpn_derived__all_subscriptions__v1.set_upstream(
         stripe_external__promotion_codes__v1
+    )
+
+    mozilla_vpn_derived__channel_group_proportions__v1.set_upstream(
+        mozilla_vpn_derived__all_subscriptions__v1
     )
 
     mozilla_vpn_derived__channel_group_proportions__v1.set_upstream(

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/channel_group_proportions/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/channel_group_proportions/view.sql
@@ -1,6 +1,21 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.mozilla_vpn.channel_group_proportions`
 AS
+WITH max_agg_date AS (
+  SELECT AS VALUE
+    MAX(subscription_start_date)
+  FROM
+    `moz-fx-data-shared-prod`.mozilla_vpn_derived.channel_group_proportions_v1
+)
+SELECT
+  mozilla_vpn_derived.channel_group_proportions_live.*
+FROM
+  `moz-fx-data-shared-prod`.mozilla_vpn_derived.channel_group_proportions_live
+CROSS JOIN
+  max_agg_date
+WHERE
+  subscription_start_date > max_agg_date
+UNION ALL
 SELECT
   *
 FROM

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_live/view.sql
@@ -1,0 +1,62 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mozilla_vpn_derived.channel_group_proportions_live`
+AS
+WITH stage_1 AS (
+  SELECT
+    event_date AS subscription_start_date,
+    country_name,
+    utm_medium,
+    utm_source,
+    utm_campaign,
+    utm_content,
+    utm_term,
+    entrypoint_experiment,
+    entrypoint_variation,
+    pricing_plan,
+    provider,
+    TO_JSON_STRING(promotion_codes) AS json_promotion_codes,
+    SUM(`count`) AS new_subscriptions,
+  FROM
+    mozdata.mozilla_vpn.subscription_events
+  WHERE
+    event_type = "New"
+  GROUP BY
+    subscription_start_date,
+    country_name,
+    utm_medium,
+    utm_source,
+    utm_campaign,
+    utm_content,
+    utm_term,
+    entrypoint_experiment,
+    entrypoint_variation,
+    pricing_plan,
+    provider,
+    json_promotion_codes
+),
+stage_2 AS (
+  SELECT
+    * EXCEPT (json_promotion_codes),
+    JSON_VALUE_ARRAY(json_promotion_codes) AS promotion_codes,
+    mozfun.vpn.channel_group(
+      utm_campaign => utm_campaign,
+      utm_content => utm_content,
+      utm_medium => utm_medium,
+      utm_source => utm_source
+    ) AS channel_group,
+    SUM(new_subscriptions) OVER (
+      PARTITION BY
+        subscription_start_date
+    ) AS total_new_subscriptions_for_date,
+  FROM
+    stage_1
+)
+SELECT
+  *,
+  SUM(new_subscriptions) OVER (
+    PARTITION BY
+      subscription_start_date,
+      channel_group
+  ) / total_new_subscriptions_for_date * 100 AS channel_group_percent_of_total_for_date,
+FROM
+  stage_2

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/metadata.yaml
@@ -9,4 +9,19 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_subplat
-  date_partition_parameter: date
+  # delay aggregates by 7 days, to ensure data is complete
+  date_partition_parameter: null
+  destination_table:
+    # TODO when airflow is updated to 2.2+ use ds_nodash filter:
+    # "active_subscriptions_v1${{macros.ds_add(ds, -7)|ds_nodash}}"
+    >-
+    channel_group_proportions_v1${{
+    macros.ds_format(macros.ds_add(ds, -7), "%Y-%m-%d", "%Y%m%d")
+    }}
+  parameters:
+    - "date:DATE:{{macros.ds_add(ds, -7)}}"
+  query_file_path:
+    # explicit query file path is necessary because the destination table
+    # includes a partition identifier that is not in the path
+    # yamllint disable rule:line-length
+    sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/query.sql

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/query.sql
@@ -1,60 +1,6 @@
-WITH stage_1 AS (
-  SELECT
-    event_date AS subscription_start_date,
-    country_name,
-    utm_medium,
-    utm_source,
-    utm_campaign,
-    utm_content,
-    utm_term,
-    entrypoint_experiment,
-    entrypoint_variation,
-    pricing_plan,
-    provider,
-    TO_JSON_STRING(promotion_codes) AS json_promotion_codes,
-    SUM(`count`) AS new_subscriptions,
-  FROM
-    `moz-fx-data-shared-prod`.mozilla_vpn_derived.subscription_events_v1
-  WHERE
-    event_type = "New"
-    AND IF(@date IS NULL, event_date < CURRENT_DATE, event_date = @date)
-  GROUP BY
-    subscription_start_date,
-    country_name,
-    utm_medium,
-    utm_source,
-    utm_campaign,
-    utm_content,
-    utm_term,
-    entrypoint_experiment,
-    entrypoint_variation,
-    pricing_plan,
-    provider,
-    json_promotion_codes
-),
-stage_2 AS (
-  SELECT
-    * EXCEPT (json_promotion_codes),
-    JSON_VALUE_ARRAY(json_promotion_codes) AS promotion_codes,
-    mozfun.vpn.channel_group(
-      utm_campaign => utm_campaign,
-      utm_content => utm_content,
-      utm_medium => utm_medium,
-      utm_source => utm_source
-    ) AS channel_group,
-    SUM(new_subscriptions) OVER (
-      PARTITION BY
-        subscription_start_date
-    ) AS total_new_subscriptions_for_date,
-  FROM
-    stage_1
-)
 SELECT
-  *,
-  SUM(new_subscriptions) OVER (
-    PARTITION BY
-      subscription_start_date,
-      channel_group
-  ) / total_new_subscriptions_for_date * 100 AS channel_group_percent_of_total_for_date,
+  *
 FROM
-  stage_2
+  `moz-fx-data-shared-prod`.mozilla_vpn_derived.channel_group_proportions_live
+WHERE
+  IF(@date IS NULL, subscription_start_date < CURRENT_DATE - 7, subscription_start_date = @date)


### PR DESCRIPTION
because it's derived from `moz-fx-data-shared-prod.mozilla_vpn_derived.subscription_events_v1`, which is delayed 7 days.
