### PR TITLE
Update query parameter for rolling_cohorts to match default 

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/query.sql
@@ -24,8 +24,8 @@ SELECT
 FROM
   telemetry_derived.unified_metrics_v1
 WHERE
-  submission_date = @submission_date
-  AND first_seen_date = @submission_date
+  submission_date = @cohort_date
+  AND first_seen_date = @cohort_date
 GROUP BY
   client_id,
   first_seen_date


### PR DESCRIPTION
The `bq` command that gets run by airflow by default gets `{date_partition_parameter}={airflow run date}` as a parameter [ref](https://github.com/mozilla/telemetry-airflow/blob/480361ea03578de9e8568669b14b446862de0f91/dags/utils/gcp.py#L227). 

eg:

```
bq query --project_id=moz-fx-data-shared-prod --parameter=cohort_date:DATE:2022-05-13 --dataset_id=telemetry_derived --destination_table=rolling_cohorts_v1$20220513
```

PR updates the query to use `cohort_date`