### PR TITLE
DENG-215 - Enable access to sanitized FxA logs

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -79,6 +79,8 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_auth_events_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_content_events_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/query.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/query.sql",  # noqa E501
+    "sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/query.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/regrets_reporter/regrets_reporter_update/view.sql",
     "sql/moz-fx-data-shared-prod/revenue_derived/client_ltv_v1/query.sql",
     "sql/moz-fx-data-shared-prod/monitoring/payload_bytes_decoded_structured/view.sql",

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -55,6 +55,36 @@ with DAG(
     tags=tags,
 ) as dag:
 
+    docker_fxa_admin_server_v1 = bigquery_etl_query(
+        task_id="docker_fxa_admin_server_v1",
+        destination_table="docker_fxa_admin_server_sanitized_v1",
+        dataset_id="firefox_accounts_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="frank@mozilla.com",
+        email=[
+            "dthorn@mozilla.com",
+            "frank@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+    )
+
+    firefox_accounts_derived__docker_fxa_customs_sanitized__v1 = bigquery_etl_query(
+        task_id="firefox_accounts_derived__docker_fxa_customs_sanitized__v1",
+        destination_table="docker_fxa_customs_sanitized_v1",
+        dataset_id="firefox_accounts_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="frank@mozilla.com",
+        email=[
+            "dthorn@mozilla.com",
+            "frank@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+    )
+
     firefox_accounts_derived__exact_mau28__v1 = bigquery_etl_query(
         task_id="firefox_accounts_derived__exact_mau28__v1",
         destination_table="exact_mau28_v1",

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/docker_fxa_admin_server_sanitized/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/docker_fxa_admin_server_sanitized/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_accounts.docker_fxa_admin_server_sanitized`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_accounts_derived.docker_fxa_admin_server_sanitized_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/docker_fxa_customs_sanitized/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/docker_fxa_customs_sanitized/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_accounts.docker_fxa_customs_sanitized`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_accounts_derived.docker_fxa_customs_sanitized_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Docker Fxa Admin Server Sanitized
+description: |-
+  Sanitized version of docker_fxa_admin_server from FxA.
+  PII is hashed.
+owners:
+- frank@mozilla.com
+labels:
+  application: fxa
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_fxa_events
+  task_name: docker_fxa_admin_server_v1
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false
+    expiration_days: null
+  clustering: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/query.sql
@@ -1,0 +1,20 @@
+-- Query for firefox_accounts_derived.docker_fxa_admin_server_sanitized_v1
+SELECT
+  * REPLACE (
+    (
+      SELECT AS STRUCT
+        jsonPayload.* REPLACE (
+          (
+            SELECT AS STRUCT
+              jsonPayload.fields.* REPLACE (
+                SHA256(jsonPayload.fields.user) AS user,
+                SHA256(jsonPayload.fields.email) AS email
+              )
+          ) AS fields
+        )
+    ) AS jsonPayload
+  )
+FROM
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_admin_server_*`
+WHERE
+  _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/query.sql
@@ -1,5 +1,6 @@
 -- Query for firefox_accounts_derived.docker_fxa_admin_server_sanitized_v1
 SELECT
+  @submission_date AS date,
   * REPLACE (
     (
       SELECT AS STRUCT

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Docker Fxa Customs Sanitized
+description: |-
+  Sanitized version of docker_fxa_customs from FxA.
+  PII is hashed.
+owners:
+- frank@mozilla.com
+labels:
+  application: fxa
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_fxa_events
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false
+    expiration_days: null
+  clustering: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/query.sql
@@ -1,5 +1,6 @@
 -- Query for firefox_accounts_derived.docker_fxa_customs_sanitized_v1
 SELECT
+  @submission_date AS date,
   * REPLACE (
     (
       SELECT AS STRUCT

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/query.sql
@@ -1,0 +1,12 @@
+-- Query for firefox_accounts_derived.docker_fxa_customs_sanitized_v1
+SELECT
+  * REPLACE (
+    (
+      SELECT AS STRUCT
+        jsonPayload.* REPLACE (SHA256(jsonPayload.email) AS email, SHA256(jsonPayload.ip) AS ip)
+    ) AS jsonPayload
+  )
+FROM
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_customs_*`
+WHERE
+  _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
