### PR TITLE
RS-595

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/metadata.yaml
@@ -22,6 +22,8 @@ bigquery:
     type: day
     field: submission_date
     require_partition_filter: true
+    expiration_days: null
   clustering:
     fields:
     - sample_id
+references: {}

--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/query.sql
@@ -261,7 +261,13 @@ counted AS (
     )
 )
 SELECT
-  * EXCEPT (_n)
+  * EXCEPT (_n),
+  `moz-fx-data-shared-prod.udf.monetized_search`(
+    engine,
+    country,
+    distribution_id,
+    submission_date
+  ) AS is_sap_monetizable
 FROM
   counted
 WHERE

--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/schema.yaml
@@ -262,3 +262,6 @@ fields:
 - mode: NULLABLE
   name: normalized_engine
   type: STRING
+- mode: NULLABLE
+  name: is_sap_monetizable
+  type: BOOLEAN

--- a/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_access_point_probes/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_access_point_probes/expect.yaml
@@ -27,6 +27,7 @@
   scalar_parent_urlbar_searchmode_topsites_urlbar_sum: []
   scalar_parent_urlbar_searchmode_touchbar_sum: []
   scalar_parent_urlbar_searchmode_typed_sum: []
+  is_sap_monetizable: False
 - <<: *base
   client_id: b
   engine: engine1

--- a/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_aggregation/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/test_aggregation/expect.yaml
@@ -27,6 +27,7 @@
   scalar_parent_urlbar_searchmode_topsites_urlbar_sum: []
   scalar_parent_urlbar_searchmode_touchbar_sum: []
   scalar_parent_urlbar_searchmode_typed_sum: []
+  is_sap_monetizable: False
 - <<: *base
   client_id: b
   engine: engine1


### PR DESCRIPTION
We are adding a new boolean field to search clients daily. This field indicates whether or not the SAP and tagged searches are monetizable. It uses the monetized_search UDF defined [here](https://github.com/mozilla/private-bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/udf/monetized_search/udf.sql#L123).

Jira: [RS-595](https://mozilla-hub.atlassian.net/browse/RS-595)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[RS-595]: https://mozilla-hub.atlassian.net/browse/RS-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ