### PR TITLE
Fix `mozilla_vpn_derived.subscription_events_live` view

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscription_events_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscription_events_live/view.sql
@@ -14,15 +14,22 @@ max_active_date AS (
   FROM
     mozdata.mozilla_vpn.active_subscription_ids
 ),
+trials AS (
+  SELECT
+    *
+  FROM
+    all_subscriptions
+  WHERE
+    trial_start IS NOT NULL
+    AND DATE(trial_start) <= (SELECT max_active_date FROM max_active_date)
+),
 new_trial_events AS (
   SELECT
     DATE(trial_start) AS event_date,
     subscription_id,
     "New Trial" AS event_type,
   FROM
-    all_subscriptions
-  WHERE
-    trial_start IS NOT NULL
+    trials
 ),
 cancelled_trial_events AS (
   SELECT
@@ -30,10 +37,9 @@ cancelled_trial_events AS (
     subscription_id,
     "Cancelled Trial" AS event_type,
   FROM
-    all_subscriptions
+    trials
   WHERE
-    trial_start IS NOT NULL
-    AND subscription_start_date IS NULL
+    subscription_start_date IS NULL
     AND ended_at IS NOT NULL
 ),
 new_events AS (


### PR DESCRIPTION
After #3031 and #3064 the `mozilla_vpn_derived.subscription_events_live` view still contains some "New Trial" events for the current date, but no other types of events.  This will prevent it from having "New Trial" events for the current date.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
