### PR TITLE
Bug 1803833 - Filter out Normandy invalid-feature events from deanonymized_events view

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/deanonymized_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/deanonymized_events/view.sql
@@ -45,3 +45,12 @@ SELECT
   *
 FROM
   events
+WHERE
+  -- See https://bugzilla.mozilla.org/show_bug.cgi?id=1803833
+  NOT (
+    event_category = 'normandy'
+    AND event_method = 'validationFailed'
+    AND mozfun.map.get_key(event_map_values, 'reason') = 'invalid-feature'
+    AND mozfun.map.get_key(event_map_values, 'feature') IN ('nimbus-qa-1', 'nimbus-qa-2')
+    AND mozfun.norm.truncate_version(metadata.uri.app_version, 'major') <= 108
+  )


### PR DESCRIPTION
Follow up to https://github.com/mozilla/bigquery-etl/pull/3401. This should fix [telemetry_derived.events_daily_v1](https://workflow.telemetry.mozilla.org/log?dag_id=bqetl_event_rollup&task_id=telemetry_derived__events_daily__v1&execution_date=2022-12-02T03%3A00%3A00%2B00%3A00) that crashed during the weekend most likely due to increased volume of events sent from Normandy.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
