### PR TITLE
feat(DENG-980): fxa_users_services_first_seen view updated to use v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_services_first_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_services_first_seen/view.sql
@@ -2,6 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_accounts.fxa_users_services_first_seen`
 AS
 SELECT
-	*
+  *
 FROM
   `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_services_first_seen_v2`

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_services_first_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_services_first_seen/view.sql
@@ -2,6 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_accounts.fxa_users_services_first_seen`
 AS
 SELECT
-  *
+	*
 FROM
-  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_services_first_seen_v1`
+  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_services_first_seen_v2`


### PR DESCRIPTION
# feat(DENG-980): fxa_users_services_first_seen view updated to use v2

The v1 of this table has not been updated for more than a year now and it does not look like anything is using this view so there shouldn't be any impact.

Checked:

- bigquery-etl
- looker-spoke-default
- looker-hub (some minimal usage, but does not look like this should break anything)