### PR TITLE
Move static publish script to CLI

### DIFF
--- a/bigquery_etl/cli/__init__.py
+++ b/bigquery_etl/cli/__init__.py
@@ -17,6 +17,7 @@ from ..cli.routine import mozfun, routine
 from ..cli.view import view
 from ..dependency import dependency
 from ..glam.cli import glam
+from ..static import static_
 from ..stripe import stripe_
 from ..subplat.apple import apple
 
@@ -37,6 +38,7 @@ def cli(prog_name=None):
         "view": view,
         "alchemer": alchemer_,
         "apple": apple,
+        "static": static_,
     }
 
     @click.group(commands=commands)

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1132,7 +1132,8 @@ def schema():
 
 
 @schema.command(
-    help="""Update the query schema based on the destination table schema and the query schema.
+    help="""
+    Update the query schema based on the destination table schema and the query schema.
     If no schema.yaml file exists for a query, one will be created.
 
     Examples:

--- a/script/publish_static
+++ b/script/publish_static
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Publish csv files as BigQuery tables.
-
-cd "$(dirname "$0")/.."
-
-exec python3 -m bigquery_etl.publish_static "$@"

--- a/sql/moz-fx-data-shared-prod/static/README.md
+++ b/sql/moz-fx-data-shared-prod/static/README.md
@@ -4,7 +4,7 @@ In particular, we have two tables based on a one-time export of Firefox Accounts
 extracted from Amplitude and imported to BigQuery.
 
 Tables can be defined as a CSV named `data.csv` and the table will be created by
-the `publish_static` script.  An optional `schema.json` and `description.txt`
+the `./bqetl static publish` command.  An optional `schema.json` and `description.txt`
 can be defined in the same directory.  If `schema.json` is not defined, column
 names are inferred from the first line of the CSV and are assumed to be strings.
 `description.txt` defines the table description in BigQuery.
@@ -16,6 +16,6 @@ ETL and analysis:
 # Generate data.csv for country_names
 bqetl generate country_code_lookup
 
-./script/publish_static --project-id mozdata
-./script/publish_static --project-id moz-fx-data-shared-prod
+./bqetl static publish --project-id mozdata
+./bqetl static publish --project-id moz-fx-data-shared-prod
 ```


### PR DESCRIPTION
Depends on https://github.com/mozilla/telemetry-airflow/pull/1545

Related to https://github.com/mozilla/bigquery-etl/issues/3080

This moves the `publish_static` script into the bqetl CLI. The script logic is left unchanged, but this is necessary for splitting out the bqetl tooling from the query definitions in the future.

