### PR TITLE
[Bug 1795092] Remove logging from column_size_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/column_size_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/column_size_v1/query.py
@@ -28,14 +28,13 @@ def get_columns(client, project, dataset):
         result = client.query(sql).result()
         return [(dataset, row.table_name, row.column_name) for row in result]
     except Exception as e:
-        print(f"Error querying dataset {dataset}: {e}")
+        print(f"Error querying dataset {dataset}")
 
     return []
 
 
 def get_column_size_json(client, date, column):
     """Return the size of a specific date partition of the specified table."""
-    print(column)
     try:
         job_config = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)
         dataset_id, table_id, column_name = column
@@ -57,7 +56,6 @@ def get_column_size_json(client, date, column):
             "byte_size": size,
         }
     except Exception as e:
-        print(e)
         return None
 
 


### PR DESCRIPTION
There seems to be a bug in Airflow that is triggered by this task: https://github.com/apache/airflow/issues/20966

```
  File "/usr/local/lib/python3.7/site-packages/airflow/providers/cncf/kubernetes/utils/pod_launcher.py", line 148, in monitor_pod
    timestamp, message = self.parse_log_line(line.decode('utf-8'))
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc6 in position 41: invalid continuation byte
```

This seems to be cause by certain logs. Removing logging for the time being so that this might get resolved