### PR TITLE
bug(1786733): added init.sql for docker_fxa_admin_server_sanitized_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/inti.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/inti.sql
@@ -1,0 +1,27 @@
+-- Query for creating firefox_accounts_derived.docker_fxa_admin_server_sanitized_v1
+
+CREATE OR REPLACE TABLE
+  firefox_accounts_derived.docker_fxa_admin_server_sanitized_v1
+PARTITION BY
+  date
+AS
+SELECT
+  DATE(timestamp) AS date,
+  * REPLACE (
+    (
+      SELECT AS STRUCT
+        jsonPayload.* REPLACE (
+          (
+            SELECT AS STRUCT
+              jsonPayload.fields.* REPLACE (
+                SHA256(jsonPayload.fields.user) AS user,
+                SHA256(jsonPayload.fields.email) AS email
+              )
+          ) AS fields
+        )
+    ) AS jsonPayload
+  )
+FROM
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_admin_server_20*`
+WHERE
+  DATE(timestamp) >= DATE("2022-08-01")

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/inti.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/inti.sql
@@ -1,5 +1,4 @@
 -- Query for creating firefox_accounts_derived.docker_fxa_admin_server_sanitized_v1
-
 CREATE OR REPLACE TABLE
   firefox_accounts_derived.docker_fxa_admin_server_sanitized_v1
 PARTITION BY
@@ -24,4 +23,4 @@ SELECT
 FROM
   `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_admin_server_20*`
 WHERE
-  DATE(timestamp) >= DATE("2022-08-01")
+  _TABLE_SUFFIX >= FORMAT_DATE('%y%m%d', DATE("2022-08-01"))

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/inti.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/inti.sql
@@ -23,4 +23,4 @@ SELECT
 FROM
   `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_admin_server_20*`
 WHERE
-  _TABLE_SUFFIX >= FORMAT_DATE('%y%m%d', DATE("2022-08-01"))
+  PARSE_DATE('%y%m%d', _TABLE_SUFFIX) >= DATE("2022-08-01")


### PR DESCRIPTION
# bug(1786733): added init.sql for docker_fxa_admin_server_sanitized_v1

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
