### PR TITLE
Bug 1811572 add new column to schema_error_counts

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/query.sql
@@ -20,7 +20,21 @@ count_errors AS (
     hour,
     job_name,
     `moz-fx-data-shared-prod.udf.extract_schema_validation_path`(error_message) AS path,
-    COUNT(*) AS error_count
+    COUNT(*) AS error_count,
+    -- aggregating distinct error messages to show sample_error messages
+    -- removing path and exception_class for better readability
+    SUBSTR(
+      STRING_AGG(
+        DISTINCT REPLACE(
+          REPLACE(error_message, "org.everit.json.schema.ValidationException: ", ""),
+          CONCAT(`moz-fx-data-shared-prod.udf.extract_schema_validation_path`(error_message), ": "),
+          ""
+        ),
+        "; "
+      ),
+      0,
+      300
+    ) AS sample_error_messages
   FROM
     extracted
   GROUP BY

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/schema.yaml
@@ -1,0 +1,29 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+- mode: NULLABLE
+  name: document_namespace
+  type: STRING
+- mode: NULLABLE
+  name: document_type
+  type: STRING
+- mode: NULLABLE
+  name: document_version
+  type: STRING
+- mode: NULLABLE
+  name: hour
+  type: TIMESTAMP
+- mode: NULLABLE
+  name: job_name
+  type: STRING
+- mode: NULLABLE
+  name: path
+  type: STRING
+- mode: NULLABLE
+  name: error_count
+  type: INTEGER
+- mode: NULLABLE
+  name: sample_error_messages
+  type: STRING
+  description: concatenated error messages, limited to 300 characters


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
