### PR TITLE
feat(): renamed event_category to fxa_log to avoid confusion with event terminology

### DIFF
--- a/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/flows_v1/query.sql
+++ b/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/flows_v1/query.sql
@@ -7,7 +7,7 @@ WITH fxa_events AS (
     `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
     DATE(`timestamp`) = @submission_date
-    AND event_category IN ('content', 'auth', 'stdout')
+    AND fxa_log IN ('content', 'auth', 'stdout')
 )
 SELECT
   DATE(`timestamp`) AS submission_date,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
@@ -104,39 +104,39 @@ fxa_stdout_events AS (
 unioned AS (
   SELECT
     *,
-    'auth' AS event_category,
+    'auth' AS fxa_log,
   FROM
     fxa_auth_events
   UNION ALL
   SELECT
     *,
-    'auth_bounce' AS event_category,
+    'auth_bounce' AS fxa_log,
   FROM
     fxa_auth_bounce_events
   UNION ALL
   SELECT
     *,
-    'content' AS event_category,
+    'content' AS fxa_log,
   FROM
     fxa_content_events
   UNION ALL
   -- oauth events, see the note on top
   SELECT
     *,
-    'oauth' AS event_category,
+    'oauth' AS fxa_log,
   FROM
     fxa_oauth_events
   UNION ALL
   SELECT
     *,
-    'stdout' AS event_category,
+    'stdout' AS fxa_log,
   FROM
     fxa_stdout_events
 )
 SELECT
   `timestamp`,
   receiveTimestamp,
-  event_category,
+  fxa_log,
   event_type,
   user_id,
   device_id,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
@@ -5,9 +5,9 @@
 --- please use `firefox_accounts.fxa_all_events` view instead
 --- in new queries.
 ---
---- Please filter on `event_category` field to limit your results
+--- Please filter on `fxa_log` field to limit your results
 --- to events coming only from a specific fxa server like so:
---- WHERE event_category IN ('auth', 'stdout', ...)
+--- WHERE fxa_log IN ('auth', 'stdout', ...)
 --- Options include:
 ---   content
 ---   auth
@@ -15,7 +15,7 @@
 ---   oauth -- this has been deprecated and merged into fxa_auth_event
 ---   auth_bounce
 --- to replicate results of this view use:
---- WHERE event_category IN (
+--- WHERE fxa_log IN (
 ---  'content',
 ---  'auth'
 --- )
@@ -107,5 +107,5 @@ FROM
 -- See DENG-582 for more info.
 -- WHERE
 --   ERROR(
---     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
+--     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `fxa_log` instead. See DENG-582 for more info.'
 --   )

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
@@ -5,9 +5,9 @@
 --- please use `firefox_accounts.fxa_all_events` view instead
 --- in new queries.
 ---
---- Please filter on `event_category` field to limit your results
+--- Please filter on `fxa_log` field to limit your results
 --- to events coming only from a specific fxa server like so:
---- WHERE event_category IN ('auth', 'stdout', ...)
+--- WHERE fxa_log IN ('auth', 'stdout', ...)
 --- Options include:
 ---   content
 ---   auth
@@ -15,7 +15,7 @@
 ---   oauth -- this has been deprecated and merged into fxa_auth_event
 ---   auth_bounce
 --- to replicate results of this view use:
---- WHERE event_category IN (
+--- WHERE fxa_log IN (
 ---  'content',
 ---  'auth',
 --   'oauth'
@@ -132,5 +132,5 @@ FROM
 -- See DENG-582 for more info.
 -- WHERE
 --   ERROR(
---     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
+--     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `fxa_log` instead. See DENG-582 for more info.'
 --   )

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
@@ -5,9 +5,9 @@
 --- please use `firefox_accounts.fxa_all_events` view instead
 --- in new queries.
 ---
---- Please filter on `event_category` field to limit your results
+--- Please filter on `fxa_log` field to limit your results
 --- to events coming only from a specific fxa server like so:
---- WHERE event_category IN ('auth', 'stdout', ...)
+--- WHERE fxa_log IN ('auth', 'stdout', ...)
 --- Options include:
 ---   content
 ---   auth
@@ -15,7 +15,7 @@
 ---   oauth -- this has been deprecated and merged into fxa_auth_event
 ---   auth_bounce
 --- to replicate results of this view use:
---- WHERE event_category IN (
+--- WHERE fxa_log IN (
 ---  'content',
 ---  'auth',
 --   'stdout'
@@ -137,5 +137,5 @@ FROM
 -- See DENG-582 for more info.
 -- WHERE
 --   ERROR(
---     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `event_category` instead. See DENG-582 for more info.'
+--     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `fxa_log` instead. See DENG-582 for more info.'
 --   )

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/query.sql
@@ -17,7 +17,7 @@ WITH fxa_events AS (
     `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
     DATE(`timestamp`) = @submission_date
-    AND event_category IN ('content', 'auth', 'oauth')
+    AND fxa_log IN ('content', 'auth', 'oauth')
 )
 SELECT
   DATE(`timestamp`) AS submission_date,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v1/metadata.yaml
@@ -3,7 +3,7 @@ friendly_name: FxA Users Daily
 description: |
   Usage aggregations per FxA user per day.
   Only the following category of events is used for building this models:
-  event_category IN ('auth', 'auth_bounce', 'content', 'oauth')
+  fxa_log IN ('auth', 'auth_bounce', 'content', 'oauth')
   Partitioned by submission_date and clustered by user_id.
 owners:
   - kignasiak@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v1/query.sql
@@ -51,7 +51,7 @@ WITH windowed AS (
   FROM
     `firefox_accounts.fxa_all_events`
   WHERE
-    event_category IN ('auth', 'auth_bounce', 'content', 'oauth')
+    fxa_log IN ('auth', 'auth_bounce', 'content', 'oauth')
     AND user_id IS NOT NULL
     AND event_type NOT IN ( --
       'fxa_email - bounced',

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/init.sql
@@ -13,6 +13,6 @@ FROM
   firefox_accounts.fxa_all_events
 WHERE
   `timestamp` > '2010-01-01'
-  AND event_category IN ('auth', 'auth_bounce', 'content', 'oauth')
+  AND fxa_log IN ('auth', 'auth_bounce', 'content', 'oauth')
 GROUP BY
   user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/query.sql
@@ -6,7 +6,7 @@ WITH _current AS (
     firefox_accounts.fxa_all_events
   WHERE
     DATE(`timestamp`) = @submission_date
-    AND event_category IN ('auth', 'auth_bounce', 'content', 'oauth')
+    AND fxa_log IN ('auth', 'auth_bounce', 'content', 'oauth')
   GROUP BY
     user_id
 ),

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v1/query.sql
@@ -50,7 +50,7 @@ WITH base AS (
   FROM
     `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
-    event_category IN ('content', 'auth', 'oauth')
+    fxa_log IN ('content', 'auth', 'oauth')
     AND user_id IS NOT NULL
     AND event_type NOT IN ( --
       'fxa_email - bounced',

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v2/query.sql
@@ -54,7 +54,7 @@ WITH fxa_events AS (
     DATE(`timestamp`)
     BETWEEN DATE_SUB(@submission_date, INTERVAL 1 DAY)
     AND @submission_date
-    AND event_category IN ('content', 'auth', 'oauth')
+    AND fxa_log IN ('content', 'auth', 'oauth')
     AND event_type NOT IN ( --
       'fxa_email - bounced',
       'fxa_email - click',

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_devices_daily_v1/query.sql
@@ -27,7 +27,7 @@ WITH fxa_events AS (
     -- this includes fields such as entrypoint, utm's etc.
     BETWEEN DATE_SUB(@submission_date, INTERVAL 1 DAY)
     AND @submission_date
-    AND event_category IN ('content', 'auth', 'oauth')
+    AND fxa_log IN ('content', 'auth', 'oauth')
     -- re-using the filter from users_services_daily_v1 for consistency across the models
     -- at some point in the future we should re-evaluate this list
     AND event_type NOT IN ( --

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/init.sql
@@ -19,7 +19,7 @@ WITH fxa_content_auth_oauth AS (
   FROM
     `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
-    event_category IN ('content', 'auth', 'oauth')
+    fxa_log IN ('content', 'auth', 'oauth')
 ),
   -- use a window function to look within each USER and SERVICE for the first value of service, os, and country.
   -- also, get the first value of flow_id for later use and create a boolean column that is true if the first instance of a service usage includes a registration.

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v1/query.sql
@@ -11,7 +11,7 @@ WITH fxa_content_auth_oauth AS (
   FROM
     `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
-    event_category IN ('content', 'auth', 'oauth')
+    fxa_log IN ('content', 'auth', 'oauth')
 ),
   -- use a window function to look within each USER and SERVICE for the first value of service, os, and country.
   -- also, get the first value of flow_id for later use and create a boolean column that is true if the first instance of a service usage includes a registration.

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
@@ -46,7 +46,7 @@ events AS (
   FROM
     `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
-    event_category IN ('content', 'auth', 'stdout')
+    fxa_log IN ('content', 'auth', 'stdout')
 ),
 flows AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/fxa_attribution_v1/query.sql
@@ -17,7 +17,7 @@ WITH fxa_content_auth_stdout_events AS (
   FROM
     `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
   WHERE
-    event_category IN ('content', 'auth', 'stdout')
+    fxa_log IN ('content', 'auth', 'stdout')
 ),
 flows AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/login_flows_v1/query.sql
@@ -17,7 +17,7 @@ WITH base AS (
     `moz-fx-data-shared-prod`.firefox_accounts.fxa_all_events
   WHERE
     IF(@date IS NULL, DATE(`timestamp`) < CURRENT_DATE, DATE(`timestamp`) = @date)
-    AND event_category IN ('content', 'auth')
+    AND fxa_log IN ('content', 'auth')
     AND service = "guardian-vpn"
   GROUP BY
     flow_id


### PR DESCRIPTION
# feat(): renamed event_category to fxa_log to avoid confusion with event terminology

Whilst working with the FxA event data, it came to my attention that in the context of events and event analysis logic `event_category` is already used. This change aims to avoid those two fields getting confused.