### PR TITLE
Move check for dags being up to date after DAGs have been generated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,12 @@ jobs:
           name: Generate DAGs
           command: |
             PATH="venv/bin:$PATH" script/bqetl dag generate
-            mv dags/ /tmp/workspace/generated-sql
+            cp -R dags/ /tmp/workspace/generated-sql
+      - run:
+          name: Verify that DAGs were correctly generated and are up-to-date
+          command: |
+            git diff --exit-code dags/
+            diff <(git ls-files dags/*.py) <(ls dags/*.py)
       # this task is overwriting the content produced by generate-sql;
       # the behaviour here is additive, generated DAGs are just added to
       # the generated-sql output
@@ -260,23 +265,6 @@ jobs:
           command: |
             cd telemetry-airflow
             bash bin/test-parse
-  verify-dags-up-to-date:
-    # todo: remove this step once we rely on generate-dags completely
-    docker: *docker
-    steps:
-      - checkout
-      - *restore_venv_cache
-      - *build
-      - *restore_mvn_cache
-      - *java_deps
-      - run:
-          name: Generate DAGs
-          command: PATH="venv/bin:$PATH" script/bqetl dag generate
-      - run:
-          name: Verify that DAGs were correctly generated and are up-to-date
-          command: |
-            git diff --exit-code
-            diff <(git ls-files dags/*.py) <(ls dags/*.py)
   validate-docs:
     docker: *docker
     steps:
@@ -588,7 +576,6 @@ workflows:
       - validate-dags:
           requires:
             - generate-dags
-      - verify-dags-up-to-date
       - validate-docs:
           requires:
             - generate-sql

--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -142,7 +142,7 @@ EXTERNAL_TASKS = {
         task_id="clients_last_seen_joined",
         schedule_interval="0 1 * * *",
         date_partition_offset=-1,
-    ): ["*.clients_last_seen_joined"],
+    ): ["*.clients_last_seen_joined*"],
     # *_stable.* should be matched last since all
     # pattern before are downstream dependencies of
     # copy_deduplicate_all.

--- a/dags/bqetl_mobile_activation.py
+++ b/dags/bqetl_mobile_activation.py
@@ -81,6 +81,21 @@ with DAG(
     fenix_derived__new_profile_activation__v1.set_upstream(
         wait_for_baseline_clients_last_seen
     )
+    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+        task_id="wait_for_copy_deduplicate_all",
+        external_dag_id="copy_deduplicate",
+        external_task_id="copy_deduplicate_all",
+        execution_delta=datetime.timedelta(days=-1, seconds=82800),
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    fenix_derived__new_profile_activation__v1.set_upstream(
+        wait_for_copy_deduplicate_all
+    )
     wait_for_search_derived__mobile_search_clients_daily__v1 = ExternalTaskSensor(
         task_id="wait_for_search_derived__mobile_search_clients_daily__v1",
         external_dag_id="bqetl_mobile_search",

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_v1/metadata.yaml
@@ -16,3 +16,16 @@ bigquery:
 scheduling:
   dag_name: bqetl_mobile_activation
   date_partition_parameter: submission_date
+  referenced_tables:
+  - - 'moz-fx-data-shared-prod'
+    - 'org_mozilla_firefox_stable'
+    - 'first_session_v1'
+  - - 'moz-fx-data-shared-prod'
+    - 'search_derived'
+    - 'mobile_search_clients_daily_v1'
+  - - 'moz-fx-data-shared-prod'
+    - 'fenix'
+    - 'baseline_clients_first_seen'
+  - - 'moz-fx-data-shared-prod'
+    - 'fenix'
+    - 'baseline_clients_last_seen'

--- a/sql_generators/feature_usage/templates/metadata.yaml
+++ b/sql_generators/feature_usage/templates/metadata.yaml
@@ -7,7 +7,6 @@ description: |-
 owners:
   - loines@mozilla.com
   - shong@mozilla.com
-  - cdowhygelund@mozilla.com
   - ascholtz@mozilla.com
   - anicholson@mozilla.com
 labels:


### PR DESCRIPTION
We currently have a separate `verify-dags-up-to-date` task which runs separately from `generate-dags`. We can move the up-to-date check into the `generate-dags` (this way we'll only need to run the generation once) and with this DAGs can now also reference and schedule generated content (which wasn't available in `verify-dags-up-to-date`)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
