### PR TITLE
During stage don't rename test dependencies that have already been renamed

### DIFF
--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -175,7 +175,9 @@ def deploy(
                             name += ".schema"
                         name += file_suffix
 
-                        test_file_path.rename(test_file_path.parent / name)
+                        test_file_path_dest = test_file_path.parent / name
+                        if not test_file_path_dest.exists():
+                            test_file_path.rename(test_file_path_dest)
 
     # remove artifacts from the "prod" folders
     if remove_updated_artifacts:


### PR DESCRIPTION
RE CI failures here: https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/21423/workflows/6d84560f-fee7-42ec-9ccb-5537dd22c03d/jobs/211743

There's a `FileNotFoundError` in the following block if `test_file_path` has already been renamed, for example if there's multiple `artifact_files` for the same `test_file_path` (`init.sql`, `query,sql`) in the case above:

```
for test_file_path in test_destination.glob("**/*"):
    for test_dep_file in artifact_files:
    ...
        test_file_path.rename(...)
```
