### PR TITLE
bug(1838605): updated clients_histogram_aggregates_v2 histogram_aggregates.aggregates type

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_aggregates_v2/schema.yaml
@@ -71,7 +71,7 @@ fields:
     - mode: NULLABLE
       name: value
       type: INTEGER
-    mode: NULLABLE
+    mode: REPEATED
     name: aggregates
     type: RECORD
   mode: REPEATED


### PR DESCRIPTION
# bug(1838605): updated clients_histogram_aggregates_v2 histogram_aggregates.aggregates type

The field type has been updated from NULLABLE to REPEATED to match the table schema inside BQ.

Error we currently see inside `bqetl_artifact_deployment`:

```
google.api_core.exceptions.BadRequest: 400 PATCH https://bigquery.googleapis.com/bigquery/v2/projects/moz-fx-data-shared-prod/datasets/telemetry_derived/tables/clients_histogram_aggregates_v2?prettyPrint=false: Provided Schema does not match Table moz-fx-data-shared-prod:telemetry_derived.clients_histogram_aggregates_v2. Field histogram_aggregates.aggregates has changed mode from REPEATED to NULLABLE
```
