### PR TITLE
CLI -> SDK for run_query script

### DIFF
--- a/bigquery_etl/run_query.py
+++ b/bigquery_etl/run_query.py
@@ -5,12 +5,14 @@ When executing a query associated metadata is parsed to determine whether
 results should be written to a corresponding public dataset.
 """
 
+import logging
 import re
-import subprocess
 import sys
 from argparse import ArgumentParser
+from pathlib import Path
 
 import yaml
+from google.cloud import bigquery
 
 from bigquery_etl.metadata.parse_metadata import Metadata
 from bigquery_etl.metadata.validate_metadata import validate_public_data
@@ -28,22 +30,94 @@ parser.add_argument(
 parser.add_argument(
     "--destination_table", help="Destination table name results are written to"
 )
+parser.add_argument(
+    "--project_id",
+    help="Default project, if not specified the sdk will determine one",
+)
+parser.add_argument(
+    "--time_partitioning_field",
+    type=lambda f: bigquery.TimePartitioning(field=f),
+    help="time partition field on the destination table",
+)
+parser.add_argument(
+    "--clustering_fields",
+    type=lambda f: f.split(","),
+    help="comma separated list of clustering fields on the destination table",
+)
+parser.add_argument(
+    "--dry_run",
+    action="store_true",
+    help="Print bytes that would be processed for each part and don't run queries",
+)
+parser.add_argument(
+    "--parameter",
+    action="append",
+    default=[],
+    dest="parameters",
+    type=lambda p: bigquery.ScalarQueryParameter(*p.split(":", 2)),
+    metavar="NAME:TYPE:VALUE",
+    help="query parameter(s) to pass when running parts",
+)
+parser.add_argument(
+    "--max_rows",
+    help="The number of rows to return in the query results.",
+    default=0,
+)
+parser.add_argument(
+    "--schema_update_option",
+    action="append",
+    choices=[
+        bigquery.SchemaUpdateOption.ALLOW_FIELD_ADDITION,
+        bigquery.SchemaUpdateOption.ALLOW_FIELD_RELAXATION,
+        # Airflow passes an empty string when the field addition date doesn't
+        # match the run date.
+        # See https://github.com/mozilla/telemetry-airflow/blob/
+        # e49fa7e6b3f5ec562dd248d257770c2303cf0cba/dags/utils/gcp.py#L515
+        "",
+    ],
+    default=[],
+    dest="schema_update_options",
+    help="Optional options for updating the schema.",
+)
+parser.add_argument(
+    "--replace",
+    action="store_true",
+    help="Whether to overwrite the `destination_table` or not.",
+)
+parser.add_argument(
+    "--write_disposition",
+    default=bigquery.WriteDisposition.WRITE_APPEND,
+    help="The action that occurs if destination table already exists.",
+)
 parser.add_argument("--dataset_id", help="Destination dataset")
 parser.add_argument("--query_file", help="File path to query to be executed")
 
 
 def run(
     query_file,
-    dataset_id,
-    destination_table,
-    query_arguments,
+    dataset_id=None,
+    destination_table=None,
+    project_id=None,
     public_project_id=PUBLIC_PROJECT_ID,
+    dry_run=False,
+    parameters=None,
+    replace=False,
+    schema_update_options=None,
+    time_partitioning_field=None,
+    clustering_fields=None,
+    max_rows=0,
+    write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
 ):
-    """Execute bq to run a query."""
-    if dataset_id is not None:
-        # dataset ID was parsed by argparse but needs to be passed as parameter
-        # when running the query
-        query_arguments.append("--dataset_id={}".format(dataset_id))
+    """Run the specified query with the provided arguments."""
+    schema_update_options = schema_update_options or []
+    parameters = parameters or []
+    clustering_fields = clustering_fields or []
+
+    if schema_update_options is None:
+        schema_update_options = []
+    query_path = Path(query_file)
+    if not query_path.exists():
+        raise FileNotFoundError(f"Path to query: {query_path} does not exist.")
 
     use_public_table = False
 
@@ -53,53 +127,92 @@ def run(
             if not validate_public_data(metadata, query_file):
                 sys.exit(1)
 
-            # change the destination table to write results to the public dataset;
-            # a view to the public table in the internal dataset is created
-            # when CI runs
-            if (
-                dataset_id is not None
-                and destination_table is not None
-                and re.match(DESTINATION_TABLE_RE, destination_table)
-            ):
-                destination_table = "{}:{}.{}".format(
-                    public_project_id, dataset_id, destination_table
-                )
-                query_arguments.append(
-                    "--destination_table={}".format(destination_table)
-                )
-                use_public_table = True
-            else:
-                print(
-                    "ERROR: Cannot run public dataset query. Parameters"
-                    " --destination_table=<table without dataset ID> and"
-                    " --dataset_id=<dataset> required"
-                )
-                sys.exit(1)
+            use_public_table = True
     except yaml.YAMLError as e:
-        print(e)
+        logging.error(e)
         sys.exit(1)
     except FileNotFoundError:
-        print("INFO: No metadata.yaml found for {}", query_file)
+        logging.warning(f"INFO: No metadata.yaml found for {query_file}")
 
-    if not use_public_table and destination_table is not None:
-        # destination table was parsed by argparse, however if it wasn't modified to
-        # point to a public table it needs to be passed as parameter for the query
-        query_arguments.append("--destination_table={}".format(destination_table))
+    can_qualify_destination_table = (
+        dataset_id is not None
+        and destination_table is not None
+        and re.match(DESTINATION_TABLE_RE, destination_table)
+    )
 
-    with open(query_file) as query_stream:
-        # run the query as shell command so that passed parameters can be used as is
-        subprocess.check_call(["bq"] + query_arguments, stdin=query_stream)
+    if not can_qualify_destination_table:
+        raise ValueError(
+            "ERROR: Unable to qualify destination table."
+            " --destination_table=<table without dataset ID> and"
+            " --dataset_id=<dataset> required"
+        )
+
+    if use_public_table:
+        # change the destination table to write results to the public dataset;
+        # a view to the public table in the internal dataset is created
+        # when CI runs
+        destination_project = public_project_id
+    else:
+        destination_project = project_id
+
+    if destination_project is None:
+        logging.info(
+            "No project provided, the BigQuery Client will determine the project "
+            "(from environment variables or a .bigqueryrc file."
+        )
+
+    qualified_table = "{}.{}.{}".format(
+        destination_project, dataset_id, destination_table
+    )
+
+    client = bigquery.Client(destination_project)
+
+    write_disposition = (
+        bigquery.WriteDisposition.WRITE_TRUNCATE if replace else write_disposition
+    )
+
+    job_config = bigquery.QueryJobConfig(
+        destination=qualified_table,
+        time_partitioning=time_partitioning_field,
+        clustering_fields=clustering_fields,
+        dry_run=dry_run,
+        schema_update_options=schema_update_options,
+        query_parameters=parameters,
+        use_legacy_sql=False,
+        write_disposition=write_disposition,
+    )
+
+    job = client.query(query=query_path.read_text(), job_config=job_config)
+
+    if job.dry_run:
+        logging.info(f"Would process {int(job.total_bytes_processed):,d} bytes")
+    else:
+        logging.info(f"Job with ID: {job.job_id} started at {job.started}")
+        logging.info(f"Job URL: {job.self_link}")
+        job.result(max_results=max_rows)
+        logging.info(
+            f"Job ended at {job.ended}; processed {int(job.total_bytes_processed):,d} bytes"
+        )
 
 
 def main():
     """Run query."""
-    args, query_arguments = parser.parse_known_args()
+    args = parser.parse_args()
+
     run(
         args.query_file,
-        args.dataset_id,
-        args.destination_table,
-        query_arguments,
-        args.public_project_id,
+        dataset_id=args.dataset_id,
+        destination_table=args.destination_table,
+        project_id=args.project_id,
+        public_project_id=args.public_project_id,
+        dry_run=args.dry_run,
+        parameters=args.parameters,
+        replace=args.replace,
+        schema_update_options=args.schema_update_options,
+        time_partitioning_field=args.time_partitioning_field,
+        clustering_fields=args.clustering_fields,
+        max_rows=args.max_rows,
+        write_disposition=args.write_disposition,
     )
 
 

--- a/script/entrypoint
+++ b/script/entrypoint
@@ -29,9 +29,8 @@ elif [ "${1:0:1}" = - ]; then
 elif [ "$1" = "query" ]; then
     # For an invocation like:
     #     query [options] FILE
-    # we dispatch to a script that inspects metadata and emulates the following call:
-    #     bq query [options] < FILE 
-    exec script/run_query --query_file="${@: -1}" "${@:1:$#-1}"
+    # we dispatch to a script that inspects metadata and runs the query in FILE
+    exec script/run_query --query_file="${@: -1}" "${@:2:$#-2}"
 elif [ "$XCOM_PUSH" = "true" ]; then
     # KubernetesPodOperator will extract the contents of /airflow/xcom/return.json as an xcom
     # if the xcom_push parameter is true

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -10,7 +10,8 @@ ENTRYPOINT_SCRIPT = Path(__file__).parent.parent / "script" / "entrypoint"
 
 class TestEntrypoint:
     @pytest.mark.integration
-    def test_run_query(self, tmp_path, project_id):
+    def test_run_query(self, tmp_path):
+        project_id = "bigquery-etl-integration-test"
         query_file_path = tmp_path / "sql" / "test" / "query_v1"
         os.makedirs(query_file_path)
 
@@ -27,14 +28,14 @@ class TestEntrypoint:
                 ],
                 stderr=subprocess.STDOUT,
             )
-            assert b"Current status: DONE" in result
+            assert b"Current status: DONE" in result  # TODO: Update success output
             assert b"No metadata.yaml found for {}" in result
         except subprocess.CalledProcessError as e:
             # running bq in CircleCI will fail since it's not installed
             # but the error output can be checked for whether bq was called
             assert b"No such file or directory: 'bq'" in e.output
             assert b"No metadata.yaml found for {}" in e.output
-            assert (
+            assert (  # TODO: Update failure output
                 b'subprocess.check_call(["bq"] + query_arguments, stdin=query_stream)'
                 in e.output
             )

--- a/tests/test_run_query.py
+++ b/tests/test_run_query.py
@@ -8,60 +8,22 @@ from bigquery_etl.run_query import run
 
 
 class TestRunQuery:
-    def test_run_query(self, tmp_path):
+    def test_raises_if_cant_qualify_destination_table(self, tmp_path):
         query_file_path = tmp_path / "sql" / "test" / "query_v1"
         os.makedirs(query_file_path)
         query_file = query_file_path / "query.sql"
         query_file.write_text("SELECT 1")
 
-        metadata_conf = {
-            "friendly_name": "test",
-            "description": "test",
-            "owners": ["test@example.org"],
-        }
+        with pytest.raises(ValueError):
+            run(query_file, dataset_id=None, destination_table=None)
 
-        metadata_file = query_file_path / "metadata.yaml"
-        metadata_file.write_text(yaml.dump(metadata_conf))
+        with pytest.raises(ValueError):
+            run(query_file, dataset_id="test", destination_table=None)
 
-        with patch("subprocess.check_call") as mock_call:
-            mock_call.return_value = True
-            run(query_file, "test", "query_v1", [])
+        with pytest.raises(ValueError):
+            run(query_file, dataset_id=None, destination_table="query_v1")
 
-            assert mock_call.call_args.args == (
-                ["bq", "--dataset_id=test", "--destination_table=query_v1"],
-            )
-            assert "stdin" in mock_call.call_args.kwargs
-
-    def test_run_query_public_project(self, tmp_path):
-        query_file_path = tmp_path / "sql" / "test" / "query_v1"
-        os.makedirs(query_file_path)
-        query_file = query_file_path / "query.sql"
-        query_file.write_text("SELECT 1")
-
-        metadata_conf = {
-            "friendly_name": "test",
-            "description": "test",
-            "owners": ["test@example.org"],
-            "labels": {"public_bigquery": True, "review_bugs": [222222]},
-        }
-
-        metadata_file = query_file_path / "metadata.yaml"
-        metadata_file.write_text(yaml.dump(metadata_conf))
-
-        with patch("subprocess.check_call") as mock_call:
-            mock_call.return_value = True
-            run(query_file, "test", "query_v1", [])
-
-            assert mock_call.call_args.args == (
-                [
-                    "bq",
-                    "--dataset_id=test",
-                    "--destination_table=mozilla-public-data:test.query_v1",
-                ],
-            )
-            assert "stdin" in mock_call.call_args.kwargs
-
-    def test_run_query_public_project_no_dataset(self, tmp_path):
+    def test_public_query_uses_public_project(self, tmp_path):
         query_file_path = tmp_path / "sql" / "test" / "query_v1"
         os.makedirs(query_file_path)
         query_file = query_file_path / "query.sql"
@@ -77,10 +39,32 @@ class TestRunQuery:
         metadata_file = query_file_path / "metadata.yaml"
         metadata_file.write_text(yaml.dump(metadata_conf))
 
-        with patch("subprocess.check_call") as mock_call:
-            mock_call.return_value = True
-            with pytest.raises(SystemExit):
-                run(query_file, None, "query_v1", [])
+        with patch("google.cloud.bigquery.Client") as mock_client:
 
-            with pytest.raises(SystemExit):
-                run(query_file, "test", None, [])
+            run(
+                query_file,
+                project_id="moz-fx-data-shared-prod",
+                public_project_id="moz-public",
+                dataset_id="test",
+                destination_table="query_v1",
+            )
+            assert mock_client.call_args.args == ("moz-public",)
+
+        metadata_conf = {
+            "friendly_name": "test",
+            "description": "test",
+            "owners": ["test@example.org"],
+            "labels": {"public_bigquery": True},  # No review bugs (invalid)
+        }
+
+        metadata_file = query_file_path / "metadata.yaml"
+        metadata_file.write_text(yaml.dump(metadata_conf))
+
+        with pytest.raises(SystemExit):
+            run(
+                query_file,
+                project_id="moz-fx-data-shared-prod",
+                public_project_id="moz-public",
+                dataset_id="test",
+                destination_table="query_v1",
+            )

--- a/tests/test_run_query.py
+++ b/tests/test_run_query.py
@@ -14,14 +14,13 @@ class TestRunQuery:
         query_file = query_file_path / "query.sql"
         query_file.write_text("SELECT 1")
 
-        with pytest.raises(ValueError):
-            run(query_file, dataset_id=None, destination_table=None)
+        with patch("google.cloud.bigquery.Client"):
 
-        with pytest.raises(ValueError):
-            run(query_file, dataset_id="test", destination_table=None)
+            with pytest.raises(ValueError):
+                run(query_file, dataset_id="test", destination_table=None)
 
-        with pytest.raises(ValueError):
-            run(query_file, dataset_id=None, destination_table="query_v1")
+            with pytest.raises(ValueError):
+                run(query_file, dataset_id=None, destination_table="query_v1")
 
     def test_public_query_uses_public_project(self, tmp_path):
         query_file_path = tmp_path / "sql" / "test" / "query_v1"


### PR DESCRIPTION
Updated the `run_query.py` script to use the BQ SDk instead of the CLI. This is primarily to expose some of the job metadata (e.g. job id and url) for easier debugging in Airflow for e.g. 