### PR TITLE
Filter out 'Focus Android Glean BrowserStack' data in mozdata.unified_metrics

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/unified_metrics/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/unified_metrics/view.sql
@@ -8,3 +8,4 @@ FROM
   `moz-fx-data-shared-prod.telemetry_derived.unified_metrics_v1`
 WHERE
   normalized_app_name != 'Focus Android Glean'
+  AND normalized_app_name != 'Focus Android Glean BrowserStack'


### PR DESCRIPTION
The view `mozdata.unified_metrics` must filter out Focus Android data from Glean until it is fully validated to avoid duplication with Legacy data, and that includes the BrowserStack records.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
