### PR TITLE
Deng 587 remove partitioning

### DIFF
--- a/dags/bqetl_monitoring.py
+++ b/dags/bqetl_monitoring.py
@@ -87,8 +87,7 @@ with DAG(
         command=[
             "python",
             "sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_table_storage_v1/query.py",
-        ]
-        + ["--date", "{{ ds }}"],
+        ],
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
         owner="wichan@mozilla.com",
         email=["ascholtz@mozilla.com", "wichan@mozilla.com"],
@@ -111,8 +110,7 @@ with DAG(
         command=[
             "python",
             "sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/query.py",
-        ]
-        + ["--date", "{{ ds }}"],
+        ],
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
         owner="wichan@mozilla.com",
         email=["ascholtz@mozilla.com", "wichan@mozilla.com"],

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_table_storage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_table_storage_v1/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: Bigquery Query Tables Storage
-description: Bigquery table storage size and costs, partitioned by day.
+description: Bigquery table storage size and costs.
 owners:
 - wichan@mozilla.com
 labels:
@@ -7,8 +7,3 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_monitoring
-  arguments: ["--date", "{{ ds }}"]
-bigquery:
-  time_partitioning:
-    field: creation_date
-    type: day

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_table_storage_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_table_storage_v1/query.py
@@ -11,7 +11,6 @@ DEFAULT_PROJECTS = [
 ]
 
 parser = ArgumentParser(description=__doc__)
-parser.add_argument("--date", required=True)  # expect string with format yyyy-mm-dd
 parser.add_argument("--project", default="moz-fx-data-shared-prod")
 # projects queries were run from that access table
 parser.add_argument("--source_projects", nargs="+", default=DEFAULT_PROJECTS)
@@ -19,11 +18,11 @@ parser.add_argument("--destination_dataset", default="monitoring_derived")
 parser.add_argument("--destination_table", default="bigquery_table_storage_v1")
 
 
-def create_query(date, source_project):
+def create_query(source_project):
     """Create query for a source project."""
     return f"""
         SELECT
-          DATE('{date}') AS creation_date,
+          DATE(creation_time) AS creation_date,
           project_id,
           table_schema AS dataset_id,
           table_name AS table_id,
@@ -43,8 +42,6 @@ def create_query(date, source_project):
           + ((long_term_physical_bytes/ POW(1024, 3)) * 0.02)
           AS physical_billing_cost_usd
         FROM `{source_project}.region-us.INFORMATION_SCHEMA.TABLE_STORAGE`
-        WHERE
-          DATE(creation_time) = '{date}'
         ORDER BY creation_date, project_id, dataset_id, table_id
     """
 
@@ -53,16 +50,17 @@ def main():
     """Run query for each source project."""
     args = parser.parse_args()
 
-    partition = args.date.replace("-", "")
-    destination_table = f"{args.project}.{args.destination_dataset}.{args.destination_table}${partition}"
+    destination_table = (
+        f"{args.project}.{args.destination_dataset}.{args.destination_table}"
+    )
 
-    # remove old partition in case of re-run
+    # remove old table in case of re-run
     client = bigquery.Client(args.project)
     client.delete_table(destination_table, not_found_ok=True)
 
     for project in args.source_projects:
         client = bigquery.Client(project)
-        query = create_query(args.date, project)
+        query = create_query(project)
         job_config = bigquery.QueryJobConfig(
             destination=destination_table, write_disposition="WRITE_APPEND"
         )

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: Bigquery Query Tables Inventory
-description: Inventory of big query tables, partitioned by day.
+description: Inventory of big query tables.
 owners:
 - wichan@mozilla.com
 labels:
@@ -7,8 +7,3 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_monitoring
-  arguments: ["--date", "{{ ds }}"]
-bigquery:
-  time_partitioning:
-    field: creation_date
-    type: day

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/query.py
@@ -11,7 +11,6 @@ DEFAULT_PROJECTS = [
 ]
 
 parser = ArgumentParser(description=__doc__)
-parser.add_argument("--date", required=True)  # expect string with format yyyy-mm-dd
 parser.add_argument("--project", default="moz-fx-data-shared-prod")
 # projects queries were run from that access table
 parser.add_argument("--source_projects", nargs="+", default=DEFAULT_PROJECTS)
@@ -19,18 +18,16 @@ parser.add_argument("--destination_dataset", default="monitoring_derived")
 parser.add_argument("--destination_table", default="bigquery_tables_inventory_v1")
 
 
-def create_query(date, source_project):
+def create_query(source_project):
     """Create query for a source project."""
     return f"""
         SELECT
-          date('{date}') AS creation_date,
+          DATE(creation_time) AS creation_date,
           table_catalog AS project_id,
           table_schema AS dataset_id,
           table_name AS table_id,
           table_type,
           FROM `{source_project}.region-us.INFORMATION_SCHEMA.TABLES`
-        WHERE
-          DATE(creation_time) = '{date}'
         ORDER BY creation_date, project_id, dataset_id, table_id, table_type
     """
 
@@ -39,16 +36,17 @@ def main():
     """Run query for each source project."""
     args = parser.parse_args()
 
-    partition = args.date.replace("-", "")
-    destination_table = f"{args.project}.{args.destination_dataset}.{args.destination_table}${partition}"
+    destination_table = (
+        f"{args.project}.{args.destination_dataset}.{args.destination_table}"
+    )
 
-    # remove old partition in case of re-run
+    # remove old table in case of re-run
     client = bigquery.Client(args.project)
     client.delete_table(destination_table, not_found_ok=True)
 
     for project in args.source_projects:
         client = bigquery.Client(project)
-        query = create_query(args.date, project)
+        query = create_query(project)
         job_config = bigquery.QueryJobConfig(
             destination=destination_table, write_disposition="WRITE_APPEND"
         )


### PR DESCRIPTION
These tables do not need to be partitioned because they are snapshots and past data can change.  They are also are small in size (<30 rows):
* bigquery_tables_inventory_v1
* bigquery_table_storage_v1

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
