### PR TITLE
Bug 1813015 - Account for new (optional) client_info field in VPN view

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/deletion_request/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/deletion_request/view.sql
@@ -25,7 +25,8 @@ SELECT
       client_info.os AS os,
       client_info.os_version AS os_version,
       client_info.telemetry_sdk_build AS telemetry_sdk_build,
-      client_info.build_date AS build_date
+      client_info.build_date AS build_date,
+      NULL AS windows_build_number -- will never exist on Android
     ) AS client_info,
     (
       SELECT AS STRUCT

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/deletion_request/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/deletion_request/view.sql
@@ -26,7 +26,9 @@ SELECT
       client_info.os_version AS os_version,
       client_info.telemetry_sdk_build AS telemetry_sdk_build,
       client_info.build_date AS build_date,
-      CAST(NULL AS INT64) AS windows_build_number  -- will never exist on Android
+      CAST(
+        NULL AS INT64
+      ) AS windows_build_number  -- will never exist on Android
     ) AS client_info,
     (
       SELECT AS STRUCT

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/deletion_request/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/deletion_request/view.sql
@@ -26,7 +26,7 @@ SELECT
       client_info.os_version AS os_version,
       client_info.telemetry_sdk_build AS telemetry_sdk_build,
       client_info.build_date AS build_date,
-      NULL AS windows_build_number -- will never exist on Android
+      CAST(NULL AS INT64) AS windows_build_number  -- will never exist on Android
     ) AS client_info,
     (
       SELECT AS STRUCT

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/main/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/main/view.sql
@@ -25,7 +25,8 @@ SELECT
       client_info.os AS os,
       client_info.os_version AS os_version,
       client_info.telemetry_sdk_build AS telemetry_sdk_build,
-      client_info.build_date AS build_date
+      client_info.build_date AS build_date,
+      NULL AS windows_build_number -- will never exist on Android
     ) AS client_info,
     (
       SELECT AS STRUCT

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/main/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/main/view.sql
@@ -26,7 +26,9 @@ SELECT
       client_info.os_version AS os_version,
       client_info.telemetry_sdk_build AS telemetry_sdk_build,
       client_info.build_date AS build_date,
-      CAST(NULL AS INT64) AS windows_build_number  -- will never exist on Android
+      CAST(
+        NULL AS INT64
+      ) AS windows_build_number  -- will never exist on Android
     ) AS client_info,
     (
       SELECT AS STRUCT

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/main/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/main/view.sql
@@ -26,7 +26,7 @@ SELECT
       client_info.os_version AS os_version,
       client_info.telemetry_sdk_build AS telemetry_sdk_build,
       client_info.build_date AS build_date,
-      NULL AS windows_build_number -- will never exist on Android
+      CAST(NULL AS INT64) AS windows_build_number  -- will never exist on Android
     ) AS client_info,
     (
       SELECT AS STRUCT


### PR DESCRIPTION
This currently causes queries against this view to fail because of a field mismatch in the `client_info` subfields.
This field was recently added, but will only ever be available on Windows (for obvious reason).
Nonetheless the column exists everywhere.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
