### PR TITLE
Format Jinja blocks like SQL blocks

### DIFF
--- a/bigquery_etl/format_sql/tokenizer.py
+++ b/bigquery_etl/format_sql/tokenizer.py
@@ -761,6 +761,28 @@ class JinjaStatement(Token):
     pattern = re.compile(r"{%.*?%}", re.DOTALL)
 
 
+class JinjaBlockStatement(JinjaStatement):
+    """Statements that start and/or end Jinja blocks."""
+
+
+class JinjaBlockStart(JinjaBlockStatement):
+    """Jinja block starts get their own line followed by increased indent."""
+
+    pattern = re.compile(r"{% *(block|call|filter|for|if|macro)\b.*?%}", re.DOTALL)
+
+
+class JinjaBlockEnd(JinjaBlockStatement):
+    """Jinja block ends get their own line preceded by decreased indent."""
+
+    pattern = re.compile(r"{% *end(block|call|filter|for|if|macro)\b.*?%}", re.DOTALL)
+
+
+class JinjaBlockMiddle(JinjaBlockEnd, JinjaBlockStart):
+    """Ends one indented Jinja block and starts another."""
+
+    pattern = re.compile(r"{% *(elif|else)\b.*?%}", re.DOTALL)
+
+
 class JinjaComment(Token):
     """Jinja comment delimiters {# #}.
 
@@ -850,6 +872,9 @@ BIGQUERY_TOKEN_PRIORITY = [
     Whitespace,
     JinjaComment,
     JinjaExpression,
+    JinjaBlockStart,
+    JinjaBlockMiddle,
+    JinjaBlockEnd,
     JinjaStatement,
     MaybeCaseSubclause,
     CaseSubclause,

--- a/tests/format_sql/jinja_example/expect.sql
+++ b/tests/format_sql/jinja_example/expect.sql
@@ -1,11 +1,11 @@
 {% set options = ["a", "b", "c"] %}{# sample comment #}
 SELECT
   {% for option in options %}
-  {% if option == "a" %}
-  "option a" AS a,
-  {% else %}
-  "{{ option }}" AS {{ option }},
-  {% endif %}
+    {% if option == "a" %}
+      "option a" AS a,
+    {% else %}
+      "{{ option }}" AS {{ option }},
+    {% endif %}
   {% endfor %}
   test,{# another comment #}
   foo


### PR DESCRIPTION
Before:
```sql
WHERE
  {% if is_init() %}
  submission_date >= "2021-08-01" {% else %}
  submission_date = @submission_date {% endif %}
```

After:
```sql
WHERE
  {% if is_init() %}
    submission_date >= "2021-08-01"
  {% else %}
    submission_date = @submission_date
  {% endif %}
```

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
