### PR TITLE
Populate all columns in `firefox_accounts_derived.funnel_events_source_v1`

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_all_events/view.sql
@@ -136,6 +136,7 @@ unioned AS (
 SELECT
   `timestamp`,
   receiveTimestamp,
+  logger,
   fxa_log,
   event_type,
   user_id,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/funnel_events_source_v1/query.sql
@@ -1,24 +1,3 @@
-WITH fxa_events AS (
-  SELECT
-    `timestamp`,
-    user_id,
-    event_type,
-    service,
-    email_type,
-    oauth_client_id,
-    connect_device_flow,
-    connect_device_os,
-    sync_device_count,
-    email_sender,
-    email_service,
-    email_template,
-    email_version,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
-  WHERE
-    DATE(`timestamp`) = @submission_date
-    AND fxa_log IN ('content', 'auth', 'oauth')
-)
 SELECT
   DATE(`timestamp`) AS submission_date,
   user_id AS client_id,
@@ -38,6 +17,42 @@ SELECT
     STRUCT('email_version' AS key, email_version AS value)
   ] AS extra,
   CAST([] AS ARRAY<STRUCT<key STRING, value STRING>>) AS experiments,
-  *,
+  logger,
+  event_type,
+  app_version,
+  os_name,
+  os_version,
+  country,
+  `language`,
+  user_id,
+  device_id,
+  `timestamp`,
+  receiveTimestamp,
+  utm_term,
+  utm_source,
+  utm_medium,
+  utm_campaign,
+  utm_content,
+  ua_version,
+  ua_browser,
+  entrypoint,
+  flow_id,
+  service,
+  email_type,
+  email_provider,
+  oauth_client_id,
+  connect_device_flow,
+  connect_device_os,
+  sync_device_count,
+  sync_active_devices_day,
+  sync_active_devices_week,
+  sync_active_devices_month,
+  email_sender,
+  email_service,
+  email_template,
+  email_version,
 FROM
-  fxa_events
+  `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
+WHERE
+  DATE(`timestamp`) = @submission_date
+  AND fxa_log IN ('content', 'auth', 'oauth')

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/schema.yaml
@@ -1,0 +1,511 @@
+fields:
+- name: logName
+  type: STRING
+  mode: NULLABLE
+- name: resource
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: type
+    type: STRING
+    mode: NULLABLE
+  - name: labels
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: instance_id
+      type: STRING
+      mode: NULLABLE
+    - name: project_id
+      type: STRING
+      mode: NULLABLE
+    - name: zone
+      type: STRING
+      mode: NULLABLE
+- name: textPayload
+  type: STRING
+  mode: NULLABLE
+- name: jsonPayload
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: type
+    type: STRING
+    mode: NULLABLE
+  - name: pid
+    type: FLOAT
+    mode: NULLABLE
+  - name: logger
+    type: STRING
+    mode: NULLABLE
+  - name: timestamp
+    type: FLOAT
+    mode: NULLABLE
+  - name: severity
+    type: FLOAT
+    mode: NULLABLE
+  - name: envversion
+    type: STRING
+    mode: NULLABLE
+  - name: fields
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: op
+      type: STRING
+      mode: NULLABLE
+    - name: os_version
+      type: STRING
+      mode: NULLABLE
+    - name: event_properties
+      type: STRING
+      mode: NULLABLE
+    - name: event_type
+      type: STRING
+      mode: NULLABLE
+    - name: country
+      type: STRING
+      mode: NULLABLE
+    - name: os_name
+      type: STRING
+      mode: NULLABLE
+    - name: time
+      type: FLOAT
+      mode: NULLABLE
+    - name: language
+      type: STRING
+      mode: NULLABLE
+    - name: user_properties
+      type: STRING
+      mode: NULLABLE
+    - name: session_id
+      type: FLOAT
+      mode: NULLABLE
+    - name: region
+      type: STRING
+      mode: NULLABLE
+    - name: app_version
+      type: STRING
+      mode: NULLABLE
+    - name: device_model
+      type: STRING
+      mode: NULLABLE
+    - name: err
+      type: STRING
+      mode: NULLABLE
+    - name: method
+      type: STRING
+      mode: NULLABLE
+    - name: path
+      type: STRING
+      mode: NULLABLE
+    - name: clientaddress
+      type: STRING
+      mode: NULLABLE
+    - name: remoteaddresschain
+      type: STRING
+      mode: NULLABLE
+    - name: useragent
+      type: STRING
+      mode: NULLABLE
+    - name: status
+      type: STRING
+      mode: NULLABLE
+    - name: t
+      type: STRING
+      mode: NULLABLE
+    - name: contentlength
+      type: STRING
+      mode: NULLABLE
+    - name: referer
+      type: STRING
+      mode: NULLABLE
+    - name: violated
+      type: STRING
+      mode: NULLABLE
+    - name: agent
+      type: STRING
+      mode: NULLABLE
+    - name: source
+      type: STRING
+      mode: NULLABLE
+    - name: line
+      type: FLOAT
+      mode: NULLABLE
+    - name: blocked
+      type: STRING
+      mode: NULLABLE
+    - name: column
+      type: FLOAT
+      mode: NULLABLE
+    - name: referrer
+      type: STRING
+      mode: NULLABLE
+    - name: sample
+      type: STRING
+      mode: NULLABLE
+    - name: msg
+      type: STRING
+      mode: NULLABLE
+    - name: error
+      type: STRING
+      mode: NULLABLE
+    - name: stack
+      type: STRING
+      mode: NULLABLE
+    - name: context
+      type: STRING
+      mode: NULLABLE
+    - name: event
+      type: STRING
+      mode: NULLABLE
+    - name: joierrors
+      type: STRING
+      mode: NULLABLE
+    - name: user_id
+      type: STRING
+      mode: NULLABLE
+    - name: device_id
+      type: STRING
+      mode: NULLABLE
+    - name: config
+      type: STRING
+      mode: NULLABLE
+    - name: tags
+      type: STRING
+      mode: NULLABLE
+    - name: release
+      type: STRING
+      mode: NULLABLE
+    - name: level
+      type: STRING
+      mode: NULLABLE
+    - name: project
+      type: STRING
+      mode: NULLABLE
+    - name: extra
+      type: STRING
+      mode: NULLABLE
+    - name: request
+      type: STRING
+      mode: NULLABLE
+    - name: exception
+      type: STRING
+      mode: NULLABLE
+    - name: fingerprint
+      type: STRING
+      mode: NULLABLE
+    - name: culprit
+      type: STRING
+      mode: NULLABLE
+    - name: logger
+      type: STRING
+      mode: NULLABLE
+    - name: event_id
+      type: STRING
+      mode: NULLABLE
+    - name: platform
+      type: STRING
+      mode: NULLABLE
+    - name: message
+      type: STRING
+      mode: NULLABLE
+    - name: value
+      type: STRING
+      mode: NULLABLE
+    - name: param
+      type: STRING
+      mode: NULLABLE
+    - name: amplitudeevent
+      type: STRING
+      mode: NULLABLE
+  - name: region
+    type: STRING
+    mode: NULLABLE
+  - name: hostname
+    type: STRING
+    mode: NULLABLE
+  - name: flow_id
+    type: STRING
+    mode: NULLABLE
+  - name: flow_time
+    type: FLOAT
+    mode: NULLABLE
+  - name: v
+    type: FLOAT
+    mode: NULLABLE
+  - name: country
+    type: STRING
+    mode: NULLABLE
+  - name: entrypoint
+    type: STRING
+    mode: NULLABLE
+  - name: event
+    type: STRING
+    mode: NULLABLE
+  - name: useragent
+    type: STRING
+    mode: NULLABLE
+  - name: op
+    type: STRING
+    mode: NULLABLE
+  - name: locale
+    type: STRING
+    mode: NULLABLE
+  - name: service
+    type: STRING
+    mode: NULLABLE
+  - name: context
+    type: STRING
+    mode: NULLABLE
+  - name: utm_campaign
+    type: STRING
+    mode: NULLABLE
+  - name: utm_medium
+    type: STRING
+    mode: NULLABLE
+  - name: utm_content
+    type: STRING
+    mode: NULLABLE
+  - name: utm_source
+    type: STRING
+    mode: NULLABLE
+  - name: user_properties
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: ua_browser
+      type: STRING
+      mode: NULLABLE
+    - name: utm_campaign
+      type: STRING
+      mode: NULLABLE
+    - name: _append
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: fxa_services_used
+        type: STRING
+        mode: NULLABLE
+      - name: experiments
+        type: STRING
+        mode: REPEATED
+    - name: flow_id
+      type: STRING
+      mode: NULLABLE
+    - name: entrypoint
+      type: STRING
+      mode: NULLABLE
+    - name: utm_source
+      type: STRING
+      mode: NULLABLE
+    - name: ua_version
+      type: STRING
+      mode: NULLABLE
+    - name: utm_content
+      type: STRING
+      mode: NULLABLE
+    - name: utm_medium
+      type: STRING
+      mode: NULLABLE
+    - name: utm_term
+      type: STRING
+      mode: NULLABLE
+    - name: newsletter_state
+      type: STRING
+      mode: NULLABLE
+  - name: user_id
+    type: STRING
+    mode: NULLABLE
+  - name: os_version
+    type: STRING
+    mode: NULLABLE
+  - name: device_id
+    type: STRING
+    mode: NULLABLE
+  - name: event_properties
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: service
+      type: STRING
+      mode: NULLABLE
+    - name: reason
+      type: STRING
+      mode: NULLABLE
+    - name: connect_device_flow
+      type: STRING
+      mode: NULLABLE
+    - name: email_provider
+      type: STRING
+      mode: NULLABLE
+    - name: email_type
+      type: STRING
+      mode: NULLABLE
+    - name: oauth_client_id
+      type: STRING
+      mode: NULLABLE
+    - name: connect_device_os
+      type: STRING
+      mode: NULLABLE
+  - name: event_type
+    type: STRING
+    mode: NULLABLE
+  - name: os_name
+    type: STRING
+    mode: NULLABLE
+  - name: app_version
+    type: STRING
+    mode: NULLABLE
+  - name: language
+    type: STRING
+    mode: NULLABLE
+  - name: session_id
+    type: FLOAT
+    mode: NULLABLE
+  - name: device_model
+    type: STRING
+    mode: NULLABLE
+- name: timestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: receiveTimestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: severity
+  type: STRING
+  mode: NULLABLE
+- name: insertId
+  type: STRING
+  mode: NULLABLE
+- name: httpRequest
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: requestMethod
+    type: STRING
+    mode: NULLABLE
+  - name: requestUrl
+    type: STRING
+    mode: NULLABLE
+  - name: requestSize
+    type: INTEGER
+    mode: NULLABLE
+  - name: status
+    type: INTEGER
+    mode: NULLABLE
+  - name: responseSize
+    type: INTEGER
+    mode: NULLABLE
+  - name: userAgent
+    type: STRING
+    mode: NULLABLE
+  - name: remoteIp
+    type: STRING
+    mode: NULLABLE
+  - name: serverIp
+    type: STRING
+    mode: NULLABLE
+  - name: referer
+    type: STRING
+    mode: NULLABLE
+  - name: cacheLookup
+    type: BOOLEAN
+    mode: NULLABLE
+  - name: cacheHit
+    type: BOOLEAN
+    mode: NULLABLE
+  - name: cacheValidatedWithOriginServer
+    type: BOOLEAN
+    mode: NULLABLE
+  - name: cacheFillBytes
+    type: INTEGER
+    mode: NULLABLE
+  - name: protocol
+    type: STRING
+    mode: NULLABLE
+- name: labels
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: type
+    type: STRING
+    mode: NULLABLE
+  - name: compute_googleapis_com_resource_name
+    type: STRING
+    mode: NULLABLE
+  - name: application
+    type: STRING
+    mode: NULLABLE
+  - name: env
+    type: STRING
+    mode: NULLABLE
+  - name: stack
+    type: STRING
+    mode: NULLABLE
+  - name: fxa________
+    type: STRING
+    mode: NULLABLE
+  - name: defau
+    type: STRING
+    mode: NULLABLE
+  - name: cont
+    type: STRING
+    mode: NULLABLE
+  - name: pro
+    type: STRING
+    mode: NULLABLE
+  - name: fxa______pi
+    type: STRING
+    mode: NULLABLE
+- name: operation
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: id
+    type: STRING
+    mode: NULLABLE
+  - name: producer
+    type: STRING
+    mode: NULLABLE
+  - name: first
+    type: BOOLEAN
+    mode: NULLABLE
+  - name: last
+    type: BOOLEAN
+    mode: NULLABLE
+- name: trace
+  type: STRING
+  mode: NULLABLE
+- name: spanId
+  type: STRING
+  mode: NULLABLE
+- name: traceSampled
+  type: BOOLEAN
+  mode: NULLABLE
+- name: sourceLocation
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: file
+    type: STRING
+    mode: NULLABLE
+  - name: line
+    type: INTEGER
+    mode: NULLABLE
+  - name: function
+    type: STRING
+    mode: NULLABLE
+- name: split
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: uid
+    type: STRING
+    mode: NULLABLE
+  - name: index
+    type: INTEGER
+    mode: NULLABLE
+  - name: totalSplits
+    type: INTEGER
+    mode: NULLABLE


### PR DESCRIPTION
When reviewing #3407 I made an ill-advised code suggestion for the [`moz-fx-data-shared-prod.firefox_accounts_derived.funnel_events_source_v1` query](https://github.com/mozilla/bigquery-etl/pull/3407/files#diff-0664d1f3c1d2b6b20ccd19697c3d973c0ab1ee00af822b4b29f741d43cd18eec) which resulted in only a subset of columns being populated.  After that PR was merged, from 2022-12-15 onward the following 21 columns in `funnel_events_source_v1` have all ended up being null:
- `app_version`
- `country`
- `device_id`
- `email_provider`
- `entrypoint`
- `flow_id`
- `language`
- `logger`
- `os_name`
- `os_version`
- `receiveTimestamp`
- `sync_active_devices_day`
- `sync_active_devices_month`
- `sync_active_devices_week`
- `ua_browser`
- `ua_version`
- `utm_campaign`
- `utm_content`
- `utm_medium`
- `utm_source`
- `utm_term`

That in turn has resulted in the following 16 columns in `moz-fx-data-shared-prod.firefox_accounts_derived.events_daily_v1` being null:
- `app_version`
- `country`
- `entrypoint`
- `flow_id`
- `language`
- `os_name`
- `os_version`
- `sync_active_devices_day`
- `sync_active_devices_month`
- `sync_active_devices_week`
- `ua_browser`
- `ua_version`
- `utm_campaign`
- `utm_medium`
- `utm_source`
- `utm_term`

After this is merged, both `moz-fx-data-shared-prod.firefox_accounts_derived.funnel_events_source_v1` and `moz-fx-data-shared-prod.firefox_accounts_derived.events_daily_v1` will need to be rebuilt back to 2022-12-15.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1045)
