### PR TITLE
Update query.sql

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
@@ -61,6 +61,7 @@ flows AS (
         1
     )[SAFE_OFFSET(0)].*,
     ARRAY_AGG(plan_id IGNORE NULLS ORDER BY `timestamp` LIMIT 1)[SAFE_OFFSET(0)] AS plan_id,
+    ARRAY_AGG(promotion_code IGNORE NULLS ORDER BY `timestamp` LIMIT 1)[SAFE_OFFSET(0)] AS promotion_code,
     LOGICAL_OR(event_type = "fxa_rp_button - view") AS rp_button_view,
     -- impression for the cta button
     LOGICAL_OR(event_type = "fxa_pay_account_setup - view") AS pay_account_setup_view,
@@ -99,6 +100,20 @@ flows AS (
       event_type = "fxa_pay_setup - 3ds_complete"
       AND user_id IS NOT NULL
     ) AS pay_setup_complete_with_uid,
+   LOGICAL_OR(
+      event_type = "fxa_pay_setup - 3ds_complete"
+      AND user_id IS NOT NULL
+    ) AS pay_setup_complete_with_uid,
+  --coupon activities 
+  LOGICAL_OR(
+      event_type = "fxa_subscribe_coupon - submit"
+    ) AS subscribe_coupon_submit,
+   LOGICAL_OR(
+      event_type = "fxa_subscribe_coupon - fail"
+    ) AS subscribe_coupon_fail,
+   LOGICAL_OR(
+      event_type = "fxa_subscribe_coupon - success"
+    ) AS subscribe_coupon_success,
   FROM
     mozdata.firefox_accounts.fxa_content_auth_stdout_events
   WHERE
@@ -127,6 +142,7 @@ flow_counts AS (
     os_version,
     entrypoint,
     plan_id,
+    promotion_code,
     COUNTIF(rp_button_view) AS rp_button_view,
     -- vpn product site hits
     COUNTIF(pay_setup_view) AS pay_setup_view,
@@ -167,6 +183,16 @@ flow_counts AS (
       AND pay_setup_engage_with_uid
       AND pay_account_setup_other
     ) AS existing_fxa_signedoff_pay_setup_complete,
+  --coupon activities
+  COUNTIF(
+      subscribe_coupon_submit
+    ) AS subscribe_coupon_submit,
+   COUNTIF(
+      subscribe_coupon_fail
+    ) AS subscribe_coupon_fail,
+   COUNTIF(
+      subscribe_coupon_success
+    ) AS subscribe_coupon_success,
   FROM
     flows
   GROUP BY
@@ -184,7 +210,8 @@ flow_counts AS (
     os_name,
     os_version,
     entrypoint,
-    plan_id
+    plan_id,
+    promotion_code
 )
 SELECT
   partition_date,
@@ -205,6 +232,7 @@ SELECT
   product_id,
   pricing_plan,
   plan_name,
+  promotion_code,
   rp_button_view AS vpn_site_hits,
   mozfun.vpn.channel_group(
     utm_campaign => utm_campaign,
@@ -254,6 +282,10 @@ SELECT
   SUM(pay_setup_view_with_uid) OVER partition_date - SUM(
     existing_fxa_signedin_pay_setup_view
   ) OVER partition_date AS overall_existing_signedoff_fxa_payment_setup_view,
+  -- coupon activities
+  subscribe_coupon_submit AS subscribe_coupon_submit,
+  subscribe_coupon_fail AS subscribe_coupon_fail,
+  subscribe_coupon_success AS subscribe_coupon_success,
 FROM
   flow_counts
 LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
@@ -61,7 +61,9 @@ flows AS (
         1
     )[SAFE_OFFSET(0)].*,
     ARRAY_AGG(plan_id IGNORE NULLS ORDER BY `timestamp` LIMIT 1)[SAFE_OFFSET(0)] AS plan_id,
-    ARRAY_AGG(promotion_code IGNORE NULLS ORDER BY `timestamp` LIMIT 1)[SAFE_OFFSET(0)] AS promotion_code,
+    ARRAY_AGG(promotion_code IGNORE NULLS ORDER BY `timestamp` LIMIT 1)[
+      SAFE_OFFSET(0)
+    ] AS promotion_code,
     LOGICAL_OR(event_type = "fxa_rp_button - view") AS rp_button_view,
     -- impression for the cta button
     LOGICAL_OR(event_type = "fxa_pay_account_setup - view") AS pay_account_setup_view,
@@ -100,20 +102,14 @@ flows AS (
       event_type = "fxa_pay_setup - 3ds_complete"
       AND user_id IS NOT NULL
     ) AS pay_setup_complete_with_uid,
-   LOGICAL_OR(
+    LOGICAL_OR(
       event_type = "fxa_pay_setup - 3ds_complete"
       AND user_id IS NOT NULL
     ) AS pay_setup_complete_with_uid,
-  --coupon activities 
-  LOGICAL_OR(
-      event_type = "fxa_subscribe_coupon - submit"
-    ) AS subscribe_coupon_submit,
-   LOGICAL_OR(
-      event_type = "fxa_subscribe_coupon - fail"
-    ) AS subscribe_coupon_fail,
-   LOGICAL_OR(
-      event_type = "fxa_subscribe_coupon - success"
-    ) AS subscribe_coupon_success,
+    -- coupon activities
+    LOGICAL_OR(event_type = "fxa_subscribe_coupon - submit") AS subscribe_coupon_submit,
+    LOGICAL_OR(event_type = "fxa_subscribe_coupon - fail") AS subscribe_coupon_fail,
+    LOGICAL_OR(event_type = "fxa_subscribe_coupon - success") AS subscribe_coupon_success,
   FROM
     mozdata.firefox_accounts.fxa_content_auth_stdout_events
   WHERE
@@ -183,16 +179,10 @@ flow_counts AS (
       AND pay_setup_engage_with_uid
       AND pay_account_setup_other
     ) AS existing_fxa_signedoff_pay_setup_complete,
-  --coupon activities
-  COUNTIF(
-      subscribe_coupon_submit
-    ) AS subscribe_coupon_submit,
-   COUNTIF(
-      subscribe_coupon_fail
-    ) AS subscribe_coupon_fail,
-   COUNTIF(
-      subscribe_coupon_success
-    ) AS subscribe_coupon_success,
+    -- coupon activities
+    COUNTIF(subscribe_coupon_submit) AS subscribe_coupon_submit,
+    COUNTIF(subscribe_coupon_fail) AS subscribe_coupon_fail,
+    COUNTIF(subscribe_coupon_success) AS subscribe_coupon_success,
   FROM
     flows
   GROUP BY


### PR DESCRIPTION
to track coupon activities in the acquisition funnel view dashboard. This time, promotion code is added for the filter/group by and  subscribe_coupon_submit,
  subscribe_coupon_fail, and subscribe_coupon_success without separating new/existing FxA user categories.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
