### PR TITLE
RS-392 - Added new profiles and activitysegment via unified_metrics

### DIFF
--- a/dags/bqetl_unified.py
+++ b/dags/bqetl_unified.py
@@ -123,6 +123,13 @@ with DAG(
         )
 
         ExternalTaskMarker(
+            task_id="bqetl_newtab__wait_for_telemetry_derived__unified_metrics__v1",
+            external_dag_id="bqetl_newtab",
+            external_task_id="wait_for_telemetry_derived__unified_metrics__v1",
+            execution_date="{{ (execution_date - macros.timedelta(seconds=10800)).isoformat() }}",
+        )
+
+        ExternalTaskMarker(
             task_id="kpi_forecasting__wait_for_unified_metrics",
             external_dag_id="kpi_forecasting",
             external_task_id="wait_for_unified_metrics",

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
@@ -198,13 +198,14 @@ aggregated_newtab_activity AS (
 client_profile_info AS (
   SELECT
     client_id AS legacy_telemetry_client_id,
-    ANY_VALUE(is_new_profile) as is_new_profile,
-    ANY_VALUE(activity_segment) as activity_segment
+    ANY_VALUE(is_new_profile) AS is_new_profile,
+    ANY_VALUE(activity_segment) AS activity_segment
   FROM
     telemetry_derived.unified_metrics_v1
   WHERE
     submission_date = @submission_date
-  GROUP BY client_id
+  GROUP BY
+    client_id
 )
 SELECT
   *

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
@@ -203,7 +203,7 @@ client_profile_info AS (
   FROM
     telemetry_derived.unified_metrics_v1
   WHERE
-    submission_date = DATE('2022-11-01')
+    submission_date = @submission_date
   GROUP BY client_id
 )
 SELECT

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
@@ -198,12 +198,13 @@ aggregated_newtab_activity AS (
 client_profile_info AS (
   SELECT
     client_id AS legacy_telemetry_client_id,
-    is_new_profile,
-    activity_segment
+    ANY_VALUE(is_new_profile) as is_new_profile,
+    ANY_VALUE(activity_segment) as activity_segment
   FROM
     telemetry_derived.unified_metrics_v1
   WHERE
-    submission_date = @submission_date
+    submission_date = DATE('2022-11-01')
+  GROUP BY client_id
 )
 SELECT
   *

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/schema.yaml
@@ -152,3 +152,12 @@ fields:
 - mode: NULLABLE
   name: newtab_search_enabled
   type: BOOLEAN
+- mode: NULLABLE
+  name: legacy_telemetry_client_id
+  type: STRING
+- mode: NULLABLE
+  name: is_new_profile
+  type: BOOLEAN
+- mode: NULLABLE
+  name: activity_segment
+  type: STRING


### PR DESCRIPTION
Additional segmentation for newtab data. Note that the legacy client id and Glean client id are different. This will only fill in client profile and segment info for Glean data that has a legacy client identifier attached.

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
