### PR TITLE
Update SSH doc deploy key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ jobs:
       - *java_deps
       - *attach_generated_sql
       - add_ssh_keys:
-          fingerprints: "38:49:5e:71:1d:b7:14:84:45:08:8a:4c:6b:67:4e:4d"
+          fingerprints: "22:b9:3c:1b:82:ab:3f:e4:b5:79:70:d1:7b:b9:28:d2"
       - run:
           name: Build and deploy docs
           command: |


### PR DESCRIPTION
I accidentally deleted the SSH key for deploying docs 🤦‍♀️. Adding it back
