### PR TITLE
DENG-96 - Create browser_version_info UDF

### DIFF
--- a/sql/mozfun/norm/browser_version_info/metadata.yaml
+++ b/sql/mozfun/norm/browser_version_info/metadata.yaml
@@ -1,0 +1,8 @@
+---
+friendly_name: Normalize Browser Version Info
+description: |
+  Adds metadata related to the browser version in a struct.
+
+  This is a temporary solution that allows browser version analysis.
+  It should eventually be replaced with one or more browser version tables
+  that serves as a source of truth for version releases.

--- a/sql/mozfun/norm/browser_version_info/udf.sql
+++ b/sql/mozfun/norm/browser_version_info/udf.sql
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION norm.browser_version_info(version_string STRING)
+RETURNS STRUCT<
+  version STRING,
+  major_version NUMERIC,
+  minor_version NUMERIC,
+  is_major_release BOOLEAN
+> AS (
+  STRUCT(
+    version_string AS version,
+    norm.truncate_version(version_string, 'major') AS major_version,
+    norm.truncate_version(version_string, 'minor') AS minor_version,
+    ARRAY_LENGTH(SPLIT(version_string, '.')) = 2
+    AND ENDS_WITH(version_string, '.0') AS is_major_release
+  )
+);
+
+-- Tests
+WITH browser_info AS (
+  SELECT AS VALUE
+    norm.browser_version_info('45.9.0')
+)
+SELECT
+  assert.equals('45.9.0', browser_info.version),
+  assert.equals(45, browser_info.major_version),
+  assert.equals(45.9, browser_info.minor_version),
+  assert.false(browser_info.is_major_release)
+FROM
+  browser_info;
+
+WITH browser_info AS (
+  SELECT AS VALUE
+    norm.browser_version_info('96.0')
+)
+SELECT
+  assert.equals('96.0', browser_info.version),
+  assert.equals(96, browser_info.major_version),
+  assert.equals(96, browser_info.minor_version),
+  assert.true(browser_info.is_major_release)
+FROM
+  browser_info;
+
+WITH browser_info AS (
+  SELECT AS VALUE
+    norm.browser_version_info('73.0.1')
+)
+SELECT
+  assert.equals('73.0.1', browser_info.version),
+  assert.equals(73, browser_info.major_version),
+  assert.equals(73.0, browser_info.minor_version),
+  assert.false(browser_info.is_major_release)
+FROM
+  browser_info;
+
+WITH browser_info AS (
+  SELECT AS VALUE
+    norm.browser_version_info('foo-bar')
+)
+SELECT
+  assert.equals('foo-bar', browser_info.version),
+  assert.null(browser_info.major_version),
+  assert.null(browser_info.minor_version),
+  assert.false(browser_info.is_major_release)
+FROM
+  browser_info;
+
+WITH browser_info AS (
+  SELECT AS VALUE
+    norm.browser_version_info(NULL)
+)
+SELECT
+  assert.null(browser_info.version),
+  assert.null(browser_info.major_version),
+  assert.null(browser_info.minor_version),
+  assert.null(browser_info.is_major_release)
+FROM
+  browser_info;


### PR DESCRIPTION
[DENG-96](https://mozilla-hub.atlassian.net/browse/DENG-96) - Creates a `browser_version_info` UDF that adds version metadata to a struct. This is primarily for views and is mimicking an external dataset that we could use for a version source of truth. This should show up in Looker as a dimension group. 

RE: the temporary part, I initially wanted to extend `telemetry.releases` but the API it's built on is missing release data for iOS and I'm not 100% sure whether it's maintained currently. So I think this is the next best thing for now. 