### PR TITLE
Fix `bqetl stage` table ID quoting

### DIFF
--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -301,14 +301,14 @@ def _update_references(artifact_files, project_id, dataset_suffix, sql_dir):
                 re.compile(
                     rf"(?<![\._])`?{original_dataset}`?\.`?{name_pattern}(?![a-zA-Z0-9_])`?"
                 ),
-                f"`{deployed_project}.{deployed_dataset}.{name}`",
+                f"`{deployed_project}`.`{deployed_dataset}`.`{name}`",
             )
         )
         # replace fully qualified references (like "moz-fx-data-shared-prod.telemetry.main")
         replace_references.append(
             (
                 rf"(?<![a-zA-Z0-9_])`?{original_project}`?\.`?{original_dataset}`?\.`?{name_pattern}(?![a-zA-Z0-9_])`?",
-                f"`{deployed_project}.{deployed_dataset}.{name}`",
+                f"`{deployed_project}`.`{deployed_dataset}`.`{name}`",
             )
         )
 

--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -310,11 +310,15 @@ def _update_references(artifact_files, project_id, dataset_suffix, sql_dir):
             ),
             # fully qualified references (like "moz-fx-data-shared-prod.telemetry.main")
             (
-                rf"`{original_project}\.{original_dataset}\.{name_pattern}`",
+                re.compile(
+                    rf"`{original_project}\.{original_dataset}\.{name_pattern}`"
+                ),
                 f"`{deployed_project}.{deployed_dataset}.{name}`",
             ),
             (
-                rf"(?<![a-zA-Z0-9_])`?{original_project}`?\.`?{original_dataset}`?\.`?{name_pattern}(?![a-zA-Z0-9_])`?",
+                re.compile(
+                    rf"(?<![a-zA-Z0-9_])`?{original_project}`?\.`?{original_dataset}`?\.`?{name_pattern}(?![a-zA-Z0-9_])`?"
+                ),
                 f"`{deployed_project}`.`{deployed_dataset}`.`{name}`",
             ),
         ]

--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -299,9 +299,7 @@ def _update_references(artifact_files, project_id, dataset_suffix, sql_dir):
         replace_references += [
             # partially qualified references (like "telemetry.main")
             (
-                re.compile(
-                    rf"(?<![\._])`{original_dataset}\.{name_pattern}(?![a-zA-Z0-9_])`"
-                ),
+                re.compile(rf"(?<![\._])`{original_dataset}\.{name_pattern}`"),
                 f"`{deployed_project}.{deployed_dataset}.{name}`",
             ),
             (
@@ -312,7 +310,7 @@ def _update_references(artifact_files, project_id, dataset_suffix, sql_dir):
             ),
             # fully qualified references (like "moz-fx-data-shared-prod.telemetry.main")
             (
-                rf"(?<![a-zA-Z0-9_])`{original_project}\.{original_dataset}\.{name_pattern}(?![a-zA-Z0-9_])`",
+                rf"`{original_project}\.{original_dataset}\.{name_pattern}`",
                 f"`{deployed_project}.{deployed_dataset}.{name}`",
             ),
             (

--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -295,22 +295,31 @@ def _update_references(artifact_files, project_id, dataset_suffix, sql_dir):
         original_project = artifact_file.parent.parent.parent.name
         deployed_project = project_id
 
-        # replace partially qualified references (like "telemetry.main")
-        replace_references.append(
+        # Replace references, preserving fully quoted references.
+        replace_references += [
+            # partially qualified references (like "telemetry.main")
+            (
+                re.compile(
+                    rf"(?<![\._])`{original_dataset}\.{name_pattern}(?![a-zA-Z0-9_])`"
+                ),
+                f"`{deployed_project}.{deployed_dataset}.{name}`",
+            ),
             (
                 re.compile(
                     rf"(?<![\._])`?{original_dataset}`?\.`?{name_pattern}(?![a-zA-Z0-9_])`?"
                 ),
                 f"`{deployed_project}`.`{deployed_dataset}`.`{name}`",
-            )
-        )
-        # replace fully qualified references (like "moz-fx-data-shared-prod.telemetry.main")
-        replace_references.append(
+            ),
+            # fully qualified references (like "moz-fx-data-shared-prod.telemetry.main")
+            (
+                rf"(?<![a-zA-Z0-9_])`{original_project}\.{original_dataset}\.{name_pattern}(?![a-zA-Z0-9_])`",
+                f"`{deployed_project}.{deployed_dataset}.{name}`",
+            ),
             (
                 rf"(?<![a-zA-Z0-9_])`?{original_project}`?\.`?{original_dataset}`?\.`?{name_pattern}(?![a-zA-Z0-9_])`?",
                 f"`{deployed_project}`.`{deployed_dataset}`.`{name}`",
-            )
-        )
+            ),
+        ]
 
     for path in Path(sql_dir).rglob("*.sql"):
         # apply substitutions


### PR DESCRIPTION
#3791 changed `bqetl stage` so that replaced table IDs were entirely in quotes, but quoting the entire table ID breaks cases where an unaliased table name is used to qualify a column reference ([example](https://github.com/mozilla/bigquery-etl/blob/cfca76f9c498d6ae0eec4fe2dae08b642d7cd426/sql/moz-fx-data-shared-prod/mozilla_vpn/active_subscription_ids/view.sql#L10-L13)).

Quoting the individual table ID parts separately does not have the same problem.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
