### PR TITLE
Ensure all necessary parameters are passed to DQ checks

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -92,7 +92,9 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             {%+ if task.arguments | length > 0 -%}
             arguments={{ task.arguments }},
             {%+ endif -%}
-            {%+ if task.parameters | length > 0 -%}
+            {%+ if task.date_partition_offset and task.date_partition_parameter -%}
+            parameters=["{{ task.date_partition_parameter }}:DATE:{% raw %}{{{% endraw %}macros.ds_add(ds, {{ task.date_partition_offset }}){% raw %}}}{%endraw%}"]{% if task.parameters | length > 0 %} + {{ task.parameters }}{% endif %},
+            {%+ elif task.parameters | length > 0 -%}
             parameters={{ task.parameters }},
             {%+ endif -%}
     {%+ else -%}

--- a/dags/bqetl_download_funnel_attribution.py
+++ b/dags/bqetl_download_funnel_attribution.py
@@ -51,6 +51,7 @@ with DAG(
         owner="gleonard@mozilla.com",
         email=["gleonard@mozilla.com", "telemetry-alerts@mozilla.com"],
         depends_on_past=False,
+        parameters=["download_date:DATE:{{macros.ds_add(ds, -1)}}"],
     )
 
     ga_derived__downloads_with_attribution__v2 = bigquery_etl_query(


### PR DESCRIPTION
This should fix the failing check: https://workflow.telemetry.mozilla.org/dags/bqetl_download_funnel_attribution/grid?dag_run_id=scheduled__2023-06-27T23%3A00%3A00%2B00%3A00&task_id=checks__ga_derived__downloads_with_attribution__v2

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1088)
