### PR TITLE
bug: fixing partition field containing value for multiple partitions error

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_last_seen_v1/schema.yaml
@@ -1,9 +1,20 @@
 fields:
 - mode: NULLABLE
   name: submission_date
+  type: DATE
+  description: |
+    Used for partitioning in BigQuery and
+    represents the date partition processed
+    by BQETL.
+
+- mode: NULLABLE
+  name: event_timestamp
   type: TIMESTAMP
   description: |
-    Timestamp when the event was recorded.
+    Timestamp when the last recorded event
+    took place. The date value for this field
+    can be older or the same in comparison
+    to submission_date.
 
 - mode: NULLABLE
   name: user_id


### PR DESCRIPTION
`timestamp` field can contain a value which corresponds to a day in the past. Fixing this by setting the value of the field by which the table is partitioned to be equal the the partition processed by bqetl.