### PR TITLE
Fix UDF library reference format

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf_js/bootstrap_percentile_ci/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/bootstrap_percentile_ci/udf.sql
@@ -26,7 +26,7 @@ RETURNS ARRAY<
 > DETERMINISTIC
 LANGUAGE js
 OPTIONS
-  (library = ['gs://moz-fx-data-circleci-tests-bigquery-etl/qbinom.js'])
+  (library = "gs://moz-fx-data-circleci-tests-bigquery-etl/qbinom.js")
 AS
   """
   function histogramSort(histogram) {


### PR DESCRIPTION
The publishing logic expects the format `library = "...."`