### PR TITLE
Add more metadata on query schema deploy create case

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1534,6 +1534,9 @@ def _create_table(
 
     metadata = Metadata.of_query_file(query_file_path)
 
+    new_table.description = metadata.description
+    new_table.friendly_name = metadata.friendly_name
+
     if metadata.bigquery and metadata.bigquery.time_partitioning:
         new_table.time_partitioning = bigquery.TimePartitioning(
             metadata.bigquery.time_partitioning.type.bigquery_type,

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1507,7 +1507,7 @@ def deploy(
                     f"{dataset_name}.{table_name}`",
                     err=True,
                 )
-                sys.exit(1)  # TODO: Should this be a continue?
+                sys.exit(1)
 
         with NamedTemporaryFile(suffix=".json") as tmp_schema_file:
             existing_schema.to_json_file(Path(tmp_schema_file.name))
@@ -1520,7 +1520,7 @@ def deploy(
 
         table.schema = bigquery_schema
 
-        if table.created is None:
+        if not table.created:
             _attach_metadata(query_file_path, table)
             client.create_table(table)
             click.echo(f"Destination table {full_table_id} created.")
@@ -1530,6 +1530,7 @@ def deploy(
 
 
 def _attach_metadata(query_file_path: Path, table: bigquery.Table) -> None:
+    """Add metadata from query file's metadata.yaml to table object."""
     metadata = Metadata.of_query_file(query_file_path)
 
     table.description = metadata.description


### PR DESCRIPTION
Currently, some metadata (friendly name, description, labels) isn't attached to new or existing derived tables in BigQuery. This PR makes it so new tables get metadata attached when created via `bqetl query schema deploy`. 

I'll add an inline question about whether we should update metadata on every schema deploy rather than just on create. 

Also a few cleanup tasks like closing temp file.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
