### PR TITLE
Change partition strategy for cohort_daily_statistics

### DIFF
--- a/dags/bqetl_analytics_aggregations.py
+++ b/dags/bqetl_analytics_aggregations.py
@@ -72,10 +72,8 @@ with DAG(
             "lvargas@mozilla.com",
             "telemetry-alerts@mozilla.com",
         ],
-        date_partition_parameter="cohort_date",
+        date_partition_parameter="activity_date",
         depends_on_past=False,
-        arguments=["--append_table"],
-        parameters=["submission_date:DATE:{{ds}}"],
     )
 
     wait_for_telemetry_derived__unified_metrics__v1 = ExternalTaskCompletedSensor(

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
@@ -13,12 +13,10 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_analytics_aggregations
-  date_partition_parameter: cohort_date
-  arguments: ["--append_table"]
-  parameters: ["submission_date:DATE:{{ds}}"]
+  date_partition_parameter: activity_date
 bigquery:
   time_partitioning:
-    field: cohort_date
+    field: activity_date
     type: day
     require_partition_filter: true
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/query.sql
@@ -5,7 +5,7 @@ WITH submission_date_activity AS (
   FROM
     telemetry_derived.unified_metrics_v1
   WHERE
-    submission_date = @submission_date
+    submission_date = @activity_date
     AND days_since_seen = 0
   GROUP BY
     client_id,
@@ -16,7 +16,7 @@ cohorts_in_range AS (
   SELECT
     client_id,
     cohort_date,
-    DATE(@submission_date) AS activity_date,
+    DATE(@activity_date) AS activity_date,
     activity_segment,
     app_version,
     attribution_campaign,
@@ -41,7 +41,7 @@ cohorts_in_range AS (
     telemetry_derived.rolling_cohorts_v1
   WHERE
     cohort_date > DATE_SUB(
-      @submission_date,
+      @activity_date,
       INTERVAL 180 DAY
     ) -- Note this is a pretty big scan... Look here for problems
 ),


### PR DESCRIPTION
Rollback #2970 - partitioning an activity_date probably makes more sense and is also easier - we currently don't have a way to easily specify "append to _previous_ partitions on every run". (we write to `destination_table:{partition}` directly).