### PR TITLE
Set `telemetry_derived.rolling_cohorts_v1` date partition offset to match upstream tables (bug 1784372)

### DIFF
--- a/dags/bqetl_unified.py
+++ b/dags/bqetl_unified.py
@@ -52,7 +52,7 @@ with DAG(
 
     telemetry_derived__rolling_cohorts__v1 = bigquery_etl_query(
         task_id="telemetry_derived__rolling_cohorts__v1",
-        destination_table="rolling_cohorts_v1",
+        destination_table='rolling_cohorts_v1${{ macros.ds_format(macros.ds_add(ds, -1), "%Y-%m-%d", "%Y%m%d") }}',
         dataset_id="telemetry_derived",
         project_id="moz-fx-data-shared-prod",
         owner="anicholson@mozilla.com",
@@ -63,8 +63,9 @@ with DAG(
             "lvargas@mozilla.com",
             "telemetry-alerts@mozilla.com",
         ],
-        date_partition_parameter="cohort_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        parameters=["cohort_date:DATE:{{macros.ds_add(ds, -1)}}"],
     )
 
     with TaskGroup(

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/metadata.yaml
@@ -16,6 +16,7 @@ labels:
 scheduling:
   dag_name: bqetl_unified
   date_partition_parameter: cohort_date
+  date_partition_offset: -1
 bigquery:
   time_partitioning:
     field: cohort_date


### PR DESCRIPTION
`telemetry_derived.rolling_cohorts_v1` and `telemetry_derived.cohort_daily_statistics_v1` have been missing data after 2022-07-04 ([bug 1784372](https://bugzilla.mozilla.org/show_bug.cgi?id=1784372)), which turns out to be due to the `bqetl_unified.telemetry_derived__rolling_cohorts__v1` task not getting the same `date_partition_offset` as its upstream tables in #3069.

### Deployment plan:
1. Merge PR and wait for CI to complete.
2. Re-run `bqetl_unified.telemetry_derived__rolling_cohorts__v1` Airflow task and downstream tasks from 2022-07-06 to date.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
