### PR TITLE
Fix product version type

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_suggest_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_suggest_v2/query.sql
@@ -58,7 +58,7 @@ SELECT
   country_code,
   region_code,
   os_family,
-  product_version,
+  CAST(product_version AS INT64) as product_version,
   impression_count,
   click_count
 FROM


### PR DESCRIPTION
The airflow DAG is failing with `product_version has changed type from INTEGER to STRING`.
The PR should fix the issue.