### PR TITLE
Retry `bqetl_pocket` DAG tasks for 10 hours rather than 1 hour (bug 1818043)

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -530,8 +530,9 @@ bqetl_pocket:
     email_on_failure: true
     email_on_retry: true
     owner: jklukas@mozilla.com
-    retries: 2
-    retry_delay: 30m
+    # Retry more than normal because the files from Pocket may not always be available on time.
+    retries: 10
+    retry_delay: 60m
     start_date: "2021-03-10"
   description: |
     Import of data from Pocket's Snowflake warehouse.

--- a/dags/bqetl_pocket.py
+++ b/dags/bqetl_pocket.py
@@ -32,10 +32,10 @@ default_args = {
     "end_date": None,
     "email": ["jklukas@mozilla.com", "telemetry-alerts@mozilla.com"],
     "depends_on_past": False,
-    "retry_delay": datetime.timedelta(seconds=1800),
+    "retry_delay": datetime.timedelta(seconds=3600),
     "email_on_failure": True,
     "email_on_retry": True,
-    "retries": 2,
+    "retries": 10,
 }
 
 tags = ["impact/tier_2", "repo/bigquery-etl"]


### PR DESCRIPTION
Because the files from Pocket may not always be available on time (e.g. [bug 1818043](https://bugzilla.mozilla.org/show_bug.cgi?id=1818043)).

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
