### PR TITLE
Fixed typo in airflow_tags.md

### DIFF
--- a/docs/reference/airflow_tags.md
+++ b/docs/reference/airflow_tags.md
@@ -21,6 +21,6 @@ We borrow the [tiering system](https://wiki.mozilla.org/Sheriffing/Job_Visibilit
 
 This tag is meant to provide guidance to a triage engineer on how to respond to a specific DAG failure when the job owner does not want the standard process to be followed.
 
-- **triage/no_record**: Failures should _only_ be record and the job owner informed without taking any active steps to fix the failure.
+- **triage/record_only**: Failures should _only_ be record and the job owner informed without taking any active steps to fix the failure.
 
 - **triage/no_triage**: No triage should be performed on this job. Should only be used in a limited number of cases, like this is still WIP, where no production processes are affected.

--- a/docs/reference/airflow_tags.md
+++ b/docs/reference/airflow_tags.md
@@ -21,6 +21,6 @@ We borrow the [tiering system](https://wiki.mozilla.org/Sheriffing/Job_Visibilit
 
 This tag is meant to provide guidance to a triage engineer on how to respond to a specific DAG failure when the job owner does not want the standard process to be followed.
 
-- **triage/record_only**: Failures should _only_ be record and the job owner informed without taking any active steps to fix the failure.
+- **triage/record_only**: Failures should _only_ be recorded and the job owner informed without taking any active steps to fix the failure.
 
 - **triage/no_triage**: No triage should be performed on this job. Should only be used in a limited number of cases, like this is still WIP, where no production processes are affected.


### PR DESCRIPTION
As Sean pointed out, the tag provided in the docs was incorrect. This change fixes that.
