### PR TITLE
Bug 1779585 - fix version comparison in public data report query

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_user_activity_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_user_activity_v1/query.sql
@@ -153,7 +153,7 @@ active_clients_weekly AS (
   SELECT
     country_name,
     client_id,
-    split(app_version, '.')[offset(0)] AS major_version,
+    `mozfun.norm.truncate_version`(app_version, "major") AS major_version,
     date_sub(submission_date, INTERVAL days_since_seen DAY) AS last_day_seen,
     week_start
   FROM
@@ -164,7 +164,7 @@ active_clients_weekly AS (
 ),
 latest_releases AS (
   SELECT
-    MAX(SPLIT(build.target.version, '.')[OFFSET(0)]) AS latest_major_version,
+    MAX(`mozfun.norm.truncate_version`(build.target.version, "major")) AS latest_major_version,
     DATE(build.build.date) AS day
   FROM
     `moz-fx-data-shared-prod.telemetry.buildhub2`


### PR DESCRIPTION
This goes together with https://github.com/mozilla/firefox-public-data-report-etl/pull/15

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
