### PR TITLE
DENG-430. Update cohorts queries to use the unified_metrics view inst…

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/query.sql
@@ -3,7 +3,7 @@ WITH submission_date_activity AS (
     client_id,
     submission_date AS activity_date
   FROM
-    telemetry_derived.unified_metrics_v1
+    telemetry.unified_metrics
   WHERE
     submission_date = @activity_date
     AND days_since_seen = 0

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/query.sql
@@ -22,7 +22,7 @@ SELECT
   ANY_VALUE(os_version_major) AS os_version_major,
   ANY_VALUE(os_version_minor) AS os_version_minor,
 FROM
-  telemetry_derived.unified_metrics_v1
+  telemetry.unified_metrics
 WHERE
   submission_date = @cohort_date
   AND first_seen_date = @cohort_date


### PR DESCRIPTION
This PR updates the cohorts aggregate to query unified_metrics view instead of the table.
See Jira task for context on why this change is required.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
