### PR TITLE
 DENG-514 capture windows version in active users aggregates

### DIFF
--- a/sql_generators/active_users/templates/desktop_query.sql
+++ b/sql_generators/active_users/templates/desktop_query.sql
@@ -13,7 +13,10 @@ WITH todays_metrics AS (
     EXTRACT(YEAR FROM first_seen_date) AS first_seen_year,
     days_since_seen,
     os,
-    normalized_os_version AS os_version,
+    COALESCE(
+      `mozfun.norm.windows_version_info`(os, normalized_os_version, windows_build_number),
+      normalized_os_version
+    ) AS os_version,
     COALESCE(
       CAST(NULLIF(SPLIT(normalized_os_version, ".")[SAFE_OFFSET(0)], "") AS INTEGER),
       0


### PR DESCRIPTION
[DENG-514](https://mozilla-hub.atlassian.net/browse/DENG-514): Updated `os_version` column to use [windows_version_info udf](https://github.com/mozilla/bigquery-etl/blob/main/sql/mozfun/norm/windows_version_info/udf.sql) to capture the correct windows version.

The following table is created for validations:  `moz-fx-data-shared-prod.analysis.wchan-deng-514-windows`

[DENG-514]: https://mozilla-hub.atlassian.net/browse/DENG-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ