### PR TITLE
Revert "Bug 1770762 - Add Focus, Firefox iOS, Klar to `nondesktop_clients_last_seen`"

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
@@ -36,36 +36,6 @@ WITH glean_final AS (
     'VR Browser Baseline' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_vrbrowser.baseline_clients_last_seen`
-  UNION ALL
-  SELECT
-    *,
-    'Firefox iOS Baseline' AS app_name,
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_ios_fennec.baseline_clients_last_seen`
-  UNION ALL
-  SELECT
-    *,
-    'Focus Android Baseline' AS app_name,
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_focus.baseline_clients_last_seen`
-  UNION ALL
-  SELECT
-    *,
-    'Focus iOS Baseline' AS app_name,
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_ios_focus.baseline_clients_last_seen`
-  UNION ALL
-  SELECT
-    *,
-    'Klar Android Baseline' AS app_name,
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_klar.baseline_clients_last_seen`
-  UNION ALL
-  SELECT
-    *,
-    'Klar iOS Baseline' AS app_name,
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_ios_klar.baseline_clients_last_seen`
 ),
 unioned AS (
   SELECT


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#2998

This is failing to deploy with `Column 28 in UNION ALL has incompatible types: DATE, DATE, DATE, DATE, DATE, DATE, DATE, STRING, DATE, STRING, DATE at [10:3]` so there is a difference in column ordering in the union we'll need to deal with.