### PR TITLE
Account for new Ad ID field in client_dedupe ping

### DIFF
--- a/dags/bqetl_org_mozilla_firefox_derived.py
+++ b/dags/bqetl_org_mozilla_firefox_derived.py
@@ -85,6 +85,7 @@ with DAG(
         email=["frank@mozilla.com", "telemetry-alerts@mozilla.com"],
         date_partition_parameter="submission_date",
         depends_on_past=False,
+        arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
     )
 
     org_mozilla_firefox_beta_derived__client_deduplication__v1 = bigquery_etl_query(
@@ -96,6 +97,7 @@ with DAG(
         email=["frank@mozilla.com", "telemetry-alerts@mozilla.com"],
         date_partition_parameter="submission_date",
         depends_on_past=False,
+        arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
     )
 
     org_mozilla_firefox_derived__client_deduplication__v1 = bigquery_etl_query(
@@ -107,6 +109,7 @@ with DAG(
         email=["frank@mozilla.com", "telemetry-alerts@mozilla.com"],
         date_partition_parameter="submission_date",
         depends_on_past=False,
+        arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
     )
 
     wait_for_baseline_clients_daily = ExternalTaskSensor(

--- a/sql/moz-fx-data-shared-prod/fenix/client_deduplication/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/client_deduplication/view.sql
@@ -1,17 +1,28 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.fenix.client_deduplication`
 AS
+WITH unioned AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_firefox.client_deduplication`
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_firefox_beta.client_deduplication`
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_fenix.client_deduplication`
+)
 SELECT
+  client_info.client_id,
+  COALESCE(
+    metrics.string.client_deduplication_hashed_gaid,
+    metrics.string.activation_identifier
+  ) AS hashed_ad_id,
   *
 FROM
-  `moz-fx-data-shared-prod.org_mozilla_firefox.client_deduplication`
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.org_mozilla_firefox_beta.client_deduplication`
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.org_mozilla_fenix.client_deduplication`
+  unioned

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/client_deduplication_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/client_deduplication_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
 scheduling:
   dag_name: bqetl_org_mozilla_firefox_derived
   depends_on_past: false
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/client_deduplication_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/client_deduplication_v1/query.sql
@@ -30,7 +30,13 @@ SELECT
                   (SELECT * FROM hmac_key),
                   CAST(metrics.string.activation_identifier AS BYTES)
                 )
-              ) AS activation_identifier
+              ) AS activation_identifier,
+              TO_HEX(
+                `moz-fx-data-shared-prod`.udf.hmac_sha256(
+                  (SELECT * FROM hmac_key),
+                  CAST(metrics.string.client_deduplication_hashed_gaid AS BYTES)
+                )
+              ) AS client_deduplication_hashed_gaid
             )
         ) AS string
       )

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/client_deduplication_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/client_deduplication_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
 scheduling:
   dag_name: bqetl_org_mozilla_firefox_derived
   depends_on_past: false
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/client_deduplication_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/client_deduplication_v1/query.sql
@@ -30,7 +30,13 @@ SELECT
                   (SELECT * FROM hmac_key),
                   CAST(metrics.string.activation_identifier AS BYTES)
                 )
-              ) AS activation_identifier
+              ) AS activation_identifier,
+              TO_HEX(
+                `moz-fx-data-shared-prod`.udf.hmac_sha256(
+                  (SELECT * FROM hmac_key),
+                  CAST(metrics.string.client_deduplication_hashed_gaid AS BYTES)
+                )
+              ) AS client_deduplication_hashed_gaid
             )
         ) AS string
       )

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/client_deduplication_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/client_deduplication_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
 scheduling:
   dag_name: bqetl_org_mozilla_firefox_derived
   depends_on_past: false
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/client_deduplication_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/client_deduplication_v1/query.sql
@@ -30,7 +30,13 @@ SELECT
                   (SELECT * FROM hmac_key),
                   CAST(metrics.string.activation_identifier AS BYTES)
                 )
-              ) AS activation_identifier
+              ) AS activation_identifier,
+              TO_HEX(
+                `moz-fx-data-shared-prod`.udf.hmac_sha256(
+                  (SELECT * FROM hmac_key),
+                  CAST(metrics.string.client_deduplication_hashed_gaid AS BYTES)
+                )
+              ) AS client_deduplication_hashed_gaid
             )
         ) AS string
       )


### PR DESCRIPTION
Details in bug 1822283. The new field is mostly the same as the old one, but without the race condition.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
