### PR TITLE
feat(): added support for `--log-level` to bqetl query command and using logging instead of print()

### DIFF
--- a/bigquery_etl/cli/__init__.py
+++ b/bigquery_etl/cli/__init__.py
@@ -24,6 +24,7 @@ from ..glam.cli import glam
 from ..static import static_
 from ..stripe import stripe_
 from ..subplat.apple import apple
+import logging
 
 
 def cli(prog_name=None):
@@ -51,9 +52,27 @@ def cli(prog_name=None):
 
     @click.group(commands=commands)
     @click.version_option(version=__version__)
-    def group():
+    @click.option("--log-level", "log_level", default="info", type=str)
+    def group(log_level):
         """CLI tools for working with bigquery-etl."""
-        pass
+
+        log_level_mapping = {
+            "debug": logging.DEBUG,
+            "info": logging.INFO,
+            "error": logging.ERROR,
+            "critical": logging.CRITICAL,
+        }
+
+        print(log_level)
+
+        try:
+            logging.root.setLevel(level=log_level_mapping[log_level.lower()])
+        except KeyError:
+            # TODO: maybe have a custom exception defined here for incorrect log level
+            raise Exception(
+                "Invalid logging option passed, valid options include: %s"
+                % log_level_mapping.keys()
+            )
 
     warnings.filterwarnings(
         "ignore", "Your application has authenticated using end user credentials"

--- a/bigquery_etl/cli/__init__.py
+++ b/bigquery_etl/cli/__init__.py
@@ -52,24 +52,16 @@ def cli(prog_name=None):
 
     @click.group(commands=commands)
     @click.version_option(version=__version__)
-@click.option(
-    "--log-level",
-    "--log_level",
-    help="Log level.",
-    default=logging.getLevelName(logging.INFO),
-    type=str.upper,
-)
+    @click.option(
+        "--log-level",
+        "--log_level",
+        help="Log level.",
+        default=logging.getLevelName(logging.INFO),
+        type=str.upper,
+    )
     def group(log_level):
         """CLI tools for working with bigquery-etl."""
-
-        try:
-            logging.root.setLevel(level=log_level_mapping[log_level.lower()])
-        except KeyError:
-            # TODO: maybe have a custom exception defined here for incorrect log level
-            raise Exception(
-                "Invalid logging option passed, valid options include: %s"
-                % log_level_mapping.keys()
-            )
+        logging.root.setLevel(level=log_level)
 
     warnings.filterwarnings(
         "ignore", "Your application has authenticated using end user credentials"

--- a/bigquery_etl/cli/__init__.py
+++ b/bigquery_etl/cli/__init__.py
@@ -52,7 +52,13 @@ def cli(prog_name=None):
 
     @click.group(commands=commands)
     @click.version_option(version=__version__)
-    @click.option("--log-level", "log_level", default="info", type=str)
+@click.option(
+    "--log-level",
+    "--log_level",
+    help="Log level.",
+    default=logging.getLevelName(logging.INFO),
+    type=str.upper,
+)
     def group(log_level):
         """CLI tools for working with bigquery-etl."""
         log_level_mapping = {

--- a/bigquery_etl/cli/__init__.py
+++ b/bigquery_etl/cli/__init__.py
@@ -61,12 +61,6 @@ def cli(prog_name=None):
 )
     def group(log_level):
         """CLI tools for working with bigquery-etl."""
-        log_level_mapping = {
-            "debug": logging.DEBUG,
-            "info": logging.INFO,
-            "error": logging.ERROR,
-            "critical": logging.CRITICAL,
-        }
 
         try:
             logging.root.setLevel(level=log_level_mapping[log_level.lower()])

--- a/bigquery_etl/cli/__init__.py
+++ b/bigquery_etl/cli/__init__.py
@@ -1,5 +1,6 @@
 """bigquery-etl CLI."""
 
+import logging
 import warnings
 
 import click
@@ -24,7 +25,6 @@ from ..glam.cli import glam
 from ..static import static_
 from ..stripe import stripe_
 from ..subplat.apple import apple
-import logging
 
 
 def cli(prog_name=None):
@@ -55,15 +55,12 @@ def cli(prog_name=None):
     @click.option("--log-level", "log_level", default="info", type=str)
     def group(log_level):
         """CLI tools for working with bigquery-etl."""
-
         log_level_mapping = {
             "debug": logging.DEBUG,
             "info": logging.INFO,
             "error": logging.ERROR,
             "critical": logging.CRITICAL,
         }
-
-        print(log_level)
 
         try:
             logging.root.setLevel(level=log_level_mapping[log_level.lower()])

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -66,31 +66,13 @@ PUBLIC_PROJECT_ID = "mozilla-public-data"
 
 
 @click.group(help="Commands for managing queries.")
-@click.option("--log-level", "log_level", default=logging.INFO, type=str)
 @click.pass_context
-def query(ctx, log_level):
+def query(ctx):
     """Create the CLI group for the query command."""
     # create temporary directory generated content is written to
     # the directory will be deleted automatically after the command exits
     ctx.ensure_object(dict)
     ctx.obj["TMP_DIR"] = ctx.with_resource(tempfile.TemporaryDirectory())
-
-    # TODO: we could consider having this in util or some other shared module
-    log_level_mapping = {
-        "debug": logging.DEBUG,
-        "info": logging.INFO,
-        "error": logging.ERROR,
-        "critical": logging.CRITICAL,
-    }
-
-    try:
-        logging.root.setLevel(level=log_level_mapping[log_level.lower()])
-    except KeyError:
-        # TODO: maybe have a custom exception defined here for incorrect log level
-        raise Exception(
-            "Invalid logging option passed, valid options include: %s"
-            % log_level_mapping.keys()
-        )
 
 
 @query.command(

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1,6 +1,7 @@
 """bigquery-etl CLI query command."""
 
 import copy
+import logging
 import os
 import re
 import string
@@ -57,7 +58,6 @@ from ..util.common import random_str
 from ..util.common import render as render_template
 from .dryrun import dryrun
 from .generate import generate_all
-import logging
 
 QUERY_NAME_RE = re.compile(r"(?P<dataset>[a-zA-z0-9_]+)\.(?P<name>[a-zA-z0-9_]+)")
 VERSION_RE = re.compile(r"_v[0-9]+")


### PR DESCRIPTION
# feat(): added support for `--log-level` to bqetl ~query~ command and using logging instead of print() inside bqetl query cli module.

The idea behind adding the `--log-level` flag is to over time tweak some of the logging statements to be debug statements to reduce the amount of noise produced by the query command unless the user explicitly wants to see all output.

Moving away from `print()` to `logging` makes the command output easier to work with and identify the source of the messages.

Example command:
`./bqetl --log-level=debug query my.query query`

The log level setting should now apply across runtime for all of the cli commands.

(part of the great bug throwdown pairing session, so kudos for @lelilia @lucia-vargas-a @akkomar @Iinh for participating and coming up with ideas to improve the command's output)
----
An alternative approach would be to have a `--verbose` flag to print all messages which could be excluded in a non-verbose mode.