### PR TITLE
RS-645 Use normalized_app_name to query search aggregates in search revenue levers query

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/query.sql
@@ -96,7 +96,7 @@ mobile_dau_data AS (
     `moz-fx-data-shared-prod.telemetry.active_users_aggregates_device`
   WHERE
     submission_date = @submission_date
-    AND app_name IN ('Fenix', 'Firefox iOS', 'Focus Android', 'Focus Android')
+    AND app_name IN ('Fenix', 'Firefox iOS', 'Focus Android')
   GROUP BY
     submission_date
 ),
@@ -125,7 +125,7 @@ mobile_data_google AS (
   WHERE
     submission_date = @submission_date
     AND country NOT IN ('RU', 'UA', 'BY', 'TR', 'KZ', 'CN')
-    AND app_name IN ('Focus', 'Fenix', 'Fennec')
+    AND normalized_app_name IN ('Focus', 'Fenix', 'Fennec')
   GROUP BY
     submission_date,
     country,
@@ -166,7 +166,7 @@ mobile_data_bing_ddg AS (
     (submission_date)
   WHERE
     submission_date = @submission_date
-    AND app_name IN ('Focus', 'Fenix', 'Fennec')
+    AND normalized_app_name IN ('Focus', 'Fenix', 'Fennec')
   GROUP BY
     submission_date,
     dau


### PR DESCRIPTION
This goes together with https://github.com/mozilla/bigquery-etl/pull/3672

Like https://github.com/mozilla/bigquery-etl/pull/3680, this will require a backfill starting from 2023-01-01, however here we'll need to backfill `moz-fx-data-shared-prod.telemetry.active_users_aggregates_device` first.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
