### PR TITLE
bug(DENG-462): letting through some of ios sync events in the fxa_auth_events query

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
@@ -47,12 +47,12 @@ WHERE
     _oauth_client_id NOT IN (
       '3332a18d142636cb', -- fennec sync
       '5882386c6d801776', -- desktop sync
-      '1b1a3e44c54fbb58'
-    ) -- ios sync
+      '1b1a3e44c54fbb58' -- ios sync
+    )
     -- We do want to let through some desktop sync events
     -- see https://github.com/mozilla/bigquery-etl/issues/573
     OR (
-      _oauth_client_id = '5882386c6d801776'
+      _oauth_client_id IN ('5882386c6d801776', '1b1a3e44c54fbb58')
       AND jsonPayload.fields.event_type NOT IN (
         'fxa_activity - access_token_checked',
         'fxa_activity - access_token_created'


### PR DESCRIPTION
# bug(DENG-462): letting through some of ios sync events in the fxa_auth_events query

cc: @clouserw