### PR TITLE
SAFE_CAST to handle values that cannot be CAST to return NULL. Bug 17…

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
@@ -209,15 +209,15 @@ mobile_with_searches AS (
     unioned.normalized_os,
     unioned.normalized_os_version,
     COALESCE(
-      CAST(NULLIF(SPLIT(unioned.normalized_os_version, ".")[SAFE_OFFSET(0)], "") AS INTEGER),
+      SAFE_CAST(NULLIF(SPLIT(unioned.normalized_os_version, ".")[SAFE_OFFSET(0)], "") AS INTEGER),
       0
     ) AS os_version_major,
     COALESCE(
-      CAST(NULLIF(SPLIT(unioned.normalized_os_version, ".")[SAFE_OFFSET(1)], "") AS INTEGER),
+      SAFE_CAST(NULLIF(SPLIT(unioned.normalized_os_version, ".")[SAFE_OFFSET(1)], "") AS INTEGER),
       0
     ) AS os_version_minor,
     COALESCE(
-      CAST(NULLIF(SPLIT(unioned.normalized_os_version, ".")[SAFE_OFFSET(2)], "") AS INTEGER),
+      SAFE_CAST(NULLIF(SPLIT(unioned.normalized_os_version, ".")[SAFE_OFFSET(2)], "") AS INTEGER),
       0
     ) AS os_version_patch,
     unioned.durations,


### PR DESCRIPTION
A record from `fenix.clients_last_seen_joined` has a normalized_os_version that fails the CAST to INTEGER with an overflow.  :
[{
  "submission_date": "2022-06-16",
  "normalized_channel": "release",
  "sample_id": "93",
  "normalized_os": "Android",
  "normalized_os_version": "666666666666666666666666666666",
  "normalized_app_name": "Fenix"
}]

This PR changes CAST to SAFE_CAST so that NULL is returned in this case. '666666666666666666666666666666' is not a valid version number.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
