### PR TITLE
Simplify GLAM template for getting the latest version

### DIFF
--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -205,6 +205,15 @@ def main():
             "minimum_client_count": 0,
         },
     }
+
+    channel_prefixes = {
+        "firefox_desktop_glam_nightly": "nightly",
+        "firefox_desktop_glam_beta": "beta",
+        "firefox_desktop_glam_release": "release",
+        "org_mozilla_fenix_glam_nightly": "nightly",
+        "org_mozilla_fenix_glam_beta": "beta",
+        "org_mozilla_fenix_glam_release": "release",
+    }
     validate(instance=config, schema=config_schema)
 
     if not config.get(args.prefix, {}).get("build_date_udf"):
@@ -213,11 +222,7 @@ def main():
     [
         table(
             "latest_versions_v1",
-            **dict(
-                source_table=(
-                    f"glam_etl.{args.prefix}__view_clients_daily_scalar_aggregates_v1"
-                )
-            ),
+            **dict(app_id_channel=(f"'{channel_prefixes[args.prefix]}'")),
         ),
         init(
             "clients_scalar_aggregates_v1",

--- a/bigquery_etl/glam/templates/latest_versions_v1.sql
+++ b/bigquery_etl/glam/templates/latest_versions_v1.sql
@@ -1,36 +1,20 @@
-{{ header }}
-WITH extracted AS (
+  {{ header }}
+WITH
+  extracted AS (
   SELECT
-    client_id,
-    channel,
-    app_version
+    build.`target`.channel AS channel,
+    MAX(mozfun.norm.extract_version(build.`target`.version,
+        'major')) AS latest_version,
   FROM
-    {{ source_table }}
+    `moz-fx-data-shared-prod.telemetry.buildhub2`
   WHERE
-    submission_date
-    BETWEEN DATE_SUB(@submission_date, INTERVAL 28 DAY)
-    AND @submission_date
-    AND channel IS NOT NULL
-),
-transformed AS (
-  SELECT
-    channel,
-    app_version
-  FROM
-    extracted
+    build.`source`.product = "firefox"
+    AND build.`target`.channel = {{ app_id_channel }}
+    AND DATE(build.build.date) <= @submission_date
   GROUP BY
-    channel,
-    app_version
-  HAVING
-    COUNT(DISTINCT client_id) > 5
-  ORDER BY
-    channel,
-    app_version DESC
-)
+    build.`target`.channel)
 SELECT
-  channel,
-  MAX(app_version) AS latest_version
+  * EXCEPT (channel),
+  "*" AS channel
 FROM
-  transformed
-GROUP BY
-  channel
+  extracted

--- a/bigquery_etl/glam/templates/latest_versions_v1.sql
+++ b/bigquery_etl/glam/templates/latest_versions_v1.sql
@@ -6,6 +6,9 @@ WITH
     MAX(mozfun.norm.extract_version(build.`target`.version,
         'major')) AS latest_version,
   FROM
+  -- We use buildhub2 data for both Desktop and Android
+  -- because they roughly follow the same release schedule,
+  -- and we don't have a comprehensive source for Fenix releases yet.
     `moz-fx-data-shared-prod.telemetry.buildhub2`
   WHERE
     build.`source`.product = "firefox"


### PR DESCRIPTION
Okay, second (and hopefully final) attempt at trying to simplify the latest_version template.

In this change we're using `buildhub2` data to make sure no bad version data gets in again. Also, `@submission_date` is added to template so the query is idempotent per @akkomar's suggestion.

Also, channel value is always `*` (channel values are switched to * in Glean pipeline because channels are processed in separate tables).

I have tested this query with some sample data and it's working as expected.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
