### PR TITLE
Add mobile + desktop view for ease of calculating days of use

### DIFF
--- a/sql/moz-fx-data-shared-prod/search/firefox_products_search_clients_engines_sources_daily/view.sql
+++ b/sql/moz-fx-data-shared-prod/search/firefox_products_search_clients_engines_sources_daily/view.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.search.firefox_products_search_clients_engines_sources_daily`
+AS
+SELECT
+  client_id,
+  submission_date,
+  source,
+  "mobile" AS device,
+  normalized_engine,
+  normalized_app_name,
+  os,
+  country,
+  sap AS searches,
+  search_with_ads,
+  ad_click,
+  tagged_sap,
+  tagged_follow_on
+FROM
+  `moz-fx-data-shared-prod.search.mobile_search_clients_engines_sources_daily`
+UNION ALL
+SELECT
+  client_id,
+  submission_date,
+  source,
+  "desktop" AS device,
+  normalized_engine,
+  'Firefox Desktop' AS normalized_app_name,
+  os,
+  country,
+  sap AS searches,
+  search_with_ads,
+  ad_click,
+  tagged_sap,
+  tagged_follow_on
+FROM
+  `moz-fx-data-shared-prod.search.search_clients_engines_sources_daily`


### PR DESCRIPTION
The [Looker dashboards](https://mozilla.cloud.looker.com/dashboards/430) are very slow and some are broken as each tile processes around 20k GB of data. 

This PR is the 1st step, creating a view, toward implementing a more efficient solution. 
The PR will be followed by exposing the view as a Looker explore and letting Looker do the heavy lifting of defining GROUP BY  expressions