### PR TITLE
Fix `events_unnested` views to consistently select the correct fields

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/events_unnested/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/events_unnested/view.sql
@@ -5,9 +5,43 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.mozilla_vpn.events_unnested`
 AS
 SELECT
-  e.* EXCEPT (events, metrics) REPLACE(
+  e.* EXCEPT (events, metrics) REPLACE (
     "release" AS normalized_channel,
-    -- Order of ping_info fields differs between tables; we're verbose here for compatibility
+    -- Order of some fields differs between tables; we're verbose here for compatibility
+    STRUCT(
+      client_info.android_sdk_version AS android_sdk_version,
+      client_info.app_build AS app_build,
+      client_info.app_channel AS app_channel,
+      client_info.app_display_version AS app_display_version,
+      client_info.architecture AS architecture,
+      client_info.client_id AS client_id,
+      client_info.device_manufacturer AS device_manufacturer,
+      client_info.device_model AS device_model,
+      client_info.first_run_date AS first_run_date,
+      client_info.locale AS locale,
+      client_info.os AS os,
+      client_info.os_version AS os_version,
+      client_info.telemetry_sdk_build AS telemetry_sdk_build,
+      client_info.build_date AS build_date
+    ) AS client_info,
+    (
+      SELECT AS STRUCT
+        metadata.* REPLACE (
+          STRUCT(
+            metadata.header.`date` AS `date`,
+            metadata.header.dnt AS dnt,
+            metadata.header.x_debug_id AS x_debug_id,
+            metadata.header.x_pingsender_version AS x_pingsender_version,
+            metadata.header.x_source_tags AS x_source_tags,
+            metadata.header.x_telemetry_agent AS x_telemetry_agent,
+            metadata.header.x_foxsec_ip_reputation AS x_foxsec_ip_reputation,
+            metadata.header.x_lb_tags AS x_lb_tags,
+            metadata.header.parsed_date AS parsed_date,
+            metadata.header.parsed_x_source_tags AS parsed_x_source_tags,
+            metadata.header.parsed_x_lb_tags AS parsed_x_lb_tags
+          ) AS header
+        )
+    ) AS metadata,
     STRUCT(
       ping_info.end_time,
       ping_info.experiments,
@@ -29,9 +63,43 @@ CROSS JOIN
   UNNEST(e.events) AS event
 UNION ALL
 SELECT
-  e.* EXCEPT (events, metrics) REPLACE(
+  e.* EXCEPT (events, metrics) REPLACE (
     "release" AS normalized_channel,
-    -- Order of ping_info fields differs between tables; we're verbose here for compatibility
+    -- Order of some fields differs between tables; we're verbose here for compatibility
+    STRUCT(
+      client_info.android_sdk_version AS android_sdk_version,
+      client_info.app_build AS app_build,
+      client_info.app_channel AS app_channel,
+      client_info.app_display_version AS app_display_version,
+      client_info.architecture AS architecture,
+      client_info.client_id AS client_id,
+      client_info.device_manufacturer AS device_manufacturer,
+      client_info.device_model AS device_model,
+      client_info.first_run_date AS first_run_date,
+      client_info.locale AS locale,
+      client_info.os AS os,
+      client_info.os_version AS os_version,
+      client_info.telemetry_sdk_build AS telemetry_sdk_build,
+      client_info.build_date AS build_date
+    ) AS client_info,
+    (
+      SELECT AS STRUCT
+        metadata.* REPLACE (
+          STRUCT(
+            metadata.header.`date` AS `date`,
+            metadata.header.dnt AS dnt,
+            metadata.header.x_debug_id AS x_debug_id,
+            metadata.header.x_pingsender_version AS x_pingsender_version,
+            metadata.header.x_source_tags AS x_source_tags,
+            metadata.header.x_telemetry_agent AS x_telemetry_agent,
+            metadata.header.x_foxsec_ip_reputation AS x_foxsec_ip_reputation,
+            metadata.header.x_lb_tags AS x_lb_tags,
+            metadata.header.parsed_date AS parsed_date,
+            metadata.header.parsed_x_source_tags AS parsed_x_source_tags,
+            metadata.header.parsed_x_lb_tags AS parsed_x_lb_tags
+          ) AS header
+        )
+    ) AS metadata,
     STRUCT(
       ping_info.end_time,
       ping_info.experiments,

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/events_unnested/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/events_unnested/view.sql
@@ -5,7 +5,7 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.mozilla_vpn.events_unnested`
 AS
 SELECT
-  e.* EXCEPT (events, metrics) REPLACE (
+  e.* EXCEPT (events, metrics) REPLACE(
     "release" AS normalized_channel,
     -- Order of some fields differs between tables; we're verbose here for compatibility
     STRUCT(
@@ -63,7 +63,7 @@ CROSS JOIN
   UNNEST(e.events) AS event
 UNION ALL
 SELECT
-  e.* EXCEPT (events, metrics) REPLACE (
+  e.* EXCEPT (events, metrics) REPLACE(
     "release" AS normalized_channel,
     -- Order of some fields differs between tables; we're verbose here for compatibility
     STRUCT(

--- a/sql_generators/glean_usage/templates/cross_channel_events_unnested.view.sql
+++ b/sql_generators/glean_usage/templates/cross_channel_events_unnested.view.sql
@@ -15,7 +15,41 @@ SELECT
     {% else -%}
     "{{ channel }}" AS normalized_channel,
     {% endif -%}
-    -- Order of ping_info fields differs between tables; we're verbose here for compatibility
+    -- Order of some fields differs between tables; we're verbose here for compatibility
+    STRUCT(
+      client_info.android_sdk_version AS android_sdk_version,
+      client_info.app_build AS app_build,
+      client_info.app_channel AS app_channel,
+      client_info.app_display_version AS app_display_version,
+      client_info.architecture AS architecture,
+      client_info.client_id AS client_id,
+      client_info.device_manufacturer AS device_manufacturer,
+      client_info.device_model AS device_model,
+      client_info.first_run_date AS first_run_date,
+      client_info.locale AS locale,
+      client_info.os AS os,
+      client_info.os_version AS os_version,
+      client_info.telemetry_sdk_build AS telemetry_sdk_build,
+      client_info.build_date AS build_date
+    ) AS client_info,
+    (
+      SELECT AS STRUCT
+        metadata.* REPLACE (
+          STRUCT(
+            metadata.header.`date` AS `date`,
+            metadata.header.dnt AS dnt,
+            metadata.header.x_debug_id AS x_debug_id,
+            metadata.header.x_pingsender_version AS x_pingsender_version,
+            metadata.header.x_source_tags AS x_source_tags,
+            metadata.header.x_telemetry_agent AS x_telemetry_agent,
+            metadata.header.x_foxsec_ip_reputation AS x_foxsec_ip_reputation,
+            metadata.header.x_lb_tags AS x_lb_tags,
+            metadata.header.parsed_date AS parsed_date,
+            metadata.header.parsed_x_source_tags AS parsed_x_source_tags,
+            metadata.header.parsed_x_lb_tags AS parsed_x_lb_tags
+          ) AS header
+        )
+    ) AS metadata,
     STRUCT (
       ping_info.end_time,
       ping_info.experiments,

--- a/sql_generators/glean_usage/templates/cross_channel_events_unnested.view.sql
+++ b/sql_generators/glean_usage/templates/cross_channel_events_unnested.view.sql
@@ -1,37 +1,36 @@
 -- Generated via ./bqetl generate glean_usage
 CREATE OR REPLACE VIEW
-    `{{ project_id }}.{{ target_view }}`
+  `{{ project_id }}.{{ target_view }}`
 AS
 {% for (dataset, channel) in datasets -%}
 {% if not loop.first -%}
 UNION ALL
 {% endif -%}
-
-SELECT 
-    e.*
-    EXCEPT (events, metrics)
-    REPLACE(
-        {% if app_name == "fenix" -%}
-        mozfun.norm.fenix_app_info("{{ dataset }}", client_info.app_build).channel AS normalized_channel,
-        {% else -%}
-        "{{ channel }}" AS normalized_channel,
-        {% endif -%}
-        -- Order of ping_info fields differs between tables; we're verbose here for compatibility
-        STRUCT (
-            ping_info.end_time,
-            ping_info.experiments,
-            ping_info.ping_type,
-            ping_info.seq,
-            ping_info.start_time,
-            ping_info.reason,
-            ping_info.parsed_start_time,
-            ping_info.parsed_end_time
-        ) AS ping_info
-    ),
-    event.timestamp AS event_timestamp,
-    event.category AS event_category,
-    event.name AS event_name,
-    event.extra AS event_extra,
+SELECT
+  e.*
+  EXCEPT (events, metrics)
+  REPLACE (
+    {% if app_name == "fenix" -%}
+    mozfun.norm.fenix_app_info("{{ dataset }}", client_info.app_build).channel AS normalized_channel,
+    {% else -%}
+    "{{ channel }}" AS normalized_channel,
+    {% endif -%}
+    -- Order of ping_info fields differs between tables; we're verbose here for compatibility
+    STRUCT (
+      ping_info.end_time,
+      ping_info.experiments,
+      ping_info.ping_type,
+      ping_info.seq,
+      ping_info.start_time,
+      ping_info.reason,
+      ping_info.parsed_start_time,
+      ping_info.parsed_end_time
+    ) AS ping_info
+  ),
+  event.timestamp AS event_timestamp,
+  event.category AS event_category,
+  event.name AS event_name,
+  event.extra AS event_extra,
 FROM `{{ project_id }}.{{ dataset }}.events` AS e
 CROSS JOIN UNNEST(e.events) AS event
 {% endfor %}

--- a/sql_generators/glean_usage/templates/cross_channel_events_unnested.view.sql
+++ b/sql_generators/glean_usage/templates/cross_channel_events_unnested.view.sql
@@ -9,7 +9,7 @@ UNION ALL
 SELECT
   e.*
   EXCEPT (events, metrics)
-  REPLACE (
+  REPLACE(
     {% if app_name == "fenix" -%}
     mozfun.norm.fenix_app_info("{{ dataset }}", client_info.app_build).channel AS normalized_channel,
     {% else -%}


### PR DESCRIPTION
While investigating [DVPN-187](https://mozilla-hub.atlassian.net/browse/DVPN-187) "Client info appears to not be properly integrated in the main tables" I discovered that the `mozilla_vpn.events_unnested` view is selecting wrong `client_info` and `metadata.header` fields from `org_mozilla_firefox_vpn.main` due to differences in the underlying table schemas.

I then also checked the other `events_unnested` views and found a similar problem where the `fenix.events_unnested` view is selecting wrong `client_info` fields from `org_mozilla_fenix.events` and `org_mozilla_fenix_nightly.events`.

This PR will fix both problems.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
