### PR TITLE
Data Validation Derived View

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_data_validation_metrics/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_data_validation_metrics/metadata.yaml
@@ -1,0 +1,14 @@
+---
+friendly_name: Sanitization Job Data Validation Metrics
+description: |-
+  The proportion of raw customer search volume that possesses characteristics like capital letters, census surnames, or English words.
+
+  We use this + other metrics to assess
+  whether the constituency using our search features is changing.
+owners:
+  - ctroy@mozilla.com
+  - dzeber@mozilla.com
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:search-terms/aggregated

--- a/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_data_validation_metrics/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_data_validation_metrics/metadata.yaml
@@ -1,7 +1,8 @@
 ---
 friendly_name: Sanitization Job Data Validation Metrics
 description: |-
-  The proportion of raw customer search volume that possesses characteristics like capital letters, census surnames, or English words.
+  The proportion of raw customer search volume that possesses
+  characteristics like capital letters, census surnames, or English words.
 
   We use this + other metrics to assess
   whether the constituency using our search features is changing.

--- a/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_data_validation_metrics/view.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_data_validation_metrics/view.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.search_terms.sanitization_job_data_validation_metrics`
+AS
+SELECT
+        finished_at,
+        total_search_terms_removed_by_sanitization_job / total_search_terms_analyzed AS pct_sanitized_search_terms,
+        contained_at / total_search_terms_analyzed AS pct_sanitized_contained_at,
+        contained_numbers / total_search_terms_analyzed AS pct_sanitized_contained_numbers,
+        contained_name / total_search_terms_analyzed AS pct_sanitized_contained_name,
+        sum_terms_containing_us_census_surname / total_search_terms_analyzed AS pct_terms_containing_us_census_surname,
+        sum_uppercase_chars_all_search_terms / sum_chars_all_search_terms AS pct_uppercase_chars_all_search_terms,
+        sum_words_all_search_terms / total_search_terms_analyzed AS avg_words_all_search_terms,
+        1 - languages.english_count / languages.all_languages_count AS pct_terms_non_english
+        FROM `moz-fx-data-shared-prod.search_terms_derived.sanitization_job_metadata_v2` AS metadata
+    JOIN
+    (
+        SELECT
+            job_start_time,
+            max(case when language_code = 'en' then search_term_count end) english_count,
+            sum(search_term_count) as all_languages_count,
+        FROM `moz-fx-data-shared-prod.search_terms.sanitization_job_languages`
+        GROUP BY job_start_time
+    ) AS languages
+    ON metadata.started_at = languages.job_start_time
+    WHERE status = 'SUCCESS'
+    ORDER BY finished_at DESC;

--- a/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_data_validation_metrics/view.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_data_validation_metrics/view.sql
@@ -3,14 +3,26 @@ CREATE OR REPLACE VIEW
 AS
 SELECT
   finished_at,
-  total_search_terms_removed_by_sanitization_job / total_search_terms_analyzed AS pct_sanitized_search_terms,
-  contained_at / total_search_terms_analyzed AS pct_sanitized_contained_at,
-  contained_numbers / total_search_terms_analyzed AS pct_sanitized_contained_numbers,
-  contained_name / total_search_terms_analyzed AS pct_sanitized_contained_name,
-  sum_terms_containing_us_census_surname / total_search_terms_analyzed AS pct_terms_containing_us_census_surname,
-  sum_uppercase_chars_all_search_terms / sum_chars_all_search_terms AS pct_uppercase_chars_all_search_terms,
-  sum_words_all_search_terms / total_search_terms_analyzed AS avg_words_all_search_terms,
-  1 - languages.english_count / languages.all_languages_count AS pct_terms_non_english
+  SAFE_DIVIDE(
+    total_search_terms_removed_by_sanitization_job,
+    total_search_terms_analyzed
+  ) AS pct_sanitized_search_terms,
+  SAFE_DIVIDE(contained_at, total_search_terms_analyzed) AS pct_sanitized_contained_at,
+  SAFE_DIVIDE(contained_numbers, total_search_terms_analyzed) AS pct_sanitized_contained_numbers,
+  SAFE_DIVIDE(contained_name, total_search_terms_analyzed) AS pct_sanitized_contained_name,
+  SAFE_DIVIDE(
+    sum_terms_containing_us_census_surname,
+    total_search_terms_analyzed
+  ) AS pct_terms_containing_us_census_surname,
+  SAFE_DIVIDE(
+    sum_uppercase_chars_all_search_terms,
+    sum_chars_all_search_terms
+  ) AS pct_uppercase_chars_all_search_terms,
+  SAFE_DIVIDE(
+    sum_words_all_search_terms,
+    total_search_terms_analyzed
+  ) AS avg_words_all_search_terms,
+  1 - SAFE_DIVIDE(languages.english_count, languages.all_languages_count) AS pct_terms_non_english
 FROM
   `moz-fx-data-shared-prod.search_terms_derived.sanitization_job_metadata_v2` AS metadata
 JOIN

--- a/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_data_validation_metrics/view.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms/sanitization_job_data_validation_metrics/view.sql
@@ -2,25 +2,31 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.search_terms.sanitization_job_data_validation_metrics`
 AS
 SELECT
-        finished_at,
-        total_search_terms_removed_by_sanitization_job / total_search_terms_analyzed AS pct_sanitized_search_terms,
-        contained_at / total_search_terms_analyzed AS pct_sanitized_contained_at,
-        contained_numbers / total_search_terms_analyzed AS pct_sanitized_contained_numbers,
-        contained_name / total_search_terms_analyzed AS pct_sanitized_contained_name,
-        sum_terms_containing_us_census_surname / total_search_terms_analyzed AS pct_terms_containing_us_census_surname,
-        sum_uppercase_chars_all_search_terms / sum_chars_all_search_terms AS pct_uppercase_chars_all_search_terms,
-        sum_words_all_search_terms / total_search_terms_analyzed AS avg_words_all_search_terms,
-        1 - languages.english_count / languages.all_languages_count AS pct_terms_non_english
-        FROM `moz-fx-data-shared-prod.search_terms_derived.sanitization_job_metadata_v2` AS metadata
-    JOIN
-    (
-        SELECT
-            job_start_time,
-            max(case when language_code = 'en' then search_term_count end) english_count,
-            sum(search_term_count) as all_languages_count,
-        FROM `moz-fx-data-shared-prod.search_terms.sanitization_job_languages`
-        GROUP BY job_start_time
-    ) AS languages
-    ON metadata.started_at = languages.job_start_time
-    WHERE status = 'SUCCESS'
-    ORDER BY finished_at DESC;
+  finished_at,
+  total_search_terms_removed_by_sanitization_job / total_search_terms_analyzed AS pct_sanitized_search_terms,
+  contained_at / total_search_terms_analyzed AS pct_sanitized_contained_at,
+  contained_numbers / total_search_terms_analyzed AS pct_sanitized_contained_numbers,
+  contained_name / total_search_terms_analyzed AS pct_sanitized_contained_name,
+  sum_terms_containing_us_census_surname / total_search_terms_analyzed AS pct_terms_containing_us_census_surname,
+  sum_uppercase_chars_all_search_terms / sum_chars_all_search_terms AS pct_uppercase_chars_all_search_terms,
+  sum_words_all_search_terms / total_search_terms_analyzed AS avg_words_all_search_terms,
+  1 - languages.english_count / languages.all_languages_count AS pct_terms_non_english
+FROM
+  `moz-fx-data-shared-prod.search_terms_derived.sanitization_job_metadata_v2` AS metadata
+JOIN
+  (
+    SELECT
+      job_start_time,
+      max(CASE WHEN language_code = 'en' THEN search_term_count END) english_count,
+      sum(search_term_count) AS all_languages_count,
+    FROM
+      `moz-fx-data-shared-prod.search_terms.sanitization_job_languages`
+    GROUP BY
+      job_start_time
+  ) AS languages
+ON
+  metadata.started_at = languages.job_start_time
+WHERE
+  status = 'SUCCESS'
+ORDER BY
+  finished_at DESC;


### PR DESCRIPTION
### This PR creates a derived view that runs daily.

The view requires tow input tables:

1. the search sanitization metadata table
2. the table that records the detected languages for each sanitization job run. 

The output table contains aggregate information describing what people searched for (total number of characters, total number of words, and total number of probably-in-English search terms versus unknown or probably-some-other-language, for example). 

We will check how these proportions vary over time to identify if our search volume is _changing_ such that the assumptions about it that we used to develop our sanitization strategy no longer apply.

**Example:** Right now, only U.S and Canada-based constituents can opt into providing their search data. Since most addresses in the U.S. and Canada contain numbers, our sanitization strategy of excluding all terms containing numbers is likely to remove all addresses. Suppose we start allowing constituents from other places to opt into providing their search data and that assumption stops holding: we might need to reevaluate our sanitization criteria to make sure we are still excluding all addresses from sanitized data.

This derived view will recalculate the whole data validation metrics table, but it's done for a job that runs daily and produces one row per run. So it's a table that grows extremely slowly (it'd take more than 25 years to hit 10,000 rows, and the calculations are all two-column arithmetic). The `sanitization_job_languages` view takes the same approach.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
