### PR TITLE
Update view metadata in a single update_table() operation

### DIFF
--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -358,7 +358,6 @@ class View:
 
                 table.description = self.metadata.description
                 table.friendly_name = self.metadata.friendly_name
-                client.update_table(table, ["description", "friendly_name"])
 
                 if table.labels != self.labels:
                     labels = self.labels.copy()
@@ -371,7 +370,11 @@ class View:
                         for key, value in labels.items()
                         if isinstance(value, str)
                     }
-                    client.update_table(table, ["labels"])
+                    client.update_table(
+                        table, ["labels", "description", "friendly_name"]
+                    )
+                else:
+                    client.update_table(table, ["description", "friendly_name"])
 
                 print(f"Published view {target_view}")
         else:

--- a/tests/view/test_view.py
+++ b/tests/view/test_view.py
@@ -106,7 +106,7 @@ class TestView:
 
         assert view.is_valid()
         assert view.publish()
-        assert mock_bigquery_client().update_table.call_count == 2
+        assert mock_bigquery_client().update_table.call_count == 1
         assert (
             mock_bigquery_client().update_table.call_args[0][0].friendly_name
             == "Test metadata file"


### PR DESCRIPTION
Related to https://github.com/mozilla/bigquery-etl/pull/3909

When calling `update_table()` multiple times it fails with
```
google.api_core.exceptions.PreconditionFailed: 412 PATCH https://bigquery.googleapis.com/bigquery/v2/projects/moz-fx-data-shared-prod/datasets/firefox_ios/tables/metrics?prettyPrint=false: Precondition check failed.
```

Moving all metadata view updates into one call.

This should also fix current Airflow failures

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1105)
