### PR TITLE
Use approximate client count in GLAM scalar_percentiles_v1

### DIFF
--- a/bigquery_etl/glam/templates/scalar_percentiles_v1.sql
+++ b/bigquery_etl/glam/templates/scalar_percentiles_v1.sql
@@ -23,7 +23,7 @@ percentiles AS (
         {{ aggregate_attributes }},
         agg_type AS client_agg_type,
         'percentiles' AS agg_type,
-        COUNT(DISTINCT(client_id)) AS total_users,
+        APPROX_COUNT_DISTINCT(client_id) AS total_users,
         APPROX_QUANTILES(value, 1000) AS aggregates
     FROM
         all_combos

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_percentiles_v1/query.sql
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_percentiles_v1/query.sql
@@ -52,8 +52,8 @@ percentiles AS (
     key,
     agg_type AS client_agg_type,
     'percentiles' AS agg_type,
-    COUNT(DISTINCT(client_id)) AS total_users,
-    APPROX_QUANTILES(value, 100) AS aggregates
+    APPROX_COUNT_DISTINCT(client_id) AS total_users,
+    APPROX_QUANTILES(value, 1000) AS aggregates
   FROM
     all_combos
   GROUP BY
@@ -69,7 +69,10 @@ percentiles AS (
 )
 SELECT
   * REPLACE (
-    mozfun.glam.map_from_array_offsets([5.0, 25.0, 50.0, 75.0, 95.0], aggregates) AS aggregates
+    mozfun.glam.map_from_array_offsets_precise(
+      [0.1, 1.0, 5.0, 25.0, 50.0, 75.0, 95.0, 99.0, 99.9],
+      aggregates
+    ) AS aggregates
   )
 FROM
   percentiles


### PR DESCRIPTION
This is a follow-up to https://github.com/mozilla/bigquery-etl/pull/3037 which unblocked `scalar_bucket_counts_v1`.
`scalar_percentiles_v1` uses the same source table (`clients_scalar_aggregates_v1`) and started failing today with the same error (disk/memory limits exceeded for shuffle operations). We haven't noticed it earlier because It is a downstream query to `scalar_bucket_counts_v1` in Airflow.

`APPROX_COUNT_DISTINCT` used here runs HLL under the hood. The reason for using it here is that we can't split the aggregation here into two stages as in the aforementioned PR due to quantiles calculation.

I have run this query locally and confirmed that it works.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
