### PR TITLE
fixed param name to submission_date

### DIFF
--- a/dags/bqetl_internet_outages.py
+++ b/dags/bqetl_internet_outages.py
@@ -64,7 +64,7 @@ with DAG(
         email=["aplacitelli@mozilla.com"],
         date_partition_parameter=None,
         depends_on_past=False,
-        parameters=["date:DATE:{{ds}}"],
+        parameters=["submission_date:DATE:{{ds}}"],
         dag=dag,
     )
 

--- a/sql/moz-fx-data-shared-prod/internet_outages/global_outages_staging_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/internet_outages/global_outages_staging_v1/metadata.yaml
@@ -22,7 +22,7 @@ scheduling:
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null
-  parameters: ["date:DATE:{{ds}}"]
+  parameters: ["submission_date:DATE:{{ds}}"]
   # provide this value so that DAG generation does not have to dry run the
   # query to get it, and that would be slow because main_v4 is referenced
   referenced_tables:


### PR DESCRIPTION
fixed param name to submission_date,

the template uses `@submission_date` param, it looks like we tried to set the value for param `date` which does not exist:
https://github.com/mozilla/bigquery-etl/blob/b9a2f77eb7b5b17e9c86d6b96c90e6ea48bdd3a0/sql/moz-fx-data-shared-prod/internet_outages/global_outages_staging_v1/query.sql#L89

error message:
```[2022-04-06 08:14:10,938] {{pod_launcher.py:149}} INFO - 'submission_date' not found at [89:23]```