### PR TITLE
feat(DENG-790): Attribution table for firefox ios clients

### DIFF
--- a/dags/bqetl_analytics_tables.py
+++ b/dags/bqetl_analytics_tables.py
@@ -88,3 +88,36 @@ with DAG(
     )
 
     firefox_android_clients.set_upstream(wait_for_baseline_clients_daily)
+<<<<<<< HEAD
+=======
+
+    firefox_ios_clients.set_upstream(wait_for_baseline_clients_daily)
+    wait_for_copy_deduplicate_all = ExternalTaskSensor(
+        task_id="wait_for_copy_deduplicate_all",
+        external_dag_id="copy_deduplicate",
+        external_task_id="copy_deduplicate_all",
+        execution_delta=datetime.timedelta(seconds=3600),
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    firefox_ios_clients.set_upstream(wait_for_copy_deduplicate_all)
+    wait_for_firefox_ios_derived__new_profile_activation__v1 = ExternalTaskSensor(
+        task_id="wait_for_firefox_ios_derived__new_profile_activation__v1",
+        external_dag_id="bqetl_mobile_activation",
+        external_task_id="firefox_ios_derived__new_profile_activation__v1",
+        execution_delta=datetime.timedelta(seconds=7200),
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    firefox_ios_clients.set_upstream(
+        wait_for_firefox_ios_derived__new_profile_activation__v1
+    )
+>>>>>>> ac558e7bb (regenerated bqetl_analytics_aggregations DAg)

--- a/dags/bqetl_analytics_tables.py
+++ b/dags/bqetl_analytics_tables.py
@@ -75,6 +75,23 @@ with DAG(
 
         firefox_android_clients_external.set_upstream(firefox_android_clients)
 
+    firefox_ios_clients = bigquery_etl_query(
+        task_id="firefox_ios_clients",
+        destination_table="firefox_ios_clients_v1",
+        dataset_id="firefox_ios_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="kignasiak@mozilla.com",
+        email=[
+            "gkaberere@mozilla.com",
+            "kignasiak@mozilla.com",
+            "lvargas@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter=None,
+        depends_on_past=True,
+        parameters=["submission_date:DATE:{{ds}}"],
+    )
+
     wait_for_baseline_clients_daily = ExternalTaskSensor(
         task_id="wait_for_baseline_clients_daily",
         external_dag_id="copy_deduplicate",
@@ -88,8 +105,6 @@ with DAG(
     )
 
     firefox_android_clients.set_upstream(wait_for_baseline_clients_daily)
-<<<<<<< HEAD
-=======
 
     firefox_ios_clients.set_upstream(wait_for_baseline_clients_daily)
     wait_for_copy_deduplicate_all = ExternalTaskSensor(
@@ -105,10 +120,10 @@ with DAG(
     )
 
     firefox_ios_clients.set_upstream(wait_for_copy_deduplicate_all)
-    wait_for_firefox_ios_derived__new_profile_activation__v1 = ExternalTaskSensor(
-        task_id="wait_for_firefox_ios_derived__new_profile_activation__v1",
+    wait_for_firefox_ios_derived__new_profile_activation__v2 = ExternalTaskSensor(
+        task_id="wait_for_firefox_ios_derived__new_profile_activation__v2",
         external_dag_id="bqetl_mobile_activation",
-        external_task_id="firefox_ios_derived__new_profile_activation__v1",
+        external_task_id="firefox_ios_derived__new_profile_activation__v2",
         execution_delta=datetime.timedelta(seconds=7200),
         check_existence=True,
         mode="reschedule",
@@ -118,6 +133,5 @@ with DAG(
     )
 
     firefox_ios_clients.set_upstream(
-        wait_for_firefox_ios_derived__new_profile_activation__v1
+        wait_for_firefox_ios_derived__new_profile_activation__v2
     )
->>>>>>> ac558e7bb (regenerated bqetl_analytics_aggregations DAg)

--- a/dags/bqetl_mobile_activation.py
+++ b/dags/bqetl_mobile_activation.py
@@ -80,6 +80,20 @@ with DAG(
         depends_on_past=False,
     )
 
+    with TaskGroup(
+        "firefox_ios_derived__new_profile_activation__v2_external"
+    ) as firefox_ios_derived__new_profile_activation__v2_external:
+        ExternalTaskMarker(
+            task_id="bqetl_analytics_tables__wait_for_firefox_ios_derived__new_profile_activation__v2",
+            external_dag_id="bqetl_analytics_tables",
+            external_task_id="wait_for_firefox_ios_derived__new_profile_activation__v2",
+            execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=79200)).isoformat() }}",
+        )
+
+        firefox_ios_derived__new_profile_activation__v2_external.set_upstream(
+            firefox_ios_derived__new_profile_activation__v2
+        )
+
     wait_for_baseline_clients_last_seen = ExternalTaskSensor(
         task_id="wait_for_baseline_clients_last_seen",
         external_dag_id="copy_deduplicate",

--- a/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
@@ -1,0 +1,43 @@
+CREATE OR REPLACE VIEW
+  firefox_ios.firefox_ios_clients
+AS
+SELECT
+  * REPLACE (
+    COALESCE(
+      first_seen_date,
+      metadata.min_first_session_ping_submission_date,
+      metadata.min_metrics_ping_submission_date
+    ) AS first_seen_date,
+    STRUCT(
+      CASE
+        WHEN adjust_info.adjust_network IS NULL
+          OR adjust_info.adjust_network = ''
+          THEN 'Unknown'
+        WHEN adjust_info.adjust_network NOT IN (
+            'Organic',
+            'Google Organic Search',
+            'Untrusted Devices',
+            'Product Marketing (Owned media)',
+            'Google Ads ACI'
+          )
+          THEN 'Other'
+        ELSE adjust_info.adjust_network
+      END AS adjust_network,
+      adjust_info.adjust_ad_group,
+      adjust_info.adjust_campaign,
+      adjust_info.adjust_creative,
+      adjust_info.submission_timestamp
+    ) AS adjust_info,
+    CASE
+      WHEN install_source IS NULL
+        OR install_source = ''
+        THEN 'Unknown'
+      WHEN install_source NOT IN (
+          'com.android.vending'
+        )  -- TODO: this needs to be changed
+        THEN 'Other'
+      ELSE install_source
+    END AS install_source
+  ),
+FROM
+  tmp.kik_firefox_ios_attribution_1st_version

--- a/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
@@ -11,14 +11,11 @@ SELECT
     STRUCT(
       CASE
         WHEN adjust_info.adjust_network IS NULL
-          OR adjust_info.adjust_network = ''
           THEN 'Unknown'
         WHEN adjust_info.adjust_network NOT IN (
-            'Organic',
-            'Google Organic Search',
-            'Untrusted Devices',
+            'Apple Search Ads',
             'Product Marketing (Owned media)',
-            'Google Ads ACI'
+            'product-owned'
           )
           THEN 'Other'
         ELSE adjust_info.adjust_network
@@ -27,17 +24,7 @@ SELECT
       adjust_info.adjust_campaign,
       adjust_info.adjust_creative,
       adjust_info.submission_timestamp
-    ) AS adjust_info,
-    CASE
-      WHEN install_source IS NULL
-        OR install_source = ''
-        THEN 'Unknown'
-      WHEN install_source NOT IN (
-          'com.android.vending'
-        )  -- TODO: this needs to be changed
-        THEN 'Other'
-      ELSE install_source
-    END AS install_source
+    ) AS adjust_info
   ),
 FROM
-  tmp.kik_firefox_ios_attribution_1st_version
+  firefox_ios_derived.firefox_ios_clients_v1

--- a/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
@@ -1,30 +1,19 @@
 CREATE OR REPLACE VIEW
-  firefox_ios.firefox_ios_clients
+  `moz-fx-data-shared-prod.firefox_ios.firefox_ios_clients`
 AS
 SELECT
   * REPLACE (
-    COALESCE(
-      first_seen_date,
-      metadata.min_first_session_ping_submission_date,
-      metadata.min_metrics_ping_submission_date
-    ) AS first_seen_date,
-    STRUCT(
-      CASE
-        WHEN adjust_info.adjust_network IS NULL
-          THEN 'Unknown'
-        WHEN adjust_info.adjust_network NOT IN (
-            'Apple Search Ads',
-            'Product Marketing (Owned media)',
-            'product-owned'
-          )
-          THEN 'Other'
-        ELSE adjust_info.adjust_network
-      END AS adjust_network,
-      adjust_info.adjust_ad_group,
-      adjust_info.adjust_campaign,
-      adjust_info.adjust_creative,
-      adjust_info.submission_timestamp
-    ) AS adjust_info
+    CASE
+      WHEN adjust_network IS NULL
+        THEN 'Unknown'
+      WHEN adjust_network NOT IN (
+          'Apple Search Ads',
+          'Product Marketing (Owned media)',
+          'product-owned'
+        )
+        THEN 'Other'
+      ELSE adjust_network
+    END AS adjust_network
   ),
 FROM
-  firefox_ios_derived.firefox_ios_clients_v1
+  `moz-fx-data-shared-prod.firefox_ios_derived.firefox_ios_clients_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
@@ -1,0 +1,53 @@
+friendly_name: Firefox iOS Clients
+description: |-
+  First observations for Firefox iOS clients of channel Release,
+  retrieved from the earliest pings: baseline, first_session and metrics.
+  The attributes stored in this table include the first attribution,
+  device, OS and ISP details.
+
+  This table should be accessed through the user-facing view
+  `firefox_ios.firefox_ios_clients`.
+
+  For analysis purposes, use first_seen_date to query clients that
+  effectively appeared on that date. The submission_date indicates
+  when the server received the data.
+
+  The query for this table overwrites the whole table instead of writing to
+  a single partition, so manual backfills must use parameter --no_partition.
+
+  Proposal:
+  https://docs.google.com/document/d/12bj4DhCybelqHVgOVq8KJlzgtbbUw3f68palNrv-gaM/.
+
+  For more details about attribution and campaign structure see:
+  https://help.adjust.com/en/article/tracker-urls#campaign-structure-parameters.
+owners:
+- kignasiak@mozilla.com
+labels:
+  application: firefox_ios
+  incremental: true
+  schedule: daily
+  owner: kignasiak@mozilla.com
+scheduling:
+  dag_name: bqetl_analytics_tables
+  task_name: firefox_ios_clients
+  depends_on_past: true
+  date_partition_parameter: null
+  depends_on:
+  - task_id: baseline_clients_daily
+    dag_name: copy_deduplicate
+    execution_delta: 1h
+  parameters:
+  - submission_date:DATE:{{ds}}
+bigquery:
+  time_partitioning:
+    type: day
+    field: first_seen_date
+    require_partition_filter: false
+    expiration_days: null
+  clustering:
+    fields:
+    - channel
+    - sample_id
+    - first_reported_country
+    - device_model
+references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
@@ -25,7 +25,6 @@ labels:
   application: firefox_ios
   incremental: true
   schedule: daily
-  owner: kignasiak@mozilla.com
 scheduling:
   dag_name: bqetl_analytics_tables
   task_name: firefox_ios_clients

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Firefox Clients (iOS)
 description: |-
-  First observations for Firefox iOS clients of channel `release`,
+  First observations for Firefox iOS clients,
   retrieved from the earliest pings: baseline, first_session and metrics.
   The attributes stored in this table include the first attribution,
   device, OS and ISP details.
@@ -23,7 +23,7 @@ owners:
 - kignasiak@mozilla.com
 labels:
   application: firefox_ios
-  incremental: true  # TODO: should this be false sinse the table is overwritten on each run?
+  incremental: true
   schedule: daily
   owner: kignasiak@mozilla.com
 scheduling:

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
@@ -47,6 +47,5 @@ bigquery:
     fields:
     - channel
     - sample_id
-    - first_reported_country
-    - device_model
+    - first_reported_isp
 references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
@@ -1,6 +1,6 @@
-friendly_name: Firefox iOS Clients
+friendly_name: Firefox Clients (iOS)
 description: |-
-  First observations for Firefox iOS clients of channel Release,
+  First observations for Firefox iOS clients of channel `release`,
   retrieved from the earliest pings: baseline, first_session and metrics.
   The attributes stored in this table include the first attribution,
   device, OS and ISP details.
@@ -9,8 +9,7 @@ description: |-
   `firefox_ios.firefox_ios_clients`.
 
   For analysis purposes, use first_seen_date to query clients that
-  effectively appeared on that date. The submission_date indicates
-  when the server received the data.
+  effectively appeared on that date.
 
   The query for this table overwrites the whole table instead of writing to
   a single partition, so manual backfills must use parameter --no_partition.
@@ -24,7 +23,7 @@ owners:
 - kignasiak@mozilla.com
 labels:
   application: firefox_ios
-  incremental: true
+  incremental: true  # TODO: should this be false sinse the table is overwritten on each run?
   schedule: daily
   owner: kignasiak@mozilla.com
 scheduling:

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -1,0 +1,291 @@
+-- Query first observations for Firefox iOS Clients.
+WITH first_seen AS (
+  SELECT
+    client_id,
+    submission_date,
+    first_run_date,
+    first_seen_date,
+    sample_id,
+    country AS first_reported_country,
+    isp AS first_reported_isp,
+    normalized_channel AS channel,
+    device_manufacturer,
+    device_model,
+    normalized_os_version AS os_version,
+    app_display_version AS app_version
+  FROM
+    `moz-fx-data-shared-prod.firefox_ios.baseline_clients_first_seen`
+  WHERE
+    submission_date = @submission_date
+    AND client_id IS NOT NULL
+    -- TODO: is this meant to be restricted to release channel only?
+    AND normalized_channel = 'release'
+),
+-- Find the most recent activation record per client_id.
+-- # TODO: new_profile_activation needs to be created for firefox_ios first
+-- #        this should probably a separate ETL and join with this using a view to avoid having to recreate this table
+-- #        to reflect users activation status
+-- activations AS (
+--   SELECT
+--     client_id,
+--     ARRAY_AGG(activated ORDER BY submission_date DESC)[SAFE_OFFSET(0)] > 0 AS activated
+--   FROM
+--     `moz-fx-data-shared-prod.fenix.new_profile_activation`
+--   WHERE
+--     submission_date = @submission_date
+--   GROUP BY
+--     client_id
+-- ),
+-- Find earliest data per client from the first_session ping.
+first_session_ping AS (
+  SELECT
+    client_id,
+    MIN(sample_id) AS sample_id,
+    DATETIME(MIN(submission_timestamp)) AS min_submission_datetime,
+    DATE(MIN(SAFE.PARSE_DATETIME('%F', SUBSTR(first_run_date, 1, 10)))) AS first_run_date,
+    ARRAY_AGG(
+      IF(
+        -- we should probably do the nullif prior to doing this is not null check
+        adjust_ad_group IS NOT NULL
+        OR adjust_campaign IS NOT NULL
+        OR adjust_creative IS NOT NULL
+        OR adjust_network IS NOT NULL,
+        STRUCT(
+          submission_timestamp,
+          adjust_ad_group,
+          adjust_campaign,
+          adjust_creative,
+          adjust_network
+        ),
+        NULL
+      ) IGNORE NULLS
+      ORDER BY
+        submission_timestamp
+      LIMIT
+        1
+    )[SAFE_OFFSET(0)] AS adjust_info,
+    FROM (
+      SELECT
+        client_info.client_id,
+        sample_id,
+        submission_timestamp,
+        client_info.first_run_date,
+        NULLIF(metrics.string.adjust_ad_group, "") AS adjust_ad_group,
+        NULLIF(metrics.string.adjust_campaign, "") AS adjust_campaign,
+        NULLIF(metrics.string.adjust_creative, "") AS adjust_creative,
+        NULLIF(metrics.string.adjust_network, "") AS adjust_network,
+      FROM
+        `moz-fx-data-shared-prod.firefox_ios.first_session`
+      WHERE
+        DATE(submission_timestamp) = @submission_date
+        AND client_info.client_id IS NOT NULL
+        AND ping_info.seq = 0 -- Pings are sent in sequence, this guarantees that the first one is returned.
+    )
+  GROUP BY
+    client_id
+),
+-- Find earliest data per client from the metrics ping.
+metrics_ping AS (
+  SELECT
+    client_id,
+    MIN(sample_id) AS sample_id,
+    DATETIME(MIN(submission_timestamp)) AS min_submission_datetime,  -- do we need this? Looks like later we might want to see timestamp corresponding to the row that contains the campaign info
+    ARRAY_AGG(
+      IF(
+        adjust_ad_group IS NOT NULL
+        OR adjust_campaign IS NOT NULL
+        OR adjust_creative IS NOT NULL
+        OR adjust_network IS NOT NULL,
+        STRUCT(
+          submission_timestamp,
+          adjust_ad_group,
+          adjust_campaign,
+          adjust_creative,
+          adjust_network
+        ),
+        NULL
+      ) IGNORE NULLS
+      ORDER BY
+        submission_timestamp
+      LIMIT
+        1
+    )[SAFE_OFFSET(0)] AS adjust_info,
+    -- # TODO: understand better the install_source field.
+    ARRAY_AGG(install_source IGNORE NULLS ORDER BY submission_timestamp ASC)[
+      SAFE_OFFSET(0)
+    ] AS install_source,
+FROM (
+  SELECT
+    client_info.client_id AS client_id,
+    sample_id,
+    submission_timestamp,
+    NULLIF(metrics.string.metrics_adjust_ad_group, "") AS adjust_ad_group,
+    NULLIF(metrics.string.metrics_adjust_campaign, "") AS adjust_campaign,
+    NULLIF(metrics.string.metrics_adjust_creative, "") AS adjust_creative,
+    NULLIF(metrics.string.metrics_adjust_network, "") AS adjust_network,
+    NULLIF(metrics.string.metrics_install_source, "") AS install_source,
+  FROM
+    `org_mozilla_firefox.metrics`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND client_info.client_id IS NOT NULL
+  )
+  GROUP BY
+    client_id
+),
+_current AS (
+  SELECT
+    * EXCEPT(min_submission_datetime, first_run_date, sample_id, adjust_info),
+    COALESCE(first_session.adjust_info, metrics.adjust_info) AS adjust_info,
+    COALESCE(first_seen.sample_id, first_session.sample_id, metrics.sample_id) AS sample_id,
+    -- activated AS activated,  -- # TODO: this field would require the whole table to be updated
+    STRUCT(
+      IF(first_session.client_id IS NULL, FALSE, TRUE) AS reported_first_session_ping,
+      IF(metrics.client_id IS NULL, FALSE, TRUE) AS reported_metrics_ping,
+      DATE(first_session.min_submission_datetime) AS min_first_session_ping_submission_date,
+      DATE(first_session.first_run_date) AS min_first_session_ping_run_date,
+      DATE(metrics.min_submission_datetime) AS min_metrics_ping_submission_date, -- are these date fields useful?
+      -- # TODO: not quite sure what this case statement is meant to do?
+      -- CASE
+      --   mozfun.norm.get_earliest_value(
+      --     [
+      --       (
+      --         STRUCT(
+      --           CAST(first_session.adjust_network AS STRING),
+      --           first_session.min_submission_datetime
+      --         )
+      --       ),
+      --       (STRUCT(CAST(metrics.adjust_network AS STRING), metrics.min_submission_datetime))
+      --     ]
+      --   )
+      --   WHEN STRUCT(first_session.adjust_network, first_session.min_submission_datetime)
+      --     THEN 'first_session'
+      --   WHEN STRUCT(metrics.adjust_network, metrics.min_submission_datetime)
+      --     THEN 'metrics'
+      --   ELSE NULL
+      -- END AS adjust_network__source_ping,
+      -- TODO: is this doing the same as above?
+      CASE
+        WHEN first_session.adjust_info IS NOT NULL THEN "first_session"
+        WHEN metrics.adjust_info IS NOT NULL THEN "metrics"
+        ELSE NULL
+      END AS adjust_info__source_ping,
+      CASE
+        WHEN metrics.install_source IS NOT NULL THEN "metrics"
+        ELSE NULL
+      END AS install_source__source_ping
+    ) AS metadata
+  FROM
+    first_seen
+  FULL OUTER JOIN
+    first_session_ping AS first_session
+  USING
+    (client_id)
+  FULL OUTER JOIN
+    metrics_ping AS metrics
+  USING
+    (client_id)
+  -- LEFT JOIN
+  --   activations
+  -- USING
+  --   (client_id)
+  -- WHERE
+  --   client_id IS NOT NULL
+)
+-- _previous AS (
+--   SELECT
+--     client_id
+--   FROM
+--     `firefox_ios_derived.firefox_ios_clients_v1`
+-- )
+SELECT
+  -- # TODO: need to do this piece of grabbing old and new entries
+  -- to complete entries for a client in case they're missing information from
+  -- when they were initially processed.
+  _current.*,
+  -- client_id,
+  -- COALESCE(_previous.sample_id, _current.sample_id) AS sample_id,
+  -- COALESCE(_previous.first_seen_date, _current.first_seen_date) AS first_seen_date,
+  -- COALESCE(_previous.submission_date, _current.submission_date) AS submission_date,
+  -- COALESCE(_previous.first_run_date, _current.first_run_date) AS first_run_date,
+  -- COALESCE(
+  --   _previous.first_reported_country,
+  --   _current.first_reported_country
+  -- ) AS first_reported_country,
+  -- COALESCE(_previous.first_reported_isp, _current.first_reported_isp) AS first_reported_isp,
+  -- COALESCE(_previous.channel, _current.channel) AS channel,
+  -- COALESCE(_previous.device_manufacturer, _current.device_manufacturer) AS device_manufacturer,
+  -- COALESCE(_previous.device_model, _current.device_model) AS device_model,
+  -- COALESCE(_previous.os_version, _current.os_version) AS os_version,
+  -- COALESCE(_previous.app_version, _current.app_version) AS app_version,
+  -- COALESCE(_previous.activated, _current.activated) AS activated,
+  -- COALESCE(_previous.adjust_campaign, _current.adjust_campaign) AS adjust_campaign,
+  -- COALESCE(_previous.adjust_ad_group, _current.adjust_ad_group) AS adjust_ad_group,
+  -- COALESCE(_previous.adjust_creative, _current.adjust_creative) AS adjust_creative,
+  -- COALESCE(_previous.adjust_network, _current.adjust_network) AS adjust_network,
+  -- COALESCE(_previous.install_source, _current.install_source) AS install_source,
+  -- STRUCT(
+  --   _previous.metadata.reported_first_session_ping
+  --   OR _current.metadata.reported_first_session_ping AS reported_first_session_ping,
+  --   _previous.metadata.reported_metrics_ping
+  --   OR _current.metadata.reported_metrics_ping AS reported_metrics_ping,
+  --   CASE
+  --     WHEN _previous.metadata.min_first_session_ping_submission_date IS NOT NULL
+  --       AND _current.metadata.min_first_session_ping_submission_date IS NOT NULL
+  --       THEN LEAST(
+  --           _previous.metadata.min_first_session_ping_submission_date,
+  --           _current.metadata.min_first_session_ping_submission_date
+  --         )
+  --     ELSE COALESCE(
+  --         _previous.metadata.min_first_session_ping_submission_date,
+  --         _current.metadata.min_first_session_ping_submission_date
+  --       )
+  --   END AS min_first_session_ping_submission_date,
+  --   CASE
+  --     WHEN _previous.metadata.min_first_session_ping_run_date IS NOT NULL
+  --       AND _current.metadata.min_first_session_ping_run_date IS NOT NULL
+  --       THEN LEAST(
+  --           _previous.metadata.min_first_session_ping_run_date,
+  --           _current.metadata.min_first_session_ping_run_date
+  --         )
+  --     ELSE COALESCE(
+  --         _previous.metadata.min_first_session_ping_run_date,
+  --         _current.metadata.min_first_session_ping_run_date
+  --       )
+  --   END AS min_first_session_ping_run_date,
+  --   CASE
+  --     WHEN _previous.metadata.min_metrics_ping_submission_date IS NOT NULL
+  --       AND _current.metadata.min_metrics_ping_submission_date IS NOT NULL
+  --       THEN LEAST(
+  --           _previous.metadata.min_metrics_ping_submission_date,
+  --           _current.metadata.min_metrics_ping_submission_date
+  --         )
+  --     ELSE COALESCE(
+  --         _previous.metadata.min_metrics_ping_submission_date,
+  --         _current.metadata.min_metrics_ping_submission_date
+  --       )
+  --   END AS min_metrics_ping_submission_date,
+  --   COALESCE(
+  --     _previous.metadata.adjust_network__source_ping,
+  --     _current.metadata.adjust_network__source_ping
+  --   ) AS adjust_network__source_ping,
+  --   COALESCE(
+  --     _previous.metadata.install_source__source_ping,
+  --     _current.metadata.install_source__source_ping
+  --   ) AS install_source__source_ping,
+  --   COALESCE(
+  --     _previous.metadata.adjust_network__source_ping_datetime,
+  --     _current.metadata.adjust_network__source_ping_datetime
+  --   ) AS adjust_network__source_ping_datetime,
+  --   COALESCE(
+  --     _previous.metadata.install_source__source_ping_datetime,
+  --     _current.metadata.install_source__source_ping_datetime
+  --   ) AS install_source__source_ping_datetime
+  -- ) AS metadata
+FROM
+  _current
+-- FULL OUTER JOIN
+--   _previous
+-- USING
+--   (client_id)
+-- WHERE _previous.client_id IS NULL

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -3,7 +3,7 @@ WITH first_seen AS (
   SELECT
     client_id,
     submission_date,
-    first_run_date,
+    -- first_run_date,
     first_seen_date,
     sample_id,
     country AS first_reported_country,
@@ -18,8 +18,6 @@ WITH first_seen AS (
   WHERE
     submission_date = @submission_date
     AND client_id IS NOT NULL
-    -- TODO: is this meant to be restricted to release channel only?
-    AND normalized_channel = 'release'
 ),
 -- Find the most recent activation record per client_id.
 activations AS (
@@ -34,12 +32,28 @@ activations AS (
     client_id
 ),
 -- Find earliest data per client from the first_session ping.
+first_session_ping_base AS (
+  SELECT
+    client_info.client_id,
+    sample_id,
+    submission_timestamp,
+    -- client_info.first_run_date,
+    NULLIF(metrics.string.adjust_ad_group, "") AS adjust_ad_group,
+    NULLIF(metrics.string.adjust_campaign, "") AS adjust_campaign,
+    NULLIF(metrics.string.adjust_creative, "") AS adjust_creative,
+    NULLIF(metrics.string.adjust_network, "") AS adjust_network,
+  FROM
+    firefox_ios.first_session
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND client_info.client_id IS NOT NULL
+),
 first_session_ping AS (
   SELECT
     client_id,
     MIN(sample_id) AS sample_id,
-    DATETIME(MIN(submission_timestamp)) AS min_submission_datetime,
-    DATE(MIN(SAFE.PARSE_DATETIME('%F', SUBSTR(first_run_date, 1, 10)))) AS first_run_date,
+    -- DATETIME(MIN(submission_timestamp)) AS min_submission_datetime,
+    -- DATE(MIN(SAFE.PARSE_DATETIME('%F', SUBSTR(first_run_date, 1, 10)))) AS first_run_date,
     ARRAY_AGG(
       IF(
         -- we should probably do the nullif prior to doing this is not null check
@@ -62,34 +76,34 @@ first_session_ping AS (
         1
     )[SAFE_OFFSET(0)] AS adjust_info,
   FROM
-    (
-      SELECT
-        client_info.client_id,
-        sample_id,
-        submission_timestamp,
-        client_info.first_run_date,
-        NULLIF(metrics.string.adjust_ad_group, "") AS adjust_ad_group,
-        NULLIF(metrics.string.adjust_campaign, "") AS adjust_campaign,
-        NULLIF(metrics.string.adjust_creative, "") AS adjust_creative,
-        NULLIF(metrics.string.adjust_network, "") AS adjust_network,
-      FROM
-        firefox_ios.first_session
-      WHERE
-        DATE(submission_timestamp) = @submission_date
-        AND client_info.client_id IS NOT NULL
-        AND ping_info.seq = 0 -- Pings are sent in sequence, this guarantees that the first one is returned.
-    )
+    first_session_ping_base
   GROUP BY
     client_id
 ),
 -- Find earliest data per client from the metrics ping.
+metrics_ping_base AS (
+  SELECT
+    client_info.client_id AS client_id,
+    sample_id,
+    submission_timestamp,
+    NULLIF(fxa_metrics.metrics.string.adjust_ad_group, "") AS adjust_ad_group,
+    NULLIF(fxa_metrics.metrics.string.adjust_campaign, "") AS adjust_campaign,
+    NULLIF(fxa_metrics.metrics.string.adjust_creative, "") AS adjust_creative,
+    NULLIF(fxa_metrics.metrics.string.adjust_network, "") AS adjust_network,
+    -- NULLIF(metrics.string.metrics_install_source, "") AS install_source,
+  FROM
+    firefox_ios.metrics AS fxa_metrics
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND client_info.client_id IS NOT NULL
+),
 metrics_ping AS (
   SELECT
     client_id,
     MIN(sample_id) AS sample_id,
-    DATETIME(
-      MIN(submission_timestamp)
-    ) AS min_submission_datetime,  -- do we need this? Looks like later we might want to see timestamp corresponding to the row that contains the campaign info
+    -- DATETIME(
+    --   MIN(submission_timestamp)
+    -- ) AS min_submission_datetime,  -- do we need this? Looks like later we might want to see timestamp corresponding to the row that contains the campaign info
     ARRAY_AGG(
       IF(
         adjust_ad_group IS NOT NULL
@@ -111,59 +125,24 @@ metrics_ping AS (
         1
     )[SAFE_OFFSET(0)] AS adjust_info,
   FROM
-    (
-      SELECT
-        client_info.client_id AS client_id,
-        sample_id,
-        submission_timestamp,
-        NULLIF(fxa_metrics.metrics.string.adjust_ad_group, "") AS adjust_ad_group,
-        NULLIF(fxa_metrics.metrics.string.adjust_campaign, "") AS adjust_campaign,
-        NULLIF(fxa_metrics.metrics.string.adjust_creative, "") AS adjust_creative,
-        NULLIF(fxa_metrics.metrics.string.adjust_network, "") AS adjust_network,
-        -- NULLIF(metrics.string.metrics_install_source, "") AS install_source,
-      FROM
-        firefox_ios.metrics AS fxa_metrics
-      WHERE
-        DATE(submission_timestamp) = @submission_date
-        AND client_info.client_id IS NOT NULL
-    )
+    metrics_ping_base
   GROUP BY
     client_id
 ),
 _current AS (
   SELECT
-    * EXCEPT (min_submission_datetime, first_run_date, sample_id, adjust_info),
+    * EXCEPT (sample_id, adjust_info),
     COALESCE(first_session.adjust_info, metrics.adjust_info) AS adjust_info,
     COALESCE(first_seen.sample_id, first_session.sample_id, metrics.sample_id) AS sample_id,
     activated AS activated,
     STRUCT(
       IF(first_session.client_id IS NULL, FALSE, TRUE) AS reported_first_session_ping,
       IF(metrics.client_id IS NULL, FALSE, TRUE) AS reported_metrics_ping,
-      DATE(first_session.min_submission_datetime) AS min_first_session_ping_submission_date,
-      DATE(first_session.first_run_date) AS min_first_session_ping_run_date,
-      DATE(
-        metrics.min_submission_datetime
-      ) AS min_metrics_ping_submission_date, -- TODO: are these date fields useful?
-      -- # TODO: not quite sure what this case statement is meant to do?
-      -- CASE
-      --   mozfun.norm.get_earliest_value(
-      --     [
-      --       (
-      --         STRUCT(
-      --           CAST(first_session.adjust_network AS STRING),
-      --           first_session.min_submission_datetime
-      --         )
-      --       ),
-      --       (STRUCT(CAST(metrics.adjust_network AS STRING), metrics.min_submission_datetime))
-      --     ]
-      --   )
-      --   WHEN STRUCT(first_session.adjust_network, first_session.min_submission_datetime)
-      --     THEN 'first_session'
-      --   WHEN STRUCT(metrics.adjust_network, metrics.min_submission_datetime)
-      --     THEN 'metrics'
-      --   ELSE NULL
-      -- END AS adjust_network__source_ping,
-      -- TODO: is this doing the same as above?
+      -- DATE(first_session.min_submission_datetime) AS min_first_session_ping_submission_date,
+      -- DATE(first_session.first_run_date) AS min_first_session_ping_run_date,
+      -- DATE(
+      --   metrics.min_submission_datetime
+      -- ) AS min_metrics_ping_submission_date, -- TODO: are these date fields useful?
       CASE
         WHEN first_session.adjust_info IS NOT NULL
           THEN "first_session"
@@ -240,18 +219,18 @@ SELECT
       _previous.metadata.reported_metrics_ping,
       _current.metadata.reported_metrics_ping
     ) AS reported_metrics_ping,
-    COALESCE(
-      _previous.metadata.min_first_session_ping_submission_date,
-      _current.metadata.min_first_session_ping_submission_date
-    ) AS min_first_session_ping_submission_date,
-    COALESCE(
-      _previous.metadata.min_first_session_ping_run_date,
-      _current.metadata.min_first_session_ping_run_date
-    ) AS min_first_session_ping_run_date,
-    COALESCE(
-      _previous.metadata.min_metrics_ping_submission_date,
-      _current.metadata.min_metrics_ping_submission_date
-    ) AS min_metrics_ping_submission_date,
+    -- COALESCE(
+    --   _previous.metadata.min_first_session_ping_submission_date,
+    --   _current.metadata.min_first_session_ping_submission_date
+    -- ) AS min_first_session_ping_submission_date,
+    -- COALESCE(
+    --   _previous.metadata.min_first_session_ping_run_date,
+    --   _current.metadata.min_first_session_ping_run_date
+    -- ) AS min_first_session_ping_run_date,
+    -- COALESCE(
+    --   _previous.metadata.min_metrics_ping_submission_date,
+    --   _current.metadata.min_metrics_ping_submission_date
+    -- ) AS min_metrics_ping_submission_date,
     COALESCE(
       _previous.metadata.adjust_info__source_ping,
       _current.metadata.adjust_info__source_ping

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -22,7 +22,7 @@ WITH first_seen AS (
 activations AS (
   SELECT
     client_id,
-    activated > 0 AS activated,
+    activated,
   FROM
     firefox_ios.new_profile_activation
   WHERE

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -131,10 +131,10 @@ metrics_ping AS (
 ),
 _current AS (
   SELECT
-    * EXCEPT (sample_id, adjust_info),
+    * EXCEPT (sample_id, adjust_info, activated),
     COALESCE(first_session.adjust_info, metrics.adjust_info) AS adjust_info,
     COALESCE(first_seen.sample_id, first_session.sample_id, metrics.sample_id) AS sample_id,
-    activated AS activated,
+    activations.activated AS activated,
     STRUCT(
       IF(first_session.client_id IS NULL, FALSE, TRUE) AS reported_first_session_ping,
       IF(metrics.client_id IS NULL, FALSE, TRUE) AS reported_metrics_ping,
@@ -188,6 +188,7 @@ SELECT
   COALESCE(_previous.device_model, _current.device_model) AS device_model,
   COALESCE(_previous.os_version, _current.os_version) AS os_version,
   COALESCE(_previous.app_version, _current.app_version) AS app_version,
+  COALESCE(_previous.activated, _current.activated) AS activated,
   STRUCT(
     COALESCE(
       _previous.adjust_info.submission_timestamp,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -64,7 +64,8 @@ first_session_ping AS (
       LIMIT
         1
     )[SAFE_OFFSET(0)] AS adjust_info,
-    FROM (
+  FROM
+    (
       SELECT
         client_info.client_id,
         sample_id,
@@ -89,7 +90,9 @@ metrics_ping AS (
   SELECT
     client_id,
     MIN(sample_id) AS sample_id,
-    DATETIME(MIN(submission_timestamp)) AS min_submission_datetime,  -- do we need this? Looks like later we might want to see timestamp corresponding to the row that contains the campaign info
+    DATETIME(
+      MIN(submission_timestamp)
+    ) AS min_submission_datetime,  -- do we need this? Looks like later we might want to see timestamp corresponding to the row that contains the campaign info
     ARRAY_AGG(
       IF(
         adjust_ad_group IS NOT NULL
@@ -111,40 +114,44 @@ metrics_ping AS (
         1
     )[SAFE_OFFSET(0)] AS adjust_info,
     -- # TODO: understand better the install_source field.
+    -- what exactly does it contain?
     ARRAY_AGG(install_source IGNORE NULLS ORDER BY submission_timestamp ASC)[
       SAFE_OFFSET(0)
     ] AS install_source,
-FROM (
-  SELECT
-    client_info.client_id AS client_id,
-    sample_id,
-    submission_timestamp,
-    NULLIF(metrics.string.metrics_adjust_ad_group, "") AS adjust_ad_group,
-    NULLIF(metrics.string.metrics_adjust_campaign, "") AS adjust_campaign,
-    NULLIF(metrics.string.metrics_adjust_creative, "") AS adjust_creative,
-    NULLIF(metrics.string.metrics_adjust_network, "") AS adjust_network,
-    NULLIF(metrics.string.metrics_install_source, "") AS install_source,
   FROM
-    `org_mozilla_firefox.metrics`
-  WHERE
-    DATE(submission_timestamp) = @submission_date
-    AND client_info.client_id IS NOT NULL
-  )
+    (
+      SELECT
+        client_info.client_id AS client_id,
+        sample_id,
+        submission_timestamp,
+        NULLIF(metrics.string.metrics_adjust_ad_group, "") AS adjust_ad_group,
+        NULLIF(metrics.string.metrics_adjust_campaign, "") AS adjust_campaign,
+        NULLIF(metrics.string.metrics_adjust_creative, "") AS adjust_creative,
+        NULLIF(metrics.string.metrics_adjust_network, "") AS adjust_network,
+        NULLIF(metrics.string.metrics_install_source, "") AS install_source,
+      FROM
+        `org_mozilla_firefox.metrics`
+      WHERE
+        DATE(submission_timestamp) = @submission_date
+        AND client_info.client_id IS NOT NULL
+    )
   GROUP BY
     client_id
 ),
 _current AS (
   SELECT
-    * EXCEPT(min_submission_datetime, first_run_date, sample_id, adjust_info),
+    * EXCEPT (min_submission_datetime, first_run_date, sample_id, adjust_info),
     COALESCE(first_session.adjust_info, metrics.adjust_info) AS adjust_info,
     COALESCE(first_seen.sample_id, first_session.sample_id, metrics.sample_id) AS sample_id,
-    -- activated AS activated,  -- # TODO: this field would require the whole table to be updated
+    -- activated AS activated,  -- # TODO: new_profile_activation needs to be created before we can get this
     STRUCT(
       IF(first_session.client_id IS NULL, FALSE, TRUE) AS reported_first_session_ping,
       IF(metrics.client_id IS NULL, FALSE, TRUE) AS reported_metrics_ping,
       DATE(first_session.min_submission_datetime) AS min_first_session_ping_submission_date,
       DATE(first_session.first_run_date) AS min_first_session_ping_run_date,
-      DATE(metrics.min_submission_datetime) AS min_metrics_ping_submission_date, -- are these date fields useful?
+      DATE(
+        metrics.min_submission_datetime
+      ) AS min_metrics_ping_submission_date, -- TODO: are these date fields useful?
       -- # TODO: not quite sure what this case statement is meant to do?
       -- CASE
       --   mozfun.norm.get_earliest_value(
@@ -166,12 +173,15 @@ _current AS (
       -- END AS adjust_network__source_ping,
       -- TODO: is this doing the same as above?
       CASE
-        WHEN first_session.adjust_info IS NOT NULL THEN "first_session"
-        WHEN metrics.adjust_info IS NOT NULL THEN "metrics"
+        WHEN first_session.adjust_info IS NOT NULL
+          THEN "first_session"
+        WHEN metrics.adjust_info IS NOT NULL
+          THEN "metrics"
         ELSE NULL
       END AS adjust_info__source_ping,
       CASE
-        WHEN metrics.install_source IS NOT NULL THEN "metrics"
+        WHEN metrics.install_source IS NOT NULL
+          THEN "metrics"
         ELSE NULL
       END AS install_source__source_ping
     ) AS metadata
@@ -189,103 +199,87 @@ _current AS (
   --   activations
   -- USING
   --   (client_id)
-  -- WHERE
-  --   client_id IS NOT NULL
+  WHERE
+    client_id IS NOT NULL
+),
+_previous AS (
+  SELECT
+    *
+  FROM
+    `firefox_ios_derived.firefox_ios_clients_v1`
 )
--- _previous AS (
---   SELECT
---     client_id
---   FROM
---     `firefox_ios_derived.firefox_ios_clients_v1`
--- )
 SELECT
-  -- # TODO: need to do this piece of grabbing old and new entries
-  -- to complete entries for a client in case they're missing information from
-  -- when they were initially processed.
-  _current.*,
-  -- client_id,
-  -- COALESCE(_previous.sample_id, _current.sample_id) AS sample_id,
-  -- COALESCE(_previous.first_seen_date, _current.first_seen_date) AS first_seen_date,
-  -- COALESCE(_previous.submission_date, _current.submission_date) AS submission_date,
-  -- COALESCE(_previous.first_run_date, _current.first_run_date) AS first_run_date,
-  -- COALESCE(
-  --   _previous.first_reported_country,
-  --   _current.first_reported_country
-  -- ) AS first_reported_country,
-  -- COALESCE(_previous.first_reported_isp, _current.first_reported_isp) AS first_reported_isp,
-  -- COALESCE(_previous.channel, _current.channel) AS channel,
-  -- COALESCE(_previous.device_manufacturer, _current.device_manufacturer) AS device_manufacturer,
-  -- COALESCE(_previous.device_model, _current.device_model) AS device_model,
-  -- COALESCE(_previous.os_version, _current.os_version) AS os_version,
-  -- COALESCE(_previous.app_version, _current.app_version) AS app_version,
-  -- COALESCE(_previous.activated, _current.activated) AS activated,
-  -- COALESCE(_previous.adjust_campaign, _current.adjust_campaign) AS adjust_campaign,
-  -- COALESCE(_previous.adjust_ad_group, _current.adjust_ad_group) AS adjust_ad_group,
-  -- COALESCE(_previous.adjust_creative, _current.adjust_creative) AS adjust_creative,
-  -- COALESCE(_previous.adjust_network, _current.adjust_network) AS adjust_network,
-  -- COALESCE(_previous.install_source, _current.install_source) AS install_source,
-  -- STRUCT(
-  --   _previous.metadata.reported_first_session_ping
-  --   OR _current.metadata.reported_first_session_ping AS reported_first_session_ping,
-  --   _previous.metadata.reported_metrics_ping
-  --   OR _current.metadata.reported_metrics_ping AS reported_metrics_ping,
-  --   CASE
-  --     WHEN _previous.metadata.min_first_session_ping_submission_date IS NOT NULL
-  --       AND _current.metadata.min_first_session_ping_submission_date IS NOT NULL
-  --       THEN LEAST(
-  --           _previous.metadata.min_first_session_ping_submission_date,
-  --           _current.metadata.min_first_session_ping_submission_date
-  --         )
-  --     ELSE COALESCE(
-  --         _previous.metadata.min_first_session_ping_submission_date,
-  --         _current.metadata.min_first_session_ping_submission_date
-  --       )
-  --   END AS min_first_session_ping_submission_date,
-  --   CASE
-  --     WHEN _previous.metadata.min_first_session_ping_run_date IS NOT NULL
-  --       AND _current.metadata.min_first_session_ping_run_date IS NOT NULL
-  --       THEN LEAST(
-  --           _previous.metadata.min_first_session_ping_run_date,
-  --           _current.metadata.min_first_session_ping_run_date
-  --         )
-  --     ELSE COALESCE(
-  --         _previous.metadata.min_first_session_ping_run_date,
-  --         _current.metadata.min_first_session_ping_run_date
-  --       )
-  --   END AS min_first_session_ping_run_date,
-  --   CASE
-  --     WHEN _previous.metadata.min_metrics_ping_submission_date IS NOT NULL
-  --       AND _current.metadata.min_metrics_ping_submission_date IS NOT NULL
-  --       THEN LEAST(
-  --           _previous.metadata.min_metrics_ping_submission_date,
-  --           _current.metadata.min_metrics_ping_submission_date
-  --         )
-  --     ELSE COALESCE(
-  --         _previous.metadata.min_metrics_ping_submission_date,
-  --         _current.metadata.min_metrics_ping_submission_date
-  --       )
-  --   END AS min_metrics_ping_submission_date,
-  --   COALESCE(
-  --     _previous.metadata.adjust_network__source_ping,
-  --     _current.metadata.adjust_network__source_ping
-  --   ) AS adjust_network__source_ping,
-  --   COALESCE(
-  --     _previous.metadata.install_source__source_ping,
-  --     _current.metadata.install_source__source_ping
-  --   ) AS install_source__source_ping,
-  --   COALESCE(
-  --     _previous.metadata.adjust_network__source_ping_datetime,
-  --     _current.metadata.adjust_network__source_ping_datetime
-  --   ) AS adjust_network__source_ping_datetime,
-  --   COALESCE(
-  --     _previous.metadata.install_source__source_ping_datetime,
-  --     _current.metadata.install_source__source_ping_datetime
-  --   ) AS install_source__source_ping_datetime
-  -- ) AS metadata
+  client_id,
+  COALESCE(_previous.sample_id, _current.sample_id) AS sample_id,
+  COALESCE(_previous.first_seen_date, _current.first_seen_date) AS first_seen_date,
+  COALESCE(
+    _previous.first_reported_country,
+    _current.first_reported_country
+  ) AS first_reported_country,
+  COALESCE(_previous.first_reported_isp, _current.first_reported_isp) AS first_reported_isp,
+  COALESCE(_previous.channel, _current.channel) AS channel,
+  COALESCE(_previous.device_manufacturer, _current.device_manufacturer) AS device_manufacturer,
+  COALESCE(_previous.device_model, _current.device_model) AS device_model,
+  COALESCE(_previous.os_version, _current.os_version) AS os_version,
+  COALESCE(_previous.app_version, _current.app_version) AS app_version,
+  COALESCE(_previous.install_source, _current.install_source) AS install_source,
+  STRUCT(
+    COALESCE(
+      _previous.adjust_info.submission_timestamp,
+      _current.adjust_info.submission_timestamp
+    ) AS submission_timestamp,
+    COALESCE(
+      _previous.adjust_info.adjust_ad_group,
+      _current.adjust_info.adjust_ad_group
+    ) AS adjust_ad_group,
+    COALESCE(
+      _previous.adjust_info.adjust_campaign,
+      _current.adjust_info.adjust_campaign
+    ) AS adjust_campaign,
+    COALESCE(
+      _previous.adjust_info.adjust_creative,
+      _current.adjust_info.adjust_creative
+    ) AS adjust_creative,
+    COALESCE(
+      _previous.adjust_info.adjust_network,
+      _current.adjust_info.adjust_network
+    ) AS adjust_network
+  ) AS adjust_info,
+  STRUCT(
+    COALESCE(
+      _previous.metadata.reported_first_session_ping,
+      _current.metadata.reported_first_session_ping
+    ) AS reported_first_session_ping,
+    COALESCE(
+      _previous.metadata.reported_metrics_ping,
+      _current.metadata.reported_metrics_ping
+    ) AS reported_metrics_ping,
+    COALESCE(
+      _previous.metadata.min_first_session_ping_submission_date,
+      _current.metadata.min_first_session_ping_submission_date
+    ) AS min_first_session_ping_submission_date,
+    COALESCE(
+      _previous.metadata.min_first_session_ping_run_date,
+      _current.metadata.min_first_session_ping_run_date
+    ) AS min_first_session_ping_run_date,
+    COALESCE(
+      _previous.metadata.min_metrics_ping_submission_date,
+      _current.metadata.min_metrics_ping_submission_date
+    ) AS min_metrics_ping_submission_date,
+    COALESCE(
+      _previous.metadata.adjust_info__source_ping,
+      _current.metadata.adjust_info__source_ping
+    ) AS adjust_info__source_ping,
+    COALESCE(
+      _previous.metadata.install_source__source_ping,
+      _current.metadata.install_source__source_ping
+    ) AS install_source__source_ping
+  ) AS metadata,
+  -- IF(_current.client_id IS NOT NULL, _current, _previous).* REPLACE (
+  -- )
 FROM
   _current
--- FULL OUTER JOIN
---   _previous
--- USING
---   (client_id)
--- WHERE _previous.client_id IS NULL
+FULL OUTER JOIN
+  _previous
+USING
+  (client_id)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -193,12 +193,14 @@ SELECT
   ).*,
   STRUCT(
     COALESCE(
-      _previous.metadata.reported_first_session_ping,
-      _current.metadata.reported_first_session_ping
+      _previous.metadata.reported_first_session_ping
+      OR _current.metadata.reported_first_session_ping,
+      FALSE
     ) AS reported_first_session_ping,
     COALESCE(
-      _previous.metadata.reported_metrics_ping,
-      _current.metadata.reported_metrics_ping
+      _previous.metadata.reported_metrics_ping
+      OR _current.metadata.reported_metrics_ping,
+      FALSE
     ) AS reported_metrics_ping,
     COALESCE(
       _previous.metadata.adjust_info__source_ping,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -27,8 +27,6 @@ activations AS (
     firefox_ios.new_profile_activation
   WHERE
     submission_date = @submission_date
-  GROUP BY
-    client_id
 ),
 -- Find earliest data per client from the first_session ping.
 first_session_ping_base AS (

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -19,8 +19,6 @@ WITH first_seen AS (
     AND client_id IS NOT NULL
 ),
 -- Find the most recent activation record per client_id.
--- TODO: Make sure new_profile_activation does not allow
--- more than 1 record per client_id.
 activations AS (
   SELECT
     client_id,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -14,7 +14,7 @@ WITH first_seen AS (
     normalized_os_version AS os_version,
     app_display_version AS app_version
   FROM
-    `moz-fx-data-shared-prod.firefox_ios.baseline_clients_first_seen`
+    firefox_ios.baseline_clients_first_seen
   WHERE
     submission_date = @submission_date
     AND client_id IS NOT NULL
@@ -30,7 +30,7 @@ WITH first_seen AS (
 --     client_id,
 --     ARRAY_AGG(activated ORDER BY submission_date DESC)[SAFE_OFFSET(0)] > 0 AS activated
 --   FROM
---     `moz-fx-data-shared-prod.fenix.new_profile_activation`
+--     firefox_ios.new_profile_activation
 --   WHERE
 --     submission_date = @submission_date
 --   GROUP BY
@@ -76,7 +76,7 @@ first_session_ping AS (
         NULLIF(metrics.string.adjust_creative, "") AS adjust_creative,
         NULLIF(metrics.string.adjust_network, "") AS adjust_network,
       FROM
-        `moz-fx-data-shared-prod.firefox_ios.first_session`
+        firefox_ios.first_session
       WHERE
         DATE(submission_timestamp) = @submission_date
         AND client_info.client_id IS NOT NULL
@@ -130,7 +130,7 @@ metrics_ping AS (
         NULLIF(metrics.string.metrics_adjust_network, "") AS adjust_network,
         NULLIF(metrics.string.metrics_install_source, "") AS install_source,
       FROM
-        `org_mozilla_firefox.metrics`
+        firefox_ios.metrics
       WHERE
         DATE(submission_timestamp) = @submission_date
         AND client_info.client_id IS NOT NULL
@@ -206,7 +206,7 @@ _previous AS (
   SELECT
     *
   FROM
-    `firefox_ios_derived.firefox_ios_clients_v1`
+    firefox_ios_derived.firefox_ios_clients_v1
 )
 SELECT
   client_id,
@@ -275,8 +275,6 @@ SELECT
       _current.metadata.install_source__source_ping
     ) AS install_source__source_ping
   ) AS metadata,
-  -- IF(_current.client_id IS NOT NULL, _current, _previous).* REPLACE (
-  -- )
 FROM
   _current
 FULL OUTER JOIN

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
@@ -1,0 +1,160 @@
+fields:
+
+- mode: NULLABLE
+  name: client_id
+  type: STRING
+  description: |
+    Unique ID for the client installation.
+
+- mode: NULLABLE
+  name: sample_id
+  type: INTEGER
+  description: |
+    Sample ID to limit query results during an analysis.
+
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+  description: |
+    Date when the app first reported a baseline ping for the client.
+
+- mode: NULLABLE
+  name: first_reported_country
+  type: STRING
+  description: |
+    First reported country for the client installation.
+
+- mode: NULLABLE
+  name: first_reported_isp
+  type: STRING
+  description: |
+    Name of the first reported isp (Internet Service Provider).
+
+- mode: NULLABLE
+  name: channel
+  type: STRING
+  description: |
+    Channel where the browser is released.
+
+- mode: NULLABLE
+  name: device_manufacturer
+  type: STRING
+  description: |
+    Manufacturer of the device where the client is installed.
+
+- mode: NULLABLE
+  name: device_model
+  type: STRING
+  description: |
+    Model of the device where the client is installed.
+
+- mode: NULLABLE
+  name: os_version
+  type: STRING
+  description: |
+    Version of the Operating System where the client is originally installed.
+
+- mode: NULLABLE
+  name: app_version
+  type: STRING
+  description: |
+    App display version for this client installation.
+
+# - mode: NULLABLE
+#   name: activated
+#   type: BOOLEAN
+#   description: |
+#     Determines if a client is activated based on the activation metric and a 7 day lag.
+
+- mode: NULLABLE
+  name: install_source
+  type: STRING
+  description: |
+    The source of a client installation.
+
+
+- mode: NULLABLE
+  name: adjust_info
+  type: RECORD
+  description: |
+    Record containing adjust fields.
+
+  fields:
+  - mode: NULLABLE
+    name: submission_timestamp
+    type: TIMESTAMP
+    description: |
+      Timestamp corresponding to the ping which contained the adjust information.
+
+  - mode: NULLABLE
+    name: adjust_ad_group
+    type: STRING
+    description: |
+      Structure parameter for the the ad group of a campaign.
+
+  - mode: NULLABLE
+    name: adjust_campaign
+    type: STRING
+    description: |
+      Structure parameter for the campaign name.
+
+  - mode: NULLABLE
+    name: adjust_creative
+    type: STRING
+    description: |
+      Structure parameter for the creative content of a campaign.
+
+  - mode: NULLABLE
+    name: adjust_network
+    type: STRING
+    description: |
+      The type of source of a client installation.
+
+- mode: NULLABLE
+  name: metadata
+  type: RECORD
+  description: |
+    Additional context around the source of this record.
+
+  fields:
+  - mode: NULLABLE
+    name: reported_first_session_ping
+    type: BOOLEAN
+    description: |
+      True if the client ever reported a first_session ping.
+
+  - mode: NULLABLE
+    name: reported_metrics_ping
+    type: BOOLEAN
+    description: |
+      True if the client ever reported a metrics ping.
+
+  - mode: NULLABLE
+    name: min_first_session_ping_submission_date
+    type: DATE
+    description: |
+      Date when the first reported first_sessin ping is received by the server.
+
+  - mode: NULLABLE
+    name: min_first_session_ping_run_date
+    type: DATE
+    description: |
+      Date of first app run as reported in the earliest first_session ping.
+
+  - mode: NULLABLE
+    name: min_metrics_ping_submission_date
+    type: DATE
+    description: |
+      Date when the first reported metrics ping is received by the server.
+
+  - mode: NULLABLE
+    name: adjust_info__source_ping
+    type: STRING
+    description: |
+      Ping from which the adjust_info values originate.
+
+  - mode: NULLABLE
+    name: install_source__source_ping
+    type: STRING
+    description: |
+      Ping from which the install_source value originates.

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
@@ -60,11 +60,11 @@ fields:
   description: |
     App display version for this client installation.
 
-# - mode: NULLABLE
-#   name: activated
-#   type: BOOLEAN
-#   description: |
-#     Determines if a client is activated based on the activation metric and a 7 day lag.
+- mode: NULLABLE
+  name: activated
+  type: BOOLEAN
+  description: |
+    Determines if a client is activated based on the activation metric and a 7 day lag.
 
 - mode: NULLABLE
   name: install_source
@@ -129,32 +129,26 @@ fields:
     description: |
       True if the client ever reported a metrics ping.
 
-  - mode: NULLABLE
-    name: min_first_session_ping_submission_date
-    type: DATE
-    description: |
-      Date when the first reported first_sessin ping is received by the server.
+  # - mode: NULLABLE
+  #   name: min_first_session_ping_submission_date
+  #   type: DATE
+  #   description: |
+  #     Date when the first reported first_sessin ping is received by the server.
 
-  - mode: NULLABLE
-    name: min_first_session_ping_run_date
-    type: DATE
-    description: |
-      Date of first app run as reported in the earliest first_session ping.
+  # - mode: NULLABLE
+  #   name: min_first_session_ping_run_date
+  #   type: DATE
+  #   description: |
+  #     Date of first app run as reported in the earliest first_session ping.
 
-  - mode: NULLABLE
-    name: min_metrics_ping_submission_date
-    type: DATE
-    description: |
-      Date when the first reported metrics ping is received by the server.
+  # - mode: NULLABLE
+  #   name: min_metrics_ping_submission_date
+  #   type: DATE
+  #   description: |
+  #     Date when the first reported metrics ping is received by the server.
 
   - mode: NULLABLE
     name: adjust_info__source_ping
     type: STRING
     description: |
       Ping from which the adjust_info values originate.
-
-  - mode: NULLABLE
-    name: install_source__source_ping
-    type: STRING
-    description: |
-      Ping from which the install_source value originates.

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
@@ -67,48 +67,34 @@ fields:
     Determines if a client is activated based on the activation metric and a 7 day lag.
 
 - mode: NULLABLE
-  name: install_source
-  type: STRING
+  name: submission_timestamp
+  type: TIMESTAMP
   description: |
-    The source of a client installation.
-
+    Timestamp of the ping which contained the adjust information.
 
 - mode: NULLABLE
-  name: adjust_info
-  type: RECORD
+  name: adjust_ad_group
+  type: STRING
   description: |
-    Record containing adjust fields.
+    Structure parameter for the the ad group of a campaign.
 
-  fields:
-  - mode: NULLABLE
-    name: submission_timestamp
-    type: TIMESTAMP
-    description: |
-      Timestamp corresponding to the ping which contained the adjust information.
+- mode: NULLABLE
+  name: adjust_campaign
+  type: STRING
+  description: |
+    Structure parameter for the campaign name.
 
-  - mode: NULLABLE
-    name: adjust_ad_group
-    type: STRING
-    description: |
-      Structure parameter for the the ad group of a campaign.
+- mode: NULLABLE
+  name: adjust_creative
+  type: STRING
+  description: |
+    Structure parameter for the creative content of a campaign.
 
-  - mode: NULLABLE
-    name: adjust_campaign
-    type: STRING
-    description: |
-      Structure parameter for the campaign name.
-
-  - mode: NULLABLE
-    name: adjust_creative
-    type: STRING
-    description: |
-      Structure parameter for the creative content of a campaign.
-
-  - mode: NULLABLE
-    name: adjust_network
-    type: STRING
-    description: |
-      The type of source of a client installation.
+- mode: NULLABLE
+  name: adjust_network
+  type: STRING
+  description: |
+    The type of source of a client installation.
 
 - mode: NULLABLE
   name: metadata
@@ -128,24 +114,6 @@ fields:
     type: BOOLEAN
     description: |
       True if the client ever reported a metrics ping.
-
-  # - mode: NULLABLE
-  #   name: min_first_session_ping_submission_date
-  #   type: DATE
-  #   description: |
-  #     Date when the first reported first_sessin ping is received by the server.
-
-  # - mode: NULLABLE
-  #   name: min_first_session_ping_run_date
-  #   type: DATE
-  #   description: |
-  #     Date of first app run as reported in the earliest first_session ping.
-
-  # - mode: NULLABLE
-  #   name: min_metrics_ping_submission_date
-  #   type: DATE
-  #   description: |
-  #     Date when the first reported metrics ping is received by the server.
 
   - mode: NULLABLE
     name: adjust_info__source_ping

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
@@ -61,7 +61,7 @@ fields:
     App display version for this client installation.
 
 - mode: NULLABLE
-  name: activated
+  name: is_activated
   type: BOOLEAN
   description: |
     Determines if a client is activated based on the activation metric and a 7 day lag.
@@ -104,13 +104,13 @@ fields:
 
   fields:
   - mode: NULLABLE
-    name: reported_first_session_ping
+    name: is_reported_first_session_ping
     type: BOOLEAN
     description: |
       True if the client ever reported a first_session ping.
 
   - mode: NULLABLE
-    name: reported_metrics_ping
+    name: is_reported_metrics_ping
     type: BOOLEAN
     description: |
       True if the client ever reported a metrics ping.


### PR DESCRIPTION
# feat(DENG-790): Attribution table for firefox ios clients

Change to introduce attribution table for firefox_ios. This is to enable to to analyze effectiveness of our marketing campaigns on the ios platform.

`fenix_derived.firefox_android_clients_v1` was used as the basis and adjusted for firefox_ios.

A test table with the results (for submission_date `2023-04-05`) of this query was created: `tmp.kik_firefox_ios_clients_v1`

Follow-up PRs (introducing more changes to enable this form of analysis):

- https://github.com/mozilla/bigquery-etl/pull/3712
- https://github.com/mozilla/bigquery-etl/pull/3713