### PR TITLE
Synthesize `stripe_subcriptions_history` records for previous plan periods (DENG-754)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform/nonprod_stripe_subscriptions_history/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/nonprod_stripe_subscriptions_history/view.sql
@@ -1,10 +1,11 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.subscription_platform.nonprod_stripe_subscriptions_history`
 AS
-WITH subscriptions_history AS (
+WITH base_subscriptions_history AS (
   SELECT
     customer_id,
     id AS subscription_id,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _fivetran_start) AS subscription_history_row_number,
     _fivetran_synced AS synced_at,
     _fivetran_start AS valid_from,
     LEAD(_fivetran_start) OVER (PARTITION BY id ORDER BY _fivetran_start) AS valid_to,
@@ -24,6 +25,40 @@ WITH subscriptions_history AS (
     JSON_VALUE(metadata, "$.previous_plan_id") AS previous_plan_id,
   FROM
     `moz-fx-data-shared-prod`.stripe_external.nonprod_subscription_history_v1
+),
+subscriptions_history AS (
+  -- If a subscription's first history record has a previous_plan_id then synthesize
+  -- an extra history record to represent that previous plan period.
+  SELECT
+    * REPLACE (
+      0 AS subscription_history_row_number,
+      plan_change_date AS valid_to,
+      CAST(NULL AS TIMESTAMP) AS cancel_at,
+      FALSE AS cancel_at_period_end,
+      CAST(NULL AS TIMESTAMP) AS canceled_at,
+      CAST(NULL AS STRING) AS canceled_for_customer_at,
+      CAST(NULL AS TIMESTAMP) AS ended_at,
+      "active" AS status,
+      CAST(NULL AS TIMESTAMP) AS plan_change_date,
+      CAST(NULL AS STRING) AS previous_plan_id
+    )
+  FROM
+    base_subscriptions_history
+  WHERE
+    subscription_history_row_number = 1
+    AND plan_change_date IS NOT NULL
+    AND previous_plan_id IS NOT NULL
+  UNION ALL
+  SELECT
+    * REPLACE (
+      IF(
+        subscription_history_row_number = 1,
+        COALESCE(plan_change_date, valid_from),
+        valid_from
+      ) AS valid_from
+    )
+  FROM
+    base_subscriptions_history
 ),
 subscriptions_history_with_lead_plan_metadata AS (
   SELECT


### PR DESCRIPTION
This is necessary because a Fivetran resync of the Stripe data on 2023-02-24 overwrote/deleted `subscription_history` records ([DENG-754](https://mozilla-hub.atlassian.net/browse/DENG-754)), so we now have 841 subscriptions where their first `subscription_history` record has a `previous_plan_id` (which shouldn't normally be possible).

Also, because we only have the most recent plan change in the Stripe subscription metadata, for any subscriptions that had more than one plan change prior to 2023-02-24 we can no longer tell what those additional previous plan changes were, so it will now appear that each subscription's most recent previous plan prior to 2023-02-24 was in effect from the beginning of the subscription (which may be before that plan was actually created/offered), and this will change the numbering sequence of their subscriptions.  This is the case for at least 42 subscriptions based on there currently being `active_subscription_id` records for 42 Stripe subscriptions with "-3" suffixes that will still not exist after this fix is applied.

After this is merged and the main subscription table ETLs for VPN and Relay have been re-run, their `active_subscription_ids`, `active_subscriptions`, `channel_group_proportions`, and `subscription_events` tables will need to be updated.
- For `mozilla_vpn_derived.active_subscription_ids_v1` we'll replace just the Stripe subscription IDs going back as far as 2022-11-01 because of the subscription numbering changes, and trying not to exacerbate the historical VPN Apple subscription issues.
  ```sql
  BEGIN TRANSACTION;

  DELETE FROM `moz-fx-data-shared-prod.mozilla_vpn_derived.active_subscription_ids_v1`
  WHERE STARTS_WITH(subscription_id, 'sub_')
    AND active_date >= '2022-11-01';

  INSERT INTO `moz-fx-data-shared-prod.mozilla_vpn_derived.active_subscription_ids_v1`
  SELECT active_date, subscription_id
  FROM `moz-fx-data-shared-prod.mozilla_vpn_derived.active_subscription_ids_live`
  WHERE STARTS_WITH(subscription_id, 'sub_')
    AND active_date >= '2022-11-01'
    AND active_date < CURRENT_DATE - 7;

  COMMIT TRANSACTION;
  ```
- For `relay_derived.active_subscription_ids_v1` we'll replace the subscription IDs going back as far as 2022-09-15 because of the subscription numbering changes.
  ```sql
  BEGIN TRANSACTION;

  DELETE FROM `moz-fx-data-shared-prod.relay_derived.active_subscription_ids_v1`
  WHERE active_date >= '2022-09-15';

  INSERT INTO `moz-fx-data-shared-prod.relay_derived.active_subscription_ids_v1`
  SELECT active_date, subscription_id
  FROM `moz-fx-data-shared-prod.relay_derived.active_subscription_ids_live`
  WHERE active_date >= '2022-09-15'
    AND active_date < CURRENT_DATE - 7;

  COMMIT TRANSACTION;
  ```
- For the other tables we'll re-run their Airflow jobs for execution date 2023-02-24 forward.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DENG-754]: https://mozilla-hub.atlassian.net/browse/DENG-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ