### PR TITLE
BUG(1808964): aliasing error message for fxa_content_* views

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
@@ -104,4 +104,4 @@ AS
 SELECT
   ERROR(
     'VIEW DEPRECATED - This view will be completely deleted after 1st of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
-  )
+  ) AS error_message

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
@@ -129,4 +129,4 @@ AS
 SELECT
   ERROR(
     'VIEW DEPRECATED - This view will be completely deleted after 1st of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
-  )
+  ) AS error_message

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
@@ -134,4 +134,4 @@ AS
 SELECT
   ERROR(
     'VIEW DEPRECATED - This view will be completely deleted after 1st of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
-  )
+  ) AS error_message


### PR DESCRIPTION
# BUG(1808964): aliasing error message for fxa_content_* views

This is to fix 400 CREATE VIEW columns must be named error.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
