### PR TITLE
Ignore missing Google Analytics data for vpn.mozilla.org after 2022-06-21 (bug 1776716)

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/site_metrics_empty_check_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/site_metrics_empty_check_v1/query.sql
@@ -6,7 +6,12 @@ WHERE
   _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d', @date)
 UNION ALL
 SELECT
-  IF(COUNT(*) = 0, ERROR(CONCAT('No data for vpn.mozilla.org on ', @date)), NULL)
+  -- We stopped getting Google Analytics data for vpn.mozilla.org after 2022-06-21.
+  IF(
+    (COUNT(*) = 0 AND @date <= '2022-06-21'),
+    ERROR(CONCAT('No data for vpn.mozilla.org on ', @date)),
+    NULL
+  )
 FROM
   `moz-fx-data-marketing-prod.220432379.ga_sessions_*`
 WHERE


### PR DESCRIPTION
Will fix [bug 1776716](https://bugzilla.mozilla.org/show_bug.cgi?id=1776716) "Airflow task `bqetl_mozilla_vpn_site_metrics .mozilla_vpn_derived__site_metrics_empty_check__v1` failing since 2022-06-22".

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
