### PR TITLE
Deng 453 add isp to unified metrics

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/query.sql
@@ -115,7 +115,7 @@ WITH unioned_source AS (
 ),
 unioned AS (
   SELECT
-    * EXCEPT (isp) REPLACE(
+    * REPLACE(
       -- Per bug 1757216 we need to exclude BrowserStack clients from KPIs,
       -- so we mark them with a separate app name here. We expect BrowserStack
       -- clients only on release channel of Fenix, so the only variant this is
@@ -202,6 +202,7 @@ mobile_with_searches AS (
     unioned.days_created_profile_bits,
     DATE_DIFF(unioned.submission_date, unioned.first_seen_date, DAY) AS days_since_first_seen,
     unioned.device_model,
+    unioned.isp,
     unioned.is_new_profile,
     unioned.locale,
     unioned.first_seen_date,
@@ -258,6 +259,7 @@ desktop AS (
     days_created_profile_bits,
     days_since_first_seen,
     CAST(NULL AS string) AS device_model,
+    isp_name AS isp,
     submission_date = first_seen_date AS is_new_profile,
     locale,
     first_seen_date,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/schema.yaml
@@ -110,3 +110,6 @@ fields:
 - mode: NULLABLE
   name: days_created_profile_bits
   type: INTEGER
+- mode: NULLABLE
+  name: isp
+  type: STRING


### PR DESCRIPTION

Implementation required before backfilling unified_metrics with Glean data for Focus Android.

Related [Jira task](https://mozilla-hub.atlassian.net/browse/DENG-453)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
