### PR TITLE
Filter non email owners from labels 

### DIFF
--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -10,7 +10,7 @@ import cattrs
 import yaml
 from google.cloud import bigquery
 
-from bigquery_etl.query_scheduling.utils import is_email_or_github_identity
+from bigquery_etl.query_scheduling.utils import is_email, is_email_or_github_identity
 
 METADATA_FILE = "metadata.yaml"
 DATASET_METADATA_FILE = "dataset_metadata.yaml"
@@ -255,11 +255,12 @@ class Metadata:
 
                 if "owners" in metadata:
                     owners = metadata["owners"]
-                    for i, owner in enumerate(metadata["owners"]):
+                    owner_idx = 1
+                    for owner in filter(is_email, owners):
                         label = owner.split("@")[0]
-                        if not Metadata.is_valid_label(label):
-                            label = ""
-                        labels[f"owner{i+1}"] = label
+                        if Metadata.is_valid_label(label):
+                            labels[f"owner{owner_idx}"] = label
+                            owner_idx += 1
 
                 if "schema" in metadata:
                     converter = cattrs.BaseConverter()

--- a/tests/data/metadata.yaml
+++ b/tests/data/metadata.yaml
@@ -3,6 +3,7 @@ friendly_name: "Test metadata file"
 owners:
   - test1@mozilla.com
   - test2@example.com
+  - mozilla/test_group
 labels:
   schedule: daily
   public_json: true

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -84,7 +84,11 @@ class TestParseMetadata(object):
         assert "number_string" in metadata.labels
         assert metadata.labels["number_string"] == "1234abcde"
         assert "123-432" in metadata.labels
-        assert metadata.owners == ["test1@mozilla.com", "test2@example.com"]
+        assert metadata.owners == [
+            "test1@mozilla.com",
+            "test2@example.com",
+            "mozilla/test_group",
+        ]
         assert metadata.labels["owner1"] == "test1"
         assert metadata.labels["owner2"] == "test2"
         assert "query.sql" in metadata.references


### PR DESCRIPTION
In some cases we have owners that are GitHub identities, e.g.: https://github.com/mozilla/bigquery-etl/blob/5b178559b3f7b9de4ed5f12763b685c29d09d67d/sql_generators/active_users/templates/metadata.yaml#L17-L19 

These aren't always valid labels and currently show up as empty strings in BQ, so we should skip them entirely. ~Also we use emails verbatim as owners in dags so it makes sense here too I think.~