### PR TITLE
DS-2965 Update UDF get_earliest_value()

### DIFF
--- a/sql/moz-fx-data-marketing-prod/ga_derived/downloads_with_attribution_v2/checks.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/downloads_with_attribution_v2/checks.sql
@@ -1,2 +1,12 @@
-ASSERT((SELECT COUNT(*) FROM `{{project_id}}.{{dataset_id}}.{{table_name}}` WHERE download_date = @download_date) > 250000)
-AS 'ETL Data Check Failed: Table {{project_id}}.{{dataset_id}}.{{table_name}} contains less than 250,000 rows for date: {{ download_date }}.'
+ASSERT(
+  (
+    SELECT
+      COUNT(*)
+    FROM
+      `{{project_id}}.{{dataset_id}}.{{table_name}}`
+    WHERE
+      download_date = @download_date
+  ) > 250000
+)
+AS
+  'ETL Data Check Failed: Table {{project_id}}.{{dataset_id}}.{{table_name}} contains less than 250,000 rows for date: {{ download_date }}.'

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/init.sql
@@ -221,24 +221,24 @@ SELECT
     DATE(first_session.min_submission_datetime) AS min_first_session_ping_submission_date,
     DATE(first_session.first_run_datetime) AS min_first_session_ping_run_date,
     DATE(metrics.min_submission_datetime) AS min_metrics_ping_submission_date,
-    CASE
-      mozfun.norm.get_earliest_value(
-        [
-          (
-            STRUCT(
-              CAST(first_session.adjust_network AS STRING),
-              first_session.min_submission_datetime
-            )
-          ),
-          (STRUCT(CAST(metrics.adjust_network AS STRING), metrics.min_submission_datetime))
-        ]
-      )
-      WHEN STRUCT(first_session.adjust_network, first_session.min_submission_datetime)
-        THEN 'first_session'
-      WHEN STRUCT(metrics.adjust_network, metrics.min_submission_datetime)
-        THEN 'metrics'
-      ELSE NULL
-    END AS adjust_network__source_ping,
+    mozfun.norm.get_earliest_value(
+      [
+        (
+          STRUCT(
+            CAST(first_session.adjust_network AS STRING),
+            'first_session_ping',
+            first_session.min_submission_datetime
+          )
+        ),
+        (
+          STRUCT(
+            CAST(metrics.adjust_network AS STRING),
+            'metrics_ping',
+            metrics.min_submission_datetime
+          )
+        )
+      ]
+    ).earliest_value_source AS adjust_network__source_ping,
     CASE
       WHEN metrics.install_source IS NOT NULL
         THEN 'metrics'
@@ -249,10 +249,17 @@ SELECT
         (
           STRUCT(
             CAST(first_session.adjust_network AS STRING),
+            'first_session_ping',
             first_session.min_submission_datetime
           )
         ),
-        (STRUCT(CAST(metrics.adjust_network AS STRING), metrics.min_submission_datetime))
+        (
+          STRUCT(
+            CAST(metrics.adjust_network AS STRING),
+            'metrics_ping',
+            metrics.min_submission_datetime
+          )
+        )
       ]
     ).earliest_date AS adjust_network__source_ping_datetime,
     CASE

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
@@ -201,24 +201,24 @@ _current AS (
       DATE(first_session.min_submission_datetime) AS min_first_session_ping_submission_date,
       DATE(first_session.first_run_datetime) AS min_first_session_ping_run_date,
       DATE(metrics.min_submission_datetime) AS min_metrics_ping_submission_date,
-      CASE
-        mozfun.norm.get_earliest_value(
-          [
-            (
-              STRUCT(
-                CAST(first_session.adjust_network AS STRING),
-                first_session.min_submission_datetime
-              )
-            ),
-            (STRUCT(CAST(metrics.adjust_network AS STRING), metrics.min_submission_datetime))
-          ]
-        )
-        WHEN STRUCT(first_session.adjust_network, first_session.min_submission_datetime)
-          THEN 'first_session'
-        WHEN STRUCT(metrics.adjust_network, metrics.min_submission_datetime)
-          THEN 'metrics'
-        ELSE NULL
-      END AS adjust_network__source_ping,
+      mozfun.norm.get_earliest_value(
+        [
+          (
+            STRUCT(
+              CAST(first_session.adjust_network AS STRING),
+              'first_session_ping',
+              first_session.min_submission_datetime
+            )
+          ),
+          (
+            STRUCT(
+              CAST(metrics.adjust_network AS STRING),
+              'metrics_ping',
+              metrics.min_submission_datetime
+            )
+          )
+        ]
+      ).earliest_value_source AS adjust_network__source_ping,
       CASE
         WHEN metrics.install_source IS NOT NULL
           THEN 'metrics'
@@ -229,10 +229,17 @@ _current AS (
           (
             STRUCT(
               CAST(first_session.adjust_network AS STRING),
+              'first_session_ping',
               first_session.min_submission_datetime
             )
           ),
-          (STRUCT(CAST(metrics.adjust_network AS STRING), metrics.min_submission_datetime))
+          (
+            STRUCT(
+              CAST(metrics.adjust_network AS STRING),
+              'metrics_ping',
+              metrics.min_submission_datetime
+            )
+          )
         ]
       ).earliest_date AS adjust_network__source_ping_datetime,
       CASE

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
@@ -206,14 +206,14 @@ _current AS (
           (
             STRUCT(
               CAST(first_session.adjust_network AS STRING),
-              'first_session_ping',
+              'first_session',
               first_session.min_submission_datetime
             )
           ),
           (
             STRUCT(
               CAST(metrics.adjust_network AS STRING),
-              'metrics_ping',
+              'metrics',
               metrics.min_submission_datetime
             )
           )
@@ -229,14 +229,14 @@ _current AS (
           (
             STRUCT(
               CAST(first_session.adjust_network AS STRING),
-              'first_session_ping',
+              'first_session',
               first_session.min_submission_datetime
             )
           ),
           (
             STRUCT(
               CAST(metrics.adjust_network AS STRING),
-              'metrics_ping',
+              'metrics',
               metrics.min_submission_datetime
             )
           )

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/schema.yaml
@@ -76,6 +76,42 @@ fields:
   mode: NULLABLE
   name: install_source
   type: STRING
+- description: Last reported client locale.
+  mode: NULLABLE
+  name: last_reported_locale
+  type: STRING
+- description: Last reported client device manufacturer.
+  mode: NULLABLE
+  name: last_reported_device_manufacturer
+  type: STRING
+- description: Last reported client device model.
+  mode: NULLABLE
+  name: last_reported_device_model
+  type: STRING
+- description: Last reported client country.
+  mode: NULLABLE
+  name: last_reported_country
+  type: STRING
+- description: Last date client seen.
+  mode: NULLABLE
+  name: last_reported_date
+  type: DATE
+- description: Last reported client campaign network.
+  mode: NULLABLE
+  name: last_reported_adjust_network
+  type: STRING
+- description: Last reported campaign name.
+  mode: NULLABLE
+  name: last_reported_adjust_creative
+  type: STRING
+- description: Last reported campaign ad group.
+  mode: NULLABLE
+  name: last_reported_adjust_ad_group
+  type: STRING
+- description: Last reported campaign name.
+  mode: NULLABLE
+  name: last_reported_adjust_campaign
+  type: STRING
 - fields:
   - description: True if the client ever reported a first_session ping.
     mode: NULLABLE
@@ -117,39 +153,3 @@ fields:
   mode: NULLABLE
   name: metadata
   type: RECORD
-- description: Last reported client locale.
-  mode: NULLABLE
-  name: last_reported_locale
-  type: STRING
-- description: Last reported client device manufacturer.
-  mode: NULLABLE
-  name: last_reported_device_manufacturer
-  type: STRING
-- description: Last reported client device model.
-  mode: NULLABLE
-  name: last_reported_device_model
-  type: STRING
-- description: Last reported client country.
-  mode: NULLABLE
-  name: last_reported_country
-  type: STRING
-- description: Last date client seen.
-  mode: NULLABLE
-  name: last_reported_date
-  type: DATE
-- description: Last reported client campaign network.
-  mode: NULLABLE
-  name: last_reported_adjust_network
-  type: STRING
-- description: Last reported campaign name.
-  mode: NULLABLE
-  name: last_reported_adjust_creative
-  type: STRING
-- description: Last reported campaign ad group.
-  mode: NULLABLE
-  name: last_reported_adjust_ad_group
-  type: STRING
-- description: Last reported campaign name.
-  mode: NULLABLE
-  name: last_reported_adjust_campaign
-  type: STRING

--- a/sql/moz-fx-data-shared-prod/firefox_ios/ad_activation_performance/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/ad_activation_performance/view.sql
@@ -53,4 +53,6 @@ FROM
   ad_stats
 INNER JOIN
   client_activation_per_campaign
-  ON ad_stats.date_day = client_activation_per_campaign.first_seen_date AND ad_stats.campaign_id = client_activation_per_campaign.campaign_id
+ON
+  ad_stats.date_day = client_activation_per_campaign.first_seen_date
+  AND ad_stats.campaign_id = client_activation_per_campaign.campaign_id

--- a/sql/mozfun/norm/get_earliest_value/README.md
+++ b/sql/mozfun/norm/get_earliest_value/README.md
@@ -2,5 +2,5 @@ Usage:
 
 ```sql
 SELECT
-   mozfun.norm.get_earliest_value(ARRAY<STRUCT<value STRING, value_source STRING, value_datetime DATETIME>>) AS <alias>
+   mozfun.norm.get_earliest_value(ARRAY<STRUCT<value STRING, value_source STRING, value_date DATETIME>>) AS <alias>
 ```

--- a/sql/mozfun/norm/get_earliest_value/README.md
+++ b/sql/mozfun/norm/get_earliest_value/README.md
@@ -2,5 +2,5 @@ Usage:
 
 ```sql
 SELECT
-   mozfun.norm.get_earliest_value(ARRAY<STRUCT<value STRING, value_date DATETIME>>) AS <alias>
+   mozfun.norm.get_earliest_value(ARRAY<STRUCT<value STRING, value_source STRING, value_datetime DATETIME>>) AS <alias>
 ```

--- a/sql/mozfun/norm/get_earliest_value/metadata.yaml
+++ b/sql/mozfun/norm/get_earliest_value/metadata.yaml
@@ -1,9 +1,9 @@
 friendly_name: Get Earliest Value
 description: |
-  This UDF returns the earliest not-null value from a list of values
-  and their corresponding timestamp.
+  This UDF returns the earliest not-null value pair and datetime
+  from a list of values and their corresponding timestamp.
 
-  The function will return the first value in the input array,
+  The function will return the first value pair in the input array,
   that is not null and has the earliest timestamp.
 
   Because there may be more than one value on the same date e.g. more

--- a/sql/mozfun/norm/get_earliest_value/udf.sql
+++ b/sql/mozfun/norm/get_earliest_value/udf.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION norm.get_earliest_value(
-  value_set ARRAY<STRUCT<value STRING, value_date DATETIME>>
+  value_set ARRAY<STRUCT<value STRING, value_source STRING, value_date DATETIME>>
 )
-RETURNS STRUCT<earliest_value STRING, earliest_date DATETIME> AS (
+RETURNS STRUCT<earliest_value STRING, earliest_value_source STRING, earliest_date DATETIME> AS (
   (
     WITH unnested AS (
       SELECT
@@ -13,7 +13,7 @@ RETURNS STRUCT<earliest_value STRING, earliest_date DATETIME> AS (
         offset ASC
     )
     SELECT
-      ARRAY_AGG(STRUCT(value, value_date) ORDER BY value_date ASC)[SAFE_OFFSET(0)]
+      ARRAY_AGG(STRUCT(value, value_source, value_date) ORDER BY value_date ASC)[SAFE_OFFSET(0)]
     FROM
       unnested
     WHERE
@@ -26,40 +26,82 @@ RETURNS STRUCT<earliest_value STRING, earliest_date DATETIME> AS (
 SELECT
   assert.equals(
     STRUCT(
-      CAST('metrics' AS STRING) AS earliest_value,
+      'XYZ' AS earliest_value,
+      'metrics_ping' AS earliest_value_source,
       DATETIME('2021-12-12T11:45:00') AS earliest_date
     ),
     norm.get_earliest_value(
       [
-        (STRUCT(CAST(NULL AS STRING), DATETIME('2022-01-01 12:00:00'))),
-        (STRUCT(CAST('first_session' AS STRING), DATETIME('2022-01-01 11:55:00'))),
-        (STRUCT(CAST('metrics' AS STRING), DATETIME('2021-12-12 11:45:00')))
+        (STRUCT(CAST(NULL AS STRING), CAST(NULL AS STRING), DATETIME('2021-11-01 12:00:00'))),
+        (
+          STRUCT(
+            CAST('MYN' AS STRING),
+            CAST('first_session_ping' AS STRING),
+            DATETIME('2022-01-01 11:55:00')
+          )
+        ),
+        (
+          STRUCT(
+            CAST('XYZ' AS STRING),
+            CAST('metrics_ping' AS STRING),
+            DATETIME('2021-12-12 11:45:00')
+          )
+        )
       ]
     )
   ),
   assert.equals(
     STRUCT(
-      CAST('existing' AS STRING) AS earliest_value,
+      'keep' AS earliest_value,
+      'main_ping' AS earliest_value_source,
       DATETIME('2019-01-01T12:00:00') AS earliest_date
     ),
     norm.get_earliest_value(
       [
-        (STRUCT(CAST('existing' AS STRING), DATETIME('2019-01-01 12:00:00'))),
-        (STRUCT(CAST('metrics' AS STRING), NULL)),
-        (STRUCT(CAST('first_session' AS STRING), DATETIME('2021-12-12 12:00:00')))
+        (STRUCT(CAST('keep' AS STRING), 'main_ping', DATETIME('2019-01-01 12:00:00'))),
+        (STRUCT(CAST('remove' AS STRING), CAST(NULL AS STRING), CAST(NULL AS DATETIME))),
+        (STRUCT(CAST('rewrite' AS STRING), 'shutdown_ping', DATETIME('2021-12-12 12:00:00')))
       ]
     )
   ),
   assert.equals(
     STRUCT(
-      CAST('first_session' AS STRING) AS earliest_value,
+      CAST('2022-12-12' AS STRING) AS earliest_value,
+      'first_session' AS earliest_value_source,
       DATETIME('2022-12-12T11:45:00') AS earliest_date
     ),
     norm.get_earliest_value(
       [
-        (STRUCT(CAST(NULL AS STRING), DATETIME('2022-12-12 12:00:00'))),
-        (STRUCT(CAST('first_session' AS STRING), DATETIME('2022-12-12 11:45:00'))),
-        (STRUCT(CAST('metrics' AS STRING), DATETIME('2022-12-12 11:46:00')))
+        (
+          STRUCT(
+            CAST('2022-12-12' AS STRING),
+            CAST(NULL AS STRING),
+            DATETIME('2022-12-12 12:00:00')
+          )
+        ),
+        (
+          STRUCT(
+            CAST('2022-12-12' AS STRING),
+            CAST('first_session' AS STRING),
+            DATETIME('2022-12-12 11:45:00')
+          )
+        ),
+        (
+          STRUCT(
+            CAST('2022-12-12' AS STRING),
+            CAST('metrics' AS STRING),
+            DATETIME('2022-12-12 11:46:00')
+          )
+        )
+      ]
+    )
+  ),
+  assert.null(
+    norm.get_earliest_value(
+      [
+        (STRUCT(CAST('ABC' AS STRING), CAST(NULL AS STRING), CAST(NULL AS DATETIME))),
+        (STRUCT(CAST('DEF' AS STRING), CAST(NULL AS STRING), CAST(NULL AS DATETIME))),
+        (STRUCT(CAST('GHI' AS STRING), CAST(NULL AS STRING), CAST(NULL AS DATETIME)))
       ]
     )
   )


### PR DESCRIPTION
This PR updates the UDF `get_earliest_value()` to facilitate the implementation of the new profiles re-definition. 
Jira [DS-2965](https://mozilla-hub.atlassian.net/browse/DS-2965).

It also reduce the lines and complexity required to retrieve earliest ping.

> Note for the reviewer. Many files are reformatted to pass the CI. The files directly affected by the change are under fenix_derived/firefox_android_clients_v1 and mozfun/norm/get_earliest_value. 


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DS-2965]: https://mozilla-hub.atlassian.net/browse/DS-2965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ