### PR TITLE
feat(DENG-582): Updated fxa_content_* views to include deprecation notice comment

### DIFF
--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -393,12 +393,20 @@ with DAG(
         firefox_accounts_derived__fxa_content_events__v1
     )
 
+    firefox_accounts_derived__fxa_users_daily__v1.set_upstream(
+        firefox_accounts_derived__fxa_stdout_events__v1
+    )
+
     firefox_accounts_derived__fxa_users_first_seen__v1.set_upstream(
         firefox_accounts_derived__fxa_auth_events__v1
     )
 
     firefox_accounts_derived__fxa_users_first_seen__v1.set_upstream(
         firefox_accounts_derived__fxa_content_events__v1
+    )
+
+    firefox_accounts_derived__fxa_users_first_seen__v1.set_upstream(
+        firefox_accounts_derived__fxa_stdout_events__v1
     )
 
     firefox_accounts_derived__fxa_users_last_seen__v1.set_upstream(

--- a/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/flows_v1/query.sql
+++ b/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/flows_v1/query.sql
@@ -14,9 +14,10 @@ SELECT
       1
   )[SAFE_OFFSET(0)].*,
 FROM
-  mozdata.firefox_accounts.fxa_content_auth_stdout_events
+  `mozdata.firefox_accounts.fxa_all_events`
 WHERE
   DATE(`timestamp`) = @submission_date
+  AND event_category IN ('fxa_content_event', 'fxa_auth_event', 'fxa_stdout_event')
   AND flow_id IS NOT NULL
 GROUP BY
   submission_date,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
@@ -3,7 +3,8 @@ CREATE OR REPLACE VIEW
 AS
 WITH fxa_auth_events AS (
   SELECT
-    timestamp AS submission_timestamp,
+    `timestamp`,
+    receiveTimestamp,
     jsonPayload.fields.user_id,
     jsonPayload.fields.country,
     jsonPayload.fields.language,
@@ -11,7 +12,11 @@ WITH fxa_auth_events AS (
     jsonPayload.fields.os_name,
     jsonPayload.fields.os_version,
     jsonPayload.fields.event_type,
-    JSON_VALUE(jsonPayload.fields.event_properties, '$.service') AS service
+    JSON_VALUE(jsonPayload.fields.event_properties, '$.service') AS service,
+    jsonPayload.logger,
+    jsonPayload.fields.user_properties,
+    jsonPayload.fields.event_properties,
+    jsonPayload.fields.device_id,
   FROM
     `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_auth_events_v1`
 ),
@@ -19,23 +24,29 @@ WITH fxa_auth_events AS (
   -- but should always be included for a complete raw event log.
 fxa_auth_bounce_events AS (
   SELECT
-    timestamp AS submission_timestamp,
+    `timestamp`,
+    receiveTimestamp,
     jsonPayload.fields.user_id,
     CAST(
       NULL AS STRING
     ) AS country,  -- No country field in auth_bounces
     jsonPayload.fields.language,
     jsonPayload.fields.app_version,
-    CAST(NULL AS STRING),
-    CAST(NULL AS STRING),
+    CAST(NULL AS STRING) AS os_name,
+    CAST(NULL AS STRING) AS os_version,
     jsonPayload.fields.event_type,
-    JSON_VALUE(jsonPayload.fields.event_properties, '$.service') AS service
+    JSON_VALUE(jsonPayload.fields.event_properties, '$.service') AS service,
+    jsonPayload.logger,
+    jsonPayload.fields.user_properties,
+    jsonPayload.fields.event_properties,
+    CAST(NULL AS STRING) AS device_id,
   FROM
     `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_auth_bounce_events_v1`
 ),
 fxa_content_events AS (
   SELECT
-    timestamp AS submission_timestamp,
+    `timestamp`,
+    receiveTimestamp,
     jsonPayload.fields.user_id,
     jsonPayload.fields.country,
     jsonPayload.fields.language,
@@ -43,13 +54,19 @@ fxa_content_events AS (
     jsonPayload.fields.os_name,
     jsonPayload.fields.os_version,
     jsonPayload.fields.event_type,
-    JSON_VALUE(jsonPayload.fields.event_properties, '$.service') AS service
+    JSON_VALUE(jsonPayload.fields.event_properties, '$.service') AS service,
+    jsonPayload.logger,
+    jsonPayload.fields.user_properties,
+    jsonPayload.fields.event_properties,
+    jsonPayload.fields.device_id,
   FROM
     `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_content_events_v1`
 ),
+--
 fxa_oauth_events AS (
   SELECT
-    timestamp AS submission_timestamp,
+    `timestamp`,
+    receiveTimestamp,
     jsonPayload.fields.user_id,
     CAST(NULL AS STRING) AS country,
     CAST(NULL AS STRING) AS language,
@@ -57,26 +74,61 @@ fxa_oauth_events AS (
     CAST(NULL AS STRING) AS os_name,
     CAST(NULL AS STRING) AS os_version,
     jsonPayload.fields.event_type,
-    JSON_VALUE(jsonPayload.fields.event_properties, '$.service') AS service
+    JSON_VALUE(jsonPayload.fields.event_properties, '$.service') AS service,
+    jsonPayload.logger,
+    jsonPayload.fields.user_properties,
+    jsonPayload.fields.event_properties,
+    CAST(NULL AS STRING) AS device_id,
   FROM
     `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_oauth_events_v1`
+),
+stdout AS (
+  SELECT
+    `timestamp`,
+    receiveTimestamp,
+    jsonPayload.fields.user_id,
+    CAST(NULL AS STRING) AS country,
+    jsonPayload.fields.language,
+    jsonPayload.fields.app_version,
+    jsonPayload.fields.os_name,
+    jsonPayload.fields.os_version,
+    jsonPayload.fields.event_type,
+    JSON_VALUE(jsonPayload.fields.event_properties, '$.service') AS service,
+    jsonPayload.logger,
+    jsonPayload.fields.user_properties,
+    jsonPayload.fields.event_properties,
+    jsonPayload.fields.device_id,
+  FROM
+    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_stdout_events_v1`
 )
 SELECT
-  *
+  *,
+  'fxa_auth_event' AS event_category,
 FROM
   fxa_auth_events
 UNION ALL
 SELECT
-  *
+  *,
+  'fxa_auth_bounce_event' AS event_category,
 FROM
   fxa_auth_bounce_events
 UNION ALL
 SELECT
-  *
+  *,
+  'fxa_content_event' AS event_category,
 FROM
   fxa_content_events
 UNION ALL
+-- TODO: fxa_oauth_events has been deprecated.
+-- This will be removed with another change.
 SELECT
-  *
+  *,
+  'fxa_oauth_event' AS event_category,
 FROM
   fxa_oauth_events
+UNION ALL
+SELECT
+  *,
+  'fxa_stdout_event' AS event_category,
+FROM
+  stdout

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
@@ -1,3 +1,25 @@
+-----
+--- ** DEPRECATION NOTICE **
+---
+--- There is currently an ongoing effort to deprecate this view
+--- please use `firefox_accounts.fxa_all_events` view instead
+--- in new queries.
+---
+--- Please filter on `event_category` field to limit your results
+--- to events coming only from a specific fxa server like so:
+--- WHERE event_category IN ('fxa_auth_event', 'fxa_stdout_event', ...)
+--- Options include:
+---   fxa_content_event
+---   fxa_auth_event
+---   fxa_stdout_event
+---   fxa_oauth -- this has been deprecated and merged into fxa_auth_event
+---   fxa_auth_bounce_event
+--- to replicate results of this view use:
+--- WHERE event_category IN (
+---  'fxa_content_event',
+---  'fxa_auth_event'
+--- )
+-----
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_accounts.fxa_content_auth_events`
 AS

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
@@ -1,3 +1,26 @@
+-----
+--- ** DEPRECATION NOTICE **
+---
+--- There is currently an ongoing effort to deprecate this view
+--- please use `firefox_accounts.fxa_all_events` view instead
+--- in new queries.
+---
+--- Please filter on `event_category` field to limit your results
+--- to events coming only from a specific fxa server like so:
+--- WHERE event_category IN ('fxa_auth_event', 'fxa_stdout_event', ...)
+--- Options include:
+---   fxa_content_event
+---   fxa_auth_event
+---   fxa_stdout_event
+---   fxa_oauth -- this has been deprecated and merged into fxa_auth_event
+---   fxa_auth_bounce_event
+--- to replicate results of this view use:
+--- WHERE event_category IN (
+---  'fxa_content_event',
+---  'fxa_auth_event',
+--   'fxa_oauth_event'
+--- )
+-----
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_accounts.fxa_content_auth_oauth_events`
 AS

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
@@ -1,3 +1,26 @@
+-----
+--- ** DEPRECATION NOTICE **
+---
+--- There is currently an ongoing effort to deprecate this view
+--- please use `firefox_accounts.fxa_all_events` view instead
+--- in new queries.
+---
+--- Please filter on `event_category` field to limit your results
+--- to events coming only from a specific fxa server like so:
+--- WHERE event_category IN ('fxa_auth_event', 'fxa_stdout_event', ...)
+--- Options include:
+---   fxa_content_event
+---   fxa_auth_event
+---   fxa_stdout_event
+---   fxa_oauth -- this has been deprecated and merged into fxa_auth_event
+---   fxa_auth_bounce_event
+--- to replicate results of this view use:
+--- WHERE event_category IN (
+---  'fxa_content_event',
+---  'fxa_auth_event',
+--   'fxa_stdout_event'
+--- )
+-----
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_accounts.fxa_content_auth_stdout_events`
 AS

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/query.sql
@@ -19,6 +19,7 @@ SELECT
   CAST([] AS ARRAY<STRUCT<key STRING, value STRING>>) AS experiments,
   *,
 FROM
-  `moz-fx-data-shared-prod.firefox_accounts.fxa_content_auth_oauth_events`
+  `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
 WHERE
-  DATE(timestamp) = @submission_date
+  DATE(`timestamp`) = @submission_date
+  AND event_category IN ('fxa_content_event', 'fxa_auth_event', 'fxa_oauth_event')

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v1/query.sql
@@ -49,7 +49,7 @@ WITH windowed AS (
       NOT (event_type = 'fxa_rp - engage' AND service = 'fx-monitor')
     ) OVER w1 = 0 AS monitor_only
   FROM
-    firefox_accounts.fxa_all_events
+    `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
     event_category IN (
       'fxa_auth_event',

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/init.sql
@@ -7,11 +7,17 @@ CLUSTER BY
 AS
 SELECT
   user_id,
-  DATE(MIN(submission_timestamp)) AS first_seen_date,
+  DATE(MIN(`timestamp`)) AS first_seen_date,
   ARRAY_AGG(DISTINCT service IGNORE NULLS ORDER BY service) AS services_used,
 FROM
   firefox_accounts.fxa_all_events
 WHERE
-  submission_timestamp > '2010-01-01'
+  `timestamp` > '2010-01-01'
+  AND event_category IN (
+    'fxa_auth_event',
+    'fxa_auth_bounce_event',
+    'fxa_content_event',
+    'fxa_oauth_event'
+  )
 GROUP BY
   user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/query.sql
@@ -5,7 +5,13 @@ WITH _current AS (
   FROM
     firefox_accounts.fxa_all_events
   WHERE
-    DATE(submission_timestamp) = @submission_date
+    DATE(`timestamp`) = @submission_date
+    AND event_category IN (
+      'fxa_auth_event',
+      'fxa_auth_bounce_event',
+      'fxa_content_event',
+      'fxa_oauth_event'
+    )
   GROUP BY
     user_id
 ),

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v1/query.sql
@@ -34,7 +34,6 @@ CREATE TEMP FUNCTION udf_contains_registration(
   )
 );
 
-  --
 WITH base AS (
   SELECT
     * REPLACE (
@@ -43,9 +42,10 @@ WITH base AS (
       IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service) AS service
     )
   FROM
-    firefox_accounts.fxa_content_auth_oauth_events
+    `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
-    user_id IS NOT NULL
+    event_category IN ('fxa_content_event', 'fxa_auth_event', 'fxa_oauth_event')
+    AND user_id IS NOT NULL
     AND event_type NOT IN ( --
       'fxa_email - bounced',
       'fxa_email - click',

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_daily_v1/query.sql
@@ -18,11 +18,12 @@ WITH fxa_events AS (
     ua_version,
     ua_browser,
   FROM
-    `moz-fx-data-shared-prod.firefox_accounts.fxa_content_auth_oauth_events` -- TODO: this will need updated to fxa_all_events once unified
+    `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
     DATE(`timestamp`)
     BETWEEN DATE_SUB(@submission_date, INTERVAL 1 DAY)
     AND @submission_date
+    AND event_category IN ('fxa_content_event', 'fxa_auth_event', 'fxa_oauth_event')
     -- re-using the filter from users_services_daily_v1 for consistency across the models
     -- at some point in the future we should re-evaluate this list
     AND event_type NOT IN ( --

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/init.sql
@@ -6,13 +6,21 @@ CLUSTER BY
   service,
   user_id
 AS
-WITH base AS (
+WITH fxa_content_auth_oauth AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
+  WHERE
+    event_category IN ('fxa_content_event', 'fxa_auth_event', 'fxa_oauth_event')
+),
+base AS (
   SELECT
     * REPLACE (
       IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service) AS service
     )
   FROM
-    firefox_accounts.fxa_content_auth_oauth_events
+    fxa_content_auth_oauth
 ),
   -- use a window function to look within each USER and SERVICE for the first value of service, os, and country.
   -- also, get the first value of flow_id for later use and create a boolean column that is true if the first instance of a service usage includes a registration.
@@ -114,7 +122,7 @@ flows AS (
   FROM
     first_services_g s
   INNER JOIN
-    firefox_accounts.fxa_content_auth_oauth_events AS f
+    fxa_content_auth_oauth AS f
   ON
     s.first_service_flow = f.flow_id
   WHERE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/query.sql
@@ -1,10 +1,18 @@
-WITH base AS (
+WITH fxa_content_auth_oauth AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
+  WHERE
+    event_category IN ('fxa_content_event', 'fxa_auth_event', 'fxa_oauth_event')
+),
+base AS (
   SELECT
     * REPLACE (
       IF(service IS NULL AND event_type = 'fxa_activity - cert_signed', 'sync', service) AS service
     )
   FROM
-    firefox_accounts.fxa_content_auth_oauth_events
+    fxa_content_auth_oauth
 ),
   -- use a window function to look within each USER and SERVICE for the first value of service, os, and country.
   -- also, get the first value of flow_id for later use and create a boolean column that is true if the first instance of a service usage includes a registration.
@@ -106,7 +114,7 @@ flows AS (
   FROM
     first_services_g s
   INNER JOIN
-    firefox_accounts.fxa_content_auth_oauth_events AS f
+    fxa_content_auth_oauth
   ON
     s.first_service_flow = f.flow_id
   WHERE

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
@@ -23,7 +23,9 @@ events AS (
     *,
     DATE(`timestamp`) AS partition_date,
   FROM
-    mozdata.firefox_accounts.fxa_content_auth_stdout_events
+    `mozdata.firefox_accounts.fxa_all_events`
+  WHERE
+    event_category IN ('fxa_content_event', 'fxa_auth_event', 'fxa_stdout_event')
 ),
 flows AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/query.sql
@@ -15,7 +15,9 @@ WITH fxa_content_auth_stdout_events AS (
     utm_source,
     utm_term,
   FROM
-    mozdata.firefox_accounts.fxa_content_auth_stdout_events
+    `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
+  WHERE
+    event_category IN ('fxa_content_event', 'fxa_auth_event', 'fxa_stdout_event')
 ),
 flows AS (
   SELECT
@@ -49,9 +51,10 @@ flows AS (
         1
     )[SAFE_OFFSET(0)] AS attribution,
   FROM
-    fxa_content_auth_stdout_events
+    `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
     IF(@date IS NULL, partition_date < CURRENT_DATE, partition_date = @date)
+    AND event_category IN ('fxa_content_event', 'fxa_auth_event', 'fxa_stdout_event')
     AND flow_id IS NOT NULL
     AND (
       -- Service attribution was implemented for VPN FxA links on 2021-12-08, so past that date we

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql
@@ -17,6 +17,7 @@ WITH base AS (
     firefox_accounts.fxa_content_auth_events
   WHERE
     IF(@date IS NULL, DATE(`timestamp`) < CURRENT_DATE, DATE(`timestamp`) = @date)
+    AND event_category IN ('fxa_content_event', 'fxa_auth_event')
     AND service = "guardian-vpn"
   GROUP BY
     flow_id

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql
@@ -14,7 +14,7 @@ WITH base AS (
     ) AS fxa_uids,
     LOGICAL_OR(event_type = "fxa_email_first - view") AS viewed_email_first_page,
   FROM
-    firefox_accounts.fxa_content_auth_events
+    `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
     IF(@date IS NULL, DATE(`timestamp`) < CURRENT_DATE, DATE(`timestamp`) = @date)
     AND event_category IN ('fxa_content_event', 'fxa_auth_event')


### PR DESCRIPTION
# feat(DENG-582): Updated fxa_content_* views to include deprecation notice comment

This is part 3 to deprecate the following views:
- `firefox_accounts.fxa_content_auth_events`
- `firefox_accounts.fxa_content_auth_oauth_events`
- `firefox_accounts.fxa_content_auth_stdout_events`

This PR depends on PR#3408, once it has been merged this PR can be rebased and reviewed.

Related PR links:

- Part 1: https://github.com/mozilla/bigquery-etl/pull/3407
- Part 2: https://github.com/mozilla/bigquery-etl/pull/3408
- Part 3: https://github.com/mozilla/bigquery-etl/pull/3409

----

The next step will be to wait until the new deprecation process in in place and then continue this deprecation with:

- Part 4: Changing the fxa event views to be deprecated to throw an error when queried (comment out the existing logic and add select ERROR(deprecation error))
- Part 5: After a time period (2-4 weeks) completely delete the view files and remove them from BQ