### PR TITLE
[Bug 1775029] Update init.sql and metadata to match query output

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/init.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/init.sql
@@ -1,14 +1,29 @@
 CREATE TABLE IF NOT EXISTS
   `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v3`(
-    timestamp timestamp,
-    request_id string,
-    query string,
-    country string,
-    region string,
-    dma string,
-    form_factor string,
-    browser string,
-    os_family string
+    request_id STRING,
+    submission_timestamp TIMESTAMP,
+    telemetry_query STRING,
+    advertiser STRING,
+    block_id INTEGER,
+    context_id STRING,
+    sample_id INTEGER,
+    is_clicked BOOLEAN,
+    locale STRING,
+    country STRING,
+    region STRING,
+    normalized_os STRING,
+    normalized_os_version STRING,
+    normalized_channel STRING,
+    position INTEGER,
+    reporting_url STRING,
+    scenario STRING,
+    version STRING,
+    timestamp TIMESTAMP,
+    query STRING,
+    dma STRING,
+    form_factor STRING,
+    browser STRING,
+    os_family STRING,
   )
 PARTITION BY
   DATE(timestamp)

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/metadata.yaml
@@ -16,7 +16,7 @@ description: |-
 
 bigquery:
   time_partitioning:
-    field: timestamp
+    field: submission_timestamp
     type: day
     require_partition_filter: true
     expiration_days: 15


### PR DESCRIPTION
Workflow failed because the partition field had null values (i think). Additionally the output of the query didn't exactly match the schema in the init sql so this attempts to rectify that.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
