### PR TITLE
Add schema for table to house unsanitized sample data

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/unsanitized_search_term_sample_data/init.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/unsanitized_search_term_sample_data/init.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.search_terms_derived.unsanitized_search_term_sample_data`(
+    timestamp timestamp,
+    request_id string,
+    session_id string,
+    sequence_no integer,
+    query string,
+    country string,
+    region string,
+    dma string,
+    form_factor string,
+    browser string,
+    os_family string
+  )
+PARTITION BY
+  DATE(timestamp)
+OPTIONS
+  (require_partition_filter = TRUE, partition_expiration_days = 15);

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/unsanitized_search_term_sample_data/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/unsanitized_search_term_sample_data/metadata.yaml
@@ -1,13 +1,14 @@
-friendly_name: Sanitized Firefox Search Terms Straight from Search Requests
+friendly_name: Unanitized Firefox Search Terms Sample for Data Validation
 owners:
   - ctroy@mozilla.com
 labels:
   incremental: true
 description: |-
-  A sanitized variant of search terms submitted to Firefox.
+  A 1% sample of raw search terms submitted to Firefox.
 
-  This table allows removal of PII and longer retention than
-  the underlying logs.
+  This table allows for data validation on raw data in the event
+  that the search volume metrics change in concerning ways.
+
   See https://github.com/mozilla/search-terms-sanitization
   for the code that populates this table.
 bigquery:


### PR DESCRIPTION
This table will house 1% of the raw search data. See [this SRE ticket](https://mozilla-hub.atlassian.net/browse/DSRE-1018) for details.

I have expiration_days here set to 15 because I'd like data to disappear from this table that is more than 15 days old. Is that the way to do this, or should I be doing something in cloudops-infra for that? And if the latter is the case, what does expiration_days do here? I tried a timeboxed lookup but my initial searches said no results for "bigquery expiration_days" and changed my query to remove the underscore.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
