### PR TITLE
# issues(3416): added missing metadata.yaml files inside glam-fenix-dev

### DIFF
--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop - Clients Daily Histogram Aggregates Metrics
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_baseline_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_baseline_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_baseline_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_baseline_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop - Clients Daily Scalar Aggregates Baseline
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_deletion_request_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_deletion_request_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop - Clients Daily Scalar Aggregates Deletion Request
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_deletion_request_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_deletion_request_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_events_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_events_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop - Clients Daily Scalar Aggregates Events
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_events_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_events_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_fog_validation_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_fog_validation_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop - Clients Daily Scalar Aggregates Fog Validation
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_fog_validation_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_fog_validation_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop - Clients Daily Scalar Aggregates Metrics
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__clients_histogram_aggregates_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__clients_histogram_aggregates_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop Glam Nightly - Clients Histogram Aggregates
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__clients_histogram_aggregates_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__clients_histogram_aggregates_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__clients_scalar_aggregates_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__clients_scalar_aggregates_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop Glam Nightly - Clients Scalar Aggregates
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__clients_scalar_aggregates_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__clients_scalar_aggregates_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__extract_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__extract_probe_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__extract_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__extract_probe_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop Glam Nightly - Extract Probe Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__extract_user_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__extract_user_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop Glam Nightly - Extract User Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__extract_user_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__extract_user_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_bucket_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_bucket_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_bucket_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_bucket_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop Glam Nightly - Histogram Bucket Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_percentiles_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_percentiles_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_percentiles_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_percentiles_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop Glam Nightly - Histogram Percentiles
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_probe_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop Glam Nightly - Histogram Probe Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__histogram_probe_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__latest_versions_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__latest_versions_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop Glam Nightly - Latest Versions
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__latest_versions_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__latest_versions_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_bucket_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_bucket_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop Glam Nightly - Scalar Bucket Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_bucket_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_bucket_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_percentiles_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_percentiles_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop Glam Nightly - Scalar Percentiles
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_percentiles_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_percentiles_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_probe_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/firefox_desktop_glam_nightly__scalar_probe_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Firefox Desktop Glam Nightly - Scalar Probe Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Histogram Aggregates Metrics
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_activation_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_activation_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Activation
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_activation_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_activation_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_addresses_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_addresses_sync_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Addresses Sync
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_addresses_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_addresses_sync_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_baseline_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_baseline_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Baseline
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_baseline_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_baseline_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_bookmarks_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_bookmarks_sync_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Bookmarks Sync
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_bookmarks_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_bookmarks_sync_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_creditcards_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_creditcards_sync_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Creditcards Sync
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_creditcards_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_creditcards_sync_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_deletion_request_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_deletion_request_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Deletion Request
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_deletion_request_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_deletion_request_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_events_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_events_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Events
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_events_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_events_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_first_session_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_first_session_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates First Session
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_first_session_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_first_session_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_history_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_history_sync_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates History Sync
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_history_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_history_sync_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_installation_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_installation_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Installation
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_installation_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_installation_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_logins_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_logins_sync_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Logins Sync
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_logins_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_logins_sync_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Metrics
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_migration_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_migration_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Migration
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_migration_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_migration_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_startup_timeline_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_startup_timeline_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Startup Timeline
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_startup_timeline_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_startup_timeline_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_sync_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Sync
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_sync_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_tabs_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_tabs_sync_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix - Clients Daily Scalar Aggregates Tabs Sync
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_tabs_sync_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix__clients_daily_scalar_aggregates_tabs_sync_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_histogram_aggregates_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_histogram_aggregates_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_histogram_aggregates_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_histogram_aggregates_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Glam Nightly - Clients Histogram Aggregates
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Glam Nightly - Clients Scalar Aggregates
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__clients_scalar_aggregates_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__extract_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__extract_probe_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Glam Nightly - Extract Probe Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__extract_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__extract_probe_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__extract_user_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__extract_user_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__extract_user_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__extract_user_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Glam Nightly - Extract User Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_bucket_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_bucket_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_bucket_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_bucket_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Glam Nightly - Histogram Bucket Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_percentiles_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_percentiles_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Glam Nightly - Histogram Percentiles
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_percentiles_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_percentiles_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_probe_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Glam Nightly - Histogram Probe Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__histogram_probe_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__latest_versions_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__latest_versions_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Glam Nightly - Latest Versions
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__latest_versions_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__latest_versions_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_bucket_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_bucket_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Glam Nightly - Scalar Bucket Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_bucket_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_bucket_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_percentiles_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_percentiles_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Glam Nightly - Scalar Percentiles
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_percentiles_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_percentiles_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_probe_counts_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Glam Nightly - Scalar Probe Counts
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_probe_counts_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_glam_nightly__scalar_probe_counts_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Nightly - Clients Daily Histogram Aggregates Metrics
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fenix_nightly__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fenix Nightly - Clients Daily Scalar Aggregates Metrics
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fennec_aurora__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fennec_aurora__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fennec_aurora__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fennec_aurora__clients_daily_histogram_aggregates_metrics_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fennec Aurora - Clients Daily Histogram Aggregates Metrics
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fennec_aurora__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fennec_aurora__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
@@ -3,4 +3,4 @@ friendly_name: |-
 description: |-
   [DESCRIPTION_MISSING]
 owners:
-- data-platform-infra-wg@mozilla.com
+- efilho@mozilla.com

--- a/sql/glam-fenix-dev/glam_etl/org_mozilla_fennec_aurora__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
+++ b/sql/glam-fenix-dev/glam_etl/org_mozilla_fennec_aurora__clients_daily_scalar_aggregates_metrics_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Glam Etl - Org Mozilla Fennec Aurora - Clients Daily Scalar Aggregates Metrics
+description: |-
+  [DESCRIPTION_MISSING]
+owners:
+- data-platform-infra-wg@mozilla.com


### PR DESCRIPTION
# issues(3416): added missing metadata.yaml files inside glam-fenix-dev

Adds metadata.yaml files for queries inside glam-fenix-dev that are missing one.

Metadata.yaml added include the following 3 keys with placeholder values:
- `friendly_name` - this is set to dataset name + table name
- `description` - set to `[DESCRIPTION_MISSING]`, this needs to be populated by the owner (as soon as one is determined)
- `owners` - set to `data-platform-infra-wg@mozilla.com` as we did not want to assign it to people without consulting with them first.

Those values for description and owners will enable us to easily search for metadata files without a description and owner assigned.

Next step is to add a CI check to ensure metadata.yaml file is added when a new query is created and contains those three keys.

related: https://github.com/mozilla/bigquery-etl/pull/3640
related: https://github.com/mozilla/bigquery-etl/pull/3656