### PR TITLE
Add product name to VPN aggregate tables (DS-2185)

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_live/view.sql
@@ -12,6 +12,7 @@ WITH stage_1 AS (
     utm_term,
     entrypoint_experiment,
     entrypoint_variation,
+    product_name,
     pricing_plan,
     provider,
     TO_JSON_STRING(promotion_codes) AS json_promotion_codes,
@@ -30,6 +31,7 @@ WITH stage_1 AS (
     utm_term,
     entrypoint_experiment,
     entrypoint_variation,
+    product_name,
     pricing_plan,
     provider,
     json_promotion_codes

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/schema.yaml
@@ -28,6 +28,9 @@ fields:
   name: entrypoint_variation
   type: STRING
 - mode: NULLABLE
+  name: product_name
+  type: STRING
+- mode: NULLABLE
   name: pricing_plan
   type: STRING
 - mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
@@ -1,17 +1,22 @@
 WITH stripe_plans AS (
   SELECT
-    id AS plan_id,
-    product_id,
+    plans.id AS plan_id,
+    plans.product_id,
+    products.name AS product_name,
     mozfun.vpn.pricing_plan(
       provider => "Stripe",
-      amount => amount,
-      currency => currency,
-      `interval` => `interval`,
-      interval_count => interval_count
+      amount => plans.amount,
+      currency => plans.currency,
+      `interval` => plans.`interval`,
+      interval_count => plans.interval_count
     ) AS pricing_plan,
-    nickname AS plan_name,
+    plans.nickname AS plan_name,
   FROM
-    `moz-fx-data-bq-fivetran`.stripe.plan
+    `moz-fx-data-bq-fivetran`.stripe.plan AS plans
+  LEFT JOIN
+    `moz-fx-data-bq-fivetran`.stripe.product AS products
+  ON
+    plans.product_id = products.id
 ),
 events AS (
   SELECT
@@ -251,8 +256,9 @@ SELECT
   os_name,
   os_version,
   entrypoint,
-  plan_id,
   product_id,
+  product_name,
+  plan_id,
   pricing_plan,
   plan_name,
   promotion_code,

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/schema.yaml
@@ -43,10 +43,13 @@ fields:
   name: entrypoint
   type: STRING
 - mode: NULLABLE
-  name: plan_id
+  name: product_id
   type: STRING
 - mode: NULLABLE
-  name: product_id
+  name: product_name
+  type: STRING
+- mode: NULLABLE
+  name: plan_id
   type: STRING
 - mode: NULLABLE
   name: pricing_plan


### PR DESCRIPTION
## [DS-2185](https://mozilla-hub.atlassian.net/browse/DS-2185): Handle multi-product bundles that include VPN

With VPN+Relay bundle subscriptions now being included in VPN ETL (#3345) it's important that we be able to differentiate between the VPN-only and VPN+Relay bundle products in reports.  To facilitate that, this adds a `product_name` column to the VPN aggregate tables `channel_group_proportions` and `funnel_product_page_to_subscribed` (other applicable aggregate tables like `active_subscriptions` and `subscription_events` already include a `product_name` column).

Since none of the tables being changed are huge I plan to add/backfill the `product_name` columns by manually running the following queries to overwrite the entire table:
- `mozilla_vpn_derived.channel_group_proportions_v1`
  ```sql
  SELECT
    subscription_start_date,
    country_name,
    utm_medium,
    utm_source,
    utm_campaign,
    utm_content,
    utm_term,
    entrypoint_experiment,
    entrypoint_variation,
    "Mozilla VPN" AS product_name,
    pricing_plan,
    provider,
    new_subscriptions,
    promotion_codes,
    channel_group,
    total_new_subscriptions_for_date,
    channel_group_percent_of_total_for_date
  FROM `moz-fx-data-shared-prod`.mozilla_vpn_derived.channel_group_proportions_v1
  ```
- `mozilla_vpn_derived.funnel_product_page_to_subscribed_v1`
  ```sql
  SELECT
    funnel.partition_date,
    funnel.country,
    funnel.utm_medium,
    funnel.utm_source,
    funnel.utm_campaign,
    funnel.utm_content,
    funnel.utm_term,
    funnel.entrypoint_experiment,
    funnel.entrypoint_variation,
    funnel.ua_browser,
    funnel.ua_version,
    funnel.os_name,
    funnel.os_version,
    funnel.entrypoint,
    funnel.product_id,
    products.name AS product_name,
    funnel.plan_id,
    funnel.pricing_plan,
    funnel.plan_name,
    funnel.promotion_code,
    funnel.vpn_site_hits,
    funnel.channel_group,
    funnel.total_acquisition_process_start,
    funnel.total_payment_setup_engage,
    funnel.total_payment_setup_complete,
    funnel.overall_total_vpn_site_hits,
    funnel.overall_total_acquisition_process_start,
    funnel.overall_total_payment_setup_complete,
    funnel.new_fxa_user_input_emails,
    funnel.new_fxa_payment_setup_engage,
    funnel.new_fxa_payment_setup_complete,
    funnel.overall_new_fxa_user_input_emails,
    funnel.overall_new_fxa_payment_setup_complete,
    funnel.existing_fxa_payment_setup_view,
    funnel.existing_fxa_payment_setup_engage,
    funnel.existing_fxa_payment_setup_complete,
    funnel.existing_fxa_signedin_payment_setup_view,
    funnel.existing_fxa_signedin_payment_setup_engage,
    funnel.existing_fxa_signedin_payment_setup_complete,
    funnel.overall_existing_fxa_signedin_payment_setup_complete,
    funnel.overall_existing_fxa_signedin_payment_setup_view,
    funnel.existing_fxa_signedoff_signin_cta_click,
    funnel.overall_existing_fxa_signedoff_signin_cta_click,
    funnel.existing_signedoff_fxa_payment_setup_view,
    funnel.existing_fxa_signedoff_payment_setup_engage,
    funnel.existing_fxa_signedoff_payment_setup_complete,
    funnel.overall_existing_fxa_signedoff_payment_setup_complete,
    funnel.overall_existing_signedoff_fxa_payment_setup_view,
    funnel.subscribe_coupon_submit,
    funnel.subscribe_coupon_fail,
    funnel.subscribe_coupon_success
  FROM `moz-fx-data-shared-prod`.mozilla_vpn_derived.funnel_product_page_to_subscribed_v1 AS funnel
  LEFT JOIN `moz-fx-data-bq-fivetran`.stripe.product AS products ON funnel.product_id = products.id
  ```

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
