### PR TITLE
Revert "Bump zetasql.version from 2022.08.1 to 2023.03.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </profiles>
 
     <properties>
-        <zetasql.version>2023.03.2</zetasql.version>
+        <zetasql.version>2022.08.1</zetasql.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#3688