### PR TITLE
Dryrun date param fixes

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -353,28 +353,28 @@ class DryRun:
             sql = self.content
         else:
             sql = self.get_sql()
-            if self.metadata:
-                # use metadata to rewrite date-type query params as submission_date
-                date_params = [
-                    query_param
-                    for query_param in (
-                        self.metadata.scheduling.get("date_partition_parameter"),
-                        *(
-                            param.split(":", 1)[0]
-                            for param in self.metadata.scheduling.get("parameters", [])
-                            if re.fullmatch(r"[^:]+:DATE:{{\s*ds\s*}}", param)
-                        ),
-                    )
-                    if query_param and query_param != "submission_date"
-                ]
-                if date_params:
-                    pattern = re.compile(
-                        "@("
-                        + "|".join(date_params)
-                        # match whole query parameter names
-                        + ")(?![a-zA-Z0-9_])"
-                    )
-                    sql = pattern.sub("@submission_date", sql)
+        if self.metadata:
+            # use metadata to rewrite date-type query params as submission_date
+            date_params = [
+                query_param
+                for query_param in (
+                    self.metadata.scheduling.get("date_partition_parameter"),
+                    *(
+                        param.split(":", 1)[0]
+                        for param in self.metadata.scheduling.get("parameters", [])
+                        if re.fullmatch(r"[^:]+:DATE:{{\s*ds\s*}}", param)
+                    ),
+                )
+                if query_param and query_param != "submission_date"
+            ]
+            if date_params:
+                pattern = re.compile(
+                    "@("
+                    + "|".join(date_params)
+                    # match whole query parameter names
+                    + ")(?![a-zA-Z0-9_])"
+                )
+                sql = pattern.sub("@submission_date", sql)
         dataset = basename(dirname(dirname(self.sqlfile)))
         try:
             if self.use_cloud_function:

--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -62,7 +62,7 @@ class Schema:
         query = f"SELECT * FROM `{project}.{dataset}.{table}`"
 
         if partitioned_by:
-            query += f" WHERE DATE({partitioned_by}) = DATE('2020-01-01')"
+            query += f" WHERE DATE(`{partitioned_by}`) = DATE('2020-01-01')"
 
         try:
             return cls(


### PR DESCRIPTION
* If SQL content is passed to dryrun we still need to rewrite date query parameters as `submission_date`, otherwise any such date parameters won't be found and the query will fail.
* The partition column name may be a reserved keyword, so it should be quoted.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
