### PR TITLE
Remove redundant GOOGLE_APPLICATION_CREDENTIALS in integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,16 +176,9 @@ jobs:
             venv/bin/pip-sync --pip-args=--no-deps requirements.txt
       - run:
           name: PyTest Integration Test
-          # Google's client libraries will check for
-          # GOOGLE_APPLICATION_CREDENTIALS
-          # and use a file in that location for credentials if present;
-          # See https://cloud.google.com/docs/authentication/production
           # yamllint disable rule:line-length
           command: |
-            export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
-            echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
             PATH="venv/bin:$PATH" script/entrypoint -m 'integration or java' -n 8
-          # yamllint enable rule:line-length
       - save_cache:
           paths:
             - ~/.m2

--- a/script/entrypoint
+++ b/script/entrypoint
@@ -30,7 +30,7 @@ elif [ "$1" = "query" ]; then
     # For an invocation like:
     #     query [options] FILE
     # we dispatch to a script that inspects metadata and emulates the following call:
-    #     bq query [options] < FILE 
+    #     bq query [options] < FILE
     exec script/run_query --query_file="${@: -1}" "${@:1:$#-1}"
 elif [ "$XCOM_PUSH" = "true" ]; then
     # KubernetesPodOperator will extract the contents of /airflow/xcom/return.json as an xcom


### PR DESCRIPTION
maybe this can solve the issue with flaky integration tests? seems unlikely, but needs fixing regardless