### PR TITLE
Bug 1836312 - Revert "feat(DENG-980): fxa_users_services_first_seen view updated to use v2"

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_services_first_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_services_first_seen/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_services_first_seen_v2`
+  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_services_first_seen_v1`


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#3870 to unblock LookML generation. This was only merged yesterday so this should be safe to revert. 