### PR TITLE
Create dev_telemetry_derived dataset for testing Glam Dev ETL

### DIFF
--- a/sql/moz-fx-data-shared-prod/dev_telemetry_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/dev_telemetry_derived/dataset_metadata.yaml
@@ -1,0 +1,12 @@
+friendly_name: Dev Telemetry Derived
+description: |-
+  Dev version of Telemetry Derived for testing Glam Dev ETL pipeline.
+  This dataset will be the destination of queries run during the tests and
+  will be removed after such tests, unless we find it useful to keep it.
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential


### PR DESCRIPTION
This intends to create a `moz-fx-data-shared-prod.dev_telemetry_derived` dataset in order to test out recent changes made on Glam ETL without overwriting Prod tables. I intend to delete this dataset after the tests.

A "dev" dataset under a "prod" project doesn't sound great. I picked such option (vs different project) because [Glam dags are already friendly to dataset parametrization](https://github.com/mozilla/telemetry-airflow/blob/36c816aeaab8f3b91c44bc955f75d5f09ce471ae/dags/glam_subdags/generate_query.py#L11)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
