### PR TITLE
feat(DENG-704): added fxa_users_first_seen_v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v2/metadata.yaml
@@ -1,0 +1,31 @@
+friendly_name: FxA Users First Seen
+description: |-
+  Contains the first entry seen inside fxa_users_daily_v2
+  for each user along with some attributes.
+
+  Partitioned by submission_date,
+  clustered by country, os_name
+owners:
+- kignasiak@mozilla.com
+labels:
+  application: firefox_accounts
+  incremental: true
+  schedule: daily
+# TODO: once we agree on the model scheduling needs to be uncommented.
+# scheduling:
+#   dag_name: bqetl_fxa_events
+#   start_date: '2021-07-09'
+#   priority: 80
+#   depends_on_past: true
+#   date_partition_parameter: null
+#   parameters:
+#   - submission_date:DATE:{{ds}}
+bigquery:
+  time_partitioning:
+    type: day
+    field: first_seen_date
+    require_partition_filter: false
+  clustering:
+    fields:
+    - country
+    - os_name

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v2/query.sql
@@ -1,0 +1,36 @@
+WITH _current AS (
+  SELECT
+    user_id,
+    country,
+    `language`,
+    os_name,
+    os_version,
+    seen_in_tier1_country,
+    registered,
+  FROM
+    `firefox_accounts_derived.fxa_users_daily_v2`
+  WHERE
+    submission_date = @submission_date
+),
+_previous AS (
+  SELECT
+    user_id
+  FROM
+    `firefox_accounts_derived.fxa_users_first_seen_v2`
+  WHERE
+    -- In reprocessing scenarios, we must always backfill from the first affected date
+    -- all the way to the present; to enforce that, we explicitly drop any data after
+    -- the target @submission_date
+    first_seen_date < @submission_date
+)
+SELECT
+  *,
+  @submission_date AS first_seen_date,
+FROM
+  _current
+FULL OUTER JOIN
+  _previous
+USING
+  (user_id)
+WHERE
+  _previous.user_id IS NULL

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v2/schema.yaml
@@ -1,0 +1,62 @@
+fields:
+
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+  description: |
+    Represents ETL job date.
+    Also, used for table partitioning.
+
+- mode: NULLABLE
+  name: user_id
+  type: STRING
+  description: |
+    A 36 char long hash value representing
+    User ID (registered user).
+    Also, used as a clustering field.
+
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: |
+    User's country where activity took place.
+    See: UDF mozdata.stats.mode_last for more
+    info on how the function operates.
+
+- mode: NULLABLE
+  name: language
+  type: STRING
+  description: |
+    User's language.
+
+- mode: NULLABLE
+  name: os_name
+  type: STRING
+  description: |
+    OS on which the app was running.
+    For example: Android.
+
+- mode: NULLABLE
+  name: os_version
+  type: STRING
+  description: |
+    Version of the OS the device was using.
+
+- mode: NULLABLE
+  name: seen_in_tier1_country
+  type: BOOLEAN
+  description: |
+    Set to True if a user sent an event from
+    one of the following countries for
+    a specific submission_date:
+    ('United States','France',
+    'Germany','United Kingdom','Canada')
+    when seen for the first time.
+
+- mode: NULLABLE
+  name: registered
+  type: BOOLEAN
+  description: |
+    Set to True if the user submitted
+    the event_type of `fxa_reg - complete`
+    event on the specific submission_date.


### PR DESCRIPTION
# feat(DENG-704): added fxa_users_first_seen_v2

depends: https://github.com/mozilla/bigquery-etl/pull/3607

---

## Context

The main difference between v2 and v1 of this table is that v2 is created using `fxa_users_daily_v2` instead of using the events table directly. This change aims to reduce code duplication and to have a cleaner and more linear flow of data which is a bit easier to reason about. Avoiding going directly to the events table also reduced the amount of data that we need to process for each run.

### Field changes:

`Removed`:
- `services_used` - this was a field which was modified on each run and aggregates a list of all services the user has ever used. This feels like a wrong place for this information as it did not include only information related to the first instance of when a user was observed making the table more difficult to reason about. Currently, this information can be retrieved from `fxa_users_services_first_seen_v2` by querying for all entries for a specific user_id. This will return us a list of all services a specific user ever accessed with the corresponding dates.

`Added`:
- `country` - shows what country the user had assigned in their first interaction
- `language` - shows what language the user had assigned in their first interaction
- `os_name` - shows what os the user had assigned in their first interaction
- `os_version` - shows what os version the user had assigned in their first interaction
- `seen_in_tier1_country` - whows if the user has an activity event in one of the tier1 countries on their first day.
- `registered` - did a user register when first observed? I believe in our case this should always be true in this table. 

These fields were added to match the fields defined inside `fxa_users_daily_v2`

tier1 countries include: `United States`, `France`, `Germany`, `United Kingdom`, `Canada`
