### PR TITLE
Fix Google Cloud SDK pin in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION=3.10
-# pinned to old version due to https://stackoverflow.com/questions/76159439/job-failing-with-error-gcloud-crashed-attributeerror-bool-object-has-no-at
-ARG CLOUD_SDK_VERSION=417.0.0 
+# pin Google Cloud SDK to old version due to https://stackoverflow.com/questions/76159439/job-failing-with-error-gcloud-crashed-attributeerror-bool-object-has-no-at
+ARG GOOGLE_CLOUD_SDK_VERSION=417.0.0
 
 # use buster image because the default bullseye image released 2021-08-17
 # sha256:ffb6539b4b233743c62170989024c6f56dcefa69a83c4bd9710d4264b19a98c0
@@ -26,10 +26,12 @@ COPY pom.xml ./
 COPY src src
 RUN mvn package
 
+FROM google/cloud-sdk:${GOOGLE_CLOUD_SDK_VERSION}-alpine AS google-cloud-sdk
+
 FROM base
 # add bash for entrypoint and jdk for jni access to zetasql
 RUN mkdir -p /usr/share/man/man1 && apt-get update -qqy && apt-get install -qqy bash default-jdk-headless git
-COPY --from=google/cloud-sdk:${CLOUD_SDK_VERSION}-alpine /google-cloud-sdk /google-cloud-sdk
+COPY --from=google-cloud-sdk /google-cloud-sdk /google-cloud-sdk
 ENV PATH /google-cloud-sdk/bin:$PATH
 COPY --from=java-deps /app/target/dependency /app/target/dependency
 COPY --from=java-deps /app/target/*.jar /app/target/


### PR DESCRIPTION
Variable expansion in Docker command flags is [not yet supported](https://github.com/docker/cli/issues/3356#issuecomment-957892224), so since #3754 the `deploy-to-private-gcr` CI jobs have been failing with
```
Step 16/24 : COPY --from=google/cloud-sdk:${CLOUD_SDK_VERSION}-alpine /google-cloud-sdk /google-cloud-sdk
invalid from flag value google/cloud-sdk:${CLOUD_SDK_VERSION}-alpine: invalid reference format
```

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
