### PR TITLE
Add check for contextual_services_derived.event_aggregates_v1

### DIFF
--- a/dags/bqetl_ctxsvc_derived.py
+++ b/dags/bqetl_ctxsvc_derived.py
@@ -82,6 +82,22 @@ with DAG(
         arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
     )
 
+    contextual_services_derived__event_aggregates_check__v1 = bigquery_etl_query(
+        task_id="contextual_services_derived__event_aggregates_check__v1",
+        destination_table=None,
+        dataset_id="contextual_services_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="wstuckey@mozilla.com",
+        email=[
+            "ctroy@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+            "wstuckey@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        sql_file_path="sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_check_v1/query.sql",
+    )
+
     contextual_services_derived__event_aggregates_spons_tiles__v1 = bigquery_etl_query(
         task_id="contextual_services_derived__event_aggregates_spons_tiles__v1",
         destination_table="event_aggregates_spons_tiles_v1",
@@ -161,6 +177,10 @@ with DAG(
 
     contextual_services_derived__event_aggregates__v1.set_upstream(
         wait_for_copy_deduplicate_all
+    )
+
+    contextual_services_derived__event_aggregates_check__v1.set_upstream(
+        contextual_services_derived__event_aggregates__v1
     )
 
     contextual_services_derived__event_aggregates_spons_tiles__v1.set_upstream(

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_check_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_check_v1/metadata.yaml
@@ -1,0 +1,26 @@
+friendly_name: Event Aggregates Check
+description: |-
+  This query checks whether there are any empty partitions in
+  contextual_services_derived.event_aggregates_check_v1 which might
+  indicate that data is missing.
+owners:
+- wstuckey@mozilla.com
+email:
+- rburwei@mozilla.com
+- ctroy@mozilla.com
+- wstuckey@mozilla.com
+- skahmann@mozilla.com
+- xluo@mozilla.com
+labels:
+  incremental: false
+scheduling:
+  dag_name: bqetl_ctxsvc_derived
+  destination_table: null
+  query_file_path:
+    sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_check_v1/query.sql
+  referenced_tables:
+  - [
+    'moz-fx-data-shared-prod',
+    'contextual_services_derived',
+    'event_aggregates_v1'
+  ]

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_check_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_check_v1/query.sql
@@ -1,0 +1,48 @@
+WITH dates AS (
+  -- Generate the date range to check for missing data
+  SELECT
+    *
+  FROM
+    UNNEST(GENERATE_DATE_ARRAY('2021-05-01', '@submission_date', INTERVAL 1 DAY)) AS date
+),
+partition_info AS (
+  SELECT
+    date
+  FROM
+    dates
+  LEFT JOIN
+    (
+    -- Based on the information we have about existing partitions
+    -- determine which partitions are either missing or have 0 rows.
+    -- This is cheaper than querying the table every day to get the row count.
+      SELECT
+        *
+      FROM
+        `contextual_services_derived.INFORMATION_SCHEMA.PARTITIONS`
+      WHERE
+        table_name = 'event_aggregates_v1'
+        AND total_rows > 0
+    ) AS p
+  ON
+    date = PARSE_DATE('%Y%m%d', p.partition_id)
+  WHERE
+    p.total_rows IS NULL
+)
+SELECT
+  IF(
+    COUNT(*) > 0,
+    ERROR(
+      CONCAT(
+        'Partitions with data missing: ',
+        (
+          SELECT
+            ARRAY_TO_STRING(ARRAY_AGG(FORMAT_DATETIME("%Y-%m-%d", date)), ", ")
+          FROM
+            partition_info
+        )
+      )
+    ),
+    NULL
+  )
+FROM
+  partition_info


### PR DESCRIPTION
This adds a check to make sure there are no empty partitions for `contextual_services_derived.event_aggregates_v1`. If empty partitions occur, for example after a backfill goes wrong then the Airflow task will fail and list affected partitions.

I can't test it on the actual dataset since I don't have permissions, so this might be a good time to hand this over to someone on the contextual services team who can test this.
