### PR TITLE
Document GLAM ETL client count filter values

### DIFF
--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -148,7 +148,9 @@ def main():
                 "minimum_client_count": {
                     "type": "integer",
                     "minimum": 0,
-                    "description": "The minimum client count for each build id.",
+                    "description": "The minimum client count for each build id."
+                    "We generally want this to be roughly 0.5% of WAU."
+                    "For context see https://github.com/mozilla/glam/issues/1575#issuecomment-946880387",  # noqa E501
                 },
             },
             "required": [

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql
@@ -54,6 +54,8 @@ build_ids AS (
     1,
     2
   HAVING
+    -- Filter out builds having less than 0.5% of WAU
+    -- for context see https://github.com/mozilla/glam/issues/1575#issuecomment-946880387
     CASE
     WHEN
       channel = 'release'

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
@@ -202,6 +202,8 @@ build_ids AS (
     1,
     2
   HAVING
+    -- Filter out builds having less than 0.5% of WAU
+    -- for context see https://github.com/mozilla/glam/issues/1575#issuecomment-946880387
     CASE
     WHEN
       channel = 'release'


### PR DESCRIPTION
This adds comments to provide some context behind client count values used when filtering out builds in GLAM ETL.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
