### PR TITLE
bug/1786733/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/init.sql

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/init.sql
@@ -1,0 +1,18 @@
+-- Query for creating firefox_accounts_derived.docker_fxa_customs_sanitized_v1
+CREATE OR REPLACE TABLE
+  `moz-fx-data-shared-prod.firefox_accounts_derived.docker_fxa_customs_sanitized_v1`
+PARTITION BY
+  date
+AS
+SELECT
+  DATE(timestamp) AS date,
+  * REPLACE (
+    (
+      SELECT AS STRUCT
+        jsonPayload.* REPLACE (SHA256(jsonPayload.email) AS email, SHA256(jsonPayload.ip) AS ip)
+    ) AS jsonPayload
+  )
+FROM
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_customs*`
+WHERE
+  _TABLE_SUFFIX >= FORMAT_DATE('%y%m%d', "2020-01-01")


### PR DESCRIPTION
# bug/1786733/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/init.sql

Added init.sql so that we can recreate the table in case job fails with schema errors.