### PR TITLE
[DS-2814]Adding granular event type in channel group proportions table

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_live/view.sql
@@ -16,6 +16,7 @@ WITH stage_1 AS (
     pricing_plan,
     provider,
     TO_JSON_STRING(promotion_codes) AS json_promotion_codes,
+    granular_event_type,
     SUM(`count`) AS new_subscriptions,
   FROM
     `moz-fx-data-shared-prod`.mozilla_vpn.subscription_events
@@ -34,7 +35,8 @@ WITH stage_1 AS (
     product_name,
     pricing_plan,
     provider,
-    json_promotion_codes
+    json_promotion_codes,
+    granular_event_type,
 ),
 stage_2 AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_live/view.sql
@@ -36,7 +36,7 @@ WITH stage_1 AS (
     pricing_plan,
     provider,
     json_promotion_codes,
-    granular_event_type,
+    granular_event_type
 ),
 stage_2 AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/schema.yaml
@@ -37,6 +37,9 @@ fields:
   name: provider
   type: STRING
 - mode: NULLABLE
+  name: granular_event_type
+  type: STRING
+- mode: NULLABLE
   name: new_subscriptions
   type: INTEGER
 - mode: REPEATED


### PR DESCRIPTION
To match new subscriptions by channels in the dashboards with VPN growth model. 
Refer to  [this comment](https://mozilla-hub.atlassian.net/browse/DS-2814?focusedCommentId=668334) for details. 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
