### PR TITLE
Update assert in udf norm.firefox_android_package_name_to_channel

### DIFF
--- a/sql/mozfun/norm/firefox_android_package_name_to_channel/udf.sql
+++ b/sql/mozfun/norm/firefox_android_package_name_to_channel/udf.sql
@@ -13,7 +13,7 @@ RETURNS STRING AS (
 );
 
 SELECT
-  assert.equal(norm.firefox_android_package_name_to_channel("org.mozilla.firefox"), "release"),
-  assert.equal(norm.firefox_android_package_name_to_channel("org.mozilla.firefox_beta"), "beta"),
-  assert.equal(norm.firefox_android_package_name_to_channel("org.mozilla.fenix"), "nightly"),
-  assert.equal(norm.firefox_android_package_name_to_channel("org.mozilla.other"), NULL),
+  assert.equals(norm.firefox_android_package_name_to_channel("org.mozilla.firefox"), "release"),
+  assert.equals(norm.firefox_android_package_name_to_channel("org.mozilla.firefox_beta"), "beta"),
+  assert.equals(norm.firefox_android_package_name_to_channel("org.mozilla.fenix"), "nightly"),
+  assert.equals(norm.firefox_android_package_name_to_channel("org.mozilla.other"), NULL),

--- a/sql/mozfun/norm/get_windows_info/udf.sql
+++ b/sql/mozfun/norm/get_windows_info/udf.sql
@@ -139,4 +139,4 @@ SELECT
   assert.equals("Windows 11", norm.get_windows_info("10.0.25145.1011").name),
   assert.equals("UNKNOWN", norm.get_windows_info("10.0.25145.1011").version_name),
   assert.equals(25145, norm.get_windows_info("10.0.25145.1011").version_number),
-  assert.equals(1011, norm.get_windows_info("10.0.25145.1011").build_number)
+  assert.equals(1011, norm.get_windows_info("10.0.25145.1011").build_number),


### PR DESCRIPTION
Fixes a [CI failure](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/20601/workflows/87d515b2-e489-403b-8086-03ba403e7f1b/jobs/201298?invite=true#step-106-94).