### PR TITLE
Bug 1761790 Point to v1 schema in impression_stats view

### DIFF
--- a/sql/moz-fx-data-shared-prod/activity_stream/impression_stats/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream/impression_stats/metadata.yaml
@@ -1,0 +1,12 @@
+---
+friendly_name: Historical Pings for `activity-stream/impression-stats`
+description: |-
+  A historical view of pings sent for the
+  `activity-stream/impression-stats`
+  document type.
+
+  This view is guaranteed to contain only complete days
+  (per `submission_timestamp`)
+  and to contain only one row per distinct `document_id` within a given date.
+
+  Clustering fields: `normalized_channel`, `sample_id`

--- a/sql/moz-fx-data-shared-prod/activity_stream/impression_stats/view.sql
+++ b/sql/moz-fx-data-shared-prod/activity_stream/impression_stats/view.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.activity_stream.impression_stats`
+AS
+SELECT
+  * REPLACE (mozfun.norm.metadata(metadata) AS metadata)
+FROM
+  -- We explicitly choose v1 for now, but will transition to a unioned view
+  -- over v1 and v2 as the new schema is rolled out; see
+  -- https://bugzilla.mozilla.org/show_bug.cgi?id=1761790
+  `moz-fx-data-shared-prod.activity_stream_stable.impression_stats_v1`


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1761790

We'll be adding a new v2 schema that's not yet used, so explicitly adding the view definition here so we don't automatically deploy a view that only looks at v2.

As we build this out, we'll need to make a coordinated change that unions the two tables and change downstream tables to accept a string-type tile `id` field.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
