### PR TITLE
Bug 1805722 - Deprecate desktop event rollup

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -407,6 +407,9 @@ bqetl_monitoring_airflow:
 
 bqetl_event_rollup:
   schedule_interval: 0 3 * * *
+  description: |
+    Desktop tables (`telemetry_derived.events_daily_v1` and upstream) are deprecated and paused
+    (have their scheduling metadata commented out) per https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
   default_args:
     owner: wlachance@mozilla.com
     start_date: "2020-11-03"

--- a/dags/bqetl_event_rollup.py
+++ b/dags/bqetl_event_rollup.py
@@ -13,6 +13,11 @@ docs = """
 
 Built from bigquery-etl repo, [`dags/bqetl_event_rollup.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/bqetl_event_rollup.py)
 
+#### Description
+
+Desktop tables (`telemetry_derived.events_daily_v1` and upstream) are deprecated and paused
+(have their scheduling metadata commented out) per https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
+
 #### Owner
 
 wlachance@mozilla.com
@@ -158,41 +163,6 @@ with DAG(
         depends_on_past=False,
     )
 
-    telemetry_derived__event_types__v1 = bigquery_etl_query(
-        task_id="telemetry_derived__event_types__v1",
-        destination_table="event_types_v1",
-        dataset_id="telemetry_derived",
-        project_id="moz-fx-data-shared-prod",
-        owner="wlachance@mozilla.com",
-        email=["akomar@mozilla.com", "wlachance@mozilla.com"],
-        date_partition_parameter=None,
-        depends_on_past=False,
-        task_concurrency=1,
-        parameters=["submission_date:DATE:{{ds}}"],
-    )
-
-    telemetry_derived__event_types_history__v1 = bigquery_etl_query(
-        task_id="telemetry_derived__event_types_history__v1",
-        destination_table="event_types_history_v1",
-        dataset_id="telemetry_derived",
-        project_id="moz-fx-data-shared-prod",
-        owner="wlachance@mozilla.com",
-        email=["akomar@mozilla.com", "wlachance@mozilla.com"],
-        date_partition_parameter="submission_date",
-        depends_on_past=True,
-    )
-
-    telemetry_derived__events_daily__v1 = bigquery_etl_query(
-        task_id="telemetry_derived__events_daily__v1",
-        destination_table="events_daily_v1",
-        dataset_id="telemetry_derived",
-        project_id="moz-fx-data-shared-prod",
-        owner="wlachance@mozilla.com",
-        email=["akomar@mozilla.com", "wlachance@mozilla.com"],
-        date_partition_parameter="submission_date",
-        depends_on_past=False,
-    )
-
     firefox_accounts_derived__event_types__v1.set_upstream(
         firefox_accounts_derived__event_types_history__v1
     )
@@ -286,13 +256,3 @@ with DAG(
     mozilla_vpn_derived__events_daily__v1.set_upstream(
         mozilla_vpn_derived__event_types__v1
     )
-
-    telemetry_derived__event_types__v1.set_upstream(
-        telemetry_derived__event_types_history__v1
-    )
-
-    telemetry_derived__event_types_history__v1.set_upstream(
-        wait_for_copy_deduplicate_all
-    )
-
-    telemetry_derived__events_daily__v1.set_upstream(telemetry_derived__event_types__v1)

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_history_v1/metadata.yaml
@@ -7,6 +7,7 @@ description: >
   and record them in a table.
   This table stores all of history, partitioned by
   submission_date.
+  Deprecated per https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
 owners:
   - wlachance@mozilla.com
   - akomar@mozilla.com
@@ -14,9 +15,10 @@ labels:
   application: telemetry
   incremental: true
   schedule: daily
-scheduling:
-  dag_name: bqetl_event_rollup
-  depends_on_past: true
+# see https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
+#scheduling:
+#  dag_name: bqetl_event_rollup
+#  depends_on_past: true
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_v1/metadata.yaml
@@ -3,7 +3,8 @@
 ---
 friendly_name: Firefox Event Types
 description: >
-  A materialized view of the most recent day of event_types data
+  A materialized view of the most recent day of event_types data.
+  Deprecated per https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
 owners:
   - wlachance@mozilla.com
   - akomar@mozilla.com
@@ -11,10 +12,11 @@ labels:
   application: telemetry
   incremental: false
   schedule: daily
-scheduling:
-  dag_name: bqetl_event_rollup
-  date_partition_parameter: null
-  parameters: ["submission_date:DATE:{{ds}}"]
-  referenced_tables: [['moz-fx-data-shared-prod',
-                       'telemetry_derived',
-                       'event_types_history_v1']]
+# see https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
+#scheduling:
+#  dag_name: bqetl_event_rollup
+#  date_partition_parameter: null
+#  parameters: ["submission_date:DATE:{{ds}}"]
+#  referenced_tables: [['moz-fx-data-shared-prod',
+#                       'telemetry_derived',
+#                       'event_types_history_v1']]

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_daily_v1/metadata.yaml
@@ -3,7 +3,8 @@
 ---
 friendly_name: 'Firefox Events Daily'
 description: >
-  Packed event representation with one-row per-client
+  Packed event representation with one-row per-client.
+  Deprecated per https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
 owners:
   - wlachance@mozilla.com
   - akomar@mozilla.com
@@ -11,15 +12,16 @@ labels:
   application: telemetry
   schedule: daily
   incremental: true
-scheduling:
-  dag_name: bqetl_event_rollup
-  referenced_tables: [
-    [
-      'moz-fx-data-shared-prod',
-      'telemetry_derived',
-      'event_types_v1'
-    ],
-  ]
+# see https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
+#scheduling:
+#  dag_name: bqetl_event_rollup
+#  referenced_tables: [
+#    [
+#      'moz-fx-data-shared-prod',
+#      'telemetry_derived',
+#      'event_types_v1'
+#    ],
+#  ]
 bigquery:
   time_partitioning:
     type: day

--- a/sql_generators/events_daily/templates/event_types_history_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/event_types_history_v1/templating.yaml
@@ -9,13 +9,14 @@ fenix_derived:
     - time_ms
   max_property_values: 1000
   dag_name: bqetl_fenix_event_rollup
-telemetry_derived:
-  name: Firefox
-  dataset: telemetry
-  source_table: telemetry_derived.deanonymized_events
-  start_date: 2020-01-01
-  max_property_values: 5000
-  dag_name: bqetl_event_rollup
+# see https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
+#telemetry_derived:
+#  name: Firefox
+#  dataset: telemetry
+#  source_table: telemetry_derived.deanonymized_events
+#  start_date: 2020-01-01
+#  max_property_values: 5000
+#  dag_name: bqetl_event_rollup
 messaging_system_derived:
   name: Firefox Messaging System
   dataset: messaging_system

--- a/sql_generators/events_daily/templates/event_types_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/event_types_v1/templating.yaml
@@ -2,10 +2,11 @@ fenix_derived:
   name: Firefox for Android
   dataset: fenix
   dag_name: bqetl_fenix_event_rollup
-telemetry_derived:
-  name: Firefox
-  dataset: telemetry
-  dag_name: bqetl_event_rollup
+# see https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
+#telemetry_derived:
+#  name: Firefox
+#  dataset: telemetry
+#  dag_name: bqetl_event_rollup
 messaging_system_derived:
   name: Firefox Messaging System
   dataset: messaging_system

--- a/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
@@ -29,38 +29,39 @@ fenix_derived:
       dest: telemetry_sdk_build
     - src: locale
       dest: locale
-telemetry_derived:
-  name: Firefox
-  include_normalized_fields: True
-  include_metadata_fields: True
-  glean: False
-  dataset: telemetry
-  source_table: telemetry_derived.deanonymized_events
-  start_date: 2020-01-01
-  dag_name: bqetl_event_rollup
-  user_properties:
-    - src: application.build_id
-      dest: build_id
-    - src: environment.build.architecture
-      dest: build_architecture
-    - src: environment.profile.creation_date
-      dest: profile_creation_date
-      type: FLOAT64
-    - src: environment.settings.is_default_browser
-      dest: is_default_browser
-      type: BOOL
-    - src: environment.settings.attribution.source
-      dest: attribution_source
-    - src: metadata.uri.app_version
-      dest: app_version
-    - src: environment.settings.locale
-      dest: locale
-    - src: environment.partner.distribution_id
-      dest: distribution_id
-    - src: environment.settings.attribution.ua
-      dest: attribution_ua
-    - src: application.display_version
-      dest: display_version
+# see https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
+#telemetry_derived:
+#  name: Firefox
+#  include_normalized_fields: True
+#  include_metadata_fields: True
+#  glean: False
+#  dataset: telemetry
+#  source_table: telemetry_derived.deanonymized_events
+#  start_date: 2020-01-01
+#  dag_name: bqetl_event_rollup
+#  user_properties:
+#    - src: application.build_id
+#      dest: build_id
+#    - src: environment.build.architecture
+#      dest: build_architecture
+#    - src: environment.profile.creation_date
+#      dest: profile_creation_date
+#      type: FLOAT64
+#    - src: environment.settings.is_default_browser
+#      dest: is_default_browser
+#      type: BOOL
+#    - src: environment.settings.attribution.source
+#      dest: attribution_source
+#    - src: metadata.uri.app_version
+#      dest: app_version
+#    - src: environment.settings.locale
+#      dest: locale
+#    - src: environment.partner.distribution_id
+#      dest: distribution_id
+#    - src: environment.settings.attribution.ua
+#      dest: attribution_ua
+#    - src: application.display_version
+#      dest: display_version
 messaging_system_derived:
   name: Firefox Messaging System
   include_normalized_fields: False


### PR DESCRIPTION
I've paused the DAG in Airflow per https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10, this adds a documentation note. We'll revisit this soon when we'll have concrete plans for handling event analysis.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
