### PR TITLE
truncating task_name to 62 characters to match the limit to allow longer dataset names derived from sql path

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -269,7 +269,8 @@ class Task:
             self.version = query_file_re.group(4)
 
             if self.task_name is None:
-                self.task_name = f"{self.dataset}__{self.table}__{self.version}"
+                # limiting task name to allow longer dataset names
+                self.task_name = f"{self.dataset}__{self.table}__{self.version}"[:62]
                 self.validate_task_name(None, self.task_name)
 
             if self.destination_table == DEFAULT_DESTINATION_TABLE_STR:

--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -270,7 +270,7 @@ class Task:
 
             if self.task_name is None:
                 # limiting task name to allow longer dataset names
-                self.task_name = f"{self.dataset}__{self.table}__{self.version}"[:62]
+                self.task_name = f"{self.dataset}__{self.table}__{self.version}"[-62:]
                 self.validate_task_name(None, self.task_name)
 
             if self.destination_table == DEFAULT_DESTINATION_TABLE_STR:

--- a/tests/query_scheduling/test_task.py
+++ b/tests/query_scheduling/test_task.py
@@ -241,8 +241,12 @@ class TestTask:
 
         metadata = Metadata("test", "test", ["test@example.org"], {}, scheduling)
 
+        task = Task.of_query(query_file, metadata)
+        assert task.task_name == "test__" + "a" * 56
+
         with pytest.raises(ValueError):
-            Task.of_query(query_file, metadata)
+            task.task_name = "a" * 64
+            Task.validate_task_name(task, "task_name", task.task_name)
 
     def test_dag_name_validation(self):
         query_file = (

--- a/tests/query_scheduling/test_task.py
+++ b/tests/query_scheduling/test_task.py
@@ -242,7 +242,7 @@ class TestTask:
         metadata = Metadata("test", "test", ["test@example.org"], {}, scheduling)
 
         task = Task.of_query(query_file, metadata)
-        assert task.task_name == "test__" + "a" * 56
+        assert task.task_name == "a" * 58 + "__v1"
 
         with pytest.raises(ValueError):
             task.task_name = "a" * 64


### PR DESCRIPTION
# truncating task_name to 62 characters to match the limit to allow longer dataset names derived from slq path

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
