### PR TITLE
GROWTH-41 Add last_seen columns to firefox_android_clients

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
@@ -152,6 +152,7 @@ _current AS (
     first_seen.device_model AS device_model,
     first_seen.os_version AS os_version,
     first_seen.app_version AS app_version,
+    first_seen.locale AS locale,
     activated AS activated,
     COALESCE(first_session.adjust_campaign, metrics.adjust_campaign) AS adjust_campaign,
     COALESCE(first_session.adjust_ad_group, metrics.adjust_ad_group) AS adjust_ad_group,
@@ -265,6 +266,7 @@ SELECT
   COALESCE(_previous.device_model, _current.device_model) AS device_model,
   COALESCE(_previous.os_version, _current.os_version) AS os_version,
   COALESCE(_previous.app_version, _current.app_version) AS app_version,
+  COALESCE(_previous.locale, _current.locale) AS locale,
   COALESCE(_previous.activated, _current.activated) AS activated,
   COALESCE(_previous.adjust_campaign, _current.adjust_campaign) AS adjust_campaign,
   COALESCE(_previous.adjust_ad_group, _current.adjust_ad_group) AS adjust_ad_group,
@@ -297,7 +299,7 @@ SELECT
     _current.last_reported_device_manufacturer,
     _previous.device_manufacturer
   ) AS last_reported_device_manufacturer,
-  COALESCE(_current.last_reported_locale, _previous.locale) AS locale,
+  COALESCE(_current.last_reported_locale, _previous.locale) AS last_reported_locale,
   STRUCT(
     COALESCE(_previous.metadata.reported_first_session_ping, FALSE)
     OR COALESCE(

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
@@ -12,7 +12,8 @@ WITH first_seen AS (
     device_manufacturer,
     device_model,
     normalized_os_version AS os_version,
-    app_display_version AS app_version
+    app_display_version AS app_version,
+    locale,
   FROM
     fenix.baseline_clients_first_seen
   WHERE
@@ -85,9 +86,53 @@ metrics_ping AS (
     )[SAFE_OFFSET(0)] AS adjust_creative,
     ARRAY_AGG(metrics.string.metrics_install_source IGNORE NULLS ORDER BY submission_timestamp ASC)[
       SAFE_OFFSET(0)
-    ] AS install_source
+    ] AS install_source,
+    ARRAY_AGG(
+      metrics.string.metrics_adjust_ad_group IGNORE NULLS
+      ORDER BY
+        submission_timestamp DESC
+    )[SAFE_OFFSET(0)] AS last_reported_adjust_ad_group,
+    ARRAY_AGG(
+      metrics.string.metrics_adjust_creative IGNORE NULLS
+      ORDER BY
+        submission_timestamp DESC
+    )[SAFE_OFFSET(0)] AS last_reported_adjust_creative,
+    ARRAY_AGG(
+      metrics.string.metrics_adjust_network IGNORE NULLS
+      ORDER BY
+        submission_timestamp DESC
+    )[SAFE_OFFSET(0)] AS last_reported_adjust_network,
+    ARRAY_AGG(
+      metrics.string.metrics_adjust_campaign IGNORE NULLS
+      ORDER BY
+        submission_timestamp DESC
+    )[SAFE_OFFSET(0)] AS last_reported_adjust_campaign,
   FROM
     org_mozilla_firefox.metrics AS org_mozilla_firefox_metrics
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+  GROUP BY
+    client_id
+),
+-- Find most recent client details from the baseline ping.
+baseline_ping AS (
+  SELECT
+    client_info.client_id,
+    DATE(MAX(submission_timestamp)) AS last_reported_date,
+    ARRAY_AGG(normalized_country_code IGNORE NULLS ORDER BY submission_timestamp DESC)[
+      SAFE_OFFSET(0)
+    ] AS last_reported_country,
+    ARRAY_AGG(client_info.device_model IGNORE NULLS ORDER BY submission_timestamp DESC)[
+      SAFE_OFFSET(0)
+    ] AS last_reported_device_model,
+    ARRAY_AGG(client_info.device_manufacturer IGNORE NULLS ORDER BY submission_timestamp DESC)[
+      SAFE_OFFSET(0)
+    ] AS last_reported_device_manufacturer,
+    ARRAY_AGG(client_info.locale IGNORE NULLS ORDER BY submission_timestamp DESC)[
+      SAFE_OFFSET(0)
+    ] AS last_reported_locale,
+  FROM
+    org_mozilla_firefox.baseline AS org_mozilla_firefox_baseline
   WHERE
     DATE(submission_timestamp) = @submission_date
   GROUP BY
@@ -113,6 +158,15 @@ _current AS (
     COALESCE(first_session.adjust_creative, metrics.adjust_creative) AS adjust_creative,
     COALESCE(first_session.adjust_network, metrics.adjust_network) AS adjust_network,
     metrics.install_source AS install_source,
+    metrics.last_reported_adjust_campaign AS last_reported_adjust_campaign,
+    metrics.last_reported_adjust_ad_group AS last_reported_adjust_ad_group,
+    metrics.last_reported_adjust_creative AS last_reported_adjust_creative,
+    metrics.last_reported_adjust_network AS last_reported_adjust_network,
+    baseline.last_reported_date AS last_reported_date,
+    baseline.last_reported_country AS last_reported_country,
+    baseline.last_reported_device_model AS last_reported_device_model,
+    baseline.last_reported_device_manufacturer AS last_reported_device_manufacturer,
+    baseline.last_reported_locale AS last_reported_locale,
     STRUCT(
       CASE
         WHEN first_session.client_id IS NULL
@@ -177,6 +231,10 @@ _current AS (
     metrics_ping AS metrics
   USING
     (client_id)
+  FULL OUTER JOIN
+    baseline_ping AS baseline
+  USING
+    (client_id)
   LEFT JOIN
     activations
   USING
@@ -213,6 +271,33 @@ SELECT
   COALESCE(_previous.adjust_creative, _current.adjust_creative) AS adjust_creative,
   COALESCE(_previous.adjust_network, _current.adjust_network) AS adjust_network,
   COALESCE(_previous.install_source, _current.install_source) AS install_source,
+  COALESCE(
+    _current.last_reported_adjust_campaign,
+    _previous.last_reported_adjust_campaign
+  ) AS last_reported_adjust_campaign,
+  COALESCE(
+    _current.last_reported_adjust_ad_group,
+    _previous.last_reported_adjust_ad_group
+  ) AS last_reported_adjust_ad_group,
+  COALESCE(
+    _current.last_reported_adjust_creative,
+    _previous.last_reported_adjust_creative
+  ) AS last_reported_adjust_creative,
+  COALESCE(_current.last_reported_adjust_network, _previous.adjust_network) AS last_reported_adjust_network,
+  COALESCE(_current.last_reported_date, _previous.last_reported_date) AS last_reported_date,
+  COALESCE(
+    _current.last_reported_country,
+    _previous.last_reported_country
+  ) AS last_reported_country,
+  COALESCE(
+    _current.last_reported_device_model,
+    _previous.last_reported_device_model
+  ) AS last_reported_device_model,
+  COALESCE(
+    _current.last_reported_device_manufacturer,
+    _previous.device_manufacturer
+  ) AS last_reported_device_manufacturer,
+  COALESCE(_current.last_reported_locale, _previous.locale) AS locale,
   STRUCT(
     COALESCE(_previous.metadata.reported_first_session_ping, FALSE)
     OR COALESCE(

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/schema.yaml
@@ -137,15 +137,15 @@ fields:
   mode: NULLABLE
   name: last_reported_adjust_network
   type: STRING
-- description:
+- description: Last reported campaign name.
   mode: NULLABLE
   name: last_reported_adjust_creative
   type: STRING
-- description:
+- description: Last reported campaign ad group.
   mode: NULLABLE
   name: last_reported_adjust_ad_group
   type: STRING
-- description:
+- description: Last reported campaign name.
   mode: NULLABLE
   name: last_reported_adjust_campaign
   type: STRING

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/schema.yaml
@@ -47,6 +47,10 @@ fields:
   mode: NULLABLE
   name: app_version
   type: STRING
+- description: Client locale.
+  mode: NULLABLE
+  name: locale
+  type: STRING
 - description: Determines if a client is activated based on the activation metric
     and a 7 day lag.
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/schema.yaml
@@ -113,3 +113,39 @@ fields:
   mode: NULLABLE
   name: metadata
   type: RECORD
+- description: Last reported client locale.
+  mode: NULLABLE
+  name: last_reported_locale
+  type: STRING
+- description: Last reported client device manufacturer.
+  mode: NULLABLE
+  name: last_reported_device_manufacturer
+  type: STRING
+- description: Last reported client device model.
+  mode: NULLABLE
+  name: last_reported_device_model
+  type: STRING
+- description: Last reported client country.
+  mode: NULLABLE
+  name: last_reported_country
+  type: STRING
+- description: Last date client seen.
+  mode: NULLABLE
+  name: last_reported_date
+  type: DATE
+- description: Last reported client campaign network.
+  mode: NULLABLE
+  name: last_reported_adjust_network
+  type: STRING
+- description:
+  mode: NULLABLE
+  name: last_reported_adjust_creative
+  type: STRING
+- description:
+  mode: NULLABLE
+  name: last_reported_adjust_ad_group
+  type: STRING
+- description:
+  mode: NULLABLE
+  name: last_reported_adjust_campaign
+  type: STRING

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/fenix.baseline_clients_first_seen.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/fenix.baseline_clients_first_seen.schema.json
@@ -44,8 +44,12 @@
     "type": "STRING",
     "name": "normalized_os_version"
   },
-    {
+  {
     "type": "STRING",
     "name": "app_display_version"
+  },
+  {
+    "type": "STRING",
+    "name": "locale"
   }
 ]

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/moz-fx-data-shared-prod.fenix_derived.firefox_android_clients_v1.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/moz-fx-data-shared-prod.fenix_derived.firefox_android_clients_v1.schema.json
@@ -48,6 +48,10 @@
     "name": "app_version"
   },
   {
+    "type": "STRING",
+    "name": "locale"
+  },
+  {
     "type": "BOOLEAN",
     "name": "activated"
   },
@@ -112,5 +116,41 @@
     ],
     "name": "metadata",
     "type": "RECORD"
+  },
+  {
+    "type": "STRING",
+    "name": "last_reported_locale"
+  },
+  {
+    "type": "STRING",
+    "name": "last_reported_device_manufacturer"
+  },
+  {
+    "type": "STRING",
+    "name": "last_reported_device_model"
+  },
+  {
+    "type": "STRING",
+    "name": "last_reported_country"
+  },
+  {
+    "type": "DATE",
+    "name": "last_reported_date"
+  },
+  {
+    "type": "STRING",
+    "name": "last_reported_adjust_network"
+  },
+  {
+    "type": "STRING",
+    "name": "last_reported_adjust_creative"
+  },
+  {
+    "type": "STRING",
+    "name": "last_reported_adjust_ad_group"
+  },
+  {
+    "type": "STRING",
+    "name": "last_reported_adjust_campaign"
   }
 ]

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/org_mozilla_firefox.baseline.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/org_mozilla_firefox.baseline.schema.json
@@ -1,0 +1,757 @@
+[
+  {
+    "name": "additional_properties",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "client_info",
+    "type": "RECORD",
+    "mode": "NULLABLE",
+    "fields": [
+      {
+        "name": "android_sdk_version",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "app_build",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "app_channel",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "app_display_version",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "architecture",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "client_id",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "device_manufacturer",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "device_model",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "first_run_date",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "locale",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "os",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "os_version",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "telemetry_sdk_build",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "build_date",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "windows_build_number",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      }
+    ]
+  },
+  {
+    "name": "document_id",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "events",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "fields": [
+      {
+        "name": "category",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "extra",
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "fields": [
+          {
+            "name": "key",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "value",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      },
+      {
+        "name": "name",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "timestamp",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      }
+    ]
+  },
+  {
+    "name": "metadata",
+    "type": "RECORD",
+    "mode": "NULLABLE",
+    "fields": [
+      {
+        "name": "geo",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [
+          {
+            "name": "city",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "country",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "db_version",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "subdivision1",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "subdivision2",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      },
+      {
+        "name": "header",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [
+          {
+            "name": "date",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "dnt",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "x_debug_id",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "x_pingsender_version",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "x_source_tags",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "x_telemetry_agent",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "x_foxsec_ip_reputation",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "x_lb_tags",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "parsed_date",
+            "type": "TIMESTAMP",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "parsed_x_source_tags",
+            "type": "STRING",
+            "mode": "REPEATED"
+          },
+          {
+            "name": "parsed_x_lb_tags",
+            "type": "RECORD",
+            "mode": "NULLABLE",
+            "fields": [
+              {
+                "name": "tls_version",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "tls_cipher_hex",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "user_agent",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [
+          {
+            "name": "browser",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "os",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "version",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      },
+      {
+        "name": "isp",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [
+          {
+            "name": "db_version",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "name",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "organization",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "metrics",
+    "type": "RECORD",
+    "mode": "NULLABLE",
+    "fields": [
+      {
+        "name": "counter",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [
+          {
+            "name": "events_total_uri_count",
+            "type": "INTEGER",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "glean_validation_metrics_ping_count",
+            "type": "INTEGER",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "events_normal_and_private_uri_count",
+            "type": "INTEGER",
+            "mode": "NULLABLE"
+          }
+        ]
+      },
+      {
+        "name": "labeled_counter",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [
+          {
+            "name": "glean_error_invalid_label",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+              {
+                "name": "key",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "value",
+                "type": "INTEGER",
+                "mode": "NULLABLE"
+              }
+            ]
+          },
+          {
+            "name": "glean_error_invalid_overflow",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+              {
+                "name": "key",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "value",
+                "type": "INTEGER",
+                "mode": "NULLABLE"
+              }
+            ]
+          },
+          {
+            "name": "glean_error_invalid_state",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+              {
+                "name": "key",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "value",
+                "type": "INTEGER",
+                "mode": "NULLABLE"
+              }
+            ]
+          },
+          {
+            "name": "glean_error_invalid_value",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+              {
+                "name": "key",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "value",
+                "type": "INTEGER",
+                "mode": "NULLABLE"
+              }
+            ]
+          },
+          {
+            "name": "metrics_search_count",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+              {
+                "name": "key",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "value",
+                "type": "INTEGER",
+                "mode": "NULLABLE"
+              }
+            ]
+          },
+          {
+            "name": "browser_search_ad_clicks",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+              {
+                "name": "key",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "value",
+                "type": "INTEGER",
+                "mode": "NULLABLE"
+              }
+            ]
+          },
+          {
+            "name": "browser_search_in_content",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+              {
+                "name": "key",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "value",
+                "type": "INTEGER",
+                "mode": "NULLABLE"
+              }
+            ]
+          },
+          {
+            "name": "browser_search_with_ads",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+              {
+                "name": "key",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "value",
+                "type": "INTEGER",
+                "mode": "NULLABLE"
+              }
+            ]
+          },
+          {
+            "name": "glean_validation_pings_submitted",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+              {
+                "name": "key",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "value",
+                "type": "INTEGER",
+                "mode": "NULLABLE"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "string",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [
+          {
+            "name": "glean_baseline_locale",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "search_default_engine_code",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "search_default_engine_name",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "metrics_distribution_id",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      },
+      {
+        "name": "timespan",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [
+          {
+            "name": "glean_baseline_duration",
+            "type": "RECORD",
+            "mode": "NULLABLE",
+            "fields": [
+              {
+                "name": "time_unit",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "value",
+                "type": "INTEGER",
+                "mode": "NULLABLE"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "jwe",
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "fields": [
+          {
+            "name": "key",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "value",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      },
+      {
+        "name": "datetime",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [
+          {
+            "name": "glean_validation_first_run_hour",
+            "type": "TIMESTAMP",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "raw_glean_validation_first_run_hour",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      },
+      {
+        "name": "labeled_rate",
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "fields": [
+          {
+            "name": "key",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "value",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+              {
+                "name": "key",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "value",
+                "type": "RECORD",
+                "mode": "NULLABLE",
+                "fields": [
+                  {
+                    "name": "denominator",
+                    "type": "INTEGER",
+                    "mode": "NULLABLE"
+                  },
+                  {
+                    "name": "numerator",
+                    "type": "INTEGER",
+                    "mode": "NULLABLE"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "url",
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "fields": [
+          {
+            "name": "key",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "value",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      },
+      {
+        "name": "text",
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "fields": [
+          {
+            "name": "key",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "value",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "normalized_app_name",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "normalized_channel",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "normalized_country_code",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "normalized_os",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "normalized_os_version",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "ping_info",
+    "type": "RECORD",
+    "mode": "NULLABLE",
+    "fields": [
+      {
+        "name": "end_time",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "experiments",
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "fields": [
+          {
+            "name": "key",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "value",
+            "type": "RECORD",
+            "mode": "NULLABLE",
+            "fields": [
+              {
+                "name": "branch",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "extra",
+                "type": "RECORD",
+                "mode": "NULLABLE",
+                "fields": [
+                  {
+                    "name": "type",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                  },
+                  {
+                    "name": "enrollment_id",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "ping_type",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "reason",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "seq",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "start_time",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "parsed_start_time",
+        "type": "TIMESTAMP",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "parsed_end_time",
+        "type": "TIMESTAMP",
+        "mode": "NULLABLE"
+      }
+    ]
+  },
+  {
+    "name": "sample_id",
+    "type": "INTEGER",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "submission_timestamp",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE"
+  }
+]

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_baseline_no_first_session/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_baseline_no_first_session/expect.yaml
@@ -4,6 +4,8 @@
   first_run_date: 2023-01-02
   first_seen_date: 2023-01-01
   submission_date: 2023-01-01
+  last_reported_date: 2023-01-01
+  last_reported_device_model: model-2
   activated: true
   install_source: com.android.vending
   channel: release
@@ -16,6 +18,7 @@
 - client_id: client-2
   activated: false
   adjust_network: Organic
+  last_reported_adjust_network: Organic
   metadata:
     reported_metrics_ping: true
     reported_first_session_ping: false

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_baseline_no_first_session/moz-fx-data-shared-prod.fenix_derived.firefox_android_clients_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_baseline_no_first_session/moz-fx-data-shared-prod.fenix_derived.firefox_android_clients_v1.yaml
@@ -3,3 +3,4 @@
   sample_id: 54
   first_seen_date: 2023-01-01
   submission_date: 2023-01-01
+  last_reported_device_model: model-1

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_baseline_no_first_session/org_mozilla_firefox.baseline.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_baseline_no_first_session/org_mozilla_firefox.baseline.yaml
@@ -1,0 +1,5 @@
+---
+- client_info:
+    client_id: client-1
+    device_model: model-2
+  submission_timestamp: '2023-01-01 00:00:00'

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_first_session_no_baseline/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_first_session_no_baseline/expect.yaml
@@ -2,6 +2,7 @@
 - client_id: client-1
   sample_id: 50
   adjust_network: Organic
+  last_reported_date: 2023-05-02
   metadata:
     reported_first_session_ping: true
     reported_metrics_ping: false
@@ -29,6 +30,7 @@
   first_seen_date: 2023-05-02
   submission_date: 2023-05-02
   first_run_date: 2023-05-02
+  last_reported_date: 2023-05-01
   channel: release
   activated: false
   install_source: com.android.vending

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_first_session_no_baseline/moz-fx-data-shared-prod.fenix_derived.firefox_android_clients_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_first_session_no_baseline/moz-fx-data-shared-prod.fenix_derived.firefox_android_clients_v1.yaml
@@ -4,6 +4,7 @@
   first_seen_date: 2023-05-02
   submission_date: 2023-05-02
   first_run_date: 2023-05-02
+  last_reported_date: 2023-05-01
   activated: false
   metadata:
     reported_first_session_ping: false

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_first_session_no_baseline/org_mozilla_firefox.baseline.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_first_session_no_baseline/org_mozilla_firefox.baseline.yaml
@@ -1,0 +1,4 @@
+---
+- client_info:
+    client_id: client-1
+  submission_timestamp: '2023-05-02 00:00:00'

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_only_metrics_ping/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_only_metrics_ping/expect.yaml
@@ -3,9 +3,12 @@
   first_seen_date: 2023-01-01
   submission_date: 2023-01-01
   first_run_date: 2023-01-02
+  last_reported_date: 2023-01-01
+  last_reported_country: CA
   sample_id: 54
   activated: false
   adjust_network: 'Organic'
+  last_reported_adjust_network: 'Organic'
   channel: release
   metadata:
     reported_first_session_ping: false

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_only_metrics_ping/org_mozilla_firefox.baseline.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/test_only_metrics_ping/org_mozilla_firefox.baseline.yaml
@@ -1,0 +1,5 @@
+---
+- client_info:
+    client_id: client-1
+  submission_timestamp: '2023-01-01 00:00:00'
+  normalized_country_code: CA


### PR DESCRIPTION
GROWTH-41

Gets latest attribution columns from metrics ping and latest client columns from baseline ping. 

(Most of the diff is adding the baseline schema)