### PR TITLE
feat(DENG-789): added apple_ads namespace views to dryrun skip 

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -87,6 +87,10 @@ SKIP = {
     "sql/moz-fx-data-shared-prod/fivetran_costs_derived/destinations_v1/query.sql",
     "sql/moz-fx-data-shared-prod/fivetran_costs_derived/incremental_mar_v1/query.sql",
     "sql/moz-fx-data-shared-prod/fivetran_costs_derived/monthly_costs_v1/query.sql",
+    *glob.glob(
+        "sql/moz-fx-data-shared-prod/apple_ads/**/view.sql",
+        recursive=True,
+    ),
     "sql/moz-fx-data-shared-prod/regrets_reporter/regrets_reporter_update/view.sql",
     "sql/moz-fx-data-shared-prod/revenue_derived/client_ltv_v1/query.sql",
     "sql/moz-fx-data-shared-prod/monitoring/payload_bytes_decoded_all/view.sql",


### PR DESCRIPTION
# feat(DENG-789): added apple_ads namespace views to dryrun skip

This is due to the views referencing tables located inside our Fivetran project.

