### PR TITLE
Deng 847 remove metadata validation for sql generarated files

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1133,43 +1133,6 @@ def validate(
         validate_metadata.validate(query.parent)
         dataset_dirs.add(query.parent.parent)
 
-    if not query_files:
-        # run SQL generators if no matching query has been found.
-        ctx.invoke(
-            generate_all,
-            output_dir=ctx.obj["TMP_DIR"],
-            ignore=[
-                "country_code_lookup",
-                "derived_view_schemas",
-                "events_daily",
-                "experiment_monitoring",
-                "feature_usage",
-                "glean_usage",
-                "search",
-                "stable_views",
-            ],
-        )
-
-        query_files = paths_matching_name_pattern(
-            name, ctx.obj["TMP_DIR"], project_id, ["query.*"]
-        )
-
-        for query in query_files:
-            ctx.invoke(format, paths=[str(query)])
-
-            if not no_dryrun:
-                ctx.invoke(
-                    dryrun,
-                    paths=[str(query)],
-                    use_cloud_function=use_cloud_function,
-                    project=project_id,
-                    validate_schemas=validate_schemas,
-                    respect_skip=respect_dryrun_skip,
-                )
-
-            validate_metadata.validate(query.parent)
-            dataset_dirs.add(query.parent.parent)
-
     if no_dryrun:
         click.echo("Dry run skipped for query files.")
 

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_product_page_to_subscribed_v1/query.sql
@@ -127,7 +127,9 @@ flows AS (
       AND user_id IS NOT NULL
     ) AS pay_setup_engage_with_uid,
     -- new fxa after entering the email
-    LOGICAL_OR(event_type IN ("fxa_pay_setup - 3ds_complete", "fxa_pay_setup - success")) AS pay_setup_complete,
+    LOGICAL_OR(
+      event_type IN ("fxa_pay_setup - 3ds_complete", "fxa_pay_setup - success")
+    ) AS pay_setup_complete,
     LOGICAL_OR(
       event_type IN ("fxa_pay_setup - 3ds_complete", "fxa_pay_setup - success")
       AND user_id IS NULL


### PR DESCRIPTION
The [CI pipeline may fail due to metadata validation of change-controlled auto-generated files](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/20304/workflows/259700b8-4ed2-48d2-92a7-9398982e6edf/jobs/197798) which have temporary paths that don't match the CODEOWNERS.

We can adjust the validations, but I'm removing the metadata validation for for auto-generated sql, because we need to refactor aqnd extend the change control process to use files that exist ion a branch different from where the PR and CODEOWNERS file exists.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
