### PR TITLE
Validate table references when deploying views

### DIFF
--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -214,7 +214,14 @@ def _view_dependencies(artifact_files, sql_dir):
             view = View.from_file(dep_file)
 
             for dependency in view.table_references:
-                project, dataset, name = dependency.split(".")
+                dependency_components = dependency.split(".")
+                if len(dependency_components) != 3:
+                    raise ValueError(
+                        f"Invalid table reference {dependency} in view {view.name}. "
+                        "Tables should be fully qualified, expected format: project.dataset.table."
+                    )
+                project, dataset, name = dependency_components
+
                 file_path = Path(view.path).parent.parent.parent / dataset / name
 
                 file_exists_for_dependency = False


### PR DESCRIPTION
https://github.com/mozilla/bigquery-etl/pull/3692 introduced a change that broke view deployment due to source table reference not being fully qualified. There was a [test failure](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/20171/workflows/43457535-6cb4-4519-b97d-167f3eb4b706/jobs/196148) that was missed, however the message wasn't obvious there: `ValueError: not enough values to unpack (expected 3, got 2)`.

This adds a check to validate table reference format to be fully qualified and throws an error with a clear message if it's not.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
