### PR TITLE
fix(bug-1841622): updated nonprod_fxa_server_events_v1 schema

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_server_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_server_events_v1/query.sql
@@ -8,7 +8,8 @@ SELECT
             SELECT AS STRUCT
               jsonPayload.fields.* EXCEPT (device_id, user_id),
               TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id,
-              TO_HEX(SHA256(jsonPayload.fields.device_id)) AS device_id
+              TO_HEX(SHA256(jsonPayload.fields.device_id)) AS device_id,
+              CAST(jsonPayload.fields.t AS STRING) AS t
           ) AS fields
         )
     ) AS jsonPayload


### PR DESCRIPTION
# fix(bug-1841622): updated nonprod_fxa_server_events_v1 schema

This is to address Airflow failures.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1103)
