### PR TITLE
Update metadata on every schema deploy

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1519,14 +1519,24 @@ def deploy(
             table = bigquery.Table(full_table_id)
 
         table.schema = bigquery_schema
+        _attach_metadata(query_file_path, table)
 
         if not table.created:
-            _attach_metadata(query_file_path, table)
             client.create_table(table)
             click.echo(f"Destination table {full_table_id} created.")
         else:
-            client.update_table(table, ["schema"])
-            click.echo(f"Schema updated for {full_table_id}.")
+            client.update_table(
+                table,
+                [
+                    "schema",
+                    "friendly_name",
+                    "description",
+                    "time_partitioning",
+                    "clustering_fields",
+                    "labels",
+                ],
+            )
+            click.echo(f"Schema (and metadata) updated for {full_table_id}.")
 
 
 def _attach_metadata(query_file_path: Path, table: bigquery.Table) -> None:


### PR DESCRIPTION
Follow up to https://github.com/mozilla/bigquery-etl/pull/3324 - update metadata along with schema deploys. We can use this to progressively backfill tables and ensure metadata stays up to date whenever a schema changes.


---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
