### PR TITLE
Enable `depends_on_past` for `mozilla_vpn_derived.active_subscription_ids` ETL.

### DIFF
--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -106,7 +106,7 @@ with DAG(
         owner="srose@mozilla.com",
         email=["srose@mozilla.com", "telemetry-alerts@mozilla.com"],
         date_partition_parameter=None,
-        depends_on_past=False,
+        depends_on_past=True,
         parameters=["date:DATE:{{macros.ds_add(ds, -7)}}"],
     )
 

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscription_ids_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscription_ids_v1/metadata.yaml
@@ -8,6 +8,9 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_subplat
+  # While this ETL doesn't depend on its own previous runs, other ETLs are built
+  # on the assumption that this is built sequentially day-by-day with no gaps.
+  depends_on_past: true
   # delay aggregates by 7 days, to ensure data is complete
   date_partition_offset: -7
   date_partition_parameter: date


### PR DESCRIPTION
While the ETL doesn't depend on its own previous runs, other ETLs are built on the assumption that it's built sequentially day-by-day with no gaps.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
