### PR TITLE
Fix `mozilla_vpn_derived.active_subscription_ids_live` view

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscription_ids_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscription_ids_live/view.sql
@@ -15,3 +15,9 @@ CROSS JOIN
   ) AS active_date
 WHERE
   subscription_start_date IS NOT NULL
+  AND DATE(subscription_start_date) < (
+    SELECT
+      DATE(MAX(end_date))
+    FROM
+      mozdata.mozilla_vpn.all_subscriptions
+  )


### PR DESCRIPTION
As a side-effect of #3031 the `mozilla_vpn_derived.active_subscription_ids_live` view is now including a few subscriptions from the current date, which is causing the `mozilla_vpn_derived.subscription_events_live` view to consider most active subscriptions as being cancelled on the current date.

To fix this `mozilla_vpn_derived.active_subscription_ids_live` will now exclude subscriptions that started after the last ETL'd date (we can't rely on `CURRENT_DATE`, otherwise there would be a time period between UTC midnight and when the ETL runs where the same problem would occur).

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
