### PR TITLE
DENG-515 Added os_grouped column to active_user_aggregates table

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/query.sql
@@ -16,6 +16,24 @@ WITH todays_metrics AS (
     normalized_app_name AS app_name,
     normalized_channel AS channel,
     normalized_os AS os,
+    CASE
+    WHEN
+      normalized_os LIKE '%Darwin%'
+    THEN "Mac OS"
+    WHEN
+      normalized_os LIKE '%Windows%'
+      OR normalized_os LIKE 'WINNT%'
+    THEN "Windows"
+    WHEN
+      normalized_os LIKE '%Linux%'
+      OR normalized_os LIKE '%BSD%'
+      OR normalized_os LIKE '%SunOS%'
+      OR normalized_os LIKE '%Solaris%'
+    THEN "Linux"
+    ELSE
+      "Other"
+    END
+    AS os_grouped,
     normalized_os_version AS os_version,
     os_version_major,
     os_version_minor,
@@ -92,6 +110,7 @@ GROUP BY
   app_name,
   channel,
   os,
+  os_grouped,
   os_version,
   os_version_major,
   os_version_minor,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/schema.yaml
@@ -33,6 +33,9 @@ fields:
   name: os
   type: STRING
 - mode: NULLABLE
+  name: os_grouped
+  type: STRING
+- mode: NULLABLE
   name: os_version
   type: STRING
 - mode: NULLABLE


### PR DESCRIPTION
[DENG 515](https://mozilla-hub.atlassian.net/browse/DENG-515):  
There is a need to clean up os grouping.  The current logic exists in lookml and should be moved into big query instead.  

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
