### PR TITLE
Bug 1761553 - Fix Rally study name label prefix in Shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -510,7 +510,7 @@ def find_pioneer_targets(pool, client, project=PIONEER_PROD, study_projects=[]):
     def __get_client_id_field__(table, deletion_request_view=False, study_name=None):
         """Determine which column should be used as client id for a given table."""
         if table.dataset_id.startswith("rally_") or (
-            study_name and study_name.startswith("rally_")
+            study_name and study_name.startswith("rally-")
         ):
             # `rally_zero_one` is a special case where top-level rally_id is used
             # both in the ping tables and the deletion_requests view


### PR DESCRIPTION
Previously Shredder was expecting study name labels on analysis datasets to have dashes converted to underscores, however this seems to not be the case in production.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
