### PR TITLE
Add `telemetry_agent` column to VPN `events_daily` table (VPN-3934)

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/events_daily_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/events_daily_v1/init.sql
@@ -19,6 +19,7 @@ SELECT
   CAST(NULL AS STRING) AS app_display_version,
   CAST(NULL AS STRING) AS architecture,
   CAST(NULL AS STRING) AS first_run_date,
+  CAST(NULL AS STRING) AS telemetry_agent,
   CAST(NULL AS STRING) AS telemetry_sdk_build,
   CAST(NULL AS STRING) AS locale,
   -- metadata

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/events_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/events_daily_v1/query.sql
@@ -17,6 +17,7 @@ WITH sample AS (
     client_info.app_display_version AS app_display_version,
     client_info.architecture AS architecture,
     client_info.first_run_date AS first_run_date,
+    metadata.header.x_telemetry_agent AS telemetry_agent,
     client_info.telemetry_sdk_build AS telemetry_sdk_build,
     client_info.locale AS locale,
     (
@@ -47,6 +48,7 @@ WITH sample AS (
     client_info.app_display_version AS app_display_version,
     client_info.architecture AS architecture,
     client_info.first_run_date AS first_run_date,
+    metadata.header.x_telemetry_agent AS telemetry_agent,
     client_info.telemetry_sdk_build AS telemetry_sdk_build,
     client_info.locale AS locale,
     (
@@ -94,6 +96,7 @@ SELECT
   mozfun.stats.mode_last(ARRAY_AGG(app_display_version)) AS app_display_version,
   mozfun.stats.mode_last(ARRAY_AGG(architecture)) AS architecture,
   mozfun.stats.mode_last(ARRAY_AGG(first_run_date)) AS first_run_date,
+  mozfun.stats.mode_last(ARRAY_AGG(telemetry_agent)) AS telemetry_agent,
   mozfun.stats.mode_last(ARRAY_AGG(telemetry_sdk_build)) AS telemetry_sdk_build,
   mozfun.stats.mode_last(ARRAY_AGG(locale)) AS locale,
   -- metadata

--- a/sql_generators/events_daily/templates/events_daily_v1/query.sql
+++ b/sql_generators/events_daily/templates/events_daily_v1/query.sql
@@ -14,7 +14,7 @@ WITH sample AS (
           normalized_os_version,
           client_info.client_id as client_id,
           {% for property in user_properties %}
-          client_info.{{property.src}} as {{property.src}},
+          {{property.src}} as {{property.dest}},
           {% endfor %}
           (
             SELECT
@@ -82,7 +82,9 @@ SELECT
   CONCAT(STRING_AGG(index, ',' ORDER BY timestamp ASC), ',') AS events,
   -- client info
   {% for property in user_properties %}
-    mozfun.stats.mode_last(ARRAY_AGG({{ property.src }})) AS {{ property.dest }},
+    mozfun.stats.mode_last(ARRAY_AGG(
+      {% if glean %}{{ property.dest }}{% else %}{{ property.src }}{% endif %}
+    )) AS {{ property.dest }},
   {% endfor %}
   -- metadata
   {% if include_metadata_fields %}

--- a/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
@@ -147,6 +147,8 @@ mozilla_vpn_derived:
       dest: architecture
     - src: client_info.first_run_date
       dest: first_run_date
+    - src: metadata.header.x_telemetry_agent
+      dest: telemetry_agent
     - src: client_info.telemetry_sdk_build
       dest: telemetry_sdk_build
     - src: client_info.locale

--- a/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
@@ -9,25 +9,25 @@ fenix_derived:
   start_date: 2020-01-01
   dag_name: bqetl_fenix_event_rollup
   user_properties:
-    - src: android_sdk_version
+    - src: client_info.android_sdk_version
       dest: android_sdk_version
-    - src: app_build
+    - src: client_info.app_build
       dest: app_build
-    - src: app_channel
+    - src: client_info.app_channel
       dest: app_channel
-    - src: app_display_version
+    - src: client_info.app_display_version
       dest: app_display_version
-    - src: architecture
+    - src: client_info.architecture
       dest: architecture
-    - src: device_manufacturer
+    - src: client_info.device_manufacturer
       dest: device_manufacturer
-    - src: device_model
+    - src: client_info.device_model
       dest: device_model
-    - src: first_run_date
+    - src: client_info.first_run_date
       dest: first_run_date
-    - src: telemetry_sdk_build
+    - src: client_info.telemetry_sdk_build
       dest: telemetry_sdk_build
-    - src: locale
+    - src: client_info.locale
       dest: locale
 # see https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
 #telemetry_derived:
@@ -137,17 +137,17 @@ mozilla_vpn_derived:
   start_date: 2021-10-01
   dag_name: bqetl_event_rollup
   user_properties:
-    - src: app_build
+    - src: client_info.app_build
       dest: app_build
-    - src: app_channel
+    - src: client_info.app_channel
       dest: app_channel
-    - src: app_display_version
+    - src: client_info.app_display_version
       dest: app_display_version
-    - src: architecture
+    - src: client_info.architecture
       dest: architecture
-    - src: first_run_date
+    - src: client_info.first_run_date
       dest: first_run_date
-    - src: telemetry_sdk_build
+    - src: client_info.telemetry_sdk_build
       dest: telemetry_sdk_build
-    - src: locale
+    - src: client_info.locale
       dest: locale


### PR DESCRIPTION
For [VPN-3934](https://mozilla-hub.atlassian.net/browse/VPN-3934) "_Update our looker dashboards to filter by Glean SDK type_".

This will require rebuilding the `moz-fx-data-shared-prod.mozilla_vpn_derived.events_daily_v1` table.

CC @brizental 

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[VPN-3934]: https://mozilla-hub.atlassian.net/browse/VPN-3934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ