### PR TITLE
bug(1841621): updated execution_delta for some firefox_ios_derived scheduled queries

### DIFF
--- a/dags/bqetl_firefox_ios.py
+++ b/dags/bqetl_firefox_ios.py
@@ -106,7 +106,7 @@ with DAG(
         task_id="wait_for_baseline_clients_daily",
         external_dag_id="copy_deduplicate",
         external_task_id="baseline_clients_daily",
-        execution_delta=datetime.timedelta(seconds=3600),
+        execution_delta=datetime.timedelta(seconds=10800),
         check_existence=True,
         mode="reschedule",
         allowed_states=ALLOWED_STATES,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/metadata.yaml
@@ -13,7 +13,7 @@ scheduling:
   depends_on:
   - task_id: baseline_clients_daily
     dag_name: copy_deduplicate
-    execution_delta: 1h
+    execution_delta: 3h
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
@@ -32,7 +32,7 @@ scheduling:
   depends_on:
   - task_id: baseline_clients_daily
     dag_name: copy_deduplicate
-    execution_delta: 1h
+    execution_delta: 3h
   parameters:
   - submission_date:DATE:{{ds}}
 bigquery:


### PR DESCRIPTION
bug(1841621): updated execution_delta for some firefox_ios_derived scheduled queries

The `execution_delta` in the `depends` has been updated for the following two queries from `1h` to `3h`:

- `attributable_clients_v1`
- `firefox_ios_clients_v1`

This was causing the sensor to look for a task instance with a different execution_date than expected and being constantly rescheduled as the result of this.