### PR TITLE
Fix typo in suggest_clients_daily_v1 query

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/suggest_clients_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/suggest_clients_daily_v1/query.sql
@@ -140,7 +140,7 @@ clients AS (
     submission_date = @submission_date
   --Suggest is only available for the following clients:
     AND country = "US"
-    AND locale LIKE "en*"
+    AND locale LIKE "en%"
     AND browser_version_info.major_version >= 92
     AND browser_version_info.version NOT IN ('92', '92.', '92.0', '92.0.0')
 )


### PR DESCRIPTION
This table is currently empty, and this will fix that. I confirmed that this will now return results:

```
SELECT 
  COUNT(1)
FROM
  `moz-fx-data-shared-prod.telemetry.clients_daily`
WHERE
  submission_date = '2022-10-15'
--Suggest is only available for the following clients:
  AND country = "US"
  AND locale LIKE "en%"
  AND browser_version_info.major_version >= 92
  AND browser_version_info.version NOT IN ('92', '92.', '92.0', '92.0.0')
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
