### PR TITLE
Exclude FxA token columns from `mozilla_vpn_external.users_v1`

### DIFF
--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -617,7 +617,7 @@ with DAG(
         date_partition_parameter=None,
         depends_on_past=True,
         parameters=[
-            "external_database_query:STRING: SELECT\n  id,\n  email,\n  fxa_uid,\n  fxa_access_token,\n  fxa_refresh_token,\n  fxa_profile_json,\n  created_at,\n  updated_at,\n  display_name,\n  avatar\nFROM users WHERE DATE(updated_at) = DATE '{{ds}}'"
+            "external_database_query:STRING: SELECT\n  id,\n  email,\n  fxa_uid,\n  fxa_profile_json,\n  created_at,\n  updated_at,\n  display_name,\n  avatar\nFROM users WHERE DATE(updated_at) = DATE '{{ds}}'"
         ],
     )
 

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/init.sql
@@ -13,8 +13,6 @@ FROM
       id,
       email,
       fxa_uid,
-      fxa_access_token,
-      fxa_refresh_token,
       fxa_profile_json,
       created_at,
       updated_at,

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/metadata.yaml
@@ -29,8 +29,6 @@ scheduling:
         id,
         email,
         fxa_uid,
-        fxa_access_token,
-        fxa_refresh_token,
         fxa_profile_json,
         created_at,
         updated_at,

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_external/users_v1/schema.yaml
@@ -8,12 +8,6 @@ fields:
 - name: fxa_uid
   type: STRING
   mode: NULLABLE
-- name: fxa_access_token
-  type: STRING
-  mode: NULLABLE
-- name: fxa_refresh_token
-  type: STRING
-  mode: NULLABLE
 - name: fxa_profile_json
   type: STRING
   mode: NULLABLE


### PR DESCRIPTION
The FxA token columns aren't needed here, and contain sensitive authentication data.

Since the `mozilla_vpn_external.users_v1` ETL is self-referential, before merging this PR I will manually overwrite the table using the following query:
```sql
SELECT
  * EXCEPT (
    fxa_access_token,
    fxa_refresh_token
  )
FROM
  `moz-fx-data-shared-prod.mozilla_vpn_external.users_v1`
```

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1044)
