### PR TITLE
Fix VPN unified views to use exact same schema (DVPN-187)

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/deletion_request/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/deletion_request/view.sql
@@ -2,13 +2,49 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.mozilla_vpn.deletion_request`
 AS
+-- Data from VPN clients using Glean.js
 SELECT
   *
 FROM
   `moz-fx-data-shared-prod.mozillavpn.deletion_request`
 UNION ALL
+-- Data from VPN Android clients using Glean Kotlin SDK
 SELECT
   * REPLACE (
+    STRUCT(
+      client_info.android_sdk_version AS android_sdk_version,
+      client_info.app_build AS app_build,
+      client_info.app_channel AS app_channel,
+      client_info.app_display_version AS app_display_version,
+      client_info.architecture AS architecture,
+      client_info.client_id AS client_id,
+      client_info.device_manufacturer AS device_manufacturer,
+      client_info.device_model AS device_model,
+      client_info.first_run_date AS first_run_date,
+      client_info.locale AS locale,
+      client_info.os AS os,
+      client_info.os_version AS os_version,
+      client_info.telemetry_sdk_build AS telemetry_sdk_build,
+      client_info.build_date AS build_date
+    ) AS client_info,
+    (
+      SELECT AS STRUCT
+        metadata.* REPLACE (
+          STRUCT(
+            metadata.header.`date` AS `date`,
+            metadata.header.dnt AS dnt,
+            metadata.header.x_debug_id AS x_debug_id,
+            metadata.header.x_pingsender_version AS x_pingsender_version,
+            metadata.header.x_source_tags AS x_source_tags,
+            metadata.header.x_telemetry_agent AS x_telemetry_agent,
+            metadata.header.x_foxsec_ip_reputation AS x_foxsec_ip_reputation,
+            metadata.header.x_lb_tags AS x_lb_tags,
+            metadata.header.parsed_date AS parsed_date,
+            metadata.header.parsed_x_source_tags AS parsed_x_source_tags,
+            metadata.header.parsed_x_lb_tags AS parsed_x_lb_tags
+          ) AS header
+        )
+    ) AS metadata,
     STRUCT(
       CAST(NULL AS ARRAY<STRUCT<key STRING, value STRING>>) AS jwe,
       metrics.labeled_counter AS labeled_counter,

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/events/view.sql
@@ -2,11 +2,13 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.mozilla_vpn.events`
 AS
+-- Data from VPN clients using Glean.js
 SELECT
   *
 FROM
   `moz-fx-data-shared-prod.mozillavpn.events`
 UNION ALL
+-- Data from VPN Android clients using Glean Kotlin SDK
 SELECT
   *
 FROM

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/main/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/main/view.sql
@@ -2,13 +2,49 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.mozilla_vpn.main`
 AS
+-- Data from VPN clients using Glean.js
 SELECT
   *
 FROM
   `moz-fx-data-shared-prod.mozillavpn.main`
 UNION ALL
+-- Data from VPN Android clients using Glean Kotlin SDK
 SELECT
   * REPLACE (
+    STRUCT(
+      client_info.android_sdk_version AS android_sdk_version,
+      client_info.app_build AS app_build,
+      client_info.app_channel AS app_channel,
+      client_info.app_display_version AS app_display_version,
+      client_info.architecture AS architecture,
+      client_info.client_id AS client_id,
+      client_info.device_manufacturer AS device_manufacturer,
+      client_info.device_model AS device_model,
+      client_info.first_run_date AS first_run_date,
+      client_info.locale AS locale,
+      client_info.os AS os,
+      client_info.os_version AS os_version,
+      client_info.telemetry_sdk_build AS telemetry_sdk_build,
+      client_info.build_date AS build_date
+    ) AS client_info,
+    (
+      SELECT AS STRUCT
+        metadata.* REPLACE (
+          STRUCT(
+            metadata.header.`date` AS `date`,
+            metadata.header.dnt AS dnt,
+            metadata.header.x_debug_id AS x_debug_id,
+            metadata.header.x_pingsender_version AS x_pingsender_version,
+            metadata.header.x_source_tags AS x_source_tags,
+            metadata.header.x_telemetry_agent AS x_telemetry_agent,
+            metadata.header.x_foxsec_ip_reputation AS x_foxsec_ip_reputation,
+            metadata.header.x_lb_tags AS x_lb_tags,
+            metadata.header.parsed_date AS parsed_date,
+            metadata.header.parsed_x_source_tags AS parsed_x_source_tags,
+            metadata.header.parsed_x_lb_tags AS parsed_x_lb_tags
+          ) AS header
+        )
+    ) AS metadata,
     STRUCT(
       CAST(NULL AS ARRAY<STRUCT<key STRING, value STRING>>) AS jwe,
       metrics.labeled_counter AS labeled_counter,


### PR DESCRIPTION
Fix-up for #3140.

Some `client_info` and `metadata.header` fields are in a different order in the VPN Android client ping tables, but since all the fields involved are strings the unions didn't fail, they just resulted in wrong data being selected.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
