### PR TITLE
Allow DAG repo to be configured

### DIFF
--- a/bigquery_etl/query_scheduling/dag.py
+++ b/bigquery_etl/query_scheduling/dag.py
@@ -117,6 +117,7 @@ class Dag:
     default_args: DagDefaultArgs
     tasks: List[Task] = attr.ib([])
     description: str = attr.ib("")
+    repo: str = attr.ib("bigquery-etl")
     tags: List[str] = attr.ib([])
 
     @name.validator
@@ -193,7 +194,7 @@ class Dag:
             name = list(d.keys())[0]
             tags: set[str] = set(d[name].get("tags", []))
             if not any(tag.startswith("repo/") for tag in tags):
-                tags.add("repo/bigquery-etl")
+                tags.add("repo/" + d[name].get("repo", "bigquery-etl"))
             d[name]["tags"] = sorted(tags)
 
             if name == PUBLIC_DATA_JSON_DAG:

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -21,7 +21,7 @@ from utils.callbacks import retry_tasks_callback
 docs = """
 ### {{ name }}
 
-Built from bigquery-etl repo, [`dags/{{ name }}.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/{{ name }}.py)
+Built from {{ repo }} repo, [`dags/{{ name }}.py`](https://github.com/mozilla/{{ repo }}/blob/main/dags/{{ name }}.py)
 
 {% if description != "" -%}
 #### Description


### PR DESCRIPTION
To support more accurate DAG generation for the [private-bigquery-etl](https://github.com/mozilla/private-bigquery-etl/) repo.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
