### PR TITLE
Added extract_version UDF, modified browser_version_info UDF

### DIFF
--- a/sql/mozfun/norm/browser_version_info/udf.sql
+++ b/sql/mozfun/norm/browser_version_info/udf.sql
@@ -3,14 +3,18 @@ RETURNS STRUCT<
   version STRING,
   major_version NUMERIC,
   minor_version NUMERIC,
+  patch_revision NUMERIC,
   is_major_release BOOLEAN
 > AS (
   STRUCT(
     version_string AS version,
     norm.truncate_version(version_string, 'major') AS major_version,
     norm.truncate_version(version_string, 'minor') AS minor_version,
-    ARRAY_LENGTH(SPLIT(version_string, '.')) = 2
-    AND ENDS_WITH(version_string, '.0') AS is_major_release
+    norm.extract_version(version_string, 'patch') AS patch_revision,
+    (
+      ARRAY_LENGTH(SPLIT(version_string, '.')) = 2
+      AND ENDS_WITH(version_string, '.0')
+    ) AS is_major_release
   )
 );
 
@@ -23,6 +27,7 @@ SELECT
   assert.equals('45.9.0', browser_info.version),
   assert.equals(45, browser_info.major_version),
   assert.equals(45.9, browser_info.minor_version),
+  assert.equals(0, browser_info.patch_revision),
   assert.false(browser_info.is_major_release)
 FROM
   browser_info;
@@ -35,6 +40,7 @@ SELECT
   assert.equals('96.0', browser_info.version),
   assert.equals(96, browser_info.major_version),
   assert.equals(96, browser_info.minor_version),
+  assert.null(browser_info.patch_revision),
   assert.true(browser_info.is_major_release)
 FROM
   browser_info;
@@ -47,6 +53,7 @@ SELECT
   assert.equals('73.0.1', browser_info.version),
   assert.equals(73, browser_info.major_version),
   assert.equals(73.0, browser_info.minor_version),
+  assert.equals(.1, browser_info.patch_revision),
   assert.false(browser_info.is_major_release)
 FROM
   browser_info;
@@ -59,6 +66,7 @@ SELECT
   assert.equals('foo-bar', browser_info.version),
   assert.null(browser_info.major_version),
   assert.null(browser_info.minor_version),
+  assert.null(browser_info.patch_revision),
   assert.false(browser_info.is_major_release)
 FROM
   browser_info;
@@ -71,6 +79,20 @@ SELECT
   assert.null(browser_info.version),
   assert.null(browser_info.major_version),
   assert.null(browser_info.minor_version),
+  assert.null(browser_info.patch_revision),
   assert.null(browser_info.is_major_release)
+FROM
+  browser_info;
+
+WITH browser_info AS (
+  SELECT AS VALUE
+    norm.browser_version_info('101.0a1')
+)
+SELECT
+  assert.equals('101.0a1', browser_info.version),
+  assert.equals(101, browser_info.major_version),
+  assert.equals(101, browser_info.minor_version),
+  assert.null(browser_info.patch_revision),
+  assert.false(browser_info.is_major_release)
 FROM
   browser_info;

--- a/sql/mozfun/norm/extract_version/README.md
+++ b/sql/mozfun/norm/extract_version/README.md
@@ -1,0 +1,19 @@
+Note: Non-zero minor and patch versions will be floating point `Numeric`.
+
+Usage:
+
+```sql
+SELECT
+    mozfun.norm.extract_version(version_string, 'major') as major_version,
+    mozfun.norm.extract_version(version_string, 'minor') as minor_version,
+    mozfun.norm.extract_version(version_string, 'patch') as patch_version
+```
+
+Example using `"96.05.01"`:
+
+```sql
+SELECT
+    mozfun.norm.extract_version('96.05.01', 'major') as major_version, -- 96
+    mozfun.norm.extract_version('96.05.01', 'minor') as minor_version, -- .05
+    mozfun.norm.extract_version('96.05.01', 'patch') as patch_version  -- .01
+```

--- a/sql/mozfun/norm/extract_version/metadata.yaml
+++ b/sql/mozfun/norm/extract_version/metadata.yaml
@@ -1,0 +1,4 @@
+friendly_name: Extract Version
+description: |
+  Extracts numeric version data from a version string like
+  `<major>.<minor>.<patch>`.

--- a/sql/mozfun/norm/extract_version/udf.sql
+++ b/sql/mozfun/norm/extract_version/udf.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION norm.extract_version(version_string STRING, extraction_level STRING)
+RETURNS NUMERIC AS (
+  CASE
+  WHEN
+    extraction_level = "patch"
+  THEN
+    CAST(REGEXP_EXTRACT(version_string, r"^[0-9]+[.][0-9]+([.][0-9]+).*") AS NUMERIC)
+  WHEN
+    extraction_level = "minor"
+  THEN
+    CAST(REGEXP_EXTRACT(version_string, r"^[0-9]+([.][0-9]+).*") AS NUMERIC)
+  WHEN
+    extraction_level = "major"
+  THEN
+    CAST(REGEXP_EXTRACT(version_string, r"^([0-9]+).*") AS NUMERIC)
+  ELSE
+    NULL
+  END
+);
+
+-- Tests
+SELECT
+  assert.equals(.1, norm.extract_version("16.1.1", "minor")),
+  assert.equals(.03, norm.extract_version("16.03.1", "minor")),
+  assert.equals(.2, norm.extract_version("16.05.2", "patch")),
+  assert.equals(16, norm.extract_version("16.1.1", "major")),
+  assert.null(norm.extract_version("10", "minor")),
+  assert.equals(.1, norm.extract_version("5.1.5-ubuntu-foobar", "minor")),
+  assert.equals(100, norm.extract_version("100.01.1", "major")),
+  assert.equals(.04, norm.extract_version("100.04.1", "minor")),
+  assert.equals(.5, norm.extract_version("5.1.5-ubuntu-foobar", "patch")),
+  assert.null(norm.extract_version("foo-bar", "minor"))


### PR DESCRIPTION
Added a new UDF to extract (rather than truncate) numerical versions - This allows analysis by patch numbers as well, given that truncating to the patch level doesn't support valid numbers. 

Also updated the `browser_version_info` UDF to use the new UDF. 

Is there any reason we shouldn't represent versions like this?