### PR TITLE
Remove dependencies on the `mozdata` project from ETL

### DIFF
--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/subscriptions_v1/query.sql
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/subscriptions_v1/query.sql
@@ -44,7 +44,7 @@ attributed_flows AS (
   FROM
     aic_flows
   JOIN
-    mozdata.subscription_platform.nonprod_stripe_subscriptions
+    `moz-fx-data-shared-prod`.subscription_platform.nonprod_stripe_subscriptions
   ON
     aic_flows.fxa_uid = nonprod_stripe_subscriptions.fxa_uid
     AND aic_flows.flow_started < nonprod_stripe_subscriptions.created
@@ -129,7 +129,7 @@ percent_discounts AS (
   FROM
     initial_discounts AS discounts
   JOIN
-    mozdata.subscription_platform.nonprod_stripe_subscriptions AS subscriptions
+    `moz-fx-data-shared-prod`.subscription_platform.nonprod_stripe_subscriptions AS subscriptions
   USING
     (subscription_id)
   WHERE
@@ -158,7 +158,7 @@ SELECT
 FROM
   attributed_subs
 JOIN
-  mozdata.subscription_platform.nonprod_stripe_subscriptions
+  `moz-fx-data-shared-prod`.subscription_platform.nonprod_stripe_subscriptions
 USING
   (subscription_id)
 LEFT JOIN

--- a/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/subscriptions_v1/query.sql
+++ b/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/subscriptions_v1/query.sql
@@ -29,7 +29,7 @@ attributed_flows AS (
   FROM
     aic_flows
   JOIN
-    mozdata.subscription_platform.stripe_subscriptions
+    `moz-fx-data-shared-prod`.subscription_platform.stripe_subscriptions
   ON
     aic_flows.fxa_uid = stripe_subscriptions.fxa_uid
     AND aic_flows.flow_started < stripe_subscriptions.created
@@ -114,7 +114,7 @@ percent_discounts AS (
   FROM
     initial_discounts AS discounts
   JOIN
-    mozdata.subscription_platform.stripe_subscriptions AS subscriptions
+    `moz-fx-data-shared-prod`.subscription_platform.stripe_subscriptions AS subscriptions
   USING
     (subscription_id)
   WHERE
@@ -143,7 +143,7 @@ SELECT
 FROM
   attributed_subs
 JOIN
-  mozdata.subscription_platform.stripe_subscriptions
+  `moz-fx-data-shared-prod`.subscription_platform.stripe_subscriptions
 USING
   (subscription_id)
 LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/fenix_derived/attributable_clients_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/attributable_clients_v1/init.sql
@@ -25,7 +25,7 @@ CLUSTER BY
         SUM(sum_map_values(metrics.labeled_counter.browser_search_with_ads)) AS searches_with_ads,
         SUM(sum_map_values(metrics.labeled_counter.browser_search_ad_clicks)) AS ad_clicks,
       FROM
-        mozdata.fenix.baseline
+        `moz-fx-data-shared-prod`.fenix.baseline
       WHERE
         DATE(submission_timestamp) >= first_date
       GROUP BY
@@ -57,7 +57,7 @@ CLUSTER BY
         country,
         first_seen_date
       FROM
-        mozdata.fenix.baseline_clients_first_seen
+        `moz-fx-data-shared-prod`.fenix.baseline_clients_first_seen
       WHERE
         submission_date >= first_date
     ),
@@ -69,7 +69,7 @@ CLUSTER BY
         adjust_campaign,
         adjust_creative,
       FROM
-        mozdata.fenix.firefox_android_clients
+        `moz-fx-data-shared-prod`.fenix.firefox_android_clients
       WHERE
         adjust_network != 'Unknown'
     )

--- a/sql/moz-fx-data-shared-prod/fenix_derived/attributable_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/attributable_clients_v1/query.sql
@@ -15,7 +15,7 @@ WITH client_day AS (
     SUM(sum_map_values(metrics.labeled_counter.browser_search_with_ads)) AS searches_with_ads,
     SUM(sum_map_values(metrics.labeled_counter.browser_search_ad_clicks)) AS ad_clicks,
   FROM
-    mozdata.fenix.baseline
+    `moz-fx-data-shared-prod`.fenix.baseline
   WHERE
     DATE(submission_timestamp) = @submission_date
   GROUP BY
@@ -47,7 +47,7 @@ first_seen AS (
     country,
     first_seen_date
   FROM
-    mozdata.fenix.baseline_clients_first_seen
+    `moz-fx-data-shared-prod`.fenix.baseline_clients_first_seen
   WHERE
     submission_date >= "2021-01-01"
 ),
@@ -59,7 +59,7 @@ adjust_client AS (
     adjust_campaign,
     adjust_creative,
   FROM
-    mozdata.fenix.firefox_android_clients
+    `moz-fx-data-shared-prod`.fenix.firefox_android_clients
   WHERE
     adjust_network != 'Unknown'
 )

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/init.sql
@@ -104,7 +104,7 @@ WITH first_seen AS (
     device_model,
     normalized_os_version AS os_version
   FROM
-    `mozdata.fenix.baseline_clients_first_seen`
+    `moz-fx-data-shared-prod.fenix.baseline_clients_first_seen`
   WHERE
     submission_date >= '2019-01-01'
     AND normalized_channel = 'release'
@@ -128,7 +128,7 @@ first_session_ping AS (
       SAFE_OFFSET(0)
     ] AS adjust_creative
   FROM
-    `mozdata.fenix.first_session` AS fenix_first_session
+    `moz-fx-data-shared-prod.fenix.first_session` AS fenix_first_session
   WHERE
     DATE(submission_timestamp) >= '2019-01-01'
     AND ping_info.seq = 0 -- Pings are sent in sequence, this guarantees that the first one is returned.

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
@@ -13,7 +13,7 @@ WITH first_seen AS (
     device_model,
     normalized_os_version AS os_version
   FROM
-    `mozdata.fenix.baseline_clients_first_seen`
+    `moz-fx-data-shared-prod.fenix.baseline_clients_first_seen`
   WHERE
     submission_date = @submission_date
     AND normalized_channel = 'release'
@@ -37,7 +37,7 @@ first_session_ping AS (
       SAFE_OFFSET(0)
     ] AS adjust_creative
   FROM
-    `mozdata.fenix.first_session` AS fenix_first_session
+    `moz-fx-data-shared-prod.fenix.first_session` AS fenix_first_session
   WHERE
     DATE(submission_timestamp) = @submission_date
     AND ping_info.seq = 0 -- Pings are sent in sequence, this guarantees that the first one is returned.

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_v1/query.sql
@@ -20,7 +20,7 @@ WITH client_first_seen AS (
     country,
     first_seen_date
   FROM
-    mozdata.fenix.baseline_clients_first_seen
+    `moz-fx-data-shared-prod`.fenix.baseline_clients_first_seen
   WHERE
     submission_date = DATE_SUB(@submission_date, INTERVAL 6 DAY)
 ),
@@ -48,7 +48,7 @@ dou AS (
       mozfun.bits28.to_dates(mozfun.bits28.range(days_seen_bits, -5, 6), submission_date)
     ) AS days_2_7,
   FROM
-    `mozdata.fenix.baseline_clients_last_seen`
+    `moz-fx-data-shared-prod.fenix.baseline_clients_last_seen`
   WHERE
     submission_date = @submission_date
     AND date_diff(submission_date, first_seen_date, DAY) = 6
@@ -63,7 +63,7 @@ adjust_client AS (
     ARRAY_AGG(metrics.string.first_session_creative)[SAFE_OFFSET(0)] AS adjust_creative,
     MIN(DATE(submission_timestamp)) AS first_session_date
   FROM
-    `mozdata.fenix.first_session`
+    `moz-fx-data-shared-prod.fenix.first_session`
   WHERE
     (
       DATE(submission_timestamp)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v1/query.sql
@@ -20,7 +20,7 @@ WITH client_first_seen AS (
     country,
     first_seen_date
   FROM
-    `mozdata.firefox_ios.baseline_clients_first_seen`
+    `moz-fx-data-shared-prod.firefox_ios.baseline_clients_first_seen`
   WHERE
     submission_date = DATE_SUB(@submission_date, INTERVAL 6 DAY)
 ),
@@ -49,7 +49,7 @@ dou AS (
       mozfun.bits28.to_dates(mozfun.bits28.range(days_seen_bits, -5, 6), submission_date)
     ) AS days_2_7,
   FROM
-    `mozdata.firefox_ios.baseline_clients_last_seen`
+    `moz-fx-data-shared-prod.firefox_ios.baseline_clients_last_seen`
   WHERE
     submission_date = @submission_date
     AND date_diff(submission_date, first_seen_date, DAY) = 6

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscription_ids_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscription_ids_live/view.sql
@@ -5,7 +5,7 @@ SELECT
   active_date,
   subscription_id,
 FROM
-  mozdata.mozilla_vpn.all_subscriptions
+  `moz-fx-data-shared-prod`.mozilla_vpn.all_subscriptions
 CROSS JOIN
   UNNEST(
     GENERATE_DATE_ARRAY(
@@ -19,5 +19,5 @@ WHERE
     SELECT
       DATE(MAX(end_date))
     FROM
-      mozdata.mozilla_vpn.all_subscriptions
+      `moz-fx-data-shared-prod`.mozilla_vpn.all_subscriptions
   )

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_live/view.sql
@@ -6,7 +6,7 @@ WITH all_subscriptions AS (
     *,
     TO_JSON_STRING(promotion_codes) AS json_promotion_codes
   FROM
-    mozdata.mozilla_vpn.all_subscriptions
+    `moz-fx-data-shared-prod`.mozilla_vpn.all_subscriptions
 )
 SELECT
   active_subscription_ids.active_date,
@@ -42,7 +42,7 @@ SELECT
 FROM
   all_subscriptions
 JOIN
-  mozdata.mozilla_vpn.active_subscription_ids
+  `moz-fx-data-shared-prod`.mozilla_vpn.active_subscription_ids
 USING
   (subscription_id)
 GROUP BY

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/query.sql
@@ -3,7 +3,7 @@ WITH standardized_country AS (
     raw_country AS country,
     standardized_country AS country_name,
   FROM
-    mozdata.static.third_party_standardized_country_names
+    `moz-fx-data-shared-prod`.static.third_party_standardized_country_names
 ),
 attribution AS (
   SELECT
@@ -24,7 +24,7 @@ users AS (
     fxa_uid,
     created_at AS user_registration_date,
   FROM
-    mozdata.mozilla_vpn.users
+    `moz-fx-data-shared-prod`.mozilla_vpn.users
 ),
 stripe_subscriptions_history AS (
   SELECT
@@ -40,7 +40,7 @@ stripe_subscriptions_history AS (
       )
     ) AS subscription_sequence_id
   FROM
-    mozdata.subscription_platform.stripe_subscriptions_history
+    `moz-fx-data-shared-prod`.subscription_platform.stripe_subscriptions_history
   WHERE
     -- Only include the current history records and the last history records for previous plans.
     (valid_to IS NULL OR plan_ended_at IS NOT NULL)
@@ -182,7 +182,7 @@ apple_iap_subscriptions AS (
     subplat.promotion_codes,
     CAST(NULL AS INT64) AS promotion_discounts_amount,
   FROM
-    mozdata.subscription_platform.apple_subscriptions AS subplat
+    `moz-fx-data-shared-prod`.subscription_platform.apple_subscriptions AS subplat
   LEFT JOIN
     users
   USING

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_live/view.sql
@@ -18,7 +18,7 @@ WITH stage_1 AS (
     TO_JSON_STRING(promotion_codes) AS json_promotion_codes,
     SUM(`count`) AS new_subscriptions,
   FROM
-    mozdata.mozilla_vpn.subscription_events
+    `moz-fx-data-shared-prod`.mozilla_vpn.subscription_events
   WHERE
     event_type = "New"
   GROUP BY

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
@@ -44,7 +44,7 @@ events AS (
     service,
     product_id,
   FROM
-    `mozdata.firefox_accounts.fxa_all_events`
+    `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
     event_category IN ('content', 'auth', 'stdout')
 ),

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/guardian_apple_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/guardian_apple_events_v1/query.sql
@@ -22,9 +22,9 @@ WITH legacy_subscriptions AS (
     subscriptions.provider = "APPLE"
 )
 SELECT
-  -- WARNING: mozdata.subscription_platform.apple_subscriptions and
-  -- mozdata.subscription_platform.nonprod_apple_subscriptions require field order of
-  -- moz-fx-data-shared-prod.mozilla_vpn_derived.guardian_apple_events_v1 to exactly match:
+  -- WARNING: subscription_platform.apple_subscriptions and
+  -- subscription_platform.nonprod_apple_subscriptions require field order of
+  -- mozilla_vpn_derived.guardian_apple_events_v1 to exactly match:
   --   legacy_subscription_id,
   --   event_timestamp,
   --   mozfun.iap.parse_apple_event(`data`).*,

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql
@@ -14,7 +14,7 @@ WITH base AS (
     ) AS fxa_uids,
     LOGICAL_OR(event_type = "fxa_email_first - view") AS viewed_email_first_page,
   FROM
-    mozdata.firefox_accounts.fxa_all_events
+    `moz-fx-data-shared-prod`.firefox_accounts.fxa_all_events
   WHERE
     IF(@date IS NULL, DATE(`timestamp`) < CURRENT_DATE, DATE(`timestamp`) = @date)
     AND event_category IN ('content', 'auth')

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscription_events_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscription_events_live/view.sql
@@ -6,13 +6,13 @@ WITH all_subscriptions AS (
     *,
     TO_JSON_STRING(promotion_codes) AS json_promotion_codes
   FROM
-    mozdata.mozilla_vpn.all_subscriptions
+    `moz-fx-data-shared-prod`.mozilla_vpn.all_subscriptions
 ),
 max_active_date AS (
   SELECT AS VALUE
     MAX(active_date)
   FROM
-    mozdata.mozilla_vpn.active_subscription_ids
+    `moz-fx-data-shared-prod`.mozilla_vpn.active_subscription_ids
 ),
 trials AS (
   SELECT
@@ -48,7 +48,7 @@ new_events AS (
     subscription_id,
     "New" AS event_type,
   FROM
-    mozdata.mozilla_vpn.active_subscription_ids
+    `moz-fx-data-shared-prod`.mozilla_vpn.active_subscription_ids
   WHERE
     TRUE -- zetasql requires QUALIFY to be used in conjunction with WHERE, GROUP BY, or HAVING
   QUALIFY
@@ -62,7 +62,7 @@ cancelled_events AS (
     subscription_id,
     "Cancelled" AS event_type,
   FROM
-    mozdata.mozilla_vpn.active_subscription_ids
+    `moz-fx-data-shared-prod`.mozilla_vpn.active_subscription_ids
   CROSS JOIN
     max_active_date
   WHERE

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/unified_metrics_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/unified_metrics_v1/query.py
@@ -160,7 +160,7 @@ def main():
     stripped = [c.split()[0].lstrip("root.") for c in column_summary]
     query_glean = generate_query(
         ['"glean" as telemetry_system', *stripped],
-        "mozdata.org_mozilla_ios_firefox.metrics",
+        "moz-fx-data-shared-prod.org_mozilla_ios_firefox.metrics",
     )
     query_legacy_replacements = {
         "submission_date": "DATE(_PARTITIONTIME) AS submission_date",

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v1/query.sql
@@ -39,7 +39,7 @@ meta_recent AS (
 unnested AS (
   SELECT
     * EXCEPT (events),
-    mozdata.udf.deanonymize_event(event).*
+    `moz-fx-data-shared-prod`.udf.deanonymize_event(event).*
   FROM
     extracted,
     UNNEST(events) AS event

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v2/query.sql
@@ -60,7 +60,7 @@ meta_recent AS (
 unnested AS (
   SELECT
     * EXCEPT (events),
-    mozdata.udf.deanonymize_event(event).*
+    `moz-fx-data-shared-prod`.udf.deanonymize_event(event).*
   FROM
     extracted,
     UNNEST(events) AS event

--- a/sql/moz-fx-data-shared-prod/relay_derived/active_subscription_ids_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/relay_derived/active_subscription_ids_live/view.sql
@@ -5,7 +5,7 @@ SELECT
   active_date,
   subscription_id,
 FROM
-  mozdata.relay.subscriptions
+  `moz-fx-data-shared-prod`.relay.subscriptions
 CROSS JOIN
   UNNEST(
     GENERATE_DATE_ARRAY(
@@ -15,4 +15,4 @@ CROSS JOIN
   ) AS active_date
 WHERE
   subscription_start_date IS NOT NULL
-  AND DATE(subscription_start_date) < (SELECT DATE(MAX(end_date)) FROM mozdata.relay.subscriptions)
+  AND DATE(subscription_start_date) < (SELECT DATE(MAX(end_date)) FROM `moz-fx-data-shared-prod`.relay.subscriptions)

--- a/sql/moz-fx-data-shared-prod/relay_derived/active_subscriptions_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/relay_derived/active_subscriptions_live/view.sql
@@ -6,7 +6,7 @@ WITH subscriptions AS (
     *,
     TO_JSON_STRING(promotion_codes) AS json_promotion_codes
   FROM
-    mozdata.relay.subscriptions
+    `moz-fx-data-shared-prod`.relay.subscriptions
 )
 SELECT
   active_subscription_ids.active_date,
@@ -27,7 +27,7 @@ SELECT
 FROM
   subscriptions
 JOIN
-  mozdata.relay.active_subscription_ids
+  `moz-fx-data-shared-prod`.relay.active_subscription_ids
 USING
   (subscription_id)
 GROUP BY

--- a/sql/moz-fx-data-shared-prod/relay_derived/subscription_events_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/relay_derived/subscription_events_live/view.sql
@@ -6,13 +6,13 @@ WITH subscriptions AS (
     *,
     TO_JSON_STRING(promotion_codes) AS json_promotion_codes
   FROM
-    mozdata.relay.subscriptions
+    `moz-fx-data-shared-prod`.relay.subscriptions
 ),
 max_active_date AS (
   SELECT AS VALUE
     MAX(active_date)
   FROM
-    mozdata.relay.active_subscription_ids
+    `moz-fx-data-shared-prod`.relay.active_subscription_ids
 ),
 trials AS (
   SELECT
@@ -48,7 +48,7 @@ new_events AS (
     subscription_id,
     "New" AS event_type,
   FROM
-    mozdata.relay.active_subscription_ids
+    `moz-fx-data-shared-prod`.relay.active_subscription_ids
   WHERE
     TRUE -- zetasql requires QUALIFY to be used in conjunction with WHERE, GROUP BY, or HAVING
   QUALIFY
@@ -62,7 +62,7 @@ cancelled_events AS (
     subscription_id,
     "Cancelled" AS event_type,
   FROM
-    mozdata.relay.active_subscription_ids
+    `moz-fx-data-shared-prod`.relay.active_subscription_ids
   CROSS JOIN
     max_active_date
   WHERE

--- a/sql/moz-fx-data-shared-prod/relay_derived/subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/relay_derived/subscriptions_v1/query.sql
@@ -3,7 +3,7 @@ WITH standardized_country AS (
     raw_country AS country,
     standardized_country AS country_name,
   FROM
-    mozdata.static.third_party_standardized_country_names
+    `moz-fx-data-shared-prod`.static.third_party_standardized_country_names
 ),
 stripe_subscriptions_history AS (
   SELECT
@@ -19,7 +19,7 @@ stripe_subscriptions_history AS (
       )
     ) AS subscription_sequence_id
   FROM
-    `mozdata.subscription_platform.stripe_subscriptions_history`
+    `moz-fx-data-shared-prod.subscription_platform.stripe_subscriptions_history`
   WHERE
     -- Only include the current history records and the last history records for previous plans.
     (valid_to IS NULL OR plan_ended_at IS NOT NULL)

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/crashes_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/crashes_daily_v1/query.sql
@@ -7,7 +7,7 @@ WITH crashes AS (
       "ShutDownKill"
     ) AS is_shutdown_kill,
   FROM
-    mozdata.telemetry.crash
+    `moz-fx-data-shared-prod`.telemetry.crash
   WHERE
     DATE(submission_timestamp) = @submission_date
 )

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_activation_day_6_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_activation_day_6_v1/query.sql
@@ -69,7 +69,7 @@ SELECT
 FROM
   client_conditions
 LEFT JOIN
-  mozdata.static.country_codes_v1 country_codes
+  `moz-fx-data-shared-prod`.static.country_codes_v1 country_codes
 ON
   (country_codes.code = country_code)
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_installs_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_installs_v1/query.sql
@@ -30,7 +30,7 @@ SELECT
 FROM
   firefox_installer.install
 LEFT JOIN
-  mozdata.static.country_codes_v1 country_codes
+  `moz-fx-data-shared-prod`.static.country_codes_v1 country_codes
 ON
   (country_codes.code = normalized_country_code)
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_new_profiles_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_new_profiles_v1/query.sql
@@ -29,7 +29,7 @@ SELECT
 FROM
   pop
 LEFT JOIN
-  mozdata.static.country_codes_v1 country_codes
+  `moz-fx-data-shared-prod`.static.country_codes_v1 country_codes
 ON
   (country_codes.code = country_code)
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fog_decision_support_percentiles_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fog_decision_support_percentiles_v1/query.sql
@@ -16,7 +16,7 @@ WITH metrics_base AS (
       SECOND
     ) AS client_submission_latency,
   FROM
-    `mozdata.firefox_desktop.metrics`
+    `moz-fx-data-shared-prod.firefox_desktop.metrics`
   WHERE
     normalized_channel IN ('nightly', 'beta', 'release')
     AND DATE(submission_timestamp) = @submission_date
@@ -111,7 +111,7 @@ baseline_base AS (
       SECOND
     ) AS client_submission_latency,
   FROM
-    `mozdata.firefox_desktop.baseline`
+    `moz-fx-data-shared-prod.firefox_desktop.baseline`
   WHERE
     normalized_channel IN ('nightly', 'beta', 'release')
     AND DATE(submission_timestamp) = @submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/query.sql
@@ -11,7 +11,7 @@ WITH clicks_main AS (
         DATE(d.submission_timestamp) AS submission_date,
         e.value AS sponsored_tiles_click_count
       FROM
-        `mozdata.telemetry.main` d
+        `moz-fx-data-shared-prod.telemetry.main` d
       CROSS JOIN
         UNNEST(d.payload.processes.parent.keyed_scalars.contextual_services_topsites_click) e
       WHERE
@@ -33,7 +33,7 @@ impressions_main AS (
         DATE(g.submission_timestamp) AS submission_date,
         h.value AS sponsored_tiles_impression_count
       FROM
-        `mozdata.telemetry.main` g
+        `moz-fx-data-shared-prod.telemetry.main` g
       CROSS JOIN
         UNNEST(g.payload.processes.parent.keyed_scalars.contextual_services_topsites_impression) h
       WHERE
@@ -59,7 +59,7 @@ desktop_activity_stream_events AS (
       AND value LIKE '%false%'
     ) AS sponsored_tiles_disable_count
   FROM
-    `mozdata.activity_stream.events`
+    `moz-fx-data-shared-prod.activity_stream.events`
   WHERE
     date(submission_timestamp) = @submission_date
   GROUP BY
@@ -86,7 +86,7 @@ ios_data AS (
       AND `mozfun.map.get_key`(event_extra, 'changed_to') = 'false'
     ) AS sponsored_tiles_disable_count
   FROM
-    `mozdata.firefox_ios.events_unnested` events
+    `moz-fx-data-shared-prod.firefox_ios.events_unnested` events
   WHERE
     DATE(submission_timestamp) = @submission_date
   GROUP BY
@@ -113,7 +113,7 @@ android_events AS (
       AND `mozfun.map.get_key`(event_extra, 'enabled') = 'false'
     ) AS sponsored_tiles_disable_count
   FROM
-    `mozdata.fenix.events_unnested` events
+    `moz-fx-data-shared-prod.fenix.events_unnested` events
   WHERE
     DATE(submission_timestamp) = @submission_date
   GROUP BY
@@ -142,7 +142,7 @@ unified_metrics AS (
     is_new_profile,
     sample_id
   FROM
-    `mozdata.telemetry.unified_metrics`
+    `moz-fx-data-shared-prod.telemetry.unified_metrics`
   WHERE
     `mozfun`.bits28.active_in_range(days_seen_bits, 0, 1)
     AND submission_date = @submission_date
@@ -253,7 +253,7 @@ LEFT JOIN
         )
       ) AS experiments
     FROM
-      `mozdata.firefox_ios.events_unnested`
+      `moz-fx-data-shared-prod.firefox_ios.events_unnested`
     WHERE
       DATE(submission_timestamp) = @submission_date
     GROUP BY
@@ -308,7 +308,7 @@ LEFT JOIN
         )
       ) AS experiments
     FROM
-      `mozdata.fenix.events_unnested`
+      `moz-fx-data-shared-prod.fenix.events_unnested`
     WHERE
       DATE(submission_timestamp) = @submission_date
     GROUP BY

--- a/sql/mozfun/iap/parse_apple_event/udf.sql
+++ b/sql/mozfun/iap/parse_apple_event/udf.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION iap.parse_apple_event(input STRING) AS (
-  -- WARNING: mozdata.subscription_platform.apple_subscriptions and
-  -- mozdata.subscription_platform.nonprod_apple_subscriptions require field order of
-  -- moz-fx-data-shared-prod.mozilla_vpn_derived.guardian_apple_events_v1 to exactly match:
+  -- WARNING: subscription_platform.apple_subscriptions and
+  -- subscription_platform.nonprod_apple_subscriptions require field order of
+  -- mozilla_vpn_derived.guardian_apple_events_v1 to exactly match:
   --   legacy_subscription_id,
   --   event_timestamp,
   --   mozfun.iap.parse_apple_event(`data`).*,

--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -148,7 +148,7 @@ def write_view_if_not_exists(target_project: str, sql_dir: Path, schema: SchemaF
         ):
             # todo: use mozfun udfs
             metrics_source = (
-                "mozdata.udf.normalize_fenix_metrics"
+                "`moz-fx-data-shared-prod`.udf.normalize_fenix_metrics"
                 "(client_info.telemetry_sdk_build, metrics)"
             )
         else:
@@ -182,7 +182,7 @@ def write_view_if_not_exists(target_project: str, sql_dir: Path, schema: SchemaF
                 "'Firefox' AS normalized_app_name",
             ]
     elif schema.schema_id.startswith("moz://mozilla.org/schemas/main/ping/"):
-        replacements += ["mozdata.udf.normalize_main_payload(payload) AS payload"]
+        replacements += ["`moz-fx-data-shared-prod`.udf.normalize_main_payload(payload) AS payload"]
     replacements_str = ",\n    ".join(replacements)
     full_sql = reformat(
         VIEW_QUERY_TEMPLATE.format(


### PR DESCRIPTION
Having dependencies on things in `mozdata` can cause issues with deployments, as deploying things to `mozdata` is usually a separate secondary step.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
