### PR TITLE
bug(1788650): Added dedup step at the end of the query to ensure we only end up with a single entry per client_id

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.init.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.init.sql
@@ -34,13 +34,12 @@ WITH
   {{ core_clients_first_seen(migration_table) }}
   SELECT
     client_id,
-    MIN(submission_date) AS submission_date,
-    MIN(COALESCE(core.first_seen_date, baseline.first_seen_date)) AS first_seen_date,
+    submission_date,
+    COALESCE(core.first_seen_date, baseline.first_seen_date) AS first_seen_date,
     sample_id,
   FROM baseline
-  LEFT JOIN _core_clients_first_seen core
+  LEFT JOIN _core_clients_first_seen AS core
   USING (client_id)
-  GROUP BY client_id, sample_id
 {% else %}
   SELECT * FROM baseline
 {% endif %}

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.init.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.init.sql
@@ -34,12 +34,13 @@ WITH
   {{ core_clients_first_seen(migration_table) }}
   SELECT
     client_id,
-    submission_date,
-    COALESCE(core.first_seen_date, baseline.first_seen_date) as first_seen_date,
-    sample_id
+    MIN(submission_date) AS submission_date,
+    MIN(COALESCE(core.first_seen_date, baseline.first_seen_date)) AS first_seen_date,
+    sample_id,
   FROM baseline
   LEFT JOIN _core_clients_first_seen core
   USING (client_id)
+  GROUP BY client_id, sample_id
 {% else %}
   SELECT * FROM baseline
 {% endif %}

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
@@ -95,8 +95,8 @@ _previous AS (
 
 -- added this as the result of bug#1788650
 SELECT
-  MIN(submission_date) AS submission_date,
-  MIN(first_seen_date) AS first_seen_date,
+  submission_date,
+  first_seen_date,
   sample_id,
   client_id
 FROM _joined

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
@@ -100,4 +100,11 @@ SELECT
   sample_id,
   client_id
 FROM _joined
-GROUP BY sample_id, client_id
+WHERE
+  TRUE
+QUALIFY
+  IF(
+    COUNT(*) OVER (PARTITION BY client_id) > 1,
+    ERROR("duplicate client_id detected"),
+    TRUE
+  )

--- a/sql_generators/glean_usage/templates/macros.sql
+++ b/sql_generators/glean_usage/templates/macros.sql
@@ -27,7 +27,14 @@ _core_clients_first_seen AS (
   JOIN
      _core
   ON _fennec_id_lookup.fennec_client_id = _core.client_id
+  WHERE
+    TRUE
   QUALIFY
-    ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY first_seen_date ASC) = 1
+    IF(
+      COUNT(*) OVER (PARTITION BY _fennec_id_lookup.client_id) > 1
+      OR COUNT(*) OVER (PARTITION BY _core.client_id) > 1,
+      ERROR("duplicate client_id detected"),
+      TRUE
+    )
 )
 {% endmacro %}

--- a/sql_generators/glean_usage/templates/macros.sql
+++ b/sql_generators/glean_usage/templates/macros.sql
@@ -27,5 +27,7 @@ _core_clients_first_seen AS (
   JOIN
      _core
   ON _fennec_id_lookup.fennec_client_id = _core.client_id
+  QUALIFY
+    ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY first_seen_date ASC) = 1
 )
 {% endmacro %}


### PR DESCRIPTION
# bug([1788650](https://bugzilla.mozilla.org/show_bug.cgi?id=1788650)): Added dedup step at the end of the query to ensure we only end up with a single entry per client_id

We started seeing a large number of duplicates inside one of our datasets which started to cause ETL failures. This should ensure that this specific table only has a single entry per user.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
