### PR TITLE
Fix overcounts gads

### DIFF
--- a/dags/bqetl_fivetran_google_ads.py
+++ b/dags/bqetl_fivetran_google_ads.py
@@ -54,3 +54,18 @@ with DAG(
         date_partition_parameter="submission_date",
         depends_on_past=False,
     )
+
+    google_ads_derived__campaign_names_map__v1 = bigquery_etl_query(
+        task_id="google_ads_derived__campaign_names_map__v1",
+        destination_table="campaign_names_map_v1",
+        dataset_id="google_ads_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="frank@mozilla.com",
+        email=["frank@mozilla.com", "telemetry-alerts@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+    )
+
+    google_ads_derived__campaign_conversions_by_date__v1.set_upstream(
+        google_ads_derived__campaign_names_map__v1
+    )

--- a/sql/moz-fx-data-shared-prod/fenix_derived/google_ads_campaign_cost_breakdowns_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/google_ads_campaign_cost_breakdowns_v1/query.sql
@@ -1,17 +1,8 @@
-WITH campaigns AS (
-  SELECT
-    CAST(start_date AS DATE) AS start_date,
-    CAST(end_date AS DATE) AS end_date,
-    id,
-    name
-  FROM
-    `moz-fx-data-bq-fivetran`.google_ads.campaign_history
-),
-campaigns_with_persisted_ids AS (
+WITH campaigns_with_persisted_ids AS (
   SELECT
     date,
-    campaigns.name AS name,
-    campaigns.id AS id,
+    campaign_name AS name,
+    id,
     FORMAT(
       "%s (%s)",
       campaigns.name,
@@ -23,15 +14,11 @@ campaigns_with_persisted_ids AS (
   FROM
     `moz-fx-data-bq-fivetran`.google_ads.campaign_conversions_by_date
   JOIN
-    campaigns
-  ON
-    campaign_conversions_by_date.campaign_id = campaigns.id
-    AND campaign_conversions_by_date.date
-    BETWEEN campaigns.start_date
-    AND campaigns.end_date
+    `moz-fx-data-shared-prod`.google_ads_derived.campaign_names_map_v1
+    USING (campaign_id)
   GROUP BY
     date,
-    campaigns.name,
+    campaign_name,
     id
 ),
 install_dou_metrics AS (

--- a/sql/moz-fx-data-shared-prod/google_ads/campaign_names_map/view.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads/campaign_names_map/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.google_ads.campaign_names_map`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.google_ads_derived.campaign_names_map_v1`

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_names_map_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_names_map_v1/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Campaign Names Map
+description: |-
+  A mapping from campaign_id to campaign_name for google_ads campaigns.
+owners:
+- frank@mozilla.com
+labels:
+  incremental: false
+scheduling:
+  dag_name: bqetl_fivetran_google_ads
+  depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_names_map_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_names_map_v1/query.sql
@@ -1,0 +1,14 @@
+WITH campaign_names AS (
+  SELECT
+    id AS campaign_id,
+    name AS campaign_name,
+    row_number() OVER (PARTITION BY id ORDER BY updated_at DESC) = 1 AS is_most_recent_record,
+  FROM
+    `moz-fx-data-bq-fivetran`.google_ads.campaign_history
+)
+SELECT
+  *
+FROM
+  campaign_names
+WHERE
+  is_most_recent_record


### PR DESCRIPTION
The previous table was causing overcounts for the recent data. The join wasn't working as we expected: `id, start_date, end_date` did not form a primary key for the table.

Now we take the most _recent_ row and apply that as the name across all of the data. This, for now, eliminates the ability to change names over time, but we've never done that so we'll cross that bridge when we get there. This was [taken directly from DBT's google_ads model](https://github.com/fivetran/dbt_google_ads_source/blob/main/models/stg_google_ads__campaign_history.sql#L37).

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
