### PR TITLE
Increase Fivetran sensors' poke interval to 30 seconds

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -218,7 +218,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
     {{ fivetran_task.task_id }}_sync_wait = FivetranSensor(
         connector_id='{% raw %}{{ var.value.{% endraw %}{{ fivetran_task.task_id }}{% raw %}_connector_id }}{% endraw %}',
         task_id='{{ fivetran_task.task_id }}_sensor',
-        poke_interval=5,
+        poke_interval=30,
         xcom="{% raw %}{{{% endraw %} task_instance.xcom_pull('{{ fivetran_task.task_id }}_task') {% raw %}}}{% endraw %}",
         on_retry_callback=retry_tasks_callback,
         params={'retry_tasks': ['{{ fivetran_task.task_id }}_task']},

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -12,8 +12,8 @@ from utils.gcp import bigquery_etl_query, gke_command
 {% for task in tasks -%}
 {% if task.depends_on_fivetran != None and task.depends_on_fivetran|length > 0 and ns.uses_fivetran == False -%}
 {% set ns.uses_fivetran = True -%}
-from operators.backport.fivetran.operator import FivetranOperator
-from operators.backport.fivetran.sensor import FivetranSensor
+from fivetran_provider.operators.fivetran import FivetranOperator
+from fivetran_provider.sensors.fivetran import FivetranSensor
 {% endif -%}
 {% endfor -%}
 
@@ -217,7 +217,8 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
     {{ fivetran_task.task_id }}_sync_wait = FivetranSensor(
         connector_id='{% raw %}{{ var.value.{% endraw %}{{ fivetran_task.task_id }}{% raw %}_connector_id }}{% endraw %}',
         task_id='{{ fivetran_task.task_id }}_sensor',
-        poke_interval=5
+        poke_interval=5,
+        xcom="{% raw %}{{{% endraw %} task_instance.xcom_pull('{{ fivetran_task.task_id }}_task') {% raw %}}}{% endraw %}",
     )
 
     {{ fivetran_task.task_id }}_sync_wait.set_upstream({{ fivetran_task.task_id }}_sync_start)

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -14,6 +14,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 {% set ns.uses_fivetran = True -%}
 from fivetran_provider.operators.fivetran import FivetranOperator
 from fivetran_provider.sensors.fivetran import FivetranSensor
+from utils.callbacks import retry_tasks_callback
 {% endif -%}
 {% endfor -%}
 
@@ -219,6 +220,8 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         task_id='{{ fivetran_task.task_id }}_sensor',
         poke_interval=5,
         xcom="{% raw %}{{{% endraw %} task_instance.xcom_pull('{{ fivetran_task.task_id }}_task') {% raw %}}}{% endraw %}",
+        on_retry_callback=retry_tasks_callback,
+        params={'retry_tasks': ['{{ fivetran_task.task_id }}_task']},
     )
 
     {{ fivetran_task.task_id }}_sync_wait.set_upstream({{ fivetran_task.task_id }}_sync_start)

--- a/dags/bqetl_cjms_nonprod.py
+++ b/dags/bqetl_cjms_nonprod.py
@@ -8,8 +8,8 @@ import datetime
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, gke_command
 
-from operators.backport.fivetran.operator import FivetranOperator
-from operators.backport.fivetran.sensor import FivetranSensor
+from fivetran_provider.operators.fivetran import FivetranOperator
+from fivetran_provider.sensors.fivetran import FivetranSensor
 
 docs = """
 ### bqetl_cjms_nonprod
@@ -98,6 +98,7 @@ with DAG(
         connector_id="{{ var.value.fivetran_stripe_nonprod_connector_id }}",
         task_id="fivetran_stripe_nonprod_sensor",
         poke_interval=5,
+        xcom="{{ task_instance.xcom_pull('fivetran_stripe_nonprod_task') }}",
     )
 
     fivetran_stripe_nonprod_sync_wait.set_upstream(fivetran_stripe_nonprod_sync_start)

--- a/dags/bqetl_cjms_nonprod.py
+++ b/dags/bqetl_cjms_nonprod.py
@@ -98,7 +98,7 @@ with DAG(
     fivetran_stripe_nonprod_sync_wait = FivetranSensor(
         connector_id="{{ var.value.fivetran_stripe_nonprod_connector_id }}",
         task_id="fivetran_stripe_nonprod_sensor",
-        poke_interval=5,
+        poke_interval=30,
         xcom="{{ task_instance.xcom_pull('fivetran_stripe_nonprod_task') }}",
         on_retry_callback=retry_tasks_callback,
         params={"retry_tasks": ["fivetran_stripe_nonprod_task"]},

--- a/dags/bqetl_cjms_nonprod.py
+++ b/dags/bqetl_cjms_nonprod.py
@@ -10,6 +10,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 
 from fivetran_provider.operators.fivetran import FivetranOperator
 from fivetran_provider.sensors.fivetran import FivetranSensor
+from utils.callbacks import retry_tasks_callback
 
 docs = """
 ### bqetl_cjms_nonprod
@@ -99,6 +100,8 @@ with DAG(
         task_id="fivetran_stripe_nonprod_sensor",
         poke_interval=5,
         xcom="{{ task_instance.xcom_pull('fivetran_stripe_nonprod_task') }}",
+        on_retry_callback=retry_tasks_callback,
+        params={"retry_tasks": ["fivetran_stripe_nonprod_task"]},
     )
 
     fivetran_stripe_nonprod_sync_wait.set_upstream(fivetran_stripe_nonprod_sync_start)

--- a/dags/bqetl_monitoring_airflow.py
+++ b/dags/bqetl_monitoring_airflow.py
@@ -8,8 +8,8 @@ import datetime
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, gke_command
 
-from operators.backport.fivetran.operator import FivetranOperator
-from operators.backport.fivetran.sensor import FivetranSensor
+from fivetran_provider.operators.fivetran import FivetranOperator
+from fivetran_provider.sensors.fivetran import FivetranSensor
 
 docs = """
 ### bqetl_monitoring_airflow
@@ -142,6 +142,7 @@ with DAG(
         connector_id="{{ var.value.fivetran_airflow_metadata_import_connector_id }}",
         task_id="fivetran_airflow_metadata_import_sensor",
         poke_interval=5,
+        xcom="{{ task_instance.xcom_pull('fivetran_airflow_metadata_import_task') }}",
     )
 
     fivetran_airflow_metadata_import_sync_wait.set_upstream(

--- a/dags/bqetl_monitoring_airflow.py
+++ b/dags/bqetl_monitoring_airflow.py
@@ -142,7 +142,7 @@ with DAG(
     fivetran_airflow_metadata_import_sync_wait = FivetranSensor(
         connector_id="{{ var.value.fivetran_airflow_metadata_import_connector_id }}",
         task_id="fivetran_airflow_metadata_import_sensor",
-        poke_interval=5,
+        poke_interval=30,
         xcom="{{ task_instance.xcom_pull('fivetran_airflow_metadata_import_task') }}",
         on_retry_callback=retry_tasks_callback,
         params={"retry_tasks": ["fivetran_airflow_metadata_import_task"]},

--- a/dags/bqetl_monitoring_airflow.py
+++ b/dags/bqetl_monitoring_airflow.py
@@ -10,6 +10,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 
 from fivetran_provider.operators.fivetran import FivetranOperator
 from fivetran_provider.sensors.fivetran import FivetranSensor
+from utils.callbacks import retry_tasks_callback
 
 docs = """
 ### bqetl_monitoring_airflow
@@ -143,6 +144,8 @@ with DAG(
         task_id="fivetran_airflow_metadata_import_sensor",
         poke_interval=5,
         xcom="{{ task_instance.xcom_pull('fivetran_airflow_metadata_import_task') }}",
+        on_retry_callback=retry_tasks_callback,
+        params={"retry_tasks": ["fivetran_airflow_metadata_import_task"]},
     )
 
     fivetran_airflow_metadata_import_sync_wait.set_upstream(

--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -10,6 +10,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 
 from fivetran_provider.operators.fivetran import FivetranOperator
 from fivetran_provider.sensors.fivetran import FivetranSensor
+from utils.callbacks import retry_tasks_callback
 
 docs = """
 ### bqetl_subplat
@@ -644,6 +645,8 @@ with DAG(
         task_id="fivetran_stripe_sensor",
         poke_interval=5,
         xcom="{{ task_instance.xcom_pull('fivetran_stripe_task') }}",
+        on_retry_callback=retry_tasks_callback,
+        params={"retry_tasks": ["fivetran_stripe_task"]},
     )
 
     fivetran_stripe_sync_wait.set_upstream(fivetran_stripe_sync_start)

--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -8,8 +8,8 @@ import datetime
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, gke_command
 
-from operators.backport.fivetran.operator import FivetranOperator
-from operators.backport.fivetran.sensor import FivetranSensor
+from fivetran_provider.operators.fivetran import FivetranOperator
+from fivetran_provider.sensors.fivetran import FivetranSensor
 
 docs = """
 ### bqetl_subplat
@@ -643,6 +643,7 @@ with DAG(
         connector_id="{{ var.value.fivetran_stripe_connector_id }}",
         task_id="fivetran_stripe_sensor",
         poke_interval=5,
+        xcom="{{ task_instance.xcom_pull('fivetran_stripe_task') }}",
     )
 
     fivetran_stripe_sync_wait.set_upstream(fivetran_stripe_sync_start)

--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -643,7 +643,7 @@ with DAG(
     fivetran_stripe_sync_wait = FivetranSensor(
         connector_id="{{ var.value.fivetran_stripe_connector_id }}",
         task_id="fivetran_stripe_sensor",
-        poke_interval=5,
+        poke_interval=30,
         xcom="{{ task_instance.xcom_pull('fivetran_stripe_task') }}",
         on_retry_callback=retry_tasks_callback,
         params={"retry_tasks": ["fivetran_stripe_task"]},

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -10,6 +10,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 
 from fivetran_provider.operators.fivetran import FivetranOperator
 from fivetran_provider.sensors.fivetran import FivetranSensor
+from utils.callbacks import retry_tasks_callback
 
 docs = """
 ### bqetl_test_dag
@@ -66,6 +67,8 @@ with DAG(
         task_id="fivetran_import_1_sensor",
         poke_interval=5,
         xcom="{{ task_instance.xcom_pull('fivetran_import_1_task') }}",
+        on_retry_callback=retry_tasks_callback,
+        params={'retry_tasks': ['fivetran_import_1_task']},
     )
 
     fivetran_import_1_sync_wait.set_upstream(fivetran_import_1_sync_start)
@@ -82,6 +85,8 @@ with DAG(
         task_id="fivetran_import_2_sensor",
         poke_interval=5,
         xcom="{{ task_instance.xcom_pull('fivetran_import_2_task') }}",
+        on_retry_callback=retry_tasks_callback,
+        params={'retry_tasks': ['fivetran_import_2_task']},
     )
 
     fivetran_import_2_sync_wait.set_upstream(fivetran_import_2_sync_start)

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -8,8 +8,8 @@ import datetime
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, gke_command
 
-from operators.backport.fivetran.operator import FivetranOperator
-from operators.backport.fivetran.sensor import FivetranSensor
+from fivetran_provider.operators.fivetran import FivetranOperator
+from fivetran_provider.sensors.fivetran import FivetranSensor
 
 docs = """
 ### bqetl_test_dag
@@ -65,6 +65,7 @@ with DAG(
         connector_id="{{ var.value.fivetran_import_1_connector_id }}",
         task_id="fivetran_import_1_sensor",
         poke_interval=5,
+        xcom="{{ task_instance.xcom_pull('fivetran_import_1_task') }}",
     )
 
     fivetran_import_1_sync_wait.set_upstream(fivetran_import_1_sync_start)
@@ -80,6 +81,7 @@ with DAG(
         connector_id="{{ var.value.fivetran_import_2_connector_id }}",
         task_id="fivetran_import_2_sensor",
         poke_interval=5,
+        xcom="{{ task_instance.xcom_pull('fivetran_import_2_task') }}",
     )
 
     fivetran_import_2_sync_wait.set_upstream(fivetran_import_2_sync_start)

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -65,7 +65,7 @@ with DAG(
     fivetran_import_1_sync_wait = FivetranSensor(
         connector_id="{{ var.value.fivetran_import_1_connector_id }}",
         task_id="fivetran_import_1_sensor",
-        poke_interval=5,
+        poke_interval=30,
         xcom="{{ task_instance.xcom_pull('fivetran_import_1_task') }}",
         on_retry_callback=retry_tasks_callback,
         params={'retry_tasks': ['fivetran_import_1_task']},
@@ -83,7 +83,7 @@ with DAG(
     fivetran_import_2_sync_wait = FivetranSensor(
         connector_id="{{ var.value.fivetran_import_2_connector_id }}",
         task_id="fivetran_import_2_sensor",
-        poke_interval=5,
+        poke_interval=30,
         xcom="{{ task_instance.xcom_pull('fivetran_import_2_task') }}",
         on_retry_callback=retry_tasks_callback,
         params={'retry_tasks': ['fivetran_import_2_task']},


### PR DESCRIPTION
Using a poke interval of 5 seconds means only 7 Fivetran sensors polling for an hour would exceed [Fivetran's rate limit](https://fivetran.com/docs/rest-api/rate-limiting) of 5,000 API requests per hour.  Increasing the poke interval to 30 seconds will allow for up to 41 Fivetran sensors polling for an hour.

This should wait until #3480 is merged (and this PR will be re-targeted to the `main` branch at that point).

CCing other DAG owners for visibility: @kik-kik

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
