### PR TITLE
Added InvalidDag when generating a DAG with no tasks

### DIFF
--- a/bigquery_etl/query_scheduling/dag.py
+++ b/bigquery_etl/query_scheduling/dag.py
@@ -214,6 +214,11 @@ class Dag:
         dag_template = env.get_template(AIRFLOW_DAG_TEMPLATE)
 
         args = self.__dict__
+        if len(args["tasks"]) == 0:
+            raise InvalidDag(
+                f"DAG {self.name} has no tasks - cannot convert it to a valid .py DAG "
+                f"file. Does it appear under `scheduling` in any metadata.yaml files?"
+            )
 
         for task in args["tasks"]:
             task.with_dependencies(dag_collection)

--- a/bigquery_etl/query_scheduling/dag_collection.py
+++ b/bigquery_etl/query_scheduling/dag_collection.py
@@ -85,8 +85,8 @@ class DagCollection:
             dag = self.dag_by_name(dag_name)
             if dag is None:
                 raise InvalidDag(
-                    f"DAG {dag_name} does not exist in dags.yaml"
-                    "but used in task definition {next(group).task_name}."
+                    f"DAG {dag_name} does not exist in dags.yaml "
+                    f"but used in task definition {next(group).task_name}."
                 )
             dag.add_tasks(list(group))
 


### PR DESCRIPTION
If you add a DAG to `dags.yaml` that doesn't appear in any metadata files it won't end up having any tasks. When trying to generate the dag python file it returns invalid python, something like:

```
...
with DAG(
  ...
) as dag:

<EOF>
```
which makes DAG generation fail at formatting the generated python file. The error raised from `Black` is pretty esoteric, so PR adds a clearer upstream error.

In future it might be worth changing this behaviour to support DAGs that don't appear in metadata files but are still bigquery-etl related, maybe with a `DummyOperator` or something. (For context this is why I put https://github.com/mozilla/telemetry-airflow/pull/1481 in telemetry-airflow)

Also updated an unrelated f-string.