### PR TITLE
issues(3416): added missing metadata.yaml files inside moz-fx-data-shared-prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs:
       - run:
           name: Verify that metadata files are valid
           command: |
+            # TODO: Add check here to make sure all queries have metadata.yaml
             PATH="venv/bin:$PATH" script/bqetl query validate \
               --respect-dryrun-skip
   integration:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_oauth_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_oauth_events_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Firefox Accounts Derived - Fxa Oauth Events
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_oauth_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_oauth_events_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/incline_executive_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/incline_executive_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Org Mozilla Firefox Derived - Incline Executive
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/incline_executive_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/incline_executive_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Search Terms Derived - Suggest Impression Sanitized V2 Exter
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: |-
-  Search Terms Derived - Suggest Impression Sanitized V2 Exter
+  Search Terms Derived - Suggest Impression Sanitized V2 External
 description: |-
   [DESCRIPTION_MISSING]
 owners:

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_daily/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_daily/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Static - Fxa Amplitude Export Users Da
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_daily/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_daily/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: |-
-  Static - Fxa Amplitude Export Users Da
+  Static - Fxa Amplitude Export Users Daily
 description: |-
   [DESCRIPTION_MISSING]
 owners:

--- a/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_daily/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_daily/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_last_seen/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_last_seen/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: |-
-  Static - Fxa Amplitude Export Users Last S
+  Static - Fxa Amplitude Export Users Last Seen
 description: |-
   [DESCRIPTION_MISSING]
 owners:

--- a/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_last_seen/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_last_seen/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Static - Fxa Amplitude Export Users Last S
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_last_seen/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_last_seen/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_content_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_content_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Daily Histogram Aggregates Content
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_content_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_content_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_gpu_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_gpu_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Daily Histogram Aggregates Gpu
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_gpu_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_gpu_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_parent_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_parent_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Daily Histogram Aggregates Parent
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_parent_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_parent_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_boolean_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_boolean_aggregates_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Daily Keyed Boolean Aggregates
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_boolean_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_boolean_aggregates_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_histogram_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_histogram_aggregates_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Daily Keyed Histogram Aggregates
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_histogram_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_histogram_aggregates_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_scalar_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_scalar_aggregates_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Daily Keyed Scalar Aggregates
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_scalar_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_scalar_aggregates_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Daily Scalar Aggregates
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_new_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_new_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Histogram Aggregates New
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_new_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_new_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Histogram Aggregates
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Histogram Bucket Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_probe_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_probe_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Histogram Probe Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_probe_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_probe_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_aggregates_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Scalar Aggregates
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_aggregates_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Clients Scalar Probe Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_first_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_first_seen_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Core Clients First Seen
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_first_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_first_seen_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Event Events
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiments_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiments_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Experiments
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiments_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiments_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Glam Client Probe Counts Extract
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_sample_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_sample_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Glam Sample Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_sample_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_sample_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_user_counts_extract_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_user_counts_extract_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Glam User Counts Extract
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_user_counts_extract_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_user_counts_extract_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_user_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_user_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Glam User Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_user_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_user_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/histogram_percentiles_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/histogram_percentiles_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Histogram Percentiles
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/histogram_percentiles_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/histogram_percentiles_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_events_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Main Events
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_events_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_user_activity_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_user_activity_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Public Data Report User Activity
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_user_activity_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_user_activity_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Telemetry Derived - Scalar Percentiles
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- nobody@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- nobody@mozilla.com
+- data-platform-infra-wg@mozilla.com


### PR DESCRIPTION
# issues(3416): added missing metadata.yaml files inside moz-fx-data-shared-prod

Adds metadata.yaml files for queries inside telemetry_derived that are missing one.

Metadata.yaml added include the following 3 keys with placeholder values:
- `friendly_name` - this is set to dataset name + table name
- `description` - set to `[DESCRIPTION_MISSING]`, this needs to be populated by the owner (as soon as one is determined)
- `owners` - set to `data-platform-infra-wg@mozilla.com` as we did not want to assign it to people without consulting with them first.

Those values for description and owners will enable us to easily search for metadata files without a description and owner assigned.

Next step is to add a CI check to ensure metadata.yaml file is added when a new query is created and contains those three keys.

related: https://github.com/mozilla/bigquery-etl/pull/3655
related: https://github.com/mozilla/bigquery-etl/pull/3656
