### PR TITLE
Add `promotion_discounts_amount` column to `mozilla_vpn.active_subscriptions`

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_live/view.sql
@@ -37,6 +37,7 @@ SELECT
   all_subscriptions.normalized_source,
   all_subscriptions.website_channel_group,
   JSON_VALUE_ARRAY(all_subscriptions.json_promotion_codes) AS promotion_codes,
+  all_subscriptions.promotion_discounts_amount,
   COUNT(*) AS `count`,
 FROM
   all_subscriptions
@@ -72,4 +73,5 @@ GROUP BY
   normalized_medium,
   normalized_source,
   website_channel_group,
-  json_promotion_codes
+  json_promotion_codes,
+  promotion_discounts_amount

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_v1/schema.yaml
@@ -83,6 +83,9 @@ fields:
 - name: promotion_codes
   type: STRING
   mode: REPEATED
+- name: promotion_discounts_amount
+  type: INTEGER
+  mode: NULLABLE
 - name: count
   type: INTEGER
   mode: NULLABLE


### PR DESCRIPTION
Requested by @wwyc.

---
Deployment process:
1. Merge PR and wait for Circle CI build and Jenkins view deployment to complete.
2. Rebuild `mozilla_vpn_derived.active_subscriptions_v1`, adding and populating the `promotion_discounts_amount` column while preserving existing records prior to 2022-03-13 when the first subscription with promotion discounts started:
    ```sql

    SELECT
      active_date,
      plan_id,
      status,
      country,
      country_name,
      entrypoint_experiment,
      entrypoint_variation,
      utm_campaign,
      utm_content,
      utm_medium,
      utm_source,
      utm_term,
      provider,
      plan_amount,
      billing_scheme,
      plan_currency,
      plan_interval,
      plan_interval_count,
      product_id,
      product_name,
      pricing_plan,
      normalized_acquisition_channel,
      normalized_campaign,
      normalized_content,
      normalized_medium,
      normalized_source,
      website_channel_group,
      promotion_codes,
      CAST(NULL AS INT64) AS promotion_discounts_amount,
      `count`
    FROM
      `moz-fx-data-shared-prod`.mozilla_vpn_derived.active_subscriptions_v1
    WHERE
      active_date < '2022-03-13'

    UNION ALL

    SELECT
      *
    FROM
      `moz-fx-data-shared-prod`.mozilla_vpn_derived.active_subscriptions_live
    WHERE
      active_date BETWEEN '2022-03-13' AND (
        SELECT MAX(active_date) FROM `moz-fx-data-shared-prod`.mozilla_vpn_derived.active_subscriptions_v1
      )
    ```

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
