### PR TITLE
Bug 1770762 - Add Focus, Firefox iOS, Klar to `nondesktop_clients_last_seen`

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
@@ -36,6 +36,36 @@ WITH glean_final AS (
     'VR Browser Baseline' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_vrbrowser.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    *,
+    'Firefox iOS Baseline' AS app_name,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_fennec.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    *,
+    'Focus Android Baseline' AS app_name,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_focus.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    *,
+    'Focus iOS Baseline' AS app_name,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_focus.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    *,
+    'Klar Android Baseline' AS app_name,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_klar.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    *,
+    'Klar iOS Baseline' AS app_name,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_klar.baseline_clients_last_seen`
 ),
 unioned AS (
   SELECT


### PR DESCRIPTION
These products were not added as their respective clients_last_seen tables, which are powered by Glean data, were not generated.
We need them in this view so that Focus/Firefox iOS/Klar can track their KPI using Glean data as well.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
