### PR TITLE
[Bug 1771733] In Glean ping, parse start_time and end_time and add unparse raw_... fields

### DIFF
--- a/sql/mozfun/norm/glean_ping_info/udf.sql
+++ b/sql/mozfun/norm/glean_ping_info/udf.sql
@@ -4,12 +4,16 @@ Accepts a glean ping_info struct as input and returns a modified struct that
 includes a few parsed or normalized variants of the input fields.
 
 */
+
 CREATE OR REPLACE FUNCTION norm.glean_ping_info(ping_info ANY TYPE) AS (
   (
     SELECT AS STRUCT
-      ping_info.*,
-      SAFE.PARSE_TIMESTAMP('%FT%H:%M%Ez', ping_info.start_time) AS parsed_start_time,
-      SAFE.PARSE_TIMESTAMP('%FT%H:%M%Ez', ping_info.end_time) AS parsed_end_time
+      ping_info.* REPLACE (
+        SAFE.PARSE_TIMESTAMP('%FT%H:%M%Ez', ping_info.start_time) AS start_time,
+        SAFE.PARSE_TIMESTAMP('%FT%H:%M%Ez', ping_info.end_time) AS end_time
+      ),
+      ping_info.start_time AS raw_start_time,
+      ping_info.end_time AS raw_end_time
   )
 );
 
@@ -19,16 +23,17 @@ SELECT
     TIMESTAMP '2019-12-01 09:22:00',
     norm.glean_ping_info(
       STRUCT('2019-12-01T20:22+11:00' AS start_time, '2019-12-01T21:24+11:00' AS end_time)
-    ).parsed_start_time
+    ).start_time
   ),
   assert.equals(
     TIMESTAMP '2019-12-01 10:24:00',
     norm.glean_ping_info(
       STRUCT('2019-12-01T20:22+11:00' AS start_time, '2019-12-01T21:24+11:00' AS end_time)
-    ).parsed_end_time
+    ).end_time
   ),
   assert.null(
     norm.glean_ping_info(
       STRUCT('2019-12-01T20:22+11:00' AS start_time, '2019-12-01T21:24:00+11:00' AS end_time)
-    ).parsed_end_time
+      -- this fails to parse because end_time includes seconds and the udf doesn't parse them
+    ).end_time
   );

--- a/sql/mozfun/norm/glean_ping_info/udf.sql
+++ b/sql/mozfun/norm/glean_ping_info/udf.sql
@@ -4,7 +4,6 @@ Accepts a glean ping_info struct as input and returns a modified struct that
 includes a few parsed or normalized variants of the input fields.
 
 */
-
 CREATE OR REPLACE FUNCTION norm.glean_ping_info(ping_info ANY TYPE) AS (
   (
     SELECT AS STRUCT


### PR DESCRIPTION
Currently, the `glean_ping_info` UDF adds `parsed_start_time` and `parsed_end_time` fields and leaves the original fields as strings. This change instead parses `start_time` and `end_time` to TIMESTAMP and puts the raw strings in new fields `raw_start_time` and `raw_end_time`

https://bugzilla.mozilla.org/show_bug.cgi?id=1771733#c5

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
