### PR TITLE
Bug 1757216 Mark BrowserStack pings in unified_metrics

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
@@ -2,7 +2,9 @@ WITH unioned AS (
   SELECT
     *,
     CAST(NULL AS string) AS distribution_id,
-    'Fenix' AS normalized_app_name
+    -- Per bug 1757216 we need to exclude BrowserStack clients from KPIs,
+    -- so we mark them with a separate app name here.
+    IF(isp = 'BrowserStack', 'Fenix BrowserStack', 'Fenix') AS normalized_app_name
   FROM
     fenix.clients_last_seen_joined
   WHERE


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1757216

Marking as a draft until stakeholders are aware and we're ready to push
a backfill to prod.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
