### PR TITLE
DENG-990 Refractor backfill cli commands

### DIFF
--- a/bigquery_etl/backfill/parse.py
+++ b/bigquery_etl/backfill/parse.py
@@ -50,7 +50,7 @@ class BackfillStatus(enum.Enum):
     """Represents backfill status types."""
 
     DRAFTING = "Drafting"
-    VALIDATING = "Validating"
+    VALIDATED = "Validated"
     COMPLETE = "Complete"
 
 

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -180,9 +180,7 @@ def validate(
         sql_dir, project_id, qualified_table_name
     )
 
-    backfill_files = list(backfills_dict.keys())
-
-    for backfill_file in backfill_files:
+    for backfill_file in backfills_dict:
         try:
             validate_file(backfill_file)
         except (yaml.YAMLError, ValueError) as e:
@@ -191,7 +189,7 @@ def validate(
 
     if qualified_table_name:
         click.echo(f"{BACKFILL_FILE} has been validated for {qualified_table_name}.")
-    elif backfill_files:
+    elif backfills_dict:
         click.echo(
             f"All {BACKFILL_FILE} files have been validated for project {project_id}."
         )

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -235,29 +235,29 @@ class TestBackfill:
             backfill_file.write_text(BACKFILL_YAML_TEMPLATE)
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 0
+            assert result.exit_code == 0
 
     def test_validate_backfill_invalid_table_name(self, runner):
         with runner.isolated_filesystem():
             SQL_DIR = "sql/moz-fx-data-shared-prod/test/test_query_v1"
             os.makedirs(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
+            assert result.exit_code == 1
             assert (
                 "Qualified table name must be named like: <project>.<dataset>.<table>"
-                in validate_backfill_result.output
+                in result.output
             )
 
     def test_validate_backfill_non_existing_table_name(self, runner):
@@ -265,14 +265,14 @@ class TestBackfill:
             SQL_DIR = "sql/moz-fx-data-shared-prod/test/test_query_v1"
             os.makedirs(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v2",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "does not exist" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "does not exist" in result.output
 
     def test_validate_backfill_invalid_default_reason(self, runner):
         with runner.isolated_filesystem():
@@ -286,14 +286,14 @@ class TestBackfill:
             backfill_file.write_text(invalid_backfill)
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "Invalid Reason" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "Invalid Reason" in result.output
 
     def test_validate_backfill_empty_reason(self, runner):
         with runner.isolated_filesystem():
@@ -308,14 +308,14 @@ class TestBackfill:
             backfill_file.write_text(invalid_backfill)
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "Invalid Reason" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "Invalid Reason" in result.output
 
     def test_validate_backfill_invalid_watcher(self, runner):
         with runner.isolated_filesystem():
@@ -330,15 +330,15 @@ class TestBackfill:
             backfill_file.write_text(invalid_backfill)
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "Invalid" in validate_backfill_result.output
-            assert "watchers" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "Invalid" in str(result.exception)
+            assert "watchers" in str(result.exception)
 
     def test_validate_backfill_empty_watcher(self, runner):
         with runner.isolated_filesystem():
@@ -353,15 +353,15 @@ class TestBackfill:
             backfill_file.write_text(invalid_backfill)
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "Invalid" in validate_backfill_result.output
-            assert "watchers" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "Invalid" in str(result.exception)
+            assert "watchers" in str(result.exception)
 
     def test_validate_backfill_watchers_duplicated(self, runner):
         with runner.isolated_filesystem():
@@ -376,14 +376,14 @@ class TestBackfill:
             backfill_file.write_text(invalid_backfill)
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "Duplicate or default watcher" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "Duplicate or default watcher" in result.output
 
     def test_validate_backfill_invalid_status(self, runner):
         with runner.isolated_filesystem():
@@ -398,14 +398,14 @@ class TestBackfill:
             backfill_file.write_text(invalid_backfill)
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert invalid_status in str(validate_backfill_result.exception)
+            assert result.exit_code == 1
+            assert invalid_status in str(result.exception)
 
     def test_validate_backfill_duplicate_entry_dates(self, runner):
         with runner.isolated_filesystem():
@@ -422,14 +422,14 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "Backfill entry already exists" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "Backfill entry already exists" in str(result.exception)
 
     def test_validate_backfill_invalid_entry_date(self, runner):
         with runner.isolated_filesystem():
@@ -444,14 +444,14 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "can't be in the future" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "can't be in the future" in str(result.exception)
 
     def test_validate_backfill_invalid_start_date_greater_than_end_date(self, runner):
         with runner.isolated_filesystem():
@@ -466,14 +466,14 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "Invalid start date" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "Invalid start date" in str(result.exception)
 
     #
     def test_validate_backfill_invalid_start_date_greater_than_entry_date(self, runner):
@@ -489,14 +489,14 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "Invalid start date" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "Invalid start date" in str(result.exception)
 
     def test_validate_backfill_invalid_end_date_greater_than_entry_date(self, runner):
         with runner.isolated_filesystem():
@@ -511,14 +511,14 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "Invalid end date" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "Invalid end date" in str(result.exception)
 
     def test_validate_backfill_invalid_excluded_dates_less_than_start_date(
         self, runner
@@ -535,14 +535,14 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "Invalid excluded dates" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "Invalid excluded dates" in str(result.exception)
 
     def test_validate_backfill_invalid_excluded_dates_greater_than_end_date(
         self, runner
@@ -559,14 +559,14 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "Invalid excluded dates" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "Invalid excluded dates" in str(result.exception)
 
     def test_validate_backfill_invalid_excluded_dates_duplicated(self, runner):
         with runner.isolated_filesystem():
@@ -591,14 +591,14 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "duplicate excluded dates" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "duplicate excluded dates" in result.output
 
     def test_validate_backfill_invalid_excluded_dates_not_sorted(self, runner):
         with runner.isolated_filesystem():
@@ -621,14 +621,14 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "excluded dates not sorted" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "excluded dates not sorted" in result.output
 
     def test_validate_backfill_entries_not_sorted(self, runner):
         with runner.isolated_filesystem():
@@ -649,14 +649,14 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "entries are not sorted" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "entries are not sorted" in result.output
 
     def test_validate_backfill_overlap_dates(self, runner):
         with runner.isolated_filesystem():
@@ -677,14 +677,14 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 1
-            assert "overlap dates" in validate_backfill_result.output
+            assert result.exit_code == 1
+            assert "overlap dates" in result.output
 
     def test_validate_backfill_overlap_dates_not_drafting_status(self, runner):
         with runner.isolated_filesystem():
@@ -705,13 +705,13 @@ class TestBackfill:
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
 
-            validate_backfill_result = runner.invoke(
+            result = runner.invoke(
                 validate,
                 [
                     "moz-fx-data-shared-prod.test.test_query_v1",
                 ],
             )
-            assert validate_backfill_result.exit_code == 0
+            assert result.exit_code == 0
 
     def test_backfill_info_one_table_all_status(self, runner):
         with runner.isolated_filesystem():
@@ -728,7 +728,7 @@ class TestBackfill:
                 "  reason: test_reason\n"
                 "  watchers:\n"
                 "  - test@example.org\n"
-                "  status: Validating\n"
+                "  status: Validated\n"
             )
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
@@ -756,7 +756,7 @@ class TestBackfill:
             assert result.exit_code == 0
             assert qualified_table_name_1 in result.output
             assert BackfillStatus.DRAFTING.value in result.output
-            assert BackfillStatus.VALIDATING.value in result.output
+            assert BackfillStatus.VALIDATED.value in result.output
             assert "total of 2 backfill(s)" in result.output
             assert qualified_table_name_2 not in result.output
             assert BackfillStatus.COMPLETE.value not in result.output
@@ -776,7 +776,7 @@ class TestBackfill:
                 "  reason: test_reason\n"
                 "  watchers:\n"
                 "  - test@example.org\n"
-                "  status: Validating\n"
+                "  status: Validated\n"
             )
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
@@ -790,7 +790,7 @@ class TestBackfill:
             assert qualified_table_name in result.output
             assert BackfillStatus.DRAFTING.value in result.output
             assert "total of 1 backfill(s)" in result.output
-            assert BackfillStatus.VALIDATING.value not in result.output
+            assert BackfillStatus.VALIDATED.value not in result.output
             assert BackfillStatus.COMPLETE.value not in result.output
 
     def test_backfill_info_all_tables_all_status(self, runner):
@@ -808,7 +808,7 @@ class TestBackfill:
                 "  reason: test_reason\n"
                 "  watchers:\n"
                 "  - test@example.org\n"
-                "  status: Validating\n"
+                "  status: Validated\n"
             )
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
@@ -837,7 +837,7 @@ class TestBackfill:
             assert qualified_table_name_1 in result.output
             assert qualified_table_name_2 in result.output
             assert BackfillStatus.DRAFTING.value in result.output
-            assert BackfillStatus.VALIDATING.value in result.output
+            assert BackfillStatus.VALIDATED.value in result.output
             assert "total of 3 backfill(s)" in result.output
             assert BackfillStatus.COMPLETE.value not in result.output
 
@@ -856,7 +856,7 @@ class TestBackfill:
                 "  reason: test_reason\n"
                 "  watchers:\n"
                 "  - test@example.org\n"
-                "  status: Validating\n"
+                "  status: Validated\n"
             )
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
@@ -874,7 +874,7 @@ class TestBackfill:
                 "  reason: test_reason\n"
                 "  watchers:\n"
                 "  - test@example.org\n"
-                "  status: Validating\n"
+                "  status: Validated\n"
             )
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
@@ -882,14 +882,14 @@ class TestBackfill:
             result = runner.invoke(
                 info,
                 [
-                    "--status=validating",
+                    "--status=validated",
                 ],
             )
 
             assert result.exit_code == 0
             assert qualified_table_name_1 in result.output
             assert qualified_table_name_2 in result.output
-            assert BackfillStatus.VALIDATING.value in result.output
+            assert BackfillStatus.VALIDATED.value in result.output
             assert "total of 2 backfill(s)" in result.output
             assert BackfillStatus.DRAFTING.value not in result.output
             assert BackfillStatus.COMPLETE.value not in result.output
@@ -928,7 +928,7 @@ class TestBackfill:
                 "  reason: test_reason\n"
                 "  watchers:\n"
                 "  - test@example.org\n"
-                "  status: Validating\n"
+                "  status: Validated\n"
             )
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)


### PR DESCRIPTION
[DENG-990](https://mozilla-hub.atlassian.net/browse/DENG-990):
* Refractored backfill `create` and `validate` cli commands

[DENG-999](https://mozilla-hub.atlassian.net/browse/DENG-999):
* Changed from `validating` to `validated` status

[DENG-990]: https://mozilla-hub.atlassian.net/browse/DENG-990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-999]: https://mozilla-hub.atlassian.net/browse/DENG-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ