### PR TITLE
Added bigquery.time_partitioning to rolling_cohorts metadata

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/metadata.yaml
@@ -17,6 +17,10 @@ scheduling:
   dag_name: bqetl_unified
   date_partition_parameter: cohort_date
 bigquery:
+  time_partitioning:
+    field: cohort_date
+    type: day
+    require_partition_filter: true
   clustering:
     fields:
     - attribution_medium


### PR DESCRIPTION
Table was created un-partitioned due to this piece of missing metadata