### PR TITLE
Fix google sheets metadata and change from "google_sheet" to "google_sheets" for consistency with google

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1843,7 +1843,7 @@ def _deploy_external_data(
 
             if not table.created:
                 if metadata.external_data.format in (
-                    ExternalDataFormat.GOOGLE_SHEET,
+                    ExternalDataFormat.GOOGLE_SHEETS,
                     ExternalDataFormat.CSV,
                 ):
                     external_config = bigquery.ExternalConfig(

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -117,7 +117,7 @@ class WorkgroupAccessMetadata:
 class ExternalDataFormat(enum.Enum):
     """Represents the external types fo data that are supported to be integrated."""
 
-    GOOGLE_SHEET = "google_sheet"
+    GOOGLE_SHEETS = "google_sheets"
     CSV = "csv"
 
 

--- a/sql/moz-fx-data-shared-prod/static/data_incidents_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/data_incidents_v1/metadata.yaml
@@ -8,7 +8,7 @@ owners:
 labels:
   incremental: false
 external_data:
-  format: google_sheet
+  format: google_sheets
   source_uris:
     - https://docs.google.com/spreadsheets/d/16Cyx_KBieRdQkSBKolivqpBaK2H-VceN9LEZcL0snHg
   options:

--- a/sql/moz-fx-data-shared-prod/static/monitoring_distinct_docids_notes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/monitoring_distinct_docids_notes_v1/metadata.yaml
@@ -8,7 +8,7 @@ owners:
 labels:
   incremental: false
 external_data:
-  format: google_sheet
+  format: google_sheets
   source_uris:
     - https://docs.google.com/spreadsheets/d/1wMKyIyzp8yW7YpNz6hpFe0sHueeeLHdHr3p-1br2TbA
   options:

--- a/sql/moz-fx-data-shared-prod/static/monitoring_missing_columns_notes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/monitoring_missing_columns_notes_v1/metadata.yaml
@@ -8,7 +8,7 @@ owners:
 labels:
   incremental: false
 external_data:
-  format: google_sheet
+  format: google_sheets
   source_uris:
     - https://docs.google.com/spreadsheets/d/1wMKyIyzp8yW7YpNz6hpFe0sHueeeLHdHr3p-1br2TbA
   options:

--- a/sql/moz-fx-data-shared-prod/static/monitoring_missing_document_namespaces_notes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/monitoring_missing_document_namespaces_notes_v1/metadata.yaml
@@ -8,7 +8,7 @@ owners:
 labels:
   incremental: false
 external_data:
-  format: google_sheet
+  format: google_sheets
   source_uris:
     - https://docs.google.com/spreadsheets/d/1wMKyIyzp8yW7YpNz6hpFe0sHueeeLHdHr3p-1br2TbA
   options:

--- a/sql/moz-fx-data-shared-prod/static/monitoring_schema_errors_notes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/monitoring_schema_errors_notes_v1/metadata.yaml
@@ -8,7 +8,7 @@ owners:
 labels:
   incremental: false
 external_data:
-  format: google_sheet
+  format: google_sheets
   source_uris:
     - https://docs.google.com/spreadsheets/d/1wMKyIyzp8yW7YpNz6hpFe0sHueeeLHdHr3p-1br2TbA]
   options:


### PR DESCRIPTION
The airflow table deployment has been failing for some tables with the following error
https://workflow.telemetry.mozilla.org/log?dag_id=bqetl_artifact_deployment&task_id=publish_new_tables&execution_date=2023-06-06T05%3A30%3A00%2B00%3A00

Upon investigating we found that a recent PR #3881 has change the way we parse the metadata for external config for google sheets. We have been using `"GOOGLE_SHEET"/"google_sheet"` in our config while google uses "GOOGLE_SHEETS." Previously we were doing the translation and #3881 changed to do it differently.

We could bring that translation back, but we thought it made more sense to bring our terminology in line with Google's.

We have a matching PR in `private-bigquery-etl` to accommodate this change https://github.com/mozilla/private-bigquery-etl/pull/234


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
