### PR TITLE
Ignore leading 0s in extract_version and browser_version UDFs

### DIFF
--- a/sql/mozfun/norm/browser_version_info/udf.sql
+++ b/sql/mozfun/norm/browser_version_info/udf.sql
@@ -53,7 +53,7 @@ SELECT
   assert.equals('73.0.1', browser_info.version),
   assert.equals(73, browser_info.major_version),
   assert.equals(73.0, browser_info.minor_version),
-  assert.equals(.1, browser_info.patch_revision),
+  assert.equals(1, browser_info.patch_revision),
   assert.false(browser_info.is_major_release)
 FROM
   browser_info;

--- a/sql/mozfun/norm/extract_version/README.md
+++ b/sql/mozfun/norm/extract_version/README.md
@@ -14,6 +14,6 @@ Example using `"96.05.01"`:
 ```sql
 SELECT
     mozfun.norm.extract_version('96.05.01', 'major') as major_version, -- 96
-    mozfun.norm.extract_version('96.05.01', 'minor') as minor_version, -- .05
-    mozfun.norm.extract_version('96.05.01', 'patch') as patch_version  -- .01
+    mozfun.norm.extract_version('96.05.01', 'minor') as minor_version, -- 5
+    mozfun.norm.extract_version('96.05.01', 'patch') as patch_version  -- 1
 ```

--- a/sql/mozfun/norm/extract_version/udf.sql
+++ b/sql/mozfun/norm/extract_version/udf.sql
@@ -4,11 +4,11 @@ RETURNS NUMERIC AS (
   WHEN
     extraction_level = "patch"
   THEN
-    CAST(REGEXP_EXTRACT(version_string, r"^[0-9]+[.][0-9]+([.][0-9]+).*") AS NUMERIC)
+    CAST(REGEXP_EXTRACT(version_string, r"^[0-9]+[.][0-9]+[.]([0-9]+).*") AS NUMERIC)
   WHEN
     extraction_level = "minor"
   THEN
-    CAST(REGEXP_EXTRACT(version_string, r"^[0-9]+([.][0-9]+).*") AS NUMERIC)
+    CAST(REGEXP_EXTRACT(version_string, r"^[0-9]+[.]([0-9]+).*") AS NUMERIC)
   WHEN
     extraction_level = "major"
   THEN
@@ -20,13 +20,13 @@ RETURNS NUMERIC AS (
 
 -- Tests
 SELECT
-  assert.equals(.1, norm.extract_version("16.1.1", "minor")),
-  assert.equals(.03, norm.extract_version("16.03.1", "minor")),
-  assert.equals(.2, norm.extract_version("16.05.2", "patch")),
+  assert.equals(1, norm.extract_version("16.1.1", "minor")),
+  assert.equals(3, norm.extract_version("16.03.1", "minor")),
+  assert.equals(2, norm.extract_version("16.05.2", "patch")),
   assert.equals(16, norm.extract_version("16.1.1", "major")),
   assert.null(norm.extract_version("10", "minor")),
-  assert.equals(.1, norm.extract_version("5.1.5-ubuntu-foobar", "minor")),
+  assert.equals(1, norm.extract_version("5.1.5-ubuntu-foobar", "minor")),
   assert.equals(100, norm.extract_version("100.01.1", "major")),
-  assert.equals(.04, norm.extract_version("100.04.1", "minor")),
-  assert.equals(.5, norm.extract_version("5.1.5-ubuntu-foobar", "patch")),
+  assert.equals(4, norm.extract_version("100.04.1", "minor")),
+  assert.equals(5, norm.extract_version("5.1.5-ubuntu-foobar", "patch")),
   assert.null(norm.extract_version("foo-bar", "minor"))


### PR DESCRIPTION
This is a breaking change but is more correct than the existing behaviour. See discussion here https://github.com/mozilla/bigquery-etl/issues/2917

Before the minor version of 96.10.1 would be parsed as .1 when it represents minor version 10 semantically (at least in [semver](https://semver.org/)). Now the minor version parses to 10.

This does break leading 0s in version numbers but this hasn't happened in release: https://www.mozilla.org/en-US/firefox/releases/ though we have had a number of minor version .10's

Note `truncate_version` still does have this problem for minor and patch versions > 10 but is more widely used so should probably be managed more carefully. 