### PR TITLE
Add normalized_campaign to firefox_android_clients

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix/firefox_android_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/firefox_android_clients/view.sql
@@ -30,5 +30,6 @@ SELECT
       THEN 'Other'
     ELSE install_source
   END AS install_source,
+  REGEXP_REPLACE(client.adjust_campaign, "(\\S+).*", "\\1") AS normalized_adjust_campaign,
 FROM
   `moz-fx-data-shared-prod.fenix_derived.firefox_android_clients_v1`


### PR DESCRIPTION
The adjust_campaign field comes in (at least) two types:
1. $campaign ($campaign_id)
2. $campaign - NULL ($campaign_id)

We really only want the $campaign part for analysis.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
