### PR TITLE
Bug 1823627 - Normalize the channel based on probeinfo data in UNIONized views

### DIFF
--- a/sql_generators/glean_usage/glean_app_ping_views.py
+++ b/sql_generators/glean_usage/glean_app_ping_views.py
@@ -31,6 +31,13 @@ description: |-
   It is used by Looker.
 """
 
+# Fields that exist in the source dataset,
+# but are manually overriden in the constructed SQL.
+# MUST be kept in sync with the query in `app_ping_view.view.sql`
+OVERRIDEN_FIELDS = [
+    "normalized_channel"
+]
+
 PATH = Path(os.path.dirname(__file__))
 
 
@@ -135,6 +142,7 @@ class GleanAppPingViews(GleanTable):
                         select_expression=select_expression,
                         dataset=channel_dataset,
                         table=view_name,
+                        channel=app.get("app_channel")
                     )
                 )
 
@@ -197,8 +205,9 @@ class GleanAppPingViews(GleanTable):
                 # field exists in app schema
 
                 if node == app_schema_nodes[node_name]:
-                    # field (and all nested fields) are identical, so just query it
-                    select_expr.append(f"{'.'.join(path + [node_name])}")
+                    if node_name not in OVERRIDEN_FIELDS:
+                        # field (and all nested fields) are identical, so just query it
+                        select_expr.append(f"{'.'.join(path + [node_name])}")
                 else:
                     # fields, and/or nested fields are not identical
                     if dtype == "RECORD":

--- a/sql_generators/glean_usage/templates/app_ping_view.view.sql
+++ b/sql_generators/glean_usage/templates/app_ping_view.view.sql
@@ -8,6 +8,11 @@ UNION ALL
 {% endif -%}
 SELECT 
   "{{ query.dataset }}" AS normalized_app_id,
+  {% if query.channel %}
+  "{{ query.channel }}" AS normalized_channel,
+  {% else %}
+  normalized_channel,
+  {% endif %}
   {{ query.select_expression }}
 FROM `{{ project_id }}.{{ query.dataset }}.{{ query.table }}`
 {% endfor %}


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
