### PR TITLE
bug: tweaked date_partition_parameter scheduling settings for campaign_names_map query

### DIFF
--- a/dags/bqetl_fivetran_google_ads.py
+++ b/dags/bqetl_fivetran_google_ads.py
@@ -63,8 +63,9 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="frank@mozilla.com",
         email=["frank@mozilla.com", "telemetry-alerts@mozilla.com"],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        task_concurrency=1,
     )
 
     google_ads_derived__campaign_conversions_by_date__v1.set_upstream(

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_names_map_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_names_map_v1/metadata.yaml
@@ -8,3 +8,4 @@ labels:
 scheduling:
   dag_name: bqetl_fivetran_google_ads
   depends_on_past: false
+  date_partition_parameter: null


### PR DESCRIPTION
# bug: tweaked date_partition_parameter scheduling settings for campaign_names_map query

This task was added and is not failing due to partitioning configuration.
