### PR TITLE
Bug(FXA-6695): ensuring fxa_users_last_seen is not run until fxa_users_daily task completes

### DIFF
--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -424,6 +424,10 @@ with DAG(
         firefox_accounts_derived__fxa_stdout_events__v1
     )
 
+    firefox_accounts_derived__fxa_users_last_seen__v1.set_upstream(
+        firefox_accounts_derived__fxa_users_daily__v1
+    )
+
     firefox_accounts_derived__fxa_users_services_daily__v1.set_upstream(
         firefox_accounts_derived__fxa_auth_events__v1
     )

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v1/metadata.yaml
@@ -19,6 +19,12 @@ scheduling:
   dag_name: bqetl_fxa_events
   depends_on_past: true
   start_date: '2019-04-23'
+  referenced_tables:
+    - [
+      'moz-fx-data-shared-prod',
+      'firefox_accounts_derived',
+      'fxa_users_daily_v1'
+    ]
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
# ensuring fxa_users_last_seen is not run until fxa_users_daily task completes