### PR TITLE
RS-722 Remove task name from printed message in DAG generation

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -336,8 +336,7 @@ class Task:
             if not is_email(owner):
                 metadata.owners.remove(owner)
                 click.echo(
-                    f"{owner} removed from email list in DAG "
-                    f"{metadata.scheduling['dag_name']}, task: {metadata.scheduling['task_name']}"
+                    f"{owner} removed from email list in DAG {metadata.scheduling['dag_name']}"
                 )
         task_config["email"] = list(set(email + metadata.owners))
 

--- a/sql/moz-fx-data-bq-performance/release_criteria/rc_flattened_test_data_v1/query.sql
+++ b/sql/moz-fx-data-bq-performance/release_criteria/rc_flattened_test_data_v1/query.sql
@@ -46,7 +46,7 @@ LEFT JOIN
   UNNEST(subtest.replicates) AS subtest_replicate
   WITH OFFSET AS subtest_replicate_offset
 WHERE
-  test_run.time >= TIMESTAMP_SUB(current_timestamp, INTERVAL (52 * 7) DAY)
+  test_run.time >= TIMESTAMP_SUB(current_timestamp, INTERVAL(52 * 7) DAY)
   AND `moz-fx-data-bq-performance.udf.is_included_project`(test_run.project)
   AND `moz-fx-data-bq-performance.udf.is_included_framework`(test_run.framework)
   AND STRPOS(test_run.platform, '-shippable') > 0

--- a/sql/moz-fx-data-marketing-prod/ga_derived/downloads_with_attribution_v2/query.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/downloads_with_attribution_v2/query.sql
@@ -30,7 +30,6 @@ CREATE TEMP FUNCTION normalize_ga_os(os STRING, nrows INTEGER) AS (
   END
 );
 
-
 -- Unnest all the hits for all  sessions, one row per hit.
 -- Different hit.type values (EVENT | PAGE)
 -- and hit.eventInfo.eventAction('Firefox Download'| 'Stub Session ID') are
@@ -42,15 +41,21 @@ WITH all_hits AS (
     visitId AS visit_id,
     hit.appInfo.landingScreenName AS landing_page,
     hit.page.pagePath AS pagepath,
-    IF (hit.type = 'EVENT'
-          AND hit.eventInfo.eventAction = 'Firefox Download'
-          AND hit.eventInfo.eventCategory IS NOT NULL
-          AND hit.eventInfo.eventLabel LIKE 'Firefox for Desktop%',
-          TRUE, FALSE)
-    AS has_ga_download_event,
+    IF(
+      hit.type = 'EVENT'
+      AND hit.eventInfo.eventAction = 'Firefox Download'
+      AND hit.eventInfo.eventCategory IS NOT NULL
+      AND hit.eventInfo.eventLabel LIKE 'Firefox for Desktop%',
+      TRUE,
+      FALSE
+    ) AS has_ga_download_event,
     hit.type AS hit_type,
-    IF (hit.type = 'EVENT' AND hit.eventInfo.eventAction = 'Stub Session ID', hit.eventInfo.eventLabel, NULL)
-    AS download_session_id
+    IF(
+      hit.type = 'EVENT'
+      AND hit.eventInfo.eventAction = 'Stub Session ID',
+      hit.eventInfo.eventLabel,
+      NULL
+    ) AS download_session_id
   FROM
     `moz-fx-data-marketing-prod.65789850.ga_sessions_*` AS ga
   CROSS JOIN
@@ -87,7 +92,7 @@ event_hits AS (
   FROM
     all_hits
   WHERE
-     hit_type = 'EVENT'
+    hit_type = 'EVENT'
   GROUP BY
     client_id,
     visit_id
@@ -134,7 +139,6 @@ ga_sessions_with_hits_fields AS (
   USING
     (client_id, visit_id)
 ),
-
 -- Extract all the download rows, de-duping and tracking number of duplicates per download token.
 stub_downloads AS (
   SELECT
@@ -153,19 +157,17 @@ stub_downloads AS (
     stub_download_session_id,
     dltoken
 ),
-
 multiple_downloads_in_session AS (
   SELECT
     stub_visit_id,
     stub_download_session_id,
-    IF (COUNT(*) > 1, TRUE, FALSE) AS additional_download_occurred
+    IF(COUNT(*) > 1, TRUE, FALSE) AS additional_download_occurred
   FROM
     stub_downloads
   GROUP BY
     stub_visit_id,
     stub_download_session_id
 ),
-
 stub_downloads_with_download_tracking AS (
   SELECT
     s1.stub_visit_id,
@@ -178,11 +180,11 @@ stub_downloads_with_download_tracking AS (
     stub_downloads s1
   JOIN
     multiple_downloads_in_session s2
-  ON (
-    s1.stub_visit_id = s2.stub_visit_id
-    AND
-    IFNULL(s1.stub_download_session_id,"null")=IFNULL(s2.stub_download_session_id, "null")
-  )
+  ON
+    (
+      s1.stub_visit_id = s2.stub_visit_id
+      AND IFNULL(s1.stub_download_session_id, "null") = IFNULL(s2.stub_download_session_id, "null")
+    )
 ),
 -- This will drop all the ga_sessions w/o a DLtoken but keep DLtoken without a GA session.
 -- This will also result in multiple rows as the ga.client_id is not unique for the day
@@ -207,9 +209,7 @@ downloads_with_ga_session AS (
     mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(landing_page)) AS landing_page,
     mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(pageviews)) AS pageviews,
     mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(unique_pageviews)) AS unique_pageviews,
-    LOGICAL_OR(
-      has_ga_download_event
-    ) AS has_ga_download_event,
+    LOGICAL_OR(has_ga_download_event) AS has_ga_download_event,
     mozfun.stats.mode_last_retain_nulls(
       ARRAY_AGG(count_dltoken_duplicates)
     ) AS count_dltoken_duplicates,
@@ -232,100 +232,108 @@ downloads_with_ga_session AS (
 -- This table is the result of joining the stub downlaod data with the GA rows
 -- using the client_id and the custom session_download_id
 v2_table AS (
-SELECT
-  dltoken,
-  download_date,
-  IF(nrows <= 1, time_on_site, NULL) AS time_on_site,
-  IF(nrows <= 1, ad_content, NULL) AS ad_content,
-  IF(nrows <= 1, campaign, NULL) AS campaign,
-  IF(nrows <= 1, medium, NULL) AS medium,
-  IF(nrows <= 1, source, NULL) AS source,
-  IF(nrows <= 1, landing_page, NULL) AS landing_page,
-  IF(nrows <= 1, country, NULL) AS country,
-  IF(nrows <= 1, cn.code, NULL) AS normalized_country_code,
-  IF(nrows <= 1, device_category, NULL) AS device_category,
-  IF(nrows <= 1, os, NULL) AS os,
-  normalize_ga_os(os, nrows) AS normalized_os,
-  IF(nrows <= 1, browser, NULL) AS browser,
-  IF(nrows <= 1, normalize_browser(browser), NULL) AS normalized_browser,
-  IF(nrows <= 1, browser_version, NULL) AS browser_version,
+  SELECT
+    dltoken,
+    download_date,
+    IF(nrows <= 1, time_on_site, NULL) AS time_on_site,
+    IF(nrows <= 1, ad_content, NULL) AS ad_content,
+    IF(nrows <= 1, campaign, NULL) AS campaign,
+    IF(nrows <= 1, medium, NULL) AS medium,
+    IF(nrows <= 1, source, NULL) AS source,
+    IF(nrows <= 1, landing_page, NULL) AS landing_page,
+    IF(nrows <= 1, country, NULL) AS country,
+    IF(nrows <= 1, cn.code, NULL) AS normalized_country_code,
+    IF(nrows <= 1, device_category, NULL) AS device_category,
+    IF(nrows <= 1, os, NULL) AS os,
+    normalize_ga_os(os, nrows) AS normalized_os,
+    IF(nrows <= 1, browser, NULL) AS browser,
+    IF(nrows <= 1, normalize_browser(browser), NULL) AS normalized_browser,
+    IF(nrows <= 1, browser_version, NULL) AS browser_version,
  -- only setting browser major version since that is the only value used in
  -- moz-fx-data-shared-prod.firefox_installer.install
-
-  IF(nrows <= 1, CAST(mozfun.norm.extract_version(browser_version, 'major') AS INTEGER), NULL) AS browser_major_version,
-  IF(nrows <= 1, `language`, NULL) AS `language`,
-  IF(nrows <= 1, pageviews, NULL) AS pageviews,
-  IF(nrows <= 1, unique_pageviews, NULL) AS unique_pageviews,
-  IF(nrows <= 1, has_ga_download_event, NULL) AS has_ga_download_event,
-  count_dltoken_duplicates,
-  additional_download_occurred,
-  CASE
-    WHEN stub_visit_id IS NULL
-      OR stub_download_session_id IS NULL
-      THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_NULL'
-    WHEN stub_visit_id = ''
-      OR stub_download_session_id = ''
-      THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_EMPTY'
-    WHEN stub_visit_id = '(not set)'
-      OR stub_download_session_id = '(not set)'
-      THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_VALUE_NOT_SET'
-    WHEN stub_visit_id = 'something'
-      OR stub_download_session_id = 'something'
-      THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_VALUE_SOMETHING'
-    WHEN client_id IS NULL
-      THEN 'MISSING_GA_CLIENT_OR_SESSION_ID'
-    WHEN nrows > 1
-      THEN 'GA_UNRESOLVABLE'
-    ELSE 'CLIENT_ID_SESSION_ID_MATCH'
-  END
-  AS join_result_v2
-FROM
-  downloads_with_ga_session
-LEFT JOIN
-  `moz-fx-data-shared-prod.static.country_names_v1` AS cn
-ON
-  cn.name = country
+    IF(
+      nrows <= 1,
+      CAST(mozfun.norm.extract_version(browser_version, 'major') AS INTEGER),
+      NULL
+    ) AS browser_major_version,
+    IF(nrows <= 1, `language`, NULL) AS `language`,
+    IF(nrows <= 1, pageviews, NULL) AS pageviews,
+    IF(nrows <= 1, unique_pageviews, NULL) AS unique_pageviews,
+    IF(nrows <= 1, has_ga_download_event, NULL) AS has_ga_download_event,
+    count_dltoken_duplicates,
+    additional_download_occurred,
+    CASE
+      WHEN stub_visit_id IS NULL
+        OR stub_download_session_id IS NULL
+        THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_NULL'
+      WHEN stub_visit_id = ''
+        OR stub_download_session_id = ''
+        THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_EMPTY'
+      WHEN stub_visit_id = '(not set)'
+        OR stub_download_session_id = '(not set)'
+        THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_VALUE_NOT_SET'
+      WHEN stub_visit_id = 'something'
+        OR stub_download_session_id = 'something'
+        THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_VALUE_SOMETHING'
+      WHEN client_id IS NULL
+        THEN 'MISSING_GA_CLIENT_OR_SESSION_ID'
+      WHEN nrows > 1
+        THEN 'GA_UNRESOLVABLE'
+      ELSE 'CLIENT_ID_SESSION_ID_MATCH'
+    END AS join_result_v2
+  FROM
+    downloads_with_ga_session
+  LEFT JOIN
+    `moz-fx-data-shared-prod.static.country_names_v1` AS cn
+  ON
+    cn.name = country
 ),
-
 -- Some of the joins for v2_table as not successful due to the GA data not including
 -- the download_session_id.  The downloads which are unable to match to a GA session
 -- are set to exception='MISSING_GA_CLIENT_OR_SESSION_ID'
 -- Those dltokens are re-processed using the V1 logic (loin using only the client_id)
 extract_dltoken_missing_ga_client AS (
-  SELECT s.stub_visit_id, v2.dltoken, v2.count_dltoken_duplicates,  v2.additional_download_occurred,  v2.download_date
-  FROM v2_table v2
-  JOIN stub_downloads_with_download_tracking s
-  ON (s.dltoken = v2.dltoken)
-  WHERE join_result_v2 = 'MISSING_GA_CLIENT_OR_SESSION_ID'
+  SELECT
+    s.stub_visit_id,
+    v2.dltoken,
+    v2.count_dltoken_duplicates,
+    v2.additional_download_occurred,
+    v2.download_date
+  FROM
+    v2_table v2
+  JOIN
+    stub_downloads_with_download_tracking s
+  ON
+    (s.dltoken = v2.dltoken)
+  WHERE
+    join_result_v2 = 'MISSING_GA_CLIENT_OR_SESSION_ID'
 ),
 v1_downloads_with_ga_session AS (
   SELECT
-  gs.client_id,
-  dltoken,
-  stub_visit_id,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(country)) AS country,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(ad_content)) AS ad_content,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(campaign)) AS campaign,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(medium)) AS medium,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(source)) AS source,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(device_category)) AS device_category,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(os)) AS os,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(browser)) AS browser,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(browser_version)) AS browser_version,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(`language`)) AS `language`,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(landing_page)) AS landing_page,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(pageviews)) AS pageviews,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(unique_pageviews)) AS unique_pageviews,
-  LOGICAL_OR(
-    has_ga_download_event
-  ) AS has_ga_download_event,
-  mozfun.stats.mode_last_retain_nulls(
-    ARRAY_AGG(count_dltoken_duplicates)
-  ) AS count_dltoken_duplicates,
-  LOGICAL_OR(additional_download_occurred) AS additional_download_occurred,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(s.download_date)) AS download_date,
-  mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(time_on_site)) AS time_on_site,
-  COUNT(*) AS nrows
+    gs.client_id,
+    dltoken,
+    stub_visit_id,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(country)) AS country,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(ad_content)) AS ad_content,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(campaign)) AS campaign,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(medium)) AS medium,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(source)) AS source,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(device_category)) AS device_category,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(os)) AS os,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(browser)) AS browser,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(browser_version)) AS browser_version,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(`language`)) AS `language`,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(landing_page)) AS landing_page,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(pageviews)) AS pageviews,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(unique_pageviews)) AS unique_pageviews,
+    LOGICAL_OR(has_ga_download_event) AS has_ga_download_event,
+    mozfun.stats.mode_last_retain_nulls(
+      ARRAY_AGG(count_dltoken_duplicates)
+    ) AS count_dltoken_duplicates,
+    LOGICAL_OR(additional_download_occurred) AS additional_download_occurred,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(s.download_date)) AS download_date,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(time_on_site)) AS time_on_site,
+    COUNT(*) AS nrows
   FROM
     ga_sessions_with_hits_fields gs
   RIGHT JOIN
@@ -333,56 +341,67 @@ v1_downloads_with_ga_session AS (
   ON
     gs.client_id = s.stub_visit_id
   GROUP BY
-    gs.client_id, stub_visit_id, dltoken
-
+    gs.client_id,
+    stub_visit_id,
+    dltoken
 ),
 v1_table AS (
-SELECT
-  dltoken,
-  download_date,
-  IF(nrows <= 1, time_on_site, NULL) AS time_on_site,
-  IF(nrows <= 1, ad_content, NULL) AS ad_content,
-  IF(nrows <= 1, campaign, NULL) AS campaign,
-  IF(nrows <= 1, medium, NULL) AS medium,
-  IF(nrows <= 1, source, NULL) AS source,
-  IF(nrows <= 1, landing_page, NULL) AS landing_page,
-  IF(nrows <= 1, country, NULL) AS country,
-  IF(nrows <= 1, cn.code, NULL) AS normalized_country_code,
-  IF(nrows <= 1, device_category, NULL) AS device_category,
-  IF(nrows <= 1, os, NULL) AS os,
-  normalize_ga_os(os, nrows) AS normalized_os,
-  IF(nrows <= 1, browser, NULL) AS browser,
-  IF(nrows <= 1, normalize_browser(browser), NULL) AS normalized_browser,
-  IF(nrows <= 1, browser_version, NULL) AS browser_version,
+  SELECT
+    dltoken,
+    download_date,
+    IF(nrows <= 1, time_on_site, NULL) AS time_on_site,
+    IF(nrows <= 1, ad_content, NULL) AS ad_content,
+    IF(nrows <= 1, campaign, NULL) AS campaign,
+    IF(nrows <= 1, medium, NULL) AS medium,
+    IF(nrows <= 1, source, NULL) AS source,
+    IF(nrows <= 1, landing_page, NULL) AS landing_page,
+    IF(nrows <= 1, country, NULL) AS country,
+    IF(nrows <= 1, cn.code, NULL) AS normalized_country_code,
+    IF(nrows <= 1, device_category, NULL) AS device_category,
+    IF(nrows <= 1, os, NULL) AS os,
+    normalize_ga_os(os, nrows) AS normalized_os,
+    IF(nrows <= 1, browser, NULL) AS browser,
+    IF(nrows <= 1, normalize_browser(browser), NULL) AS normalized_browser,
+    IF(nrows <= 1, browser_version, NULL) AS browser_version,
  -- only setting browser major version since that is the only value used in
  -- moz-fx-data-shared-prod.firefox_installer.install
-
-  IF(nrows <= 1, CAST(mozfun.norm.extract_version(browser_version, 'major') AS INTEGER), NULL) AS browser_major_version,
-  IF(nrows <= 1, `language`, NULL) AS `language`,
-  IF(nrows <= 1, pageviews, NULL) AS pageviews,
-  IF(nrows <= 1, unique_pageviews, NULL) AS unique_pageviews,
-  IF(nrows <= 1, has_ga_download_event, NULL) AS has_ga_download_event,
-  count_dltoken_duplicates,
-  additional_download_occurred,
-  CASE
-    WHEN client_id IS NULL
-      THEN 'MISSING_GA_CLIENT'
-    WHEN nrows > 1
-      THEN 'GA_UNRESOLVABLE'
-    ELSE 'CLIENT_ID_ONLY_MATCH'
-  END
-  AS join_result_v1
-FROM
-  v1_downloads_with_ga_session
-LEFT JOIN
-  `moz-fx-data-shared-prod.static.country_names_v1` AS cn
-ON
-  cn.name = country
+    IF(
+      nrows <= 1,
+      CAST(mozfun.norm.extract_version(browser_version, 'major') AS INTEGER),
+      NULL
+    ) AS browser_major_version,
+    IF(nrows <= 1, `language`, NULL) AS `language`,
+    IF(nrows <= 1, pageviews, NULL) AS pageviews,
+    IF(nrows <= 1, unique_pageviews, NULL) AS unique_pageviews,
+    IF(nrows <= 1, has_ga_download_event, NULL) AS has_ga_download_event,
+    count_dltoken_duplicates,
+    additional_download_occurred,
+    CASE
+      WHEN client_id IS NULL
+        THEN 'MISSING_GA_CLIENT'
+      WHEN nrows > 1
+        THEN 'GA_UNRESOLVABLE'
+      ELSE 'CLIENT_ID_ONLY_MATCH'
+    END AS join_result_v1
+  FROM
+    v1_downloads_with_ga_session
+  LEFT JOIN
+    `moz-fx-data-shared-prod.static.country_names_v1` AS cn
+  ON
+    cn.name = country
 )
-
-SELECT * EXCEPT (join_result_v1), 'MISSING_GA_CLIENT_OR_SESSION_ID' AS join_result_v2, join_result_v1 AS join_result_v1
-FROM v1_table
+SELECT
+  * EXCEPT (join_result_v1),
+  'MISSING_GA_CLIENT_OR_SESSION_ID' AS join_result_v2,
+  join_result_v1 AS join_result_v1
+FROM
+  v1_table
 UNION ALL
-SELECT * EXCEPT (join_result_v2), join_result_v2 AS join_result_v2, NULL AS join_result_v1
-FROM v2_table
-WHERE join_result_v2 != 'MISSING_GA_CLIENT_OR_SESSION_ID'
+SELECT
+  * EXCEPT (join_result_v2),
+  join_result_v2 AS join_result_v2,
+  NULL AS join_result_v1
+FROM
+  v2_table
+WHERE
+  join_result_v2 != 'MISSING_GA_CLIENT_OR_SESSION_ID'

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_suggest_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_suggest_v2/query.sql
@@ -58,7 +58,7 @@ SELECT
   country_code,
   region_code,
   os_family,
-  CAST(product_version AS INT64) as product_version,
+  CAST(product_version AS INT64) AS product_version,
   impression_count,
   click_count
 FROM

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_tiles_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_tiles_v2/query.sql
@@ -22,10 +22,9 @@ extracted AS (
     JSON_VALUE(si.parsedReportingUrl.params.country_code) AS country_code,
     JSON_VALUE(si.parsedReportingUrl.params.region_code) AS region_code,
     JSON_VALUE(si.parsedReportingUrl.params.os_family) AS os_family,
-    CAST(REGEXP_EXTRACT(
-      JSON_VALUE(si.parsedReportingUrl.params.product_version),
-      '[^_]*$'
-    ) AS INT64) AS product_version,
+    CAST(
+      REGEXP_EXTRACT(JSON_VALUE(si.parsedReportingUrl.params.product_version), '[^_]*$') AS INT64
+    ) AS product_version,
     IF(si.interactionType = 'impression', si.interactionCount, 0) AS impression_count,
     IF(si.interactionType = 'click', 1, 0) AS click_count
   FROM

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v1/view.sql
@@ -15,7 +15,7 @@ WITH extracted AS (
     submission_timestamp < TIMESTAMP_TRUNC(current_timestamp, day)
     AND submission_timestamp > TIMESTAMP_SUB(
       TIMESTAMP_TRUNC(current_timestamp, day),
-      INTERVAL (28 * 24) hour
+      INTERVAL(28 * 24) hour
     )
     AND exception_class = 'org.everit.json.schema.ValidationException'
 ),

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/structured_detailed_error_counts_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/structured_detailed_error_counts_v1/view.sql
@@ -17,7 +17,7 @@ WITH error_examples AS (
   FROM
     `moz-fx-data-shared-prod.monitoring.payload_bytes_error_structured`
   WHERE
-    submission_timestamp >= TIMESTAMP_SUB(current_timestamp, INTERVAL (28 * 24) HOUR)
+    submission_timestamp >= TIMESTAMP_SUB(current_timestamp, INTERVAL(28 * 24) HOUR)
   GROUP BY
     hour,
     document_namespace,

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/structured_error_counts_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/structured_error_counts_v1/view.sql
@@ -11,7 +11,7 @@ WITH ping_counts AS (
   FROM
     `moz-fx-data-shared-prod.monitoring.payload_bytes_decoded_structured`
   WHERE
-    submission_timestamp >= TIMESTAMP_SUB(current_timestamp, INTERVAL (28 * 24) HOUR)
+    submission_timestamp >= TIMESTAMP_SUB(current_timestamp, INTERVAL(28 * 24) HOUR)
   GROUP BY
     hour,
     document_namespace,
@@ -29,7 +29,7 @@ error_counts AS (
   FROM
     `moz-fx-data-shared-prod.monitoring.payload_bytes_error_structured`
   WHERE
-    submission_timestamp >= TIMESTAMP_SUB(current_timestamp, INTERVAL (28 * 24) HOUR)
+    submission_timestamp >= TIMESTAMP_SUB(current_timestamp, INTERVAL(28 * 24) HOUR)
   GROUP BY
     hour,
     document_namespace,

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v2/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v2/view.sql
@@ -22,7 +22,7 @@ extracted AS (
     -- only observe full days of data
     (
       DATE(submission_timestamp) = DATE_SUB(current_date, INTERVAL 1 day)
-      OR DATE(submission_timestamp) = DATE_SUB(current_date, INTERVAL (1 + 7) day)
+      OR DATE(submission_timestamp) = DATE_SUB(current_date, INTERVAL(1 + 7) day)
     )
     -- https://cloud.google.com/bigquery/docs/querying-wildcard-tables#filtering_selected_tables_using_table_suffix
     -- exclude pings derived from main schema to save on space, 300GB vs 3TB

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version_v1/query.sql
@@ -85,7 +85,7 @@ enumerated_build_hours AS (
       GENERATE_TIMESTAMP_ARRAY(
         TIMESTAMP_SUB(
           TIMESTAMP_TRUNC(CAST(@submission_date AS timestamp), HOUR),
-          INTERVAL (14 + 2) DAY
+          INTERVAL(14 + 2) DAY
         ),
         TIMESTAMP_TRUNC(CAST(@submission_date AS timestamp), HOUR),
         INTERVAL 1 HOUR


### PR DESCRIPTION
Implements [RS-722](https://mozilla-hub.atlassian.net/browse/RS-722) to remove [CI error](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/21258/workflows/fde57dfe-620e-4418-aff7-6216ca291b22/jobs/209703) due to printed message.


[RS-722]: https://mozilla-hub.atlassian.net/browse/RS-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ