### PR TITLE
Include `metrics` column in VPN Glean unified views (DENG-210)

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/deletion_request/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/deletion_request/view.sql
@@ -3,11 +3,28 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.mozilla_vpn.deletion_request`
 AS
 SELECT
-  * EXCEPT (metrics)
+  *
 FROM
   `moz-fx-data-shared-prod.mozillavpn.deletion_request`
 UNION ALL
 SELECT
-  * EXCEPT (metrics)
+  * REPLACE (
+    STRUCT(
+      CAST(NULL AS ARRAY<STRUCT<key STRING, value STRING>>) AS jwe,
+      metrics.labeled_counter AS labeled_counter,
+      CAST(
+        NULL
+        AS
+          ARRAY<
+            STRUCT<
+              key STRING,
+              value ARRAY<STRUCT<key STRING, value STRUCT<denominator INT64, numerator INT64>>>
+            >
+          >
+      ) AS labeled_rate,
+      CAST(NULL AS ARRAY<STRUCT<key STRING, value STRING>>) AS url,
+      CAST(NULL AS ARRAY<STRUCT<key STRING, value STRING>>) AS text
+    ) AS metrics
+  )
 FROM
   `moz-fx-data-shared-prod.org_mozilla_firefox_vpn.deletion_request`

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/events/view.sql
@@ -3,11 +3,11 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.mozilla_vpn.events`
 AS
 SELECT
-  * EXCEPT (metrics)
+  *
 FROM
   `moz-fx-data-shared-prod.mozillavpn.events`
 UNION ALL
 SELECT
-  * EXCEPT (metrics)
+  *
 FROM
   `moz-fx-data-shared-prod.org_mozilla_firefox_vpn.events`

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/main/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/main/view.sql
@@ -3,11 +3,28 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.mozilla_vpn.main`
 AS
 SELECT
-  * EXCEPT (metrics)
+  *
 FROM
   `moz-fx-data-shared-prod.mozillavpn.main`
 UNION ALL
 SELECT
-  * EXCEPT (metrics)
+  * REPLACE (
+    STRUCT(
+      CAST(NULL AS ARRAY<STRUCT<key STRING, value STRING>>) AS jwe,
+      metrics.labeled_counter AS labeled_counter,
+      CAST(
+        NULL
+        AS
+          ARRAY<
+            STRUCT<
+              key STRING,
+              value ARRAY<STRUCT<key STRING, value STRUCT<denominator INT64, numerator INT64>>>
+            >
+          >
+      ) AS labeled_rate,
+      CAST(NULL AS ARRAY<STRUCT<key STRING, value STRING>>) AS url,
+      CAST(NULL AS ARRAY<STRUCT<key STRING, value STRING>>) AS text
+    ) AS metrics
+  )
 FROM
   `moz-fx-data-shared-prod.org_mozilla_firefox_vpn.main`


### PR DESCRIPTION
This is an attempt to fix the generation of `mozilla_vpn/explores/main.explore.lkml`, `mozilla_vpn/views/main.view.lkml`, `mozilla_vpn/explores/deletion_request.explore.lkml`, and `mozilla_vpn/views/deletion_request.view.lkml` in [looker-hub](https://github.com/mozilla/looker-hub/tree/main/mozilla_vpn), which [got deleted](https://github.com/mozilla/looker-hub/commit/6ff45902a248d0151dd259c49771bf27beaa19e4#diff-9a13687d374409d7375c5752b9bf34e57673d21eebe6cd43e09dec724778e730) after #3140 & #3149 for [DENG-210](https://mozilla-hub.atlassian.net/browse/DENG-210).  I think this is because the views didn't match the `schema.yaml` files which include the `metrics` column.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
