### PR TITLE
Fix exception for requiring auth with no default project

### DIFF
--- a/bigquery_etl/cli/routine.py
+++ b/bigquery_etl/cli/routine.py
@@ -432,7 +432,7 @@ def publish(ctx, path, project_id, dependency_dir, gcs_bucket, gcs_path):
 
     public = False
 
-    if not is_authenticated(project_id):
+    if not is_authenticated():
         click.echo("User needs to be authenticated to publish routines.", err=True)
         sys.exit(1)
 

--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -1,15 +1,16 @@
 """Utility functions used by the CLI."""
 
-import os
 import fnmatch
+import os
+import re
 from fnmatch import fnmatchcase
 from pathlib import Path
 
 import click
-import re
+from google.auth.exceptions import DefaultCredentialsError
 from google.cloud import bigquery
 
-from bigquery_etl.util.common import project_dirs, TempDatasetReference
+from bigquery_etl.util.common import TempDatasetReference, project_dirs
 
 QUERY_FILE_RE = re.compile(
     r"^.*/([a-zA-Z0-9-]+)/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+(_v[0-9]+)?)/"
@@ -33,13 +34,12 @@ def is_valid_file(ctx, param, value):
     return value
 
 
-def is_authenticated(project_id=None):
-    """Check if the user is authenticated to GCP and can access the project."""
-    client = bigquery.Client()
-
-    if project_id:
-        return client.project == project_id
-
+def is_authenticated():
+    """Check if the user is authenticated to GCP."""
+    try:
+        bigquery.Client(project="")
+    except DefaultCredentialsError:
+        return False
     return True
 
 

--- a/tests/cli/test_cli_utils.py
+++ b/tests/cli/test_cli_utils.py
@@ -32,7 +32,7 @@ class TestUtils:
 
     @pytest.mark.integration
     def test_is_authenticated(self):
-        assert is_authenticated("non-existing-project") is False
+        assert is_authenticated()
 
     def test_is_valid_project(self):
         assert is_valid_project(None, None, "mozfun")


### PR DESCRIPTION
and run isort on touched files

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
