### PR TITLE
Skip deploy jobs on non-main branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,21 +425,15 @@ jobs:
     executor: ubuntu-machine-executor
     steps:
       - checkout
-      - when:
-          condition: &deploy-condition
-            or:
-              - equal: [main, << pipeline.git.branch >>]
-              - << pipeline.git.tag >>
-          steps:
-            - *attach_generated_sql
-            - *copy_generated_sql
-            - docker/check:
-                docker-password: DOCKER_PASS
-                docker-username: DOCKER_USER
-            - docker/build: &public-image
-                image: ${CIRCLE_PROJECT_USERNAME+$CIRCLE_PROJECT_USERNAME/}${CIRCLE_PROJECT_REPONAME:-bigquery-etl}
-                tag: ${CIRCLE_TAG:-latest}
-            - docker/push: *public-image
+      - *attach_generated_sql
+      - *copy_generated_sql
+      - docker/check:
+          docker-password: DOCKER_PASS
+          docker-username: DOCKER_USER
+      - docker/build: &public-image
+          image: ${CIRCLE_PROJECT_USERNAME+$CIRCLE_PROJECT_USERNAME/}${CIRCLE_PROJECT_REPONAME:-bigquery-etl}
+          tag: ${CIRCLE_TAG:-latest}
+      - docker/push: *public-image
   private-generate-sql:
     docker: *docker
     steps:
@@ -519,10 +513,7 @@ jobs:
       - gcp-gcr/build-image: &private-image
           image: bigquery-etl
           tag: ${CIRCLE_TAG:-latest}
-      - when:
-          condition: *deploy-condition
-          steps:
-            - gcp-gcr/push-image: *private-image
+      - gcp-gcr/push-image: *private-image
   generate-diff:
     docker: *docker
     steps:
@@ -708,9 +699,6 @@ workflows:
             branches:
               only:
                 - main
-            tags:
-              only:
-                - /.+/
       # The following "private" jobs are basically clones of the public jobs
       # for generate-sql, deploy, and push-generated-sql, except that they pull
       # in some additional content from an internal Mozilla repository for
@@ -738,9 +726,6 @@ workflows:
             branches:
               only:
                 - main
-            tags:
-              only:
-                - /.+/
   nightly: # Run after schema-generator to ensure we are up-to-date
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,6 +704,13 @@ workflows:
             # webhooks used in Ops logic. For details, see:
             # https://bugzilla.mozilla.org/show_bug.cgi?id=1715628#c0
             - deploy-to-private-gcr
+          filters:
+            branches:
+              only:
+                - main
+            tags:
+              only:
+                - /.+/
       # The following "private" jobs are basically clones of the public jobs
       # for generate-sql, deploy, and push-generated-sql, except that they pull
       # in some additional content from an internal Mozilla repository for
@@ -727,6 +734,13 @@ workflows:
             # can't run in parallel because CIRCLE_BUILD_NUM is same
             - build
             - generate-sql
+          filters:
+            branches:
+              only:
+                - main
+            tags:
+              only:
+                - /.+/
   nightly: # Run after schema-generator to ensure we are up-to-date
     triggers:
       - schedule:


### PR DESCRIPTION
Skip the entire deploy job on non-main branches instead of just some steps. Also remove the tag condition since we're not doing that anymore