### PR TITLE
bug(1816398): fxa_users_services_first_seen_v2 partition_field changes to submission_date

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v2/metadata.yaml
@@ -15,7 +15,7 @@ scheduling:
 bigquery:
   time_partitioning:
     type: day
-    field: first_service_flow_timestamp
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v2/query.sql
@@ -51,6 +51,7 @@ existing_entries AS (
     DATE(first_service_flow_timestamp) < @submission_date
 )
 SELECT
+  new_records.submission_date,
   new_records.user_id,
   new_records.`service`,
   new_records.registered AS did_register,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v2/schema.yaml
@@ -1,6 +1,20 @@
 fields:
 
 - mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: |
+    Corresponds to the submission_date of the record
+    used from fxa_users_services_daily_v2.
+
+    IMPORTANT:
+    submission_date and first_service_flow_timestamp
+    will not always have the same date (should at most be 1
+    day difference). When filtering for users that we first
+    saw on x day should be done using
+    DATE(first_service_flow_timestamp) = "DAY".
+
+- mode: NULLABLE
   name: user_id
   type: STRING
   description: |


### PR DESCRIPTION
# bug(1816398): fxa_users_services_first_seen_v2 partition_field changes to submission_date

This is because previous partition field could contain records for two different days.
