### PR TITLE
Fix query multipart parameter order

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -872,8 +872,8 @@ def _run_query(
     help="Print bytes that would be processed for each part and don't run queries",
 )
 @click.option(
-    "--parameter",
     "--parameters",
+    "--parameter",
     multiple=True,
     default=[],
     type=lambda p: bigquery.ScalarQueryParameter(*p.split(":", 2)),
@@ -891,8 +891,8 @@ def _run_query(
     ),
 )
 @click.option(
-    "--schema_update_option",
     "--schema_update_options",
+    "--schema_update_option",
     multiple=True,
     type=click.Choice(
         [


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
