### PR TITLE
bug: making sure device_id is hashed in fxa_log_auth_events

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_auth_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_auth_events_v1/query.sql
@@ -3,6 +3,7 @@ SELECT
   jsonPayload.fields.event,
   jsonPayload.fields.flow_id,
   jsonPayload.fields.device_id,
+  TO_HEX(SHA256(COALESCE(jsonPayload.fields.device_id, jsonPayload.fields.deviceid))) AS device_id,
   jsonPayload.fields.entrypoint,
   jsonPayload.fields.service,
   jsonPayload.fields.useragent,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_content_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_content_events_v1/query.sql
@@ -8,7 +8,6 @@ WITH base AS (
     jsonPayload.country,
     jsonPayload.entrypoint,
     jsonPayload.flow_id,
-    jsonPayload.device_id,
     jsonPayload.region,
     jsonPayload.service,
     jsonPayload.utm_campaign,


### PR DESCRIPTION
# bug: making sure device_id is hashed in fxa_log_auth_events

Also, removed the field from `fxa_log_content_events` as the source table used does not have `device_id` or `deviceid` field.
