### PR TITLE
Prevent glean_usage generation if referenced dataset doesn't exist

### DIFF
--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -108,8 +108,8 @@ def referenced_table_exists(view_sql):
     # since dryruns on views will also return 403 due to the table CREATE
     # 404 is returned if referenced table or view doesn't exist
     return not any([
-        404 == e.get("code") or 
-        (403 == e.get("code") and "does not exist in location" in e.get("message")) 
+        404 == e.get("code")
+        or (403 == e.get("code") and "bigquery.tables.create denied" not in e.get("message")) 
         for e in dryrun.errors()
     ])
 


### PR DESCRIPTION
I could reproduce the issue described in https://mozilla.slack.com/archives/C01E8GDG80N/p1675877827569069 and earlier with`treeherder`. The generation logic checks if referenced tables in generated queries exist and aborts if they don't. However, if a dataset that is referenced does not exist dryrun returns a different error code which was considered as "all references exist" (even though they didn't). This resulted in some tables and the `dataset_metadata.yaml` getting created, which resulted in the dataset actually being deployed. So in the next run the dryrun did get the correct error code for missing references and deleted the generated datasets again.

This should fix this issue.

cc @whd 