### PR TITLE
Reduce logging to speed up Netlify CI builds (bug 1761292)

### DIFF
--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -195,8 +195,8 @@ class Schema:
                             nodes[node_name][node_attr_key] = node_attr_value
                             # Netlify has a problem starting 2022-03-07 where lots of
                             # logging slows down builds to the point where our builds hit
-                            # the time limit and fail, and this print statement accounts
-                            # for 84% of our build logging.
+                            # the time limit and fail (bug 1761292), and this print
+                            # statement accounts for 84% of our build logging.
                             # TODO: Uncomment this print when Netlify fixes the problem.
                             # print(
                             #    f"Attribute {node_attr_key} added to {prefix}.{field_path}"

--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -7,8 +7,8 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Dict, List, Optional
 
 import attr
-from google.api_core.exceptions import NotFound
 import yaml
+from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 
 from .. import dryrun
@@ -193,9 +193,14 @@ class Schema:
                         if update:
                             # add field attributes if not exists in schema
                             nodes[node_name][node_attr_key] = node_attr_value
-                            print(
-                                f"Attribute {node_attr_key} added to {prefix}.{field_path}"
-                            )
+                            # Netlify has a problem starting 2022-03-07 where lots of
+                            # logging slows down builds to the point where our builds hit
+                            # the time limit and fail, and this print statement accounts
+                            # for 84% of our build logging.
+                            # TODO: Uncomment this print when Netlify fixes the problem.
+                            # print(
+                            #    f"Attribute {node_attr_key} added to {prefix}.{field_path}"
+                            # )
                         else:
                             if node_attr_key == "description":
                                 print(

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = """
     # Install Maven
-    wget http://apache.mirrors.pair.com/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
+    wget --no-verbose http://apache.mirrors.pair.com/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
     tar -xvzf apache-maven-3.6.3-bin.tar.gz
     mv apache-maven-3.6.3 maven
     export PATH=$PWD/maven/bin:$PATH

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@ command = """
     tar -xvzf apache-maven-3.6.3-bin.tar.gz
     mv apache-maven-3.6.3 maven
     export PATH=$PWD/maven/bin:$PATH
-    mvn package
+    mvn --no-transfer-progress package
     # Generate SQL
     mkdir sql-output
     cp -r sql/ sql-output/sql


### PR DESCRIPTION
Workaround for [bug 1761292](https://bugzilla.mozilla.org/show_bug.cgi?id=1761292) "Netlify tasks for bigquery-etl failing due to timeout".

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
