### PR TITLE
Fix plan_interval_count schema type for channel_group_proportions_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/channel_group_proportions_v1/schema.yaml
@@ -41,7 +41,7 @@ fields:
   type: STRING
 - mode: NULLABLE
   name: plan_interval_count
-  type: STRING
+  type: INTEGER
 - mode: NULLABLE
   name: provider
   type: STRING


### PR DESCRIPTION
Table deploys are currently failing due to incompatible types.
