### PR TITLE
bug: Forcing date param to be null

### DIFF
--- a/dags/bqetl_monitoring_airflow.py
+++ b/dags/bqetl_monitoring_airflow.py
@@ -56,8 +56,9 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="kignasiak@mozilla.com",
         email=["kignasiak@mozilla.com"],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        task_concurrency=1,
     )
 
     monitoring_derived__airflow_dag_run__v1 = bigquery_etl_query(
@@ -67,8 +68,9 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="kignasiak@mozilla.com",
         email=["kignasiak@mozilla.com"],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        task_concurrency=1,
     )
 
     monitoring_derived__airflow_dag_tag__v1 = bigquery_etl_query(
@@ -78,8 +80,9 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="kignasiak@mozilla.com",
         email=["kignasiak@mozilla.com"],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        task_concurrency=1,
     )
 
     monitoring_derived__airflow_slot_pool__v1 = bigquery_etl_query(
@@ -89,8 +92,9 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="kignasiak@mozilla.com",
         email=["kignasiak@mozilla.com"],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        task_concurrency=1,
     )
 
     monitoring_derived__airflow_task_fail__v1 = bigquery_etl_query(
@@ -100,8 +104,9 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="kignasiak@mozilla.com",
         email=["kignasiak@mozilla.com"],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        task_concurrency=1,
     )
 
     monitoring_derived__airflow_task_reschedule__v1 = bigquery_etl_query(
@@ -111,8 +116,9 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="kignasiak@mozilla.com",
         email=["kignasiak@mozilla.com"],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        task_concurrency=1,
     )
 
     monitoring_derived__airflow_user__v1 = bigquery_etl_query(
@@ -122,8 +128,9 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="kignasiak@mozilla.com",
         email=["kignasiak@mozilla.com"],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        task_concurrency=1,
     )
 
     fivetran_airflow_metadata_import_sync_start = FivetranOperator(

--- a/sql/moz-fx-data-shared-prod/monitoring/airflow_dag/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/airflow_dag/view.sql
@@ -2,9 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.monitoring.airflow_dag`
 AS
 SELECT
-  * EXCEPT (is_deleted, is_active)
+  *
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.airflow_dag_v1`
-WHERE
-  NOT is_deleted
-  AND is_active

--- a/sql/moz-fx-data-shared-prod/monitoring/airflow_dag_run/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/airflow_dag_run/view.sql
@@ -2,8 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.monitoring.airflow_dag_run`
 AS
 SELECT
-  * EXCEPT (is_deleted)
+  *
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.airflow_dag_run_v1`
-WHERE
-  NOT is_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring/airflow_dag_tag/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/airflow_dag_tag/view.sql
@@ -6,5 +6,3 @@ SELECT
   tag_name
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.airflow_dag_tag_v1`
-WHERE
-  NOT is_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring/airflow_slot_pool/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/airflow_slot_pool/view.sql
@@ -2,8 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.monitoring.airflow_slot_pool`
 AS
 SELECT
-  * EXCEPT (is_deleted)
+  *
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.airflow_slot_pool_v1`
-WHERE
-  NOT is_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring/airflow_task_fail/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/airflow_task_fail/view.sql
@@ -10,5 +10,3 @@ SELECT
   end_date
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.airflow_task_fail_v1`
-WHERE
-  NOT is_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring/airflow_task_reschedule/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/airflow_task_reschedule/view.sql
@@ -2,8 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.monitoring.airflow_task_reschedule`
 AS
 SELECT
-  * EXCEPT (is_deleted)
+  *
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.airflow_task_reschedule_v1`
-WHERE
-  NOT is_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_run_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_run_v1/init.sql
@@ -9,6 +9,7 @@ SELECT
   execution_date,
   start_date,
   end_date,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.dag_run`
+WHERE
+  NOT _fivetran_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_run_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_run_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
   - kignasiak@mozilla.com
 scheduling:
   dag_name: bqetl_monitoring_airflow
+  date_partition_parameter: null
   referenced_tables:
     - ['moz-fx-data-bq-fivetran', 'airflow_metadata_airflow_db', 'dag_run']
   depends_on_fivetran:

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_run_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_run_v1/query.sql
@@ -6,6 +6,7 @@ SELECT
   execution_date,
   start_date,
   end_date,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.dag_run`
+WHERE
+  NOT _fivetran_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_tag_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_tag_v1/init.sql
@@ -4,6 +4,7 @@ AS
 SELECT
   dag_id,
   name AS tag_name,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.dag_tag`
+WHERE
+  NOT _fivetran_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_tag_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_tag_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
   - kignasiak@mozilla.com
 scheduling:
   dag_name: bqetl_monitoring_airflow
+  date_partition_parameter: null
   referenced_tables:
     - ['moz-fx-data-bq-fivetran', 'airflow_metadata_airflow_db', 'dag_tag']
   depends_on_fivetran:

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_tag_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_tag_v1/query.sql
@@ -1,6 +1,7 @@
 SELECT
   dag_id,
   name AS tag_name,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.dag_tag`
+WHERE
+  NOT _fivetran_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_v1/init.sql
@@ -7,10 +7,11 @@ SELECT
   IF(is_subdag, SPLIT(dag_id, ".")[OFFSET(1)], NULL) AS subdag_id,
   is_subdag,
   owners,
-  is_active,
   is_paused,
   has_task_concurrency_limits,
   concurrency,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.dag`
+WHERE
+  NOT _fivetran_deleted
+  AND is_active

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
   - kignasiak@mozilla.com
 scheduling:
   dag_name: bqetl_monitoring_airflow
+  date_partition_parameter: null
   referenced_tables:
     - ['moz-fx-data-bq-fivetran', 'airflow_metadata_airflow_db', 'dag']
   depends_on_fivetran:

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_dag_v1/query.sql
@@ -4,11 +4,12 @@ SELECT
   IF(is_subdag, SPLIT(dag_id, ".")[OFFSET(1)], NULL) AS subdag_id,
   is_subdag,
   owners,
-  is_active,
   is_paused,
   has_task_concurrency_limits,
   concurrency,
   max_active_runs,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.dag`
+WHERE
+  NOT _fivetran_deleted
+  AND is_active

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_slot_pool_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_slot_pool_v1/init.sql
@@ -6,6 +6,7 @@ SELECT
   pool,
   description,
   slots,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.slot_pool`
+WHERE
+  NOT _fivetran_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_slot_pool_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_slot_pool_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
   - kignasiak@mozilla.com
 scheduling:
   dag_name: bqetl_monitoring_airflow
+  date_partition_parameter: null
   referenced_tables:
     - ['moz-fx-data-bq-fivetran', 'airflow_metadata_airflow_db', 'slot_pool']
   depends_on_fivetran:

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_slot_pool_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_slot_pool_v1/query.sql
@@ -3,6 +3,7 @@ SELECT
   pool,
   description,
   slots,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.slot_pool`
+WHERE
+  NOT _fivetran_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_fail_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_fail_v1/init.sql
@@ -8,6 +8,7 @@ SELECT
   execution_date,
   start_date,
   end_date,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.task_fail`
+WHERE
+  NOT _fivetran_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_fail_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_fail_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
   - kignasiak@mozilla.com
 scheduling:
   dag_name: bqetl_monitoring_airflow
+  date_partition_parameter: null
   referenced_tables:
     - ['moz-fx-data-bq-fivetran', 'airflow_metadata_airflow_db', 'task_fail']
   depends_on_fivetran:

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_fail_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_fail_v1/query.sql
@@ -5,6 +5,7 @@ SELECT
   execution_date,
   start_date,
   end_date,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.task_fail`
+WHERE
+  NOT _fivetran_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_reschedule_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_reschedule_v1/init.sql
@@ -9,6 +9,7 @@ SELECT
   start_date,
   end_date,
   duration,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.task_reschedule`
+WHERE
+  NOT _fivetran_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_reschedule_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_reschedule_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
   - kignasiak@mozilla.com
 scheduling:
   dag_name: bqetl_monitoring_airflow
+  date_partition_parameter: null
   referenced_tables:
     - [
       'moz-fx-data-bq-fivetran',

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_reschedule_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_reschedule_v1/query.sql
@@ -6,6 +6,7 @@ SELECT
   start_date,
   end_date,
   duration,
-  _fivetran_deleted AS is_deleted
 FROM
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.task_reschedule`
+WHERE
+  NOT _fivetran_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_user_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_user_v1/init.sql
@@ -14,3 +14,6 @@ LEFT JOIN
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.ab_user_role` AS user_role
 ON
   user.id = user_role.user_id
+WHERE
+  NOT user._fivetran_deleted
+  AND NOT user_role._fivetran_deleted

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_user_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_user_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
   - kignasiak@mozilla.com
 scheduling:
   dag_name: bqetl_monitoring_airflow
+  date_partition_parameter: null
   referenced_tables:
     - ['moz-fx-data-bq-fivetran', 'airflow_metadata_airflow_db', 'ab_user']
     - ['moz-fx-data-bq-fivetran', 'airflow_metadata_airflow_db', "ab_user_role"]

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_user_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_user_v1/query.sql
@@ -11,3 +11,6 @@ LEFT JOIN
   `moz-fx-data-bq-fivetran.airflow_metadata_airflow_db.ab_user_role` AS user_role
 ON
   user.id = user_role.user_id
+WHERE
+  NOT user._fivetran_deleted
+  AND NOT user_role._fivetran_deleted


### PR DESCRIPTION
It seems otherwise the generated DAG attempts to pass date param and results in the following error:

```
Cannot add storage to a non-partitioned table with a partition reference
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
