### PR TITLE
DVPN-89 - Run cjms dag later to catch almost all events at end of day

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -696,12 +696,13 @@ bqetl_regrets_reporter_summary:
     - impact/tier_1
 
 bqetl_cjms_nonprod:
-  schedule_interval: 22 * * * *
+  schedule_interval: 59 * * * *
   description: |
     Hourly ETL for cjms nonprod.
 
-    Scheduled to run after fivetran stripe_nonprod, which runs hourly at minute
-    17 and takes less than 5 minutes.
+    Copies data from a Firefox Accounts (FxA) project. Those source tables are
+    populated via Cloud Logging (Stackdriver). Runs as late as possible to
+    minimize the chance of missed logs on date boundaries.
   default_args:
     owner: dthorn@mozilla.com
     start_date: "2022-03-24"

--- a/dags/bqetl_cjms_nonprod.py
+++ b/dags/bqetl_cjms_nonprod.py
@@ -17,8 +17,9 @@ Built from bigquery-etl repo, [`dags/bqetl_cjms_nonprod.py`](https://github.com/
 
 Hourly ETL for cjms nonprod.
 
-Scheduled to run after fivetran stripe_nonprod, which runs hourly at minute
-17 and takes less than 5 minutes.
+Copies data from a Firefox Accounts (FxA) project. Those source tables are
+populated via Cloud Logging (Stackdriver). Runs as late as possible to
+minimize the chance of missed logs on date boundaries.
 
 #### Owner
 
@@ -43,7 +44,7 @@ tags = ["impact/tier_3", "repo/bigquery-etl"]
 with DAG(
     "bqetl_cjms_nonprod",
     default_args=default_args,
-    schedule_interval="22 * * * *",
+    schedule_interval="59 * * * *",
     doc_md=docs,
     tags=tags,
 ) as dag:


### PR DESCRIPTION
intermediate table flows_v1 was not getting events for the previous UTC date that arrive after 00:22 UTC, this pushes back that cutoff to 00:59 UTC. this isn't a perfect solution, but I think it's sufficient for nonprod.

the following nonprod tables read by `flows_v1` in the last 30 days had events later than the new cutoff:

```json
{  "table_name": "docker_fxa_auth",  "partition_date": "2022-03-31",  "last_modified_time": "2022-04-01T01:00:10.655Z"}
{  "table_name": "stdout",  "partition_date": "2022-03-26",  "last_modified_time": "2022-03-27T01:01:07.998Z"}
{  "table_name": "stdout",  "partition_date": "2022-03-21",  "last_modified_time": "2022-03-22T01:00:02.732Z"}
{  "table_name": "docker_fxa_auth",  "partition_date": "2022-03-14",  "last_modified_time": "2022-03-15T00:59:21.709Z"}
{  "table_name": "stdout",  "partition_date": "2022-03-09",  "last_modified_time": "2022-03-10T00:59:24.170Z"}
```