### PR TITLE
Correct BigQuery partitioning/clustering metadata in ETL `metadata.yaml` files

### DIFF
--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -57,8 +57,8 @@ class PartitionType(enum.Enum):
 class PartitionMetadata:
     """Metadata for defining BigQuery table partitions."""
 
-    field: str
     type: PartitionType
+    field: Optional[str] = attr.ib(None)
     require_partition_filter: bool = attr.ib(True)
     expiration_days: Optional[float] = attr.ib(None)
 

--- a/docs/cookbooks/creating_a_derived_dataset.md
+++ b/docs/cookbooks/creating_a_derived_dataset.md
@@ -58,8 +58,8 @@ owners:
   - wlachance@mozilla.com
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: true
     expiration_days: null
   clustering:
@@ -91,8 +91,8 @@ owners:
   - wlachance@mozilla.com
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/metadata.yaml
@@ -27,6 +27,6 @@ scheduling:
     sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/query.sql
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/metadata.yaml
@@ -25,3 +25,8 @@ scheduling:
     # explicit query file path is necessary because the destination table
     # includes a partition identifier that is not in the path
     sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/query.sql
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/flows_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/flows_v1/metadata.yaml
@@ -9,3 +9,8 @@ labels:
 scheduling:
   dag_name: bqetl_subplat
   query_project: moz-fx-data-shared-prod
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/flows_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/flows_v1/metadata.yaml
@@ -11,6 +11,6 @@ scheduling:
   query_project: moz-fx-data-shared-prod
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-experiments/monitoring/query_cost_v1/metadata.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/query_cost_v1/metadata.yaml
@@ -7,3 +7,8 @@ owners:
 scheduling:
   dag_name: bqetl_experiments_daily
   referenced_tables: [['region-us', 'INFORMATION_SCHEMA', 'JOBS_BY_PROJECT']]
+bigquery:
+  time_partitioning:
+    field: submission_timestamp
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-experiments/monitoring/query_cost_v1/metadata.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/query_cost_v1/metadata.yaml
@@ -9,6 +9,6 @@ scheduling:
   referenced_tables: [['region-us', 'INFORMATION_SCHEMA', 'JOBS_BY_PROJECT']]
 bigquery:
   time_partitioning:
-    field: submission_timestamp
     type: day
+    field: submission_timestamp
     require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/acoustic/contact_current_snapshot_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/contact_current_snapshot_v1/metadata.yaml
@@ -21,8 +21,8 @@ scheduling:
 
 bigquery:
   time_partitioning:
-    field: last_modified_date
     type: day
+    field: last_modified_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-marketing-prod/acoustic/contact_current_snapshot_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/contact_current_snapshot_v1/metadata.yaml
@@ -26,8 +26,7 @@ bigquery:
     require_partition_filter: false
   clustering:
     fields:
-      - double_opt_in
       - has_opted_out_of_email
+      - double_opt_in
       - email_lang
       - mailing_country
-      - cohort

--- a/sql/moz-fx-data-marketing-prod/acoustic/contact_raw_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/contact_raw_v1/metadata.yaml
@@ -37,3 +37,9 @@ bigquery:
     field: last_modified_date
     type: day
     require_partition_filter: false
+  clustering:
+    fields:
+      - has_opted_out_of_email
+      - double_opt_in
+      - email_lang
+      - mailing_country

--- a/sql/moz-fx-data-marketing-prod/acoustic/contact_raw_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/contact_raw_v1/metadata.yaml
@@ -34,8 +34,8 @@ scheduling:
 
 bigquery:
   time_partitioning:
-    field: last_modified_date
     type: day
+    field: last_modified_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-marketing-prod/acoustic/contact_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/contact_v1/metadata.yaml
@@ -24,8 +24,8 @@ scheduling:
 
 bigquery:
   time_partitioning:
-    field: last_modified_date
     type: day
+    field: last_modified_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-marketing-prod/acoustic/contact_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/contact_v1/metadata.yaml
@@ -29,8 +29,7 @@ bigquery:
     require_partition_filter: false
   clustering:
     fields:
-      - double_opt_in
       - has_opted_out_of_email
+      - double_opt_in
       - email_lang
       - mailing_country
-      - cohort

--- a/sql/moz-fx-data-marketing-prod/acoustic/raw_recipient_raw_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/raw_recipient_raw_v1/metadata.yaml
@@ -37,8 +37,8 @@ scheduling:
 
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-marketing-prod/acoustic/raw_recipient_raw_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/raw_recipient_raw_v1/metadata.yaml
@@ -40,3 +40,8 @@ bigquery:
     field: submission_date
     type: day
     require_partition_filter: false
+  clustering:
+    fields:
+      - event_type
+      - recipient_type
+      - body_type

--- a/sql/moz-fx-data-marketing-prod/acoustic/raw_recipient_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/raw_recipient_v1/metadata.yaml
@@ -24,8 +24,8 @@ scheduling:
 
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-marketing-prod/ga_derived/blogs_daily_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/blogs_daily_summary_v1/metadata.yaml
@@ -10,3 +10,14 @@ scheduling:
   referenced_tables:
     - ['moz-fx-data-marketing-prod', 'ga_derived', 'blogs_goals_v1']
     - ['moz-fx-data-marketing-prod', 'ga_derived', 'blogs_sessions_v1']
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - country
+      - browser
+      - blog
+      - subblog

--- a/sql/moz-fx-data-marketing-prod/ga_derived/blogs_daily_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/blogs_daily_summary_v1/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
     - ['moz-fx-data-marketing-prod', 'ga_derived', 'blogs_sessions_v1']
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-marketing-prod/ga_derived/blogs_goals_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/blogs_goals_v1/metadata.yaml
@@ -9,3 +9,8 @@ scheduling:
   dag_name: bqetl_google_analytics_derived
   referenced_tables:
     - ['moz-fx-data-marketing-prod', 'ga_derived', 'blogs_empty_check_v1']
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/ga_derived/blogs_goals_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/blogs_goals_v1/metadata.yaml
@@ -11,6 +11,6 @@ scheduling:
     - ['moz-fx-data-marketing-prod', 'ga_derived', 'blogs_empty_check_v1']
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/ga_derived/blogs_landing_page_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/blogs_landing_page_summary_v1/metadata.yaml
@@ -13,8 +13,8 @@ scheduling:
     - ["moz-fx-data-marketing-prod", "ga_derived", "blogs_sessions_v1"]
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-marketing-prod/ga_derived/blogs_landing_page_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/blogs_landing_page_summary_v1/metadata.yaml
@@ -11,3 +11,14 @@ scheduling:
   referenced_tables:
     - ["moz-fx-data-marketing-prod", "ga_derived", "blogs_goals_v1"]
     - ["moz-fx-data-marketing-prod", "ga_derived", "blogs_sessions_v1"]
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - cleaned_landing_page
+      - browser
+      - blog
+      - subblog

--- a/sql/moz-fx-data-marketing-prod/ga_derived/blogs_sessions_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/blogs_sessions_v1/metadata.yaml
@@ -10,3 +10,8 @@ scheduling:
   dag_name: bqetl_google_analytics_derived
   referenced_tables:
     - ["moz-fx-data-marketing-prod", "ga_derived", "blogs_empty_check_v1"]
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/ga_derived/blogs_sessions_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/blogs_sessions_v1/metadata.yaml
@@ -12,6 +12,6 @@ scheduling:
     - ["moz-fx-data-marketing-prod", "ga_derived", "blogs_empty_check_v1"]
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v1/metadata.yaml
@@ -9,6 +9,6 @@ scheduling:
   dag_name: bqetl_google_analytics_derived
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v1/metadata.yaml
@@ -7,3 +7,8 @@ owners:
   - ascholtz@mozilla.com
 scheduling:
   dag_name: bqetl_google_analytics_derived
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_events_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_events_metrics_v1/metadata.yaml
@@ -7,3 +7,14 @@ owners:
   - ascholtz@mozilla.com
 scheduling:
   dag_name: bqetl_google_analytics_derived
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - page_name
+      - event_category
+      - event_action
+      - event_label

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_events_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_events_metrics_v1/metadata.yaml
@@ -9,8 +9,8 @@ scheduling:
   dag_name: bqetl_google_analytics_derived
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v1/metadata.yaml
@@ -11,6 +11,6 @@ scheduling:
     - ['moz-fx-data-marketing-prod', 'ga_derived', 'www_site_empty_check_v1']
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v1/metadata.yaml
@@ -9,3 +9,8 @@ scheduling:
   dag_name: bqetl_google_analytics_derived
   referenced_tables:
     - ['moz-fx-data-marketing-prod', 'ga_derived', 'www_site_empty_check_v1']
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_landing_page_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_landing_page_metrics_v1/metadata.yaml
@@ -7,3 +7,14 @@ owners:
   - ascholtz@mozilla.com
 scheduling:
   dag_name: bqetl_google_analytics_derived
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - page_name
+      - country
+      - locale
+      - medium

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_landing_page_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_landing_page_metrics_v1/metadata.yaml
@@ -9,8 +9,8 @@ scheduling:
   dag_name: bqetl_google_analytics_derived
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_metrics_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_metrics_summary_v1/metadata.yaml
@@ -9,8 +9,8 @@ scheduling:
   dag_name: bqetl_google_analytics_derived
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_metrics_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_metrics_summary_v1/metadata.yaml
@@ -7,3 +7,14 @@ owners:
   - ascholtz@mozilla.com
 scheduling:
   dag_name: bqetl_google_analytics_derived
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - country
+      - browser
+      - source
+      - medium

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_page_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_page_metrics_v1/metadata.yaml
@@ -7,3 +7,14 @@ owners:
   - ascholtz@mozilla.com
 scheduling:
   dag_name: bqetl_google_analytics_derived
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - page_name
+      - country
+      - locale
+      - medium

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_page_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_page_metrics_v1/metadata.yaml
@@ -9,8 +9,8 @@ scheduling:
   dag_name: bqetl_google_analytics_derived
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-marketing-prod/iprospect/adspend_meta_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/iprospect/adspend_meta_v1/metadata.yaml
@@ -13,6 +13,6 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/iprospect/adspend_raw_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/iprospect/adspend_raw_v1/metadata.yaml
@@ -16,6 +16,6 @@ scheduling:
   arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/iprospect/adspend_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/iprospect/adspend_v1/metadata.yaml
@@ -18,6 +18,6 @@ scheduling:
 
 bigquery:
   time_partitioning:
-    field: submission_date
+    field: date
     type: day
     require_partition_filter: false

--- a/sql/moz-fx-data-marketing-prod/iprospect/adspend_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/iprospect/adspend_v1/metadata.yaml
@@ -18,6 +18,6 @@ scheduling:
 
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
@@ -15,7 +15,7 @@ bigquery:
     type: day
     field: submission_timestamp
     require_partition_filter: true
-    expiration_days: 180.0
+    expiration_days: 180
   clustering:
     fields:
       - experiment_id

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
   dag_name: bqetl_activity_stream
 bigquery:
   time_partitioning:
-    field: submission_timestamp
     type: day
+    field: submission_timestamp
     require_partition_filter: true
     expiration_days: 180.0
   clustering:

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
@@ -10,6 +10,15 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_activity_stream
+bigquery:
+  time_partitioning:
+    field: submission_timestamp
+    type: day
+    require_partition_filter: true
+    expiration_days: 180.0
+  clustering:
+    fields:
+      - experiment_id
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
@@ -10,8 +10,8 @@ scheduling:
   dag_name: bqetl_activity_stream
 bigquery:
   time_partitioning:
-    field: submission_timestamp
     type: day
+    field: submission_timestamp
     require_partition_filter: true
     expiration_days: 180.0
   clustering:

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
@@ -8,6 +8,16 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_activity_stream
+bigquery:
+  time_partitioning:
+    field: submission_timestamp
+    type: day
+    require_partition_filter: true
+    expiration_days: 180.0
+  clustering:
+    fields:
+      - release_channel
+      - sample_id
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
@@ -13,7 +13,7 @@ bigquery:
     type: day
     field: submission_timestamp
     require_partition_filter: true
-    expiration_days: 180.0
+    expiration_days: 180
   clustering:
     fields:
       - release_channel

--- a/sql/moz-fx-data-shared-prod/amo_dev/amo_stats_dau_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_dev/amo_stats_dau_v2/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
   dag_name: bqetl_amo_stats
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/amo_dev/amo_stats_dau_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_dev/amo_stats_dau_v2/metadata.yaml
@@ -10,3 +10,11 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_amo_stats
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - addon_id

--- a/sql/moz-fx-data-shared-prod/amo_dev/amo_stats_installs_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_dev/amo_stats_installs_v3/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
   dag_name: bqetl_amo_stats
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/amo_dev/amo_stats_installs_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_dev/amo_stats_installs_v3/metadata.yaml
@@ -10,3 +10,11 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_amo_stats
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - hashed_addon_id

--- a/sql/moz-fx-data-shared-prod/amo_prod/amo_stats_dau_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_prod/amo_stats_dau_v2/metadata.yaml
@@ -15,3 +15,11 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_amo_stats
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - addon_id

--- a/sql/moz-fx-data-shared-prod/amo_prod/amo_stats_dau_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_prod/amo_stats_dau_v2/metadata.yaml
@@ -17,8 +17,8 @@ scheduling:
   dag_name: bqetl_amo_stats
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/amo_prod/amo_stats_installs_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_prod/amo_stats_installs_v3/metadata.yaml
@@ -15,3 +15,11 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_amo_stats
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - hashed_addon_id

--- a/sql/moz-fx-data-shared-prod/amo_prod/amo_stats_installs_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_prod/amo_stats_installs_v3/metadata.yaml
@@ -17,8 +17,8 @@ scheduling:
   dag_name: bqetl_amo_stats
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/amo_prod/desktop_addons_by_client_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_prod/desktop_addons_by_client_v1/metadata.yaml
@@ -15,3 +15,11 @@ scheduling:
   # query to get it, and that would be slow because main_v4 is referenced
   referenced_tables: [['moz-fx-data-shared-prod', 'telemetry_stable',
                        'main_v4']]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/amo_prod/desktop_addons_by_client_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_prod/desktop_addons_by_client_v1/metadata.yaml
@@ -17,8 +17,8 @@ scheduling:
                        'main_v4']]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/amo_prod/fenix_addons_by_client_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_prod/fenix_addons_by_client_v1/metadata.yaml
@@ -14,8 +14,8 @@ scheduling:
   dag_name: bqetl_amo_stats
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/amo_prod/fenix_addons_by_client_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_prod/fenix_addons_by_client_v1/metadata.yaml
@@ -12,3 +12,11 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_amo_stats
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/adm_forecasting_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/adm_forecasting_v1/metadata.yaml
@@ -10,7 +10,7 @@ scheduling:
   dag_name: bqetl_ctxsvc_derived
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_spons_tiles_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_spons_tiles_v1/metadata.yaml
@@ -8,5 +8,9 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_ctxsvc_derived
-bigquery: null
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
 references: {}

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_spons_tiles_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_spons_tiles_v1/metadata.yaml
@@ -10,7 +10,7 @@ scheduling:
   dag_name: bqetl_ctxsvc_derived
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
 references: {}

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/metadata.yaml
@@ -8,5 +8,9 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_ctxsvc_derived
-bigquery: null
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
 references: {}

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/metadata.yaml
@@ -10,7 +10,7 @@ scheduling:
   dag_name: bqetl_ctxsvc_derived
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
 references: {}

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/metadata.yaml
@@ -9,3 +9,12 @@ labels:
 scheduling:
   dag_name: bqetl_ctxsvc_derived
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - source
+      - event_type

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/metadata.yaml
@@ -11,8 +11,8 @@ scheduling:
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/domain_metadata_derived/top_domains_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/domain_metadata_derived/top_domains_v1/metadata.yaml
@@ -13,8 +13,8 @@ labels:
 
 bigquery:
   time_partitioning:
-    field: submission_date
     type: month
+    field: submission_date
     require_partition_filter: true
 
 scheduling:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/attributable_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/attributable_clients_v1/metadata.yaml
@@ -26,8 +26,8 @@ scheduling:
     execution_delta: 0h
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/attributable_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/attributable_clients_v1/metadata.yaml
@@ -28,7 +28,7 @@ bigquery:
   time_partitioning:
     field: submission_date
     type: day
-    require_partition_filter: true
+    require_partition_filter: false
   clustering:
     fields:
     - adjust_network

--- a/sql/moz-fx-data-shared-prod/fenix_derived/clients_yearly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/clients_yearly_v1/metadata.yaml
@@ -22,8 +22,8 @@ scheduling:
     execution_delta: 1h
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/event_types_history_v1/metadata.yaml
@@ -19,8 +19,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/event_types_history_v1/metadata.yaml
@@ -17,3 +17,12 @@ labels:
 scheduling:
   dag_name: bqetl_fenix_event_rollup
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - category
+      - event

--- a/sql/moz-fx-data-shared-prod/fenix_derived/events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/events_daily_v1/metadata.yaml
@@ -20,3 +20,11 @@ scheduling:
       'event_types_v1'
     ],
   ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/fenix_derived/events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/events_daily_v1/metadata.yaml
@@ -22,8 +22,8 @@ scheduling:
   ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/metadata.yaml
@@ -43,8 +43,8 @@ scheduling:
   - submission_date:DATE:{{ds}}
 bigquery:
   time_partitioning:
-    field: first_seen_date
     type: day
+    field: first_seen_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_v1/metadata.yaml
@@ -7,8 +7,8 @@ labels:
   incremental: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/metadata.yaml
@@ -14,8 +14,8 @@ scheduling:
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false
     expiration_days: null
   clustering: null

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/metadata.yaml
@@ -13,8 +13,8 @@ scheduling:
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false
     expiration_days: null
   clustering: null

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/event_types_history_v1/metadata.yaml
@@ -19,8 +19,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/event_types_history_v1/metadata.yaml
@@ -17,3 +17,12 @@ labels:
 scheduling:
   dag_name: bqetl_event_rollup
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - category
+      - event

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/events_daily_v1/metadata.yaml
@@ -20,3 +20,11 @@ scheduling:
       'event_types_v1'
     ],
   ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/events_daily_v1/metadata.yaml
@@ -22,8 +22,8 @@ scheduling:
   ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/exact_mau28_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/exact_mau28_v1/metadata.yaml
@@ -11,6 +11,6 @@ scheduling:
   dag_name: bqetl_fxa_events
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/exact_mau28_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/exact_mau28_v1/metadata.yaml
@@ -9,3 +9,8 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_fxa_events
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/metadata.yaml
@@ -13,4 +13,8 @@ scheduling:
   dag_name: bqetl_event_rollup
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
   task_name: funnel_events_source__v1
-bigquery: null
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/metadata.yaml
@@ -15,6 +15,6 @@ scheduling:
   task_name: funnel_events_source__v1
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_export_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_export_v1/metadata.yaml
@@ -11,8 +11,8 @@ labels:
   schedule: daily
 bigquery:
   time_partitioning:
-    field: submission_date_pacific
     type: day
+    field: submission_date_pacific
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_export_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_export_v1/metadata.yaml
@@ -9,3 +9,11 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
+bigquery:
+  time_partitioning:
+    field: submission_date_pacific
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_bounce_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_bounce_events_v1/metadata.yaml
@@ -15,3 +15,8 @@ labels:
 #   dag_name: bqetl_fxa_events
 #   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 #   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: timestamp
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_bounce_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_bounce_events_v1/metadata.yaml
@@ -17,6 +17,6 @@ labels:
 #   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/metadata.yaml
@@ -13,6 +13,6 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/metadata.yaml
@@ -11,3 +11,8 @@ scheduling:
   dag_name: bqetl_fxa_events
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: timestamp
+    type: day
+    require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/metadata.yaml
@@ -11,3 +11,8 @@ scheduling:
   dag_name: bqetl_fxa_events
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: timestamp
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/metadata.yaml
@@ -13,6 +13,6 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/metadata.yaml
@@ -18,6 +18,6 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: submission_timestamp
     type: day
+    field: submission_timestamp
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/metadata.yaml
@@ -16,3 +16,8 @@ scheduling:
   # depends only on fxa logs produced via Stackdriver integration, so no other
   # scheduled tasks are involved and the referenced_tables list is empty.
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: submission_timestamp
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_auth_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_auth_events_v1/metadata.yaml
@@ -16,8 +16,8 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_auth_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_auth_events_v1/metadata.yaml
@@ -14,3 +14,11 @@ labels:
 scheduling:
   dag_name: bqetl_fxa_events
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: timestamp
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - event

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_content_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_content_events_v1/metadata.yaml
@@ -16,8 +16,8 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_content_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_content_events_v1/metadata.yaml
@@ -14,3 +14,11 @@ labels:
 scheduling:
   dag_name: bqetl_fxa_events
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: timestamp
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - event

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/metadata.yaml
@@ -19,8 +19,8 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/metadata.yaml
@@ -17,3 +17,11 @@ scheduling:
   # depends only on fxa logs produced via Stackdriver integration, so no other
   # scheduled tasks are involved and the referenced_tables list is empty.
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: timestamp
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - command

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
@@ -12,6 +12,6 @@ scheduling:
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
@@ -10,3 +10,8 @@ labels:
 scheduling:
   dag_name: bqetl_fxa_events
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+bigquery:
+  time_partitioning:
+    field: timestamp
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v1/metadata.yaml
@@ -15,8 +15,8 @@ scheduling:
   dag_name: bqetl_fxa_events
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/metadata.yaml
@@ -21,8 +21,8 @@ scheduling:
   - submission_date:DATE:{{ds}}
 bigquery:
   time_partitioning:
-    field: first_seen_date
     type: day
+    field: first_seen_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v1/metadata.yaml
@@ -21,8 +21,8 @@ scheduling:
   start_date: '2019-04-23'
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v1/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
   date_partition_parameter: submission_date
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v1/metadata.yaml
@@ -10,3 +10,12 @@ labels:
 scheduling:
   dag_name: bqetl_fxa_events
   date_partition_parameter: submission_date
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - service
+      - user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_daily_v1/metadata.yaml
@@ -24,8 +24,8 @@ scheduling:
   date_partition_parameter: submission_date
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_first_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_first_seen_v1/metadata.yaml
@@ -25,8 +25,8 @@ scheduling:
     ]
 bigquery:
   time_partitioning:
-    field: first_seen_date
     type: day
+    field: first_seen_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_last_seen_v1/metadata.yaml
@@ -22,8 +22,8 @@ scheduling:
     ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/metadata.yaml
@@ -15,3 +15,12 @@ labels:
 #   # making it incremental is possible but nuanced since it windows over
 #   # events that may cross the midnight boundary.
 #   date_partition_parameter: null
+bigquery:
+  time_partitioning:
+    field: first_service_timestamp
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - service
+      - user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/metadata.yaml
@@ -17,8 +17,8 @@ labels:
 #   date_partition_parameter: null
 bigquery:
   time_partitioning:
-    field: first_service_timestamp
     type: day
+    field: first_service_timestamp
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_last_seen_v1/metadata.yaml
@@ -14,3 +14,12 @@ labels:
 #   dag_name: bqetl_fxa_events
 #   depends_on_past: true
 #   start_date: '2019-10-08'
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - service
+      - user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_last_seen_v1/metadata.yaml
@@ -16,8 +16,8 @@ labels:
 #   start_date: '2019-10-08'
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_auth_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_auth_events_v1/metadata.yaml
@@ -12,3 +12,8 @@ scheduling:
   dag_name: bqetl_fxa_events
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: timestamp
+    type: day
+    require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_auth_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_auth_events_v1/metadata.yaml
@@ -14,6 +14,6 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_content_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_content_events_v1/metadata.yaml
@@ -12,3 +12,8 @@ scheduling:
   dag_name: bqetl_fxa_events
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: timestamp
+    type: day
+    require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_content_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_content_events_v1/metadata.yaml
@@ -14,6 +14,6 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/metadata.yaml
@@ -11,3 +11,8 @@ labels:
 scheduling:
   dag_name: bqetl_fxa_events
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+bigquery:
+  time_partitioning:
+    field: timestamp
+    type: day
+    require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/metadata.yaml
@@ -13,6 +13,6 @@ scheduling:
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v1/metadata.yaml
@@ -7,8 +7,8 @@ labels:
   incremental: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/metadata.yaml
@@ -76,8 +76,8 @@ scheduling:
     - health_v4
 bigquery:
   time_partitioning:
-    field: datetime
     type: day
+    field: datetime
     require_partition_filter: null
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_exact_mau28_by_dimensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_exact_mau28_by_dimensions_v1/metadata.yaml
@@ -8,3 +8,8 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_messaging_system
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_exact_mau28_by_dimensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_exact_mau28_by_dimensions_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_messaging_system
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_users_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_users_daily_v1/metadata.yaml
@@ -9,8 +9,8 @@ scheduling:
   dag_name: bqetl_messaging_system
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_users_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_users_daily_v1/metadata.yaml
@@ -7,3 +7,11 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_messaging_system
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - release_channel

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_users_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_users_last_seen_v1/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_users_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/cfr_users_last_seen_v1/metadata.yaml
@@ -10,3 +10,11 @@ labels:
 scheduling:
   dag_name: bqetl_messaging_system
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - release_channel

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/event_types_history_v1/metadata.yaml
@@ -19,8 +19,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/event_types_history_v1/metadata.yaml
@@ -17,3 +17,12 @@ labels:
 scheduling:
   dag_name: bqetl_event_rollup
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - category
+      - event

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/events_daily_v1/metadata.yaml
@@ -20,3 +20,11 @@ scheduling:
       'event_types_v1'
     ],
   ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/events_daily_v1/metadata.yaml
@@ -22,8 +22,8 @@ scheduling:
   ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_exact_mau28_by_dimensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_exact_mau28_by_dimensions_v1/metadata.yaml
@@ -12,6 +12,6 @@ scheduling:
   task_name: messaging_system_onboarding_exact_mau28_by_dimensions
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_exact_mau28_by_dimensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_exact_mau28_by_dimensions_v1/metadata.yaml
@@ -10,3 +10,8 @@ labels:
 scheduling:
   dag_name: bqetl_messaging_system
   task_name: messaging_system_onboarding_exact_mau28_by_dimensions
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_users_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_users_daily_v1/metadata.yaml
@@ -9,8 +9,8 @@ scheduling:
   dag_name: bqetl_messaging_system
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_users_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_users_daily_v1/metadata.yaml
@@ -7,3 +7,11 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_messaging_system
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - release_channel

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_users_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_users_last_seen_v1/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_users_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/onboarding_users_last_seen_v1/metadata.yaml
@@ -10,3 +10,11 @@ labels:
 scheduling:
   dag_name: bqetl_messaging_system
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - release_channel

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_exact_mau28_by_dimensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_exact_mau28_by_dimensions_v1/metadata.yaml
@@ -12,6 +12,6 @@ scheduling:
   task_name: messaging_system_snippets_exact_mau28_by_dimensions
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_exact_mau28_by_dimensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_exact_mau28_by_dimensions_v1/metadata.yaml
@@ -10,3 +10,8 @@ labels:
 scheduling:
   dag_name: bqetl_messaging_system
   task_name: messaging_system_snippets_exact_mau28_by_dimensions
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_users_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_users_daily_v1/metadata.yaml
@@ -9,8 +9,8 @@ scheduling:
   dag_name: bqetl_messaging_system
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_users_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_users_daily_v1/metadata.yaml
@@ -7,3 +7,11 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_messaging_system
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - release_channel

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_users_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_users_last_seen_v1/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_users_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_users_last_seen_v1/metadata.yaml
@@ -10,3 +10,11 @@ labels:
 scheduling:
   dag_name: bqetl_messaging_system
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - release_channel

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/average_ping_sizes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/average_ping_sizes_v1/metadata.yaml
@@ -10,3 +10,8 @@ scheduling:
   referenced_tables:
     - ['moz-fx-data-shared-prod', 'monitoring_derived', 'stable_table_sizes_v1']
     - ['moz-fx-data-shared-prod', '*_stable', "*"]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/average_ping_sizes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/average_ping_sizes_v1/metadata.yaml
@@ -12,6 +12,6 @@ scheduling:
     - ['moz-fx-data-shared-prod', '*_stable', "*"]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_scheduled_queries_cost_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_scheduled_queries_cost_v1/metadata.yaml
@@ -9,3 +9,8 @@ owners:
 scheduling:
   dag_name: bqetl_monitoring
   arguments: ["--date", "{{ ds }}"]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_scheduled_queries_cost_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_scheduled_queries_cost_v1/metadata.yaml
@@ -11,6 +11,6 @@ scheduling:
   arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_scheduled_query_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_scheduled_query_usage_v1/metadata.yaml
@@ -12,6 +12,6 @@ scheduling:
   arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_scheduled_query_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_scheduled_query_usage_v1/metadata.yaml
@@ -10,3 +10,8 @@ owners:
 scheduling:
   dag_name: bqetl_monitoring
   arguments: ["--date", "{{ ds }}"]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_table_storage_timeline_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_table_storage_timeline_daily_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:
-    field: change_date
     type: day
+    field: change_date
     require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/metadata.yaml
@@ -12,3 +12,4 @@ bigquery:
   time_partitioning:
     field: submission_date
     type: day
+    require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:
-    field: creation_date
     type: day
+    field: creation_date
     require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/column_size_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/column_size_v1/metadata.yaml
@@ -10,3 +10,8 @@ scheduling:
   arguments: ["--date", "{{ ds }}"]
   referenced_tables:
     - ['moz-fx-data-shared-prod', 'telemetry_stable', 'main_v4']
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/column_size_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/column_size_v1/metadata.yaml
@@ -12,6 +12,6 @@ scheduling:
     - ['moz-fx-data-shared-prod', 'telemetry_stable', 'main_v4']
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/deletion_request_volume_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/deletion_request_volume_v1/metadata.yaml
@@ -20,6 +20,6 @@ scheduling:
        'payload_bytes_decoded_telemetry']
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/deletion_request_volume_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/deletion_request_volume_v1/metadata.yaml
@@ -18,3 +18,8 @@ scheduling:
     - ['moz-fx-data-shared-prod',
        'monitoring',
        'payload_bytes_decoded_telemetry']
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/metadata.yaml
@@ -11,8 +11,8 @@ scheduling:
   dag_name: bqetl_monitoring
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/metadata.yaml
@@ -9,3 +9,14 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_monitoring
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - document_namespace
+      - document_type
+      - path
+      - job_name

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/metadata.yaml
@@ -17,6 +17,6 @@ scheduling:
     - ['moz-fx-data-shared-prod', '*_derived', '*']
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/metadata.yaml
@@ -15,3 +15,8 @@ scheduling:
     - ['moz-fx-data-shared-prod', '*_stable', '*']
     - ['moz-fx-data-shared-prod', 'telemetry_stable', 'main_v4']
     - ['moz-fx-data-shared-prod', '*_derived', '*']
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_table_column_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_table_column_counts_v1/metadata.yaml
@@ -15,6 +15,6 @@ scheduling:
   parameters: ["submission_date:DATE:{{ds}}"]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/structured_distinct_docids_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/structured_distinct_docids_v1/metadata.yaml
@@ -10,8 +10,8 @@ labels:
   incremental: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
 scheduling:
   dag_name: bqetl_monitoring

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/structured_missing_columns_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/structured_missing_columns_v1/metadata.yaml
@@ -14,6 +14,6 @@ scheduling:
     - ['moz-fx-data-shared-prod', '*_stable', '*']
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/structured_missing_columns_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/structured_missing_columns_v1/metadata.yaml
@@ -12,3 +12,8 @@ scheduling:
   arguments: ["--date", "{{ ds }}"]
   referenced_tables:
     - ['moz-fx-data-shared-prod', '*_stable', '*']
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_distinct_docids_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_distinct_docids_v1/metadata.yaml
@@ -10,8 +10,8 @@ labels:
   incremental: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
 scheduling:
   dag_name: bqetl_monitoring

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/metadata.yaml
@@ -12,3 +12,8 @@ scheduling:
   dag_name: bqetl_monitoring
   referenced_tables:
     - ['moz-fx-data-shared-prod', '*_stable', '*']
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/metadata.yaml
@@ -14,6 +14,6 @@ scheduling:
     - ['moz-fx-data-shared-prod', '*_stable', '*']
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscription_ids_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscription_ids_v1/metadata.yaml
@@ -14,3 +14,8 @@ scheduling:
   # delay aggregates by 7 days, to ensure data is complete
   date_partition_offset: -7
   date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    field: active_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscription_ids_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscription_ids_v1/metadata.yaml
@@ -16,6 +16,6 @@ scheduling:
   date_partition_parameter: date
 bigquery:
   time_partitioning:
-    field: active_date
     type: day
+    field: active_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_v1/metadata.yaml
@@ -13,6 +13,6 @@ scheduling:
   date_partition_parameter: date
 bigquery:
   time_partitioning:
-    field: active_date
     type: day
+    field: active_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/active_subscriptions_v1/metadata.yaml
@@ -11,3 +11,8 @@ scheduling:
   # delay aggregates by 7 days, to ensure data is complete
   date_partition_offset: -7
   date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    field: active_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_subplat
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/add_device_events_v1/metadata.yaml
@@ -8,3 +8,8 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_subplat
+bigquery:
+  time_partitioning:
+    field: timestamp
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/metadata.yaml
@@ -12,3 +12,8 @@ scheduling:
   # delay aggregates by 7 days, to ensure data is complete
   date_partition_offset: -7
   date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    field: subscription_start_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/metadata.yaml
@@ -14,6 +14,6 @@ scheduling:
   date_partition_parameter: date
 bigquery:
   time_partitioning:
-    field: subscription_start_date
     type: day
+    field: subscription_start_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/event_types_history_v1/metadata.yaml
@@ -19,8 +19,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/event_types_history_v1/metadata.yaml
@@ -17,3 +17,12 @@ labels:
 scheduling:
   dag_name: bqetl_event_rollup
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - category
+      - event

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/events_daily_v1/metadata.yaml
@@ -20,3 +20,11 @@ scheduling:
       'event_types_v1'
     ],
   ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/events_daily_v1/metadata.yaml
@@ -22,8 +22,8 @@ scheduling:
   ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/exchange_rates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/exchange_rates_v1/metadata.yaml
@@ -53,6 +53,6 @@ scheduling:
     ]
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/exchange_rates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/exchange_rates_v1/metadata.yaml
@@ -51,3 +51,8 @@ scheduling:
       "TZS",
       "UAH",
     ]
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_fxa_login_to_protected_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_fxa_login_to_protected_v1/metadata.yaml
@@ -12,3 +12,8 @@ scheduling:
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null
+bigquery:
+  time_partitioning:
+    field: start_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_fxa_login_to_protected_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_fxa_login_to_protected_v1/metadata.yaml
@@ -14,6 +14,6 @@ scheduling:
   date_partition_parameter: null
 bigquery:
   time_partitioning:
-    field: start_date
     type: day
+    field: start_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v1/metadata.yaml
@@ -9,3 +9,8 @@ labels:
 scheduling:
   dag_name: bqetl_mozilla_vpn_site_metrics
   date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v1/metadata.yaml
@@ -11,6 +11,6 @@ scheduling:
   date_partition_parameter: date
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/metadata.yaml
@@ -8,3 +8,8 @@ labels:
 scheduling:
   dag_name: bqetl_subplat
   date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    field: partition_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   date_partition_parameter: date
 bigquery:
   time_partitioning:
-    field: partition_date
     type: day
+    field: partition_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/site_metrics_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/site_metrics_summary_v1/metadata.yaml
@@ -16,8 +16,8 @@ scheduling:
       - site_metrics_empty_check_v1
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/site_metrics_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/site_metrics_summary_v1/metadata.yaml
@@ -14,3 +14,11 @@ scheduling:
     - - moz-fx-data-shared-prod
       - mozilla_vpn_derived
       - site_metrics_empty_check_v1
+bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - site

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscription_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscription_events_v1/metadata.yaml
@@ -12,3 +12,8 @@ scheduling:
   # delayed 7 days, and this needs an additional day of delay for cancel events.
   date_partition_offset: -8
   date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    field: event_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscription_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/subscription_events_v1/metadata.yaml
@@ -14,6 +14,6 @@ scheduling:
   date_partition_parameter: date
 bigquery:
   time_partitioning:
-    field: event_date
     type: day
+    field: event_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_cancellation_of_service_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_cancellation_of_service_v1/metadata.yaml
@@ -25,6 +25,6 @@ scheduling:
     ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_cancellation_of_service_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_cancellation_of_service_v1/metadata.yaml
@@ -23,3 +23,8 @@ scheduling:
       "--destination_table",
       "moz-fx-data-shared-prod.mozilla_vpn_derived.survey_cancellation_of_service_v1",
     ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_intercept_q3_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_intercept_q3_v1/metadata.yaml
@@ -25,6 +25,6 @@ scheduling:
     ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_intercept_q3_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_intercept_q3_v1/metadata.yaml
@@ -23,3 +23,8 @@ scheduling:
       "--destination_table",
       "moz-fx-data-shared-prod.mozilla_vpn_derived.survey_intercept_q3_v1",
     ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_lifecycle_28d_desktop_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_lifecycle_28d_desktop_v1/metadata.yaml
@@ -25,6 +25,6 @@ scheduling:
     ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_lifecycle_28d_desktop_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_lifecycle_28d_desktop_v1/metadata.yaml
@@ -23,3 +23,8 @@ scheduling:
       "--destination_table",
       "moz-fx-data-shared-prod.mozilla_vpn_derived.survey_lifecycle_28d_desktop_v1",
     ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_lifecycle_28d_mobile_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_lifecycle_28d_mobile_v1/metadata.yaml
@@ -25,6 +25,6 @@ scheduling:
     ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_lifecycle_28d_mobile_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_lifecycle_28d_mobile_v1/metadata.yaml
@@ -23,3 +23,8 @@ scheduling:
       "--destination_table",
       "moz-fx-data-shared-prod.mozilla_vpn_derived.survey_lifecycle_28d_mobile_v1",
     ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_market_fit_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_market_fit_v1/metadata.yaml
@@ -25,6 +25,6 @@ scheduling:
     ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_market_fit_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_market_fit_v1/metadata.yaml
@@ -23,3 +23,8 @@ scheduling:
       "--destination_table",
       "moz-fx-data-shared-prod.mozilla_vpn_derived.survey_market_fit_v1",
     ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_product_quality_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_product_quality_v1/metadata.yaml
@@ -25,6 +25,6 @@ scheduling:
     ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_product_quality_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_product_quality_v1/metadata.yaml
@@ -23,3 +23,8 @@ scheduling:
       "--destination_table",
       "moz-fx-data-shared-prod.mozilla_vpn_derived.survey_product_quality_v1",
     ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_recommend_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_recommend_v1/metadata.yaml
@@ -25,6 +25,6 @@ scheduling:
     ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_recommend_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_recommend_v1/metadata.yaml
@@ -23,3 +23,8 @@ scheduling:
       "--destination_table",
       "moz-fx-data-shared-prod.mozilla_vpn_derived.survey_recommend_v1",
     ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/devices_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/devices_v1/metadata.yaml
@@ -44,6 +44,6 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: updated_at
     type: day
+    field: updated_at
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/devices_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/devices_v1/metadata.yaml
@@ -42,3 +42,8 @@ scheduling:
       FROM devices
       WHERE DATE(updated_at) = DATE '{{ds}}'
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: updated_at
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/subscriptions_v1/metadata.yaml
@@ -47,3 +47,8 @@ scheduling:
       FROM subscriptions
       WHERE DATE(updated_at) = DATE '{{ds}}'
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: updated_at
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/subscriptions_v1/metadata.yaml
@@ -49,6 +49,6 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: updated_at
     type: day
+    field: updated_at
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/metadata.yaml
@@ -41,6 +41,6 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: updated_at
     type: day
+    field: updated_at
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/metadata.yaml
@@ -39,3 +39,8 @@ scheduling:
       FROM users
       WHERE DATE(updated_at) = DATE '{{ds}}'
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: updated_at
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version_v1/metadata.yaml
@@ -12,3 +12,8 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_org_mozilla_fenix_derived
+bigquery:
+  time_partitioning:
+    field: null
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version_v1/metadata.yaml
@@ -14,6 +14,5 @@ scheduling:
   dag_name: bqetl_org_mozilla_fenix_derived
 bigquery:
   time_partitioning:
-    field: null
     type: day
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_metrics_v1/metadata.yaml
@@ -6,6 +6,5 @@ owners:
   - amiyaguchi@mozilla.com
 bigquery:
   time_partitioning:
-    field: null
     type: day
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_metrics_v1/metadata.yaml
@@ -4,3 +4,8 @@ labels:
   incremental: true
 owners:
   - amiyaguchi@mozilla.com
+bigquery:
+  time_partitioning:
+    field: null
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_core_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_core_v1/metadata.yaml
@@ -6,6 +6,5 @@ owners:
   - amiyaguchi@mozilla.com
 bigquery:
   time_partitioning:
-    field: null
     type: day
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_core_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_core_v1/metadata.yaml
@@ -4,3 +4,8 @@ labels:
   incremental: true
 owners:
   - amiyaguchi@mozilla.com
+bigquery:
+  time_partitioning:
+    field: null
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_core_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_core_v2/metadata.yaml
@@ -6,6 +6,5 @@ owners:
   - amiyaguchi@mozilla.com
 bigquery:
   time_partitioning:
-    field: null
     type: day
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_core_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_core_v2/metadata.yaml
@@ -4,3 +4,8 @@ labels:
   incremental: true
 owners:
   - amiyaguchi@mozilla.com
+bigquery:
+  time_partitioning:
+    field: null
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v1/metadata.yaml
@@ -6,6 +6,5 @@ owners:
   - amiyaguchi@mozilla.com
 bigquery:
   time_partitioning:
-    field: null
     type: day
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v1/metadata.yaml
@@ -4,3 +4,8 @@ labels:
   incremental: true
 owners:
   - amiyaguchi@mozilla.com
+bigquery:
+  time_partitioning:
+    field: null
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v2/metadata.yaml
@@ -6,6 +6,5 @@ owners:
   - amiyaguchi@mozilla.com
 bigquery:
   time_partitioning:
-    field: null
     type: day
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/legacy_mobile_event_counts_v2/metadata.yaml
@@ -4,3 +4,8 @@ labels:
   incremental: true
 owners:
   - amiyaguchi@mozilla.com
+bigquery:
+  time_partitioning:
+    field: null
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/pocket_derived/rolling_monthly_active_user_counts_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/rolling_monthly_active_user_counts_history_v1/metadata.yaml
@@ -9,8 +9,8 @@ labels:
   incremental: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
 scheduling:
   dag_name: bqetl_pocket

--- a/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_history_v1/metadata.yaml
@@ -7,8 +7,8 @@ labels:
   incremental: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
 scheduling:
   dag_name: bqetl_pocket

--- a/sql/moz-fx-data-shared-prod/pocket_derived/twice_weekly_active_user_counts_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/twice_weekly_active_user_counts_history_v1/metadata.yaml
@@ -9,8 +9,8 @@ labels:
   incremental: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
 scheduling:
   dag_name: bqetl_pocket

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/metadata.yaml
@@ -22,8 +22,8 @@ scheduling:
                        'main_events_v1']]
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/regrets_reporter_derived/regrets_reporter_summary_v1/metadata.yaml
@@ -21,6 +21,10 @@ scheduling:
                        'regrets_reporter_ucs_stable',
                        'main_events_v1']]
 bigquery:
+  time_partitioning:
+    field: date
+    type: day
+    require_partition_filter: true
   clustering:
     fields:
     - country

--- a/sql/moz-fx-data-shared-prod/relay_derived/active_subscription_ids_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/relay_derived/active_subscription_ids_v1/metadata.yaml
@@ -14,3 +14,8 @@ scheduling:
   # delay aggregates by 7 days, to ensure data is complete
   date_partition_offset: -7
   date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    field: active_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/relay_derived/active_subscription_ids_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/relay_derived/active_subscription_ids_v1/metadata.yaml
@@ -16,6 +16,6 @@ scheduling:
   date_partition_parameter: date
 bigquery:
   time_partitioning:
-    field: active_date
     type: day
+    field: active_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/relay_derived/active_subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/relay_derived/active_subscriptions_v1/metadata.yaml
@@ -13,6 +13,6 @@ scheduling:
   date_partition_parameter: date
 bigquery:
   time_partitioning:
-    field: active_date
     type: day
+    field: active_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/relay_derived/active_subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/relay_derived/active_subscriptions_v1/metadata.yaml
@@ -11,3 +11,8 @@ scheduling:
   # delay aggregates by 7 days, to ensure data is complete
   date_partition_offset: -7
   date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    field: active_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/relay_derived/subscription_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/relay_derived/subscription_events_v1/metadata.yaml
@@ -12,3 +12,8 @@ scheduling:
   # delayed 7 days, and this needs an additional day of delay for cancel events.
   date_partition_offset: -8
   date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    field: event_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/relay_derived/subscription_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/relay_derived/subscription_events_v1/metadata.yaml
@@ -14,6 +14,6 @@ scheduling:
   date_partition_parameter: date
 bigquery:
   time_partitioning:
-    field: event_date
     type: day
+    field: event_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_mobile_search_clients_monthly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_mobile_search_clients_monthly_v1/metadata.yaml
@@ -21,7 +21,7 @@ scheduling:
   parameters: ["submission_date:DATE:{{ds}}"]
 bigquery:
   time_partitioning:
-    field: submission_month
     type: month
+    field: submission_month
     require_partition_filter: true
   clustering: null

--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/metadata.yaml
@@ -14,8 +14,8 @@ scheduling:
   depends_on_past: false
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_for_searchreport_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_for_searchreport_v1/metadata.yaml
@@ -14,8 +14,8 @@ scheduling:
   depends_on_past: false
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_for_searchreport_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_for_searchreport_v1/metadata.yaml
@@ -12,3 +12,14 @@ owners:
 scheduling:
   dag_name: bqetl_search_dashboard
   depends_on_past: false
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+    - geo
+    - locale
+    - engine
+    - app_version

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_for_searchreport_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_for_searchreport_v1/metadata.yaml
@@ -16,8 +16,8 @@ scheduling:
   depends_on_past: false
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_for_searchreport_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_for_searchreport_v1/metadata.yaml
@@ -14,3 +14,13 @@ owners:
 scheduling:
   dag_name: bqetl_search_dashboard
   depends_on_past: false
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+    - country
+    - product
+    - normalized_engine

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/metadata.yaml
@@ -9,3 +9,8 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_mobile_search
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/metadata.yaml
@@ -11,6 +11,6 @@ scheduling:
   dag_name: bqetl_mobile_search
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/metadata.yaml
@@ -14,8 +14,8 @@ scheduling:
   dag_name: bqetl_mobile_search
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/metadata.yaml
@@ -12,3 +12,11 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_mobile_search
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_last_seen_v1/metadata.yaml
@@ -15,8 +15,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_last_seen_v1/metadata.yaml
@@ -13,3 +13,12 @@ labels:
 scheduling:
   dag_name: bqetl_mobile_search
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id
+      - client_id

--- a/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/metadata.yaml
@@ -11,7 +11,7 @@ scheduling:
   dag_name: bqetl_search
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering: null

--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/metadata.yaml
@@ -18,8 +18,8 @@ scheduling:
     execution_delta: 1h
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_last_seen_v1/metadata.yaml
@@ -19,8 +19,8 @@ scheduling:
     execution_delta: 1h
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_metric_contribution_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_metric_contribution_v1/metadata.yaml
@@ -12,3 +12,8 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_search
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/search_derived/search_metric_contribution_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_metric_contribution_v1/metadata.yaml
@@ -14,6 +14,6 @@ scheduling:
   dag_name: bqetl_search
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_v1/metadata.yaml
@@ -16,6 +16,7 @@ bigquery:
   time_partitioning:
     field: submission_date
     type: day
+    require_partition_filter: true
 scheduling:
   dag_name: bqetl_search_terms_daily
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_v1/metadata.yaml
@@ -14,8 +14,8 @@ workgroup_access:
       - workgroup:search-terms/aggregated
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
 scheduling:
   dag_name: bqetl_search_terms_daily

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/aggregated_search_terms_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/aggregated_search_terms_daily_v1/metadata.yaml
@@ -10,8 +10,8 @@ owners:
   - rburwei@mozilla.com
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
 scheduling:
   dag_name: bqetl_search_terms_daily

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/merino_log_sanitized_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/merino_log_sanitized_v3/metadata.yaml
@@ -12,8 +12,8 @@ description: |-
   for the code that populates this table.
 bigquery:
   time_partitioning:
-    field: timestamp
     type: day
+    field: timestamp
     require_partition_filter: true
     expiration_days: 15
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/metadata.yaml
@@ -12,8 +12,8 @@ labels:
   incremental: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
 scheduling:

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2/metadata.yaml
@@ -18,8 +18,8 @@ scheduling:
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
-    field: submission_timestamp
     type: day
+    field: submission_timestamp
     require_partition_filter: true
     expiration_days: 14
   clustering:

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/metadata.yaml
@@ -16,8 +16,8 @@ description: |-
 
 bigquery:
   time_partitioning:
-    field: submission_timestamp
     type: day
+    field: submission_timestamp
     require_partition_filter: true
     expiration_days: 15
 

--- a/sql/moz-fx-data-shared-prod/stripe_external/itemized_payout_reconciliation_v5/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/itemized_payout_reconciliation_v5/metadata.yaml
@@ -21,8 +21,8 @@ scheduling:
   email_on_retry: false
 bigquery:
   time_partitioning:
-    field: automatic_payout_effective_at
     type: day
+    field: automatic_payout_effective_at
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/stripe_external/itemized_payout_reconciliation_v5/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/itemized_payout_reconciliation_v5/metadata.yaml
@@ -19,3 +19,11 @@ scheduling:
   retry_delay: 30m
   retries: 47
   email_on_retry: false
+bigquery:
+  time_partitioning:
+    field: automatic_payout_effective_at
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - automatic_payout_effective_at

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/accessibility_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/accessibility_clients_v1/metadata.yaml
@@ -13,6 +13,6 @@ scheduling:
   start_date: "2018-11-01"
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/accessibility_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/accessibility_clients_v1/metadata.yaml
@@ -11,3 +11,8 @@ labels:
 scheduling:
   dag_name: bqetl_desktop_platform
   start_date: "2018-11-01"
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_attribution_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_attribution_v1/metadata.yaml
@@ -25,8 +25,8 @@ scheduling:
   task_name: active_users_aggregates_attribution_v1
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_device_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_device_v1/metadata.yaml
@@ -17,8 +17,8 @@ scheduling:
   task_name: active_users_aggregates_device_v1
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/metadata.yaml
@@ -17,8 +17,8 @@ scheduling:
   task_name: active_users_aggregates_v1
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/addon_aggregates_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/addon_aggregates_v2/metadata.yaml
@@ -17,8 +17,8 @@ scheduling:
                        'main_v4']]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/addon_aggregates_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/addon_aggregates_v2/metadata.yaml
@@ -15,3 +15,11 @@ scheduling:
   # query to get it, and that would be slow because main_v4 is referenced
   referenced_tables: [['moz-fx-data-shared-prod', 'telemetry_stable',
                        'main_v4']]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/addons_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/addons_daily_v1/metadata.yaml
@@ -11,8 +11,8 @@ scheduling:
   dag_name: bqetl_addons
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/addons_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/addons_daily_v1/metadata.yaml
@@ -9,3 +9,11 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_addons
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - addon_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/addons_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/addons_v2/metadata.yaml
@@ -13,3 +13,11 @@ scheduling:
   # query to get it, and that would be slow because main_v4 is referenced
   referenced_tables: [['moz-fx-data-shared-prod', 'telemetry_stable',
                        'main_v4']]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/addons_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/addons_v2/metadata.yaml
@@ -15,8 +15,8 @@ scheduling:
                        'main_v4']]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/adm_engagements_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/adm_engagements_daily_v1/metadata.yaml
@@ -14,6 +14,5 @@ owners:
   - akomar@mozilla.com
 bigquery:
   time_partitioning:
-    field: null
     type: day
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/adm_engagements_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/adm_engagements_daily_v1/metadata.yaml
@@ -12,3 +12,8 @@ description: |-
     - normalized_channel
 owners:
   - akomar@mozilla.com
+bigquery:
+  time_partitioning:
+    field: null
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_event_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_event_v1/metadata.yaml
@@ -16,8 +16,8 @@ scheduling:
   priority: 85
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_event_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_event_v1/metadata.yaml
@@ -14,3 +14,11 @@ scheduling:
   dag_name: bqetl_main_summary
   start_date: "2021-01-19"
   priority: 85
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/metadata.yaml
@@ -19,8 +19,8 @@ scheduling:
   priority: 85
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
@@ -29,8 +29,8 @@ scheduling:
     execution_delta: 1h
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/metadata.yaml
@@ -24,8 +24,8 @@ scheduling:
   - submission_date:DATE:{{ds}}
 bigquery:
   time_partitioning:
-    field: first_seen_date
     type: day
+    field: first_seen_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_event_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_event_v1/metadata.yaml
@@ -17,8 +17,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_event_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_event_v1/metadata.yaml
@@ -15,3 +15,11 @@ scheduling:
   start_date: "2021-01-19"
   priority: 85
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/metadata.yaml
@@ -22,8 +22,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
@@ -29,8 +29,8 @@ scheduling:
     execution_delta: 2h
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
@@ -16,8 +16,8 @@ scheduling:
   date_partition_parameter: activity_date
 bigquery:
   time_partitioning:
-    field: activity_date
     type: day
+    field: activity_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_daily_v1/metadata.yaml
@@ -13,8 +13,8 @@ scheduling:
   priority: 75
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_daily_v1/metadata.yaml
@@ -11,3 +11,13 @@ labels:
 scheduling:
   dag_name: bqetl_core
   priority: 75
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - is_new_profile
+      - app_name
+      - os

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/metadata.yaml
@@ -13,8 +13,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/metadata.yaml
@@ -11,3 +11,12 @@ scheduling:
   dag_name: bqetl_core
   priority: 70
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - app_name
+      - os

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/crashes_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/crashes_daily_v1/metadata.yaml
@@ -16,8 +16,8 @@ scheduling:
   priority: 85
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_activation_day_6_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_activation_day_6_v1/metadata.yaml
@@ -12,7 +12,7 @@ scheduling:
   dag_name: bqetl_desktop_funnel
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering: null

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_installs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_installs_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_desktop_funnel
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_new_profiles_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_new_profiles_v1/metadata.yaml
@@ -12,6 +12,6 @@ scheduling:
   dag_name: bqetl_desktop_funnel
 bigquery:
   time_partitioning:
-    field: date
     type: day
+    field: date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/devtools_accessiblility_panel_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/devtools_accessiblility_panel_usage_v1/metadata.yaml
@@ -14,8 +14,8 @@ scheduling:
   start_date: "2018-08-01"
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/devtools_accessiblility_panel_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/devtools_accessiblility_panel_usage_v1/metadata.yaml
@@ -12,3 +12,11 @@ labels:
 scheduling:
   dag_name: bqetl_devtools
   start_date: "2018-08-01"
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - normalized_channel

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/devtools_panel_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/devtools_panel_usage_v1/metadata.yaml
@@ -11,7 +11,7 @@ scheduling:
   start_date: '2019-11-25'
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: null
   clustering: null

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/error_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/error_aggregates_v1/metadata.yaml
@@ -12,3 +12,11 @@ scheduling:
   # This dag runs more frequently than upstream tables, so it can't depend on
   # them directly, which is fine because it also queries live tables.
   referenced_tables: []
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - window_start

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/error_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/error_aggregates_v1/metadata.yaml
@@ -14,8 +14,8 @@ scheduling:
   referenced_tables: []
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_history_v1/metadata.yaml
@@ -19,8 +19,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_history_v1/metadata.yaml
@@ -17,3 +17,12 @@ labels:
 scheduling:
   dag_name: bqetl_event_rollup
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - category
+      - event

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_1pct_v1/metadata.yaml
@@ -18,7 +18,7 @@ bigquery:
     type: day
     field: submission_date
     require_partition_filter: true
-    expiration_days: 180.0
+    expiration_days: 180
   clustering:
     fields:
     - event_category

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_1pct_v1/metadata.yaml
@@ -13,3 +13,13 @@ scheduling:
   dag_name: bqetl_main_summary
   start_date: '2020-08-01'
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+    expiration_days: 180.0
+  clustering:
+    fields:
+    - event_category
+    - sample_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_1pct_v1/metadata.yaml
@@ -15,8 +15,8 @@ scheduling:
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: 180.0
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_daily_v1/metadata.yaml
@@ -20,3 +20,11 @@ scheduling:
       'event_types_v1'
     ],
   ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_daily_v1/metadata.yaml
@@ -22,8 +22,8 @@ scheduling:
   ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_v1/metadata.yaml
@@ -4,3 +4,12 @@ owners:
 - ascholtz@mozilla.com
 scheduling:
   dag_name: bqetl_experiments_daily
+bigquery:
+  time_partitioning:
+    field: window_start
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+    - experiment
+    - branch

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_v1/metadata.yaml
@@ -6,8 +6,8 @@ scheduling:
   dag_name: bqetl_experiments_daily
 bigquery:
   time_partitioning:
-    field: window_start
     type: day
+    field: window_start
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_daily_active_population_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_daily_active_population_v1/metadata.yaml
@@ -8,3 +8,7 @@ scheduling:
   dag_name: bqetl_experiments_daily
   task_name: experiment_enrollment_daily_active_population
   date_partition_parameter: null
+bigquery:
+  clustering:
+    fields:
+    - experiment

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/metadata.yaml
@@ -11,8 +11,8 @@ scheduling:
   dag_name: bqetl_experiments_daily
 bigquery:
   time_partitioning:
-    field: window_start
     type: day
+    field: window_start
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiments_daily_active_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiments_daily_active_clients_v1/metadata.yaml
@@ -10,8 +10,8 @@ scheduling:
   dag_name: bqetl_experiments_daily
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: null
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/metadata.yaml
@@ -17,8 +17,8 @@ scheduling:
   dag_name: bqetl_feature_usage
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
     expiration_days: null
   clustering: null

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
@@ -13,7 +13,7 @@ scheduling:
   task_name: firefox_desktop_exact_mau28_by_client_count_dimensions
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering: null

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/metadata.yaml
@@ -13,7 +13,7 @@ scheduling:
   task_name: firefox_desktop_exact_mau28_by_dimensions
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering: null

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v2/metadata.yaml
@@ -14,7 +14,7 @@ scheduling:
   task_name: firefox_desktop_exact_mau28_by_dimensions_v2
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering: null

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_usage_v1/metadata.yaml
@@ -27,8 +27,8 @@ scheduling:
   date_partition_parameter: null
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/metadata.yaml
@@ -13,3 +13,8 @@ labels:
 scheduling:
   dag_name: bqetl_nondesktop
   email: ['jklukas@mozilla.com']
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/metadata.yaml
@@ -15,6 +15,6 @@ scheduling:
   email: ['jklukas@mozilla.com']
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
@@ -12,3 +12,8 @@ labels:
 scheduling:
   dag_name: bqetl_nondesktop
   task_name: firefox_nondesktop_exact_mau28_by_client_count_dimensions
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
@@ -14,6 +14,6 @@ scheduling:
   task_name: firefox_nondesktop_exact_mau28_by_client_count_dimensions
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_v1/metadata.yaml
@@ -10,3 +10,8 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_nondesktop
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_v1/metadata.yaml
@@ -12,6 +12,6 @@ scheduling:
   dag_name: bqetl_nondesktop
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fog_decision_support_percentiles_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fog_decision_support_percentiles_v1/metadata.yaml
@@ -16,7 +16,7 @@ scheduling:
   task_name: fog_decision_support_v1
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/metadata.yaml
@@ -35,7 +35,7 @@ bigquery:
     type: day
     field: submission_timestamp
     require_partition_filter: true
-    expiration_days: 180.0
+    expiration_days: 180
   clustering:
     fields:
     - normalized_channel

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/metadata.yaml
@@ -32,8 +32,8 @@ scheduling:
                        'main_v4']]
 bigquery:
   time_partitioning:
-    field: submission_timestamp
     type: day
+    field: submission_timestamp
     require_partition_filter: true
     expiration_days: 180.0
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/metadata.yaml
@@ -30,3 +30,14 @@ scheduling:
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
   referenced_tables: [['moz-fx-data-shared-prod', 'telemetry_stable',
                        'main_v4']]
+bigquery:
+  time_partitioning:
+    field: submission_timestamp
+    type: day
+    require_partition_filter: true
+    expiration_days: 180.0
+  clustering:
+    fields:
+    - normalized_channel
+    - sample_id
+    - subsample_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
@@ -36,7 +36,7 @@ bigquery:
     type: day
     field: submission_timestamp
     require_partition_filter: true
-    expiration_days: 180.0
+    expiration_days: 180
   clustering:
     fields:
     - normalized_channel

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
@@ -31,3 +31,13 @@ scheduling:
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
   referenced_tables: [['moz-fx-data-shared-prod', 'telemetry_stable',
                        'main_v4']]
+bigquery:
+  time_partitioning:
+    field: submission_timestamp
+    type: day
+    require_partition_filter: true
+    expiration_days: 180.0
+  clustering:
+    fields:
+    - normalized_channel
+    - sample_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
@@ -33,8 +33,8 @@ scheduling:
                        'main_v4']]
 bigquery:
   time_partitioning:
-    field: submission_timestamp
     type: day
+    field: submission_timestamp
     require_partition_filter: true
     expiration_days: 180.0
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_summary_v4/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_summary_v4/metadata.yaml
@@ -25,3 +25,12 @@ scheduling:
     - task_id: wait_for_main_summary
       dag_name: parquet_export
       execution_delta: 1h
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - normalized_channel
+      - sample_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_summary_v4/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_summary_v4/metadata.yaml
@@ -27,8 +27,8 @@ scheduling:
       execution_delta: 1h
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/mobile_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/mobile_usage_v1/metadata.yaml
@@ -29,3 +29,8 @@ scheduling:
   - task_id: wait_for_mobile_usage
     dag_name: kpi_forecasting
     execution_delta: 1h
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/mobile_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/mobile_usage_v1/metadata.yaml
@@ -31,6 +31,6 @@ scheduling:
     execution_delta: 1h
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
   dag_name: bqetl_newtab
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/metadata.yaml
@@ -18,8 +18,8 @@ scheduling:
   date_partition_parameter: cohort_date
 bigquery:
   time_partitioning:
-    field: cohort_date
     type: day
+    field: cohort_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_compressed_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_compressed_v2/metadata.yaml
@@ -11,8 +11,8 @@ scheduling:
   dag_name: bqetl_gud
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: null
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_v2/metadata.yaml
@@ -11,8 +11,8 @@ scheduling:
   dag_name: bqetl_gud
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: null
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_compressed_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_compressed_v2/metadata.yaml
@@ -9,3 +9,12 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_gud
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - usage
+      - id_bucket

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_compressed_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_compressed_v2/metadata.yaml
@@ -11,8 +11,8 @@ scheduling:
   dag_name: bqetl_gud
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_v2/metadata.yaml
@@ -9,3 +9,12 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_gud
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - usage
+      - id_bucket

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_v2/metadata.yaml
@@ -11,8 +11,8 @@ scheduling:
   dag_name: bqetl_gud
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_new_profiles_compressed_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_new_profiles_compressed_v2/metadata.yaml
@@ -9,8 +9,8 @@ scheduling:
   dag_name: bqetl_gud
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: null
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_new_profiles_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_new_profiles_v2/metadata.yaml
@@ -9,8 +9,8 @@ scheduling:
   dag_name: bqetl_gud
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: null
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_compressed_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_compressed_v2/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
   dag_name: bqetl_gud
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_compressed_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_compressed_v2/metadata.yaml
@@ -10,3 +10,12 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_gud
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - usage
+      - id_bucket

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_v2/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
   dag_name: bqetl_gud
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_v2/metadata.yaml
@@ -10,3 +10,12 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_gud
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - usage
+      - id_bucket

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
@@ -10,8 +10,8 @@ scheduling:
   task_name: sponsored_tiles_clients_daily_v1
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/suggest_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/suggest_clients_daily_v1/metadata.yaml
@@ -9,8 +9,8 @@ scheduling:
   dag_name: bqetl_main_summary
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/metadata.yaml
@@ -23,8 +23,8 @@ scheduling:
     execution_delta: 1h
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/urlbar_clients_daily_v1/metadata.yaml
@@ -12,8 +12,8 @@ scheduling:
   dag_name: bqetl_urlbar
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql_generators/events_daily/templates/event_types_history_v1/metadata.yaml
+++ b/sql_generators/events_daily/templates/event_types_history_v1/metadata.yaml
@@ -15,4 +15,13 @@ labels:
 scheduling:
   dag_name: {{ dag_name }}
   depends_on_past: true
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: false
+  clustering:
+    fields:
+      - category
+      - event
 

--- a/sql_generators/events_daily/templates/event_types_history_v1/metadata.yaml
+++ b/sql_generators/events_daily/templates/event_types_history_v1/metadata.yaml
@@ -17,8 +17,8 @@ scheduling:
   depends_on_past: true
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql_generators/events_daily/templates/events_daily_v1/metadata.yaml
+++ b/sql_generators/events_daily/templates/events_daily_v1/metadata.yaml
@@ -20,8 +20,8 @@ scheduling:
   ]
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql_generators/events_daily/templates/events_daily_v1/metadata.yaml
+++ b/sql_generators/events_daily/templates/events_daily_v1/metadata.yaml
@@ -18,4 +18,12 @@ scheduling:
       'event_types_v1'
     ],
   ]
+bigquery:
+  time_partitioning:
+    field: submission_date
+    type: day
+    require_partition_filter: true
+  clustering:
+    fields:
+      - sample_id
 

--- a/sql_generators/experiment_monitoring/templates/experiment_search_aggregates_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_search_aggregates_v1/metadata.yaml
@@ -11,8 +11,8 @@ scheduling:
   dag_name: bqetl_experiments_daily
 bigquery:
   time_partitioning:
-    field: window_start
     type: day
+    field: window_start
     require_partition_filter: false
   clustering:
     fields:

--- a/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v1/metadata.yaml
@@ -10,8 +10,8 @@ scheduling:
   dag_name: bqetl_experiments_daily
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: null
   clustering:
     fields:

--- a/sql_generators/feature_usage/templates/metadata.yaml
+++ b/sql_generators/feature_usage/templates/metadata.yaml
@@ -18,6 +18,6 @@ scheduling:
   dag_name: bqetl_feature_usage
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: false

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.metadata.yaml
@@ -10,8 +10,8 @@ owners:
   - jklukas@mozilla.com
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.metadata.yaml
@@ -14,8 +14,8 @@ owners:
   - jklukas@mozilla.com
 bigquery:
   time_partitioning:
-    field: first_seen_date
     type: day
+    field: first_seen_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
@@ -11,8 +11,8 @@ owners:
   - jklukas@mozilla.com
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
@@ -10,8 +10,8 @@ owners:
   - ascholtz@mozilla.com
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
@@ -6,8 +6,8 @@ owners:
   - ascholtz@mozilla.com
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:

--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
@@ -11,8 +11,8 @@ owners:
   - ascholtz@mozilla.com
 bigquery:
   time_partitioning:
-    field: submission_date
     type: day
+    field: submission_date
     require_partition_filter: true
   clustering:
     fields:


### PR DESCRIPTION
- 135 ETLs (39%) are missing BigQuery partitioning/clustering metadata.
- 4 ETLs have incorrect BigQuery partitioning/clustering metadata.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
