### PR TITLE
DENG-437. Update template for sql_generators

### DIFF
--- a/sql_generators/glean_usage/templates/metrics_templating.yaml
+++ b/sql_generators/glean_usage/templates/metrics_templating.yaml
@@ -24,3 +24,11 @@ focus_ios:
   is_default_browser:
     # Placeholder for metric that is required for cross-app reporting
     sql: "LOGICAL_OR(CAST(NULL AS boolean))"
+focus_android:
+  uri_count:
+    # Placeholder for metric that is required for cross-app reporting
+    sql: "SUM(CAST(NULL AS int64))"
+    counter: true
+  is_default_browser:
+    # Placeholder for metric that is required for cross-app reporting
+    sql: "LOGICAL_OR(CAST(NULL AS boolean))"


### PR DESCRIPTION
This PR is to include Focus Android in the sql-generators template that retrieves the metrics data.

The columns required (`is_default_browser` and `uri_count`) are available in the source view `org_mozilla_focus.metrics`.

More details on [DENG-437](https://mozilla-hub.atlassian.net/browse/DENG-437).


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
