### PR TITLE
Simplify GLAM template for getting latest versions

### DIFF
--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -28,6 +28,13 @@ class TemplateResult:
     query_text: str
 
 
+APP_ID_TO_CHANNELS = {
+    "firefox_desktop_glam_nightly": "nightly",
+    "firefox_desktop_glam_beta": "beta",
+    "firefox_desktop_glam_release": "release",
+}
+
+
 def from_template(
     query_type: QueryType,
     template_name: str,
@@ -213,11 +220,7 @@ def main():
     [
         table(
             "latest_versions_v1",
-            **dict(
-                source_table=(
-                    f"glam_etl.{args.prefix}__view_clients_daily_scalar_aggregates_v1"
-                )
-            ),
+            **dict(app_id_channel=(f"'{APP_ID_TO_CHANNELS[args.prefix]}'")),
         ),
         init(
             "clients_scalar_aggregates_v1",

--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -28,10 +28,13 @@ class TemplateResult:
     query_text: str
 
 
-APP_ID_TO_CHANNELS = {
+APP_PREFIX_CHANNELS = {
     "firefox_desktop_glam_nightly": "nightly",
     "firefox_desktop_glam_beta": "beta",
     "firefox_desktop_glam_release": "release",
+    "org_mozilla_fenix_glam_nightly": "nightly",
+    "org_mozilla_fenix_glam_beta": "beta",
+    "org_mozilla_fenix_glam_release": "release",
 }
 
 
@@ -220,7 +223,7 @@ def main():
     [
         table(
             "latest_versions_v1",
-            **dict(app_id_channel=(f"'{APP_ID_TO_CHANNELS[args.prefix]}'")),
+            **dict(app_id_channel=(f"'{APP_PREFIX_CHANNELS[args.prefix]}'")),
         ),
         init(
             "clients_scalar_aggregates_v1",

--- a/bigquery_etl/glam/templates/latest_versions_v1.sql
+++ b/bigquery_etl/glam/templates/latest_versions_v1.sql
@@ -1,36 +1,10 @@
 {{ header }}
-WITH extracted AS (
-  SELECT
-    client_id,
-    channel,
-    app_version
-  FROM
-    {{ source_table }}
-  WHERE
-    submission_date
-    BETWEEN DATE_SUB(@submission_date, INTERVAL 28 DAY)
-    AND @submission_date
-    AND channel IS NOT NULL
-),
-transformed AS (
-  SELECT
-    channel,
-    app_version
-  FROM
-    extracted
-  GROUP BY
-    channel,
-    app_version
-  HAVING
-    COUNT(DISTINCT client_id) > 5
-  ORDER BY
-    channel,
-    app_version DESC
-)
 SELECT
-  channel,
-  MAX(app_version) AS latest_version
+    channel,
+    MAX(major_version)
 FROM
-  transformed
+    `moz-fx-data-shared-prod.telemetry.releases_latest`
+WHERE
+    channel={{ app_id_channel }}
 GROUP BY
-  channel
+    channel

--- a/bigquery_etl/glam/templates/latest_versions_v1.sql
+++ b/bigquery_etl/glam/templates/latest_versions_v1.sql
@@ -1,10 +1,12 @@
 {{ header }}
 SELECT
-    channel,
-    MAX(major_version)
+  build.`target`.channel AS channel,
+  MAX(mozfun.norm.extract_version(build.`target`.version,
+  'major')) AS latest_version
 FROM
-    `moz-fx-data-shared-prod.telemetry.releases_latest`
+  `moz-fx-data-shared-prod.telemetry.buildhub2`
 WHERE
-    channel={{ app_id_channel }}
+  build.`source`.product = "firefox"
+  AND    build.`target`.channel = {{ app_id_channel }}
 GROUP BY
-    channel
+  build.`target`.channel


### PR DESCRIPTION
GLAM release currently has little data due to bad version number (999). This PR rewrites the `latest_version_v1` template to prevent this from happening again.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
