### PR TITLE
DENG-515 Added normalized os column to active_users_aggregates tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
@@ -3,6 +3,6 @@ CREATE OR REPLACE VIEW
 AS
 SELECT
   *,
-  `mozfun.norm.os`(os) AS normalized_os
+  `mozfun.norm.os`(os) AS os_grouped
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.active_users_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
@@ -2,6 +2,7 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
 AS
 SELECT
-  *
+  *,
+  `mozfun.norm.os`(os) AS normalized_os
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.active_users_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates_device/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates_device/view.sql
@@ -2,6 +2,7 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.active_users_aggregates_device`
 AS
 SELECT
-  *
+  *,
+  `mozfun.norm.os`(os) AS normalized_os
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.active_users_aggregates_device_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates_device/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates_device/view.sql
@@ -3,6 +3,6 @@ CREATE OR REPLACE VIEW
 AS
 SELECT
   *,
-  `mozfun.norm.os`(os) AS normalized_os
+  `mozfun.norm.os`(os) AS os_grouped
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.active_users_aggregates_device_v1`


### PR DESCRIPTION
[DENG 515](https://mozilla-hub.atlassian.net/browse/DENG-515):
There is a need to clean up os grouping in the active_users_aggregates tables. The current logic exists in lookml and should be moved into big query views instead.

`Active_users_aggregates_attribution` view was not updated since `os` column does not exist in the table.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
