### PR TITLE
Don't use legacy subscription ids from guardian for apple subscriptions

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform/apple_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/apple_subscriptions/view.sql
@@ -5,7 +5,6 @@ WITH apple_iap_events AS (
   SELECT
     document_id,
     -- WARNING: field order from here must exactly match guardian_apple_events_v1
-    CAST(NULL AS STRING) AS legacy_subscription_id,
     `timestamp` AS event_timestamp,
     mozfun.iap.parse_apple_event(`data`).*,
   FROM
@@ -82,10 +81,7 @@ apple_iap_period_aggregates AS (
     periods.start_time,
     periods.end_time,
     periods.period_offset,
-    COALESCE(
-      MAX(events.legacy_subscription_id),
-      periods.original_transaction_id
-    ) AS original_subscription_id,
+    periods.original_transaction_id,
     MIN(events.original_purchase_date) AS original_purchase_date,
     ARRAY_AGG(DISTINCT events.offer_identifier IGNORE NULLS) AS promotion_codes,
     ARRAY_AGG(

--- a/sql/moz-fx-data-shared-prod/subscription_platform/apple_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/apple_subscriptions/view.sql
@@ -81,7 +81,7 @@ apple_iap_period_aggregates AS (
     periods.start_time,
     periods.end_time,
     periods.period_offset,
-    periods.original_transaction_id,
+    periods.original_transaction_id AS original_subscription_id,
     MIN(events.original_purchase_date) AS original_purchase_date,
     ARRAY_AGG(DISTINCT events.offer_identifier IGNORE NULLS) AS promotion_codes,
     ARRAY_AGG(

--- a/sql/moz-fx-data-shared-prod/subscription_platform/nonprod_apple_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/nonprod_apple_subscriptions/view.sql
@@ -5,7 +5,6 @@ WITH apple_iap_events AS (
   SELECT
     document_id,
     -- WARNING: field order from here must exactly match guardian_apple_events_v1
-    CAST(NULL AS STRING) AS legacy_subscription_id,
     `timestamp` AS event_timestamp,
     mozfun.iap.parse_apple_event(`data`).*,
   FROM
@@ -82,10 +81,7 @@ apple_iap_period_aggregates AS (
     periods.start_time,
     periods.end_time,
     periods.period_offset,
-    COALESCE(
-      MAX(events.legacy_subscription_id),
-      periods.original_transaction_id
-    ) AS original_subscription_id,
+    periods.original_transaction_id,
     MIN(events.original_purchase_date) AS original_purchase_date,
     ARRAY_AGG(DISTINCT events.offer_identifier IGNORE NULLS) AS promotion_codes,
     ARRAY_AGG(

--- a/sql/moz-fx-data-shared-prod/subscription_platform/nonprod_apple_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/nonprod_apple_subscriptions/view.sql
@@ -81,7 +81,7 @@ apple_iap_period_aggregates AS (
     periods.start_time,
     periods.end_time,
     periods.period_offset,
-    periods.original_transaction_id,
+    periods.original_transaction_id AS original_subscription_id,
     MIN(events.original_purchase_date) AS original_purchase_date,
     ARRAY_AGG(DISTINCT events.offer_identifier IGNORE NULLS) AS promotion_codes,
     ARRAY_AGG(

--- a/sql/mozfun/iap/parse_apple_event/udf.sql
+++ b/sql/mozfun/iap/parse_apple_event/udf.sql
@@ -2,7 +2,6 @@ CREATE OR REPLACE FUNCTION iap.parse_apple_event(input STRING) AS (
   -- WARNING: subscription_platform.apple_subscriptions and
   -- subscription_platform.nonprod_apple_subscriptions require field order of
   -- mozilla_vpn_derived.guardian_apple_events_v1 to exactly match:
-  --   legacy_subscription_id,
   --   event_timestamp,
   --   mozfun.iap.parse_apple_event(`data`).*,
   STRUCT(


### PR DESCRIPTION
This requires updating historical subscription ids with the following DML:

<details>
<summary>migration.sql</summary>

```
UPDATE
  `moz-fx-data-shared-prod`.mozilla_vpn_derived.active_subscription_ids_v1
SET
  subscription_id = migration.original_transaction_id
FROM
  (
    SELECT DISTINCT
      CAST(id AS STRING) AS legacy_subscription_id,
      original_transaction_id,
    FROM
      (
        SELECT
          id,
          mozfun.iap.parse_apple_receipt(provider_receipt_json) AS apple_receipt,
        FROM
          `moz-fx-data-shared-prod`.mozilla_vpn_external.subscriptions_v1 AS subscriptions
        WHERE
          -- Subscriptions migrated to fxa no longer have subscriptions.provider = "APPLE"
          provider_receipt_json IS NOT NULL
          AND JSON_VALUE(provider_receipt_json, "$.receipt.bundle_id") = "org.mozilla.ios.FirefoxVPN"
          -- Exclude duplicate subscriptions rejected by FxA migration
          AND provider IS DISTINCT FROM "FXANOMIGRATE"
      )
    CROSS JOIN
      UNNEST(
        ARRAY(
          SELECT AS STRUCT
            original_transaction_id
          FROM
            UNNEST(apple_receipt.latest_receipt_info)
          ORDER BY
            original_purchase_date_ms DESC
          LIMIT
            1
        )
      )
    WHERE
      apple_receipt.environment = "Production"
  ) AS migration
WHERE
  active_subscription_ids_v1.subscription_id = migration.legacy_subscription_id
```

</details>