### PR TITLE
Don't restrict access to the `subscription_platform` datasets

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/dataset_metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: Subscription Platform
 description: |-
   Combined subscription information from multiple products
   and payment platforms; see bug 1703340
-dataset_base_acl: view_restricted
+dataset_base_acl: view
 user_facing: true
 labels: {}
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/dataset_metadata.yaml
@@ -2,7 +2,10 @@ friendly_name: Subscription Platform Derived
 description: |-
   Tables combining subscription information from multiple products
   and payment platforms
-dataset_base_acl: derived_restricted
+dataset_base_acl: derived
 user_facing: false
 labels: {}
-workgroup_access: []
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential


### PR DESCRIPTION
Plans have changed and they'll only contain data considered Mozilla-confidential.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
