### PR TITLE
feat(DENG-722): preparing for fxa migration (prod)

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -59,6 +59,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_user_ids_v1/query.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_user_ids_v1/init.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/query.sql
+  - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/query.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_auth_events_v1/query.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_content_events_v1/query.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/query.sql

--- a/dags/bqetl_event_rollup.py
+++ b/dags/bqetl_event_rollup.py
@@ -204,6 +204,21 @@ with DAG(
     funnel_events_source__v1.set_upstream(
         wait_for_firefox_accounts_derived__fxa_content_events__v1
     )
+    wait_for_firefox_accounts_derived__fxa_server_events__v1 = ExternalTaskSensor(
+        task_id="wait_for_firefox_accounts_derived__fxa_server_events__v1",
+        external_dag_id="bqetl_fxa_events",
+        external_task_id="firefox_accounts_derived__fxa_server_events__v1",
+        execution_delta=datetime.timedelta(seconds=5400),
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    funnel_events_source__v1.set_upstream(
+        wait_for_firefox_accounts_derived__fxa_server_events__v1
+    )
     wait_for_firefox_accounts_derived__fxa_stdout_events__v1 = ExternalTaskSensor(
         task_id="wait_for_firefox_accounts_derived__fxa_stdout_events__v1",
         external_dag_id="bqetl_fxa_events",

--- a/dags/bqetl_fxa_events.py
+++ b/dags/bqetl_fxa_events.py
@@ -214,6 +214,7 @@ with DAG(
         project_id="moz-fx-data-shared-prod",
         owner="kik@mozilla.com",
         email=["dthorn@mozilla.com", "kik@mozilla.com", "telemetry-alerts@mozilla.com"],
+        start_date=datetime.datetime(2023, 9, 7, 0, 0),
         date_partition_parameter="submission_date",
         depends_on_past=False,
         arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],

--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -1224,6 +1224,21 @@ with DAG(
     cjms_bigquery__flows__v1.set_upstream(
         wait_for_firefox_accounts_derived__fxa_content_events__v1
     )
+    wait_for_firefox_accounts_derived__fxa_server_events__v1 = ExternalTaskSensor(
+        task_id="wait_for_firefox_accounts_derived__fxa_server_events__v1",
+        external_dag_id="bqetl_fxa_events",
+        external_task_id="firefox_accounts_derived__fxa_server_events__v1",
+        execution_delta=datetime.timedelta(seconds=900),
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    cjms_bigquery__flows__v1.set_upstream(
+        wait_for_firefox_accounts_derived__fxa_server_events__v1
+    )
     wait_for_firefox_accounts_derived__fxa_stdout_events__v1 = ExternalTaskSensor(
         task_id="wait_for_firefox_accounts_derived__fxa_stdout_events__v1",
         external_dag_id="bqetl_fxa_events",
@@ -1353,6 +1368,9 @@ with DAG(
         wait_for_firefox_accounts_derived__fxa_content_events__v1
     )
     mozilla_vpn_derived__funnel_product_page_to_subscribed__v1.set_upstream(
+        wait_for_firefox_accounts_derived__fxa_server_events__v1
+    )
+    mozilla_vpn_derived__funnel_product_page_to_subscribed__v1.set_upstream(
         wait_for_firefox_accounts_derived__fxa_stdout_events__v1
     )
 
@@ -1371,6 +1389,9 @@ with DAG(
         wait_for_firefox_accounts_derived__fxa_content_events__v1
     )
     mozilla_vpn_derived__fxa_attribution__v1.set_upstream(
+        wait_for_firefox_accounts_derived__fxa_server_events__v1
+    )
+    mozilla_vpn_derived__fxa_attribution__v1.set_upstream(
         wait_for_firefox_accounts_derived__fxa_stdout_events__v1
     )
 
@@ -1383,6 +1404,9 @@ with DAG(
     )
     mozilla_vpn_derived__login_flows__v1.set_upstream(
         wait_for_firefox_accounts_derived__fxa_content_events__v1
+    )
+    mozilla_vpn_derived__login_flows__v1.set_upstream(
+        wait_for_firefox_accounts_derived__fxa_server_events__v1
     )
     mozilla_vpn_derived__login_flows__v1.set_upstream(
         wait_for_firefox_accounts_derived__fxa_stdout_events__v1
@@ -1719,6 +1743,9 @@ with DAG(
     )
     subscription_platform_derived__subplat_flow_events__v1.set_upstream(
         wait_for_firefox_accounts_derived__fxa_content_events__v1
+    )
+    subscription_platform_derived__subplat_flow_events__v1.set_upstream(
+        wait_for_firefox_accounts_derived__fxa_server_events__v1
     )
     subscription_platform_derived__subplat_flow_events__v1.set_upstream(
         wait_for_firefox_accounts_derived__fxa_stdout_events__v1

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
@@ -26,6 +26,7 @@ WITH auth_events AS (
     jsonPayload.fields.device_id,
   FROM
     `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_auth_events_v1`
+  -- TODO: add a cut off date once AWS to GCP migration is complete.
 ),
   -- This table doesn't include any user events that are considered "active",
   -- but should always be included for a complete raw event log.
@@ -72,6 +73,7 @@ content_events AS (
     jsonPayload.fields.device_id,
   FROM
     `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_content_events_v1`
+  -- TODO: add a cut off date once AWS to GCP migration is complete.
 ),
 -- oauth events, see the note on top
 oauth_events AS (
@@ -94,6 +96,7 @@ oauth_events AS (
     CAST(NULL AS STRING) AS device_id,
   FROM
     `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_oauth_events_v1`
+  -- TODO: add a cut off date once AWS to GCP migration is complete.
 ),
 stdout_events AS (
   SELECT
@@ -115,6 +118,7 @@ stdout_events AS (
     jsonPayload.fields.device_id,
   FROM
     `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_stdout_events_v1`
+  -- TODO: add a cut off date once AWS to GCP migration is complete.
 ),
 -- New fxa event table (prod) includes, content and auth events (TODO: confirm what about auth_bounce)
 server_events AS (
@@ -135,6 +139,10 @@ server_events AS (
     jsonPayload.fields.device_id,
   FROM
     `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_server_events_v1`
+  WHERE
+    -- this is when traffic switch over started, all prior dates contain test data.
+    -- see: DENG-1035 for more info.
+    DATE(`timestamp`) >= "2023-09-07"
 ),
 unioned AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
@@ -32,6 +32,8 @@ WITH auth_events AS (
   -- but should always be included for a complete raw event log.
 auth_bounce_events AS (
   SELECT
+    -- TODO: once no longer aliasing to fxa_log in the final part of the query,
+    -- we should change this label to "auth"
     "auth_bounce" AS fxa_server,
     `timestamp`,
     receiveTimestamp,
@@ -100,7 +102,9 @@ oauth_events AS (
 ),
 stdout_events AS (
   SELECT
-    "stdout" AS fxa_server,  -- TODO: should we rename this to "payments"?
+    -- TODO: once no longer aliasing to fxa_log in the final part of the query,
+    -- we should change this label to "payments"
+    "stdout" AS fxa_server,
     `timestamp`,
     receiveTimestamp,
     SAFE.TIMESTAMP_MILLIS(SAFE_CAST(jsonPayload.fields.time AS INT64)) AS event_time,
@@ -177,7 +181,8 @@ unioned AS (
     server_events
 )
 SELECT
-  fxa_server AS fxa_log,  -- TODO: remove this aliasing, this will require changes downstream why broken down into multiple changes / PRs
+  -- TODO: remove this aliasing, however, this will require changes downstream why broken down into multiple changes / PRs
+  fxa_server AS fxa_log,
   `timestamp`,
   receiveTimestamp,
   event_time,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/init.sql
@@ -1,9 +1,0 @@
-CREATE TABLE IF NOT EXISTS
-  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_server_events_v1`(
-    `timestamp` TIMESTAMP,
-    fxa_log STRING
-  )
-PARTITION BY
-  DATE(`timestamp`)
-CLUSTER BY
-  fxa_log

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/init.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS
+  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_server_events_v1`(
+    `timestamp` TIMESTAMP,
+    fxa_log STRING
+  )
+PARTITION BY
+  DATE(`timestamp`)
+CLUSTER BY
+  fxa_log

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
@@ -4,7 +4,7 @@ description: |
   FxA server events extracted from accounts server stdout logs.
   This new table is the direct result of FxA migration from AWS to GCP
   (see: OPST-296 for more context).
-  Effective x (TODO: add a date here prior to merging) date the events from the following servers will land in this table:
+  Effective 2023-09-07 the events from the following servers will land in this table:
   - auth    (previous table: `fxa_auth_events_v1`)
   - content (previous table: `fxa_content_events_v1`)
 
@@ -18,7 +18,7 @@ labels:
   owner1: kik
 scheduling:
   dag_name: bqetl_fxa_events
-  # start_date: '2023-05-26'  # TODO: confirm from when we start getting data
+  start_date: '2023-09-07'
   arguments:
   - --schema_update_option=ALLOW_FIELD_ADDITION
 bigquery:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
@@ -1,0 +1,32 @@
+---
+friendly_name: FxA Server Events (prod)
+description: |
+  FxA server events extracted from accounts server stdout logs.
+  This new table is the direct result of FxA migration from AWS to GCP
+  (see: OPST-296 for more context).
+  Effective x (TODO: add a date here prior to merging) date the events from the following servers will land in this table:
+  - auth    (previous table: `fxa_auth_events_v1`)
+  - content (previous table: `fxa_content_events_v1`)
+  Payment server events will continue landing inside: `fxa_stdout_events_v1`
+owners:
+  - kik@mozilla.com
+labels:
+  application: fxa
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_fxa_events
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']  # after initing the table with one column this should just add all the other fields automatically
+bigquery:
+  time_partitioning:
+    type: day
+    field: timestamp
+    require_partition_filter: true
+  # cannot set clustering via this config file as no schema.yaml
+  # file due to how volatile the table schema can be.
+  # To mitigate this we create the table using the init.sql file
+  # which creates an empty table with the following fields and configuration:
+  # - timestamp TIMESTAMP - partition field
+  # - fxa_log STRING - cluster field
+  # the argument ALLOW_FIELD_ADDITION takes care of adding all the missing field
+  # as part of the ETL execution.

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
@@ -30,4 +30,5 @@ bigquery:
   clustering:
     fields:
     - fxa_server
+    - event_type
 references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
@@ -4,9 +4,14 @@ description: |
   FxA server events extracted from accounts server stdout logs.
   This new table is the direct result of FxA migration from AWS to GCP
   (see: OPST-296 for more context).
-  Effective 2023-09-07 the events from the following servers will land in this table:
+  Effective 2023-09-07 rebalancing of traffic began (AWS to GCP) and this table contains partial
+  event data for auth and content fxa servers. Once the migrations is complete all events for the following
+  fxa servers will land in this table:
+
   - auth    (previous table: `fxa_auth_events_v1`)
   - content (previous table: `fxa_content_events_v1`)
+
+  !!! Thereafter, those (previous) tables will no longer contain new event data.
 
   Payment server events will continue landing inside: `fxa_stdout_events_v1`
 owners:
@@ -30,5 +35,4 @@ bigquery:
   clustering:
     fields:
     - fxa_server
-    - event_type
 references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
@@ -10,15 +10,17 @@ description: |
 
   Payment server events will continue landing inside: `fxa_stdout_events_v1`
 owners:
-  - kik@mozilla.com
+- kik@mozilla.com
 labels:
   application: fxa
   incremental: true
   schedule: daily
+  owner1: kik
 scheduling:
   dag_name: bqetl_fxa_events
   # start_date: '2023-05-26'  # TODO: confirm from when we start getting data
-  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+  arguments:
+  - --schema_update_option=ALLOW_FIELD_ADDITION
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
@@ -1,4 +1,3 @@
----
 friendly_name: FxA Server Events (prod)
 description: |
   FxA server events extracted from accounts server stdout logs.
@@ -21,6 +20,7 @@ labels:
   incremental: true
   schedule: daily
   owner1: kik
+  dag: bqetl_fxa_events
 scheduling:
   dag_name: bqetl_fxa_events
   start_date: '2023-09-07'

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/metadata.yaml
@@ -7,6 +7,7 @@ description: |
   Effective x (TODO: add a date here prior to merging) date the events from the following servers will land in this table:
   - auth    (previous table: `fxa_auth_events_v1`)
   - content (previous table: `fxa_content_events_v1`)
+
   Payment server events will continue landing inside: `fxa_stdout_events_v1`
 owners:
   - kik@mozilla.com
@@ -16,17 +17,15 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_fxa_events
-  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']  # after initing the table with one column this should just add all the other fields automatically
+  # start_date: '2023-05-26'  # TODO: confirm from when we start getting data
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
     type: day
     field: timestamp
     require_partition_filter: true
-  # cannot set clustering via this config file as no schema.yaml
-  # file due to how volatile the table schema can be.
-  # To mitigate this we create the table using the init.sql file
-  # which creates an empty table with the following fields and configuration:
-  # - timestamp TIMESTAMP - partition field
-  # - fxa_log STRING - cluster field
-  # the argument ALLOW_FIELD_ADDITION takes care of adding all the missing field
-  # as part of the ETL execution.
+    expiration_days: null
+  clustering:
+    fields:
+    - fxa_server
+references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/query.sql
@@ -1,5 +1,5 @@
 SELECT
-  SPLIT(jsonPayload.logger, "-")[OFFSET(1)] fxa_server,  -- example expected input: fxa-auth-server
+  SPLIT(jsonPayload.logger, "-")[OFFSET(1)] AS fxa_server,  -- example expected input: fxa-auth-server
   * REPLACE (
     (
       SELECT AS STRUCT

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/query.sql
@@ -1,4 +1,5 @@
 SELECT
+  SPLIT(jsonPayload.logger, "-")[OFFSET(1)] fxa_server,  -- example expected input: fxa-auth-server
   * REPLACE (
     (
       SELECT AS STRUCT
@@ -12,7 +13,6 @@ SELECT
         )
     ) AS jsonPayload
   ),
-  SPLIT(jsonPayload.logger, "-")[OFFSET(1)] fxa_log,  -- example expected input: fxa-auth-server
 FROM
   `moz-fx-fxa-prod.gke_fxa_prod_log.stdout`
 WHERE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/query.sql
@@ -1,14 +1,17 @@
 SELECT
-  SPLIT(jsonPayload.logger, "-")[OFFSET(1)] AS fxa_server,  -- example expected input: fxa-auth-server
+  SPLIT(jsonPayload.logger, "-")[
+    OFFSET(1)
+  ] AS fxa_server,  -- example expected input: fxa-auth-server
   * REPLACE (
     (
       SELECT AS STRUCT
         jsonPayload.* REPLACE (
           (
             SELECT AS STRUCT
-              jsonPayload.fields.* EXCEPT (device_id, user_id),
-              TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id,
-              TO_HEX(SHA256(jsonPayload.fields.device_id)) AS device_id
+              jsonPayload.fields.* REPLACE (
+                TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id,
+                TO_HEX(SHA256(jsonPayload.fields.device_id)) AS device_id
+              )
           ) AS fields
         )
     ) AS jsonPayload
@@ -16,7 +19,9 @@ SELECT
 FROM
   `moz-fx-fxa-prod.gke_fxa_prod_log.stdout`
 WHERE
-  jsonPayload.type = 'amplitudeEvent'
+  -- TODO: Looks like partition field is different as expected, need to confirm with SRE that this is intended.
+  -- DATE(`timestamp`) = @submission_date
+  _PARTITIONTIME = @submission_date
+  AND jsonPayload.type = 'amplitudeEvent'
   AND jsonPayload.logger IS NOT NULL
   AND jsonPayload.fields.event_type IS NOT NULL
-  AND DATE(`timestamp`) = @submission_date

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/schema.yaml
@@ -1,0 +1,379 @@
+fields:
+- name: fxa_server
+  type: STRING
+  mode: NULLABLE
+- name: resource
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: type
+    type: STRING
+    mode: NULLABLE
+  - name: labels
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: cluster_name
+      type: STRING
+      mode: NULLABLE
+    - name: pod_name
+      type: STRING
+      mode: NULLABLE
+    - name: location
+      type: STRING
+      mode: NULLABLE
+    - name: project_id
+      type: STRING
+      mode: NULLABLE
+    - name: namespace_name
+      type: STRING
+      mode: NULLABLE
+    - name: container_name
+      type: STRING
+      mode: NULLABLE
+- name: textPayload
+  type: STRING
+  mode: NULLABLE
+- name: jsonPayload
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: x_forwarded_for
+    type: STRING
+    mode: NULLABLE
+  - name: request
+    type: STRING
+    mode: NULLABLE
+  - name: status
+    type: STRING
+    mode: NULLABLE
+  - name: request_time
+    type: FLOAT
+    mode: NULLABLE
+  - name: bytes_sent
+    type: FLOAT
+    mode: NULLABLE
+  - name: remote_user
+    type: STRING
+    mode: NULLABLE
+  - name: referrer
+    type: STRING
+    mode: NULLABLE
+  - name: trace
+    type: STRING
+    mode: NULLABLE
+  - name: x_forwarded_proto
+    type: STRING
+    mode: NULLABLE
+  - name: user_agent
+    type: STRING
+    mode: NULLABLE
+  - name: remote_addr
+    type: STRING
+    mode: NULLABLE
+  - name: proxy_host
+    type: STRING
+    mode: NULLABLE
+  - name: envversion
+    type: STRING
+    mode: NULLABLE
+  - name: pid
+    type: FLOAT
+    mode: NULLABLE
+  - name: timestamp
+    type: FLOAT
+    mode: NULLABLE
+  - name: fields
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: contentlength
+      type: STRING
+      mode: NULLABLE
+    - name: remoteaddresschain
+      type: STRING
+      mode: NULLABLE
+    - name: path
+      type: STRING
+      mode: NULLABLE
+    - name: t
+      type: STRING
+      mode: NULLABLE
+    - name: method
+      type: STRING
+      mode: NULLABLE
+    - name: useragent
+      type: STRING
+      mode: NULLABLE
+    - name: clientaddress
+      type: STRING
+      mode: NULLABLE
+    - name: status
+      type: STRING
+      mode: NULLABLE
+    - name: msg
+      type: STRING
+      mode: NULLABLE
+    - name: err
+      type: STRING
+      mode: NULLABLE
+    - name: messageid
+      type: STRING
+      mode: NULLABLE
+    - name: clientid
+      type: STRING
+      mode: NULLABLE
+    - name: message
+      type: STRING
+      mode: NULLABLE
+    - name: statuscode
+      type: FLOAT
+      mode: NULLABLE
+    - name: clientcapabilities
+      type: STRING
+      mode: NULLABLE
+    - name: referer
+      type: STRING
+      mode: NULLABLE
+    - name: event
+      type: STRING
+      mode: NULLABLE
+    - name: context
+      type: STRING
+      mode: NULLABLE
+    - name: session_id
+      type: FLOAT
+      mode: NULLABLE
+    - name: os_name
+      type: STRING
+      mode: NULLABLE
+    - name: app_version
+      type: STRING
+      mode: NULLABLE
+    - name: user_properties
+      type: STRING
+      mode: NULLABLE
+    - name: event_type
+      type: STRING
+      mode: NULLABLE
+    - name: op
+      type: STRING
+      mode: NULLABLE
+    - name: time
+      type: FLOAT
+      mode: NULLABLE
+    - name: os_version
+      type: STRING
+      mode: NULLABLE
+    - name: event_properties
+      type: STRING
+      mode: NULLABLE
+    - name: response
+      type: STRING
+      mode: NULLABLE
+    - name: device_model
+      type: STRING
+      mode: NULLABLE
+    - name: port
+      type: FLOAT
+      mode: NULLABLE
+    - name: directory
+      type: STRING
+      mode: NULLABLE
+    - name: changed
+      type: STRING
+      mode: NULLABLE
+    - name: removed
+      type: STRING
+      mode: NULLABLE
+    - name: webhooks
+      type: STRING
+      mode: NULLABLE
+    - name: joierrors
+      type: STRING
+      mode: NULLABLE
+    - name: country
+      type: STRING
+      mode: NULLABLE
+    - name: countrycode
+      type: STRING
+      mode: NULLABLE
+    - name: language
+      type: STRING
+      mode: NULLABLE
+    - name: country_code
+      type: STRING
+      mode: NULLABLE
+    - name: resourceservers
+      type: STRING
+      mode: NULLABLE
+    - name: user_id
+      type: STRING
+      mode: NULLABLE
+    - name: device_id
+      type: STRING
+      mode: NULLABLE
+  - name: logger
+    type: STRING
+    mode: NULLABLE
+  - name: type
+    type: STRING
+    mode: NULLABLE
+  - name: severity
+    type: FLOAT
+    mode: NULLABLE
+  - name: log_type
+    type: STRING
+    mode: NULLABLE
+- name: timestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: receiveTimestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: severity
+  type: STRING
+  mode: NULLABLE
+- name: insertId
+  type: STRING
+  mode: NULLABLE
+- name: httpRequest
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: requestMethod
+    type: STRING
+    mode: NULLABLE
+  - name: requestUrl
+    type: STRING
+    mode: NULLABLE
+  - name: requestSize
+    type: INTEGER
+    mode: NULLABLE
+  - name: status
+    type: INTEGER
+    mode: NULLABLE
+  - name: responseSize
+    type: INTEGER
+    mode: NULLABLE
+  - name: userAgent
+    type: STRING
+    mode: NULLABLE
+  - name: remoteIp
+    type: STRING
+    mode: NULLABLE
+  - name: serverIp
+    type: STRING
+    mode: NULLABLE
+  - name: referer
+    type: STRING
+    mode: NULLABLE
+  - name: cacheLookup
+    type: BOOLEAN
+    mode: NULLABLE
+  - name: cacheHit
+    type: BOOLEAN
+    mode: NULLABLE
+  - name: cacheValidatedWithOriginServer
+    type: BOOLEAN
+    mode: NULLABLE
+  - name: cacheFillBytes
+    type: INTEGER
+    mode: NULLABLE
+  - name: protocol
+    type: STRING
+    mode: NULLABLE
+- name: labels
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: k8s_pod_app_kubernetes_io_part_of
+    type: STRING
+    mode: NULLABLE
+  - name: k8s_pod_fullname
+    type: STRING
+    mode: NULLABLE
+  - name: k8s_pod_app_kubernetes_io_component
+    type: STRING
+    mode: NULLABLE
+  - name: k8s_pod_app_kubernetes_io_name
+    type: STRING
+    mode: NULLABLE
+  - name: k8s_pod_app_kubernetes_io_version
+    type: STRING
+    mode: NULLABLE
+  - name: k8s_pod_app_kubernetes_io_managed_by
+    type: STRING
+    mode: NULLABLE
+  - name: compute_googleapis_com_resource_name
+    type: STRING
+    mode: NULLABLE
+  - name: k8s_pod_jenkins_build_id
+    type: STRING
+    mode: NULLABLE
+  - name: k8s_pod_app_kubernetes_io_instance
+    type: STRING
+    mode: NULLABLE
+  - name: k8s_pod_pod_template_hash
+    type: STRING
+    mode: NULLABLE
+  - name: k8s_pod_pod_template_generation
+    type: STRING
+    mode: NULLABLE
+  - name: k8s_pod_controller_revision_hash
+    type: STRING
+    mode: NULLABLE
+  - name: k8s_pod_k8s_app
+    type: STRING
+    mode: NULLABLE
+- name: operation
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: id
+    type: STRING
+    mode: NULLABLE
+  - name: producer
+    type: STRING
+    mode: NULLABLE
+  - name: first
+    type: BOOLEAN
+    mode: NULLABLE
+  - name: last
+    type: BOOLEAN
+    mode: NULLABLE
+- name: trace
+  type: STRING
+  mode: NULLABLE
+- name: spanId
+  type: STRING
+  mode: NULLABLE
+- name: traceSampled
+  type: BOOLEAN
+  mode: NULLABLE
+- name: sourceLocation
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: file
+    type: STRING
+    mode: NULLABLE
+  - name: line
+    type: INTEGER
+    mode: NULLABLE
+  - name: function
+    type: STRING
+    mode: NULLABLE
+- name: split
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: uid
+    type: STRING
+    mode: NULLABLE
+  - name: index
+    type: INTEGER
+    mode: NULLABLE
+  - name: totalSplits
+    type: INTEGER
+    mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_server_events_v1/schema.yaml
@@ -2,6 +2,9 @@ fields:
 - name: fxa_server
   type: STRING
   mode: NULLABLE
+- name: logName
+  type: STRING
+  mode: NULLABLE
 - name: resource
   type: RECORD
   mode: NULLABLE
@@ -13,22 +16,22 @@ fields:
     type: RECORD
     mode: NULLABLE
     fields:
-    - name: cluster_name
+    - name: project_id
       type: STRING
       mode: NULLABLE
     - name: pod_name
       type: STRING
       mode: NULLABLE
-    - name: location
+    - name: container_name
       type: STRING
       mode: NULLABLE
-    - name: project_id
+    - name: cluster_name
       type: STRING
       mode: NULLABLE
     - name: namespace_name
       type: STRING
       mode: NULLABLE
-    - name: container_name
+    - name: location
       type: STRING
       mode: NULLABLE
 - name: textPayload
@@ -38,43 +41,43 @@ fields:
   type: RECORD
   mode: NULLABLE
   fields:
-  - name: x_forwarded_for
+  - name: log_type
     type: STRING
     mode: NULLABLE
   - name: request
     type: STRING
     mode: NULLABLE
-  - name: status
-    type: STRING
-    mode: NULLABLE
   - name: request_time
     type: FLOAT
+    mode: NULLABLE
+  - name: x_forwarded_for
+    type: STRING
     mode: NULLABLE
   - name: bytes_sent
     type: FLOAT
     mode: NULLABLE
-  - name: remote_user
-    type: STRING
-    mode: NULLABLE
-  - name: referrer
-    type: STRING
-    mode: NULLABLE
-  - name: trace
+  - name: user_agent
     type: STRING
     mode: NULLABLE
   - name: x_forwarded_proto
     type: STRING
     mode: NULLABLE
-  - name: user_agent
+  - name: trace
+    type: STRING
+    mode: NULLABLE
+  - name: remote_user
     type: STRING
     mode: NULLABLE
   - name: remote_addr
     type: STRING
     mode: NULLABLE
-  - name: proxy_host
+  - name: referrer
     type: STRING
     mode: NULLABLE
-  - name: envversion
+  - name: status
+    type: STRING
+    mode: NULLABLE
+  - name: logger
     type: STRING
     mode: NULLABLE
   - name: pid
@@ -87,13 +90,7 @@ fields:
     type: RECORD
     mode: NULLABLE
     fields:
-    - name: contentlength
-      type: STRING
-      mode: NULLABLE
     - name: remoteaddresschain
-      type: STRING
-      mode: NULLABLE
-    - name: path
       type: STRING
       mode: NULLABLE
     - name: t
@@ -102,49 +99,61 @@ fields:
     - name: method
       type: STRING
       mode: NULLABLE
+    - name: status
+      type: STRING
+      mode: NULLABLE
     - name: useragent
+      type: STRING
+      mode: NULLABLE
+    - name: contentlength
       type: STRING
       mode: NULLABLE
     - name: clientaddress
       type: STRING
       mode: NULLABLE
-    - name: status
+    - name: path
       type: STRING
       mode: NULLABLE
-    - name: msg
-      type: STRING
-      mode: NULLABLE
-    - name: err
-      type: STRING
-      mode: NULLABLE
-    - name: messageid
-      type: STRING
-      mode: NULLABLE
-    - name: clientid
-      type: STRING
-      mode: NULLABLE
-    - name: message
-      type: STRING
-      mode: NULLABLE
-    - name: statuscode
+    - name: errno
       type: FLOAT
       mode: NULLABLE
-    - name: clientcapabilities
+    - name: code
+      type: FLOAT
+      mode: NULLABLE
+    - name: agent
+      type: STRING
+      mode: NULLABLE
+    - name: client_id
+      type: STRING
+      mode: NULLABLE
+    - name: uid
       type: STRING
       mode: NULLABLE
     - name: referer
       type: STRING
       mode: NULLABLE
+    - name: message
+      type: STRING
+      mode: NULLABLE
     - name: event
       type: STRING
       mode: NULLABLE
-    - name: context
+    - name: time
+      type: FLOAT
+      mode: NULLABLE
+    - name: event_type
+      type: STRING
+      mode: NULLABLE
+    - name: region
+      type: STRING
+      mode: NULLABLE
+    - name: country
       type: STRING
       mode: NULLABLE
     - name: session_id
       type: FLOAT
       mode: NULLABLE
-    - name: os_name
+    - name: language
       type: STRING
       mode: NULLABLE
     - name: app_version
@@ -153,67 +162,148 @@ fields:
     - name: user_properties
       type: STRING
       mode: NULLABLE
-    - name: event_type
-      type: STRING
-      mode: NULLABLE
-    - name: op
-      type: STRING
-      mode: NULLABLE
-    - name: time
-      type: FLOAT
-      mode: NULLABLE
-    - name: os_version
-      type: STRING
-      mode: NULLABLE
     - name: event_properties
-      type: STRING
-      mode: NULLABLE
-    - name: response
-      type: STRING
-      mode: NULLABLE
-    - name: device_model
-      type: STRING
-      mode: NULLABLE
-    - name: port
-      type: FLOAT
-      mode: NULLABLE
-    - name: directory
-      type: STRING
-      mode: NULLABLE
-    - name: changed
-      type: STRING
-      mode: NULLABLE
-    - name: removed
-      type: STRING
-      mode: NULLABLE
-    - name: webhooks
-      type: STRING
-      mode: NULLABLE
-    - name: joierrors
-      type: STRING
-      mode: NULLABLE
-    - name: country
-      type: STRING
-      mode: NULLABLE
-    - name: countrycode
-      type: STRING
-      mode: NULLABLE
-    - name: language
-      type: STRING
-      mode: NULLABLE
-    - name: country_code
-      type: STRING
-      mode: NULLABLE
-    - name: resourceservers
-      type: STRING
-      mode: NULLABLE
-    - name: user_id
       type: STRING
       mode: NULLABLE
     - name: device_id
       type: STRING
       mode: NULLABLE
-  - name: logger
+    - name: op
+      type: STRING
+      mode: NULLABLE
+    - name: os_name
+      type: STRING
+      mode: NULLABLE
+    - name: err
+      type: STRING
+      mode: NULLABLE
+    - name: joierrors
+      type: STRING
+      mode: NULLABLE
+    - name: stack
+      type: STRING
+      mode: NULLABLE
+    - name: reason
+      type: STRING
+      mode: NULLABLE
+    - name: result
+      type: STRING
+      mode: NULLABLE
+    - name: api
+      type: FLOAT
+      mode: NULLABLE
+    - name: os_version
+      type: STRING
+      mode: NULLABLE
+    - name: user_id
+      type: STRING
+      mode: NULLABLE
+    - name: msg
+      type: STRING
+      mode: NULLABLE
+    - name: error
+      type: STRING
+      mode: NULLABLE
+    - name: source
+      type: STRING
+      mode: NULLABLE
+    - name: blocked
+      type: STRING
+      mode: NULLABLE
+    - name: column
+      type: FLOAT
+      mode: NULLABLE
+    - name: line
+      type: FLOAT
+      mode: NULLABLE
+    - name: referrer
+      type: STRING
+      mode: NULLABLE
+    - name: violated
+      type: STRING
+      mode: NULLABLE
+    - name: url
+      type: STRING
+      mode: NULLABLE
+    - name: version
+      type: STRING
+      mode: NULLABLE
+    - name: directory
+      type: STRING
+      mode: NULLABLE
+    - name: port
+      type: FLOAT
+      mode: NULLABLE
+    - name: poolstats
+      type: STRING
+      mode: NULLABLE
+    - name: signal
+      type: STRING
+      mode: NULLABLE
+    - name: reqtime
+      type: FLOAT
+      mode: NULLABLE
+    - name: rp
+      type: STRING
+      mode: NULLABLE
+    - name: assertion_verification_time
+      type: FLOAT
+      mode: NULLABLE
+    - name: trustedissuers
+      type: STRING
+      mode: NULLABLE
+    - name: assertion
+      type: STRING
+      mode: NULLABLE
+    - name: host
+      type: STRING
+      mode: NULLABLE
+    - name: header
+      type: STRING
+      mode: NULLABLE
+    - name: usergroupheader
+      type: STRING
+      mode: NULLABLE
+    - name: usergroupheader_notnull
+      type: STRING
+      mode: NULLABLE
+    - name: user
+      type: STRING
+      mode: NULLABLE
+    - name: email
+      type: STRING
+      mode: NULLABLE
+    - name: search_type
+      type: STRING
+      mode: NULLABLE
+    - name: auto_completed
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: payload
+      type: STRING
+      mode: NULLABLE
+    - name: user_agent
+      type: STRING
+      mode: NULLABLE
+    - name: ip_address
+      type: STRING
+      mode: NULLABLE
+    - name: document_version
+      type: STRING
+      mode: NULLABLE
+    - name: document_namespace
+      type: STRING
+      mode: NULLABLE
+    - name: document_type
+      type: STRING
+      mode: NULLABLE
+    - name: document_id
+      type: STRING
+      mode: NULLABLE
+    - name: originaltransactionid
+      type: STRING
+      mode: NULLABLE
+  - name: envversion
     type: STRING
     mode: NULLABLE
   - name: type
@@ -221,9 +311,6 @@ fields:
     mode: NULLABLE
   - name: severity
     type: FLOAT
-    mode: NULLABLE
-  - name: log_type
-    type: STRING
     mode: NULLABLE
 - name: timestamp
   type: TIMESTAMP
@@ -287,43 +374,22 @@ fields:
   type: RECORD
   mode: NULLABLE
   fields:
-  - name: k8s_pod_app_kubernetes_io_part_of
-    type: STRING
-    mode: NULLABLE
-  - name: k8s_pod_fullname
-    type: STRING
-    mode: NULLABLE
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
-  - name: k8s_pod_app_kubernetes_io_name
-    type: STRING
-    mode: NULLABLE
-  - name: k8s_pod_app_kubernetes_io_version
-    type: STRING
-    mode: NULLABLE
-  - name: k8s_pod_app_kubernetes_io_managed_by
+  - name: k8s_pod_deployment
     type: STRING
     mode: NULLABLE
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
-  - name: k8s_pod_jenkins_build_id
-    type: STRING
-    mode: NULLABLE
-  - name: k8s_pod_app_kubernetes_io_instance
+  - name: k8s_pod_env_code
     type: STRING
     mode: NULLABLE
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
-  - name: k8s_pod_pod_template_generation
-    type: STRING
-    mode: NULLABLE
-  - name: k8s_pod_controller_revision_hash
-    type: STRING
-    mode: NULLABLE
-  - name: k8s_pod_k8s_app
+  - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
 - name: operation


### PR DESCRIPTION
# feat(DENG-722): preparing for fxa migration (prod)

follows-up: https://github.com/mozilla/bigquery-etl/pull/3882

Updating prod set up to include the new fxa log event table which will be populated with auth and content server events once the application is migrated over to GCP.


