### PR TITLE
bug(): Fixing parse_sponsoder_interaction and extract_string_from_bytes udfs

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf_js/extract_string_from_bytes/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/extract_string_from_bytes/udf.sql
@@ -1,20 +1,13 @@
 /*
 The function extracts string data from `payload` which is in bytes.
 */
-CREATE OR REPLACE FUNCTION  udf_js.extract_string_from_bytes(payload bytes)
-returns string as (
-  regexp_extract(
-    SAFE_CONVERT_BYTES_TO_STRING(payload),
-    r'{(.*)}$',
-    1
-  )
+CREATE OR REPLACE FUNCTION udf_js.extract_string_from_bytes(payload bytes)
+RETURNS STRING AS (
+  REGEXP_EXTRACT(SAFE_CONVERT_BYTES_TO_STRING(payload), r'{(.*)}$', 1)
 );
+
     --
 SELECT
-  assert.array_equals("{test}",udf_js.extract_string_from_bytes(FROM_BASE64("e3Rlc3R9"))),
-  assert.array_equals("{}",udf_js.extract_string_from_bytes(FROM_BASE64("e30="))),
-  assert.null(null,udf_js.extract_string_from_bytes(FROM_BASE64(null)))
-FROM
-  extracted
-
-
+  assert.array_equals("{test}", udf_js.extract_string_from_bytes(FROM_BASE64("e3Rlc3R9"))),
+  assert.array_equals("{}", udf_js.extract_string_from_bytes(FROM_BASE64("e30="))),
+  assert.null(udf_js.extract_string_from_bytes(FROM_BASE64(NULL)))

--- a/sql/moz-fx-data-shared-prod/udf_js/extract_string_from_bytes/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/extract_string_from_bytes/udf.sql
@@ -1,13 +1,13 @@
 /*
 The function extracts string data from `payload` which is in bytes.
 */
-CREATE OR REPLACE FUNCTION udf_js.extract_string_from_bytes(payload bytes)
+CREATE OR REPLACE FUNCTION udf_js.extract_string_from_bytes(payload BYTES)
 RETURNS STRING AS (
   REGEXP_EXTRACT(SAFE_CONVERT_BYTES_TO_STRING(payload), r'{(.*)}$', 1)
 );
 
     --
 SELECT
-  assert.array_equals("{test}", udf_js.extract_string_from_bytes(FROM_BASE64("e3Rlc3R9"))),
-  assert.array_equals("{}", udf_js.extract_string_from_bytes(FROM_BASE64("e30="))),
+  assert.equals("test", udf_js.extract_string_from_bytes(FROM_BASE64("e3Rlc3R9"))),
+  assert.equals("", udf_js.extract_string_from_bytes(FROM_BASE64("e30="))),
   assert.null(udf_js.extract_string_from_bytes(FROM_BASE64(NULL)))

--- a/sql/moz-fx-data-shared-prod/udf_js/parse_sponsored_interaction/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/parse_sponsored_interaction/udf.sql
@@ -2,22 +2,25 @@
 The function parses the `payload` column in `moz-fx-data-shared-prod.payload_bytes_error.contextual_services`
 to extract the `source` column
 */
-CREATE OR REPLACE FUNCTION  udf_js.parse_sponsored_interaction(params string)
-returns struct<
-  source string,
-  formFactor string, 
-  scenario string,
-  interactionType string, 
-  contextId string, 
-  reportingUrl string, 
-  requestId string, 
-  submissionTimestamp timestamp,
-  parsedReportingUrl json,
-  originalDocType string,
-  originalNamespace string,
-  interactionCount integer,
-  flaggedFraud bool> 
-LANGUAGE js AS """
+CREATE OR REPLACE FUNCTION udf_js.parse_sponsored_interaction(params string)
+RETURNS STRUCT<
+  source STRING,
+  formFactor STRING,
+  scenario STRING,
+  interactionType STRING,
+  contextId STRING,
+  reportingUrl STRING,
+  requestId STRING,
+  submissionTimestamp TIMESTAMP,
+  parsedReportingUrl JSON,
+  originalDocType STRING,
+  originalNamespace STRING,
+  interactionCount INTEGER,
+  flaggedFraud BOOLEAN
+>
+LANGUAGE js
+AS
+  """
   const parseURL = (url) => {
     const [base, params] = url.split("?");
     const [scheme, _, host, ...path] = base.split("/")
@@ -49,7 +52,7 @@ LANGUAGE js AS """
         return acc;
       }, {});
 
-    
+
     if (interaction.parsedReportingUrl?.params?.impressions) {
       interaction.source = "topsites";
       interaction.formFactor = interaction.parsedReportingUrl.params.form_factor;
@@ -63,9 +66,9 @@ LANGUAGE js AS """
     }
 
     interaction.flaggedFraud = (
-      interaction.reportingUrl.includes("click-status=65") 
+      interaction.reportingUrl.includes("click-status=65")
       || interaction.reportingUrl.includes("custom-data=invalid"));
-     
+
     return interaction;
   }
   catch(err) {
@@ -75,7 +78,7 @@ LANGUAGE js AS """
 
 WITH events AS (
   SELECT AS VALUE
-   "source\u003dtopsites, formFactor\u003ddesktop, scenario\u003dnull, interactionType\u003dclick, contextId\u003d{10679079-b1cd-45a3-9e40-cdfb364d3476}, reportingUrl\u003dhttps://bridge.sfo1.ap01.net/ctp?ci\u003d1681139740815.12791\u0026country-code\u003dDE\u0026ctag\u003dpd_sl_08aeb79c14ac3da0f8e9116cdcb0afadec2e24da616da802ba033bf6\u0026dma-code\u003d\u0026form-factor\u003ddesktop\u0026key\u003d1681139740400900002.1\u0026os-family\u003dWindows\u0026product-version\u003dfirefox_111\u0026region-code\u003dNW\u0026version\u003d16.0.0, requestId\u003dnull, submissionTimestamp\u003d2023-04-10T15:41:55Z, originalDocType\u003dtopsites-click, originalNamespace\u003dcontextual-services"
+    "source\u003dtopsites, formFactor\u003ddesktop, scenario\u003dnull, interactionType\u003dclick, contextId\u003d{10679079-b1cd-45a3-9e40-cdfb364d3476}, reportingUrl\u003dhttps://bridge.sfo1.ap01.net/ctp?ci\u003d1681139740815.12791\u0026country-code\u003dDE\u0026ctag\u003dpd_sl_08aeb79c14ac3da0f8e9116cdcb0afadec2e24da616da802ba033bf6\u0026dma-code\u003d\u0026form-factor\u003ddesktop\u0026key\u003d1681139740400900002.1\u0026os-family\u003dWindows\u0026product-version\u003dfirefox_111\u0026region-code\u003dNW\u0026version\u003d16.0.0, requestId\u003dnull, submissionTimestamp\u003d2023-04-10T15:41:55Z, originalDocType\u003dtopsites-click, originalNamespace\u003dcontextual-services"
 ),
 extracted AS (
   SELECT
@@ -83,20 +86,27 @@ extracted AS (
   FROM
     events
 )
-    --
 SELECT
-  assert.array_equals("topsites",e.source),
-  assert.array_equals("desktop",e.formFactor),
-  assert.array_equals(null,e.scenario),
-  assert.array_equals("click",e.interactionType),
-  assert.array_equals("{10679079-b1cd-45a3-9e40-cdfb364d3476}",e.contextId),
-  assert.array_equals("https://bridge.sfo1.ap01.net/ctp?ci=1681139740815.12791&country-code=DE&ctag=pd_sl_08aeb79c14ac3da0f8e9116cdcb0afadec2e24da616da802ba033bf6&dma-code=&form-factor=desktop&key=1681139740400900002.1&os-family=Windows&product-version=firefox_111&region-code=NW&version=16.0.0",e.reportingUrl),
-  assert.array_equals(null,e.requestId),
-  assert.array_equals("2023-04-10 15:41:55 UTC",e.submissionTimestamp),
-  assert.array_equals("topsites-click",e.originalDocType),
-  assert.array_equals("contextual-services",e.originalNamespace),
-  assert.array_equals(1,e.interactionCount),
-  assert.array_equals(false,e.flaggedFraud),
-  assert.array_equals(JSON('{\"host\":\"bridge.sfo1.ap01.net\",\"params\":{\"ci\":\"1681139740815.12791\",\"country_code\":\"DE\",\"ctag\":\"pd_sl_08aeb79c14ac3da0f8e9116cdcb0afadec2e24da616da802ba033bf6\",\"dma_code\":\"\",\"form_factor\":\"desktop\",\"key\":\"1681139740400900002.1\",\"os_family\":\"Windows\",\"product_version\":\"firefox_111\",\"region_code\":\"NW\",\"version\":\"16.0.0\"},\"path\":\"ctp\",\"scheme\":\"https:\"}'), e.parsedReportingUrl)
+  assert.array_equals("topsites", e.source),
+  assert.array_equals("desktop", e.formFactor),
+  assert.null(e.scenario),
+  assert.array_equals("click", e.interactionType),
+  assert.array_equals("{10679079-b1cd-45a3-9e40-cdfb364d3476}", e.contextId),
+  assert.array_equals(
+    "https://bridge.sfo1.ap01.net/ctp?ci=1681139740815.12791&country-code=DE&ctag=pd_sl_08aeb79c14ac3da0f8e9116cdcb0afadec2e24da616da802ba033bf6&dma-code=&form-factor=desktop&key=1681139740400900002.1&os-family=Windows&product-version=firefox_111&region-code=NW&version=16.0.0",
+    e.reportingUrl
+  ),
+  assert.null(e.requestId),
+  assert.array_equals("2023-04-10 15:41:55 UTC", e.submissionTimestamp),
+  assert.array_equals("topsites-click", e.originalDocType),
+  assert.array_equals("contextual-services", e.originalNamespace),
+  assert.array_equals(1, e.interactionCount),
+  assert.array_equals(FALSE, e.flaggedFraud),
+  assert.array_equals(
+    JSON(
+      '{\"host\":\"bridge.sfo1.ap01.net\",\"params\":{\"ci\":\"1681139740815.12791\",\"country_code\":\"DE\",\"ctag\":\"pd_sl_08aeb79c14ac3da0f8e9116cdcb0afadec2e24da616da802ba033bf6\",\"dma_code\":\"\",\"form_factor\":\"desktop\",\"key\":\"1681139740400900002.1\",\"os_family\":\"Windows\",\"product_version\":\"firefox_111\",\"region_code\":\"NW\",\"version\":\"16.0.0\"},\"path\":\"ctp\",\"scheme\":\"https:\"}'
+    ),
+    e.parsedReportingUrl
+  )
 FROM
   extracted

--- a/sql/moz-fx-data-shared-prod/udf_js/parse_sponsored_interaction/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/parse_sponsored_interaction/udf.sql
@@ -2,9 +2,9 @@
 The function parses the `payload` column in `moz-fx-data-shared-prod.payload_bytes_error.contextual_services`
 to extract the `source` column
 */
-CREATE OR REPLACE FUNCTION udf_js.parse_sponsored_interaction(params string)
+CREATE OR REPLACE FUNCTION udf_js.parse_sponsored_interaction(params STRING)
 RETURNS STRUCT<
-  source STRING,
+  `source` STRING,
   formFactor STRING,
   scenario STRING,
   interactionType STRING,
@@ -87,22 +87,22 @@ extracted AS (
     events
 )
 SELECT
-  assert.array_equals("topsites", e.source),
-  assert.array_equals("desktop", e.formFactor),
+  assert.equals("topsites", e.`source`),
+  assert.equals("desktop", e.formFactor),
   assert.null(e.scenario),
-  assert.array_equals("click", e.interactionType),
-  assert.array_equals("{10679079-b1cd-45a3-9e40-cdfb364d3476}", e.contextId),
-  assert.array_equals(
+  assert.equals("click", e.interactionType),
+  assert.equals("{10679079-b1cd-45a3-9e40-cdfb364d3476}", e.contextId),
+  assert.equals(
     "https://bridge.sfo1.ap01.net/ctp?ci=1681139740815.12791&country-code=DE&ctag=pd_sl_08aeb79c14ac3da0f8e9116cdcb0afadec2e24da616da802ba033bf6&dma-code=&form-factor=desktop&key=1681139740400900002.1&os-family=Windows&product-version=firefox_111&region-code=NW&version=16.0.0",
     e.reportingUrl
   ),
   assert.null(e.requestId),
-  assert.array_equals("2023-04-10 15:41:55 UTC", e.submissionTimestamp),
-  assert.array_equals("topsites-click", e.originalDocType),
-  assert.array_equals("contextual-services", e.originalNamespace),
-  assert.array_equals(1, e.interactionCount),
-  assert.array_equals(FALSE, e.flaggedFraud),
-  assert.array_equals(
+  assert.equals("2023-04-10 15:41:55 UTC", e.submissionTimestamp),
+  assert.equals("topsites-click", e.originalDocType),
+  assert.equals("contextual-services", e.originalNamespace),
+  assert.equals(1, e.interactionCount),
+  assert.false(e.flaggedFraud),
+  assert.equals(
     JSON(
       '{\"host\":\"bridge.sfo1.ap01.net\",\"params\":{\"ci\":\"1681139740815.12791\",\"country_code\":\"DE\",\"ctag\":\"pd_sl_08aeb79c14ac3da0f8e9116cdcb0afadec2e24da616da802ba033bf6\",\"dma_code\":\"\",\"form_factor\":\"desktop\",\"key\":\"1681139740400900002.1\",\"os_family\":\"Windows\",\"product_version\":\"firefox_111\",\"region_code\":\"NW\",\"version\":\"16.0.0\"},\"path\":\"ctp\",\"scheme\":\"https:\"}'
     ),


### PR DESCRIPTION
PR aiming to fix CI `test_sql` step. 

Fixes include the following two udf's:

- parse_sponsoder_interaction
- extract_string_from_bytes

----

Also, run bqetl formatting against the two definitions.