### PR TITLE
feat(DENG-609): Added extra note in fxa_all_events around oauth events

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
@@ -1,3 +1,8 @@
+-- NOTE regarding oauth events:
+-- oauth events have been merged into the auth table.
+-- However, the oauth events table still contains around
+-- 162 days of data from 2019H2 hence why it's still available
+-- via this view.
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
 AS
@@ -59,8 +64,7 @@ fxa_content_events AS (
   FROM
     `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_content_events_v1`
 ),
--- TODO: fxa_oauth_events has been deprecated.
--- This will be removed with another change.
+-- oauth events, see the note on top
 fxa_oauth_events AS (
   SELECT
     `timestamp`,
@@ -116,8 +120,7 @@ unioned AS (
   FROM
     fxa_content_events
   UNION ALL
-  -- TODO: fxa_oauth_events has been deprecated.
-  -- This will be removed with another change.
+  -- oauth events, see the note on top
   SELECT
     *,
     'oauth' AS event_category,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: Funnel Events Source
 description: |-
   The materialized events used to create the events_daily rollup.
   Not exposed as a view since it's not meant for consumption;
-  use firefox_accounts.fxa_content_auth_oauth_events
+  use firefox_accounts.fxa_all_events
   instead. This is materialized solely because
   the events_daily queries are too complex for BigQuery
   otherwise.


### PR DESCRIPTION
# feat(DENG-609): Added extra note in fxa_all_events around oauth events

This is due to the fact that oauth log event table no longer exists and has been merged into auth server/event log. This change aims to reflect this change.