### PR TITLE
Correct `clients_probe_processes` view name.

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/clients_probe_processes/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_probe_processes/view.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.telemetry.client_probe_processes`
+  `moz-fx-data-shared-prod.telemetry.clients_probe_processes`
 AS
 SELECT
   metric,


### PR DESCRIPTION
It currently conflicts with [sql/moz-fx-data-shared-prod/telemetry/client_probe_processes/view.sql](https://github.com/mozilla/bigquery-etl/blob/6558dd29565f1850ee338619b92e70e1bc9a2442/sql/moz-fx-data-shared-prod/telemetry/client_probe_processes/view.sql).

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
