### PR TITLE
Add project ID qualifiers to Fenix views

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix/attributable_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/attributable_clients/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  fenix_derived.attributable_clients_v1
+  `moz-fx-data-shared-prod.fenix_derived.attributable_clients_v1`

--- a/sql/moz-fx-data-shared-prod/fenix/marketing_attributable_metrics/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/marketing_attributable_metrics/view.sql
@@ -7,4 +7,4 @@ SELECT
   IF(is_new_profile, 1, 0) AS new_profiles,
   searches AS search_count,
 FROM
-  fenix.attributable_clients
+  `moz-fx-data-shared-prod.fenix.attributable_clients`


### PR DESCRIPTION
References in views need to be fully qualified. The main reason is that views get deployed to both `shraed-prod` and `mozdata`, but in `mozdata` the `_derived` datasets do not exist. Also there is a CI check that is failing
