### PR TITLE
fix(DENG-353): removing submission_date from firefox_accounts_derived.event_types_v1 schema

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/event_types_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/event_types_v1/schema.yaml
@@ -1,7 +1,4 @@
 fields:
-- mode: NULLABLE
-  name: submission_date
-  type: DATE
 - name: category
   type: STRING
   mode: NULLABLE


### PR DESCRIPTION
# fix(DENG-353): removing submission_date from firefox_accounts_derived.event_types_v1 schema

follows-up: https://github.com/mozilla/bigquery-etl/pull/3968

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1047)
