### PR TITLE
Increase task name limit from 62 characters to 250 characters

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -249,10 +249,10 @@ class Task:
     def validate_task_name(self, attribute, value):
         """Validate the task name."""
         if value is not None:
-            if len(value) < 1 or len(value) > 62:
+            if len(value) < 1 or len(value) > 250:
                 raise ValueError(
                     f"Invalid task name {value}. "
-                    + "The task name has to be 1 to 62 characters long."
+                    + "The task name has to be 1 to 250 characters long."
                 )
 
     @retry_delay.validator
@@ -275,7 +275,7 @@ class Task:
 
             if self.task_name is None:
                 # limiting task name to allow longer dataset names
-                self.task_name = f"{self.dataset}__{self.table}__{self.version}"[-62:]
+                self.task_name = f"{self.dataset}__{self.table}__{self.version}"[-250:]
                 self.validate_task_name(None, self.task_name)
 
             if self.destination_table == DEFAULT_DESTINATION_TABLE_STR:

--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -29,6 +29,7 @@ QUERY_FILE_RE = re.compile(
     r"([a-zA-Z0-9_]+)_(v[0-9]+)/(?:query\.sql|part1\.sql|script\.sql|query\.py)$"
 )
 DEFAULT_DESTINATION_TABLE_STR = "use-default-destination-table"
+MAX_TASK_NAME_LENGTH = 250
 
 
 class TaskParseException(Exception):
@@ -249,10 +250,10 @@ class Task:
     def validate_task_name(self, attribute, value):
         """Validate the task name."""
         if value is not None:
-            if len(value) < 1 or len(value) > 250:
+            if len(value) < 1 or len(value) > MAX_TASK_NAME_LENGTH:
                 raise ValueError(
                     f"Invalid task name {value}. "
-                    + "The task name has to be 1 to 250 characters long."
+                    f"The task name has to be 1 to {MAX_TASK_NAME_LENGTH} characters long."
                 )
 
     @retry_delay.validator
@@ -275,7 +276,9 @@ class Task:
 
             if self.task_name is None:
                 # limiting task name to allow longer dataset names
-                self.task_name = f"{self.dataset}__{self.table}__{self.version}"[-250:]
+                self.task_name = f"{self.dataset}__{self.table}__{self.version}"[
+                    -MAX_TASK_NAME_LENGTH:
+                ]
                 self.validate_task_name(None, self.task_name)
 
             if self.destination_table == DEFAULT_DESTINATION_TABLE_STR:

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -344,6 +344,36 @@ with DAG(
         depends_on_past=False,
     )
 
+    firefox_accounts_derived__fxa_users_services_devices_first_seen__v1 = bigquery_etl_query(
+        task_id="firefox_accounts_derived__fxa_users_services_devices_first_seen__v1",
+        destination_table="fxa_users_services_devices_first_seen_v1",
+        dataset_id="firefox_accounts_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="kignasiak@mozilla.com",
+        email=[
+            "dthorn@mozilla.com",
+            "kignasiak@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=True,
+    )
+
+    firefox_accounts_derived__fxa_users_services_devices_last_seen__v1 = bigquery_etl_query(
+        task_id="firefox_accounts_derived__fxa_users_services_devices_last_seen__v1",
+        destination_table="fxa_users_services_devices_last_seen_v1",
+        dataset_id="firefox_accounts_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="kignasiak@mozilla.com",
+        email=[
+            "dthorn@mozilla.com",
+            "kignasiak@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=True,
+    )
+
     firefox_accounts_derived__fxa_users_services_first_seen__v2 = bigquery_etl_query(
         task_id="firefox_accounts_derived__fxa_users_services_first_seen__v2",
         destination_table="fxa_users_services_first_seen_v2",
@@ -393,36 +423,6 @@ with DAG(
         date_partition_parameter="submission_date",
         depends_on_past=False,
         arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
-    )
-
-    fox_accounts_derived__fxa_users_services_devices_last_seen__v1 = bigquery_etl_query(
-        task_id="fox_accounts_derived__fxa_users_services_devices_last_seen__v1",
-        destination_table="fxa_users_services_devices_last_seen_v1",
-        dataset_id="firefox_accounts_derived",
-        project_id="moz-fx-data-shared-prod",
-        owner="kignasiak@mozilla.com",
-        email=[
-            "dthorn@mozilla.com",
-            "kignasiak@mozilla.com",
-            "telemetry-alerts@mozilla.com",
-        ],
-        date_partition_parameter="submission_date",
-        depends_on_past=True,
-    )
-
-    ox_accounts_derived__fxa_users_services_devices_first_seen__v1 = bigquery_etl_query(
-        task_id="ox_accounts_derived__fxa_users_services_devices_first_seen__v1",
-        destination_table="fxa_users_services_devices_first_seen_v1",
-        dataset_id="firefox_accounts_derived",
-        project_id="moz-fx-data-shared-prod",
-        owner="kignasiak@mozilla.com",
-        email=[
-            "dthorn@mozilla.com",
-            "kignasiak@mozilla.com",
-            "telemetry-alerts@mozilla.com",
-        ],
-        date_partition_parameter="submission_date",
-        depends_on_past=True,
     )
 
     firefox_accounts_derived__exact_mau28__v1.set_upstream(
@@ -493,14 +493,14 @@ with DAG(
         firefox_accounts_derived__fxa_stdout_events__v1
     )
 
+    firefox_accounts_derived__fxa_users_services_devices_first_seen__v1.set_upstream(
+        firefox_accounts_derived__fxa_users_services_devices_daily__v1
+    )
+
+    firefox_accounts_derived__fxa_users_services_devices_last_seen__v1.set_upstream(
+        firefox_accounts_derived__fxa_users_services_devices_daily__v1
+    )
+
     firefox_accounts_derived__fxa_users_services_first_seen__v2.set_upstream(
         firefox_accounts_derived__fxa_users_services_daily__v2
-    )
-
-    fox_accounts_derived__fxa_users_services_devices_last_seen__v1.set_upstream(
-        firefox_accounts_derived__fxa_users_services_devices_daily__v1
-    )
-
-    ox_accounts_derived__fxa_users_services_devices_first_seen__v1.set_upstream(
-        firefox_accounts_derived__fxa_users_services_devices_daily__v1
     )

--- a/dags/bqetl_org_mozilla_focus_derived.py
+++ b/dags/bqetl_org_mozilla_focus_derived.py
@@ -40,15 +40,17 @@ with DAG(
     doc_md=docs,
     tags=tags,
 ) as dag:
-    g_mozilla_focus_beta_derived__additional_deletion_requests__v1 = bigquery_etl_query(
-        task_id="g_mozilla_focus_beta_derived__additional_deletion_requests__v1",
-        destination_table="additional_deletion_requests_v1",
-        dataset_id="org_mozilla_focus_beta_derived",
-        project_id="moz-fx-data-shared-prod",
-        owner="dthorn@mozilla.com",
-        email=["dthorn@mozilla.com", "telemetry-alerts@mozilla.com"],
-        date_partition_parameter="submission_date",
-        depends_on_past=False,
+    org_mozilla_focus_beta_derived__additional_deletion_requests__v1 = (
+        bigquery_etl_query(
+            task_id="org_mozilla_focus_beta_derived__additional_deletion_requests__v1",
+            destination_table="additional_deletion_requests_v1",
+            dataset_id="org_mozilla_focus_beta_derived",
+            project_id="moz-fx-data-shared-prod",
+            owner="dthorn@mozilla.com",
+            email=["dthorn@mozilla.com", "telemetry-alerts@mozilla.com"],
+            date_partition_parameter="submission_date",
+            depends_on_past=False,
+        )
     )
 
     org_mozilla_focus_derived__additional_deletion_requests__v1 = bigquery_etl_query(
@@ -62,8 +64,8 @@ with DAG(
         depends_on_past=False,
     )
 
-    ozilla_focus_nightly_derived__additional_deletion_requests__v1 = bigquery_etl_query(
-        task_id="ozilla_focus_nightly_derived__additional_deletion_requests__v1",
+    org_mozilla_focus_nightly_derived__additional_deletion_requests__v1 = bigquery_etl_query(
+        task_id="org_mozilla_focus_nightly_derived__additional_deletion_requests__v1",
         destination_table="additional_deletion_requests_v1",
         dataset_id="org_mozilla_focus_nightly_derived",
         project_id="moz-fx-data-shared-prod",
@@ -85,7 +87,7 @@ with DAG(
         pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
-    g_mozilla_focus_beta_derived__additional_deletion_requests__v1.set_upstream(
+    org_mozilla_focus_beta_derived__additional_deletion_requests__v1.set_upstream(
         wait_for_copy_deduplicate_all
     )
 
@@ -93,6 +95,6 @@ with DAG(
         wait_for_copy_deduplicate_all
     )
 
-    ozilla_focus_nightly_derived__additional_deletion_requests__v1.set_upstream(
+    org_mozilla_focus_nightly_derived__additional_deletion_requests__v1.set_upstream(
         wait_for_copy_deduplicate_all
     )

--- a/tests/query_scheduling/test_task.py
+++ b/tests/query_scheduling/test_task.py
@@ -193,7 +193,7 @@ class TestTask:
         scheduling = {
             "dag_name": "bqetl_test_dag",
             "default_args": {"owner": "test@example.org"},
-            "task_name": "a" * 63,
+            "task_name": "a" * 251,
         }
 
         metadata = Metadata("test", "test", ["test@example.org"], {}, scheduling)
@@ -215,13 +215,13 @@ class TestTask:
         scheduling = {
             "dag_name": "bqetl_test_dag",
             "default_args": {"owner": "test@example.org"},
-            "task_name": "a" * 62,
+            "task_name": "a" * 250,
         }
 
         metadata = Metadata("test", "test", ["test@example.org"], {}, scheduling)
 
         task = Task.of_query(query_file, metadata)
-        assert task.task_name == "a" * 62
+        assert task.task_name == "a" * 250
 
     def test_validate_task_name(self):
         query_file = (

--- a/tests/query_scheduling/test_task.py
+++ b/tests/query_scheduling/test_task.py
@@ -230,7 +230,7 @@ class TestTask:
             / "test_sql"
             / "moz-fx-data-test-project"
             / "test"
-            / (("a" * 63) + "_v1")
+            / (("a" * 250) + "_v1")
             / "query.sql"
         )
 
@@ -242,10 +242,10 @@ class TestTask:
         metadata = Metadata("test", "test", ["test@example.org"], {}, scheduling)
 
         task = Task.of_query(query_file, metadata)
-        assert task.task_name == "a" * 58 + "__v1"
+        assert task.task_name == "a" * 246 + "__v1"
 
         with pytest.raises(ValueError):
-            task.task_name = "a" * 64
+            task.task_name = "a" * 250 + "__v1"
             Task.validate_task_name(task, "task_name", task.task_name)
 
     def test_dag_name_validation(self):


### PR DESCRIPTION
Airflow's limit for task names seems to be 250 characters ([ref](https://github.com/apache/airflow/blob/2.3.3/airflow/models/baseoperator.py#L754), [ref](https://github.com/apache/airflow/blob/2.3.3/airflow/utils/helpers.py#L56)).

As far as I can tell the 62 character limit was due to Airflow putting task names in Kubernetes pod labels and those label values being limited to 63 characters, which has been [worked around as of Airflow 2.0.1](https://github.com/apache/airflow/issues/13189#issuecomment-779419350) by using [`make_safe_label_value`](https://github.com/apache/airflow/blob/2.3.3/airflow/kubernetes/pod_generator.py#L45) to automatically truncate Kubernetes label values longer than the limit.

The only downside I see is the Kubernetes labels for long task names will be weird in a different way:  instead of being the last 62 characters of the task name, it'll be the first 53 characters plus a partial hash of the full value.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
