### PR TITLE
DENG-685 Fix tables inventory dates

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/metadata.yaml
@@ -12,4 +12,3 @@ bigquery:
   time_partitioning:
     type: day
     field: submission_date
-    require_partition_filter: true


### PR DESCRIPTION
[DENG-685](https://mozilla-hub.atlassian.net/browse/DENG-685):
* partition filter requirement was removed given small table size (~100MB)
* It was discovered that `submission_date` captured from airflow is always one day less than today’s date. Filters are added to remove creation dates greater than submission_date.

[DENG-685]: https://mozilla-hub.atlassian.net/browse/DENG-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ