### PR TITLE
bug(): firefox_ios_derived.new_profile_activation_v2 exlude existing client_id entries

### DIFF
--- a/dags/bqetl_mobile_activation.py
+++ b/dags/bqetl_mobile_activation.py
@@ -77,7 +77,7 @@ with DAG(
             "vsabino@mozilla.com",
         ],
         date_partition_parameter="submission_date",
-        depends_on_past=False,
+        depends_on_past=True,
     )
 
     with TaskGroup(

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v2/metadata.yaml
@@ -19,3 +19,4 @@ bigquery:
 scheduling:
   dag_name: bqetl_mobile_activation
   date_partition_parameter: submission_date
+  depends_on_past: true


### PR DESCRIPTION
# bug(): firefox_ios_derived.new_profile_activation_v2 exlude existing client_id entries

This is due to the investigation as part of `DENG-790`.