### PR TITLE
bug(1809857): tweaked date_partition_parameter scheduling settings for campaign_conversions_by_date

### DIFF
--- a/dags/bqetl_fivetran_google_ads.py
+++ b/dags/bqetl_fivetran_google_ads.py
@@ -51,6 +51,7 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="frank@mozilla.com",
         email=["frank@mozilla.com", "telemetry-alerts@mozilla.com"],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        task_concurrency=1,
     )

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_conversions_by_date_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_conversions_by_date_v1/metadata.yaml
@@ -9,6 +9,7 @@ owners:
 scheduling:
   dag_name: bqetl_fivetran_google_ads
   depends_on_past: false
+  date_partition_parameter: null
 labels:
   incremental: false
 bigquery:


### PR DESCRIPTION
# bug(1809857): tweaked date_partition_parameter scheduling settings for campaign_conversions_by_date

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
