### PR TITLE
Fix Firefox iOS `unified_metrics` view (bug 1805485)

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/unified_metrics_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/unified_metrics_v1/query.py
@@ -169,12 +169,12 @@ def main():
             " AS glean_validation_first_run_hour"
         ),
     }
-    query_legacy_events = generate_query(
+    query_legacy_core = generate_query(
         ['"legacy" as telemetry_system', *stripped],
         legacy_core,
         replacements=query_legacy_replacements,
     )
-    query_legacy_core = generate_query(
+    query_legacy_events = generate_query(
         ['"legacy" as telemetry_system', *stripped],
         legacy_event,
         replacements=query_legacy_replacements,


### PR DESCRIPTION
As a result of #3453 the `org_mozilla_ios_firefox.unified_metrics` ETL is failing ([bug 1805485](https://bugzilla.mozilla.org/show_bug.cgi?id=1805485)) because the generated legacy telemetry subqueries contain a Glean datetime metric column as a string (based on the stable table schema) while the Glean metrics view now selects the datetime metric column as a timestamp.

This changes the generated legacy telemetry subqueries to apply the `mozfun.glean.parse_datetime()` function to the column (even though the column contains no data), like the Glean metrics view does.

---
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [x] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [x] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [x] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [x] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
