### PR TITLE
Only merge descriptions from Glean stable table schemas to views

### DIFF
--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -239,7 +239,6 @@ class Schema:
                         update=update,
                         add_missing_fields=add_missing_fields,
                         ignore_missing_fields=ignore_missing_fields,
-                        exclude=exclude,
                         attributes=attributes,
                     )
             else:

--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -204,7 +204,9 @@ def write_view_if_not_exists(target_project: str, sql_dir: Path, schema: SchemaF
         view_schema = Schema.from_query_file(target_file, content=content)
 
         stable_table_schema = Schema.from_json({"fields": schema.schema})
-        view_schema.merge(stable_table_schema, add_missing_fields=False)
+        view_schema.merge(
+            stable_table_schema, attributes=["description"], add_missing_fields=False
+        )
         view_schema.to_yaml_file(target_dir / "schema.yaml")
     except Exception as e:
         print(f"Cannot generate schema.yaml for {target_file}: {e}")


### PR DESCRIPTION
After #3343 `schema.yaml` files are failing to be generated for the Glean stable views because the step to merge Glean stable table schemas with their view schemas is failing due to the datetime metric column types being different.  That schema merge is only being done to copy the column descriptions to the view, so this tweaks that schema merge logic to only copy the `description` attributes (ignoring other attributes like `type`).

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
