### PR TITLE
Added decode_uri_attribution to parse the install.attribution field

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf_js/decode_uri_attribution/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf_js/decode_uri_attribution/metadata.yaml
@@ -1,0 +1,5 @@
+description: URL decodes the raw firefox_installer.install.attribution string
+  to a STRUCT.  The fields campaign, content, dlsource, dltoken, experiment,
+  medium, source, ua, variation the string are extracted.  If any value is
+  (not+set) is is converted to (not set).
+friendly_name: Decode Uri Attribution

--- a/sql/moz-fx-data-shared-prod/udf_js/decode_uri_attribution/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/decode_uri_attribution/udf.sql
@@ -1,0 +1,165 @@
+-- Definition for udf_js.decode_uri_attribution
+-- For more information on writing UDFs see:
+-- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
+CREATE OR REPLACE FUNCTION udf_js.decode_uri_attribution(attribution STRING)
+RETURNS STRUCT<
+  campaign STRING,
+  content STRING,
+  dlsource STRING,
+  dltoken STRING,
+  experiment STRING,
+  medium STRING,
+  source STRING,
+  ua STRING,
+  variation STRING
+> DETERMINISTIC
+LANGUAGE js
+AS
+  """
+ if (attribution == null) {
+  return {};
+ }
+const columns = [
+  'campaign',
+  'content',
+  'dlsource',
+  'dltoken',
+  'experiment',
+  'medium',
+  'source',
+  'ua',
+  'variation',
+];
+return decodeURIComponent(decodeURIComponent(attribution))
+  .split('&')
+  .map((kv) => kv.split(/=(.*)/s))
+  .reduce((acc, [key, value]) => {
+    key = key.trim('\\n');
+    if (columns.includes(key)) {
+      acc[key] = value.trim().replace('not+set', 'not set');
+    }
+    return acc;
+  }, {});
+
+""";
+
+-- Tests
+-- complete string
+SELECT
+  assert.struct_equals(
+    STRUCT(
+      'whatsnew',
+      '(not set)',
+      'mozorg',
+      '19d1fd9b-ae19-4155-8d26-fd91aaa55953',
+      '(not set)',
+      'firefox-browser',
+      'firefox-browser',
+      'firefox',
+      '(not set)'
+    ),
+    udf_js.decode_uri_attribution(
+      "campaign%3Dwhatsnew%26content%3D%2528not%2Bset%2529%26dlsource%3Dmozorg%26dltoken%3D19d1fd9b-ae19-4155-8d26-fd91aaa55953%26experiment%3D%2528not%2Bset%2529%26medium%3Dfirefox-browser%26source%3Dfirefox-browser%26ua%3Dfirefox%26variation%3D%2528not%2Bset%2529"
+    )
+  );
+
+-- missing fields, need to include schema whenever using NULL
+SELECT
+  assert.struct_equals(
+    STRUCT<
+      campaign STRING,
+      content STRING,
+      dlsource STRING,
+      dltoken STRING,
+      experiment STRING,
+      medium STRING,
+      source STRING,
+      ua STRING,
+      variation STRING
+    >(
+      'whatsnew',
+      '(not set)',
+      'mozorg',
+      '19d1fd9b-ae19-4155-8d26-fd91aaa55953',
+      NULL,
+      'firefox-browser',
+      'firefox-browser',
+      'firefox',
+      NULL
+    ),
+    udf_js.decode_uri_attribution(
+      "campaign%3Dwhatsnew%26content%3D%2528not%2Bset%2529%26dlsource%3Dmozorg%26dltoken%3D19d1fd9b-ae19-4155-8d26-fd91aaa55953%26medium%3Dfirefox-browser%26source%3Dfirefox-browser%26ua%3Dfirefox"
+    )
+  );
+
+-- extra fields, need to include schema whenever using NULL
+SELECT
+  assert.struct_equals(
+    STRUCT(
+      'whatsnew',
+      '(not set)',
+      'mozorg',
+      '19d1fd9b-ae19-4155-8d26-fd91aaa55953',
+      '(not set)',
+      'firefox-browser',
+      'firefox-browser',
+      'firefox',
+      '(not set)'
+    ),
+    udf_js.decode_uri_attribution(
+      "extra%3Dsomething%26campaign%3Dwhatsnew%26content%3D%2528not%2Bset%2529%26dlsource%3Dmozorg%26dltoken%3D19d1fd9b-ae19-4155-8d26-fd91aaa55953%26experiment%3D%2528not%2Bset%2529%26medium%3Dfirefox-browser%26source%3Dfirefox-browser%26ua%3Dfirefox%26variation%3D%2528not%2Bset%2529"
+    )
+  );
+
+-- NULL, need to include schema whenever using NULL
+SELECT
+  assert.struct_equals(
+    STRUCT<
+      campaign STRING,
+      content STRING,
+      dlsource STRING,
+      dltoken STRING,
+      experiment STRING,
+      medium STRING,
+      source STRING,
+      ua STRING,
+      variation STRING
+    >(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    udf_js.decode_uri_attribution(NULL)
+  );
+
+-- empty string, need to include schema whenever using NULL
+SELECT
+  assert.struct_equals(
+    STRUCT<
+      campaign STRING,
+      content STRING,
+      dlsource STRING,
+      dltoken STRING,
+      experiment STRING,
+      medium STRING,
+      source STRING,
+      ua STRING,
+      variation STRING
+    >(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    udf_js.decode_uri_attribution('')
+  );
+
+-- not encoded
+SELECT
+  assert.struct_equals(
+    STRUCT(
+      'whatsnew',
+      '(not set)',
+      'mozorg',
+      '19d1fd9b-ae19-4155-8d26-fd91aaa55953',
+      '(not set)',
+      'firefox-browser',
+      'firefox-browser',
+      'firefox',
+      '(not set)'
+    ),
+    udf_js.decode_uri_attribution(
+      "campaign=whatsnew&content=(not set)&dlsource=mozorg&dltoken=19d1fd9b-ae19-4155-8d26-fd91aaa55953&experiment=(not set)&medium=firefox-browser&source=firefox-browser&ua=firefox&variation=(not set)"
+    )
+  );


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

**Summary of changes:**
Added `udf_js.decode_uri_attribution(attribution STRING)` to URL decode `firefox_installer.install.attribution`.  The column contains a URL encoded string.  Extracting those fields into a STRUCT will simplify queries for table users.

Note that if any value is the text `(not+set)` is is converted to `(not set)` to match the text from GA when the fields are not set.

Input example: 
`"campaign%3D%2528not%2Bset%2529%26content%3D%2528not%2Bset%2529%26dlsource%3Dmozorg%26dltoken%3D1f3f72c0-c6d0-4ebb-a1e6-304a4b587f06%26experiment%3D%2528not%2Bset%2529%26medium%3Dreferral%26source%3Dwww.google.com%26ua%3Dchrome%26variation%3D%2528not%2Bset%2529"`

Output Format:
```
STRUCT<
  campaign STRING,
  content STRING,
  dlsource STRING,
  dltoken STRING,
  experiment STRING,
  medium STRING,
  source STRING,
  ua STRING,
  variation STRING
>
```

This UDF will be used by a new view which will be created once this UDF is deployed.