### PR TITLE
Remove partitioning metadata for firefox_ios_clients_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
@@ -37,11 +37,6 @@ scheduling:
   parameters:
   - submission_date:DATE:{{ds}}
 bigquery:
-  time_partitioning:
-    type: day
-    field: first_seen_date
-    require_partition_filter: false
-    expiration_days: null
   clustering:
     fields:
     - channel


### PR DESCRIPTION
This is breaking artifact deploys

Based on the query it seems like the whole table should get overwritten, so we need to remove partitioning metadata

