### PR TITLE
Deps: Update wheel hash for yamllint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1357,7 +1357,7 @@ wheel==0.37.1 \
     --hash=sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4
     # via pip-tools
 yamllint==1.28.0 \
-    --hash=sha256:9e3d8ddd16d0583214c5fdffe806c9344086721f107435f68bad990e5a88826b
+    --hash=sha256:89bb5b5ac33b1ade059743cf227de73daa34d5e5a474b06a5e17fc16583b0cf2
     # via -r requirements.in
 yarl==1.7.2 \
     --hash=sha256:044daf3012e43d4b3538562da94a88fb12a6490652dbc29fb19adfa02cf72eac \


### PR DESCRIPTION
Update wheel hash for yamllint

This wheel was published on 2022-10-11.
This was documented in https://github.com/adrienverge/yamllint/issues/501
The hash is taken from https://pypi.org/project/yamllint/