### PR TITLE
Escape table names in stable_and_derived_table_sizes_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/query.py
@@ -48,7 +48,7 @@ def get_partition_size_json(client, date, table):
 
     if len(partition_column_name) > 0 and partition_column_name[0] in ('submission_date', 'submission_timestamp'):
         sql = f"""
-                SELECT * FROM {dataset_id}.{table_id}
+                SELECT * FROM `{dataset_id}.{table_id}`
                 WHERE DATE({partition_column_name[0]}) = '{date}'
             """
         job = client.query(sql, job_config=job_config)


### PR DESCRIPTION
This job is failing because some table names have dashes `-` in them
