### PR TITLE
Only publish static tables in user-facing datasets to `mozdata` (bug 1768018)

### DIFF
--- a/bigquery_etl/publish_static.py
+++ b/bigquery_etl/publish_static.py
@@ -34,7 +34,7 @@ def _load_table(
     data_file_path, schema_file_path=None, description_file_path=None, project=None
 ):
     # Assume path is ...project/dataset/table/data.csv
-    path_split = os.path.normcase(data_file_path).split("/")
+    path_split = os.path.normcase(data_file_path).split(os.path.sep)
     dataset_id = path_split[-3]
     table_id = path_split[-2]
     if not project:

--- a/bigquery_etl/publish_static.py
+++ b/bigquery_etl/publish_static.py
@@ -16,7 +16,12 @@ DESCRIPTION_FILENAME = "description.txt"
 def _parse_args():
     parser = ArgumentParser(__doc__)
     parser.add_argument(
-        "--project-id", "--project_id", help="Project to publish tables to"
+        "--project-id",
+        "--project_id",
+        help=(
+            "Project to publish static tables for.  If this is `mozdata` it will publish"
+            " static tables from `moz-fx-data-shared-prod` to `mozdata`."
+        ),
     )
     return parser.parse_args()
 
@@ -78,12 +83,13 @@ def main():
     """Publish csv files as BigQuery tables."""
     args = _parse_args()
 
-    # This machinery is only compatible with
-    # the sql/moz-fx-data-shared-prod/static directory.
-    projects = project_dirs("moz-fx-data-shared-prod")
+    source_project = args.project_id
+    target_project = args.project_id
+    if target_project == "mozdata":
+        source_project = "moz-fx-data-shared-prod"
 
-    for data_dir in projects:
-        for root, dirs, files in os.walk(data_dir):
+    for project_dir in project_dirs(source_project):
+        for root, dirs, files in os.walk(project_dir):
             for filename in files:
                 if filename == DATA_FILENAME:
                     schema_file_path = (
@@ -100,7 +106,7 @@ def main():
                         os.path.join(root, filename),
                         schema_file_path,
                         description_file_path,
-                        args.project_id,
+                        target_project,
                     )
 
 

--- a/bigquery_etl/publish_static.py
+++ b/bigquery_etl/publish_static.py
@@ -33,14 +33,14 @@ def _parse_args():
 def _load_table(
     data_file_path, schema_file_path=None, description_file_path=None, project=None
 ):
-    client = bigquery.Client(project)
-
     # Assume path is ...project/dataset/table/data.csv
     path_split = os.path.normcase(data_file_path).split("/")
     dataset_id = path_split[-3]
     table_id = path_split[-2]
     if not project:
-        project = path_split[0]
+        project = path_split[-4]
+
+    client = bigquery.Client(project)
     dataset_ref = client.dataset(dataset_id, project=project)
     table_ref = dataset_ref.table(table_id)
 


### PR DESCRIPTION
This will resolve [bug 1768018](https://bugzilla.mozilla.org/show_bug.cgi?id=1768018) "_Airflow task publish_bqetl_static.publish_static_mozdata failing on 2022-05-03_".

Also:
- Allows the `publish_static` script to work for any project rather than just `moz-fx-data-shared-prod`.
- Fixes a couple of bugs.
- Uses a more efficient approach for finding `data.csv` files.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
