### PR TITLE
Reapply "Have Glean stable views parse datetime metrics as timestamps (bug 1771733) (#3343)"

### DIFF
--- a/sql/mozfun/glean/parse_datetime/metadata.yaml
+++ b/sql/mozfun/glean/parse_datetime/metadata.yaml
@@ -1,0 +1,6 @@
+---
+description: |
+  Parses a Glean datetime metric string value as a BigQuery timestamp.
+
+  See https://mozilla.github.io/glean/book/reference/metrics/datetime.html
+friendly_name: Parse Datetime

--- a/sql/mozfun/glean/parse_datetime/udf.sql
+++ b/sql/mozfun/glean/parse_datetime/udf.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION glean.parse_datetime(datetime_string STRING)
+RETURNS TIMESTAMP AS (
+  COALESCE(
+    SAFE.PARSE_TIMESTAMP('%FT%H:%M:%E*S%Ez', datetime_string),
+    SAFE.PARSE_TIMESTAMP('%FT%H:%M%Ez', datetime_string),
+    SAFE.PARSE_TIMESTAMP('%FT%H%Ez', datetime_string),
+    SAFE.PARSE_TIMESTAMP('%F%Ez', datetime_string)
+  )
+);
+
+-- Tests
+SELECT
+  assert.equals(
+    TIMESTAMP '2000-01-02 03:04:05.123456',
+    glean.parse_datetime('2000-01-02T03:04:05.123456789+00:00')
+  ),
+  assert.equals(
+    TIMESTAMP '2000-01-02 03:04:05.123456',
+    glean.parse_datetime('2000-01-02T03:04:05.123456+00:00')
+  ),
+  assert.equals(
+    TIMESTAMP '2000-01-02 03:04:05.123',
+    glean.parse_datetime('2000-01-02T03:04:05.123+00:00')
+  ),
+  assert.equals(TIMESTAMP '2000-01-02 03:04:05', glean.parse_datetime('2000-01-02T03:04:05+00:00')),
+  assert.equals(TIMESTAMP '2000-01-02 09:04:05', glean.parse_datetime('2000-01-02T03:04:05-06:00')),
+  assert.equals(TIMESTAMP '2000-01-02 03:04:00', glean.parse_datetime('2000-01-02T03:04+00:00')),
+  assert.equals(TIMESTAMP '2000-01-02 03:00:00', glean.parse_datetime('2000-01-02T03+00:00')),
+  assert.equals(TIMESTAMP '2000-01-02 00:00:00', glean.parse_datetime('2000-01-02+00:00')),
+  assert.null(glean.parse_datetime('2000-01-02 00:00:00 Z'))

--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -139,11 +139,34 @@ def write_view_if_not_exists(target_project: str, sql_dir: Path, schema: SchemaF
             and schema.bq_table == "metrics_v1"
         ):
             # todo: use mozfun udfs
-            replacements += [
+            metrics_source = (
                 "mozdata.udf.normalize_fenix_metrics"
                 "(client_info.telemetry_sdk_build, metrics)"
-                " AS metrics"
+            )
+        else:
+            metrics_source = "metrics"
+        if metrics_datetime_fields := [
+            metrics_datetime_field["name"]
+            for field in schema.schema
+            if field["name"] == "metrics"
+            for metrics_field in field["fields"]
+            if metrics_field["name"] == "datetime"
+            for metrics_datetime_field in metrics_field["fields"]
+        ]:
+            replacements += [
+                f"(SELECT AS STRUCT {metrics_source}.* REPLACE (STRUCT("
+                + ", ".join(
+                    field_select
+                    for field in metrics_datetime_fields
+                    for field_select in (
+                        f"mozfun.glean.parse_datetime(metrics.datetime.{field}) AS {field}",
+                        f"metrics.datetime.{field} AS raw_{field}",
+                    )
+                )
+                + ") AS datetime)) AS metrics"
             ]
+        elif metrics_source != "metrics":
+            replacements += [f"{metrics_source} AS metrics"]
         if schema.bq_dataset_family == "firefox_desktop":
             # FOG does not provide an app_name, so we inject the one that
             # people already associate with desktop Firefox per bug 1672191.


### PR DESCRIPTION
This reapplies #3343, which was temporarily reverted in #3394 because it had the unfortunate side effect of causing the `search_derived.mobile_search_clients_daily_v1` ETL query to exceed the query complexity limit in the `moz-fx-data-shared-prod` project ([bug 1803534](https://bugzilla.mozilla.org/show_bug.cgi?id=1803534)).

Now the query complexity limit in the `moz-fx-data-shared-prod` project has been [increased](https://console.cloud.google.com/support/cases/detail/v2/42514957?project=moz-fx-data-shared-prod), and I've confirmed that the `search_derived.mobile_search_clients_daily_v1` ETL won't exceed the query complexity limit with this change applied.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
