### PR TITLE
bug(FXA-6593): reverted fxa_content_events query to use sharded table

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/query.sql
@@ -13,8 +13,16 @@ SELECT
     ) AS jsonPayload
   )
 FROM
-  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_content`
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_content_20*`
 WHERE
   jsonPayload.type = 'amplitudeEvent'
   AND jsonPayload.fields.event_type IS NOT NULL
-  AND DATE(`timestamp`) = @submission_date
+  -- FXA-6593: the partitioned version of the table
+  -- seems to be missing some data.
+  -- For now reverting this query to the sharded version
+  -- Once the issue has been resolves:
+  -- 1. uncomment the DATE(...) = @submission_date line
+  -- 2. Remove the _TABLE_SUFFIX line below
+  -- 3. Change source table to be `docker_fxa_content`
+  -- AND DATE(`timestamp`) = @submission_date
+  AND _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)


### PR DESCRIPTION
# bug(FXA-6593): reverted fxa_content_events query to use sharded table

This is because it appears the partitioned version of the table is partially missing data. There is an open issue for this and will be investigated by the right engineer. Until then we will continue using the sharded table.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
