### PR TITLE
Fix #3303: Add support to backfill monthly partition tables

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -15,6 +15,7 @@ from tempfile import NamedTemporaryFile
 
 import click
 import yaml
+from dateutil.rrule import MONTHLY, rrule
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 
@@ -457,14 +458,22 @@ def _backfill_query(
     dry_run,
     no_partition,
     args,
+    partitioning_type,
     backfill_date,
 ):
     """Run a query backfill for a specific date."""
     project, dataset, table = extract_from_query_path(query_file_path)
 
+    match partitioning_type:
+        case PartitionType.DAY:
+            partition = backfill_date.strftime("%Y%m%d")
+        case PartitionType.MONTH:
+            partition = backfill_date.strftime("%Y%m")
+        case _:
+            raise ValueError(f"Unsupported partitioning type: {partitioning_type}")
+
     backfill_date = backfill_date.strftime("%Y-%m-%d")
     if backfill_date not in exclude:
-        partition = backfill_date.replace("-", "")
 
         if no_partition:
             destination_table = table
@@ -552,6 +561,7 @@ def _backfill_query(
 @click.option(
     "--exclude",
     "-x",
+    multiple=True,
     help="Dates excluded from backfill. Date format: yyyy-mm-dd",
     default=[],
 )
@@ -625,6 +635,41 @@ def backfill(
             date_partition_parameter = metadata.scheduling.get(
                 "date_partition_parameter", date_partition_parameter
             )
+
+            # For backwards compatibility assume partitioning type is day
+            # in case metadata is missing
+            if metadata.bigquery:
+                partitioning_type = metadata.bigquery.time_partitioning.type
+            else:
+                partitioning_type = PartitionType.DAY
+                click.echo(
+                    "Bigquery partitioning type not set. Using PartitionType.DAY"
+                )
+
+            match partitioning_type:
+                case PartitionType.DAY:
+                    dates = [
+                        start_date + timedelta(i)
+                        for i in range((end_date - start_date).days + 1)
+                    ]
+                case PartitionType.MONTH:
+                    dates = list(
+                        rrule(
+                            freq=MONTHLY,
+                            dtstart=start_date.replace(day=1),
+                            until=end_date,
+                        )
+                    )
+                    # Dates in excluded must be the first day of the month to match `dates`
+                    exclude = [
+                        date.fromisoformat(day).replace(day=1).strftime("%Y-%m-%d")
+                        for day in exclude
+                    ]
+                case _:
+                    raise ValueError(
+                        f"Unsupported partitioning type: {partitioning_type}"
+                    )
+
         except FileNotFoundError:
             click.echo(f"No metadata defined for {query_file_path}")
 
@@ -651,6 +696,7 @@ def backfill(
             dry_run,
             no_partition,
             ctx.args,
+            partitioning_type,
         )
 
         if not depends_on_past:


### PR DESCRIPTION
Fix #3303

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
