### PR TITLE
[Bug 1839733] Fix stable view generation for use counter tables

### DIFF
--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -182,7 +182,10 @@ def write_view_if_not_exists(target_project: str, sql_dir: Path, schema: SchemaF
             replacements += [
                 "'Firefox' AS normalized_app_name",
             ]
-    elif schema.schema_id.startswith("moz://mozilla.org/schemas/main/ping/"):
+    elif (
+        schema.schema_id.startswith("moz://mozilla.org/schemas/main/ping/")
+        and "_use_counter_" not in schema.stable_table
+    ):
         replacements += [
             "`moz-fx-data-shared-prod`.udf.normalize_main_payload(payload) AS payload"
         ]


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1839733

View deploys are currently failing due to the stable views for the new use counter tables:

```
Invalid function moz-fx-data-shared-prod.udf.normalize_main_payload Field name info does not exist in STRUCT<histograms STRUCT<use_counter2_appearance_nonwidget_button_document STRING, use_counter2_appearance_nonwidget_button_page STRING, use_counter2_appearance_nonwidget_checkbox_document STRING, ...>, processes STRUCT<content STRUCT<histograms STRUCT<use_counter2_appearance_nonwidget_button_document STRING, use_counter2_appearance_nonwidget_button_page STRING, use_counter2_appearance_nonwidget_checkbox_document STRING, ...>>>> Analysis of function Templated_SQL_Function:moz-fx-data-shared-prod.udf.normalize_main_payload failed at [8:5] 
```

This PR changes the generation logic slightly for these views and references the `payload` field in the generated views as is without passing them to `udf.normalize_main_payload`

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1059)
