### PR TITLE
Don't stop updating and deploying schemas if one has failed

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -13,6 +13,7 @@ from graphlib import TopologicalSorter
 from multiprocessing.pool import Pool, ThreadPool
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from traceback import print_exc
 
 import click
 import yaml
@@ -1267,50 +1268,55 @@ def update(
     query_files_ordered = ts.static_order()
 
     for query_file in query_files_ordered:
-        changed = _update_query_schema(
-            query_file,
-            sql_dir,
-            project_id,
-            tmp_dataset,
-            tmp_tables,
-            use_cloud_function,
-            respect_dryrun_skip,
-        )
+        try:
+            changed = _update_query_schema(
+                query_file,
+                sql_dir,
+                project_id,
+                tmp_dataset,
+                tmp_tables,
+                use_cloud_function,
+                respect_dryrun_skip,
+            )
 
-        if update_downstream:
-            # update downstream dependencies
-            if changed:
-                if not is_authenticated():
-                    click.echo(
-                        "Cannot update downstream dependencies."
-                        "Authentication to GCP required. Run `gcloud auth login` "
-                        "and check that the project is set correctly."
-                    )
-                    sys.exit(1)
+            if update_downstream:
+                # update downstream dependencies
+                if changed:
+                    if not is_authenticated():
+                        click.echo(
+                            "Cannot update downstream dependencies."
+                            "Authentication to GCP required. Run `gcloud auth login` "
+                            "and check that the project is set correctly."
+                        )
+                        sys.exit(1)
 
-                project, dataset, table = extract_from_query_path(query_file)
-                identifier = f"{project}.{dataset}.{table}"
-                tmp_identifier = f"{project}.{tmp_dataset}.{table}_{random_str(12)}"
+                    project, dataset, table = extract_from_query_path(query_file)
+                    identifier = f"{project}.{dataset}.{table}"
+                    tmp_identifier = f"{project}.{tmp_dataset}.{table}_{random_str(12)}"
 
-                # create temporary table with updated schema
-                if identifier not in tmp_tables:
-                    schema = Schema.from_schema_file(query_file.parent / SCHEMA_FILE)
-                    schema.deploy(tmp_identifier)
-                    tmp_tables[identifier] = tmp_identifier
+                    # create temporary table with updated schema
+                    if identifier not in tmp_tables:
+                        schema = Schema.from_schema_file(
+                            query_file.parent / SCHEMA_FILE
+                        )
+                        schema.deploy(tmp_identifier)
+                        tmp_tables[identifier] = tmp_identifier
 
-                # get downstream dependencies that will be updated in the next iteration
-                dependencies = [
-                    p
-                    for k, refs in dependency_graph.items()
-                    for p in paths_matching_name_pattern(
-                        k, sql_dir, project_id, files=("query.sql",)
-                    )
-                    if identifier in refs
-                ]
+                    # get downstream dependencies that will be updated in the next iteration
+                    dependencies = [
+                        p
+                        for k, refs in dependency_graph.items()
+                        for p in paths_matching_name_pattern(
+                            k, sql_dir, project_id, files=("query.sql",)
+                        )
+                        if identifier in refs
+                    ]
 
-                for d in dependencies:
-                    click.echo(f"Update downstream dependency schema for {d}")
-                    query_files.append(d)
+                    for d in dependencies:
+                        click.echo(f"Update downstream dependency schema for {d}")
+                        query_files.append(d)
+        except Exception:
+            print_exc()
 
     if len(tmp_tables) > 0:
         client = bigquery.Client()
@@ -1575,6 +1581,7 @@ def deploy(
             name, ctx.obj["TMP_DIR"], project_id, ["query.*"]
         )
 
+    failed_deploys = []
     for query_file in query_files:
         if respect_dryrun_skip and str(query_file) in SKIP:
             click.echo(f"{query_file} dry runs are skipped. Cannot validate schemas.")
@@ -1587,60 +1594,75 @@ def deploy(
             click.echo(f"No schema file found for {query_file}")
             continue
 
-        table_name = query_file_path.parent.name
-        dataset_name = query_file_path.parent.parent.name
-        project_name = query_file_path.parent.parent.parent.name
-        full_table_id = f"{project_name}.{dataset_name}.{table_name}"
-
-        existing_schema = Schema.from_schema_file(existing_schema_path)
-
-        if not force and str(query_file_path).endswith("query.sql"):
-            query_schema = Schema.from_query_file(
-                query_file_path,
-                use_cloud_function=use_cloud_function,
-                respect_skip=respect_dryrun_skip,
-            )
-            if not existing_schema.equal(query_schema):
-                click.echo(
-                    f"Query {query_file_path} does not match "
-                    f"schema in {existing_schema_path}. "
-                    f"To update the local schema file, "
-                    f"run `./bqetl query schema update "
-                    f"{dataset_name}.{table_name}`",
-                    err=True,
-                )
-                sys.exit(1)
-
-        with NamedTemporaryFile(suffix=".json") as tmp_schema_file:
-            existing_schema.to_json_file(Path(tmp_schema_file.name))
-            bigquery_schema = client.schema_from_json(tmp_schema_file.name)
-
         try:
-            table = client.get_table(full_table_id)
-        except NotFound:
-            table = bigquery.Table(full_table_id)
+            table_name = query_file_path.parent.name
+            dataset_name = query_file_path.parent.parent.name
+            project_name = query_file_path.parent.parent.parent.name
+            full_table_id = f"{project_name}.{dataset_name}.{table_name}"
 
-        table.schema = bigquery_schema
-        _attach_metadata(query_file_path, table)
+            existing_schema = Schema.from_schema_file(existing_schema_path)
 
-        if not table.created:
-            client.create_table(table)
-            click.echo(f"Destination table {full_table_id} created.")
-        elif not skip_existing:
-            client.update_table(
-                table,
-                [
-                    "schema",
-                    "friendly_name",
-                    "description",
-                    "time_partitioning",
-                    "clustering_fields",
-                    "labels",
-                ],
-            )
-            click.echo(f"Schema (and metadata) updated for {full_table_id}.")
+            if not force and str(query_file_path).endswith("query.sql"):
+                query_schema = Schema.from_query_file(
+                    query_file_path,
+                    use_cloud_function=use_cloud_function,
+                    respect_skip=respect_dryrun_skip,
+                )
+                if not existing_schema.equal(query_schema):
+                    click.echo(
+                        f"Query {query_file_path} does not match "
+                        f"schema in {existing_schema_path}. "
+                        f"To update the local schema file, "
+                        f"run `./bqetl query schema update "
+                        f"{dataset_name}.{table_name}`",
+                        err=True,
+                    )
+                    sys.exit(1)
 
-    _deploy_external_data(name, sql_dir, project_id, skip_existing)
+            with NamedTemporaryFile(suffix=".json") as tmp_schema_file:
+                existing_schema.to_json_file(Path(tmp_schema_file.name))
+                bigquery_schema = client.schema_from_json(tmp_schema_file.name)
+
+            try:
+                table = client.get_table(full_table_id)
+            except NotFound:
+                table = bigquery.Table(full_table_id)
+
+            table.schema = bigquery_schema
+            _attach_metadata(query_file_path, table)
+
+            if not table.created:
+                client.create_table(table)
+                click.echo(f"Destination table {full_table_id} created.")
+            elif not skip_existing:
+                client.update_table(
+                    table,
+                    [
+                        "schema",
+                        "friendly_name",
+                        "description",
+                        "time_partitioning",
+                        "clustering_fields",
+                        "labels",
+                    ],
+                )
+                click.echo(f"Schema (and metadata) updated for {full_table_id}.")
+        except Exception:
+            print_exc()
+            failed_deploys.append(query_file)
+
+    failed_external_deploys = _deploy_external_data(
+        name, sql_dir, project_id, skip_existing
+    )
+    failed_deploys += failed_external_deploys
+
+    if len(failed_deploys) > 0:
+        click.echo("The following tables could not be deployed:")
+        for failed_deploy in failed_deploys:
+            click.echo(failed_deploy)
+        sys.exit(1)
+
+    click.echo("All tables have been deployed.")
 
 
 def _attach_metadata(query_file_path: Path, table: bigquery.Table) -> None:
@@ -1675,13 +1697,14 @@ def _deploy_external_data(
     sql_dir,
     project_id,
     skip_existing,
-) -> None:
+) -> list:
     """Publish external data tables."""
     # whether a table should be created from external data is defined in the metadata
     metadata_files = paths_matching_name_pattern(
         name, sql_dir, project_id, ["metadata.yaml"]
     )
     client = bigquery.Client()
+    failed_deploys = []
     for metadata_file_path in metadata_files:
         metadata = Metadata.from_file(metadata_file_path)
         if not metadata.external_data:
@@ -1695,53 +1718,59 @@ def _deploy_external_data(
             click.echo(f"No schema file found for {metadata_file_path}")
             continue
 
-        table_name = metadata_file_path.parent.name
-        dataset_name = metadata_file_path.parent.parent.name
-        project_name = metadata_file_path.parent.parent.parent.name
-        full_table_id = f"{project_name}.{dataset_name}.{table_name}"
-
-        existing_schema = Schema.from_schema_file(existing_schema_path)
-
         try:
-            table = client.get_table(full_table_id)
-        except NotFound:
-            table = bigquery.Table(full_table_id)
+            table_name = metadata_file_path.parent.name
+            dataset_name = metadata_file_path.parent.parent.name
+            project_name = metadata_file_path.parent.parent.parent.name
+            full_table_id = f"{project_name}.{dataset_name}.{table_name}"
 
-        with NamedTemporaryFile(suffix=".json") as tmp_schema_file:
-            existing_schema.to_json_file(Path(tmp_schema_file.name))
-            bigquery_schema = client.schema_from_json(tmp_schema_file.name)
+            existing_schema = Schema.from_schema_file(existing_schema_path)
 
-        table.schema = bigquery_schema
-        _attach_metadata(metadata_file_path, table)
+            try:
+                table = client.get_table(full_table_id)
+            except NotFound:
+                table = bigquery.Table(full_table_id)
 
-        if not table.created:
-            if metadata.external_data.format == ExternalDataFormat.GOOGLE_SHEET:
-                external_config = bigquery.ExternalConfig("GOOGLE_SHEETS")
-                external_config.source_uris = metadata.external_data.source_uris
-                external_config.ignore_unknown_values = True
-                external_config.autodetect = False
+            with NamedTemporaryFile(suffix=".json") as tmp_schema_file:
+                existing_schema.to_json_file(Path(tmp_schema_file.name))
+                bigquery_schema = client.schema_from_json(tmp_schema_file.name)
 
-                for key, v in metadata.external_data.options.items():
-                    setattr(external_config.options, key, v)
+            table.schema = bigquery_schema
+            _attach_metadata(metadata_file_path, table)
 
-                table.external_data_configuration = external_config
-                table = client.create_table(table)
-                click.echo(f"Destination table {full_table_id} created.")
-            else:
-                click.echo(
-                    f"External data format {metadata.external_data.format} unsupported."
+            if not table.created:
+                if metadata.external_data.format == ExternalDataFormat.GOOGLE_SHEET:
+                    external_config = bigquery.ExternalConfig("GOOGLE_SHEETS")
+                    external_config.source_uris = metadata.external_data.source_uris
+                    external_config.ignore_unknown_values = True
+                    external_config.autodetect = False
+
+                    for key, v in metadata.external_data.options.items():
+                        setattr(external_config.options, key, v)
+
+                    table.external_data_configuration = external_config
+                    table = client.create_table(table)
+                    click.echo(f"Destination table {full_table_id} created.")
+                else:
+                    click.echo(
+                        f"External data format {metadata.external_data.format} unsupported."
+                    )
+            elif not skip_existing:
+                client.update_table(
+                    table,
+                    [
+                        "schema",
+                        "friendly_name",
+                        "description",
+                        "labels",
+                    ],
                 )
-        elif not skip_existing:
-            client.update_table(
-                table,
-                [
-                    "schema",
-                    "friendly_name",
-                    "description",
-                    "labels",
-                ],
-            )
-            click.echo(f"Schema (and metadata) updated for {full_table_id}.")
+                click.echo(f"Schema (and metadata) updated for {full_table_id}.")
+        except Exception:
+            print_exc()
+            failed_deploys.append(metadata_file_path)
+
+    return failed_deploys
 
 
 def _validate_schema_from_path(


### PR DESCRIPTION
This PR makes some improvements to unblock table deploys:
If a deploy fails for some table, then this changes ensures that the deploys for the remaining tables will keep running instead of stopping immediately. 
