### PR TITLE
Add --skip-dryrun option for CLI validation commands

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -25,6 +25,7 @@ from ..cli.format import format
 from ..cli.utils import (
     is_authenticated,
     is_valid_project,
+    no_dryrun_option,
     paths_matching_name_pattern,
     project_id_option,
     respect_dryrun_skip_option,
@@ -1085,6 +1086,7 @@ def _run_part(
     default=False,
 )
 @respect_dryrun_skip_option(default=False)
+@no_dryrun_option(default=False)
 @click.pass_context
 def validate(
     ctx,
@@ -1094,6 +1096,7 @@ def validate(
     use_cloud_function,
     validate_schemas,
     respect_dryrun_skip,
+    no_dryrun,
 ):
     """Validate queries by dry running, formatting and checking scheduling configs."""
     if name is None:
@@ -1103,16 +1106,22 @@ def validate(
     dataset_dirs = set()
     for query in query_files:
         ctx.invoke(format, paths=[str(query)])
-        ctx.invoke(
-            dryrun,
-            paths=[str(query)],
-            use_cloud_function=use_cloud_function,
-            project=project_id,
-            validate_schemas=validate_schemas,
-            respect_skip=respect_dryrun_skip,
-        )
+
+        if not no_dryrun:
+            ctx.invoke(
+                dryrun,
+                paths=[str(query)],
+                use_cloud_function=use_cloud_function,
+                project=project_id,
+                validate_schemas=validate_schemas,
+                respect_skip=respect_dryrun_skip,
+            )
+
         validate_metadata.validate(query.parent)
         dataset_dirs.add(query.parent.parent)
+
+    if no_dryrun:
+        click.echo("Dry run skipped for query files.")
 
     for dataset_dir in dataset_dirs:
         validate_metadata.validate_datasets(dataset_dir)

--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -173,6 +173,17 @@ def respect_dryrun_skip_option(default=True):
     )
 
 
+def no_dryrun_option(default=False):
+    """Generate a skip_dryrun option."""
+    return click.option(
+        "--no-dryrun",
+        "--no_dryrun",
+        help="Skip running dryrun. " f"Default is {default}.",
+        default=default,
+        is_flag=True,
+    )
+
+
 def temp_dataset_option(default="moz-fx-data-shared-prod.tmp"):
     """Generate a temp-dataset option."""
     return click.option(

--- a/bigquery_etl/cli/view.py
+++ b/bigquery_etl/cli/view.py
@@ -11,6 +11,7 @@ from traceback import print_exc
 import click
 
 from ..cli.utils import (
+    no_dryrun_option,
     parallelism_option,
     paths_matching_name_pattern,
     project_id_option,
@@ -98,6 +99,7 @@ def create(name, sql_dir, project_id, owner):
 )
 @parallelism_option
 @respect_dryrun_skip_option()
+@no_dryrun_option(default=False)
 @click.pass_context
 def validate(
     ctx,
@@ -108,6 +110,7 @@ def validate(
     validate_schemas,
     parallelism,
     respect_dryrun_skip,
+    no_dryrun,
 ):
     """Validate the view definition."""
     view_files = paths_matching_name_pattern(
@@ -121,14 +124,17 @@ def validate(
         sys.exit(1)
 
     # dryrun views
-    ctx.invoke(
-        dryrun,
-        paths=[str(f) for f in view_files],
-        use_cloud_function=use_cloud_function,
-        project=project_id,
-        validate_schemas=validate_schemas,
-        respect_skip=respect_dryrun_skip,
-    )
+    if not no_dryrun:
+        ctx.invoke(
+            dryrun,
+            paths=[str(f) for f in view_files],
+            use_cloud_function=use_cloud_function,
+            project=project_id,
+            validate_schemas=validate_schemas,
+            respect_skip=respect_dryrun_skip,
+        )
+    else:
+        click.echo("Dry run skipped for view files.")
 
     click.echo("All views are valid.")
 


### PR DESCRIPTION
Adding `--skip-dryrun` options to some validation commands. This is for adding CI tests to private-bigquery-etl: https://github.com/mozilla/private-bigquery-etl/pull/179 Most of the views/queries in that repo are restricted, so dryruns will always fail. Running some checks is still useful however, e.g. to detect incorrect references in views (which has caused some issues in the past).


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
