### PR TITLE
Sidefill newtab.opened and filter invalid events in newtab_interactions

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
@@ -244,6 +244,6 @@ FROM
   side_filled
 WHERE
    -- If we're not able to attach newtab_open_source and newtab_visit_started_at,
-   -- we haven't received a valid newtab.opened event:
+   -- we haven't received a valid newtab.opened event within the partition (submission date):
   newtab_open_source IS NOT NULL
   AND newtab_visit_started_at IS NOT NULL

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
@@ -242,7 +242,10 @@ side_filled AS (
       OR pocket_impressions > 0
       OR pocket_clicks > 0
       OR pocket_saves > 0
-    ) OVER (PARTITION BY newtab_visit_id) AS visit_had_any_interaction
+    ) OVER (
+      PARTITION BY
+        newtab_visit_id
+    ) AS visit_had_any_interaction -- Note this will have to be updated when other valid interactions are added.
   FROM
     aggregated_newtab_activity
   LEFT JOIN
@@ -256,5 +259,7 @@ FROM
   side_filled
 WHERE
    -- Keep only rows with interactions, unless we receive a valid newtab.opened event.
+   -- This is meant to drop only interactions that only have a newtab.closed event on the same partition
+   -- (these are suspected to be from pre-loaded tabs)
   visit_had_any_interaction = TRUE
   OR (visit_had_any_interaction = FALSE AND newtab_open_source IS NOT NULL)

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
@@ -245,5 +245,5 @@ FROM
 WHERE
    -- If we're not able to attach newtab_open_source and newtab_visit_started_at,
    -- we haven't received a valid newtab.opened event:
-   newtab_open_source IS NOT NULL
-   AND newtab_visit_started_at IS NOT NULL
+  newtab_open_source IS NOT NULL
+  AND newtab_visit_started_at IS NOT NULL

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
@@ -203,7 +203,7 @@ client_profile_info AS (
     ANY_VALUE(is_new_profile) AS is_new_profile,
     ANY_VALUE(activity_segment) AS activity_segment
   FROM
-    telemetry_derived.unified_metrics_v1
+    `moz-fx-data-shared-prod.telemetry_derived.unified_metrics_v1`
   WHERE
     submission_date = @submission_date
   GROUP BY


### PR DESCRIPTION
This addresses two problems that led to over-counting visits in some cases:
1. Some valid interactions are not tagged with their newtab_open_source. This led to some visits having one interaction with a null `visit_id` and another with the actual `visit_id`
2. Some visits come from tab-preloading. We identify these by the fact that they do not have a `newtab.opened` event which has `newtab_open_source` and `newtab_visit_started_at` as extras OR any interactions. 

As a side note, we remove interactions without a `visit_id`, these won't be valid in any case.

See analysis of difference [here](https://sql.telemetry.mozilla.org/queries/90564/source) and broader context [here](https://docs.google.com/document/d/1chY8z6noN5CF3k8YX2TPThLRF3bTGuUR93zUZR8nX1Q/edit#) and [here](https://docs.google.com/document/d/1ShDAY-PfOakCwA00t_pvOwIYDJpYOifVEIPMTM30-a4/edit#).