### PR TITLE
[DO NOT MERGE]feat(DENG-537): Updating fxa content events v1 query to use partitioned table

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/query.sql
@@ -13,16 +13,8 @@ SELECT
     ) AS jsonPayload
   )
 FROM
-  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_content_20*`
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_content`
 WHERE
-  jsonPayload.type = 'amplitudeEvent'
+  DATE(`timestamp`) = @submission_date
+  AND jsonPayload.type = 'amplitudeEvent'
   AND jsonPayload.fields.event_type IS NOT NULL
-  -- FXA-6593: the partitioned version of the table
-  -- seems to be missing some data.
-  -- For now reverting this query to the sharded version
-  -- Once the issue has been resolves:
-  -- 1. uncomment the DATE(...) = @submission_date line
-  -- 2. Remove the _TABLE_SUFFIX line below
-  -- 3. Change source table to be `docker_fxa_content`
-  -- AND DATE(`timestamp`) = @submission_date
-  AND _TABLE_SUFFIX = FORMAT_DATE('%y%m%d', @submission_date)

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_oauth_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_oauth_events_v1/query.sql
@@ -27,6 +27,11 @@ WITH base AS (
           )
       ) AS jsonPayload
     )
+  -- this query is still "using" sharded instead of partitioned source table
+  -- as it is no longer active and currently kept for "archiving" reasons.
+  --
+  -- TODO: we should check if we can just delete this query file, and
+  -- only keep the table itself.
   FROM
     `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_oauth_20*`
   WHERE


### PR DESCRIPTION
# feat(DENG-537): Updating fxa content events v1 query to use partitioned table

- updated `fxa_content_events_v1` query to use partitioned source table
- updated `fxa_oauth_events_v1` query with a comment explaining why it still references a sharded fxa log table.