### PR TITLE
bug(DENG-788): adding first_seen_date to schema.yaml to match with the query.sql file

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/schema.yaml
@@ -8,6 +8,12 @@ fields:
     when generating this record.
 
 - mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+  description: |
+    Date when we observed the user for the first time.
+
+- mode: NULLABLE
   name: client_id
   type: STRING
   description: |


### PR DESCRIPTION
# bug(DENG-788): adding first_seen_date to schema.yaml to match with the query.sql file

This is a direct follow-up to #3712 where an incorrect `schema.yaml` was added. This PR is to fix that.

The table has already been deployed with the correct schema. This is just to make sure the file is correct in in the main branch.