### PR TITLE
revert: fxa_content_* views commented out where clause raising error

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
@@ -100,7 +100,12 @@ SELECT
   JSON_VALUE(event_properties, "$.email_version") AS email_version,
 FROM
   unioned
-WHERE
-  ERROR(
-    'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
-  )
+-- Commented out for now, to restore FxA Looker dashboards
+-- Once dashboards have been migrated to use fxa_all_events view
+-- this will be uncommented to see if we can pick up any other usage
+-- of this view.
+-- See DENG-582 for more info.
+-- WHERE
+--   ERROR(
+--     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
+--   )

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
@@ -125,7 +125,12 @@ SELECT
   JSON_VALUE(event_properties, "$.email_version") AS email_version,
 FROM
   unioned
-WHERE
-  ERROR(
-    'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
-  )
+-- Commented out for now, to restore FxA Looker dashboards
+-- Once dashboards have been migrated to use fxa_all_events view
+-- this will be uncommented to see if we can pick up any other usage
+-- of this view.
+-- See DENG-582 for more info.
+-- WHERE
+--   ERROR(
+--     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
+--   )

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
@@ -130,7 +130,12 @@ SELECT
   JSON_VALUE(event_properties, "$.source_country") AS source_country,
 FROM
   unioned
-WHERE
-  ERROR(
-    'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
-  )
+-- Commented out for now, to restore FxA Looker dashboards
+-- Once dashboards have been migrated to use fxa_all_events view
+-- this will be uncommented to see if we can pick up any other usage
+-- of this view.
+-- See DENG-582 for more info.
+-- WHERE
+--   ERROR(
+--     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
+--   )


### PR DESCRIPTION
revert: fxa_content_* views commented out where clause raising error

This is due to  Looker dashboards breaking, once they have been migrated this will be done again.
