### PR TITLE
DS 2965 Follow up UDF get_earliest_value()

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/init.sql
@@ -227,14 +227,14 @@ SELECT
           STRUCT(
             CAST(first_session.adjust_network AS STRING),
             'first_session_ping',
-            first_session.min_submission_datetime
+            DATETIME(first_session.min_submission_datetime)
           )
         ),
         (
           STRUCT(
             CAST(metrics.adjust_network AS STRING),
             'metrics_ping',
-            metrics.min_submission_datetime
+            DATETIME(metrics.min_submission_datetime)
           )
         )
       ]
@@ -250,14 +250,14 @@ SELECT
           STRUCT(
             CAST(first_session.adjust_network AS STRING),
             'first_session_ping',
-            first_session.min_submission_datetime
+            DATETIME(first_session.min_submission_datetime)
           )
         ),
         (
           STRUCT(
             CAST(metrics.adjust_network AS STRING),
             'metrics_ping',
-            metrics.min_submission_datetime
+            DATETIME(metrics.min_submission_datetime)
           )
         )
       ]

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
@@ -207,14 +207,14 @@ _current AS (
             STRUCT(
               CAST(first_session.adjust_network AS STRING),
               'first_session',
-              first_session.min_submission_datetime
+              DATETIME(first_session.min_submission_datetime)
             )
           ),
           (
             STRUCT(
               CAST(metrics.adjust_network AS STRING),
               'metrics',
-              metrics.min_submission_datetime
+              DATETIME(metrics.min_submission_datetime)
             )
           )
         ]
@@ -230,14 +230,14 @@ _current AS (
             STRUCT(
               CAST(first_session.adjust_network AS STRING),
               'first_session',
-              first_session.min_submission_datetime
+              DATETIME(first_session.min_submission_datetime)
             )
           ),
           (
             STRUCT(
               CAST(metrics.adjust_network AS STRING),
               'metrics',
-              metrics.min_submission_datetime
+              DATETIME(metrics.min_submission_datetime)
             )
           )
         ]

--- a/sql/mozfun/norm/get_earliest_value/udf.sql
+++ b/sql/mozfun/norm/get_earliest_value/udf.sql
@@ -96,6 +96,38 @@ SELECT
       ]
     )
   ),
+  assert.equals(
+    STRUCT(
+      CAST('2022-12-13' AS STRING) AS earliest_value,
+      'first_session' AS earliest_value_source,
+      DATETIME('2022-12-13T00:00:00') AS earliest_date
+    ),
+    norm.get_earliest_value(
+      [
+        (
+          STRUCT(
+            CAST('2022-12-14' AS STRING),
+            CAST(NULL AS STRING),
+            DATETIME('2022-12-14')
+          )
+        ),
+        (
+          STRUCT(
+            CAST('2022-12-13' AS STRING),
+            CAST('first_session' AS STRING),
+            DATETIME('2022-12-13')
+          )
+        ),
+        (
+          STRUCT(
+            CAST('2022-12-13' AS STRING),
+            CAST('abc' AS STRING),
+            DATETIME('2022-12-13')
+          )
+        )
+      ]
+    )
+  ),
   assert.null(
     norm.get_earliest_value(
       [


### PR DESCRIPTION
UDF norm.get_earliest_value requires a DATETIME for the third parameter.  This PR updates the usage of this UDF to retrieve a DATETIME, and adds a test case.

