### PR TITLE
Expose disqualification and validation_failed counts in experiment_enrollment_other_events_overall_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_other_events_overall_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_other_events_overall_v1/view.sql
@@ -11,7 +11,9 @@ WITH pivot AS (
       STRUCT("enroll_failed" AS event, enroll_failed_count AS count),
       STRUCT("unenroll_failed" AS event, unenroll_failed_count AS count),
       STRUCT("updated" AS event, update_count AS count),
-      STRUCT("update_failed" AS event, update_failed_count AS count)
+      STRUCT("update_failed" AS event, update_failed_count AS count),
+      STRUCT("disqualification" AS event, disqualification_count AS count),
+      STRUCT("validation_failed" AS event, validation_failed_count AS count)
     ] AS events
   FROM
     `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v1`


### PR DESCRIPTION
Used for the experiment enrollments dashboard: https://mozilla.cloud.looker.com/dashboards/216?Experiment=bug-1727596-pref-search-experiment-measuring-the-impacts-of-diffe-release-79-96&Time%20Range%20%5BUTC%5D=28%20day

cc @danielkberry 