### PR TITLE
feat(DENG-610): added fxa_users_daily_v2 model

### DIFF
--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -255,6 +255,21 @@ with DAG(
         depends_on_past=False,
     )
 
+    firefox_accounts_derived__fxa_users_daily__v2 = bigquery_etl_query(
+        task_id="firefox_accounts_derived__fxa_users_daily__v2",
+        destination_table="fxa_users_daily_v2",
+        dataset_id="firefox_accounts_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="kignasiak@mozilla.com",
+        email=[
+            "dthorn@mozilla.com",
+            "kignasiak@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+    )
+
     firefox_accounts_derived__fxa_users_first_seen__v1 = bigquery_etl_query(
         task_id="firefox_accounts_derived__fxa_users_first_seen__v1",
         destination_table="fxa_users_first_seen_v1",
@@ -439,6 +454,10 @@ with DAG(
 
     firefox_accounts_derived__fxa_users_daily__v1.set_upstream(
         firefox_accounts_derived__fxa_stdout_events__v1
+    )
+
+    firefox_accounts_derived__fxa_users_daily__v2.set_upstream(
+        firefox_accounts_derived__fxa_users_services_daily__v2
     )
 
     firefox_accounts_derived__fxa_users_first_seen__v1.set_upstream(

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -255,21 +255,6 @@ with DAG(
         depends_on_past=False,
     )
 
-    firefox_accounts_derived__fxa_users_daily__v2 = bigquery_etl_query(
-        task_id="firefox_accounts_derived__fxa_users_daily__v2",
-        destination_table="fxa_users_daily_v2",
-        dataset_id="firefox_accounts_derived",
-        project_id="moz-fx-data-shared-prod",
-        owner="kignasiak@mozilla.com",
-        email=[
-            "dthorn@mozilla.com",
-            "kignasiak@mozilla.com",
-            "telemetry-alerts@mozilla.com",
-        ],
-        date_partition_parameter="submission_date",
-        depends_on_past=False,
-    )
-
     firefox_accounts_derived__fxa_users_first_seen__v1 = bigquery_etl_query(
         task_id="firefox_accounts_derived__fxa_users_first_seen__v1",
         destination_table="fxa_users_first_seen_v1",
@@ -454,10 +439,6 @@ with DAG(
 
     firefox_accounts_derived__fxa_users_daily__v1.set_upstream(
         firefox_accounts_derived__fxa_stdout_events__v1
-    )
-
-    firefox_accounts_derived__fxa_users_daily__v2.set_upstream(
-        firefox_accounts_derived__fxa_users_services_daily__v2
     )
 
     firefox_accounts_derived__fxa_users_first_seen__v1.set_upstream(

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
@@ -1,14 +1,13 @@
 ---
 friendly_name: FxA Users Daily
 description: |
-  Usage aggregations per FxA user per day. Build from fxa_users_services_daily.
-  If the user had multiple different entries on a single day, then we grab
-  the attributes from the first service observed that day.
+  Derived from fxa_users_services (user/service level) and aggregated
+  to the user level. This includes information about which users were
+  active on a specific day along with some attributes related to that user.
+  See the schema for a list of attributes and their descriptions.
 
-  This lower level model uses the following category of events:
-  event_category IN ('auth', 'auth_bounce', 'content', 'oauth')
-
-  Partitioned by submission_date and clustered by country, os_name, and user_id
+  Partitioned by submission_date,
+  clustered by country, os_name, and user_id
 owners:
   - kignasiak@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
@@ -1,0 +1,29 @@
+---
+friendly_name: FxA Users Daily
+description: |
+  Usage aggregations per FxA user per day. Build from fxa_users_services_daily.
+  If the user had multiple different entries on a single day, then we grab
+  the attributes from the first service observed that day.
+
+  This lower level model uses the following category of events:
+  event_category IN ('auth', 'auth_bounce', 'content', 'oauth')
+
+  Partitioned by submission_date and clustered by country, os_name, and user_id
+owners:
+  - kignasiak@mozilla.com
+labels:
+  application: fxa
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_fxa_events
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+  clustering:
+    fields:
+      - country
+      - os_name
+      - user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
@@ -14,8 +14,9 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-scheduling:
-  dag_name: bqetl_fxa_events
+# TODO: once we agree on the model scheduling needs to be uncommented.
+# scheduling:
+#   dag_name: bqetl_fxa_events
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/query.sql
@@ -1,17 +1,39 @@
+WITH base AS (
+  SELECT
+    user_id,
+    country,
+    `language`,
+    os_name,
+    os_version,
+    seen_in_tier1_country,
+    registered,
+    user_service_first_daily_flow_info,
+  FROM
+    `firefox_accounts_derived.fxa_users_services_daily_v2`
+  WHERE
+    submission_date = @submission_date
+),
+bool_fields AS (
+  SELECT
+    user_id,
+    LOGICAL_OR(seen_in_tier1_country) AS seen_in_tier1_country,
+    LOGICAL_OR(registered) AS registered,
+  FROM
+    base
+  GROUP BY
+    user_id
+)
 SELECT
-  submission_date,
-  user_id,
-  country,
-  `language`,
-  app_version,
-  os_name,
-  os_version,
-  seen_in_tier1_country,
-  registered,
+  @submission_date AS submission_date,
+  * EXCEPT (seen_in_tier1_country, registered, user_service_first_daily_flow_info),
+  bool_fields.seen_in_tier1_country,
+  bool_fields.registered,
 FROM
-  `firefox_accounts_derived.fxa_users_services_daily_v2`
-WHERE
-  submission_date = @submission_date
+  base
+LEFT JOIN
+  bool_fields
+USING
+  (user_id)
 QUALIFY
   ROW_NUMBER() OVER (
     PARTITION BY

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/query.sql
@@ -1,43 +1,22 @@
-WITH base AS (
-  SELECT
-    user_id,
-    country,
-    `language`,
-    os_name,
-    os_version,
-    seen_in_tier1_country,
-    registered,
-    user_service_first_daily_flow_info,
-  FROM
-    `firefox_accounts_derived.fxa_users_services_daily_v2`
-  WHERE
-    submission_date = @submission_date
-),
-bool_fields AS (
-  SELECT
-    user_id,
-    LOGICAL_OR(seen_in_tier1_country) AS seen_in_tier1_country,
-    LOGICAL_OR(registered) AS registered,
-  FROM
-    base
-  GROUP BY
-    user_id
-)
 SELECT
-  @submission_date AS submission_date,
-  * EXCEPT (seen_in_tier1_country, registered, user_service_first_daily_flow_info),
-  bool_fields.seen_in_tier1_country,
-  bool_fields.registered,
+  submission_date,
+  user_id,
+  country,
+  `language`,
+  os_name,
+  os_version,
+  LOGICAL_OR(seen_in_tier1_country) OVER (user_window) AS seen_in_tier1_country,
+  LOGICAL_OR(registered) OVER (user_window) AS registered,
 FROM
-  base
-LEFT JOIN
-  bool_fields
-USING
-  (user_id)
+  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_services_daily_v2`
+WHERE
+  submission_date = @submission_date
 QUALIFY
-  ROW_NUMBER() OVER (
+  ROW_NUMBER() OVER (user_window) = 1
+WINDOW
+  user_window AS (
     PARTITION BY
       user_id
     ORDER BY
-      user_service_first_daily_flow_info.`timestamp` ASC
-  ) = 1
+      user_service_first_daily_flow_info.timestamp ASC
+  )

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/query.sql
@@ -1,0 +1,21 @@
+SELECT
+  submission_date,
+  user_id,
+  country,
+  `language`,
+  app_version,
+  os_name,
+  os_version,
+  seen_in_tier1_country,
+  registered,
+FROM
+  `firefox_accounts_derived.fxa_users_services_daily_v2`
+WHERE
+  submission_date = @submission_date
+QUALIFY
+  ROW_NUMBER() OVER (
+    PARTITION BY
+      user_id
+    ORDER BY
+      user_service_first_daily_flow_info.`timestamp` ASC
+  ) = 1

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/schema.yaml
@@ -1,0 +1,68 @@
+fields:
+
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: |
+    Represents ETL job date.
+    Also, used for table partitioning.
+
+- mode: NULLABLE
+  name: user_id
+  type: STRING
+  description: |
+    A 36 char long hash value representing
+    User ID (registered user).
+    Also, used as a clustering field.
+
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: |
+    User's country where activity took place.
+    See: UDF mozdata.stats.mode_last for more
+    info on how the function operates.
+
+- mode: NULLABLE
+  name: language
+  type: STRING
+  description: |
+    User's language.
+
+- mode: NULLABLE
+  name: app_version
+  type: STRING
+  description: |
+    Mozilla app version,
+    follows format: major.minor.patch (e.g. 99.3.3).
+
+- mode: NULLABLE
+  name: os_name
+  type: STRING
+  description: |
+    OS on which the app was running.
+    For example: Android.
+
+- mode: NULLABLE
+  name: os_version
+  type: STRING
+  description: |
+    Version of the OS the device was using.
+
+- mode: NULLABLE
+  name: seen_in_tier1_country
+  type: BOOLEAN
+  description: |
+    Set to True if a user sent an event from
+    one of the following countries for
+    a specific submission_date:
+    ('United States','France',
+    'Germany','United Kingdom','Canada')
+
+- mode: NULLABLE
+  name: registered
+  type: BOOLEAN
+  description: |
+    Set to True if the user submitted
+    the event_type of `fxa_reg - complete`
+    event on the specific submission_date.

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/schema.yaml
@@ -30,13 +30,6 @@ fields:
     User's language.
 
 - mode: NULLABLE
-  name: app_version
-  type: STRING
-  description: |
-    Mozilla app version,
-    follows format: major.minor.patch (e.g. 99.3.3).
-
-- mode: NULLABLE
   name: os_name
   type: STRING
   description: |
@@ -58,6 +51,7 @@ fields:
     a specific submission_date:
     ('United States','France',
     'Germany','United Kingdom','Canada')
+    for any of the services they used that day.
 
 - mode: NULLABLE
   name: registered

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/schema.yaml
@@ -19,28 +19,31 @@ fields:
   name: country
   type: STRING
   description: |
-    User's country where activity took place.
-    See: UDF mozdata.stats.mode_last for more
-    info on how the function operates.
+    The first country value observed
+    in a day for a specific user.
+    For example: Android
 
 - mode: NULLABLE
   name: language
   type: STRING
   description: |
-    User's language.
+    The first language value observed
+    in a day for a specific user.
 
 - mode: NULLABLE
   name: os_name
   type: STRING
   description: |
-    OS on which the app was running.
-    For example: Android.
+    The first os_name value observed
+    in a day for a specific user.
+    For example: Android
 
 - mode: NULLABLE
   name: os_version
   type: STRING
   description: |
-    Version of the OS the device was using.
+    The first os_version value observed
+    in a day for a specific user.
 
 - mode: NULLABLE
   name: seen_in_tier1_country


### PR DESCRIPTION
# feat(DENG-610): added fxa_users_daily_v2 model

## Context:
The primary change introduced by the v2 compared to v1 is that it is now derived from a lower granularity table which contains users/service level granularity (`fxa_users_services_daily_v2`) instead of accessing the events table directly. This should reduce the amount of data we have to process as part of the FxA pipeline and reduced code duplication across different models (for example, only the initial users services table needs to filter for specific events).

### Removed fields:
- `app_version` - as pointed out by Arkadiusz, this field does not seem to make sense on the user level as it is related to the service used and as the result provides no useful meaning here. Also, it can be accessed via the upstream table `fxa_users_services_daily_v2`.
- `monitor_only` - based on the conversation under this PR it appears this field is a legacy field and is no longer used/needed.

### Follow-up PR's:
- https://github.com/mozilla/bigquery-etl/pull/3610 - first_seen_v2 added
- https://github.com/mozilla/bigquery-etl/pull/3611 - last_seen_v2 added