### PR TITLE
DENG-590: Fixed inventory schema

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/schema.yaml
@@ -30,12 +30,12 @@ fields:
   type: STRING
   description: The table type
 
-- mode: REPEATED
+- mode: NULLABLE
   name: last_modified_date
   type: DATE
   description: The table's last modified date
 
-- mode: NULLABLE
+- mode: REPEATED
   name: owners
   type: STRING
   description: The owner of the table listed in metadata yaml file


### PR DESCRIPTION
This will fix the schema error introduced from #3638 causing an airflow DAG failure ([1821055](https://bugzilla.mozilla.org/show_bug.cgi?id=1821055)). 