### PR TITLE
bug(): fixing assert in parse_sponsored_interaction checking for null, null string is returned not null value

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf_js/parse_sponsored_interaction/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/parse_sponsored_interaction/udf.sql
@@ -89,14 +89,14 @@ extracted AS (
 SELECT
   assert.equals("topsites", e.`source`),
   assert.equals("desktop", e.formFactor),
-  assert.null(e.scenario),
+  assert.equals("null", e.scenario),
   assert.equals("click", e.interactionType),
   assert.equals("{10679079-b1cd-45a3-9e40-cdfb364d3476}", e.contextId),
   assert.equals(
     "https://bridge.sfo1.ap01.net/ctp?ci=1681139740815.12791&country-code=DE&ctag=pd_sl_08aeb79c14ac3da0f8e9116cdcb0afadec2e24da616da802ba033bf6&dma-code=&form-factor=desktop&key=1681139740400900002.1&os-family=Windows&product-version=firefox_111&region-code=NW&version=16.0.0",
     e.reportingUrl
   ),
-  assert.null(e.requestId),
+  assert.equals("null", e.requestId),
   assert.equals(TIMESTAMP("2023-04-10 15:41:55 UTC"), e.submissionTimestamp),
   assert.equals("topsites-click", e.originalDocType),
   assert.equals("contextual-services", e.originalNamespace),


### PR DESCRIPTION
💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩💩 :trollface: 

follow-up to: https://github.com/mozilla/bigquery-etl/pull/3741
follow-up to: https://github.com/mozilla/bigquery-etl/pull/3742
follow-up to: https://github.com/mozilla/bigquery-etl/pull/3743