### PR TITLE
Apply days_since_seen = 0 consistently in unified_metrics

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
@@ -1,4 +1,4 @@
-WITH unioned AS (
+WITH clients_last_seen_unioned AS (
   SELECT
     *,
     'Fenix' AS normalized_app_name
@@ -61,12 +61,18 @@ WITH unioned AS (
   FROM
     telemetry.core_clients_last_seen
   WHERE
-    days_since_seen = 0
+    submission_date = @submission_date
     AND app_name = 'Focus'
     AND os = 'Android'
-    AND submission_date = @submission_date
 ),
-search_clients AS (
+unioned AS (
+  SELECT
+    *
+  FROM
+    clients_last_seen_unioned
+  WHERE
+    days_since_seen = 0
+) search_clients AS (
   SELECT
     *
   FROM
@@ -90,6 +96,8 @@ search_metrics AS (
   ON
     unioned.client_id = m.client_id
     AND DATE_ADD(unioned.submission_date, INTERVAL 1 DAY) = m.submission_date
+  WHERE
+    days_since_seen = 0
   GROUP BY
     1,
     2

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
@@ -97,8 +97,6 @@ search_metrics AS (
   ON
     unioned.client_id = m.client_id
     AND DATE_ADD(unioned.submission_date, INTERVAL 1 DAY) = m.submission_date
-  WHERE
-    days_since_seen = 0
   GROUP BY
     1,
     2

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
@@ -72,7 +72,8 @@ unioned AS (
     clients_last_seen_unioned
   WHERE
     days_since_seen = 0
-) search_clients AS (
+),
+search_clients AS (
   SELECT
     *
   FROM


### PR DESCRIPTION
Currently, the Firefox for iOS and Fenix numbers are inflated due to considering clients not active on the given day.

This was uncovered while helping @lucia-vargas-a understand differences between this dataset and GUD.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
