### PR TITLE
Ignore `jsonPayload.fields.metricsoptoutat` column for `fxa_auth_events` (bugs 1791061, 1791062)

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
@@ -15,7 +15,8 @@ WITH base AS (
                   CAST(NULL AS FLOAT64) AS emailverified,
                   CAST(NULL AS FLOAT64) AS isprimary,
                   CAST(NULL AS FLOAT64) AS isverified,
-                  CAST(NULL AS STRING) AS id
+                  CAST(NULL AS STRING) AS id,
+                  CAST(NULL AS STRING) AS metricsoptoutat
                 ),
                 TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id
             ) AS fields


### PR DESCRIPTION
It changed type from string to float in recent `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_20*` tables, which is breaking the `fxa_auth_events` ETL (bugs [1791061](https://bugzilla.mozilla.org/show_bug.cgi?id=1791061), [1791062](https://bugzilla.mozilla.org/show_bug.cgi?id=1791062)), and it isn't populated for `amplitudeEvent` records anyway.

This is a follow-on from #3229, where the same problem happened with the `jsonPayload.fields.id` column.

I've now manually verified that the ETL should run successfully in this state targeting the existing `fxa_auth_events_v1` table schema.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
