### PR TITLE
remove unwanted versions from fenix etl

### DIFF
--- a/bigquery_etl/glam/templates/extract_probe_counts_v1.sql
+++ b/bigquery_etl/glam/templates/extract_probe_counts_v1.sql
@@ -21,6 +21,7 @@ FROM
     `{{ dataset }}.{{ prefix }}__view_probe_counts_v1`
 WHERE
     total_users > {{ total_users }}
+    AND app_version NOT IN (2015815747, 2015819723, 2015828803, 2015829155, 3015815747)
 GROUP BY
     channel,
     app_version,


### PR DESCRIPTION
This is a quick fix to remove the unwanted app_versions creeping into the extracts for Fenix (release channel)
Related to [the issue](https://github.com/mozilla/glam/issues/1893)

A permanent solution needs to be brainstormed and put in place. 

