### PR TITLE
DENG-601 Add is_default_browser and uri_count for Klar iOS

### DIFF
--- a/dags/bqetl_analytics_aggregations.py
+++ b/dags/bqetl_analytics_aggregations.py
@@ -87,7 +87,7 @@ with DAG(
             task_id="bqetl_search_dashboard__wait_for_active_users_aggregates_device_v1",
             external_dag_id="bqetl_search_dashboard",
             external_task_id="wait_for_active_users_aggregates_device_v1",
-            execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=75600)).isoformat() }}",
+            execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=84600)).isoformat() }}",
         )
 
         active_users_aggregates_device_v1_external.set_upstream(

--- a/dags/bqetl_search_dashboard.py
+++ b/dags/bqetl_search_dashboard.py
@@ -159,7 +159,7 @@ with DAG(
         task_id="wait_for_active_users_aggregates_device_v1",
         external_dag_id="bqetl_analytics_aggregations",
         external_task_id="active_users_aggregates_device_v1",
-        execution_delta=datetime.timedelta(seconds=10800),
+        execution_delta=datetime.timedelta(seconds=1800),
         check_existence=True,
         mode="reschedule",
         allowed_states=ALLOWED_STATES,

--- a/sql_generators/glean_usage/templates/metrics_templating.yaml
+++ b/sql_generators/glean_usage/templates/metrics_templating.yaml
@@ -27,3 +27,9 @@ focus_android:
     counter: true
   is_default_browser:
     sql: "LOGICAL_OR(metrics.boolean.browser_is_default)"
+klar_ios:
+  uri_count:
+    sql: "SUM(metrics.counter.browser_total_uri_count)"
+    counter: true
+  is_default_browser:
+    sql: "LOGICAL_OR(metrics.counter.app_opened_as_default_browser > 0)"


### PR DESCRIPTION
This PR complements `org_mozilla_ios_klar.metrics` to align with the other browsers. It's adding `uri_count` & `is_default_browser`, which follows [same approach of Firefox iOS](https://github.com/mozilla/bigquery-etl/blob/8913f6543eced30d502f67c298a881d35d44b2d7/sql/moz-fx-data-shared-prod/firefox_ios_derived/metrics_clients_daily_v1/query.sql#L9).

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
