### PR TITLE
Round VPN exchange rates to fit in the BigQuery decimal type (bug 1840566)

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/exchange_rates_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/exchange_rates_v1/query.py
@@ -73,7 +73,7 @@ for base_currency in args.base_currencies:
                 quote_currency=currency_pair["quoteCurrency"],
                 base_currency=currency_pair["baseCurrency"],
                 price_type=currency_pair["type"],
-                price=price,
+                price=round(Decimal(price), 9),
             )
             for currency_pair in response.json()["widget"]
             for millis, price in currency_pair["data"]


### PR DESCRIPTION
OANDA's historical exchange rates API moved to a different URL, which was addressed in #3991.

However, that API now apparently has slightly different behavior where it may return exchange rates which have more than the 9 decimal places allowed by [BigQuery's decimal type](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types), in which case the `mozilla_vpn_derived.exchange_rates_v1` ETL will fail due to a behind-the-scenes "Invalid NUMERIC value" error ([bug 1840566](https://bugzilla.mozilla.org/show_bug.cgi?id=1840566)).

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)