### PR TITLE
Fix destination paths when copying stage files in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,8 +372,8 @@ jobs:
           name: Copy generated SQL to temporary stage directory
           command: |
             mkdir -p /tmp/workspace/staged-generated-sql
-            cp -r sql/ /tmp/workspace/staged-generated-sql
-            cp -r tests/ /tmp/workspace/staged-generated-sql
+            cp -r sql/ /tmp/workspace/staged-generated-sql/sql
+            cp -r tests/ /tmp/workspace/staged-generated-sql/tests
       - persist_to_workspace:
           root: /tmp/workspace
           paths:


### PR DESCRIPTION
Previously, we potentially copied the `sql` and `test` files directly into `staged-generated-sql` instead of into the corresponding subdirectories
