### PR TITLE
Bug 1783427 - GLAM ETL: filter out negative values in aggregate queries

### DIFF
--- a/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
@@ -28,7 +28,9 @@ AS (
     -- Prevent overflows by only keeping buckets where value is less than 2^40
     -- allowing 2^24 entries. This value was chosen somewhat abitrarily, typically
     -- the max histogram value is somewhere on the order of ~20 bits.
-    WHERE agg.value <= POW(2, 40)
+    -- Negative values are incorrect and should not happen but were observed,
+    -- probably due to some bit flips.
+    WHERE agg.value BETWEEN 0 AND POW(2, 40)
     GROUP BY agg.key
   )
 );

--- a/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
@@ -73,7 +73,9 @@ scalar_aggregates_new AS (
     version_filtered_new
   WHERE
     -- avoid overflows from very large numbers that are typically anomalies
-    value <= POW(2, 40)
+    -- Negative values are incorrect and should not happen but were observed,
+    -- probably due to some bit flips.
+    value BETWEEN 0 AND POW(2, 40)
   GROUP BY
     {{ attributes }},
     {{ user_data_attributes }},


### PR DESCRIPTION
This should fix `extract_probe_counts_v1` query failing due to integer overflows on casting.
We got some big negative numbers in few histogram probes around 2022-08-04 which seem to be some random bit flips. I'm putting a lower bound for a value in a filter at 0 as we do not expect them to be negative in any case.

This is a follow up to investigation in https://colab.research.google.com/drive/1Ny6sUEeXtvyjroPCMlQeOUVSWbDWPYF3?usp=sharing

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
