### PR TITLE
feat(DENG-788): adding firefox_ios.attributable_clients table

### DIFF
--- a/dags/bqetl_analytics_tables.py
+++ b/dags/bqetl_analytics_tables.py
@@ -92,6 +92,15 @@ with DAG(
         parameters=["submission_date:DATE:{{ds}}"],
     )
 
+    with TaskGroup("firefox_ios_clients_external") as firefox_ios_clients_external:
+        ExternalTaskMarker(
+            task_id="bqetl_org_mozilla_firefox_derived__wait_for_firefox_ios_clients",
+            external_dag_id="bqetl_org_mozilla_firefox_derived",
+            external_task_id="wait_for_firefox_ios_clients",
+        )
+
+        firefox_ios_clients_external.set_upstream(firefox_ios_clients)
+
     wait_for_baseline_clients_daily = ExternalTaskSensor(
         task_id="wait_for_baseline_clients_daily",
         external_dag_id="copy_deduplicate",

--- a/dags/bqetl_org_mozilla_firefox_derived.py
+++ b/dags/bqetl_org_mozilla_firefox_derived.py
@@ -76,6 +76,21 @@ with DAG(
         depends_on_past=True,
     )
 
+    firefox_ios_derived__attributable_clients__v1 = bigquery_etl_query(
+        task_id="firefox_ios_derived__attributable_clients__v1",
+        destination_table="attributable_clients_v1",
+        dataset_id="firefox_ios_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="kignasiak@mozilla.com",
+        email=[
+            "frank@mozilla.com",
+            "kignasiak@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+    )
+
     org_mozilla_fenix_derived__client_deduplication__v1 = bigquery_etl_query(
         task_id="org_mozilla_fenix_derived__client_deduplication__v1",
         destination_table="client_deduplication_v1",
@@ -145,6 +160,9 @@ with DAG(
 
     fenix_derived__clients_yearly__v1.set_upstream(wait_for_baseline_clients_daily)
 
+    firefox_ios_derived__attributable_clients__v1.set_upstream(
+        wait_for_baseline_clients_daily
+    )
     wait_for_copy_deduplicate_all = ExternalTaskSensor(
         task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
@@ -155,6 +173,27 @@ with DAG(
         allowed_states=ALLOWED_STATES,
         failed_states=FAILED_STATES,
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    firefox_ios_derived__attributable_clients__v1.set_upstream(
+        wait_for_copy_deduplicate_all
+    )
+    wait_for_firefox_ios_clients = ExternalTaskSensor(
+        task_id="wait_for_firefox_ios_clients",
+        external_dag_id="bqetl_analytics_tables",
+        external_task_id="firefox_ios_clients",
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    firefox_ios_derived__attributable_clients__v1.set_upstream(
+        wait_for_firefox_ios_clients
+    )
+    firefox_ios_derived__attributable_clients__v1.set_upstream(
+        wait_for_search_derived__mobile_search_clients_daily__v1
     )
 
     org_mozilla_fenix_derived__client_deduplication__v1.set_upstream(

--- a/dags/bqetl_org_mozilla_firefox_derived.py
+++ b/dags/bqetl_org_mozilla_firefox_derived.py
@@ -192,9 +192,6 @@ with DAG(
     firefox_ios_derived__attributable_clients__v1.set_upstream(
         wait_for_firefox_ios_clients
     )
-    firefox_ios_derived__attributable_clients__v1.set_upstream(
-        wait_for_search_derived__mobile_search_clients_daily__v1
-    )
 
     org_mozilla_fenix_derived__client_deduplication__v1.set_upstream(
         wait_for_copy_deduplicate_all

--- a/sql/moz-fx-data-shared-prod/firefox_ios/attributable_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/attributable_clients/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  firefox_ios.attributable_clients
+AS
+SELECT
+  *
+FROM
+  firefox_ios_derived.attributable_clients_v1

--- a/sql/moz-fx-data-shared-prod/firefox_ios/attributable_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/attributable_clients/view.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE VIEW
-  firefox_ios.attributable_clients
+  `moz-fx-data-shared-prod.firefox_ios.attributable_clients`
 AS
 SELECT
   *
 FROM
-  firefox_ios_derived.attributable_clients_v1
+  `moz-fx-data-shared-prod.firefox_ios_derived.attributable_clients_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/init.sql
@@ -1,0 +1,64 @@
+------
+-- PLEASE create the table using the ./bqetl deploy command
+-- then run this query and append the results to it.
+--
+-- Running init.sql to generate the initial table vs schema + backfill approach
+-- allows us to save a lot of time as we do not have to re-run the query for each partition date
+-- instead all partitions to date could be used to generate the table and have the ETL take over.
+------
+CREATE TEMP FUNCTION sum_map_values(map ARRAY<STRUCT<key STRING, value INT64>>)
+RETURNS INT64 AS (
+  (SELECT SUM(value) FROM UNNEST(map))
+);
+
+WITH client_search_activity AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    sample_id,
+    client_info.client_id,
+    SUM(sum_map_values(metrics.labeled_counter.search_in_content)) AS searches,
+    SUM(sum_map_values(metrics.labeled_counter.browser_search_with_ads)) AS searches_with_ads,
+    SUM(sum_map_values(metrics.labeled_counter.browser_search_ad_clicks)) AS ad_clicks,
+  FROM
+    firefox_ios.baseline
+  WHERE
+    DATE(submission_timestamp) < CURRENT_DATE
+  GROUP BY
+    submission_date,
+    sample_id,
+    client_id
+),
+adjust_client_info AS (
+  SELECT
+    client_id,
+    sample_id,
+    first_seen_date,
+    adjust_network,
+    adjust_ad_group AS adjust_adgroup,
+    adjust_campaign,
+    adjust_creative,
+    metadata.is_reported_first_session_ping,
+  FROM
+    firefox_ios.firefox_ios_clients
+  WHERE
+    adjust_network NOT IN ("Unknown", "Other")
+)
+SELECT
+  submission_date,
+  first_seen_date,
+  sample_id,
+  client_id,
+  adjust_network,
+  adjust_adgroup,
+  adjust_campaign,
+  adjust_creative,
+  first_seen_date = submission_date AS is_new_profile,
+  COALESCE(searches, 0) AS searches,
+  COALESCE(searches_with_ads, 0) AS searches_with_ads,
+  COALESCE(ad_clicks, 0) AS ad_clicks,
+FROM
+  client_search_activity
+INNER JOIN
+  adjust_client_info
+USING
+  (client_id, sample_id)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Attributable Clients
 description: |
-  For clients who send a first_session ping,
+  For clients who have attribution data,
   this table records daily information about
   them and their activity.
 owners:

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/metadata.yaml
@@ -1,0 +1,27 @@
+friendly_name: Attributable Clients
+description: |
+  For clients who send a first_session ping,
+  this table records daily information about
+  them and their activity.
+owners:
+- kignasiak@mozilla.com
+labels:
+  schedule: daily
+scheduling:
+  dag_name: bqetl_org_mozilla_firefox_derived
+  depends_on_past: false
+  depends_on:
+  - task_id: baseline_clients_daily
+    dag_name: copy_deduplicate
+    execution_delta: 1h
+  - task_id: search_derived__mobile_search_clients_daily__v1
+    dag_name: bqetl_mobile_search
+    execution_delta: 0h
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+  clustering:
+    fields:
+    - country

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/metadata.yaml
@@ -14,9 +14,6 @@ scheduling:
   - task_id: baseline_clients_daily
     dag_name: copy_deduplicate
     execution_delta: 1h
-  - task_id: search_derived__mobile_search_clients_daily__v1
-    dag_name: bqetl_mobile_search
-    execution_delta: 0h
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/metadata.yaml
@@ -22,6 +22,3 @@ bigquery:
     type: day
     field: submission_date
     require_partition_filter: false
-  clustering:
-    fields:
-    - country

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/query.sql
@@ -49,8 +49,6 @@ first_seen AS (
     first_seen_date
   FROM
     firefox_ios.baseline_clients_first_seen
-  WHERE
-    submission_date >= "2021-01-01"  -- # TODO: should this be @submission_date AKA @submission_date?
 ),
 adjust_client AS (
   SELECT
@@ -64,16 +62,6 @@ adjust_client AS (
     firefox_ios.firefox_ios_clients
   WHERE
     adjust_info.adjust_network <> "Unknown"
-),
-activations AS (
-  SELECT
-    client_id,
-    submission_date,
-    activated > 0 AS activated,
-  FROM
-    firefox_ios.new_profile_activation
-  WHERE
-    submission_date = @submission_date
 )
 SELECT
   submission_date,
@@ -91,8 +79,6 @@ SELECT
     FALSE
   ) AS is_new_install,
   COALESCE(first_seen_date = submission_date, FALSE) AS is_new_profile,
-  -- TODO: is this right? The below
-  -- CASE statements can result in NULL
   COALESCE(
     CASE
       WHEN client_day.has_search_data
@@ -123,7 +109,6 @@ SELECT
     END,
     0
   ) AS ad_clicks,
-  COALESCE(activated, FALSE) AS activated,
 FROM
   adjust_client
 JOIN
@@ -138,7 +123,3 @@ JOIN
   first_seen
 USING
   (client_id)
-LEFT JOIN
-  activations
-USING
-  (client_id, submission_date)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/query.sql
@@ -35,9 +35,8 @@ searches AS (
     search_derived.mobile_search_clients_daily_v1
   WHERE
     submission_date = @submission_date
-    -- #TODO: is there a specific app we should be filtering for here for search info for ios?
-    -- AND normalized_app_name = 'Klar'
     AND os = 'iOS'
+    AND normalized_app_name = 'Fennec'
   GROUP BY
     submission_date,
     client_id
@@ -46,22 +45,22 @@ first_seen AS (
   SELECT
     client_id,
     country,
-    first_seen_date
+    first_seen_date,
   FROM
     firefox_ios.baseline_clients_first_seen
 ),
 adjust_client AS (
   SELECT
     client_id,
-    adjust_info.adjust_network,
-    adjust_info.adjust_ad_group AS adjust_adgroup,
-    adjust_info.adjust_campaign,
-    adjust_info.adjust_creative,
+    adjust_network,
+    adjust_ad_group AS adjust_adgroup,
+    adjust_campaign,
+    adjust_creative,
     metadata.reported_first_session_ping,
   FROM
     firefox_ios.firefox_ios_clients
   WHERE
-    adjust_info.adjust_network <> "Unknown"
+    adjust_network <> "Unknown"
 )
 SELECT
   submission_date,
@@ -111,7 +110,7 @@ SELECT
   ) AS ad_clicks,
 FROM
   adjust_client
-JOIN
+LEFT JOIN
   client_day
 USING
   (client_id)
@@ -119,7 +118,7 @@ FULL OUTER JOIN
   searches AS metrics_searches
 USING
   (client_id, submission_date)
-JOIN
+LEFT JOIN
   first_seen
 USING
   (client_id)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/query.sql
@@ -1,0 +1,144 @@
+CREATE TEMP FUNCTION sum_map_values(map ARRAY<STRUCT<key STRING, value INT64>>)
+RETURNS INT64 AS (
+  (SELECT SUM(value) FROM UNNEST(map))
+);
+
+WITH client_day AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    sample_id,
+    client_info.client_id,
+    LOGICAL_OR(
+      mozfun.norm.extract_version(client_info.app_display_version, 'major') >= 107
+    ) AS has_search_data,
+    SUM(sum_map_values(metrics.labeled_counter.search_in_content)) AS searches,
+    SUM(sum_map_values(metrics.labeled_counter.browser_search_with_ads)) AS searches_with_ads,
+    SUM(sum_map_values(metrics.labeled_counter.browser_search_ad_clicks)) AS ad_clicks,
+  FROM
+    firefox_ios.baseline
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+  GROUP BY
+    submission_date,
+    sample_id,
+    client_id
+),
+searches AS (
+  SELECT
+    submission_date,
+    client_id,
+    LOGICAL_OR(mozfun.norm.extract_version(app_version, 'major') < 107) AS has_search_data,
+    SUM(search_count) AS searches,
+    SUM(search_with_ads) AS searches_with_ads,
+    SUM(ad_click) AS ad_clicks
+  FROM
+    search_derived.mobile_search_clients_daily_v1
+  WHERE
+    submission_date = @submission_date
+    -- #TODO: is there a specific app we should be filtering for here for search info for ios?
+    -- AND normalized_app_name = 'Klar'
+    AND os = 'iOS'
+  GROUP BY
+    submission_date,
+    client_id
+),
+first_seen AS (
+  SELECT
+    client_id,
+    country,
+    first_seen_date
+  FROM
+    firefox_ios.baseline_clients_first_seen
+  WHERE
+    submission_date >= "2021-01-01"  -- # TODO: should this be @submission_date AKA @submission_date?
+),
+adjust_client AS (
+  SELECT
+    client_id,
+    adjust_info.adjust_network,
+    adjust_info.adjust_ad_group AS adjust_adgroup,
+    adjust_info.adjust_campaign,
+    adjust_info.adjust_creative,
+    metadata.reported_first_session_ping,
+  FROM
+    firefox_ios.firefox_ios_clients
+  WHERE
+    adjust_info.adjust_network <> "Unknown"
+),
+activations AS (
+  SELECT
+    client_id,
+    submission_date,
+    activated > 0 AS activated,
+  FROM
+    firefox_ios.new_profile_activation
+  WHERE
+    submission_date = @submission_date
+)
+SELECT
+  submission_date,
+  first_seen_date AS cohort_date,
+  sample_id,
+  client_id,
+  country,
+  adjust_network,
+  adjust_adgroup,
+  adjust_campaign,
+  adjust_creative,
+  COALESCE(
+    first_seen_date = submission_date
+    AND reported_first_session_ping,
+    FALSE
+  ) AS is_new_install,
+  COALESCE(first_seen_date = submission_date, FALSE) AS is_new_profile,
+  -- TODO: is this right? The below
+  -- CASE statements can result in NULL
+  COALESCE(
+    CASE
+      WHEN client_day.has_search_data
+        THEN client_day.searches
+      WHEN metrics_searches.has_search_data
+        THEN metrics_searches.searches
+      ELSE 0
+    END,
+    0
+  ) AS searches,
+  COALESCE(
+    CASE
+      WHEN client_day.has_search_data
+        THEN client_day.searches_with_ads
+      WHEN metrics_searches.has_search_data
+        THEN metrics_searches.searches_with_ads
+      ELSE 0
+    END,
+    0
+  ) AS searches_with_ads,
+  COALESCE(
+    CASE
+      WHEN client_day.has_search_data
+        THEN client_day.ad_clicks
+      WHEN metrics_searches.has_search_data
+        THEN metrics_searches.ad_clicks
+      ELSE 0
+    END,
+    0
+  ) AS ad_clicks,
+  COALESCE(activated, FALSE) AS activated,
+FROM
+  adjust_client
+JOIN
+  client_day
+USING
+  (client_id)
+FULL OUTER JOIN
+  searches AS metrics_searches
+USING
+  (client_id, submission_date)
+JOIN
+  first_seen
+USING
+  (client_id)
+LEFT JOIN
+  activations
+USING
+  (client_id, submission_date)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/schema.yaml
@@ -84,9 +84,3 @@ fields:
   type: BOOLEAN
   description: |
     Determines if a client is a new profile.
-
-- mode: NULLABLE
-  name: activated
-  type: BOOLEAN
-  description: |
-    Determines if a client is activated based on the activation metric and a 7 day lag.

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/schema.yaml
@@ -1,0 +1,92 @@
+fields:
+
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: |
+    Processing date, this indicates which date partiion was used
+    when generating this record.
+
+- mode: NULLABLE
+  name: client_id
+  type: STRING
+  description: |
+    Unique ID for the client installation.
+
+- mode: NULLABLE
+  name: sample_id
+  type: INTEGER
+  description: |
+    Sample ID to limit query results during an analysis.
+
+- mode: NULLABLE
+  name: cohort_date
+  type: DATE
+  description: |
+    TODO:
+
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: |
+    Unique ID for the client installation.
+
+- mode: NULLABLE
+  name: adjust_adgroup
+  type: STRING
+  description: |
+    Structure parameter for the the ad group of a campaign.
+
+- mode: NULLABLE
+  name: adjust_campaign
+  type: STRING
+  description: |
+    Structure parameter for the campaign name.
+
+- mode: NULLABLE
+  name: adjust_creative
+  type: STRING
+  description: |
+    Structure parameter for the creative content of a campaign.
+
+- mode: NULLABLE
+  name: adjust_network
+  type: STRING
+  description: |
+    The type of source of a client installation.
+
+- mode: NULLABLE
+  name: searches
+  type: INTEGER
+  description: |
+    TODO:
+
+- mode: NULLABLE
+  name: searches_with_ads
+  type: INTEGER
+  description: |
+    TODO:
+
+- mode: NULLABLE
+  name: ad_clicks
+  type: INTEGER
+  description: |
+    TODO:
+
+- mode: NULLABLE
+  name: is_new_install
+  type: BOOLEAN
+  description: |
+    Determines if this is a brand new installation.
+
+- mode: NULLABLE
+  name: is_new_profile
+  type: BOOLEAN
+  description: |
+    Determines if a client is a new profile.
+
+- mode: NULLABLE
+  name: activated
+  type: BOOLEAN
+  description: |
+    Determines if a client is activated based on the activation metric and a 7 day lag.

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/schema.yaml
@@ -20,18 +20,6 @@ fields:
     Sample ID to limit query results during an analysis.
 
 - mode: NULLABLE
-  name: cohort_date
-  type: DATE
-  description: |
-    TODO:
-
-- mode: NULLABLE
-  name: country
-  type: STRING
-  description: |
-    Unique ID for the client installation.
-
-- mode: NULLABLE
   name: adjust_adgroup
   type: STRING
   description: |
@@ -59,25 +47,19 @@ fields:
   name: searches
   type: INTEGER
   description: |
-    TODO:
+    The number of search interactions the user had on SERP pages.
 
 - mode: NULLABLE
   name: searches_with_ads
   type: INTEGER
   description: |
-    TODO:
+    The number of SERP pages with ads shown to the user.
 
 - mode: NULLABLE
   name: ad_clicks
   type: INTEGER
   description: |
-    TODO:
-
-- mode: NULLABLE
-  name: is_new_install
-  type: BOOLEAN
-  description: |
-    Determines if this is a brand new installation.
+    The number of times a user clicked on an ad on SERP pages.
 
 - mode: NULLABLE
   name: is_new_profile


### PR DESCRIPTION
# feat(DENG-788): adding firefox_ios.attributable_clients table

This change introduces a new table attributable_clients_v1 for firefox_ios. `fenix_derived.attributable_clients_v1` was used as the basis for this query.

This table will enable us to understand effectiveness of our marketing campaigns on ios.

depends on: https://github.com/mozilla/bigquery-etl/pull/3709
