### PR TITLE
Bug 1788650 - relax client_id uniqueness check in baseline_clients_first_seen_v1

### DIFF
--- a/sql_generators/glean_usage/templates/macros.sql
+++ b/sql_generators/glean_usage/templates/macros.sql
@@ -27,14 +27,5 @@ _core_clients_first_seen AS (
   JOIN
      _core
   ON _fennec_id_lookup.fennec_client_id = _core.client_id
-  WHERE
-    TRUE
-  QUALIFY
-    IF(
-      COUNT(*) OVER (PARTITION BY _fennec_id_lookup.client_id) > 1
-      OR COUNT(*) OVER (PARTITION BY _core.client_id) > 1,
-      ERROR("duplicate client_id detected"),
-      TRUE
-    )
 )
 {% endmacro %}


### PR DESCRIPTION
This is a follow-up to https://github.com/mozilla/bigquery-etl/pull/3201 where client_id uniqueness checks were introduced in `baseline_clients_first_seen` queries. Afterwards, `moz-fx-data-shared-prod.org_mozilla_firefox_beta_derived.baseline_clients_first_seen_v1` is failing with `@submission_date=2022-10-10`.

It looks like the source of duplicates in this case is [mapping from the new client_id to the old fennec_client_id](https://github.com/mozilla/bigquery-etl/blob/307dc7ffad4c9b1b596c5619e020e665c9f77af9/sql_generators/glean_usage/templates/macros.sql#L4-L13) that [is not 1-to-1 for 300 clients](https://sql.telemetry.mozilla.org/queries/88003/source)(@chutten is this expected?). Looking at the following CTEs in this query, it seems like `SELECT DISTINCT` [here](https://github.com/mozilla/bigquery-etl/blob/307dc7ffad4c9b1b596c5619e020e665c9f77af9/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql#L20-L30) might have been introduced to work around the issue we're hitting now. I think it's relatively safe to remove the first uniqueness check as it relates to legacy subset of data that we no longer receive.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
