### PR TITLE
Allow dry runs from mozdata

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1050,13 +1050,12 @@ def validate(
     query_files = paths_matching_name_pattern(name, sql_dir, project_id)
     dataset_dirs = set()
     for query in query_files:
-        project = query.parent.parent.parent.name
         ctx.invoke(format, paths=[str(query)])
         ctx.invoke(
             dryrun,
             paths=[str(query)],
             use_cloud_function=use_cloud_function,
-            project=project,
+            project=project_id,
             validate_schemas=validate_schemas,
             respect_skip=respect_dryrun_skip,
         )

--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -16,6 +16,7 @@ QUERY_FILE_RE = re.compile(
     r"(?:query\.sql|part1\.sql|script\.sql|query\.py|view\.sql)$"
 )
 TEST_PROJECT = "bigquery-etl-integration-test"
+MOZDATA = "mozdata"
 
 
 def is_valid_dir(ctx, param, value):
@@ -45,7 +46,8 @@ def is_authenticated(project_id=None):
 def is_valid_project(ctx, param, value):
     """Check if the provided project_id corresponds to an existing project."""
     if value is None or value in [Path(p).name for p in project_dirs()] + [
-        TEST_PROJECT
+        TEST_PROJECT,
+        MOZDATA,
     ]:
         return value
     raise click.BadParameter(f"Invalid project {value}")
@@ -69,7 +71,7 @@ def paths_matching_name_pattern(pattern, sql_path, project_id, files=("*.sql")):
             for file in files:
                 matching_files.extend(Path(root).rglob(file))
     elif os.path.isfile(pattern):
-        matching_files.append(pattern)
+        matching_files.append(Path(pattern))
     else:
         sql_path = Path(sql_path)
         if project_id is not None:


### PR DESCRIPTION
This will allow dry runs from `mozdata`, like:

`./bqetl query validate --use-cloud-function=false --project-id=mozdata moz-fx-data-shared-prod.contextual_services.event_aggregates`

For example, DS don't have permissions for running queries in moz-fx-data-shared-prod, so they need to use mozdata.
