### PR TITLE
Use fast versione of bytes algorithm

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf/bits_to_days_since_seen/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf/bits_to_days_since_seen/udf.sql
@@ -5,7 +5,7 @@ last seen.
 If no bits are set, returns NULL, indicating we don't know.
 Otherwise the results are 0-indexed, meaning \x01 will return 0.
 
-Tests showed this being 5-10x faster than the simpler alternative:
+Tests showed this being 100-300x faster than the simpler alternative:
 CREATE OR REPLACE FUNCTION
   udf.bits_to_days_since_seen(b BYTES) AS ((
     SELECT MIN(n)
@@ -13,35 +13,12 @@ CREATE OR REPLACE FUNCTION
     WHERE BIT_COUNT(SUBSTR(b >> n, -1) & b'\x01') > 0));
 
 See also: bits_to_days_since_first_seen.sql
-CREATE OR REPLACE FUNCTION udf.bits_to_days_since_seen(b BYTES) AS (
-  (
-    WITH trailing AS (
-      -- Extract the first set byte with the trailing zeroes
-      -- LTRIM forces NULL for bytes with no set bits
-      SELECT
-        REGEXP_EXTRACT(LTRIM(b, b'\x00'), CAST('(.\x00*$)' AS BYTES)) AS tail
-    )
-    SELECT
-      -- Sum all trailing zeroes
-      (8 * (BYTE_LENGTH(tail) - 1))
-      -- Add the loc of the last set bit
-      + udf.pos_of_trailing_set_bit(TO_CODE_POINTS(SUBSTR(tail, 1, 1))[OFFSET(0)])
-    FROM
-      trailing
-  )
-);
-
 */
--- Bug 1803786 - Temp fix for this function
 CREATE OR REPLACE FUNCTION udf.bits_to_days_since_seen(b BYTES) AS (
-  (
-    SELECT
-      MIN(n)
-    FROM
-      UNNEST(GENERATE_ARRAY(0, 364)) AS n
-    WHERE
-      BIT_COUNT(SUBSTR(b >> n, -1) & b'\x01') > 0
-  )
+   -- Number of trailing zero bytes
+  (8 * (BYTE_LENGTH(b) - BYTE_LENGTH(RTRIM(b, b'\x00'))))
+  -- Plus the index of the last set bit in the last set byte
+  + udf.pos_of_trailing_set_bit(TO_CODE_POINTS(b)[SAFE_ORDINAL(BYTE_LENGTH(RTRIM(b, b'\x00')))])
 );
 
 -- Tests
@@ -51,4 +28,36 @@ SELECT
   assert.equals(8, udf.bits_to_days_since_seen(b'\x01\x00')),
   assert.equals(NULL, udf.bits_to_days_since_seen(b'\x00\x00')),
   assert.equals(0, udf.bits_to_days_since_seen(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03')),
-  assert.equals(76, udf.bits_to_days_since_seen(b'\xF0\x00\x00\x00\x00\x00\x00\x00\x00\x00'));
+  assert.equals(76, udf.bits_to_days_since_seen(b'\xF0\x00\x00\x00\x00\x00\x00\x00\x00\x00')),
+  assert.equals(
+    1,
+    udf.bits_to_days_since_seen(
+      FROM_HEX(
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a"
+      )
+    )
+  ),
+  assert.equals(
+    9,
+    udf.bits_to_days_since_seen(
+      FROM_HEX(
+        "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00"
+      )
+    )
+  ),
+  assert.equals(
+    17,
+    udf.bits_to_days_since_seen(
+      FROM_HEX(
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0000"
+      )
+    )
+  ),
+  assert.equals(
+    233,
+    udf.bits_to_days_since_seen(
+      FROM_HEX(
+        "000000000000000000000000000045100a0000000000000000000000000000000000000000000000000000000000"
+      )
+    )
+  ),


### PR DESCRIPTION
The interim bits algorithm which unnested an array, one value per-bit, was extremely slow.

This new algorithm is roughly 300x faster on large datasets.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
