### PR TITLE
Updated metadata and DAG for cohort_daily_statistics

### DIFF
--- a/dags/bqetl_analytics_aggregations.py
+++ b/dags/bqetl_analytics_aggregations.py
@@ -75,6 +75,7 @@ with DAG(
         date_partition_parameter="cohort_date",
         depends_on_past=False,
         arguments=["--append_table"],
+        parameters=["submission_date:DATE:{{ds}}"],
     )
 
     wait_for_telemetry_derived__unified_metrics__v1 = ExternalTaskCompletedSensor(

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
@@ -14,8 +14,13 @@ labels:
 scheduling:
   dag_name: bqetl_analytics_aggregations
   date_partition_parameter: cohort_date
-  arguments: ['--append_table']
+  arguments: ["--append_table"]
+  parameters: ["submission_date:DATE:{{ds}}"]
 bigquery:
+  time_partitioning:
+    field: cohort_date
+    type: day
+    require_partition_filter: true
   clustering:
     fields:
     - attribution_medium


### PR DESCRIPTION
Updates similar to #2969 and #2968. PR explicitly adds `submission_date` as a `bq` parameter to get activity for that day. 