### PR TITLE
feat(DENG-854?): added fenix app id to the fxa_activity event filter list

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
@@ -45,14 +45,19 @@ WHERE
     -- are redundant with cert_signed events;
     -- see https://github.com/mozilla/bigquery-etl/issues/348
     _oauth_client_id NOT IN (
-      '3332a18d142636cb', -- fennec sync
+      '3332a18d142636cb', -- fennec sync # we are no longer receiving events for this id.
       '5882386c6d801776', -- desktop sync
-      '1b1a3e44c54fbb58' -- ios sync
+      '1b1a3e44c54fbb58', -- ios sync
+      'a2270f727f45f648' -- fenix sync
     )
     -- We do want to let through some desktop sync events
     -- see https://github.com/mozilla/bigquery-etl/issues/573
     OR (
-      _oauth_client_id IN ('5882386c6d801776', '1b1a3e44c54fbb58')
+      _oauth_client_id IN (
+        '5882386c6d801776', -- desktop sync
+        '1b1a3e44c54fbb58', -- ios sync
+        'a2270f727f45f648' -- fenix sync
+      )
       AND jsonPayload.fields.event_type NOT IN (
         'fxa_activity - access_token_checked',
         'fxa_activity - access_token_created'

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/init.sql
@@ -1,0 +1,176 @@
+CREATE OR REPLACE TABLE
+`analysis.kik_ios_attribution`
+AS
+-- Query first observations for Firefox iOS Clients.
+WITH first_seen AS (
+  SELECT
+    client_id,
+    submission_date,
+    first_seen_date,
+    sample_id,
+    country AS first_reported_country,
+    isp AS first_reported_isp,
+    normalized_channel AS channel,
+    device_manufacturer,
+    device_model,
+    normalized_os_version AS os_version,
+    app_display_version AS app_version
+  FROM
+    firefox_ios.baseline_clients_first_seen
+  WHERE
+    submission_date < CURRENT_DATE
+    AND client_id IS NOT NULL
+),
+-- Find the most recent activation record per client_id.
+activations AS (
+  SELECT
+    client_id,
+    is_activated,
+  FROM
+    firefox_ios_derived.new_profile_activation_v2
+  WHERE
+    `date` < CURRENT_DATE
+),
+-- Find earliest data per client from the first_session ping.
+first_session_ping_base AS (
+  SELECT
+    client_info.client_id,
+    sample_id,
+    submission_timestamp,
+    NULLIF(metrics.string.adjust_ad_group, "") AS adjust_ad_group,
+    NULLIF(metrics.string.adjust_campaign, "") AS adjust_campaign,
+    NULLIF(metrics.string.adjust_creative, "") AS adjust_creative,
+    NULLIF(metrics.string.adjust_network, "") AS adjust_network,
+  FROM
+    firefox_ios.first_session
+  WHERE
+    DATE(submission_timestamp) < CURRENT_DATE
+    AND client_info.client_id IS NOT NULL
+),
+first_session_ping AS (
+  SELECT
+    client_id,
+    sample_id,
+    ARRAY_AGG(
+      IF(
+        adjust_ad_group IS NOT NULL
+        OR adjust_campaign IS NOT NULL
+        OR adjust_creative IS NOT NULL
+        OR adjust_network IS NOT NULL,
+        STRUCT(
+          submission_timestamp,
+          adjust_ad_group,
+          adjust_campaign,
+          adjust_creative,
+          adjust_network
+        ),
+        NULL
+      ) IGNORE NULLS
+      ORDER BY
+        submission_timestamp ASC
+      LIMIT
+        1
+    )[SAFE_OFFSET(0)] AS adjust_info,
+  FROM
+    first_session_ping_base
+  GROUP BY
+    client_id,
+    sample_id
+),
+-- Find earliest data per client from the metrics ping.
+metrics_ping_base AS (
+  SELECT
+    client_info.client_id AS client_id,
+    sample_id,
+    submission_timestamp,
+    NULLIF(fxa_metrics.metrics.string.adjust_ad_group, "") AS adjust_ad_group,
+    NULLIF(fxa_metrics.metrics.string.adjust_campaign, "") AS adjust_campaign,
+    NULLIF(fxa_metrics.metrics.string.adjust_creative, "") AS adjust_creative,
+    NULLIF(fxa_metrics.metrics.string.adjust_network, "") AS adjust_network,
+  FROM
+    firefox_ios.metrics AS fxa_metrics
+  WHERE
+    DATE(submission_timestamp) < CURRENT_DATE
+    AND client_info.client_id IS NOT NULL
+),
+metrics_ping AS (
+  SELECT
+    client_id,
+    sample_id,
+    ARRAY_AGG(
+      IF(
+        adjust_ad_group IS NOT NULL
+        OR adjust_campaign IS NOT NULL
+        OR adjust_creative IS NOT NULL
+        OR adjust_network IS NOT NULL,
+        STRUCT(
+          submission_timestamp,
+          adjust_ad_group,
+          adjust_campaign,
+          adjust_creative,
+          adjust_network
+        ),
+        NULL
+      ) IGNORE NULLS
+      ORDER BY
+        submission_timestamp ASC
+      LIMIT
+        1
+    )[SAFE_OFFSET(0)] AS adjust_info,
+  FROM
+    metrics_ping_base
+  GROUP BY
+    client_id,
+    sample_id
+),
+_current AS (
+SELECT
+  * EXCEPT (adjust_info, sample_id),
+  COALESCE(first_seen.sample_id, first_session.sample_id, metrics.sample_id) AS sample_id,
+  COALESCE(first_session.adjust_info, metrics.adjust_info) AS adjust_info,
+  STRUCT(
+    IF(first_session.client_id IS NULL, FALSE, TRUE) AS is_reported_first_session_ping,
+    IF(metrics.client_id IS NULL, FALSE, TRUE) AS is_reported_metrics_ping,
+    CASE
+      WHEN first_session.adjust_info IS NOT NULL
+        THEN "first_session"
+      WHEN metrics.adjust_info IS NOT NULL
+        THEN "metrics"
+      ELSE NULL
+    END AS adjust_info__source_ping
+  ) AS metadata
+FROM
+  first_seen
+FULL OUTER JOIN
+  first_session_ping AS first_session
+USING
+  (client_id, sample_id)
+FULL OUTER JOIN
+  metrics_ping AS metrics
+USING
+  (client_id, sample_id)
+WHERE
+  client_id IS NOT NULL
+)
+SELECT
+client_id,
+sample_id,
+first_seen_date,
+first_reported_country,
+first_reported_isp,
+channel,
+device_manufacturer,
+device_model,
+os_version,
+app_version,
+adjust_info,
+metadata.is_reported_first_session_ping,
+metadata.is_reported_metrics_ping,
+metadata.adjust_info__source_ping,
+activations.is_activated,
+FROM
+  _current
+LEFT JOIN
+  activations
+USING
+  (client_id)


### PR DESCRIPTION
feat(DENG-854?): added fenix app id to the fxa_activity event filter list

It was brought to our attention that we might be getting high volume event data from fenix and that we might want to exclude them from our derived tables. This PR suggests a similar approach as for `firefox-ios` of excluding the highest volume events from making it through.