### PR TITLE
Get DAG task dependencies when generating a single DAG

### DIFF
--- a/bigquery_etl/cli/dag.py
+++ b/bigquery_etl/cli/dag.py
@@ -240,7 +240,7 @@ def generate(name, dags_config, output_dir):
             click.echo(f"DAG {name} does not exist.", err=True)
             sys.exit(1)
 
-        dags.dag_to_airflow(output_dir, dag)
+        dags.to_airflow_dags(output_dir, dag_to_generate=dag)
         click.echo(f"Generated {output_dir}{dag.name}.py")
     else:
         # re-generate all DAGs


### PR DESCRIPTION
Currently, generating a single DAG using `bqetl dag generate` doesn't include upstream/downstream dependencies. 

To reproduce try generating a DAG that depends on a stable table for eg. Generating with `bqetl generate` includes dependencies but with `bqetl generate your_dag` doesn't