### PR TITLE
DVPN-89 - Catch all flows at end of day for cjms nonprod

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -696,12 +696,9 @@ bqetl_regrets_reporter_summary:
     - impact/tier_1
 
 bqetl_cjms_nonprod:
-  schedule_interval: 22 * * * *
+  schedule_interval: 0 * * * *
   description: |
     Hourly ETL for cjms nonprod.
-
-    Scheduled to run after fivetran stripe_nonprod, which runs hourly at minute
-    17 and takes less than 5 minutes.
   default_args:
     owner: dthorn@mozilla.com
     start_date: "2022-03-24"

--- a/dags/bqetl_cjms_nonprod.py
+++ b/dags/bqetl_cjms_nonprod.py
@@ -17,9 +17,6 @@ Built from bigquery-etl repo, [`dags/bqetl_cjms_nonprod.py`](https://github.com/
 
 Hourly ETL for cjms nonprod.
 
-Scheduled to run after fivetran stripe_nonprod, which runs hourly at minute
-17 and takes less than 5 minutes.
-
 #### Owner
 
 dthorn@mozilla.com
@@ -43,21 +40,24 @@ tags = ["impact/tier_3", "repo/bigquery-etl"]
 with DAG(
     "bqetl_cjms_nonprod",
     default_args=default_args,
-    schedule_interval="22 * * * *",
+    schedule_interval="0 * * * *",
     doc_md=docs,
     tags=tags,
 ) as dag:
 
     cjms_bigquery__flows__v1 = bigquery_etl_query(
         task_id="cjms_bigquery__flows__v1",
-        destination_table="flows_v1",
+        destination_table='flows_v1${{ (execution_date - macros.timedelta(hours=2)).strftime("%Y%m%d") }}',
         dataset_id="moz-fx-cjms-nonprod-9a36:cjms_bigquery",
         project_id="moz-fx-data-shared-prod",
-        sql_file_path="sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/query.sql",
         owner="dthorn@mozilla.com",
         email=["dthorn@mozilla.com", "telemetry-alerts@mozilla.com"],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        parameters=[
+            'submission_date:DATE:{{ (execution_date - macros.timedelta(hours=2)).strftime("%F") }}'
+        ],
+        sql_file_path="sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/query.sql",
         dag=dag,
     )
 

--- a/dags/bqetl_cjms_nonprod.py
+++ b/dags/bqetl_cjms_nonprod.py
@@ -55,7 +55,7 @@ with DAG(
         date_partition_parameter=None,
         depends_on_past=False,
         parameters=[
-            'submission_date:DATE:{{ (execution_date - macros.timedelta(hours=2)).strftime("%F") }}'
+            'submission_date:DATE:{{ (execution_date - macros.timedelta(hours=2)).strftime("%Y-%m-%d") }}'
         ],
         sql_file_path="sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/query.sql",
         dag=dag,

--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_live/view.sql
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_live/view.sql
@@ -1,0 +1,56 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-cjms-nonprod-9a36.cjms_bigquery.flows_live`
+AS
+WITH fxa_content_auth_stdout_events_live AS (
+  SELECT
+    PARSE_DATE('%y%m%d', _TABLE_SUFFIX) AS submission_date,
+    JSON_VALUE(jsonPayload.fields.user_properties, '$.flow_id') AS flow_id,
+    `timestamp`,
+    TO_HEX(SHA256(jsonPayload.fields.user_id)) AS fxa_uid,
+  FROM
+    `moz-fx-fxa-nonprod-375e.fxa_stage_logs.docker_fxa_auth_20*`
+  WHERE
+    jsonPayload.type = 'amplitudeEvent'
+    AND jsonPayload.fields.event_type IS NOT NULL
+    AND jsonPayload.fields.user_id IS NOT NULL
+  UNION ALL
+  SELECT
+    PARSE_DATE('%y%m%d', _TABLE_SUFFIX) AS submission_date,
+    JSON_VALUE(jsonPayload.fields.user_properties, '$.flow_id') AS flow_id,
+    `timestamp`,
+    TO_HEX(SHA256(jsonPayload.fields.user_id)) AS fxa_uid,
+  FROM
+    `moz-fx-fxa-nonprod-375e.fxa_stage_logs.docker_fxa_content_20*`
+  WHERE
+    jsonPayload.type = 'amplitudeEvent'
+    AND jsonPayload.fields.event_type IS NOT NULL
+  UNION ALL
+  SELECT
+    PARSE_DATE('%y%m%d', _TABLE_SUFFIX) AS submission_date,
+    JSON_VALUE(jsonPayload.fields.user_properties, '$.flow_id') AS flow_id,
+    `timestamp`,
+    TO_HEX(SHA256(jsonPayload.fields.user_id)) AS fxa_uid,
+  FROM
+    `moz-fx-fxa-nonprod-375e.fxa_stage_logs.stdout_20*`
+  WHERE
+    jsonPayload.type = 'amplitudeEvent'
+    AND jsonPayload.fields.event_type IS NOT NULL
+)
+SELECT
+  submission_date,
+  flow_id,
+  MIN(`timestamp`) AS flow_started,
+  ARRAY_AGG(
+    IF(fxa_uid IS NULL, NULL, STRUCT(fxa_uid, `timestamp` AS fxa_uid_timestamp)) IGNORE NULLS
+    ORDER BY
+      `timestamp` DESC
+    LIMIT
+      1
+  )[SAFE_OFFSET(0)].*,
+FROM
+  fxa_content_auth_stdout_events_live
+WHERE
+  flow_id IS NOT NULL
+GROUP BY
+  submission_date,
+  flow_id

--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/metadata.yaml
@@ -9,3 +9,19 @@ labels:
 scheduling:
   dag_name: bqetl_cjms_nonprod
   query_project: moz-fx-data-shared-prod
+  # delay aggregates by 2 hours, to ensure data is complete
+  date_partition_parameter: null
+  destination_table:
+    >-
+    flows_v1${{
+    (execution_date - macros.timedelta(hours=2)).strftime("%Y%m%d")
+    }}
+  parameters:
+    - >-
+      submission_date:DATE:{{
+      (execution_date - macros.timedelta(hours=2)).strftime("%F")
+      }}
+  query_file_path:
+    # explicit query file path is necessary because the destination table
+    # includes a partition identifier that is not in the path
+    sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/query.sql

--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/metadata.yaml
@@ -19,7 +19,7 @@ scheduling:
   parameters:
     - >-
       submission_date:DATE:{{
-      (execution_date - macros.timedelta(hours=2)).strftime("%F")
+      (execution_date - macros.timedelta(hours=2)).strftime("%Y-%m-%d")
       }}
   query_file_path:
     # explicit query file path is necessary because the destination table

--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/query.sql
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/query.sql
@@ -1,54 +1,6 @@
-WITH fxa_content_auth_stdout_events_live AS (
-  SELECT
-    PARSE_DATE('%y%m%d', _TABLE_SUFFIX) AS submission_date,
-    JSON_VALUE(jsonPayload.fields.user_properties, '$.flow_id') AS flow_id,
-    `timestamp`,
-    TO_HEX(SHA256(jsonPayload.fields.user_id)) AS fxa_uid,
-  FROM
-    `moz-fx-fxa-nonprod-375e.fxa_stage_logs.docker_fxa_auth_20*`
-  WHERE
-    jsonPayload.type = 'amplitudeEvent'
-    AND jsonPayload.fields.event_type IS NOT NULL
-    AND jsonPayload.fields.user_id IS NOT NULL
-  UNION ALL
-  SELECT
-    PARSE_DATE('%y%m%d', _TABLE_SUFFIX) AS submission_date,
-    JSON_VALUE(jsonPayload.fields.user_properties, '$.flow_id') AS flow_id,
-    `timestamp`,
-    TO_HEX(SHA256(jsonPayload.fields.user_id)) AS fxa_uid,
-  FROM
-    `moz-fx-fxa-nonprod-375e.fxa_stage_logs.docker_fxa_content_20*`
-  WHERE
-    jsonPayload.type = 'amplitudeEvent'
-    AND jsonPayload.fields.event_type IS NOT NULL
-  UNION ALL
-  SELECT
-    PARSE_DATE('%y%m%d', _TABLE_SUFFIX) AS submission_date,
-    JSON_VALUE(jsonPayload.fields.user_properties, '$.flow_id') AS flow_id,
-    `timestamp`,
-    TO_HEX(SHA256(jsonPayload.fields.user_id)) AS fxa_uid,
-  FROM
-    `moz-fx-fxa-nonprod-375e.fxa_stage_logs.stdout_20*`
-  WHERE
-    jsonPayload.type = 'amplitudeEvent'
-    AND jsonPayload.fields.event_type IS NOT NULL
-)
 SELECT
-  submission_date,
-  flow_id,
-  MIN(`timestamp`) AS flow_started,
-  ARRAY_AGG(
-    IF(fxa_uid IS NULL, NULL, STRUCT(fxa_uid, `timestamp` AS fxa_uid_timestamp)) IGNORE NULLS
-    ORDER BY
-      `timestamp` DESC
-    LIMIT
-      1
-  )[SAFE_OFFSET(0)].*,
+  *
 FROM
-  fxa_content_auth_stdout_events_live
+  `moz-fx-cjms-nonprod-9a36`.cjms_bigquery.flows_live
 WHERE
   submission_date = @submission_date
-  AND flow_id IS NOT NULL
-GROUP BY
-  submission_date,
-  flow_id

--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/subscriptions_v1/query.sql
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/subscriptions_v1/query.sql
@@ -1,4 +1,17 @@
-WITH aic_flows AS (
+WITH flows_live AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-cjms-nonprod-9a36`.cjms_bigquery.flows_v1
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-cjms-nonprod-9a36`.cjms_bigquery.flows_live
+  WHERE
+    submission_date = CURRENT_DATE
+),
+aic_flows AS (
   -- last fxa_uid for each flow_id
   SELECT
     flow_id,
@@ -7,7 +20,7 @@ WITH aic_flows AS (
       SAFE_OFFSET(0)
     ] AS fxa_uid,
   FROM
-    `moz-fx-cjms-nonprod-9a36`.cjms_bigquery.flows_v1
+    flows_live
   JOIN
     EXTERNAL_QUERY("moz-fx-cjms-nonprod-9a36.us.cjms-sql", "SELECT flow_id FROM aic")
   USING

--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/subscriptions_v1/query.sql
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/subscriptions_v1/query.sql
@@ -3,6 +3,8 @@ WITH flows_live AS (
     *
   FROM
     `moz-fx-cjms-nonprod-9a36`.cjms_bigquery.flows_v1
+  WHERE
+    submission_date < CURRENT_DATE
   UNION ALL
   SELECT
     *


### PR DESCRIPTION
flows_v1 was not getting events for the previous UTC date that arrive after 00:22 UTC, this pushes back that cutoff to 02:00 UTC, and uses a live view to catch not-yet-aggregated flows from the current date.