### PR TITLE
Add isp to unified_metrics

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
@@ -20,6 +20,7 @@ WITH unioned AS (
     uri_count,
     is_default_browser,
     CAST(NULL AS string) AS distribution_id,
+    isp,
     'Fenix' AS normalized_app_name
   FROM
     fenix.clients_last_seen_joined
@@ -47,6 +48,7 @@ WITH unioned AS (
     uri_count,
     is_default_browser,
     CAST(NULL AS string) AS distribution_id,
+    isp,
     'Firefox iOS' AS normalized_app_name
   FROM
     firefox_ios.clients_last_seen_joined
@@ -74,6 +76,7 @@ WITH unioned AS (
     uri_count,
     is_default_browser,
     CAST(NULL AS string) AS distribution_id,
+    isp,
     'Focus iOS' AS normalized_app_name
   FROM
     focus_ios.clients_last_seen_joined
@@ -101,6 +104,7 @@ WITH unioned AS (
     NULL AS uri_count,
     default_browser AS is_default_browser,
     distribution_id,
+    CAST(NULL AS string) AS isp,
     'Focus Android' AS normalized_app_name
   FROM
     telemetry.core_clients_last_seen
@@ -182,6 +186,7 @@ mobile_with_searches AS (
     unioned.days_created_profile_bits,
     DATE_DIFF(unioned.submission_date, unioned.first_seen_date, DAY) AS days_since_first_seen,
     unioned.device_model,
+    unioned.isp,
     unioned.is_new_profile,
     unioned.locale,
     unioned.first_seen_date,
@@ -238,6 +243,7 @@ desktop AS (
     days_created_profile_bits,
     days_since_first_seen,
     CAST(NULL AS string) AS device_model,
+    CAST(NULL AS string) AS isp,
     submission_date = first_seen_date AS is_new_profile,
     locale,
     first_seen_date,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/schema.yaml
@@ -110,3 +110,6 @@ fields:
 - mode: NULLABLE
   name: days_created_profile_bits
   type: INTEGER
+- mode: NULLABLE
+  name: isp
+  type: STRING


### PR DESCRIPTION
Adding the Internet Service Provider data (isp) to unified_metrics.
 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
