### PR TITLE
Add a documentation note on faster single test execution

### DIFF
--- a/docs/cookbooks/testing.md
+++ b/docs/cookbooks/testing.md
@@ -21,6 +21,9 @@ mvn package
 # use -k to selectively run a set of tests that matches the expression `udf`
 ./venv/bin/pytest -k udf
 
+# narrow down testpaths for quicker turnaround when selecting a single test
+./venv/bin/pytest -o "testpaths=tests/sql" -k mobile_search_aggregates_v1
+
 # run integration tests with 4 workers in parallel
 gcloud auth application-default login # or set GOOGLE_APPLICATION_CREDENTIALS
 export GOOGLE_PROJECT_ID=bigquery-etl-integration-test


### PR DESCRIPTION
@lelilia following up on our discussion last week - narrowing down `testpaths` speeds up single test execution. On my machine it cuts ~1 min from the run time.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
