### PR TITLE
Delay `monitoring_derived.stable_and_derived_table_size_v1` by 1 day (bug 1787922)

### DIFF
--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -111,7 +111,7 @@ with DAG(
             "python",
             "sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/query.py",
         ]
-        + ["--date", "{{ ds }}"],
+        + ["--date", "{{ macros.ds_add(ds, -1) }}"],
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
         owner="ascholtz@mozilla.com",
         email=["ascholtz@mozilla.com"],

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/metadata.yaml
@@ -9,7 +9,8 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_monitoring
-  arguments: ["--date", "{{ ds }}"]
+  # Delay by 1 day to allow all derived tables to get populated for the date.
+  arguments: ["--date", "{{ macros.ds_add(ds, -1) }}"]
   referenced_tables:
     - ['moz-fx-data-shared-prod', '*_stable', '*']
     - ['moz-fx-data-shared-prod', 'telemetry_stable', 'main_v4']

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/metadata.yaml
@@ -1,7 +1,7 @@
 ---
-friendly_name: Stable Table Sizes
+friendly_name: Stable & Derived Table Sizes
 description: >
-  Table sizes of stable tables, partitioned by day.
+  Table sizes of stable and derived tables, partitioned by day.
 owners:
   - ascholtz@mozilla.com
 labels:


### PR DESCRIPTION
To allow all derived tables to get populated for the date.

Currently the Airflow task waits for `copy_deduplicate`, which works for stable tables but not the derived tables.  For example, on 2022-08-18 the task for `telemetry_derived.event_events_v1` was failing but because the task for `monitoring_derived.stable_and_derived_table_size_v1` isn't configured to wait for derived table tasks it went ahead and ran when `telemetry_derived.event_events_v1` contained no data for 2022-08-17 ([bug 1787922](https://bugzilla.mozilla.org/show_bug.cgi?id=1787922)).

A more comprehensive solution could be to configure all derived table tasks as upstream of `monitoring_derived.stable_and_derived_table_size_v1`, but that seems like it'd be pretty complex.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
