### PR TITLE
Coalesce country in unified metrics

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/unified_metrics/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/unified_metrics/view.sql
@@ -2,6 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.unified_metrics`
 AS
 SELECT
-  *
+  * REPLACE (COALESCE(country, '??') AS country)
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.unified_metrics_v1`


### PR DESCRIPTION
The `country` field coming from Desktop is coalesced with `??`, but mobile isn't. This unifies the two. 