### PR TITLE
docs: Tweaking Apple Silicon comment to red to make it more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more information, see [https://mozilla.github.io/bigquery-etl/](https://mozi
 
 ## Quick Start
 
-> Apple Silicon (M1) user requirement
+> :exclamation: Apple Silicon (M1) user requirement
 >
 > Enable [Rosetta mode](https://support.apple.com/en-ca/HT211861) for your terminal _**BEFORE**_ installing below tools using your terminal. It'll save you a lot of headaches. For tips on maintaining parallel stacks of python and homebrew running with and without Rosetta, see blog posts from [Thinknum](https://medium.com/thinknum/how-to-install-python-under-rosetta-2-f98c0865e012) and [Sixty North](http://sixty-north.com/blog/pyenv-apple-silicon.html).
 


### PR DESCRIPTION
docs: Tweaking Apple Silicon comment to red to make it more prominent

The objective is to make sure that this stands out and hopefully results in the first thing being read and taken action upon.