### PR TITLE
Fix publishing UDFs with fully qualified identifiers

### DIFF
--- a/bigquery_etl/routine/publish_routines.py
+++ b/bigquery_etl/routine/publish_routines.py
@@ -167,6 +167,7 @@ def publish_routine(
             # ensure UDF definitions are not replaced twice as would be the case for
             # `mozfun`.stats.mode_last and `mozfun`.stats.mode_last_retain_nulls
             # since one name is a substring of the other
+            definition = definition.replace(f"`{project_id}.{udf}`", udf)
             definition = definition.replace(f"`{project_id}`.{udf}", udf)
             definition = definition.replace(f"{project_id}.{udf}", udf)
             definition = definition.replace(udf, f"`{project_id}`.{udf}")


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/19235/workflows/e8f9dfd8-e019-4fe7-9e02-6c500596d8cd/jobs/184664

To deploy UDFs to stage for testing the names are fully qualified with "`" around the identifier. The UDF publishing logic currently doesn't handle this case. The PR should fix that