### PR TITLE
[Bug 1821767] Speed up table deploys and schema updates

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -3,6 +3,7 @@
 import copy
 import datetime
 import logging
+import multiprocessing
 import os
 import re
 import string
@@ -12,7 +13,6 @@ import tempfile
 import typing
 from datetime import date, timedelta
 from functools import partial
-from graphlib import TopologicalSorter
 from multiprocessing.pool import Pool, ThreadPool
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -59,6 +59,7 @@ from ..util import extract_from_query_path
 from ..util.bigquery_id import sql_table_id
 from ..util.common import random_str
 from ..util.common import render as render_template
+from ..util.parallel_topological_sorter import ParallelTopologicalSorter
 from .dryrun import dryrun
 from .generate import generate_all
 
@@ -1388,6 +1389,7 @@ def schema():
 )
 @use_cloud_function_option
 @respect_dryrun_skip_option(default=True)
+@parallelism_option
 def update(
     name,
     sql_dir,
@@ -1396,6 +1398,7 @@ def update(
     tmp_dataset,
     use_cloud_function,
     respect_dryrun_skip,
+    parallelism,
 ):
     """CLI command for generating the query schema."""
     if not is_authenticated():
@@ -1408,7 +1411,8 @@ def update(
         name, sql_dir, project_id, files=["query.sql"]
     )
     dependency_graph = get_dependency_graph([sql_dir], without_views=True)
-    tmp_tables = {}
+    manager = multiprocessing.Manager()
+    tmp_tables = manager.dict({})
 
     # order query files to make sure derived_from dependencies are resolved
     query_file_graph = {}
@@ -1431,65 +1435,90 @@ def update(
         except FileNotFoundError:
             query_file_graph[query_file] = []
 
-    ts = TopologicalSorter(query_file_graph)
-    query_files_ordered = ts.static_order()
-
-    for query_file in query_files_ordered:
-        try:
-            changed = _update_query_schema(
-                query_file,
-                sql_dir,
-                project_id,
-                tmp_dataset,
-                tmp_tables,
-                use_cloud_function,
-                respect_dryrun_skip,
-            )
-
-            if update_downstream:
-                # update downstream dependencies
-                if changed:
-                    if not is_authenticated():
-                        click.echo(
-                            "Cannot update downstream dependencies."
-                            "Authentication to GCP required. Run `gcloud auth login` "
-                            "and check that the project is set correctly."
-                        )
-                        sys.exit(1)
-
-                    project, dataset, table = extract_from_query_path(query_file)
-                    identifier = f"{project}.{dataset}.{table}"
-                    tmp_identifier = f"{project}.{tmp_dataset}.{table}_{random_str(12)}"
-
-                    # create temporary table with updated schema
-                    if identifier not in tmp_tables:
-                        schema = Schema.from_schema_file(
-                            query_file.parent / SCHEMA_FILE
-                        )
-                        schema.deploy(tmp_identifier)
-                        tmp_tables[identifier] = tmp_identifier
-
-                    # get downstream dependencies that will be updated in the next iteration
-                    dependencies = [
-                        p
-                        for k, refs in dependency_graph.items()
-                        for p in paths_matching_name_pattern(
-                            k, sql_dir, project_id, files=("query.sql",)
-                        )
-                        if identifier in refs
-                    ]
-
-                    for d in dependencies:
-                        click.echo(f"Update downstream dependency schema for {d}")
-                        query_files_ordered.append(d)
-        except Exception:
-            print_exc()
+    ts = ParallelTopologicalSorter(
+        query_file_graph, parallelism=parallelism, with_follow_up=update_downstream
+    )
+    ts.map(
+        partial(
+            _update_query_schema_with_downstream,
+            sql_dir,
+            project_id,
+            tmp_dataset,
+            dependency_graph,
+            tmp_tables,
+            use_cloud_function,
+            respect_dryrun_skip,
+            update_downstream,
+        )
+    )
 
     if len(tmp_tables) > 0:
         client = bigquery.Client()
         # delete temporary tables
         for _, table in tmp_tables.items():
             client.delete_table(table, not_found_ok=True)
+
+
+def _update_query_schema_with_downstream(
+    sql_dir,
+    project_id,
+    tmp_dataset,
+    dependency_graph,
+    tmp_tables={},
+    use_cloud_function=True,
+    respect_dryrun_skip=True,
+    update_downstream=False,
+    query_file=None,
+    follow_up_queue=None,
+):
+    try:
+        changed = _update_query_schema(
+            query_file,
+            sql_dir,
+            project_id,
+            tmp_dataset,
+            tmp_tables,
+            use_cloud_function,
+            respect_dryrun_skip,
+        )
+
+        if update_downstream:
+            # update downstream dependencies
+            if changed:
+                if not is_authenticated():
+                    click.echo(
+                        "Cannot update downstream dependencies."
+                        "Authentication to GCP required. Run `gcloud auth login` "
+                        "and check that the project is set correctly."
+                    )
+                    sys.exit(1)
+
+                project, dataset, table = extract_from_query_path(query_file)
+                identifier = f"{project}.{dataset}.{table}"
+                tmp_identifier = f"{project}.{tmp_dataset}.{table}_{random_str(12)}"
+
+                # create temporary table with updated schema
+                if identifier not in tmp_tables:
+                    schema = Schema.from_schema_file(query_file.parent / SCHEMA_FILE)
+                    schema.deploy(tmp_identifier)
+                    tmp_tables[identifier] = tmp_identifier
+
+                # get downstream dependencies that will be updated in the next iteration
+                dependencies = [
+                    p
+                    for k, refs in dependency_graph.items()
+                    for p in paths_matching_name_pattern(
+                        k, sql_dir, project_id, files=("query.sql",)
+                    )
+                    if identifier in refs
+                ]
+
+                for d in dependencies:
+                    click.echo(f"Update downstream dependency schema for {d}")
+                    if follow_up_queue:
+                        follow_up_queue.put(d)
+    except Exception:
+        print_exc()
 
 
 def _update_query_schema(

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1481,7 +1481,7 @@ def update(
 
                     for d in dependencies:
                         click.echo(f"Update downstream dependency schema for {d}")
-                        query_files.append(d)
+                        query_files_ordered.append(d)
         except Exception:
             print_exc()
 

--- a/bigquery_etl/util/parallel_topological_sorter.py
+++ b/bigquery_etl/util/parallel_topological_sorter.py
@@ -1,0 +1,90 @@
+"""Threaded TopologialSorter."""
+
+import multiprocessing
+import queue
+from copy import deepcopy
+from graphlib import TopologicalSorter
+from typing import Dict, Set
+
+
+class ParallelTopologicalSorter:
+    """TopologicalSorter that processes sorted items concurrently."""
+
+    def __init__(
+        self,
+        dependencies: Dict[str, Set[str]],
+        parallelism: int = 8,
+        with_follow_up=False,
+    ):
+        """Initialize."""
+        self.dependencies = deepcopy(dependencies)
+        self.parallelism = parallelism
+
+        manager = multiprocessing.Manager()
+        self.visited = manager.dict({dep: False for dep, _ in dependencies.items()})
+        self.with_follow_up = with_follow_up
+
+    def _worker(
+        self, task_queue, finalized_tasks_queue, followup_queue, visited_map, callback
+    ):
+        while True:
+            item = task_queue.get()
+            callback(item, followup_queue)
+            if item in visited_map:
+                visited_map[item] = True
+            finalized_tasks_queue.put(item)
+            task_queue.task_done()
+
+    def map(self, callback):
+        """Sort and process dependencies."""
+        task_queue = multiprocessing.JoinableQueue()
+        finalized_tasks_queue = multiprocessing.JoinableQueue()
+        processes = []
+
+        if self.with_follow_up:
+            followup_queue = queue.Queue()
+        else:
+            followup_queue = None
+
+        for _ in range(self.parallelism):
+            process = multiprocessing.Process(
+                target=self._worker,
+                args=(
+                    task_queue,
+                    finalized_tasks_queue,
+                    followup_queue,
+                    self.visited,
+                    callback,
+                ),
+                daemon=True,
+            )
+            process.start()
+            processes.append(process)
+
+        # pallel sorting and processing
+        ts = TopologicalSorter(self.dependencies)
+        ts.prepare()
+
+        while ts.is_active():
+            # queue task to process
+            for task in ts.get_ready():
+                task_queue.put(task)
+
+            # task done
+            task = finalized_tasks_queue.get()
+            ts.done(task)
+            finalized_tasks_queue.task_done()
+
+            # add follow up tasks to be processed
+            if followup_queue:
+                while not followup_queue.empty():
+                    follow_up_item = followup_queue.get()
+                    ts.add(follow_up_item)
+                    self.visited[follow_up_item] = False
+
+        task_queue.join()
+        finalized_tasks_queue.join()
+
+        # check that all dependencies have been processed
+        for task, _ in self.visited.items():
+            assert self.visited[task]

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
@@ -14,7 +14,7 @@ owners:
 labels:
   application: firefox
   schedule: daily
-  owner1: dthorn
+  owner: dthorn
 scheduling:
   dag_name: bqetl_main_summary
   start_date: '2019-11-05'

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
@@ -14,6 +14,7 @@ owners:
 labels:
   application: firefox
   schedule: daily
+  owner1: dthorn
 scheduling:
   dag_name: bqetl_main_summary
   start_date: '2019-11-05'


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1821767

Deploying tables takes around 45 minutes at the moment. Most time is spent updating table/query schemas, which is currently done sequentially. The order of how schemas are updated is important due to dependencies between queries. To get the right order, we have been using `TopologialSorter`. 

This PR, uses still keeps using `TopologialSorter` but processes queries as they get sorted in parallel. 

Updating schemas in `moz-fx-shared-prod` alone took around 30min. With this change it took around 8min running locally.

This PR will not only speed up the nightly table deploys, but also the stage deploy CI task in bigquery-etl.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
