### PR TITLE
DENG-784 - Add organic and rows topsite columns and to newtab_interactions

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   application: firefox
   incremental: true
   schedule: daily
+  owner1: anicholson
 scheduling:
   dag_name: bqetl_newtab
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/schema.yaml
@@ -164,3 +164,12 @@ fields:
 - mode: NULLABLE
   name: activity_segment
   type: STRING
+- mode: NULLABLE
+  name: topsites_rows
+  type: INTEGER
+- mode: NULLABLE
+  name: organic_topsite_clicks
+  type: INTEGER
+- mode: NULLABLE
+  name: organic_topsite_impressions
+  type: INTEGER


### PR DESCRIPTION
Adds `organic_topsite_clicks`, `organic_topsite_impressions`, `topsites_rows` to `newtab_interactions_v1`.

Adding `topsite_position` adds a lot of cardinality to this table, particularly the impressions data. I'll do some tests to see whether this is a huge difference in terms of storage and/or data scanned. This might call for a v2 of this table with more nesting which will unfortunately require unnesting at query time.