### PR TITLE
bug(1826384): add telemetry latest releases

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/releases/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/releases/view.sql
@@ -2,6 +2,9 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.releases`
 AS
 SELECT
-  *
+  *,
+  mozfun.norm.extract_version(version, "major") AS major_version,
+  mozfun.norm.extract_version(version, "minor") AS minor_version,
+  mozfun.norm.extract_version(version, "patch") AS patch_version,
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.releases_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/releases/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/releases/view.sql
@@ -6,5 +6,6 @@ SELECT
   mozfun.norm.extract_version(version, "major") AS major_version,
   mozfun.norm.extract_version(version, "minor") AS minor_version,
   mozfun.norm.extract_version(version, "patch") AS patch_version,
+  mozfun.norm.extract_version(version, "beta") AS beta_version,
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.releases_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/releases_latest/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/releases_latest/metadata.yaml
@@ -1,9 +1,10 @@
 friendly_name: Releases Latest
 description: |-
-  This is built on top of telemtry.releases and aims
-  to provide an entry on each day for release and beta channels
-  along with the newest firefox app version being available
-  that day on those channels.
+  This is built on top of telemetry.releases and aims
+  to provide an entry on each day for on each day
+  for the major release channels ("release", "beta", "esr")
+  along with the latest Firefox version released on
+  that day or earlier for those channels.
 
   Firefox release information imported from
   https://product-details.mozilla.org/1.0/firefox.json

--- a/sql/moz-fx-data-shared-prod/telemetry/releases_latest/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/releases_latest/metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: Releases Latest
+description: |-
+  This is built on top of telemtry.releases and aims
+  to provide an entry on each day for release and beta channels
+  along with the newest firefox app version being available
+  that day on those channels.
+
+  Firefox release information imported from
+  https://product-details.mozilla.org/1.0/firefox.json
+
+  For more context, see
+  https://wiki.mozilla.org/Release_Management/Product_details
+owners:
+- kignasiak@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry/releases_latest/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/releases_latest/view.sql
@@ -1,3 +1,6 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.latest_releases`
+AS
 WITH channels AS (
   SELECT
     "release" AS channel
@@ -36,7 +39,7 @@ releases AS (
     END AS channel,
     build_number,
   FROM
-    telemetry.releases
+    `moz-fx-data-shared-prod.telemetry.releases`
 ),
 joined AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/telemetry/releases_latest/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/releases_latest/view.sql
@@ -2,13 +2,14 @@ WITH channels AS (
   SELECT
   "release" AS channel
   UNION ALL SELECT "beta"
+  UNION ALL SELECT "esr"
 ),
 dates_and_channels AS (
   SELECT
     `date`, channel
   FROM
     UNNEST(
-      (SELECT GENERATE_DATE_ARRAY(DATE_SUB(CURRENT_DATE, INTERVAL 1 YEAR), CURRENT_DATE, INTERVAL 1 DAY) AS dates)
+      (SELECT GENERATE_DATE_ARRAY("2016-01-01", CURRENT_DATE, INTERVAL 1 DAY) AS dates)
     ) AS `date`
     CROSS JOIN channels
 ),
@@ -30,6 +31,7 @@ releases AS (
     category,
     product,
     build_date,
+    build_number,
     COALESCE(
       channel,
       CASE
@@ -42,6 +44,8 @@ releases AS (
   LEFT JOIN builds using(`version`)
   -- we need to dedup per date, channel due to some cases where
   -- we get some versions marked as the wrong channel.
+  WHERE
+    TRUE
   QUALIFY
     ROW_NUMBER() OVER(PARTITION BY `date`, channel ORDER BY submission_timestamp DESC) = 1
 ),
@@ -52,11 +56,13 @@ joined AS (
   FIRST_VALUE(category IGNORE NULLS) OVER latest_values AS category,
   channel,
   DATE(FIRST_VALUE(build_date IGNORE NULLS) OVER latest_values) AS build_date,
+  FIRST_VALUE(build_number IGNORE NULLS) OVER latest_values AS build_number,
   FIRST_VALUE(releases.`date` IGNORE NULLS) OVER latest_values AS release_date,
   FIRST_VALUE(`version` IGNORE NULLS) OVER latest_values AS `version`,
   FROM dates_and_channels
   FULL OUTER JOIN releases USING(`date`, channel)
-  WHERE channel NOT IN ("aurora", "esr")
+  WHERE channel IN ("release", "beta", "esr")
+  AND channel IN ("beta")
   WINDOW latest_values AS (
     PARTITION BY channel ORDER BY DATE DESC
     ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
@@ -64,6 +70,7 @@ joined AS (
 )
 SELECT
   *,
+  IF(channel = "beta", SPLIT(version, "b")[SAFE_OFFSET(1)], NULL) AS beta_version,
   mozfun.norm.extract_version(version, "major") AS major_version,
   mozfun.norm.extract_version(version, "minor") AS minor_version,
   mozfun.norm.extract_version(version, "patch") AS patch_version,

--- a/sql/moz-fx-data-shared-prod/telemetry/releases_latest/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/releases_latest/view.sql
@@ -69,14 +69,14 @@ joined AS (
 )
 SELECT
   *,
-  IF(channel = "beta", REGEXP_EXTRACT(version, r"[a-z]+([0-9]+)$"), NULL) AS beta_version,
   mozfun.norm.extract_version(version, "major") AS major_version,
   mozfun.norm.extract_version(version, "minor") AS minor_version,
   mozfun.norm.extract_version(version, "patch") AS patch_version,
+  mozfun.norm.extract_version(version, "beta") AS beta_version,
 FROM
   joined
 WHERE
-  TRUE
+  version IS NOT NULL
 QUALIFY
   ROW_NUMBER() OVER (
     PARTITION BY

--- a/sql/moz-fx-data-shared-prod/telemetry/releases_latest/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/releases_latest/view.sql
@@ -1,0 +1,70 @@
+WITH channels AS (
+  SELECT
+  "release" AS channel
+  UNION ALL SELECT "beta"
+),
+dates_and_channels AS (
+  SELECT
+    `date`, channel
+  FROM
+    UNNEST(
+      (SELECT GENERATE_DATE_ARRAY(DATE_SUB(CURRENT_DATE, INTERVAL 1 YEAR), CURRENT_DATE, INTERVAL 1 DAY) AS dates)
+    ) AS `date`
+    CROSS JOIN channels
+),
+builds AS (
+  SELECT
+    submission_timestamp,
+    build.target.channel AS channel,
+    build.target.`version`,
+    build.build.`date` AS build_date,
+  FROM `moz-fx-data-shared-prod.telemetry.buildhub2`
+  WHERE build.source.product = "firefox"
+  QUALIFY
+    ROW_NUMBER() OVER(PARTITION BY channel, version ORDER BY submission_timestamp DESC) = 1
+),
+releases AS (
+  SELECT
+    `date`,
+    `version`,
+    category,
+    product,
+    build_date,
+    COALESCE(
+      channel,
+      CASE
+          WHEN category NOT IN ('esr', 'dev') THEN "release"
+          WHEN category = 'esr' THEN "esr"
+          WHEN category = 'dev' THEN 'beta'
+      END
+    ) AS channel,
+  FROM telemetry.releases
+  LEFT JOIN builds using(`version`)
+  -- we need to dedup per date, channel due to some cases where
+  -- we get some versions marked as the wrong channel.
+  QUALIFY
+    ROW_NUMBER() OVER(PARTITION BY `date`, channel ORDER BY submission_timestamp DESC) = 1
+),
+joined AS (
+  SELECT
+  dates_and_channels.`date`,
+  FIRST_VALUE(product IGNORE NULLS) OVER latest_values AS product,
+  FIRST_VALUE(category IGNORE NULLS) OVER latest_values AS category,
+  channel,
+  DATE(FIRST_VALUE(build_date IGNORE NULLS) OVER latest_values) AS build_date,
+  FIRST_VALUE(releases.`date` IGNORE NULLS) OVER latest_values AS release_date,
+  FIRST_VALUE(`version` IGNORE NULLS) OVER latest_values AS `version`,
+  FROM dates_and_channels
+  FULL OUTER JOIN releases USING(`date`, channel)
+  WHERE channel NOT IN ("aurora", "esr")
+  WINDOW latest_values AS (
+    PARTITION BY channel ORDER BY DATE DESC
+    ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+  )
+)
+SELECT
+  *,
+  mozfun.norm.extract_version(version, "major") AS major_version,
+  mozfun.norm.extract_version(version, "minor") AS minor_version,
+  mozfun.norm.extract_version(version, "patch") AS patch_version,
+FROM joined

--- a/sql/moz-fx-data-shared-prod/telemetry/releases_latest/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/releases_latest/view.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.telemetry.latest_releases`
+  `moz-fx-data-shared-prod.telemetry.releases_latest`
 AS
 WITH channels AS (
   SELECT

--- a/sql/mozfun/norm/extract_version/udf.sql
+++ b/sql/mozfun/norm/extract_version/udf.sql
@@ -7,6 +7,8 @@ RETURNS NUMERIC AS (
       THEN CAST(REGEXP_EXTRACT(version_string, r"^[0-9]+[.]([0-9]+).*") AS NUMERIC)
     WHEN extraction_level = "major"
       THEN CAST(REGEXP_EXTRACT(version_string, r"^([0-9]+).*") AS NUMERIC)
+    WHEN extraction_level = "beta"
+      THEN CAST(REGEXP_EXTRACT(version_string, r"^[0-9\.]+[rc|b]+([0-9]+)$") AS NUMERIC)
     ELSE NULL
   END
 );
@@ -22,4 +24,9 @@ SELECT
   assert.equals(100, norm.extract_version("100.01.1", "major")),
   assert.equals(4, norm.extract_version("100.04.1", "minor")),
   assert.equals(5, norm.extract_version("5.1.5-ubuntu-foobar", "patch")),
-  assert.null(norm.extract_version("foo-bar", "minor"))
+  assert.null(norm.extract_version("foo-bar", "minor")),
+  assert.equals(1, norm.extract_version("100.04b1", "beta")),
+  assert.equals(4, norm.extract_version("100.04rc4", "beta")),
+  assert.null(norm.extract_version("100.04esr4", "beta")),
+  assert.equnullals(norm.extract_version("100.04.1", "beta")),
+  assert.null(norm.extract_version("5.1.5-ubuntu-foobar", "beta"))


### PR DESCRIPTION
# bug(1826384): add telemetry latest releases

## Changes:

- Added `major`, `minor`, `patch` fields to the `telemetry.releases` view
- Added `telemetry.releases_latest` view to provide an entry for each day for release and beta channels and what app versions were available that day.