### PR TITLE
Add firefox_desktop and top_sites views to skiplist

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -202,6 +202,8 @@ SKIP = {
     "sql/moz-fx-data-marketing-prod/ga_derived/downloads_with_attribution_v2/query.sql",
     "sql/moz-fx-data-shared-prod/fenix_external/installs_by_country_v1/query.sql",
     "sql/moz-fx-data-shared-prod/fenix/installs_by_country/view.sql",
+    "sql/moz-fx-data-shared-prod/firefox_desktop/top_sites/view.sql",
+    "sql/moz-fx-data-shared-prod/firefox_desktop/quick_suggest/view.sql",
     # Materialized views
     "sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_events_live_v1/init.sql",  # noqa E501
     "sql/moz-fx-data-shared-prod/telemetry_derived/experiment_events_live_v1/init.sql",  # noqa E501


### PR DESCRIPTION
The CI has been failing with below errors -
https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/22374/workflows/a5160b11-a36e-40bf-a109-ad42a6fa61c4/jobs/224612?invite=true#step-106-707
https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/22374/workflows/a5160b11-a36e-40bf-a109-ad42a6fa61c4/jobs/224612?invite=true#step-106-685
as the tables have been classified as confidential.
This PR adds the tables to skiplist.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1087)
