### PR TITLE
Allow pioneer projects for copy_deduplicate invocations

### DIFF
--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -18,6 +18,8 @@ QUERY_FILE_RE = re.compile(
 )
 TEST_PROJECT = "bigquery-etl-integration-test"
 MOZDATA = "mozdata"
+PIONEER_NONPROD = "moz-fx-data-pioneer-nonprod"
+PIONEER_PROD = "moz-fx-data-pioneer-prod"
 
 
 def is_valid_dir(ctx, param, value):
@@ -48,6 +50,8 @@ def is_valid_project(ctx, param, value):
     if value is None or value in [Path(p).name for p in project_dirs()] + [
         TEST_PROJECT,
         MOZDATA,
+        PIONEER_NONPROD,
+        PIONEER_PROD,
     ]:
         return value
     raise click.BadParameter(f"Invalid project {value}")


### PR DESCRIPTION
Trying to fix copy-deduplicate in the pioneer environments: https://github.com/mozilla-services/cloudops-infra/compare/copy-dedup?expand=1

Currently seeing the following when trying to update [Rally's copy_deduplicate](https://github.com/mozilla-services/cloudops-infra/blob/master/projects/data-pioneer/Jenkinsfile.copy_deduplicate#L47):

```
+ cd /app
+ /app/script/bqetl copy_deduplicate --dry-run --billing-projects moz-fx-data-pioneer-prod --project_id moz-fx-data-pioneer-prod --dates 2022-09-06
Usage: /app/script/bqetl copy_deduplicate [OPTIONS]
Try '/app/script/bqetl copy_deduplicate --help' for help.

Error: Invalid value for '--project-id' / '--project_id': Invalid project moz-fx-data-pioneer-prod
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
