### PR TITLE
Use substring match rather than suffix match for VPN Google SKUs.

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/query.sql
@@ -235,20 +235,20 @@ android_iap_periods AS (
     (
       CASE
       WHEN
-        ENDS_WITH(sku, ".1_month_subscription")
-        OR ENDS_WITH(sku, ".monthly")
+        CONTAINS_SUBSTR(sku, ".1_month_subscription")
+        OR CONTAINS_SUBSTR(sku, ".monthly")
       THEN
         STRUCT("month" AS plan_interval, 1 AS plan_interval_count)
       WHEN
-        ENDS_WITH(sku, ".6_month_subscription")
+        CONTAINS_SUBSTR(sku, ".6_month_subscription")
       THEN
         ("month", 6)
       WHEN
-        ENDS_WITH(sku, ".12_month_subscription")
+        CONTAINS_SUBSTR(sku, ".12_month_subscription")
       THEN
         ("year", 1)
       WHEN
-        ENDS_WITH(sku, ".1_day_subscription")
+        CONTAINS_SUBSTR(sku, ".1_day_subscription")
       THEN
         -- only used for testing
         ("day", 1)


### PR DESCRIPTION
The substring that identifies the plan interval may not be at the very end (e.g. `org.mozilla.gps.mozillavpn.product.12_month_subscription_free_trial`).

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
