### PR TITLE
DSRE-661 Add metadataViewer access to search_terms_derived dataset

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/dataset_metadata.yaml
@@ -5,4 +5,9 @@ description: |-
 dataset_base_acl: derived_restricted
 user_facing: false
 labels: {}
-workgroup_access: []
+# legacy streaming insert API requires bigquery.datasets.get access, which is
+# easiest to apply via metadataViewer
+workgroup_access:
+- role: roles/bigquery.metadataViewer
+  members:
+  - workgroup:search-terms/sanitized-writer


### PR DESCRIPTION
/CC @chelseatroy @quiiver 

needs to be merged at the same time as https://github.com/mozilla-services/cloudops-infra/pull/4120, which itself depends on https://github.com/mozilla-services/cloudops-infra-terraform-modules/pull/121

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
