### PR TITLE
Prototype dataset authorization metadata

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/dataset_metadata.yaml
@@ -4,6 +4,8 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
+dataset_authorized_by:
+- moz-fx-fxa-prod-0712.fxa_prod_logs
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/DSRE-959

This might make sense under `labels` as that's where we put metadata about authorizations [(example)](https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/monitoring_derived/topsites_click_rate_live_v1/metadata.yaml#L9) but it's a list so I'm not sure how that would look.

This metadata would currently be unactionable by infrastructure but is useful for humans to reason about. It could therefore potentially be a comment as well [(example)](https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/telemetry/buildhub2/view.sql#L1). I suspect we'd eventually want to support this as an alternative to specifically authorized views [DSRE-947] but I'm happy to defer proper codification of this for the implementation in a specific use case.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DSRE-947]: https://mozilla-hub.atlassian.net/browse/DSRE-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ