### PR TITLE
Add a virtual view for the language data from the sanitization job

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_languages/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_languages/metadata.yaml
@@ -1,0 +1,13 @@
+---
+friendly_name: Sanitization Job Languages
+description: |-
+  How many search terms got each language tag, by job.
+
+  We use this + other metrics to assess
+  whether the constituency using our search features is changing.
+owners:
+  - ctroy@mozilla.com
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:search-terms/aggregated

--- a/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_languages/view.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_languages/view.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.search_terms.sanitization_job_languages`
+AS
+SELECT
+  started_at as job_start_time,
+  lang.key AS language_code,
+  CAST(lang.value AS int) AS search_term_count
+FROM
+  `moz-fx-data-shared-prod.search_terms_derived.sanitization_job_metadata`
+CROSS JOIN
+  UNNEST(mozfun.json.js_extract_string_map(approximate_language_proportions_json)) AS lang

--- a/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_languages/view.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_languages/view.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.search_terms.sanitization_job_languages`
 AS
 SELECT
-  started_at as job_start_time,
+  started_at AS job_start_time,
   lang.key AS language_code,
   SAFE_CAST(lang.value AS int) AS search_term_count
 FROM

--- a/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_languages/view.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_languages/view.sql
@@ -4,7 +4,7 @@ AS
 SELECT
   started_at as job_start_time,
   lang.key AS language_code,
-  CAST(lang.value AS int) AS search_term_count
+  SAFE_CAST(lang.value AS int) AS search_term_count
 FROM
   `moz-fx-data-shared-prod.search_terms_derived.sanitization_job_metadata`
 CROSS JOIN


### PR DESCRIPTION
This PR adds a virtual view that offers a tabular representation, for each sanitation job, of:

- Which languages the NLP model detected in the search terms
- How many search terms got categorized as each language

We will use this on the job's Looker dashboard to visualize the language distribution in our search data, and to create an alarm if changes in the language distribution indicate that our constituency for search features might be changing.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
