### PR TITLE
Don't deduplicate query arguments

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -868,9 +868,8 @@ def _run_query(
             query_arguments.append("--use_legacy_sql=False")
 
         # this assumed query command should always be passed inside query_arguments
-        # also dedup the query_arguments in case the same option is passed multiple times.
         if "query" not in query_arguments:
-            query_arguments = ["query"] + list(set(query_arguments))
+            query_arguments = ["query"] + query_arguments
 
         # write rendered query to a temporary file;
         # query string cannot be passed directly to bq as SQL comments will be interpreted as CLI arguments


### PR DESCRIPTION
partially reverts #3922

query arguments are ordered, and can override previous flags. this behavior is sometimes used to override flags set in one place with flags set in another. `list(set(query_arguments))` will not only deduplicate, it will non-deterministically order the flags, and neither of those are safe things.

for example `bq query --use_legacy_sql=False --use_legacy_sql=True --use_legacy_sql=False` should behave as `bq query --use_legacy_sql=False`, but with `list(set(query_arguments))` it could do either one depending on when and where it's run.