### PR TITLE
Publish view metadata

### DIFF
--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -354,10 +354,11 @@ class View:
 
                 table = client.get_table(target_view)
                 if not self.metadata:
-                    return
+                    print(f"Missing metadata for {self.path}")
 
                 table.description = self.metadata.description
                 table.friendly_name = self.metadata.friendly_name
+                client.update_table(table, ["description", "friendly_name"])
 
                 if table.labels != self.labels:
                     labels = self.labels.copy()

--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -353,6 +353,12 @@ class View:
                     print(f"Could not update field descriptions for {target_view}: {e}")
 
                 table = client.get_table(target_view)
+                if not self.metadata:
+                    return
+
+                table.description = self.metadata.description
+                table.friendly_name = self.metadata.friendly_name
+
                 if table.labels != self.labels:
                     labels = self.labels.copy()
                     for key in table.labels:

--- a/tests/data/test_sql/moz-fx-data-test-project/test/view_with_metadata/metadata.yaml
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/view_with_metadata/metadata.yaml
@@ -1,0 +1,20 @@
+---
+friendly_name: "Test metadata file"
+description: "Test description"
+owners:
+  - test1@mozilla.com
+  - test2@example.com
+  - mozilla/test_group
+labels:
+  schedule: daily
+  public_json: true
+  incremental: true
+  incremental_export: true
+  1232341234: valid
+  1234_abcd: valid
+  number_value: 1234234
+  number_string: 1234abcde
+  123-432: valid
+references:
+  query.sql:
+    - project.dataset_derived.table_v1

--- a/tests/data/test_sql/moz-fx-data-test-project/test/view_with_metadata/view.sql
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/view_with_metadata/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-test-project.test.view_with_metadata`
+AS
+SELECT
+  1
+FROM
+  "moz-fx-data-test-project.test.simple_table"

--- a/tests/view/test_view.py
+++ b/tests/view/test_view.py
@@ -130,7 +130,7 @@ class TestView:
         }
         assert (
             mock_bigquery_client()
-            .get_table("moz-fx-data-test-project.test.view_with_metadata.friendly_name")
+            .get_table("moz-fx-data-test-project.test.view_with_metadata")
             .friendly_name
             == "Test metadata file"
         )

--- a/tests/view/test_view.py
+++ b/tests/view/test_view.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -87,3 +88,20 @@ class TestView:
             view.path.write_text("SELECT 1")
             assert view.is_valid() is False
             assert view.publish() is False
+
+    @patch("google.cloud.bigquery.Client", autospec=True)
+    def test_publish_valid_view(self, mock_bigquery_client):
+        mock_client = MagicMock()
+        mock_bigquery_client.return_value = mock_client
+        view = View.from_file(
+            TEST_DIR
+            / "data"
+            / "test_sql"
+            / "moz-fx-data-test-project"
+            / "test"
+            / "view_with_metadata"
+            / "view.sql"
+        )
+
+        assert view.is_valid()
+        assert view.publish()


### PR DESCRIPTION
Make sure that metadata `friendly_name` and `description` are published to views. Fixes #3850.
 
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
