### PR TITLE
fix the publish_view issue introduced via DENG 710

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
@@ -2,9 +2,40 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
 AS
 SELECT
-  *
+  segment,
+  attribution_medium,
+  attribution_source,
+  attributed,
+  city,
+  country,
+  distribution_id,
+  first_seen_year,
+  is_default_browser,
+  channel,
+  os,
+  os_version,
+  os_version_major,
+  os_version_minor,
+  submission_date,
+  language_name,
+  dau,
+  wau,
+  mau,
+  new_profiles,
+  ad_clicks,
+  organic_search_count,
+  search_count,
+  search_with_ads,
+  uri_count,
+  active_hours,
+  app_name,
+  app_version,
+  app_version_major,
+  app_version_minor,
+  app_version_patch_revision,
+  app_version_is_major_release
 FROM
-  `telemetry.active_users_aggregates_mobile`
+  `moz-fx-data-shared-prod.telemetry.active_users_aggregates_mobile`
 UNION ALL
 SELECT
   segment,


### PR DESCRIPTION
The dag bqetl_artifact_deployment has been failing at the `publish_views` task.
This is caused due to missing  project_id in the view name (not fully qualified)
https://workflow.telemetry.mozilla.org/log?dag_id=bqetl_artifact_deployment&task_id=publish_views&execution_date=2023-04-14T05%3A30%3A00%2B00%3A00