### PR TITLE
Fix query for firefox desktop active_users_aggregates

### DIFF
--- a/sql_generators/active_users/templates/desktop_query.sql
+++ b/sql_generators/active_users/templates/desktop_query.sql
@@ -8,7 +8,7 @@ WITH todays_metrics AS (
     normalized_channel AS channel,
     IFNULL(country, '??') country,
     city,
-    locale,
+    COALESCE(REGEXP_EXTRACT(locale, r'^(.+?)-'), locale, NULL) AS locale,
     first_seen_date,
     EXTRACT(YEAR FROM first_seen_date) AS first_seen_year,
     days_since_seen,


### PR DESCRIPTION
This is a fix for DENG-682 #3609 that set up a derived table and view for firefox desktop acitve users aggregates.  It was discovered that the counts were different between the existing aua table (`moz-fx-data-shared-prod.telemetry_derived.active_users_aggregates_v1`) and the new table (`moz-fx-data-shared-prod.firefox_desktop_derived.active_users_aggregates_v1`).  This PR fixes the `locale` field that attributed to the count differences.

Note there will still be a count difference between the two tables given the recent change in `os_version` field (#3646 )
