### PR TITLE
chore(ci): use unit tests from telemetry-airflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ jobs:
       - run:
           name: Replace telemetry-airflow DAGs with BigQuery ETL DAGs
           command: |
-            rm telemetry-airflow/dags/*
+            rm telemetry-airflow/dags/* -f || true
             cp -a dags/. telemetry-airflow/dags/
       - *attach_generated_sql
       - *copy_generated_sql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,23 +246,26 @@ jobs:
           name: Pull telemetry-airflow
           # TODO: clone main when feat/clean-deps is merged
           command: |
-            git clone --branch feat/clean-deps https://github.com/mozilla/telemetry-airflow.git
+            git clone --branch feat/clean-deps https://github.com/mozilla/telemetry-airflow.git ~/telemetry-airflow
       - run:
           name: Replace telemetry-airflow DAGs with BigQuery ETL DAGs
           command: |
-            rm telemetry-airflow/dags/* -f || true
-            cp -a dags/. telemetry-airflow/dags/
+            rm ~/telemetry-airflow/dags/* -f || true
+            cp -a dags/. ~/telemetry-airflow/dags/
       - *attach_generated_sql
       - *copy_generated_sql
       - run:
           name: Install telemetry-airflow dependencies
           command: |
-            cd telemetry-airflow
+            cd ~/telemetry-airflow
+            virtualenv .venv
+            source .venv/bin/activate   
             pip install -r requirements.txt
       - run:
           name: 🧪 Test valid DAGs
           command: |
-            cd telemetry-airflow
+            cd ~/telemetry-airflow
+            source .venv/bin/activate   
             python -m pytest tests/dags/test_dag_validity.py --junitxml=test-results/junit.xml
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,8 +244,9 @@ jobs:
             fi
       - run:
           name: Pull telemetry-airflow
+          # TODO: clone main when feat/clean-deps is merged
           command: |
-            git clone https://github.com/mozilla/telemetry-airflow.git
+            git clone --branch feat/clean-deps https://github.com/mozilla/telemetry-airflow.git
       - run:
           name: Replace telemetry-airflow DAGs with BigQuery ETL DAGs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,16 +259,16 @@ jobs:
           command: |
             cd ~/telemetry-airflow
             virtualenv .venv
-            source .venv/bin/activate   
+            source .venv/bin/activate
             pip install -r requirements.txt
       - run:
           name: 🧪 Test valid DAGs
           command: |
             cd ~/telemetry-airflow
-            source .venv/bin/activate   
-            python -m pytest tests/dags/test_dag_validity.py --junitxml=test-results/junit.xml
+            source .venv/bin/activate
+            python -m pytest tests/dags/test_dag_validity.py --junitxml=~/telemetry-airflow/test-results/junit.xml
       - store_test_results:
-          path: test-results
+          path: ~/telemetry-airflow/test-results/junit.xml
   validate-docs:
     docker: *docker
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ version: 2.1
 orbs:
   gcp-gcr: circleci/gcp-gcr@0.13.0
   docker: circleci/docker@1.5
+  python: circleci/python@2.1.1
 
 parameters:
   python-version:
@@ -220,11 +221,9 @@ jobs:
           paths:
             - generated-sql
   validate-dags:
-    # based on
-    # https://github.com/mozilla/telemetry-airflow/blob/main/.circleci/config.yml
-    machine:
-      image: ubuntu-2004:202111-01
-      docker_layer_caching: true
+    executor:
+      name: python/default
+      tag: 3.8.12
     steps:
       - checkout
       - run:
@@ -247,24 +246,25 @@ jobs:
           name: Pull telemetry-airflow
           command: |
             git clone https://github.com/mozilla/telemetry-airflow.git
+      - run:
+          name: Replace telemetry-airflow DAGs with BigQuery ETL DAGs
+          command: |
+            rm telemetry-airflow/dags/*
             cp -a dags/. telemetry-airflow/dags/
       - *attach_generated_sql
       - *copy_generated_sql
       - run:
+          name: Install telemetry-airflow dependencies
           command: |
             cd telemetry-airflow
-            docker-compose pull
-            docker-compose build
-            # now take ownership of the folder
-            sudo chown -R 10001:10001 .
+            pip install -r requirements.txt
       - run:
-          name: |
-            Test if dag scripts can be parsed by Airflow
-            and tags have set correctly
-          # Valid tags defined in `telemetry-airflow/bin/test-dag-tags.py`
+          name: 🧪 Test valid DAGs
           command: |
             cd telemetry-airflow
-            bash bin/test-parse
+            python -m pytest tests/dags/test_dag_validity.py --junitxml=test-results/junit.xml
+      - store_test_results:
+          path: test-results
   validate-docs:
     docker: *docker
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,9 +256,8 @@ jobs:
             fi
       - run:
           name: Pull telemetry-airflow
-          # TODO: clone main when feat/clean-deps is merged
           command: |
-            git clone --branch feat/clean-deps https://github.com/mozilla/telemetry-airflow.git ~/telemetry-airflow
+            git clone https://github.com/mozilla/telemetry-airflow.git ~/telemetry-airflow
       - run:
           name: Replace telemetry-airflow DAGs with BigQuery ETL DAGs
           command: |


### PR DESCRIPTION
# Description
Update CircleCI config to use unit tests from `telemetry-airflow` instead of running docker-compose. This significantly shortens CircleCI job `validate-dags` runtime from 5-6 minutes down to around 2 minutes.

Current implementation requires the job's executor to match `telemetry-airflow`'s python version. There's is a fairly low risk we encounter issues when updating `telemetry-airflow` to a new python version if we don't update the executor version in this CI config **_IF_** _there are breaking changes in key packages_. 

A possible alternative is to pull the latest `telemetry-airflow` image, mount the generated DAGs as a volume and run a pytest command. This will probably be the long-term solution as we would not need to pull a git repo and install python dependencies. I would probably switch to this solution after the related PRs are merged.

# Related PR
- https://github.com/mozilla/telemetry-airflow/pull/1638
- https://github.com/mozilla-services/cloudops-infra/pull/4705

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
