### PR TITLE
Fix docs formatting

### DIFF
--- a/docs/cookbooks/common_workflows.md
+++ b/docs/cookbooks/common_workflows.md
@@ -121,7 +121,7 @@ The following is an example to update a new field in `telemetry_derived.clients_
     * [x] The `dry-run-sql` task fails.
 1. PR is reviewed and approved.
 1. Deploy schema changes by running:
-   ```
+   ```bash
    ./bqetl query schema deploy telemetry_derived.clients_daily_v6;
    ./bqetl query schema deploy telemetry_derived.clients_daily_joined_v1;
    ./bqetl query schema deploy --force --ignore-dryrun-skip telemetry_derived.clients_last_seen_v1;

--- a/docs/cookbooks/common_workflows.md
+++ b/docs/cookbooks/common_workflows.md
@@ -13,24 +13,24 @@ The [Creating derived datasets tutorial](https://mozilla.github.io/bigquery-etl/
    1. Directories and files are generated automatically
 1. Open `query.sql` file that has been created in `sql/moz-fx-data-shared-prod/<dataset>/<table>_<version>/` to write the query
 1. [Optional] Run `./bqetl query schema update <dataset>.<table>_<version>` to generate the `schema.yaml` file
-    * Optionally add column descriptions to `schema.yaml`
+   * Optionally add column descriptions to `schema.yaml`
 1. Open the `metadata.yaml` file in `sql/moz-fx-data-shared-prod/<dataset>/<table>_<version>/`
-    * Add a description of the query
-    * Add BigQuery information such as table partitioning or clustering
-        * See [clients_daily_v6](https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml) for reference
+   * Add a description of the query
+   * Add BigQuery information such as table partitioning or clustering
+     * See [clients_daily_v6](https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml) for reference
 1. Run `./bqetl query validate <dataset>.<table>_<version>` to dry run and format the query
 1. To schedule the query, first select a DAG from the `./bqetl dag info` list or create a new DAG `./bqetl dag create <bqetl_new_dag>`
 1. Run `./bqetl query schedule <dataset>.<table>_<version> --dag <bqetl_dag>` to schedule the query
 1. Run `./bqetl dag generate <bqetl_dag>` to update the DAG file
 1. Create a pull request
-    * CI fails since table doesn't exist yet
+   * CI fails since table doesn't exist yet
 1. PR gets reviewed and eventually approved
 1. Create destination table: `./bqetl query schema deploy` (requires a `schema.yaml` file to be present)
-     * This step needs to be performed by a data engineer as it requires DE credentials.
+   * This step needs to be performed by a data engineer as it requires DE credentials.
 1. Merge pull-request
 1. Backfill data
-     * Option 1: via Airflow interface
-     * Option 2: `./bqetl query backfill --project-id <project id> <dataset>.<table>_<version>`
+   * Option 1: via Airflow interface
+   * Option 2: `./bqetl query backfill --project-id <project id> <dataset>.<table>_<version>`
 
 ## Update an existing query
 
@@ -39,7 +39,7 @@ The [Creating derived datasets tutorial](https://mozilla.github.io/bigquery-etl/
 1. If the query scheduling metadata has changed, run `./bqetl dag generate <bqetl_dag>` to update the DAG file
 1. If the query adds new columns, run `./bqetl query schema update <dataset>.<table>_<version>` to make local `schema.yaml` updates
 1. Open PR with changes
-    * CI can fail if schema updates haven't been propagated to destination tables, for example when adding new fields
+   * CI can fail if schema updates haven't been propagated to destination tables, for example when adding new fields
 1. PR reviewed and approved
 1. Deploy schema changes by running `./bqetl query schema deploy <dataset>.<table>_<version>`
 1. Merge pull-request
@@ -92,10 +92,10 @@ Adding a new field to a table schema also means that the field has to propagate 
 1. Open the `query.sql` file inside the `<dataset>.<table>` location and add the new definitions for the field.
 1. Run `./bqetl format <path to the query>` to format the query. Alternatively, run `./bqetl format $(git ls-tree -d HEAD --name-only)` validate the format of all queries that have been modified.
 1. Run `./bqetl query validate <dataset>.<table>` to dry run the query.
-    * For data scientists (and anyone without `jobs.create` permissions in `moz-fx-data-shared-prod`), run:
-        * (a) `gcloud auth login --update-adc   # to authenticate to GCP`
-        * (b) `gcloud config set project mozdata    # to set the project`
-        * (c) `./bqetl query validate --use-cloud-function=false --project-id=mozdata <full path to the query file>`
+   * For data scientists (and anyone without `jobs.create` permissions in `moz-fx-data-shared-prod`), run:
+     * (a) `gcloud auth login --update-adc   # to authenticate to GCP`
+     * (b) `gcloud config set project mozdata    # to set the project`
+     * (c) `./bqetl query validate --use-cloud-function=false --project-id=mozdata <full path to the query file>`
 1. Run `./bqetl query schema update <dataset>.<table> --update_downstream` to make local schema.yaml updates and update schemas of downstream dependencies.
    * [x] This requires [GCP access](https://docs.telemetry.mozilla.org/cookbooks/bigquery/access.html#bigquery-access-request).
    * [x] `--update_downstream` is optional as it takes longer. It is recommended when you know that there are downstream dependencies whose `schema.yaml` need to be updated, in which case, the update will happen automatically.
@@ -116,9 +116,9 @@ The following is an example to update a new field in `telemetry_derived.clients_
 1. Run `./bqetl format sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql`
 1. Run `./bqetl query validate telemetry_derived.clients_daily_v6`.
 1. Run `./bqetl query schema update telemetry_derived.clients_daily_v6 --update_downstream`.
-    * [x] `schema.yaml` files of downstream dependencies, like `clients_last_seen_v1` are updated.
+   * [x] `schema.yaml` files of downstream dependencies, like `clients_last_seen_v1` are updated.
 1. Open a PR with these changes.
-    * [x] The `dry-run-sql` task fails.
+   * [x] The `dry-run-sql` task fails.
 1. PR is reviewed and approved.
 1. Deploy schema changes by running:
    ```bash
@@ -148,8 +148,8 @@ Deleting a field from an existing table schema should be done only when is total
 4. Open a PR.
 5. PR gets reviewed, approved and merged.
 6. To publish UDF immediately:
-    * Go to Airflow `mozfun` DAG and clear latest run.
-    * Or else it will get published within a day when mozfun is executed next.
+   * Go to Airflow `mozfun` DAG and clear latest run.
+   * Or else it will get published within a day when mozfun is executed next.
 
 ## Adding a new internal UDF
 
@@ -158,12 +158,12 @@ Internal UDFs are usually only used by specific queries. If your UDF might be us
 1. Run `./bqetl routine create <dataset>.<name> --udf`
 2. Navigate to the `udf.sql` in `sql/moz-fx-data-shared-prod/<dataset>/<name>/` file and add UDF definition and tests
 3. Run `./bqetl routine validate <dataset>.<name>` for formatting and running tests
-    * Before running the tests, you need to [setup the access to the Google Cloud API](https://mozilla.github.io/bigquery-etl/cookbooks/testing/).
+   * Before running the tests, you need to [setup the access to the Google Cloud API](https://mozilla.github.io/bigquery-etl/cookbooks/testing/).
 5. Open a PR
 6. PR gets reviewed and approved and merged
 7. To publish UDF immediately:
-    * Run `./bqetl routine publish`
-    * Or else it will take a day until UDF gets published automatically
+   * Run `./bqetl routine publish`
+   * Or else it will take a day until UDF gets published automatically
 
 ## Adding a stored procedure
 
@@ -179,7 +179,7 @@ The same steps as creating a new UDF apply for creating stored procedures, excep
 ## Renaming an existing UDF
 
 1. Run `./bqetl mozfun rename <dataset>.<name> <new_dataset>.<new_name>`
-    * References in queries to the UDF are automatically updated
+   * References in queries to the UDF are automatically updated
 1. Open a PR
 1. PR gets reviews, approved and merged
 
@@ -231,14 +231,14 @@ See also the reference for [Public Data](../reference/public_data.md).
 
 1. Get a data review by following the [data publishing process](https://wiki.mozilla.org/Data_Publishing#Dataset_Publishing_Process_2)
 1. Update the `metadata.yaml` file of the query to be published
-    * Set `public_bigquery: true` and optionally `public_json: true`
-    * Specify the `review_bugs`
+   * Set `public_bigquery: true` and optionally `public_json: true`
+   * Specify the `review_bugs`
 1. If an internal dataset already exists, move it to `mozilla-public-data`
 1. If an `init.sql` file exists for the query, change the destination project for the created table to `mozilla-public-data`
 1. Run `./bqetl dag generate bqetl_public_public_data_json` to update the DAG
 1. Open a PR
 1. PR gets reviewed, approved and merged
-    * Once, ETL is running a view will get automatically published to `moz-fx-data-shared-prod` referencing the public dataset
+   * Once, ETL is running a view will get automatically published to `moz-fx-data-shared-prod` referencing the public dataset
 
 ## Adding new Python requirements
 

--- a/docs/cookbooks/testing.md
+++ b/docs/cookbooks/testing.md
@@ -2,7 +2,7 @@
 
 This repository uses `pytest`:
 
-```
+```bash
 # create a venv
 python3.10 -m venv venv/
 
@@ -108,7 +108,7 @@ Simply name the test `test_init`. The other guidelines still apply.
 _Note_: Init SQL statements must contain a create statement with the dataset
 and table name, like so:
 
-```
+```sql
 CREATE OR REPLACE TABLE
   dataset.table_v1
 AS
@@ -152,7 +152,7 @@ AS
 - Run `circleci build` and set required environment variables `GOOGLE_PROJECT_ID` and
   `GCLOUD_SERVICE_KEY`:
 
-```
+```bash
 gcloud_service_key=`cat /path/to/key_file.json`
 
 # to run a specific job, e.g. integration:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -24,6 +24,8 @@ google_analytics:
 
 markdown_extensions:
   - mdx_truly_sane_lists
+  - pymdownx.highlight
+  - pymdownx.superfences
 plugins:
   - search
   - awesome-pages

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -22,6 +22,8 @@ google_analytics:
   - UA-104326577-3
   - auto
 
+markdown_extensions:
+  - mdx_truly_sane_lists
 plugins:
   - search
   - awesome-pages

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -26,6 +26,7 @@ markdown_extensions:
   - mdx_truly_sane_lists
   - pymdownx.highlight
   - pymdownx.superfences
+  - pymdownx.tasklist
 plugins:
   - search
   - awesome-pages

--- a/docs/reference/recommended_practices.md
+++ b/docs/reference/recommended_practices.md
@@ -131,7 +131,7 @@ labels:
   Errors normally appear in the parent job and may or may not include the dataset and
   table names, therefore it is important to check for errors in the jobs ran on that date.
   Here is a query you may use for this purpose:
-  ```
+  ```sql
   SELECT
     job_id,
     user_email,

--- a/requirements.in
+++ b/requirements.in
@@ -10,6 +10,7 @@ google-cloud-storage==2.5.0
 Jinja2==3.1.2
 jsonschema==4.17.0
 markdown-include==0.7.0
+mdx_truly_sane_lists==1.3
 mkdocs==1.4.2
 mkdocs-material==8.5.7
 mkdocs-awesome-pages-plugin==2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -552,6 +552,7 @@ markdown==3.3.7 \
     --hash=sha256:f5da449a6e1c989a4cea2631aa8ee67caa5a2ef855d551c88f9e309f4634c621
     # via
     #   markdown-include
+    #   mdx-truly-sane-lists
     #   mkdocs
     #   mkdocs-material
     #   pymdown-extensions
@@ -604,6 +605,10 @@ mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
     # via flake8
+mdx-truly-sane-lists==1.3 \
+    --hash=sha256:b661022df7520a1e113af7c355c62216b384c867e4f59fb8ee7ad511e6e77f45 \
+    --hash=sha256:b9546a4c40ff8f1ab692f77cee4b6bfe8ddf9cccf23f0a24e71f3716fe290a37
+    # via -r requirements.in
 mergedeep==1.3.4 \
     --hash=sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8 \
     --hash=sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307


### PR DESCRIPTION
Most nested lists in the generated [BigQuery ETL docs](https://mozilla.github.io/bigquery-etl/) have ended up improperly formatted in HTML, because by default mkdocs requires nested lists to be indented by four spaces in Markdown ([ref](https://github.com/mkdocs/mkdocs/issues/545#issuecomment-316821418)), but most nested lists in our docs haven't been formatted that way (probably because many people are more used to [GitHub Flavored Markdown](https://github.github.com/gfm/), which is more lenient when it comes to list formatting).

To allow more lenient Markdown list formatting in our docs this adds and enables the [mdx_truly_sane_lists](https://github.com/radude/mdx_truly_sane_lists) extension with mkdocs.  Note that some existing nested lists which had been formatted to work with the previously required four-space indents did need to be reformatted to work with the new list parsing setup.

This also adds a few more niceties to the docs formatting:
- Syntax highlighting in fenced code blocks.
- Fenced code blocks supported within lists.
- Support for GitHub Flavored Markdown's task lists, which are currently used in several places on the [common workflows](https://mozilla.github.io/bigquery-etl/cookbooks/common_workflows/) page ([example](https://github.com/mozilla/bigquery-etl/blob/afea1c35b9918f74128102247521bc964d81419f/docs/cookbooks/common_workflows.md?plain=1#L100-L102)).

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
