### PR TITLE
Bug 1770762 - Add Focus, Firefox iOS, Klar to nondesktop_clients_last_seen

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
@@ -3,39 +3,202 @@ CREATE OR REPLACE VIEW
 AS
 WITH glean_final AS (
   SELECT
-    *
+    submission_date,
+    client_id,
+    first_seen_date,
+    days_seen_bits,
+    days_since_seen,
+    days_created_profile_bits,
+    days_since_created_profile,
+    normalized_os,
+    normalized_os_version,
+    normalized_channel,
+    country,
+    locale,
+    app_display_version,
+    app_name,
   FROM
     `moz-fx-data-shared-prod.telemetry.fenix_clients_last_seen`
   UNION ALL
   SELECT
-    *,
+    submission_date,
+    client_id,
+    first_seen_date,
+    days_seen_bits,
+    days_since_seen,
+    days_created_profile_bits,
+    days_since_created_profile,
+    normalized_os,
+    normalized_os_version,
+    normalized_channel,
+    country,
+    locale,
+    app_display_version,
     'Lockwise Baseline' AS app_name,
   FROM
     `moz-fx-data-shared-prod.mozilla_lockbox.baseline_clients_last_seen`
   UNION ALL
   SELECT
-    *,
+    submission_date,
+    client_id,
+    first_seen_date,
+    days_seen_bits,
+    days_since_seen,
+    days_created_profile_bits,
+    days_since_created_profile,
+    normalized_os,
+    normalized_os_version,
+    normalized_channel,
+    country,
+    locale,
+    app_display_version,
     'Lockwise Baseline' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_ios_lockbox.baseline_clients_last_seen`
   UNION ALL
   SELECT
-    *,
+    submission_date,
+    client_id,
+    first_seen_date,
+    days_seen_bits,
+    days_since_seen,
+    days_created_profile_bits,
+    days_since_created_profile,
+    normalized_os,
+    normalized_os_version,
+    normalized_channel,
+    country,
+    locale,
+    app_display_version,
     'Reference Browser Baseline' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_reference_browser.baseline_clients_last_seen`
   UNION ALL
   SELECT
-    *,
+    submission_date,
+    client_id,
+    first_seen_date,
+    days_seen_bits,
+    days_since_seen,
+    days_created_profile_bits,
+    days_since_created_profile,
+    normalized_os,
+    normalized_os_version,
+    normalized_channel,
+    country,
+    locale,
+    app_display_version,
     'Firefox TV Baseline' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_tv_firefox.baseline_clients_last_seen`
   UNION ALL
   SELECT
-    *,
+    submission_date,
+    client_id,
+    first_seen_date,
+    days_seen_bits,
+    days_since_seen,
+    days_created_profile_bits,
+    days_since_created_profile,
+    normalized_os,
+    normalized_os_version,
+    normalized_channel,
+    country,
+    locale,
+    app_display_version,
     'VR Browser Baseline' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_vrbrowser.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    submission_date,
+    client_id,
+    first_seen_date,
+    days_seen_bits,
+    days_since_seen,
+    days_created_profile_bits,
+    days_since_created_profile,
+    normalized_os,
+    normalized_os_version,
+    normalized_channel,
+    country,
+    locale,
+    app_display_version,
+    'Firefox iOS Baseline' AS app_name,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_fennec.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    submission_date,
+    client_id,
+    first_seen_date,
+    days_seen_bits,
+    days_since_seen,
+    days_created_profile_bits,
+    days_since_created_profile,
+    normalized_os,
+    normalized_os_version,
+    normalized_channel,
+    country,
+    locale,
+    app_display_version,
+    'Focus Android Baseline' AS app_name,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_focus.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    submission_date,
+    client_id,
+    first_seen_date,
+    days_seen_bits,
+    days_since_seen,
+    days_created_profile_bits,
+    days_since_created_profile,
+    normalized_os,
+    normalized_os_version,
+    normalized_channel,
+    country,
+    locale,
+    app_display_version,
+    'Focus iOS Baseline' AS app_name,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_focus.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    submission_date,
+    client_id,
+    first_seen_date,
+    days_seen_bits,
+    days_since_seen,
+    days_created_profile_bits,
+    days_since_created_profile,
+    normalized_os,
+    normalized_os_version,
+    normalized_channel,
+    country,
+    locale,
+    app_display_version,
+    'Klar Android Baseline' AS app_name,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_klar.baseline_clients_last_seen`
+  UNION ALL
+  SELECT
+    submission_date,
+    client_id,
+    first_seen_date,
+    days_seen_bits,
+    days_since_seen,
+    days_created_profile_bits,
+    days_since_created_profile,
+    normalized_os,
+    normalized_os_version,
+    normalized_channel,
+    country,
+    locale,
+    app_display_version,
+    'Klar iOS Baseline' AS app_name,
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_klar.baseline_clients_last_seen`
 ),
 unioned AS (
   SELECT


### PR DESCRIPTION
Replaces #2998 which had mismatched columns.

We now explicitly list all columns in the union to prevent further regressions.

The underlying problem was that `isp` appeared at the end of the column list
for existing tables, but appears mid-list for the more newly created tables.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
