### PR TITLE
Fix data type for fivetran_costs_derived.montly_costs

### DIFF
--- a/sql/moz-fx-data-shared-prod/fivetran_costs_derived/monthly_costs_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fivetran_costs_derived/monthly_costs_v1/schema.yaml
@@ -16,6 +16,6 @@ fields:
     Total credits used by the destination for the given month. Only used until September 2022 when Fivetran switched to USD.
 - mode: NULLABLE
   name: dollars_spent
-  type: NUMERIC
+  type: BIGNUMERIC
   description: |
     Total USD used by the destination for the given month. Since September 2022 Fivetran gives the costs in USD.


### PR DESCRIPTION
The provided schema doesn't match with what is deployed