### PR TITLE
Deng 72 add first seen date to active users

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/query.sql
@@ -30,8 +30,8 @@ SELECT
   SUM(organic_search_count) AS organic_search_count,
   SUM(search_count) AS search_count,
   SUM(search_with_ads) AS search_with_ads,
-  SUM(uri_count) as uri_count,
-  SUM(active_hours_sum) as active_hours
+  SUM(uri_count) AS uri_count,
+  SUM(active_hours_sum) AS active_hours
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.unified_metrics_v1`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/query.sql
@@ -1,4 +1,4 @@
--- Aggregated clients data including active users, uri_count, new profiles and search metrics
+-- Aggregated clients data including active users, new profiles and search metrics
 SELECT
   activity_segment AS segment,
   app_version AS app_version,
@@ -12,6 +12,7 @@ SELECT
   country,
   device_model,
   distribution_id,
+  first_seen_date,
   is_default_browser,
   locale,
   normalized_app_name AS app_name,
@@ -29,8 +30,8 @@ SELECT
   SUM(organic_search_count) AS organic_search_count,
   SUM(search_count) AS search_count,
   SUM(search_with_ads) AS search_with_ads,
-  SUM(uri_count) AS uri_count,
-  SUM(active_hours_sum) AS active_hours
+  SUM(uri_count) as uri_count,
+  SUM(active_hours_sum) as active_hours
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.unified_metrics_v1`
 WHERE
@@ -47,6 +48,7 @@ GROUP BY
   country,
   device_model,
   distribution_id,
+  first_seen_date,
   is_default_browser,
   locale,
   app_name,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/schema.yaml
@@ -92,3 +92,6 @@ fields:
 - mode: NULLABLE
   name: active_hours
   type: FLOAT
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE


### PR DESCRIPTION
PR to add `first_seen_date` column to `telemetry_derived.active_users_aggregates_v1`.


Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [x] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
