### PR TITLE
Increase yamllint max line length

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -3,6 +3,7 @@ extends: default
 
 rules:
   line-length:
+    max: 160
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: true
   document-start: disable


### PR DESCRIPTION
I don't know what the best length is, the default 80 characters max has been causing some friction. We can double it for now and see.
