### PR TITLE
add match type for Firefox Suggestions

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/init.sql
@@ -17,6 +17,7 @@ SELECT
   CAST(NULL AS STRING) AS subdivision1,
   CAST(NULL AS STRING) AS advertiser,
   CAST(NULL AS STRING) AS release_channel,
+  CAST(NULL AS STRING) AS match_type,
   CAST(NULL AS INT64) AS position,
   CAST(NULL AS INT64) AS event_count,
   CAST(NULL AS INT64) AS user_count,

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/query.sql
@@ -19,6 +19,7 @@ WITH combined AS (
       'merino'
     END
     AS provider,
+    match_type,
   FROM
     contextual_services.quicksuggest_impression
   UNION ALL
@@ -42,6 +43,7 @@ WITH combined AS (
       'merino'
     END
     AS provider,
+    match_type,
   FROM
     contextual_services.quicksuggest_click
   UNION ALL
@@ -65,6 +67,7 @@ WITH combined AS (
       'contile'
     END
     AS provider,
+    NULL AS match_type,
   FROM
     contextual_services.topsites_impression
   UNION ALL
@@ -88,6 +91,7 @@ WITH combined AS (
       'contile'
     END
     AS provider,
+    NULL AS match_type,
   FROM
     contextual_services.topsites_click
   UNION ALL
@@ -115,6 +119,7 @@ WITH combined AS (
       'contile'
     END
     AS provider,
+    NULL AS match_type,
   FROM
     org_mozilla_firefox.topsites_impression
   UNION ALL
@@ -140,6 +145,7 @@ WITH combined AS (
       'contile'
     END
     AS provider,
+    NULL AS match_type,
   FROM
     org_mozilla_firefox_beta.topsites_impression
   UNION ALL
@@ -165,6 +171,7 @@ WITH combined AS (
       'contile'
     END
     AS provider,
+    NULL AS match_type,
   FROM
     org_mozilla_fenix.topsites_impression
 ),
@@ -204,4 +211,5 @@ GROUP BY
   advertiser,
   release_channel,
   position,
-  provider
+  provider,
+  match_type

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/contextual_services.quicksuggest_click.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/contextual_services.quicksuggest_click.yaml
@@ -9,3 +9,4 @@
   release_channel: release
   position: 1
   request_id: "HASH123"
+  match_type: "firefox-suggest"

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/contextual_services.quicksuggest_impression.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/contextual_services.quicksuggest_impression.yaml
@@ -9,3 +9,4 @@
   release_channel: release
   position: 1
   request_id: "HASH123"
+  match_type: "firefox-suggest"

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/expect.yaml
@@ -9,6 +9,7 @@
   subdivision1: AZ
   advertiser: ad1
   release_channel: release
+  match_type: "firefox-suggest"
   position: 1
   event_count: 1
   user_count: 1
@@ -40,6 +41,7 @@
   subdivision1: NY
   advertiser: ad3
   release_channel: release
+  match_type: ""
   position: 1
   event_count: 1
   user_count: 1

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/expect.yaml
@@ -9,21 +9,23 @@
   subdivision1: AZ
   advertiser: ad1
   release_channel: release
-  match_type: "firefox-suggest"
   position: 1
   event_count: 1
   user_count: 1
 - <<: *base
   source: suggest
   event_type: click
+  match_type: "firefox-suggest"
 - <<: *base
   source: topsites
   provider: contile
   event_type: click
+  match_type: ""
 - <<: *base
   source: topsites
   provider: contile
   event_type: impression
+  match_type: ""
   event_count: 3
   user_count: 2
 - <<: *base
@@ -31,6 +33,7 @@
   provider: contile
   event_type: impression
   advertiser: ad2
+  match_type: ""
 - &base_mobile
   submission_date: "2020-01-01"
   source: topsites

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/contextual_services.quicksuggest_click.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/contextual_services.quicksuggest_click.yaml
@@ -10,6 +10,7 @@
   release_channel: release
   position: 1
   request_id: "HASH123"
+  match_type: "firefox-suggest"
 - <<: *base
   context_id: b
 - <<: *base

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/contextual_services.quicksuggest_impression.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/contextual_services.quicksuggest_impression.yaml
@@ -10,6 +10,7 @@
   release_channel: release
   position: 1
   request_id: "HASH123"
+  match_type: "firefox-suggest"
 - <<: *base
   context_id: b
 - <<: *base

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/expect.yaml
@@ -16,6 +16,7 @@
   source: topsites
   provider: contile
   event_type: impression
+  match_type: ""
   event_count: 52
   user_count: 2
 - <<: *base
@@ -28,6 +29,7 @@
   source: topsites
   provider: contile
   event_type: click
+  match_type: ""
   event_count: 1
   user_count: 1
 - &base_mobile

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/expect.yaml
@@ -9,7 +9,6 @@
   subdivision1: AZ
   advertiser: ad1
   release_channel: release
-  match_type: "firefox-suggest"
   position: 1
   event_count: 52
   user_count: 2
@@ -22,6 +21,7 @@
 - <<: *base
   source: suggest
   event_type: click
+  match_type: "firefox-suggest"
   event_count: 1
   user_count: 1
 - <<: *base

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/expect.yaml
@@ -9,6 +9,7 @@
   subdivision1: AZ
   advertiser: ad1
   release_channel: release
+  match_type: "firefox-suggest"
   position: 1
   event_count: 52
   user_count: 2
@@ -39,6 +40,7 @@
   subdivision1: NY
   advertiser: ad3
   release_channel: release
+  match_type: ""
   position: 1
   event_count: 1
   user_count: 1


### PR DESCRIPTION
Match type is only valid for Firefox Suggest and has values "best-match", "firefox-suggest" and NULL.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
