### PR TITLE
feat(DENG-711): Adding fxa_users_last_seen_v2

### DIFF
--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -54,6 +54,7 @@ with DAG(
     doc_md=docs,
     tags=tags,
 ) as dag:
+
     docker_fxa_admin_server_v1 = bigquery_etl_query(
         task_id="docker_fxa_admin_server_v1",
         destination_table="docker_fxa_admin_server_sanitized_v1",
@@ -317,6 +318,22 @@ with DAG(
         firefox_accounts_derived__fxa_users_last_seen__v1_external.set_upstream(
             firefox_accounts_derived__fxa_users_last_seen__v1
         )
+
+    firefox_accounts_derived__fxa_users_last_seen__v2 = bigquery_etl_query(
+        task_id="firefox_accounts_derived__fxa_users_last_seen__v2",
+        destination_table="fxa_users_last_seen_v2",
+        dataset_id="firefox_accounts_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="kignasiak@mozilla.com",
+        email=[
+            "dthorn@mozilla.com",
+            "kignasiak@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        start_date=datetime.datetime(2019, 4, 23, 0, 0),
+        date_partition_parameter="submission_date",
+        depends_on_past=True,
+    )
 
     firefox_accounts_derived__fxa_users_services_daily__v1 = bigquery_etl_query(
         task_id="firefox_accounts_derived__fxa_users_services_daily__v1",

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -255,6 +255,21 @@ with DAG(
         depends_on_past=False,
     )
 
+    firefox_accounts_derived__fxa_users_daily__v2 = bigquery_etl_query(
+        task_id="firefox_accounts_derived__fxa_users_daily__v2",
+        destination_table="fxa_users_daily_v2",
+        dataset_id="firefox_accounts_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="kignasiak@mozilla.com",
+        email=[
+            "dthorn@mozilla.com",
+            "kignasiak@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+    )
+
     firefox_accounts_derived__fxa_users_first_seen__v1 = bigquery_etl_query(
         task_id="firefox_accounts_derived__fxa_users_first_seen__v1",
         destination_table="fxa_users_first_seen_v1",
@@ -452,6 +467,10 @@ with DAG(
 
     firefox_accounts_derived__fxa_users_daily__v1.set_upstream(
         firefox_accounts_derived__fxa_stdout_events__v1
+    )
+
+    firefox_accounts_derived__fxa_users_daily__v2.set_upstream(
+        firefox_accounts_derived__fxa_users_services_daily__v2
     )
 
     firefox_accounts_derived__fxa_users_first_seen__v1.set_upstream(

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -54,7 +54,6 @@ with DAG(
     doc_md=docs,
     tags=tags,
 ) as dag:
-
     docker_fxa_admin_server_v1 = bigquery_etl_query(
         task_id="docker_fxa_admin_server_v1",
         destination_table="docker_fxa_admin_server_sanitized_v1",
@@ -256,21 +255,6 @@ with DAG(
         depends_on_past=False,
     )
 
-    firefox_accounts_derived__fxa_users_daily__v2 = bigquery_etl_query(
-        task_id="firefox_accounts_derived__fxa_users_daily__v2",
-        destination_table="fxa_users_daily_v2",
-        dataset_id="firefox_accounts_derived",
-        project_id="moz-fx-data-shared-prod",
-        owner="kignasiak@mozilla.com",
-        email=[
-            "dthorn@mozilla.com",
-            "kignasiak@mozilla.com",
-            "telemetry-alerts@mozilla.com",
-        ],
-        date_partition_parameter="submission_date",
-        depends_on_past=False,
-    )
-
     firefox_accounts_derived__fxa_users_first_seen__v1 = bigquery_etl_query(
         task_id="firefox_accounts_derived__fxa_users_first_seen__v1",
         destination_table="fxa_users_first_seen_v1",
@@ -318,22 +302,6 @@ with DAG(
         firefox_accounts_derived__fxa_users_last_seen__v1_external.set_upstream(
             firefox_accounts_derived__fxa_users_last_seen__v1
         )
-
-    firefox_accounts_derived__fxa_users_last_seen__v2 = bigquery_etl_query(
-        task_id="firefox_accounts_derived__fxa_users_last_seen__v2",
-        destination_table="fxa_users_last_seen_v2",
-        dataset_id="firefox_accounts_derived",
-        project_id="moz-fx-data-shared-prod",
-        owner="kignasiak@mozilla.com",
-        email=[
-            "dthorn@mozilla.com",
-            "kignasiak@mozilla.com",
-            "telemetry-alerts@mozilla.com",
-        ],
-        start_date=datetime.datetime(2019, 4, 23, 0, 0),
-        date_partition_parameter="submission_date",
-        depends_on_past=True,
-    )
 
     firefox_accounts_derived__fxa_users_services_daily__v1 = bigquery_etl_query(
         task_id="firefox_accounts_derived__fxa_users_services_daily__v1",
@@ -484,10 +452,6 @@ with DAG(
 
     firefox_accounts_derived__fxa_users_daily__v1.set_upstream(
         firefox_accounts_derived__fxa_stdout_events__v1
-    )
-
-    firefox_accounts_derived__fxa_users_daily__v2.set_upstream(
-        firefox_accounts_derived__fxa_users_services_daily__v2
     )
 
     firefox_accounts_derived__fxa_users_first_seen__v1.set_upstream(

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
@@ -2,9 +2,17 @@
 friendly_name: FxA Users Daily
 description: |
   Derived from fxa_users_services (user/service level) and aggregated
-  to the user level. This includes information about which users were
-  active on a specific day along with some attributes related to that user.
+  to the user level. If the user had multiple different entries on a single day,
+  then we grab the attributes from the first service observed that day.
+  This includes information about which users were active on a specific day
+  along with some attributes related to that user.
   See the schema for a list of attributes and their descriptions.
+
+  Partitioned by submission_date,
+  clustered by country, os_name, and user_id
+
+  This lower level model uses the following category of events:
+  event_category IN ('auth', 'auth_bounce', 'content', 'oauth')
 
   Partitioned by submission_date,
   clustered by country, os_name, and user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/metadata.yaml
@@ -1,0 +1,31 @@
+---
+friendly_name: FxA Users Last Seen
+description: |
+  Usage aggregations per FxA user per day over a 28-day window.
+  The fields containing the 28-day user activity info include:
+  days_seen_bits, days_seen_in_tier1_country_bits, days_registered_bits
+
+  These fields are calculated from `fxa_users_daily_v2` table
+  which only looks at the following category of events:
+  auth, auth_bounce, content, oauth.
+
+owners:
+  - kignasiak@mozilla.com
+labels:
+  application: fxa
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_fxa_events
+  depends_on_past: true
+  start_date: '2019-04-23'
+  referenced_tables: []
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  clustering:
+    fields:
+      - user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/metadata.yaml
@@ -15,11 +15,11 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-scheduling:
-  dag_name: bqetl_fxa_events
-  depends_on_past: true
-  start_date: '2019-04-23'
-  referenced_tables: []
+# scheduling:
+#   dag_name: bqetl_fxa_events
+#   depends_on_past: true
+#   start_date: '2019-04-23'
+#   referenced_tables: []
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/query.sql
@@ -1,0 +1,57 @@
+WITH _current AS (
+  SELECT
+    user_id,
+    -- In this raw table, we capture the history of activity over the past
+    -- 28 days for each usage criterion as a single 64-bit integer. The
+    -- rightmost bit represents whether the user was active in the current day.
+    CAST(TRUE AS INT64) AS days_seen_bits,
+    -- Record days on which the user was in a "Tier 1" country;
+    -- this allows a variant of country-segmented MAU where we can still count
+    -- a user that appeared in one of the target countries in the previous
+    -- 28 days even if the most recent "country" value is not in this set.
+    CAST(seen_in_tier1_country AS INT64) AS days_seen_in_tier1_country_bits,
+    CAST(registered AS INT64) AS days_registered_bits,
+  FROM
+    `firefox_accounts_derived.fxa_users_daily_v2`
+  WHERE
+    submission_date = @submission_date
+),
+_previous AS (
+  SELECT
+    user_id,
+    days_seen_bits,
+    days_seen_in_tier1_country_bits,
+    days_registered_bits,
+  FROM
+    `firefox_accounts_derived.fxa_users_last_seen_v2`
+  WHERE
+    submission_date = DATE_SUB(@submission_date, INTERVAL 1 DAY)
+    -- Filter out rows from yesterday that have now fallen outside the 28-day window.
+    AND udf.shift_28_bits_one_day(days_seen_bits) > 0
+)
+SELECT
+  @submission_date AS submission_date,
+  IF(
+    _current.user_id IS NOT NULL,
+    _current,
+    _previous
+  ).* REPLACE ( --
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_seen_bits,
+      _current.days_seen_bits
+    ) AS days_seen_bits,
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_seen_in_tier1_country_bits,
+      _current.days_seen_in_tier1_country_bits
+    ) AS days_seen_in_tier1_country_bits,
+    udf.coalesce_adjacent_days_28_bits(
+      _previous.days_registered_bits,
+      _current.days_registered_bits
+    ) AS days_registered_bits
+  )
+FROM
+  _current
+FULL JOIN
+  _previous
+USING
+  (user_id)

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/schema.yaml
@@ -1,0 +1,33 @@
+fields:
+
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: |
+    Corresponds to ETL processing date.
+    Also, used for partitioning the table.
+
+- mode: NULLABLE
+  name: user_id
+  type: STRING
+  description: |
+    A 36 char long hash value representing
+    User ID (registered user).
+
+- mode: NULLABLE
+  name: days_seen_bits
+  type: INTEGER
+  description: |
+    No. of days since the user had activity event.
+
+- mode: NULLABLE
+  name: days_seen_in_tier1_country_bits
+  type: INTEGER
+  description: |
+    No. of days since seen_in_tier1_country was last True.
+
+- mode: NULLABLE
+  name: days_registered_bits
+  type: INTEGER
+  description: |
+    No. of days since registration event.


### PR DESCRIPTION
# feat(DENG-711): Adding fxa_users_last_seen_v2

relates to: https://github.com/mozilla/bigquery-etl/pull/3607

---

## Context

This change is introducing `fxa_users_last_seen_v2` to build on top of the work done completed for `fxa_users_daily_v2`. The main reason for introducing v2 here is to enable both v1 and v2 to run in parallel until we validate that v2 is correctly generated at which point v1 if this table can be deprecated.

### Field Changes

`Removed`:
- `days_seen_no_monitor_bits` - based of a monitor field in the daily table which appear to be no longer needed and is being removed in `fxa_users_daily_v2` and hence it is being removed here.

Below fields are being removed as they do not appear to fit in this table, primarily due to how we track the activity fields in this table (each activity field contains information for the last 28 days):
- `country`
- `language`  
- `app_version` 
- `os_name`
- `os_version` 

Unless we do the same for the above fields, I'm not sure those fields should live in this table as they could not apply to all of the 28 days of recorded activity in each partition. This information could be alternatively accessed using the `fxa_users_daily_v2` table instead.