### PR TITLE
Split main_1pct

### DIFF
--- a/dags/bqetl_feature_usage.py
+++ b/dags/bqetl_feature_usage.py
@@ -137,10 +137,10 @@ with DAG(
     telemetry_derived__feature_usage__v2.set_upstream(
         wait_for_telemetry_derived__clients_last_seen__v1
     )
-    wait_for_telemetry_derived__main_1pct__v1 = ExternalTaskSensor(
-        task_id="wait_for_telemetry_derived__main_1pct__v1",
+    wait_for_telemetry_derived__main_remainder_1pct__v1 = ExternalTaskSensor(
+        task_id="wait_for_telemetry_derived__main_remainder_1pct__v1",
         external_dag_id="bqetl_main_summary",
-        external_task_id="telemetry_derived__main_1pct__v1",
+        external_task_id="telemetry_derived__main_remainder_1pct__v1",
         execution_delta=datetime.timedelta(seconds=10800),
         check_existence=True,
         mode="reschedule",
@@ -150,5 +150,5 @@ with DAG(
     )
 
     telemetry_derived__feature_usage__v2.set_upstream(
-        wait_for_telemetry_derived__main_1pct__v1
+        wait_for_telemetry_derived__main_remainder_1pct__v1
     )

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -303,7 +303,7 @@ with DAG(
             external_task_id="wait_for_telemetry_derived__clients_last_seen__v1",
             execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=81000)).isoformat() }}",
         )
-
+        
         ExternalTaskMarker(
             task_id="bqetl_search_dashboard__wait_for_telemetry_derived__clients_last_seen__v1",
             external_dag_id="bqetl_search_dashboard",
@@ -441,20 +441,6 @@ with DAG(
         arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
     )
 
-    with TaskGroup(
-        "telemetry_derived__main_1pct__v1_external"
-    ) as telemetry_derived__main_1pct__v1_external:
-        ExternalTaskMarker(
-            task_id="bqetl_feature_usage__wait_for_telemetry_derived__main_1pct__v1",
-            external_dag_id="bqetl_feature_usage",
-            external_task_id="wait_for_telemetry_derived__main_1pct__v1",
-            execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=75600)).isoformat() }}",
-        )
-
-        telemetry_derived__main_1pct__v1_external.set_upstream(
-            telemetry_derived__main_1pct__v1
-        )
-
     telemetry_derived__main_nightly__v1 = bigquery_etl_query(
         task_id="telemetry_derived__main_nightly__v1",
         destination_table="main_nightly_v1",
@@ -471,6 +457,38 @@ with DAG(
         depends_on_past=False,
         arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
     )
+
+    telemetry_derived__main_remainder_1pct__v1 = bigquery_etl_query(
+        task_id="telemetry_derived__main_remainder_1pct__v1",
+        destination_table="main_remainder_1pct_v1",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="ascholtz@mozilla.com",
+        email=[
+            "ascholtz@mozilla.com",
+            "dthorn@mozilla.com",
+            "jklukas@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        start_date=datetime.datetime(2023, 7, 1, 0, 0),
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
+    )
+
+    with TaskGroup(
+        "telemetry_derived__main_remainder_1pct__v1_external"
+    ) as telemetry_derived__main_remainder_1pct__v1_external:
+        ExternalTaskMarker(
+            task_id="bqetl_feature_usage__wait_for_telemetry_derived__main_remainder_1pct__v1",
+            external_dag_id="bqetl_feature_usage",
+            external_task_id="wait_for_telemetry_derived__main_remainder_1pct__v1",
+            execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=75600)).isoformat() }}",
+        )
+
+        telemetry_derived__main_remainder_1pct__v1_external.set_upstream(
+            telemetry_derived__main_remainder_1pct__v1
+        )
 
     telemetry_derived__main_summary__v4 = bigquery_etl_query(
         task_id="telemetry_derived__main_summary__v4",
@@ -518,6 +536,24 @@ with DAG(
         telemetry_derived__main_summary__v4_external.set_upstream(
             telemetry_derived__main_summary__v4
         )
+
+    telemetry_derived__main_use_counter_1pct__v1 = bigquery_etl_query(
+        task_id="telemetry_derived__main_use_counter_1pct__v1",
+        destination_table="main_use_counter_1pct_v1",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="ascholtz@mozilla.com",
+        email=[
+            "ascholtz@mozilla.com",
+            "dthorn@mozilla.com",
+            "jklukas@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        start_date=datetime.datetime(2023, 7, 1, 0, 0),
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        arguments=["--schema_update_option=ALLOW_FIELD_ADDITION"],
+    )
 
     telemetry_derived__suggest_clients_daily__v1 = bigquery_etl_query(
         task_id="telemetry_derived__suggest_clients_daily__v1",
@@ -655,8 +691,16 @@ with DAG(
         wait_for_copy_deduplicate_main_ping
     )
 
+    telemetry_derived__main_remainder_1pct__v1.set_upstream(
+        wait_for_copy_deduplicate_all
+    )
+
     telemetry_derived__main_summary__v4.set_upstream(
         wait_for_copy_deduplicate_main_ping
+    )
+
+    telemetry_derived__main_use_counter_1pct__v1.set_upstream(
+        wait_for_copy_deduplicate_all
     )
 
     telemetry_derived__suggest_clients_daily__v1.set_upstream(wait_for_bq_main_events)

--- a/sql/moz-fx-data-shared-prod/telemetry/main_1pct/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_1pct/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-shared-prod.telemetry_derived.main_1pct_v1`
+  `moz-fx-data-shared-prod.telemetry.main_remainder_1pct`

--- a/sql/moz-fx-data-shared-prod/telemetry/main_remainder_1pct/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_remainder_1pct/metadata.yaml
@@ -1,9 +1,9 @@
 ---
-friendly_name: Main 1 percent
+friendly_name: Main Remainder 1 percent
 description: |-
-  A materialized 1 percent sample of main pings without use counters
-  intended as a performance optimization for exploratory queries.
-  It contains only the most recent six months of data.
+  A materialized 1 percent sample of main pings without use counter data
+  intended as a performance optimization for exploratory queries. It contains
+  only the most recent six months of data.
 
   Queries on this table are logically equivalent to queries on top of `main_remainder_v4`
   with a filter on `sample_id = 0`, but this table has a few advantages.

--- a/sql/moz-fx-data-shared-prod/telemetry/main_remainder_1pct/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_remainder_1pct/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.main_remainder_1pct`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.main_remainder_1pct_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/main_use_counter_1pct/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_use_counter_1pct/metadata.yaml
@@ -1,17 +1,17 @@
 ---
-friendly_name: Main 1 percent
+friendly_name: Main Use Counter 1 percent
 description: |-
-  A materialized 1 percent sample of main pings without use counters
-  intended as a performance optimization for exploratory queries.
-  It contains only the most recent six months of data.
+  A materialized 1 percent sample of main pings use counter data
+  intended as a performance optimization for exploratory queries. It contains
+  only the most recent six months of data.
 
-  Queries on this table are logically equivalent to queries on top of `main_remainder_v4`
+  Queries on this table are logically equivalent to queries on top of `main_use_counter_v4`
   with a filter on `sample_id = 0`, but this table has a few advantages.
   First, query estimates will be much more accurate; estimates of bytes scanned
   can't take into account clustering, so we sometimes see valid queries get
   rejected by Redash due to appearing expensive when they really aren't.
   Second, simple queries should complete much more quickly on this table
-  compared to `main_remainder_v4`; for simple queries on a very wide table like this,
+  compared to `main_use_counter_v4`; for simple queries on a very wide table like this,
   the execution time appears to be dominated by BQ simply scanning metadata
   for all the blocks it might need to touch. Because this table contains
   only 1% of main ping data, it is likely to have many fewer blocks to

--- a/sql/moz-fx-data-shared-prod/telemetry/main_use_counter_1pct/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_use_counter_1pct/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.main_use_counter_1pct`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.main_use_counter_1pct_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/feature_usage_v2/query.sql
@@ -313,7 +313,7 @@ main AS (
       )
     ) AS keyboard_shortcut_total,
   FROM
-    telemetry.main_1pct
+    telemetry.main_remainder_1pct
   WHERE
     DATE(submission_timestamp) = @submission_date
     AND sample_id = 0

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/metadata.yaml
@@ -1,9 +1,9 @@
----
-friendly_name: Main 1 percent
+friendly_name: Main Remainder 1 percent
 description: |-
-  A materialized 1 percent sample of main pings without use counters
-  intended as a performance optimization for exploratory queries.
-  It contains only the most recent six months of data.
+  A materialized 1 percent sample of main pings without use counter data
+  intended as a performance optimization for exploratory queries. It contains
+  only the most recent six months of data. Also see main_nightly for a derived
+  table containing only data where normalized_channel = 'nightly'.
 
   Queries on this table are logically equivalent to queries on top of `main_remainder_v4`
   with a filter on `sample_id = 0`, but this table has a few advantages.
@@ -20,11 +20,24 @@ description: |-
   An extra-experimental feature here is the addition of subsample_id, an
   additional clustering field that allows for queries to efficiently filter
   down to a 0.01% sample. Like sample_id, it ranges from 0 to 99.
-
-  Clustering fields: `normalized_channel`, `sample_id`, `subsample_id`
-
-  See also: `main_nightly`
-owners:
-  - ascholtz@mozilla.com
 labels:
-  application: firefox
+  incremental: true
+owners:
+- ascholtz@mozilla.com
+scheduling:
+  dag_name: bqetl_main_summary
+  start_date: '2023-07-01'
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+  referenced_tables: [['moz-fx-data-shared-prod', 'telemetry_stable',
+                       'main_remainder_v4']]
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_timestamp
+    require_partition_filter: true
+    expiration_days: 180
+  clustering:
+    fields:
+    - normalized_channel
+    - sample_id
+    - subsample_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/query.sql
@@ -1,0 +1,20 @@
+SELECT
+  -- subsample_id can allow you to efficiently filter down to a 0.01% sample.
+  -- The choice of implementation here is not particularly well vetted;
+  -- it's simply chosen to be a hash that's stable, has a reasonable
+  -- avalanche effect, and is _different_ from sample_id. We use this same approach
+  -- for choosing id_bucket in exact_mau28 tables.
+  MOD(ABS(FARM_FINGERPRINT(client_id)), 100) AS subsample_id,
+  -- We apply field cleaning at the table level rather than the view level because
+  -- the logic here ends up becoming the bottleneck for simple queries on top of
+  -- this table. The limited size and retention policy on this table makes it feasible
+  -- to perform full backfills as needed if this logic changes.
+  * REPLACE (
+    mozfun.norm.metadata(metadata) AS metadata,
+    `moz-fx-data-shared-prod.udf.normalize_main_payload`(payload) AS payload
+  )
+FROM
+  telemetry_stable.main_remainder_v4
+WHERE
+  sample_id = 0
+  AND DATE(submission_timestamp) = @submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/schema.yaml
@@ -1,0 +1,23228 @@
+fields:
+- name: subsample_id
+  type: INTEGER
+  mode: NULLABLE
+- name: additional_properties
+  type: STRING
+  mode: NULLABLE
+- name: application
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: architecture
+    type: STRING
+    mode: NULLABLE
+  - name: build_id
+    type: STRING
+    mode: NULLABLE
+  - name: channel
+    type: STRING
+    mode: NULLABLE
+  - name: display_version
+    type: STRING
+    mode: NULLABLE
+  - name: name
+    type: STRING
+    mode: NULLABLE
+  - name: platform_version
+    type: STRING
+    mode: NULLABLE
+  - name: vendor
+    type: STRING
+    mode: NULLABLE
+  - name: version
+    type: STRING
+    mode: NULLABLE
+  - name: xpcom_abi
+    type: STRING
+    mode: NULLABLE
+- name: client_id
+  type: STRING
+  mode: NULLABLE
+- name: creation_date
+  type: STRING
+  mode: NULLABLE
+- name: document_id
+  type: STRING
+  mode: NULLABLE
+- name: environment
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: addons
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: active_addons
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: app_disabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: blocklisted
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: description
+          type: STRING
+          mode: NULLABLE
+        - name: foreign_install
+          type: INTEGER
+          mode: NULLABLE
+        - name: has_binary_components
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: install_day
+          type: INTEGER
+          mode: NULLABLE
+        - name: is_system
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: is_web_extension
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: multiprocess_compatible
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: name
+          type: STRING
+          mode: NULLABLE
+        - name: scope
+          type: INTEGER
+          mode: NULLABLE
+        - name: signed_state
+          type: INTEGER
+          mode: NULLABLE
+        - name: type
+          type: STRING
+          mode: NULLABLE
+        - name: update_day
+          type: INTEGER
+          mode: NULLABLE
+        - name: user_disabled
+          type: INTEGER
+          mode: NULLABLE
+        - name: version
+          type: STRING
+          mode: NULLABLE
+    - name: active_experiment
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: branch
+        type: STRING
+        mode: NULLABLE
+      - name: id
+        type: STRING
+        mode: NULLABLE
+    - name: active_gm_plugins
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: apply_background_updates
+          type: INTEGER
+          mode: NULLABLE
+        - name: user_disabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: version
+          type: STRING
+          mode: NULLABLE
+    - name: active_plugins
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: blocklisted
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: clicktoplay
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: description
+        type: STRING
+        mode: NULLABLE
+      - name: disabled
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: mime_types
+        type: STRING
+        mode: REPEATED
+      - name: name
+        type: STRING
+        mode: NULLABLE
+      - name: update_day
+        type: INTEGER
+        mode: NULLABLE
+      - name: version
+        type: STRING
+        mode: NULLABLE
+    - name: persona
+      type: STRING
+      mode: NULLABLE
+    - name: theme
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: app_disabled
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: blocklisted
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: description
+        type: STRING
+        mode: NULLABLE
+      - name: foreign_install
+        type: INTEGER
+        mode: NULLABLE
+      - name: has_binary_components
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: id
+        type: STRING
+        mode: NULLABLE
+      - name: install_day
+        type: INTEGER
+        mode: NULLABLE
+      - name: name
+        type: STRING
+        mode: NULLABLE
+      - name: scope
+        type: INTEGER
+        mode: NULLABLE
+      - name: update_day
+        type: INTEGER
+        mode: NULLABLE
+      - name: user_disabled
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: version
+        type: STRING
+        mode: NULLABLE
+  - name: build
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: application_id
+      type: STRING
+      mode: NULLABLE
+    - name: application_name
+      type: STRING
+      mode: NULLABLE
+    - name: architecture
+      type: STRING
+      mode: NULLABLE
+    - name: architectures_in_binary
+      type: STRING
+      mode: NULLABLE
+    - name: build_id
+      type: STRING
+      mode: NULLABLE
+    - name: display_version
+      type: STRING
+      mode: NULLABLE
+    - name: hotfix_version
+      type: STRING
+      mode: NULLABLE
+    - name: platform_version
+      type: STRING
+      mode: NULLABLE
+    - name: updater_available
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: vendor
+      type: STRING
+      mode: NULLABLE
+    - name: version
+      type: STRING
+      mode: NULLABLE
+    - name: xpcom_abi
+      type: STRING
+      mode: NULLABLE
+  - name: experiments
+    type: RECORD
+    mode: REPEATED
+    fields:
+    - name: key
+      type: STRING
+      mode: NULLABLE
+    - name: value
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: branch
+        type: STRING
+        mode: NULLABLE
+      - name: enrollment_id
+        type: STRING
+        mode: NULLABLE
+      - name: type
+        type: STRING
+        mode: NULLABLE
+  - name: partner
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: distribution_id
+      type: STRING
+      mode: NULLABLE
+    - name: distribution_version
+      type: STRING
+      mode: NULLABLE
+    - name: distributor
+      type: STRING
+      mode: NULLABLE
+    - name: distributor_channel
+      type: STRING
+      mode: NULLABLE
+    - name: partner_id
+      type: STRING
+      mode: NULLABLE
+    - name: partner_names
+      type: STRING
+      mode: REPEATED
+  - name: profile
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: creation_date
+      type: FLOAT
+      mode: NULLABLE
+    - name: first_use_date
+      type: FLOAT
+      mode: NULLABLE
+    - name: is_stub_profile
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: reset_date
+      type: FLOAT
+      mode: NULLABLE
+  - name: services
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: account_enabled
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: sync_enabled
+      type: BOOLEAN
+      mode: NULLABLE
+  - name: settings
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: addon_compatibility_check_enabled
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: attribution
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: campaign
+        type: STRING
+        mode: NULLABLE
+      - name: content
+        type: STRING
+        mode: NULLABLE
+      - name: dlsource
+        type: STRING
+        mode: NULLABLE
+      - name: dltoken
+        type: STRING
+        mode: NULLABLE
+      - name: experiment
+        type: STRING
+        mode: NULLABLE
+      - name: medium
+        type: STRING
+        mode: NULLABLE
+      - name: source
+        type: STRING
+        mode: NULLABLE
+      - name: ua
+        type: STRING
+        mode: NULLABLE
+      - name: variation
+        type: STRING
+        mode: NULLABLE
+    - name: blocklist_enabled
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: default_private_search_engine
+      type: STRING
+      mode: NULLABLE
+    - name: default_private_search_engine_data
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: load_path
+        type: STRING
+        mode: NULLABLE
+      - name: name
+        type: STRING
+        mode: NULLABLE
+      - name: origin
+        type: STRING
+        mode: NULLABLE
+      - name: submission_url
+        type: STRING
+        mode: NULLABLE
+    - name: default_search_engine
+      type: STRING
+      mode: NULLABLE
+    - name: default_search_engine_data
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: load_path
+        type: STRING
+        mode: NULLABLE
+      - name: name
+        type: STRING
+        mode: NULLABLE
+      - name: origin
+        type: STRING
+        mode: NULLABLE
+      - name: submission_url
+        type: STRING
+        mode: NULLABLE
+    - name: e10s_cohort
+      type: STRING
+      mode: NULLABLE
+    - name: e10s_enabled
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: e10s_multi_processes
+      type: INTEGER
+      mode: NULLABLE
+    - name: fission_enabled
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: intl
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: accept_languages
+        type: STRING
+        mode: REPEATED
+      - name: app_locales
+        type: STRING
+        mode: REPEATED
+      - name: available_locales
+        type: STRING
+        mode: REPEATED
+      - name: regional_prefs_locales
+        type: STRING
+        mode: REPEATED
+      - name: requested_locales
+        type: STRING
+        mode: REPEATED
+      - name: system_locales
+        type: STRING
+        mode: REPEATED
+    - name: is_default_browser
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: is_in_optout_sample
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: launcher_process_state
+      type: INTEGER
+      mode: NULLABLE
+    - name: locale
+      type: STRING
+      mode: NULLABLE
+    - name: sandbox
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: content_win32k_lockdown_state
+        type: INTEGER
+        mode: NULLABLE
+      - name: effective_content_process_level
+        type: INTEGER
+        mode: NULLABLE
+    - name: search_cohort
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_enabled
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: update
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: auto_download
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: background
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: channel
+        type: STRING
+        mode: NULLABLE
+      - name: enabled
+        type: BOOLEAN
+        mode: NULLABLE
+    - name: user_prefs
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+  - name: system
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: apple_model_id
+      type: STRING
+      mode: NULLABLE
+    - name: cpu
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: cores
+        type: INTEGER
+        mode: NULLABLE
+      - name: count
+        type: INTEGER
+        mode: NULLABLE
+      - name: extensions
+        type: STRING
+        mode: REPEATED
+      - name: family
+        type: INTEGER
+        mode: NULLABLE
+      - name: is_windows_s_mode
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: l2cache_kb
+        type: FLOAT
+        mode: NULLABLE
+      - name: l3cache_kb
+        type: FLOAT
+        mode: NULLABLE
+      - name: model
+        type: INTEGER
+        mode: NULLABLE
+      - name: name
+        type: STRING
+        mode: NULLABLE
+      - name: speed_m_hz
+        type: FLOAT
+        mode: NULLABLE
+      - name: stepping
+        type: INTEGER
+        mode: NULLABLE
+      - name: vendor
+        type: STRING
+        mode: NULLABLE
+    - name: device
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: hardware
+        type: STRING
+        mode: NULLABLE
+      - name: is_tablet
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: manufacturer
+        type: STRING
+        mode: NULLABLE
+      - name: model
+        type: STRING
+        mode: NULLABLE
+    - name: gfx
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: adapters
+        type: RECORD
+        mode: REPEATED
+        fields:
+        - name: description
+          type: STRING
+          mode: NULLABLE
+        - name: device_id
+          type: STRING
+          mode: NULLABLE
+        - name: driver
+          type: STRING
+          mode: NULLABLE
+        - name: driver_date
+          type: STRING
+          mode: NULLABLE
+        - name: driver_vendor
+          type: STRING
+          mode: NULLABLE
+        - name: driver_version
+          type: STRING
+          mode: NULLABLE
+        - name: gpu_active
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: ram
+          type: INTEGER
+          mode: NULLABLE
+        - name: subsys_id
+          type: STRING
+          mode: NULLABLE
+        - name: vendor_id
+          type: STRING
+          mode: NULLABLE
+      - name: content_backend
+        type: STRING
+        mode: NULLABLE
+      - name: d2d_enabled
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: d_write_enabled
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: embedded_in_firefox_reality
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: features
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: advanced_layers
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: no_constant_buffer_offsetting
+            type: BOOLEAN
+            mode: NULLABLE
+          - name: status
+            type: STRING
+            mode: NULLABLE
+        - name: compositor
+          type: STRING
+          mode: NULLABLE
+        - name: d2d
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: status
+            type: STRING
+            mode: NULLABLE
+          - name: version
+            type: STRING
+            mode: NULLABLE
+        - name: d3d11
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: blacklisted
+            type: BOOLEAN
+            mode: NULLABLE
+          - name: blocklisted
+            type: BOOLEAN
+            mode: NULLABLE
+          - name: status
+            type: STRING
+            mode: NULLABLE
+          - name: texture_sharing
+            type: BOOLEAN
+            mode: NULLABLE
+          - name: version
+            type: FLOAT
+            mode: NULLABLE
+          - name: warp
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: gpu_process
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: status
+            type: STRING
+            mode: NULLABLE
+        - name: hw_compositing
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: status
+            type: STRING
+            mode: NULLABLE
+        - name: omtp
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: status
+            type: STRING
+            mode: NULLABLE
+        - name: opengl_compositing
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: status
+            type: STRING
+            mode: NULLABLE
+        - name: webrender
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: status
+            type: STRING
+            mode: NULLABLE
+        - name: wr_compositor
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: status
+            type: STRING
+            mode: NULLABLE
+        - name: wr_qualified
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: status
+            type: STRING
+            mode: NULLABLE
+        - name: wr_software
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: status
+            type: STRING
+            mode: NULLABLE
+      - name: headless
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: low_end_machine
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: monitors
+        type: RECORD
+        mode: REPEATED
+        fields:
+        - name: pseudo_display
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: refresh_rate
+          type: FLOAT
+          mode: NULLABLE
+        - name: scale
+          type: FLOAT
+          mode: NULLABLE
+        - name: screen_height
+          type: INTEGER
+          mode: NULLABLE
+        - name: screen_width
+          type: INTEGER
+          mode: NULLABLE
+      - name: target_frame_rate
+        type: INTEGER
+        mode: NULLABLE
+    - name: has_win_package_id
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: hdd
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: binary
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: model
+          type: STRING
+          mode: NULLABLE
+        - name: revision
+          type: STRING
+          mode: NULLABLE
+        - name: type
+          type: STRING
+          mode: NULLABLE
+      - name: profile
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: model
+          type: STRING
+          mode: NULLABLE
+        - name: revision
+          type: STRING
+          mode: NULLABLE
+        - name: type
+          type: STRING
+          mode: NULLABLE
+      - name: system
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: model
+          type: STRING
+          mode: NULLABLE
+        - name: revision
+          type: STRING
+          mode: NULLABLE
+        - name: type
+          type: STRING
+          mode: NULLABLE
+    - name: is_wow64
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: is_wow_arm64
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: memory_mb
+      type: FLOAT
+      mode: NULLABLE
+    - name: os
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: has_prefetch
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: has_superfetch
+        type: BOOLEAN
+        mode: NULLABLE
+      - name: install_year
+        type: FLOAT
+        mode: NULLABLE
+      - name: kernel_version
+        type: STRING
+        mode: NULLABLE
+      - name: locale
+        type: STRING
+        mode: NULLABLE
+      - name: name
+        type: STRING
+        mode: NULLABLE
+      - name: service_pack_major
+        type: FLOAT
+        mode: NULLABLE
+      - name: service_pack_minor
+        type: FLOAT
+        mode: NULLABLE
+      - name: version
+        type: STRING
+        mode: NULLABLE
+      - name: windows_build_number
+        type: FLOAT
+        mode: NULLABLE
+      - name: windows_ubr
+        type: FLOAT
+        mode: NULLABLE
+    - name: sec
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: antispyware
+        type: STRING
+        mode: REPEATED
+      - name: antivirus
+        type: STRING
+        mode: REPEATED
+      - name: firewall
+        type: STRING
+        mode: REPEATED
+    - name: virtual_max_mb
+      type: FLOAT
+      mode: NULLABLE
+    - name: win_package_family_name
+      type: STRING
+      mode: NULLABLE
+- name: id
+  type: STRING
+  mode: NULLABLE
+- name: metadata
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: geo
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: city
+      type: STRING
+      mode: NULLABLE
+    - name: country
+      type: STRING
+      mode: NULLABLE
+    - name: db_version
+      type: STRING
+      mode: NULLABLE
+    - name: subdivision1
+      type: STRING
+      mode: NULLABLE
+    - name: subdivision2
+      type: STRING
+      mode: NULLABLE
+  - name: header
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: date
+      type: STRING
+      mode: NULLABLE
+    - name: dnt
+      type: STRING
+      mode: NULLABLE
+    - name: x_debug_id
+      type: STRING
+      mode: NULLABLE
+    - name: x_foxsec_ip_reputation
+      type: STRING
+      mode: NULLABLE
+    - name: x_lb_tags
+      type: STRING
+      mode: NULLABLE
+    - name: x_pingsender_version
+      type: STRING
+      mode: NULLABLE
+    - name: x_source_tags
+      type: STRING
+      mode: NULLABLE
+    - name: x_telemetry_agent
+      type: STRING
+      mode: NULLABLE
+    - name: parsed_date
+      type: TIMESTAMP
+      mode: NULLABLE
+    - name: parsed_x_source_tags
+      type: STRING
+      mode: REPEATED
+    - name: parsed_x_lb_tags
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: tls_version
+        type: STRING
+        mode: NULLABLE
+      - name: tls_cipher_hex
+        type: STRING
+        mode: NULLABLE
+  - name: isp
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: db_version
+      type: STRING
+      mode: NULLABLE
+    - name: name
+      type: STRING
+      mode: NULLABLE
+    - name: organization
+      type: STRING
+      mode: NULLABLE
+  - name: uri
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: app_build_id
+      type: STRING
+      mode: NULLABLE
+    - name: app_name
+      type: STRING
+      mode: NULLABLE
+    - name: app_update_channel
+      type: STRING
+      mode: NULLABLE
+    - name: app_version
+      type: STRING
+      mode: NULLABLE
+  - name: user_agent
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: browser
+      type: STRING
+      mode: NULLABLE
+    - name: os
+      type: STRING
+      mode: NULLABLE
+    - name: version
+      type: STRING
+      mode: NULLABLE
+- name: normalized_app_name
+  type: STRING
+  mode: NULLABLE
+- name: normalized_channel
+  type: STRING
+  mode: NULLABLE
+- name: normalized_country_code
+  type: STRING
+  mode: NULLABLE
+- name: normalized_os
+  type: STRING
+  mode: NULLABLE
+- name: normalized_os_version
+  type: STRING
+  mode: NULLABLE
+- name: payload
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: histograms
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: a11y_consumers
+      type: STRING
+      mode: NULLABLE
+    - name: a11y_iatable_usage_flag
+      type: STRING
+      mode: NULLABLE
+    - name: a11y_instantiated_flag
+      type: STRING
+      mode: NULLABLE
+    - name: a11y_isimpledom_usage_flag
+      type: STRING
+      mode: NULLABLE
+    - name: a11y_tree_update_timing_ms
+      type: STRING
+      mode: NULLABLE
+    - name: a11y_uia_detection_timing_ms
+      type: STRING
+      mode: NULLABLE
+    - name: a11y_update_time
+      type: STRING
+      mode: NULLABLE
+    - name: about_config_features_usage
+      type: STRING
+      mode: NULLABLE
+    - name: addon_manager_upgrade_ui_shown
+      type: STRING
+      mode: NULLABLE
+    - name: addon_signature_verification_status
+      type: STRING
+      mode: NULLABLE
+    - name: alerts_service_dnd_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: alerts_service_dnd_supported_flag
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_allowlist_match
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_binary
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_binary_archive
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_binary_type
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_blocklist_match
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_count
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_hash_length
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_local
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_reason
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_remote_lookup_response_time
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_remote_lookup_timeout
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_server
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_server_2
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_server_verdict
+      type: STRING
+      mode: NULLABLE
+    - name: application_reputation_should_block
+      type: STRING
+      mode: NULLABLE
+    - name: apz_aware_key_listeners
+      type: STRING
+      mode: NULLABLE
+    - name: apz_aware_mousemove_listeners
+      type: STRING
+      mode: NULLABLE
+    - name: apz_zoom_pinchsource
+      type: STRING
+      mode: NULLABLE
+    - name: async_animation_content_too_large_frame_size
+      type: STRING
+      mode: NULLABLE
+    - name: async_animation_content_too_large_percentage
+      type: STRING
+      mode: NULLABLE
+    - name: async_animation_frame_size
+      type: STRING
+      mode: NULLABLE
+    - name: audio_mft_output_null_samples
+      type: STRING
+      mode: NULLABLE
+    - name: audio_track_silence_proportion
+      type: STRING
+      mode: NULLABLE
+    - name: audiostream_backend_used
+      type: STRING
+      mode: NULLABLE
+    - name: audiostream_first_open_ms
+      type: STRING
+      mode: NULLABLE
+    - name: audiostream_later_open_ms
+      type: STRING
+      mode: NULLABLE
+    - name: aushelper_cpu_error_code
+      type: STRING
+      mode: NULLABLE
+    - name: aushelper_cpu_result_code
+      type: STRING
+      mode: NULLABLE
+    - name: aushelper_websense_error_code
+      type: STRING
+      mode: NULLABLE
+    - name: aushelper_websense_reg_exists
+      type: STRING
+      mode: NULLABLE
+    - name: auto_rejected_translation_offers
+      type: STRING
+      mode: NULLABLE
+    - name: autoplay_default_setting_change
+      type: STRING
+      mode: NULLABLE
+    - name: autoplay_sites_setting_change
+      type: STRING
+      mode: NULLABLE
+    - name: avif_a1lx
+      type: STRING
+      mode: NULLABLE
+    - name: avif_a1op
+      type: STRING
+      mode: NULLABLE
+    - name: avif_alpha
+      type: STRING
+      mode: NULLABLE
+    - name: avif_aom_decode_error
+      type: STRING
+      mode: NULLABLE
+    - name: avif_bit_depth
+      type: STRING
+      mode: NULLABLE
+    - name: avif_cicp_cp
+      type: STRING
+      mode: NULLABLE
+    - name: avif_cicp_mc
+      type: STRING
+      mode: NULLABLE
+    - name: avif_cicp_tc
+      type: STRING
+      mode: NULLABLE
+    - name: avif_clap
+      type: STRING
+      mode: NULLABLE
+    - name: avif_colr
+      type: STRING
+      mode: NULLABLE
+    - name: avif_decode_result
+      type: STRING
+      mode: NULLABLE
+    - name: avif_decoder
+      type: STRING
+      mode: NULLABLE
+    - name: avif_grid
+      type: STRING
+      mode: NULLABLE
+    - name: avif_ipro
+      type: STRING
+      mode: NULLABLE
+    - name: avif_ispe
+      type: STRING
+      mode: NULLABLE
+    - name: avif_lsel
+      type: STRING
+      mode: NULLABLE
+    - name: avif_major_brand
+      type: STRING
+      mode: NULLABLE
+    - name: avif_pasp
+      type: STRING
+      mode: NULLABLE
+    - name: avif_pixi
+      type: STRING
+      mode: NULLABLE
+    - name: avif_sequence
+      type: STRING
+      mode: NULLABLE
+    - name: avif_yuv_color_space
+      type: STRING
+      mode: NULLABLE
+    - name: backgroundfilesaver_thread_count
+      type: STRING
+      mode: NULLABLE
+    - name: bad_fallback_font
+      type: STRING
+      mode: NULLABLE
+    - name: base_font_families_per_page
+      type: STRING
+      mode: NULLABLE
+    - name: bfcache_combo
+      type: STRING
+      mode: NULLABLE
+    - name: bfcache_page_restored
+      type: STRING
+      mode: NULLABLE
+    - name: blink_filesystem_used
+      type: STRING
+      mode: NULLABLE
+    - name: blocklist_sync_file_load
+      type: STRING
+      mode: NULLABLE
+    - name: box_align_props_in_blocks_flag
+      type: STRING
+      mode: NULLABLE
+    - name: br_9_2_1_subject_alt_names
+      type: STRING
+      mode: NULLABLE
+    - name: br_9_2_2_subject_common_name
+      type: STRING
+      mode: NULLABLE
+    - name: browser_attribution_errors
+      type: STRING
+      mode: NULLABLE
+    - name: browser_is_assist_default
+      type: STRING
+      mode: NULLABLE
+    - name: browser_is_user_default
+      type: STRING
+      mode: NULLABLE
+    - name: browser_is_user_default_error
+      type: STRING
+      mode: NULLABLE
+    - name: browser_set_default_always_check
+      type: STRING
+      mode: NULLABLE
+    - name: browser_set_default_dialog_prompt_rawcount
+      type: STRING
+      mode: NULLABLE
+    - name: browser_set_default_error
+      type: STRING
+      mode: NULLABLE
+    - name: browser_set_default_pdf_handler_user_choice_result
+      type: STRING
+      mode: NULLABLE
+    - name: browser_set_default_result
+      type: STRING
+      mode: NULLABLE
+    - name: browser_set_default_time_to_completion_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: browser_set_default_user_choice_result
+      type: STRING
+      mode: NULLABLE
+    - name: browser_shim_usage_blocked
+      type: STRING
+      mode: NULLABLE
+    - name: browserprovider_xul_import_bookmarks
+      type: STRING
+      mode: NULLABLE
+    - name: bucket_order_errors
+      type: STRING
+      mode: NULLABLE
+    - name: busy_tab_abandoned
+      type: STRING
+      mode: NULLABLE
+    - name: cache_device_search_2
+      type: STRING
+      mode: NULLABLE
+    - name: cache_disk_search_2
+      type: STRING
+      mode: NULLABLE
+    - name: cache_lm_inconsistent
+      type: STRING
+      mode: NULLABLE
+    - name: cache_memory_search_2
+      type: STRING
+      mode: NULLABLE
+    - name: cache_offline_search_2
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_2
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_2
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nsasyncdoomevent_run
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nsblockoncachethreadevent_run
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_close
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_doom
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_doomandfailpendingrequests
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getcacheelement
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getclientid
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getdatasize
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getdeviceid
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getexpirationtime
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getfetchcount
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getfile
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getkey
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getlastfetched
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getlastmodified
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getmetadataelement
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getpredicteddatasize
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getsecurityinfo
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getstoragedatasize
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getstoragepolicy
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_isstreambased
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_markvalid
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_openinputstream
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_openoutputstream
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_requestdatasizechange
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setcacheelement
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setdatasize
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setexpirationtime
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setmetadataelement
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setpredicteddatasize
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setsecurityinfo
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setstoragepolicy
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_visitmetadata
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_closeallstreams
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_diskdeviceheapsize
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_evictentriesforclient
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_getcacheiotarget
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_isstorageenabledforpolicy
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_onprofilechanged
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_onprofileshutdown
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_opencacheentry
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_processrequest
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_setdiskcachecapacity
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_setdiskcacheenabled
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_setdiskcachemaxentrysize
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_setdisksmartsize
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_setmemorycache
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_setmemorycachemaxentrysize
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_setofflinecachecapacity
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_setofflinecacheenabled
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_shutdown
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscacheservice_visitentries
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nscompressoutputstreamwrapper_release
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nsdecompressinputstreamwrapper_release
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nsinputstreamwrapper_closeinternal
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nsinputstreamwrapper_lazyinit
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nsinputstreamwrapper_release
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nsoutputstreamwrapper_closeinternal
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nsoutputstreamwrapper_lazyinit
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nsoutputstreamwrapper_release
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nsprocessrequestevent_run
+      type: STRING
+      mode: NULLABLE
+    - name: cache_service_lock_wait_mainthread_nssetdisksmartsizecallback_notify
+      type: STRING
+      mode: NULLABLE
+    - name: canvas_2d_used
+      type: STRING
+      mode: NULLABLE
+    - name: canvas_webgl2_success
+      type: STRING
+      mode: NULLABLE
+    - name: canvas_webgl_success
+      type: STRING
+      mode: NULLABLE
+    - name: canvas_webgl_used
+      type: STRING
+      mode: NULLABLE
+    - name: cert_chain_key_size_status
+      type: STRING
+      mode: NULLABLE
+    - name: cert_chain_sha1_policy_status
+      type: STRING
+      mode: NULLABLE
+    - name: cert_ev_status
+      type: STRING
+      mode: NULLABLE
+    - name: cert_ocsp_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: cert_ocsp_required
+      type: STRING
+      mode: NULLABLE
+    - name: cert_pinning_failures_by_ca
+      type: STRING
+      mode: NULLABLE
+    - name: cert_pinning_moz_results
+      type: STRING
+      mode: NULLABLE
+    - name: cert_pinning_moz_results_by_host
+      type: STRING
+      mode: NULLABLE
+    - name: cert_pinning_moz_test_results
+      type: STRING
+      mode: NULLABLE
+    - name: cert_pinning_moz_test_results_by_host
+      type: STRING
+      mode: NULLABLE
+    - name: cert_pinning_results
+      type: STRING
+      mode: NULLABLE
+    - name: cert_pinning_test_results
+      type: STRING
+      mode: NULLABLE
+    - name: cert_revocation_mechanisms
+      type: STRING
+      mode: NULLABLE
+    - name: cert_validation_http_request_canceled_time
+      type: STRING
+      mode: NULLABLE
+    - name: cert_validation_http_request_failed_time
+      type: STRING
+      mode: NULLABLE
+    - name: cert_validation_http_request_result
+      type: STRING
+      mode: NULLABLE
+    - name: cert_validation_http_request_succeeded_time
+      type: STRING
+      mode: NULLABLE
+    - name: cert_validation_success_by_ca
+      type: STRING
+      mode: NULLABLE
+    - name: changes_of_detected_language
+      type: STRING
+      mode: NULLABLE
+    - name: changes_of_target_language
+      type: STRING
+      mode: NULLABLE
+    - name: charset_override_situation
+      type: STRING
+      mode: NULLABLE
+    - name: charset_override_used
+      type: STRING
+      mode: NULLABLE
+    - name: check_addons_modified_ms
+      type: STRING
+      mode: NULLABLE
+    - name: check_java_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: checkerboard_duration
+      type: STRING
+      mode: NULLABLE
+    - name: checkerboard_peak
+      type: STRING
+      mode: NULLABLE
+    - name: checkerboard_potential_duration
+      type: STRING
+      mode: NULLABLE
+    - name: checkerboard_severity
+      type: STRING
+      mode: NULLABLE
+    - name: child_process_launch_ms
+      type: STRING
+      mode: NULLABLE
+    - name: client_certificate_scan_time
+      type: STRING
+      mode: NULLABLE
+    - name: components_shim_accessed_by_content
+      type: STRING
+      mode: NULLABLE
+    - name: composite_frame_roundtrip_time
+      type: STRING
+      mode: NULLABLE
+    - name: composite_swap_time
+      type: STRING
+      mode: NULLABLE
+    - name: composite_time
+      type: STRING
+      mode: NULLABLE
+    - name: compositor_animation_duration
+      type: STRING
+      mode: NULLABLE
+    - name: compositor_animation_max_contiguous_drops_apz
+      type: STRING
+      mode: NULLABLE
+    - name: compositor_animation_max_contiguous_drops_chrome
+      type: STRING
+      mode: NULLABLE
+    - name: compositor_animation_max_contiguous_drops_content
+      type: STRING
+      mode: NULLABLE
+    - name: compositor_animation_max_layer_area
+      type: STRING
+      mode: NULLABLE
+    - name: compositor_animation_throughput_apz
+      type: STRING
+      mode: NULLABLE
+    - name: compositor_animation_throughput_chrome
+      type: STRING
+      mode: NULLABLE
+    - name: compositor_animation_throughput_content
+      type: STRING
+      mode: NULLABLE
+    - name: container_used
+      type: STRING
+      mode: NULLABLE
+    - name: content_documents_destroyed
+      type: STRING
+      mode: NULLABLE
+    - name: content_frame_time
+      type: STRING
+      mode: NULLABLE
+    - name: content_frame_time_reason
+      type: STRING
+      mode: NULLABLE
+    - name: content_frame_time_vsync
+      type: STRING
+      mode: NULLABLE
+    - name: content_frame_time_with_svg
+      type: STRING
+      mode: NULLABLE
+    - name: content_frame_time_without_resource_upload
+      type: STRING
+      mode: NULLABLE
+    - name: content_frame_time_without_upload
+      type: STRING
+      mode: NULLABLE
+    - name: content_full_paint_time
+      type: STRING
+      mode: NULLABLE
+    - name: content_js_background_tick_delay_total_ms
+      type: STRING
+      mode: NULLABLE
+    - name: content_js_foreground_tick_delay_total_ms
+      type: STRING
+      mode: NULLABLE
+    - name: content_js_known_tick_delay_ms
+      type: STRING
+      mode: NULLABLE
+    - name: content_paint_time
+      type: STRING
+      mode: NULLABLE
+    - name: content_process_count
+      type: STRING
+      mode: NULLABLE
+    - name: content_process_launch_is_sync
+      type: STRING
+      mode: NULLABLE
+    - name: content_process_launch_mainthread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: content_process_launch_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: content_process_launch_total_ms
+      type: STRING
+      mode: NULLABLE
+    - name: content_process_max
+      type: STRING
+      mode: NULLABLE
+    - name: content_process_precise_count
+      type: STRING
+      mode: NULLABLE
+    - name: content_process_precise_max
+      type: STRING
+      mode: NULLABLE
+    - name: content_process_sync_launch_ms
+      type: STRING
+      mode: NULLABLE
+    - name: content_process_time_since_last_launch_ms
+      type: STRING
+      mode: NULLABLE
+    - name: content_response_duration
+      type: STRING
+      mode: NULLABLE
+    - name: content_signature_verification_status
+      type: STRING
+      mode: NULLABLE
+    - name: cookie_behavior
+      type: STRING
+      mode: NULLABLE
+    - name: cookie_leave_secure_alone
+      type: STRING
+      mode: NULLABLE
+    - name: cookie_purging_duration_ms
+      type: STRING
+      mode: NULLABLE
+    - name: cookie_purging_interval_hours
+      type: STRING
+      mode: NULLABLE
+    - name: cookie_purging_origins_purged
+      type: STRING
+      mode: NULLABLE
+    - name: cookie_purging_trackers_user_interaction_remaining_days
+      type: STRING
+      mode: NULLABLE
+    - name: cookie_purging_trackers_with_user_interaction
+      type: STRING
+      mode: NULLABLE
+    - name: cookie_retrieval_samesite_problem
+      type: STRING
+      mode: NULLABLE
+    - name: cookie_samesite_set_vs_unset
+      type: STRING
+      mode: NULLABLE
+    - name: cookie_scheme_https
+      type: STRING
+      mode: NULLABLE
+    - name: cookie_scheme_security
+      type: STRING
+      mode: NULLABLE
+    - name: crash_store_compressed_bytes
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_beforeunloadevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_compositionevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_customevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_devicemotionevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_deviceorientationevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_dragevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_errorevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_event
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_events
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_hashchangeevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_htmlevents
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_keyboardevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_keyevents
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_messageevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_mouseevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_mouseevents
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_mousescrollevents
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_mutationevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_mutationevents
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_popstateevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_scrollareaevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_storageevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_svgevents
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_textevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_timeevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_touchevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_uievent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_uievents
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_xulcommandevent
+      type: STRING
+      mode: NULLABLE
+    - name: create_event_xulcommandevents
+      type: STRING
+      mode: NULLABLE
+    - name: creditcard_num_uses
+      type: STRING
+      mode: NULLABLE
+    - name: crlite_faster_than_ocsp_ms
+      type: STRING
+      mode: NULLABLE
+    - name: crlite_result
+      type: STRING
+      mode: NULLABLE
+    - name: crlite_vs_ocsp_result
+      type: STRING
+      mode: NULLABLE
+    - name: cryptominers_blocked_count
+      type: STRING
+      mode: NULLABLE
+    - name: csp_documents_count
+      type: STRING
+      mode: NULLABLE
+    - name: csp_referrer_directive
+      type: STRING
+      mode: NULLABLE
+    - name: csp_unsafe_eval_documents_count
+      type: STRING
+      mode: NULLABLE
+    - name: csp_unsafe_inline_documents_count
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_async_snow_white_freeing
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_collected
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_finish_igc
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_full
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_max_pause
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_need_gc
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_oom
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_slice_during_idle
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_sync_skippable
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_time_between
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_visited_gced
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_visited_ref_counted
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_worker
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_worker_collected
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_worker_need_gc
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_worker_oom
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_worker_visited_gced
+      type: STRING
+      mode: NULLABLE
+    - name: cycle_collector_worker_visited_ref_counted
+      type: STRING
+      mode: NULLABLE
+    - name: d3d11_sync_handle_failure
+      type: STRING
+      mode: NULLABLE
+    - name: data_storage_entries
+      type: STRING
+      mode: NULLABLE
+    - name: database_locked_exception
+      type: STRING
+      mode: NULLABLE
+    - name: database_successful_unlock
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_ibm866
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_iso2022jp
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_iso_8859_5
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_koi8r
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_koi8u
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_macarabic
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_macce
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_maccroatian
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_maccyrillic
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_macdevanagari
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_macfarsi
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_macgreek
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_macgujarati
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_macgurmukhi
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_machebrew
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_macicelandic
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_macromanian
+      type: STRING
+      mode: NULLABLE
+    - name: decoder_instantiated_macturkish
+      type: STRING
+      mode: NULLABLE
+    - name: dedicated_worker_destroyed
+      type: STRING
+      mode: NULLABLE
+    - name: dedicated_worker_spawn_gets_queued
+      type: STRING
+      mode: NULLABLE
+    - name: defective_permissions_sql_removed
+      type: STRING
+      mode: NULLABLE
+    - name: deferred_finalize_async
+      type: STRING
+      mode: NULLABLE
+    - name: denied_translation_offers
+      type: STRING
+      mode: NULLABLE
+    - name: deserialize_bytes
+      type: STRING
+      mode: NULLABLE
+    - name: deserialize_items
+      type: STRING
+      mode: NULLABLE
+    - name: deserialize_us
+      type: STRING
+      mode: NULLABLE
+    - name: device_reset_reason
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_about_devtools_opened_key
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_about_devtools_opened_reason
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_aboutdebugging_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_aboutdebugging_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_accessibility_picker_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_accessibility_service_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_accessibility_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_animationinspector_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_animationinspector_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_application_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_browserconsole_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_browserconsole_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_canvasdebugger_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_canvasdebugger_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_changesview_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_compatibilityview_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_compatibilityview_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_computedview_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_computedview_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_custom_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_custom_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_debugger_display_source_local_ms
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_debugger_display_source_remote_ms
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_debugger_load_source_ms
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_developertoolbar_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_developertoolbar_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_dom_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_dom_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_entry_point
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_eyedropper_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_flexbox_highlighter_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_flexinspector_element_type_displayed
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_fonteditor_font_type_displayed
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_fonteditor_n_font_axes
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_fonteditor_n_fonts_rendered
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_fontinspector_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_fontinspector_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_grid_highlighter_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_heap_snapshot_edge_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_heap_snapshot_node_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_inspector_new_root_to_reload_delay_ms
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_inspector_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_inspector_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_jsbrowserdebugger_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_jsbrowserdebugger_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_jsdebugger_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_jsdebugger_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_jsprofiler_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_jsprofiler_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_layoutview_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_layoutview_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_memory_diff_census
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_memory_dominator_tree_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_memory_export_snapshot_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_memory_filter_census
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_memory_import_snapshot_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_memory_inverted_census
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_memory_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_memory_take_snapshot_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_memory_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_menu_eyedropper_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_netmonitor_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_netmonitor_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_number_of_css_grids_in_a_page
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_options_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_options_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_os_enumerated_per_user
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_os_is_64_bits_per_user
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_paintflashing_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_paintflashing_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_perftools_console_recording_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_perftools_recording_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_perftools_recording_duration_ms
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_perftools_recording_export_flag
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_perftools_recording_import_flag
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_picker_eyedropper_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_read_heap_snapshot_ms
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_reload_addon_installed_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_reload_addon_reload_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_responsive_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_responsive_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_ruleview_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_ruleview_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_save_heap_snapshot_ms
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_scratchpad_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_scratchpad_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_scratchpad_window_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_screen_resolution_enumerated_per_user
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_shadereditor_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_shadereditor_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_storage_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_storage_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_styleeditor_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_styleeditor_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_tabs_open_average_linear
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_tabs_open_peak_linear
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_tabs_pinned_average_linear
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_tabs_pinned_peak_linear
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_tilt_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_tilt_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_toolbox_host
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_toolbox_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_toolbox_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webaudioeditor_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webaudioeditor_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webconsole_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webconsole_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_connection_debug_used
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_connection_play_used
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_connection_result
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_connection_time_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_import_project_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_local_connection_result
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_new_project_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_other_connection_result
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_project_editor_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_project_editor_save_count
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_project_editor_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_remote_connection_result
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_simulator_connection_result
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_time_active_seconds
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_usb_connection_result
+      type: STRING
+      mode: NULLABLE
+    - name: devtools_webide_wifi_connection_result
+      type: STRING
+      mode: NULLABLE
+    - name: display_item_usage_count
+      type: STRING
+      mode: NULLABLE
+    - name: display_scaling
+      type: STRING
+      mode: NULLABLE
+    - name: dns_blacklist_count
+      type: STRING
+      mode: NULLABLE
+    - name: dns_by_type_cleanup_age
+      type: STRING
+      mode: NULLABLE
+    - name: dns_by_type_failed_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: dns_by_type_premature_eviction
+      type: STRING
+      mode: NULLABLE
+    - name: dns_by_type_succeeded_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: dns_cleanup_age
+      type: STRING
+      mode: NULLABLE
+    - name: dns_failed_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: dns_httpssvc_connection_failed_reason
+      type: STRING
+      mode: NULLABLE
+    - name: dns_httpssvc_record_receiving_stage
+      type: STRING
+      mode: NULLABLE
+    - name: dns_lookup_algorithm
+      type: STRING
+      mode: NULLABLE
+    - name: dns_lookup_disposition
+      type: STRING
+      mode: NULLABLE
+    - name: dns_lookup_method2
+      type: STRING
+      mode: NULLABLE
+    - name: dns_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: dns_native_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: dns_native_queuing
+      type: STRING
+      mode: NULLABLE
+    - name: dns_odoh_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: dns_premature_eviction
+      type: STRING
+      mode: NULLABLE
+    - name: dns_renewal_time
+      type: STRING
+      mode: NULLABLE
+    - name: dns_renewal_time_for_ttl
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_blacklisted
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_compare
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_disabled
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_first
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_first2
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_http_version
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_ns_verfified
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_processing_time
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_race
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_race2
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_redirected
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_request_per_conn
+      type: STRING
+      mode: NULLABLE
+    - name: dns_trr_success
+      type: STRING
+      mode: NULLABLE
+    - name: dnt_usage
+      type: STRING
+      mode: NULLABLE
+    - name: document_data_uri_loads
+      type: STRING
+      mode: NULLABLE
+    - name: document_with_expanded_principal
+      type: STRING
+      mode: NULLABLE
+    - name: dom_script_is_streamed
+      type: STRING
+      mode: NULLABLE
+    - name: dom_script_kind
+      type: STRING
+      mode: NULLABLE
+    - name: dom_script_load_emit_time_percent
+      type: STRING
+      mode: NULLABLE
+    - name: dom_script_load_incremental_avg_transfer_rate
+      type: STRING
+      mode: NULLABLE
+    - name: dom_script_load_incremental_ratio
+      type: STRING
+      mode: NULLABLE
+    - name: dom_script_load_parse_time_percent
+      type: STRING
+      mode: NULLABLE
+    - name: dom_script_load_stream_time_percent
+      type: STRING
+      mode: NULLABLE
+    - name: dom_script_load_streamparse_estimate_percent
+      type: STRING
+      mode: NULLABLE
+    - name: dom_script_preload_result
+      type: STRING
+      mode: NULLABLE
+    - name: dwritefont_delayedinitfontlist_collect
+      type: STRING
+      mode: NULLABLE
+    - name: dwritefont_delayedinitfontlist_count
+      type: STRING
+      mode: NULLABLE
+    - name: dwritefont_delayedinitfontlist_total
+      type: STRING
+      mode: NULLABLE
+    - name: dwritefont_init_problem
+      type: STRING
+      mode: NULLABLE
+    - name: e10s_blocked_from_running
+      type: STRING
+      mode: NULLABLE
+    - name: e10s_status
+      type: STRING
+      mode: NULLABLE
+    - name: echconfig_success_rate
+      type: STRING
+      mode: NULLABLE
+    - name: eh_final_response
+      type: STRING
+      mode: NULLABLE
+    - name: eh_num_of_hints_per_page
+      type: STRING
+      mode: NULLABLE
+    - name: eh_state_of_preload_request
+      type: STRING
+      mode: NULLABLE
+    - name: eh_time_to_final_response
+      type: STRING
+      mode: NULLABLE
+    - name: email_tracker_count
+      type: STRING
+      mode: NULLABLE
+    - name: enable_privilege_ever_called
+      type: STRING
+      mode: NULLABLE
+    - name: encoding_detection_outcome_html
+      type: STRING
+      mode: NULLABLE
+    - name: encoding_detection_outcome_text
+      type: STRING
+      mode: NULLABLE
+    - name: encoding_override_situation
+      type: STRING
+      mode: NULLABLE
+    - name: encoding_override_situation_2
+      type: STRING
+      mode: NULLABLE
+    - name: esni_keys_record_fetch_delays
+      type: STRING
+      mode: NULLABLE
+    - name: esni_keys_records_found
+      type: STRING
+      mode: NULLABLE
+    - name: esni_noesni_tls_success_rate
+      type: STRING
+      mode: NULLABLE
+    - name: eventloop_ui_activity_exp_ms
+      type: STRING
+      mode: NULLABLE
+    - name: extension_install_prompt_result
+      type: STRING
+      mode: NULLABLE
+    - name: extension_update_type
+      type: STRING
+      mode: NULLABLE
+    - name: fallback_to_base_font
+      type: STRING
+      mode: NULLABLE
+    - name: fallback_to_langpack_font
+      type: STRING
+      mode: NULLABLE
+    - name: fallback_to_prefs_font
+      type: STRING
+      mode: NULLABLE
+    - name: fallback_to_user_font
+      type: STRING
+      mode: NULLABLE
+    - name: family_safety
+      type: STRING
+      mode: NULLABLE
+    - name: feed_protocol_usage
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_activity_stream_highlights_loader_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_activity_stream_topsites_loader_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_bookmarks_count
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_custom_homepage
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_distribution_code_category
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_distribution_download_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_distribution_referrer_invalid
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_globalhistory_add_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_globalhistory_update_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_globalhistory_visited_build_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_homepanels_custom
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_load_saved_page
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_loop_other_latency
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_loop_ui_latency
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_orbot_installed
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_reader_view_cache_size
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_reading_list_count
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_restoring_activity
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_search_loader_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sessionstore_all_files_damaged
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sessionstore_damaged_session_file
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sessionstore_restoring_from_backup
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_startup_time_geckoready
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_startup_time_javaui
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sync11_migration_notifications_offered
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sync11_migration_sentinels_seen
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sync11_migrations_completed
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sync11_migrations_failed
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sync11_migrations_succeeded
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sync_number_of_syncs_completed
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sync_number_of_syncs_failed
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sync_number_of_syncs_failed_backoff
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_sync_number_of_syncs_started
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_tabqueue_queuesize
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_topsites_loader_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_tracking_protection_state
+      type: STRING
+      mode: NULLABLE
+    - name: fennec_was_killed
+      type: STRING
+      mode: NULLABLE
+    - name: fetch_is_mainthread
+      type: STRING
+      mode: NULLABLE
+    - name: file_embedded_serviceworkers
+      type: STRING
+      mode: NULLABLE
+    - name: find_plugins
+      type: STRING
+      mode: NULLABLE
+    - name: fingerprinters_blocked_count
+      type: STRING
+      mode: NULLABLE
+    - name: fips_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: fog_eval_user_active_s
+      type: STRING
+      mode: NULLABLE
+    - name: fog_eval_user_inactive_s
+      type: STRING
+      mode: NULLABLE
+    - name: fog_eval_window_raised_s
+      type: STRING
+      mode: NULLABLE
+    - name: font_cache_hit
+      type: STRING
+      mode: NULLABLE
+    - name: fontlist_bundledfonts_activate
+      type: STRING
+      mode: NULLABLE
+    - name: fontlist_initfacenamelists
+      type: STRING
+      mode: NULLABLE
+    - name: fontlist_initotherfamilynames
+      type: STRING
+      mode: NULLABLE
+    - name: fontlist_initotherfamilynames_no_deferring
+      type: STRING
+      mode: NULLABLE
+    - name: forced_device_reset_reason
+      type: STRING
+      mode: NULLABLE
+    - name: forget_skippable_during_idle
+      type: STRING
+      mode: NULLABLE
+    - name: forget_skippable_frequency
+      type: STRING
+      mode: NULLABLE
+    - name: forget_skippable_max
+      type: STRING
+      mode: NULLABLE
+    - name: form_isindex_used
+      type: STRING
+      mode: NULLABLE
+    - name: fullscreen_change_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fullscreen_transition_black_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_bookmarks_toolbar_init_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_browser_fullscreen_used
+      type: STRING
+      mode: NULLABLE
+    - name: fx_content_crash_dump_unavailable
+      type: STRING
+      mode: NULLABLE
+    - name: fx_content_crash_not_submitted
+      type: STRING
+      mode: NULLABLE
+    - name: fx_content_crash_presented
+      type: STRING
+      mode: NULLABLE
+    - name: fx_gesture_compress_snapshot_of_page
+      type: STRING
+      mode: NULLABLE
+    - name: fx_gesture_install_snapshot_of_page
+      type: STRING
+      mode: NULLABLE
+    - name: fx_lazyload_image_page_load_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_migration_entry_point
+      type: STRING
+      mode: NULLABLE
+    - name: fx_migration_entry_point_categorical
+      type: STRING
+      mode: NULLABLE
+    - name: fx_migration_source_browser
+      type: STRING
+      mode: NULLABLE
+    - name: fx_new_window_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_all_tabs
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_document
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_1
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_10_14
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_15_19
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_20_24
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_25_29
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_2_4
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_30_34
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_35_39
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_40_44
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_45_49
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_50_plus
+      type: STRING
+      mode: NULLABLE
+    - name: fx_number_of_unique_site_origins_per_loaded_tabs_5_9
+      type: STRING
+      mode: NULLABLE
+    - name: fx_page_action_added
+      type: STRING
+      mode: NULLABLE
+    - name: fx_page_action_managed
+      type: STRING
+      mode: NULLABLE
+    - name: fx_page_action_panel_used
+      type: STRING
+      mode: NULLABLE
+    - name: fx_page_action_removed
+      type: STRING
+      mode: NULLABLE
+    - name: fx_page_action_urlbar_used
+      type: STRING
+      mode: NULLABLE
+    - name: fx_page_load_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_page_load_ms_2
+      type: STRING
+      mode: NULLABLE
+    - name: fx_page_reload_key_combo
+      type: STRING
+      mode: NULLABLE
+    - name: fx_page_reload_normal_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_page_reload_skip_cache_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_picture_in_picture_background_tab_playing_duration
+      type: STRING
+      mode: NULLABLE
+    - name: fx_picture_in_picture_foreground_tab_playing_duration
+      type: STRING
+      mode: NULLABLE
+    - name: fx_picture_in_picture_window_open_duration
+      type: STRING
+      mode: NULLABLE
+    - name: fx_preferences_category_opened
+      type: STRING
+      mode: NULLABLE
+    - name: fx_preferences_category_opened_v2
+      type: STRING
+      mode: NULLABLE
+    - name: fx_preferences_opened_via
+      type: STRING
+      mode: NULLABLE
+    - name: fx_refresh_driver_chrome_frame_delay_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_refresh_driver_content_frame_delay_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_refresh_driver_sync_scroll_frame_delay_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_sanitize_cache
+      type: STRING
+      mode: NULLABLE
+    - name: fx_sanitize_cookies_2
+      type: STRING
+      mode: NULLABLE
+    - name: fx_sanitize_downloads
+      type: STRING
+      mode: NULLABLE
+    - name: fx_sanitize_formdata
+      type: STRING
+      mode: NULLABLE
+    - name: fx_sanitize_history
+      type: STRING
+      mode: NULLABLE
+    - name: fx_sanitize_openwindows
+      type: STRING
+      mode: NULLABLE
+    - name: fx_sanitize_sessions
+      type: STRING
+      mode: NULLABLE
+    - name: fx_sanitize_sitesettings
+      type: STRING
+      mode: NULLABLE
+    - name: fx_sanitize_total
+      type: STRING
+      mode: NULLABLE
+    - name: fx_schedule_pressure_idle_sample_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_searchbar_selected_result_method
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_all_files_corrupt
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_auto_restore_duration_until_eager_tabs_restored_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_collect_all_windows_data_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_collect_data_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_collect_session_history_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_corrupt_file
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_dom_storage_size_estimate_chars
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_file_size_bytes
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_manual_restore_duration_until_eager_tabs_restored_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_number_of_eager_tabs_restored
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_number_of_tabs_restored
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_number_of_windows_restored
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_privacy_level
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_read_file_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_restore_window_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_send_update_caused_oom
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_serialize_data_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_startup_init_session_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_startup_onload_initial_window_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_session_restore_write_file_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_startup_migration_automated_import_process_success
+      type: STRING
+      mode: NULLABLE
+    - name: fx_startup_migration_automated_import_undo
+      type: STRING
+      mode: NULLABLE
+    - name: fx_startup_migration_browser_count
+      type: STRING
+      mode: NULLABLE
+    - name: fx_startup_migration_existing_default_browser
+      type: STRING
+      mode: NULLABLE
+    - name: fx_startup_migration_undo_offered
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_click_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_close_permit_unload_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_close_time_anim_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_close_time_no_anim_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_switch_composite_e10s_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_switch_request_tab_warming_state
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_switch_spinner_type
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_switch_spinner_visible_long_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_switch_spinner_visible_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_switch_spinner_visible_trigger
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_switch_total_e10s_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_switch_total_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_tab_switch_update_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_thumbnails_bg_capture_canvas_draw_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_thumbnails_bg_capture_done_reason_2
+      type: STRING
+      mode: NULLABLE
+    - name: fx_thumbnails_bg_capture_page_load_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_thumbnails_bg_capture_queue_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_thumbnails_bg_capture_service_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_thumbnails_bg_queue_size_on_capture
+      type: STRING
+      mode: NULLABLE
+    - name: fx_thumbnails_capture_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_thumbnails_hit_or_miss
+      type: STRING
+      mode: NULLABLE
+    - name: fx_thumbnails_store_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_total_top_visits
+      type: STRING
+      mode: NULLABLE
+    - name: fx_touch_used
+      type: STRING
+      mode: NULLABLE
+    - name: fx_urlbar_merino_latency_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_urlbar_merino_latency_weather_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_urlbar_merino_response
+      type: STRING
+      mode: NULLABLE
+    - name: fx_urlbar_merino_response_weather
+      type: STRING
+      mode: NULLABLE
+    - name: fx_urlbar_quick_suggest_remote_settings_latency_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fx_urlbar_selected_result_index
+      type: STRING
+      mode: NULLABLE
+    - name: fx_urlbar_selected_result_method
+      type: STRING
+      mode: NULLABLE
+    - name: fx_urlbar_selected_result_type
+      type: STRING
+      mode: NULLABLE
+    - name: fx_urlbar_selected_result_type_2
+      type: STRING
+      mode: NULLABLE
+    - name: fx_urlbar_zero_prefix_dwell_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: fxa_configured
+      type: STRING
+      mode: NULLABLE
+    - name: fxrpc_entry_method
+      type: STRING
+      mode: NULLABLE
+    - name: fxrpc_ff_installation_from
+      type: STRING
+      mode: NULLABLE
+    - name: gc_animation_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_budget_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_budget_ms_2
+      type: STRING
+      mode: NULLABLE
+    - name: gc_budget_overrun
+      type: STRING
+      mode: NULLABLE
+    - name: gc_budget_was_increased
+      type: STRING
+      mode: NULLABLE
+    - name: gc_compact_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_effectiveness
+      type: STRING
+      mode: NULLABLE
+    - name: gc_in_progress_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_incremental_disabled
+      type: STRING
+      mode: NULLABLE
+    - name: gc_is_compartmental
+      type: STRING
+      mode: NULLABLE
+    - name: gc_mark_gray_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_mark_gray_ms_2
+      type: STRING
+      mode: NULLABLE
+    - name: gc_mark_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_mark_rate
+      type: STRING
+      mode: NULLABLE
+    - name: gc_mark_rate_2
+      type: STRING
+      mode: NULLABLE
+    - name: gc_mark_roots_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_mark_roots_us
+      type: STRING
+      mode: NULLABLE
+    - name: gc_mark_weak_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_max_pause_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_max_pause_ms_2
+      type: STRING
+      mode: NULLABLE
+    - name: gc_minor_reason
+      type: STRING
+      mode: NULLABLE
+    - name: gc_minor_reason_long
+      type: STRING
+      mode: NULLABLE
+    - name: gc_minor_us
+      type: STRING
+      mode: NULLABLE
+    - name: gc_mmu_50
+      type: STRING
+      mode: NULLABLE
+    - name: gc_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_non_incremental
+      type: STRING
+      mode: NULLABLE
+    - name: gc_non_incremental_reason
+      type: STRING
+      mode: NULLABLE
+    - name: gc_nursery_bytes
+      type: STRING
+      mode: NULLABLE
+    - name: gc_nursery_bytes_2
+      type: STRING
+      mode: NULLABLE
+    - name: gc_nursery_promotion_rate
+      type: STRING
+      mode: NULLABLE
+    - name: gc_parallel_mark_interruptions
+      type: STRING
+      mode: NULLABLE
+    - name: gc_parallel_mark_speedup
+      type: STRING
+      mode: NULLABLE
+    - name: gc_parallel_mark_utilization
+      type: STRING
+      mode: NULLABLE
+    - name: gc_prepare_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_pretenure_count
+      type: STRING
+      mode: NULLABLE
+    - name: gc_pretenure_count_2
+      type: STRING
+      mode: NULLABLE
+    - name: gc_reason_2
+      type: STRING
+      mode: NULLABLE
+    - name: gc_reset
+      type: STRING
+      mode: NULLABLE
+    - name: gc_reset_reason
+      type: STRING
+      mode: NULLABLE
+    - name: gc_scc_sweep_max_pause_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_scc_sweep_total_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_slice_count
+      type: STRING
+      mode: NULLABLE
+    - name: gc_slice_during_idle
+      type: STRING
+      mode: NULLABLE
+    - name: gc_slice_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_slice_was_long
+      type: STRING
+      mode: NULLABLE
+    - name: gc_slow_phase
+      type: STRING
+      mode: NULLABLE
+    - name: gc_slow_task
+      type: STRING
+      mode: NULLABLE
+    - name: gc_sweep_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_task_start_delay_us
+      type: STRING
+      mode: NULLABLE
+    - name: gc_tenured_survival_rate
+      type: STRING
+      mode: NULLABLE
+    - name: gc_time_between_s
+      type: STRING
+      mode: NULLABLE
+    - name: gc_time_between_slices_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gc_wait_for_idle_count
+      type: STRING
+      mode: NULLABLE
+    - name: gc_zone_count
+      type: STRING
+      mode: NULLABLE
+    - name: gc_zones_collected
+      type: STRING
+      mode: NULLABLE
+    - name: gdi_initfontlist_total
+      type: STRING
+      mode: NULLABLE
+    - name: geolocation_accuracy_exponential
+      type: STRING
+      mode: NULLABLE
+    - name: geolocation_error
+      type: STRING
+      mode: NULLABLE
+    - name: geolocation_getcurrentposition_secure_origin
+      type: STRING
+      mode: NULLABLE
+    - name: geolocation_getcurrentposition_visible
+      type: STRING
+      mode: NULLABLE
+    - name: geolocation_osx_source_is_mls
+      type: STRING
+      mode: NULLABLE
+    - name: geolocation_request_granted
+      type: STRING
+      mode: NULLABLE
+    - name: geolocation_watchposition_secure_origin
+      type: STRING
+      mode: NULLABLE
+    - name: geolocation_watchposition_visible
+      type: STRING
+      mode: NULLABLE
+    - name: geolocation_win8_source_is_mls
+      type: STRING
+      mode: NULLABLE
+    - name: gfx_content_failed_to_acquire_device
+      type: STRING
+      mode: NULLABLE
+    - name: gfx_crash
+      type: STRING
+      mode: NULLABLE
+    - name: gfx_macos_video_low_power
+      type: STRING
+      mode: NULLABLE
+    - name: ghost_windows
+      type: STRING
+      mode: NULLABLE
+    - name: gpu_process_crash_fallbacks
+      type: STRING
+      mode: NULLABLE
+    - name: gpu_process_initialization_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gpu_process_launch_time_ms_2
+      type: STRING
+      mode: NULLABLE
+    - name: gpu_wait_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gradient_duration
+      type: STRING
+      mode: NULLABLE
+    - name: gradient_retention_time
+      type: STRING
+      mode: NULLABLE
+    - name: graphics_driver_startup_test
+      type: STRING
+      mode: NULLABLE
+    - name: graphics_sanity_test
+      type: STRING
+      mode: NULLABLE
+    - name: graphics_sanity_test_os_snapshot
+      type: STRING
+      mode: NULLABLE
+    - name: graphics_sanity_test_reason
+      type: STRING
+      mode: NULLABLE
+    - name: gv_content_process_lifetime_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gv_page_load_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gv_page_load_progress_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gv_page_reload_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gv_startup_modules_ms
+      type: STRING
+      mode: NULLABLE
+    - name: gv_startup_runtime_ms
+      type: STRING
+      mode: NULLABLE
+    - name: hidden_viewport_overflow_type
+      type: STRING
+      mode: NULLABLE
+    - name: history_lastvisited_tree_query_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: history_sidebar_view_type
+      type: STRING
+      mode: NULLABLE
+    - name: hover_until_unselected_tab_opened
+      type: STRING
+      mode: NULLABLE
+    - name: hpack_bytes_evicted_compressor
+      type: STRING
+      mode: NULLABLE
+    - name: hpack_bytes_evicted_decompressor
+      type: STRING
+      mode: NULLABLE
+    - name: hpack_bytes_evicted_ratio_compressor
+      type: STRING
+      mode: NULLABLE
+    - name: hpack_bytes_evicted_ratio_decompressor
+      type: STRING
+      mode: NULLABLE
+    - name: hpack_elements_evicted_compressor
+      type: STRING
+      mode: NULLABLE
+    - name: hpack_elements_evicted_decompressor
+      type: STRING
+      mode: NULLABLE
+    - name: hpack_peak_count_compressor
+      type: STRING
+      mode: NULLABLE
+    - name: hpack_peak_count_decompressor
+      type: STRING
+      mode: NULLABLE
+    - name: hpack_peak_size_compressor
+      type: STRING
+      mode: NULLABLE
+    - name: hpack_peak_size_decompressor
+      type: STRING
+      mode: NULLABLE
+    - name: hsts_upgrade_source
+      type: STRING
+      mode: NULLABLE
+    - name: http2_fail_before_settings
+      type: STRING
+      mode: NULLABLE
+    - name: http3_0rtt_state
+      type: STRING
+      mode: NULLABLE
+    - name: http3_blocked_by_stream_limit_per_conn
+      type: STRING
+      mode: NULLABLE
+    - name: http3_drop_dgrams
+      type: STRING
+      mode: NULLABLE
+    - name: http3_loss_ratio
+      type: STRING
+      mode: NULLABLE
+    - name: http3_request_per_conn
+      type: STRING
+      mode: NULLABLE
+    - name: http3_saved_dgrams
+      type: STRING
+      mode: NULLABLE
+    - name: http3_sending_blocked_by_flow_control_per_trans
+      type: STRING
+      mode: NULLABLE
+    - name: http3_timer_delayed
+      type: STRING
+      mode: NULLABLE
+    - name: http3_trans_blocked_by_stream_limit_per_conn
+      type: STRING
+      mode: NULLABLE
+    - name: http3_trans_sending_blocked_by_flow_control_per_conn
+      type: STRING
+      mode: NULLABLE
+    - name: http_09_info
+      type: STRING
+      mode: NULLABLE
+    - name: http_altsvc_entries_per_header
+      type: STRING
+      mode: NULLABLE
+    - name: http_altsvc_mapping_changed_target
+      type: STRING
+      mode: NULLABLE
+    - name: http_auth_confirm_prompt
+      type: STRING
+      mode: NULLABLE
+    - name: http_auth_dialog_stats_2
+      type: STRING
+      mode: NULLABLE
+    - name: http_auth_dialog_stats_3
+      type: STRING
+      mode: NULLABLE
+    - name: http_auth_resource_type
+      type: STRING
+      mode: NULLABLE
+    - name: http_auth_type_stats
+      type: STRING
+      mode: NULLABLE
+    - name: http_auth_userinfo_uri
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_disposition_2
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_disposition_2_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_entry_alive_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_entry_reload_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_entry_reuse_count
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_io_queue_2_evict
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_io_queue_2_index
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_io_queue_2_management
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_io_queue_2_open
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_io_queue_2_open_priority
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_io_queue_2_read
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_io_queue_2_read_priority
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_io_queue_2_write
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_io_queue_2_write_priority
+      type: STRING
+      mode: NULLABLE
+    - name: http_cache_miss_halflife_experiment_2
+      type: STRING
+      mode: NULLABLE
+    - name: http_channel_disposition
+      type: STRING
+      mode: NULLABLE
+    - name: http_channel_onstart_success
+      type: STRING
+      mode: NULLABLE
+    - name: http_channel_onstart_success_odoh
+      type: STRING
+      mode: NULLABLE
+    - name: http_connection_entry_cache_hit_1
+      type: STRING
+      mode: NULLABLE
+    - name: http_content_encoding
+      type: STRING
+      mode: NULLABLE
+    - name: http_disk_cache_disposition_2
+      type: STRING
+      mode: NULLABLE
+    - name: http_disk_cache_overhead
+      type: STRING
+      mode: NULLABLE
+    - name: http_kbread_per_conn
+      type: STRING
+      mode: NULLABLE
+    - name: http_kbread_per_conn2
+      type: STRING
+      mode: NULLABLE
+    - name: http_memory_cache_disposition_2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstart_notrevalidated_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstart_qbig_highpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstart_qbig_normalpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstart_qmed_highpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstart_qmed_normalpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstart_qsmall_highpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstart_qsmall_normalpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstart_revalidated_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstop_large_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstop_notrevalidated_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstop_qbig_highpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstop_qbig_normalpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstop_qmed_highpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstop_qmed_normalpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstop_qsmall_highpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstop_qsmall_normalpri_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstop_revalidated_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_net_vs_cache_onstop_small_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_offline_cache_disposition_2
+      type: STRING
+      mode: NULLABLE
+    - name: http_offline_cache_document_load
+      type: STRING
+      mode: NULLABLE
+    - name: http_onstart_suspend_total_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_cache_read_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_cache_read_time_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_complete_load
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_complete_load_cached
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_complete_load_cached_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_complete_load_net
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_complete_load_net_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_complete_load_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_dns_issue_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_dns_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_dns_odoh_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_first_sent_to_last_received
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_open_to_first_from_cache
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_open_to_first_from_cache_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_open_to_first_received
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_open_to_first_sent
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_revalidation
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_tcp_connection
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_tcp_connection_2
+      type: STRING
+      mode: NULLABLE
+    - name: http_page_tls_handshake
+      type: STRING
+      mode: NULLABLE
+    - name: http_pageload_is_ssl
+      type: STRING
+      mode: NULLABLE
+    - name: http_proxy_type
+      type: STRING
+      mode: NULLABLE
+    - name: http_request_per_conn
+      type: STRING
+      mode: NULLABLE
+    - name: http_request_per_page
+      type: STRING
+      mode: NULLABLE
+    - name: http_request_per_page_from_cache
+      type: STRING
+      mode: NULLABLE
+    - name: http_response_status_code
+      type: STRING
+      mode: NULLABLE
+    - name: http_response_version
+      type: STRING
+      mode: NULLABLE
+    - name: http_saw_quic_alt_protocol
+      type: STRING
+      mode: NULLABLE
+    - name: http_saw_quic_alt_protocol_2
+      type: STRING
+      mode: NULLABLE
+    - name: http_scheme_upgrade
+      type: STRING
+      mode: NULLABLE
+    - name: http_scheme_upgrade_type
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_cache_read_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_cache_read_time_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_complete_load
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_complete_load_cached
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_complete_load_cached_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_complete_load_net
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_complete_load_net_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_complete_load_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_dns_issue_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_dns_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_dns_odoh_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_first_sent_to_last_received
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_open_to_first_from_cache
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_open_to_first_from_cache_v2
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_open_to_first_received
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_open_to_first_sent
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_revalidation
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_tcp_connection
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_tcp_connection_2
+      type: STRING
+      mode: NULLABLE
+    - name: http_sub_tls_handshake
+      type: STRING
+      mode: NULLABLE
+    - name: http_subitem_first_byte_latency_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_subitem_open_latency_time
+      type: STRING
+      mode: NULLABLE
+    - name: http_transaction_is_ssl
+      type: STRING
+      mode: NULLABLE
+    - name: http_transaction_restart_reason
+      type: STRING
+      mode: NULLABLE
+    - name: http_transaction_use_altsvc
+      type: STRING
+      mode: NULLABLE
+    - name: http_transaction_use_altsvc_oe
+      type: STRING
+      mode: NULLABLE
+    - name: httpconnmgr_total_speculative_conn
+      type: STRING
+      mode: NULLABLE
+    - name: httpconnmgr_unused_speculative_conn
+      type: STRING
+      mode: NULLABLE
+    - name: httpconnmgr_used_speculative_conn
+      type: STRING
+      mode: NULLABLE
+    - name: https_rr_presented
+      type: STRING
+      mode: NULLABLE
+    - name: https_rr_with_http3_presented
+      type: STRING
+      mode: NULLABLE
+    - name: https_upgrade_with_https_rr
+      type: STRING
+      mode: NULLABLE
+    - name: hyphenation_load_time
+      type: STRING
+      mode: NULLABLE
+    - name: hyphenation_memory
+      type: STRING
+      mode: NULLABLE
+    - name: idb_custom_open_with_options_count
+      type: STRING
+      mode: NULLABLE
+    - name: idle_notify_idle_ms
+      type: STRING
+      mode: NULLABLE
+    - name: image_animated_decode_count
+      type: STRING
+      mode: NULLABLE
+    - name: image_animated_decode_on_draw_latency
+      type: STRING
+      mode: NULLABLE
+    - name: image_animated_decode_time
+      type: STRING
+      mode: NULLABLE
+    - name: image_decode_chunks
+      type: STRING
+      mode: NULLABLE
+    - name: image_decode_count
+      type: STRING
+      mode: NULLABLE
+    - name: image_decode_latency_us
+      type: STRING
+      mode: NULLABLE
+    - name: image_decode_on_draw_latency
+      type: STRING
+      mode: NULLABLE
+    - name: image_decode_speed_avif
+      type: STRING
+      mode: NULLABLE
+    - name: image_decode_speed_gif
+      type: STRING
+      mode: NULLABLE
+    - name: image_decode_speed_jpeg
+      type: STRING
+      mode: NULLABLE
+    - name: image_decode_speed_png
+      type: STRING
+      mode: NULLABLE
+    - name: image_decode_speed_webp
+      type: STRING
+      mode: NULLABLE
+    - name: image_decode_time
+      type: STRING
+      mode: NULLABLE
+    - name: image_request_dispatched
+      type: STRING
+      mode: NULLABLE
+    - name: innerwindows_with_mutation_listeners
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_handled_apz_mouse_move_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_handled_apz_touch_move_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_handled_apz_wheel_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_handled_keyboard_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_handled_mouse_down_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_handled_mouse_up_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_queued_apz_mouse_move_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_queued_apz_touch_move_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_queued_apz_wheel_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_queued_click_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_queued_keyboard_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_response_coalesced_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_response_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_response_post_startup_ms
+      type: STRING
+      mode: NULLABLE
+    - name: input_event_response_startup_ms
+      type: STRING
+      mode: NULLABLE
+    - name: intermediate_preloading_errors
+      type: STRING
+      mode: NULLABLE
+    - name: intermediate_preloading_update_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: ipc_message_size2
+      type: STRING
+      mode: NULLABLE
+    - name: ipc_same_process_message_copy_oom_kb
+      type: STRING
+      mode: NULLABLE
+    - name: ipc_transaction_cancel
+      type: STRING
+      mode: NULLABLE
+    - name: ipv4_and_ipv6_address_connectivity
+      type: STRING
+      mode: NULLABLE
+    - name: js_aot_usage
+      type: STRING
+      mode: NULLABLE
+    - name: js_deprecated_language_extensions_in_addons
+      type: STRING
+      mode: NULLABLE
+    - name: js_deprecated_language_extensions_in_content
+      type: STRING
+      mode: NULLABLE
+    - name: js_privileged_parser_compile_lazy_after_ms
+      type: STRING
+      mode: NULLABLE
+    - name: js_web_parser_compile_lazy_after_ms
+      type: STRING
+      mode: NULLABLE
+    - name: keypress_present_latency
+      type: STRING
+      mode: NULLABLE
+    - name: langpack_font_families_per_page
+      type: STRING
+      mode: NULLABLE
+    - name: lazyload_image_not_viewport
+      type: STRING
+      mode: NULLABLE
+    - name: lazyload_image_started
+      type: STRING
+      mode: NULLABLE
+    - name: lazyload_image_total
+      type: STRING
+      mode: NULLABLE
+    - name: lazyload_image_viewport_loaded
+      type: STRING
+      mode: NULLABLE
+    - name: lazyload_image_viewport_loading
+      type: STRING
+      mode: NULLABLE
+    - name: link_icon_sizes_attr_dimension
+      type: STRING
+      mode: NULLABLE
+    - name: link_icon_sizes_attr_usage
+      type: STRING
+      mode: NULLABLE
+    - name: load_input_event_response_ms
+      type: STRING
+      mode: NULLABLE
+    - name: load_input_event_response_no_preload_ms
+      type: STRING
+      mode: NULLABLE
+    - name: load_input_event_response_preload_ms
+      type: STRING
+      mode: NULLABLE
+    - name: loaded_tab_count
+      type: STRING
+      mode: NULLABLE
+    - name: localdomstorage_clear_blocking_ms
+      type: STRING
+      mode: NULLABLE
+    - name: localdomstorage_getallkeys_blocking_ms
+      type: STRING
+      mode: NULLABLE
+    - name: localdomstorage_getkey_blocking_ms
+      type: STRING
+      mode: NULLABLE
+    - name: localdomstorage_getlength_blocking_ms
+      type: STRING
+      mode: NULLABLE
+    - name: localdomstorage_getvalue_blocking_ms
+      type: STRING
+      mode: NULLABLE
+    - name: localdomstorage_preload_pending_on_first_access
+      type: STRING
+      mode: NULLABLE
+    - name: localdomstorage_removekey_blocking_ms
+      type: STRING
+      mode: NULLABLE
+    - name: localdomstorage_sessiononly_preload_blocking_ms
+      type: STRING
+      mode: NULLABLE
+    - name: localdomstorage_setvalue_blocking_ms
+      type: STRING
+      mode: NULLABLE
+    - name: localdomstorage_shutdown_database_ms
+      type: STRING
+      mode: NULLABLE
+    - name: localdomstorage_unload_blocking_ms
+      type: STRING
+      mode: NULLABLE
+    - name: login_reputation_login_whitelist_lookup_time
+      type: STRING
+      mode: NULLABLE
+    - name: login_reputation_login_whitelist_result
+      type: STRING
+      mode: NULLABLE
+    - name: long_reflow_interruptible
+      type: STRING
+      mode: NULLABLE
+    - name: low_memory_events_commit_space
+      type: STRING
+      mode: NULLABLE
+    - name: low_memory_events_physical
+      type: STRING
+      mode: NULLABLE
+    - name: low_memory_events_virtual
+      type: STRING
+      mode: NULLABLE
+    - name: mac_initfontlist_total
+      type: STRING
+      mode: NULLABLE
+    - name: master_password_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: media_android_video_tunneling_support
+      type: STRING
+      mode: NULLABLE
+    - name: media_audio_backend
+      type: STRING
+      mode: NULLABLE
+    - name: media_audio_init_failure
+      type: STRING
+      mode: NULLABLE
+    - name: media_control_platform_usage
+      type: STRING
+      mode: NULLABLE
+    - name: media_control_setting_change
+      type: STRING
+      mode: NULLABLE
+    - name: media_decoder_backend_used
+      type: STRING
+      mode: NULLABLE
+    - name: media_decoding_process_crash
+      type: STRING
+      mode: NULLABLE
+    - name: media_eme_request_deprecated_warnings
+      type: STRING
+      mode: NULLABLE
+    - name: media_eme_secure_context
+      type: STRING
+      mode: NULLABLE
+    - name: media_gmp_update_content_process_has_h264
+      type: STRING
+      mode: NULLABLE
+    - name: media_gmp_update_xml_fetch_result
+      type: STRING
+      mode: NULLABLE
+    - name: media_hls_canplay_requested
+      type: STRING
+      mode: NULLABLE
+    - name: media_hls_decoder_success
+      type: STRING
+      mode: NULLABLE
+    - name: media_mkv_canplay_requested
+      type: STRING
+      mode: NULLABLE
+    - name: media_mp4_parse_num_sample_description_entries
+      type: STRING
+      mode: NULLABLE
+    - name: media_mp4_parse_sample_description_entries_have_multiple_codecs
+      type: STRING
+      mode: NULLABLE
+    - name: media_mp4_parse_sample_description_entries_have_multiple_crypto
+      type: STRING
+      mode: NULLABLE
+    - name: media_ogg_loaded_is_chained
+      type: STRING
+      mode: NULLABLE
+    - name: media_play_promise_resolution
+      type: STRING
+      mode: NULLABLE
+    - name: media_played_time_after_autoplay_blocked
+      type: STRING
+      mode: NULLABLE
+    - name: media_recorder_recording_duration
+      type: STRING
+      mode: NULLABLE
+    - name: media_recorder_track_encoder_init_timeout_type
+      type: STRING
+      mode: NULLABLE
+    - name: media_rust_mp4parse_error_code
+      type: STRING
+      mode: NULLABLE
+    - name: media_rust_mp4parse_success
+      type: STRING
+      mode: NULLABLE
+    - name: media_rust_mp4parse_track_match_audio
+      type: STRING
+      mode: NULLABLE
+    - name: media_rust_mp4parse_track_match_video
+      type: STRING
+      mode: NULLABLE
+    - name: media_sniffer_mp4_brand_pattern
+      type: STRING
+      mode: NULLABLE
+    - name: media_wmf_decode_error
+      type: STRING
+      mode: NULLABLE
+    - name: mediacache_blockowners_watermark
+      type: STRING
+      mode: NULLABLE
+    - name: mediacache_memory_watermark
+      type: STRING
+      mode: NULLABLE
+    - name: mediacache_watermark_kb
+      type: STRING
+      mode: NULLABLE
+    - name: mediacachestream_length_kb
+      type: STRING
+      mode: NULLABLE
+    - name: mediacachestream_notified_length
+      type: STRING
+      mode: NULLABLE
+    - name: memory_collection_time
+      type: STRING
+      mode: NULLABLE
+    - name: memory_free_purged_pages_ms
+      type: STRING
+      mode: NULLABLE
+    - name: memory_heap_allocated
+      type: STRING
+      mode: NULLABLE
+    - name: memory_heap_committed_unused
+      type: STRING
+      mode: NULLABLE
+    - name: memory_heap_overhead_fraction
+      type: STRING
+      mode: NULLABLE
+    - name: memory_images_content_used_uncompressed
+      type: STRING
+      mode: NULLABLE
+    - name: memory_js_compartments_system
+      type: STRING
+      mode: NULLABLE
+    - name: memory_js_compartments_user
+      type: STRING
+      mode: NULLABLE
+    - name: memory_js_gc_heap
+      type: STRING
+      mode: NULLABLE
+    - name: memory_js_realms_system
+      type: STRING
+      mode: NULLABLE
+    - name: memory_js_realms_user
+      type: STRING
+      mode: NULLABLE
+    - name: memory_resident_fast
+      type: STRING
+      mode: NULLABLE
+    - name: memory_resident_peak
+      type: STRING
+      mode: NULLABLE
+    - name: memory_storage_sqlite
+      type: STRING
+      mode: NULLABLE
+    - name: memory_total
+      type: STRING
+      mode: NULLABLE
+    - name: memory_unique
+      type: STRING
+      mode: NULLABLE
+    - name: memory_vsize
+      type: STRING
+      mode: NULLABLE
+    - name: memory_vsize_max_contiguous
+      type: STRING
+      mode: NULLABLE
+    - name: memoryblockcache_errors
+      type: STRING
+      mode: NULLABLE
+    - name: missing_font
+      type: STRING
+      mode: NULLABLE
+    - name: missing_font_langpack
+      type: STRING
+      mode: NULLABLE
+    - name: missing_font_user
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_audio
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_downloads
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_hsts
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_hsts_priming
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_hsts_priming_2
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_hsts_priming_requests
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_hsts_priming_result
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_images
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_object_subrequest
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_page_load
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_unblock_counter
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_upgrade_success
+      type: STRING
+      mode: NULLABLE
+    - name: mixed_content_video
+      type: STRING
+      mode: NULLABLE
+    - name: mouseup_followed_by_click_present_latency
+      type: STRING
+      mode: NULLABLE
+    - name: moz_blob_in_xhr
+      type: STRING
+      mode: NULLABLE
+    - name: moz_chunked_arraybuffer_in_xhr
+      type: STRING
+      mode: NULLABLE
+    - name: moz_chunked_text_in_xhr
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_block_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_block_main_thread_ms_v2
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_old_schema
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_open_readahead_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_read_b
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_read_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_read_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_sync_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_sync_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_time_to_block_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_write_b
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_write_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_cookies_write_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_open_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_open_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_other_read_b
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_other_read_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_other_read_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_other_sync_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_other_sync_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_other_write_b
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_other_write_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_other_write_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_places_read_b
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_places_read_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_places_read_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_places_sync_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_places_sync_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_places_write_b
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_places_write_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_places_write_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_truncate_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_truncate_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_webapps_read_b
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_webapps_read_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_webapps_read_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_webapps_sync_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_webapps_sync_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_webapps_write_b
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_webapps_write_main_thread_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_sqlite_webapps_write_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_storage_async_requests_ms
+      type: STRING
+      mode: NULLABLE
+    - name: moz_storage_async_requests_success
+      type: STRING
+      mode: NULLABLE
+    - name: ms_message_request_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: mse_source_buffer_type
+      type: STRING
+      mode: NULLABLE
+    - name: narrate_content_speaktime_ms
+      type: STRING
+      mode: NULLABLE
+    - name: network_back_pressure_suspension_cp_type
+      type: STRING
+      mode: NULLABLE
+    - name: network_back_pressure_suspension_delay_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: network_back_pressure_suspension_rate
+      type: STRING
+      mode: NULLABLE
+    - name: network_back_pressure_suspension_rate_v2
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_fs_type
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_hash_stats
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_hit_miss_stat_per_cache_size
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_hit_rate_per_cache_size
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_metadata_first_read_size
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_metadata_first_read_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_metadata_second_read_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_metadata_size
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_metadata_size_2
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_size_full_fat
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_v1_hit_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_v1_miss_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_v1_truncate_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_v2_hit_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_v2_input_stream_status
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_v2_miss_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: network_cache_v2_output_stream_status
+      type: STRING
+      mode: NULLABLE
+    - name: network_connection_count
+      type: STRING
+      mode: NULLABLE
+    - name: network_cookie_unicode_byte
+      type: STRING
+      mode: NULLABLE
+    - name: network_cross_origin_stylesheet_content_type
+      type: STRING
+      mode: NULLABLE
+    - name: network_disk_cache2_shutdown_clear_private
+      type: STRING
+      mode: NULLABLE
+    - name: network_disk_cache_deletedir
+      type: STRING
+      mode: NULLABLE
+    - name: network_disk_cache_deletedir_shutdown
+      type: STRING
+      mode: NULLABLE
+    - name: network_disk_cache_open
+      type: STRING
+      mode: NULLABLE
+    - name: network_disk_cache_shutdown
+      type: STRING
+      mode: NULLABLE
+    - name: network_disk_cache_shutdown_clear_private
+      type: STRING
+      mode: NULLABLE
+    - name: network_disk_cache_shutdown_v2
+      type: STRING
+      mode: NULLABLE
+    - name: network_disk_cache_trashrename
+      type: STRING
+      mode: NULLABLE
+    - name: network_http_backup_conn_won_1
+      type: STRING
+      mode: NULLABLE
+    - name: network_id
+      type: STRING
+      mode: NULLABLE
+    - name: network_id2
+      type: STRING
+      mode: NULLABLE
+    - name: network_id_online
+      type: STRING
+      mode: NULLABLE
+    - name: network_pac_url_scheme
+      type: STRING
+      mode: NULLABLE
+    - name: network_probe_maxcount
+      type: STRING
+      mode: NULLABLE
+    - name: network_race_cache_bandwidth_not_race
+      type: STRING
+      mode: NULLABLE
+    - name: network_race_cache_bandwidth_race_cache_win
+      type: STRING
+      mode: NULLABLE
+    - name: network_race_cache_bandwidth_race_network_win
+      type: STRING
+      mode: NULLABLE
+    - name: network_race_cache_bandwith_not_race
+      type: STRING
+      mode: NULLABLE
+    - name: network_race_cache_bandwith_race_cache_win
+      type: STRING
+      mode: NULLABLE
+    - name: network_race_cache_bandwith_race_network_win
+      type: STRING
+      mode: NULLABLE
+    - name: network_race_cache_validation
+      type: STRING
+      mode: NULLABLE
+    - name: network_race_cache_with_network_ocec_on_start_diff
+      type: STRING
+      mode: NULLABLE
+    - name: network_race_cache_with_network_saved_time
+      type: STRING
+      mode: NULLABLE
+    - name: network_race_cache_with_network_usage
+      type: STRING
+      mode: NULLABLE
+    - name: network_race_cache_with_network_usage_2
+      type: STRING
+      mode: NULLABLE
+    - name: network_session_at_900fd
+      type: STRING
+      mode: NULLABLE
+    - name: network_time_between_network_change_events
+      type: STRING
+      mode: NULLABLE
+    - name: newtab_page_blocked_sites_count
+      type: STRING
+      mode: NULLABLE
+    - name: newtab_page_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: newtab_page_enhanced
+      type: STRING
+      mode: NULLABLE
+    - name: newtab_page_life_span
+      type: STRING
+      mode: NULLABLE
+    - name: newtab_page_life_span_suggested
+      type: STRING
+      mode: NULLABLE
+    - name: newtab_page_pinned_sites_count
+      type: STRING
+      mode: NULLABLE
+    - name: newtab_page_shown
+      type: STRING
+      mode: NULLABLE
+    - name: newtab_page_site_clicked
+      type: STRING
+      mode: NULLABLE
+    - name: ntlm_module_used_2
+      type: STRING
+      mode: NULLABLE
+    - name: number_of_profiles
+      type: STRING
+      mode: NULLABLE
+    - name: ocsp_age_at_crlite_override
+      type: STRING
+      mode: NULLABLE
+    - name: ocsp_faster_than_crlite_ms
+      type: STRING
+      mode: NULLABLE
+    - name: odoh_skip_reason_odoh_first
+      type: STRING
+      mode: NULLABLE
+    - name: onbeforeunload_prompt_action
+      type: STRING
+      mode: NULLABLE
+    - name: onbeforeunload_prompt_count
+      type: STRING
+      mode: NULLABLE
+    - name: opaque_response_blocking_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: orb_block_initiator
+      type: STRING
+      mode: NULLABLE
+    - name: orb_block_reason
+      type: STRING
+      mode: NULLABLE
+    - name: orb_did_ever_block_response
+      type: STRING
+      mode: NULLABLE
+    - name: osfile_worker_launch_ms
+      type: STRING
+      mode: NULLABLE
+    - name: osfile_worker_ready_ms
+      type: STRING
+      mode: NULLABLE
+    - name: osfile_writeatomic_jank_ms
+      type: STRING
+      mode: NULLABLE
+    - name: page_faults_hard
+      type: STRING
+      mode: NULLABLE
+    - name: page_max_scroll_y
+      type: STRING
+      mode: NULLABLE
+    - name: page_metadata_size
+      type: STRING
+      mode: NULLABLE
+    - name: paint_build_displaylist_time
+      type: STRING
+      mode: NULLABLE
+    - name: paint_rasterize_time
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_document_generator
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_document_generator_2
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_document_size_kb
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_document_version
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_document_version_2
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_embed
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_embed_2
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_fallback_error
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_fallback_reason
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_fallback_shown
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_font_types
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_font_types_2
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_form
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_form_2
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_print
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_stream_types
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_stream_types_2
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_time_to_view_ms
+      type: STRING
+      mode: NULLABLE
+    - name: pdf_viewer_used
+      type: STRING
+      mode: NULLABLE
+    - name: perf_monitoring_test_cpu_rescheduling_proportion_moved
+      type: STRING
+      mode: NULLABLE
+    - name: permissions_migration_7_error
+      type: STRING
+      mode: NULLABLE
+    - name: permissions_remigration_comparison
+      type: STRING
+      mode: NULLABLE
+    - name: permissions_sql_corrupted
+      type: STRING
+      mode: NULLABLE
+    - name: places_annos_bookmarks_count
+      type: STRING
+      mode: NULLABLE
+    - name: places_annos_pages_count
+      type: STRING
+      mode: NULLABLE
+    - name: places_autocomplete_1st_result_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: places_autocomplete_6_first_results_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: places_autocomplete_urlinline_domain_query_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: places_backups_bookmarkstree_ms
+      type: STRING
+      mode: NULLABLE
+    - name: places_backups_daysfromlast
+      type: STRING
+      mode: NULLABLE
+    - name: places_backups_tojson_ms
+      type: STRING
+      mode: NULLABLE
+    - name: places_bookmarks_count
+      type: STRING
+      mode: NULLABLE
+    - name: places_bookmarks_searchbar_cumulative_searches
+      type: STRING
+      mode: NULLABLE
+    - name: places_database_corruption_handling_stage
+      type: STRING
+      mode: NULLABLE
+    - name: places_database_favicons_filesize_mb
+      type: STRING
+      mode: NULLABLE
+    - name: places_database_filesize_mb
+      type: STRING
+      mode: NULLABLE
+    - name: places_database_pagesize_b
+      type: STRING
+      mode: NULLABLE
+    - name: places_database_size_per_page_b
+      type: STRING
+      mode: NULLABLE
+    - name: places_expiration_steps_to_clean2
+      type: STRING
+      mode: NULLABLE
+    - name: places_export_tohtml_ms
+      type: STRING
+      mode: NULLABLE
+    - name: places_favicon_bmp_sizes
+      type: STRING
+      mode: NULLABLE
+    - name: places_favicon_gif_sizes
+      type: STRING
+      mode: NULLABLE
+    - name: places_favicon_ico_sizes
+      type: STRING
+      mode: NULLABLE
+    - name: places_favicon_jpeg_sizes
+      type: STRING
+      mode: NULLABLE
+    - name: places_favicon_other_sizes
+      type: STRING
+      mode: NULLABLE
+    - name: places_favicon_png_sizes
+      type: STRING
+      mode: NULLABLE
+    - name: places_favicon_svg_sizes
+      type: STRING
+      mode: NULLABLE
+    - name: places_frecency_recalc_chunk_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: places_history_library_search_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: places_idle_frecency_decay_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: places_idle_maintenance_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: places_keywords_count
+      type: STRING
+      mode: NULLABLE
+    - name: places_library_cumulative_bookmark_searches
+      type: STRING
+      mode: NULLABLE
+    - name: places_library_cumulative_history_searches
+      type: STRING
+      mode: NULLABLE
+    - name: places_maintenance_daysfromlast
+      type: STRING
+      mode: NULLABLE
+    - name: places_most_recent_expired_visit_days
+      type: STRING
+      mode: NULLABLE
+    - name: places_pages_count
+      type: STRING
+      mode: NULLABLE
+    - name: places_searchbar_cumulative_filter_count
+      type: STRING
+      mode: NULLABLE
+    - name: places_searchbar_cumulative_searches
+      type: STRING
+      mode: NULLABLE
+    - name: places_searchbar_filter_type
+      type: STRING
+      mode: NULLABLE
+    - name: places_sorted_bookmarks_perc
+      type: STRING
+      mode: NULLABLE
+    - name: places_tagged_bookmarks_perc
+      type: STRING
+      mode: NULLABLE
+    - name: places_tags_count
+      type: STRING
+      mode: NULLABLE
+    - name: plugin_drawing_model
+      type: STRING
+      mode: NULLABLE
+    - name: plugin_hang_notice_count
+      type: STRING
+      mode: NULLABLE
+    - name: plugin_hang_time
+      type: STRING
+      mode: NULLABLE
+    - name: plugin_hang_ui_dont_ask
+      type: STRING
+      mode: NULLABLE
+    - name: plugin_hang_ui_response_time
+      type: STRING
+      mode: NULLABLE
+    - name: plugin_hang_ui_user_response
+      type: STRING
+      mode: NULLABLE
+    - name: plugin_load_metadata
+      type: STRING
+      mode: NULLABLE
+    - name: plugin_shutdown_ms
+      type: STRING
+      mode: NULLABLE
+    - name: plugins_infobar_allow
+      type: STRING
+      mode: NULLABLE
+    - name: plugins_infobar_block
+      type: STRING
+      mode: NULLABLE
+    - name: plugins_infobar_dismissed
+      type: STRING
+      mode: NULLABLE
+    - name: plugins_infobar_shown
+      type: STRING
+      mode: NULLABLE
+    - name: plugins_notification_plugin_count
+      type: STRING
+      mode: NULLABLE
+    - name: plugins_notification_shown
+      type: STRING
+      mode: NULLABLE
+    - name: plugins_notification_user_action
+      type: STRING
+      mode: NULLABLE
+    - name: plugins_notification_user_action_2
+      type: STRING
+      mode: NULLABLE
+    - name: prclose_tcp_blocking_time_connectivity_change
+      type: STRING
+      mode: NULLABLE
+    - name: prclose_tcp_blocking_time_link_change
+      type: STRING
+      mode: NULLABLE
+    - name: prclose_tcp_blocking_time_normal
+      type: STRING
+      mode: NULLABLE
+    - name: prclose_tcp_blocking_time_offline
+      type: STRING
+      mode: NULLABLE
+    - name: prclose_tcp_blocking_time_shutdown
+      type: STRING
+      mode: NULLABLE
+    - name: prclose_udp_blocking_time_connectivity_change
+      type: STRING
+      mode: NULLABLE
+    - name: prclose_udp_blocking_time_link_change
+      type: STRING
+      mode: NULLABLE
+    - name: prclose_udp_blocking_time_normal
+      type: STRING
+      mode: NULLABLE
+    - name: prclose_udp_blocking_time_offline
+      type: STRING
+      mode: NULLABLE
+    - name: prclose_udp_blocking_time_shutdown
+      type: STRING
+      mode: NULLABLE
+    - name: prconnect_blocking_time_connectivity_change
+      type: STRING
+      mode: NULLABLE
+    - name: prconnect_blocking_time_link_change
+      type: STRING
+      mode: NULLABLE
+    - name: prconnect_blocking_time_normal
+      type: STRING
+      mode: NULLABLE
+    - name: prconnect_blocking_time_offline
+      type: STRING
+      mode: NULLABLE
+    - name: prconnect_blocking_time_shutdown
+      type: STRING
+      mode: NULLABLE
+    - name: prconnect_fail_blocking_time_connectivity_change
+      type: STRING
+      mode: NULLABLE
+    - name: prconnect_fail_blocking_time_link_change
+      type: STRING
+      mode: NULLABLE
+    - name: prconnect_fail_blocking_time_normal
+      type: STRING
+      mode: NULLABLE
+    - name: prconnect_fail_blocking_time_offline
+      type: STRING
+      mode: NULLABLE
+    - name: prconnect_fail_blocking_time_shutdown
+      type: STRING
+      mode: NULLABLE
+    - name: prconnectcontinue_blocking_time_connectivity_change
+      type: STRING
+      mode: NULLABLE
+    - name: prconnectcontinue_blocking_time_link_change
+      type: STRING
+      mode: NULLABLE
+    - name: prconnectcontinue_blocking_time_normal
+      type: STRING
+      mode: NULLABLE
+    - name: prconnectcontinue_blocking_time_offline
+      type: STRING
+      mode: NULLABLE
+    - name: prconnectcontinue_blocking_time_shutdown
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_base_confidence
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_confidence
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_global_degradation
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_learn_attempts
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_learn_full_queue
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_learn_work_time
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_predict_attempts
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_predict_full_queue
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_predict_time_to_action
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_predict_time_to_inaction
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_predict_work_time
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_predictions_calculated
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_prefetch_decision_reason
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_prefetch_ignore_reason
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_prefetch_time
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_prefetch_use_status
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_subresource_degradation
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_total_preconnects
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_total_preconnects_created
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_total_preconnects_unused
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_total_preconnects_used
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_total_predictions
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_total_prefetches
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_total_prefetches_used
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_total_preresolves
+      type: STRING
+      mode: NULLABLE
+    - name: predictor_wait_time
+      type: STRING
+      mode: NULLABLE
+    - name: presshell_reqs_per_style_flush
+      type: STRING
+      mode: NULLABLE
+    - name: print_init_to_platform_sent_settings_ms
+      type: STRING
+      mode: NULLABLE
+    - name: print_init_to_preview_doc_shown_ms
+      type: STRING
+      mode: NULLABLE
+    - name: print_preview_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: print_preview_simplify_page_opened_count
+      type: STRING
+      mode: NULLABLE
+    - name: print_preview_simplify_page_unavailable_count
+      type: STRING
+      mode: NULLABLE
+    - name: profile_directory_file_age
+      type: STRING
+      mode: NULLABLE
+    - name: push_api_notify
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_blocklist_num_sites
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_form_autofill_result
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_import_logins_from_file_categorical
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_import_logins_from_file_jank_ms
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_import_logins_from_file_ms
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_login_last_used_days
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_login_page_safety
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_manage_copied_password
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_manage_copied_username
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_manage_deleted
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_manage_deleted_all
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_manage_opened
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_manage_visibility_toggled
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_num_httpauth_passwords
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_num_improved_generated_passwords
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_num_passwords_per_hostname
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_num_saved_passwords
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_password_input_in_form
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_prompt_remember_action
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_prompt_update_action
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_saving_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: pwmgr_username_present
+      type: STRING
+      mode: NULLABLE
+    - name: qm_repositories_initialization_time
+      type: STRING
+      mode: NULLABLE
+    - name: qm_repositories_initialization_time_v2
+      type: STRING
+      mode: NULLABLE
+    - name: query_stripping_count
+      type: STRING
+      mode: NULLABLE
+    - name: query_stripping_count_by_param
+      type: STRING
+      mode: NULLABLE
+    - name: query_stripping_param_count
+      type: STRING
+      mode: NULLABLE
+    - name: quirks_mode
+      type: STRING
+      mode: NULLABLE
+    - name: range_checksum_errors
+      type: STRING
+      mode: NULLABLE
+    - name: reader_mode_download_result
+      type: STRING
+      mode: NULLABLE
+    - name: reader_mode_parse_result
+      type: STRING
+      mode: NULLABLE
+    - name: referrer_policy_count
+      type: STRING
+      mode: NULLABLE
+    - name: refresh_driver_tick
+      type: STRING
+      mode: NULLABLE
+    - name: region_location_services_difference
+      type: STRING
+      mode: NULLABLE
+    - name: requests_of_original_content
+      type: STRING
+      mode: NULLABLE
+    - name: safe_mode_usage
+      type: STRING
+      mode: NULLABLE
+    - name: sandbox_broker_initialized
+      type: STRING
+      mode: NULLABLE
+    - name: sandbox_content_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: sandbox_failed_launch
+      type: STRING
+      mode: NULLABLE
+    - name: sandbox_has_seccomp_bpf
+      type: STRING
+      mode: NULLABLE
+    - name: sandbox_has_seccomp_tsync
+      type: STRING
+      mode: NULLABLE
+    - name: sandbox_has_user_namespaces
+      type: STRING
+      mode: NULLABLE
+    - name: sandbox_has_user_namespaces_privileged
+      type: STRING
+      mode: NULLABLE
+    - name: sandbox_media_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: script_block_incorrect_mime
+      type: STRING
+      mode: NULLABLE
+    - name: script_block_incorrect_mime_2
+      type: STRING
+      mode: NULLABLE
+    - name: script_block_incorrect_mime_3
+      type: STRING
+      mode: NULLABLE
+    - name: script_file_protocol_correct_mime
+      type: STRING
+      mode: NULLABLE
+    - name: script_loaded_with_version
+      type: STRING
+      mode: NULLABLE
+    - name: script_preloader_requests
+      type: STRING
+      mode: NULLABLE
+    - name: script_preloader_wait_time
+      type: STRING
+      mode: NULLABLE
+    - name: scroll_anchor_adjustment_count
+      type: STRING
+      mode: NULLABLE
+    - name: scroll_anchor_adjustment_length
+      type: STRING
+      mode: NULLABLE
+    - name: scroll_input_methods
+      type: STRING
+      mode: NULLABLE
+    - name: scroll_present_latency
+      type: STRING
+      mode: NULLABLE
+    - name: search_reset_result
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_country_fetch_caused_sync_init
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_country_fetch_result
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_country_fetch_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_country_timeout
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_engine_count
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_init2_ms
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_init_ms
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_init_sync
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_nonus_country_mismatched_platform_osx
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_nonus_country_mismatched_platform_win
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_us_country_mismatched_platform_osx
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_us_country_mismatched_platform_win
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_us_country_mismatched_timezone
+      type: STRING
+      mode: NULLABLE
+    - name: search_service_us_timezone_mismatched_country
+      type: STRING
+      mode: NULLABLE
+    - name: security_ui
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_controlled_documents
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_destroyed
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_fetch_running
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_isolated_launch_time
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_launch_time
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_launch_time_2
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_life_time
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_registration_loading
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_registrations
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_request_passthrough
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_spawn_attempts
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_spawn_gets_queued
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_updated
+      type: STRING
+      mode: NULLABLE
+    - name: service_worker_was_spawned
+      type: STRING
+      mode: NULLABLE
+    - name: session_resumption_with_external_cache_time_until_ready_ms
+      type: STRING
+      mode: NULLABLE
+    - name: session_resumption_with_internal_cache_time_until_ready_ms
+      type: STRING
+      mode: NULLABLE
+    - name: shared_memory_ua_sheets_mapped_parent
+      type: STRING
+      mode: NULLABLE
+    - name: shared_memory_ua_sheets_mapped_parent_after_freeze
+      type: STRING
+      mode: NULLABLE
+    - name: shared_memory_ua_sheets_toshmem_succeeded
+      type: STRING
+      mode: NULLABLE
+    - name: shared_worker_count
+      type: STRING
+      mode: NULLABLE
+    - name: shared_worker_destroyed
+      type: STRING
+      mode: NULLABLE
+    - name: shared_worker_spawn_gets_queued
+      type: STRING
+      mode: NULLABLE
+    - name: shellexecutebyexplorer_duration_ms
+      type: STRING
+      mode: NULLABLE
+    - name: should_auto_detect_language
+      type: STRING
+      mode: NULLABLE
+    - name: should_translation_ui_appear
+      type: STRING
+      mode: NULLABLE
+    - name: shutdown_ok
+      type: STRING
+      mode: NULLABLE
+    - name: shutdown_phase_duration_ticks_profile_before_change
+      type: STRING
+      mode: NULLABLE
+    - name: shutdown_phase_duration_ticks_profile_before_change_qm
+      type: STRING
+      mode: NULLABLE
+    - name: shutdown_phase_duration_ticks_profile_change_net_teardown
+      type: STRING
+      mode: NULLABLE
+    - name: shutdown_phase_duration_ticks_profile_change_teardown
+      type: STRING
+      mode: NULLABLE
+    - name: shutdown_phase_duration_ticks_quit_application
+      type: STRING
+      mode: NULLABLE
+    - name: shutdown_phase_duration_ticks_xpcom_shutdown
+      type: STRING
+      mode: NULLABLE
+    - name: shutdown_phase_duration_ticks_xpcom_will_shutdown
+      type: STRING
+      mode: NULLABLE
+    - name: slow_addon_warning_response_time
+      type: STRING
+      mode: NULLABLE
+    - name: slow_addon_warning_states
+      type: STRING
+      mode: NULLABLE
+    - name: slow_script_notice_count
+      type: STRING
+      mode: NULLABLE
+    - name: slow_script_notify_delay
+      type: STRING
+      mode: NULLABLE
+    - name: slow_script_page_count
+      type: STRING
+      mode: NULLABLE
+    - name: social_enabled_on_session
+      type: STRING
+      mode: NULLABLE
+    - name: social_panel_clicks
+      type: STRING
+      mode: NULLABLE
+    - name: social_sidebar_open_duration
+      type: STRING
+      mode: NULLABLE
+    - name: social_sidebar_state
+      type: STRING
+      mode: NULLABLE
+    - name: social_toolbar_buttons
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_chunk_recvd
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_continued_headers
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_goaway_local
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_goaway_peer
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_kbread_per_conn
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_kbread_per_conn2
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_npn_connect
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_npn_join
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_parallel_streams
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_request_per_conn
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_request_per_conn_2
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_request_per_conn_3
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_server_initiated_streams
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_settings_iw
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_settings_max_streams
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_syn_ratio
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_syn_reply_ratio
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_syn_reply_size
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_syn_size
+      type: STRING
+      mode: NULLABLE
+    - name: spdy_version2
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_auth_algorithm_full
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_auth_ecdsa_curve_full
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_auth_rsa_key_size_full
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_bytes_before_cert_callback
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_cert_error_overrides
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_cert_verification_errors
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_cipher_suite_full
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_cipher_suite_resumed
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_ct_policy_compliance_of_ev_certs
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_ct_policy_compliant_connections_by_ca
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_ct_policy_non_compliant_connections_by_ca
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_handshake_privacy
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_handshake_result
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_handshake_result_conservative
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_handshake_result_ech
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_handshake_result_ech_grease
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_handshake_result_first_try
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_handshake_type
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_handshake_version
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_initial_failed_cert_validation_time_mozillapkix
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_kea_dhe_key_size_full
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_kea_ecdhe_curve_full
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_kea_rsa_key_size_full
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_key_exchange_algorithm_full
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_key_exchange_algorithm_resumed
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_npn_type
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_observed_end_entity_certificate_lifetime
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_ocsp_may_fetch
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_ocsp_stapling
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_permanent_cert_error_overrides
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_reasons_for_not_false_starting
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_resumed_session
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_scts_origin
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_scts_per_connection
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_scts_verification_status
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_server_auth_eku
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_succesful_cert_validation_time_mozillapkix
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_symmetric_cipher_full
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_symmetric_cipher_resumed
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_time_until_handshake_finished
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_time_until_ready
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_time_until_ready_conservative
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_time_until_ready_ech
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_time_until_ready_ech_grease
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_time_until_ready_first_try
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_tls10_intolerance_reason_post
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_tls10_intolerance_reason_pre
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_tls11_intolerance_reason_post
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_tls11_intolerance_reason_pre
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_tls12_intolerance_reason_post
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_tls12_intolerance_reason_pre
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_tls13_intolerance_reason_post
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_tls13_intolerance_reason_pre
+      type: STRING
+      mode: NULLABLE
+    - name: ssl_version_fallback_inappropriate
+      type: STRING
+      mode: NULLABLE
+    - name: startup_cache_requests
+      type: STRING
+      mode: NULLABLE
+    - name: startup_crash_detected
+      type: STRING
+      mode: NULLABLE
+    - name: startup_measurement_errors
+      type: STRING
+      mode: NULLABLE
+    - name: storage_access_api_ui
+      type: STRING
+      mode: NULLABLE
+    - name: storage_access_granted_count
+      type: STRING
+      mode: NULLABLE
+    - name: storage_access_remaining_days
+      type: STRING
+      mode: NULLABLE
+    - name: sts_number_of_onsocketready_calls
+      type: STRING
+      mode: NULLABLE
+    - name: sts_number_of_pending_events
+      type: STRING
+      mode: NULLABLE
+    - name: sts_number_of_pending_events_in_the_last_cycle
+      type: STRING
+      mode: NULLABLE
+    - name: sts_poll_and_event_the_last_cycle
+      type: STRING
+      mode: NULLABLE
+    - name: sts_poll_and_events_cycle
+      type: STRING
+      mode: NULLABLE
+    - name: sts_poll_block_time
+      type: STRING
+      mode: NULLABLE
+    - name: sts_poll_cycle
+      type: STRING
+      mode: NULLABLE
+    - name: stumbler_observations_per_day
+      type: STRING
+      mode: NULLABLE
+    - name: stumbler_time_between_received_locations_sec
+      type: STRING
+      mode: NULLABLE
+    - name: stumbler_time_between_start_sec
+      type: STRING
+      mode: NULLABLE
+    - name: stumbler_time_between_uploads_sec
+      type: STRING
+      mode: NULLABLE
+    - name: stumbler_upload_bytes
+      type: STRING
+      mode: NULLABLE
+    - name: stumbler_upload_cell_count
+      type: STRING
+      mode: NULLABLE
+    - name: stumbler_upload_observation_count
+      type: STRING
+      mode: NULLABLE
+    - name: stumbler_upload_wifi_ap_count
+      type: STRING
+      mode: NULLABLE
+    - name: stumbler_volume_bytes_uploaded_per_sec
+      type: STRING
+      mode: NULLABLE
+    - name: subject_principal_accessed_without_script_on_stack
+      type: STRING
+      mode: NULLABLE
+    - name: system_font_fallback
+      type: STRING
+      mode: NULLABLE
+    - name: system_font_fallback_first
+      type: STRING
+      mode: NULLABLE
+    - name: system_font_fallback_script
+      type: STRING
+      mode: NULLABLE
+    - name: tab_audio_indicator_used
+      type: STRING
+      mode: NULLABLE
+    - name: tab_count
+      type: STRING
+      mode: NULLABLE
+    - name: tab_media_blocking_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: tab_unload_to_reload
+      type: STRING
+      mode: NULLABLE
+    - name: tabchild_paint_time
+      type: STRING
+      mode: NULLABLE
+    - name: tabs_audio_competition
+      type: STRING
+      mode: NULLABLE
+    - name: tap_to_load_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: tap_to_load_image_size
+      type: STRING
+      mode: NULLABLE
+    - name: tcp_fast_open
+      type: STRING
+      mode: NULLABLE
+    - name: tcp_fast_open_2
+      type: STRING
+      mode: NULLABLE
+    - name: tcp_fast_open_3
+      type: STRING
+      mode: NULLABLE
+    - name: tcp_fast_open_status
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_archive_checking_over_quota_ms
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_archive_directories_count
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_archive_evicted_old_dirs
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_archive_evicted_over_quota
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_archive_evicting_dirs_ms
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_archive_evicting_over_quota_ms
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_archive_load_ms
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_archive_oldest_directory_age
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_archive_scan_ping_count
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_archive_session_ping_count
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_archive_size_mb
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_assemble_payload_exception
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_compress
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_discarded_archived_pings_size_mb
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_discarded_content_pings_count
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_discarded_pending_pings_size_mb
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_discarded_send_pings_size_mb
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_event_ping_sent
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_event_recording_error
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_event_registration_error
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_failed_send_pings_size_kb
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_invalid_payload_submitted
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_memory_reporter_ms
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_pending_checking_over_quota_ms
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_pending_evicting_over_quota_ms
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_pending_load_failure_parse
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_pending_load_failure_read
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_pending_load_ms
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_pending_pings_age
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_pending_pings_evicted_over_quota
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_pending_pings_size_mb
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_ping_evicted_for_server_errors
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_ping_size_exceeded_archived
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_ping_size_exceeded_pending
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_ping_size_exceeded_send
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_ping_submission_waiting_clientid
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_scheduler_tick_exception
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_scheduler_wakeup
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_send_failure
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_send_failure_type
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_send_success
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_sessiondata_failed_load
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_sessiondata_failed_parse
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_sessiondata_failed_save
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_sessiondata_failed_validation
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_stringify
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_success
+      type: STRING
+      mode: NULLABLE
+    - name: telemetry_successful_send_pings_size_kb
+      type: STRING
+      mode: NULLABLE
+    - name: text_recognition_api_performance
+      type: STRING
+      mode: NULLABLE
+    - name: text_recognition_interaction_timing
+      type: STRING
+      mode: NULLABLE
+    - name: text_recognition_text_length
+      type: STRING
+      mode: NULLABLE
+    - name: thunderbird_conversations_time_to_2nd_gloda_query_ms
+      type: STRING
+      mode: NULLABLE
+    - name: thunderbird_gloda_size_mb
+      type: STRING
+      mode: NULLABLE
+    - name: thunderbird_indexing_rate_msg_per_s
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_dom_complete_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_dom_content_loaded_end_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_dom_content_loaded_start_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_dom_interactive_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_dom_loading_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_first_click_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_first_contentful_paint_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_first_interaction_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_first_interaction_no_preload_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_first_interaction_preload_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_first_key_input_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_first_mouse_move_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_first_scroll_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_load_event_end_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_load_event_end_no_preload_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_load_event_end_preload_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_load_event_start_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_load_event_start_no_preload_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_load_event_start_preload_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_non_blank_paint_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_non_blank_paint_netopt_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_non_blank_paint_no_netopt_ms
+      type: STRING
+      mode: NULLABLE
+    - name: time_to_response_start_ms
+      type: STRING
+      mode: NULLABLE
+    - name: timeout_execution_bg_ms
+      type: STRING
+      mode: NULLABLE
+    - name: timeout_execution_bg_tracking_ms
+      type: STRING
+      mode: NULLABLE
+    - name: timeout_execution_fg_ms
+      type: STRING
+      mode: NULLABLE
+    - name: timeout_execution_fg_tracking_ms
+      type: STRING
+      mode: NULLABLE
+    - name: tls_1_3_client_auth_uses_pha
+      type: STRING
+      mode: NULLABLE
+    - name: tls_delegated_credentials_time_until_ready_ms
+      type: STRING
+      mode: NULLABLE
+    - name: tls_early_data_accepted
+      type: STRING
+      mode: NULLABLE
+    - name: tls_early_data_bytes_written
+      type: STRING
+      mode: NULLABLE
+    - name: tls_early_data_negotiated
+      type: STRING
+      mode: NULLABLE
+    - name: tls_error_report_ui
+      type: STRING
+      mode: NULLABLE
+    - name: top_level_content_documents_destroyed
+      type: STRING
+      mode: NULLABLE
+    - name: total_containers_opened
+      type: STRING
+      mode: NULLABLE
+    - name: total_content_page_load_time
+      type: STRING
+      mode: NULLABLE
+    - name: total_count_high_errors
+      type: STRING
+      mode: NULLABLE
+    - name: total_count_low_errors
+      type: STRING
+      mode: NULLABLE
+    - name: total_scroll_y
+      type: STRING
+      mode: NULLABLE
+    - name: touch_enabled_device
+      type: STRING
+      mode: NULLABLE
+    - name: touchbar_button_presses
+      type: STRING
+      mode: NULLABLE
+    - name: tracking_protection_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: tracking_protection_events
+      type: STRING
+      mode: NULLABLE
+    - name: tracking_protection_pbm_disabled
+      type: STRING
+      mode: NULLABLE
+    - name: tracking_protection_shield
+      type: STRING
+      mode: NULLABLE
+    - name: transaction_ech_retry_ech_failed_count
+      type: STRING
+      mode: NULLABLE
+    - name: transaction_ech_retry_others_count
+      type: STRING
+      mode: NULLABLE
+    - name: transaction_ech_retry_with_ech_count
+      type: STRING
+      mode: NULLABLE
+    - name: transaction_ech_retry_without_ech_count
+      type: STRING
+      mode: NULLABLE
+    - name: transaction_wait_time_http
+      type: STRING
+      mode: NULLABLE
+    - name: transaction_wait_time_http2_sup_http3
+      type: STRING
+      mode: NULLABLE
+    - name: transaction_wait_time_http3
+      type: STRING
+      mode: NULLABLE
+    - name: transaction_wait_time_spdy
+      type: STRING
+      mode: NULLABLE
+    - name: translated_characters
+      type: STRING
+      mode: NULLABLE
+    - name: translated_pages
+      type: STRING
+      mode: NULLABLE
+    - name: translation_opportunities
+      type: STRING
+      mode: NULLABLE
+    - name: trr_skip_reason_dns_worked
+      type: STRING
+      mode: NULLABLE
+    - name: trr_skip_reason_trr_first
+      type: STRING
+      mode: NULLABLE
+    - name: types_of_user_clicks
+      type: STRING
+      mode: NULLABLE
+    - name: unique_containers_opened
+      type: STRING
+      mode: NULLABLE
+    - name: update_bits_result_complete
+      type: STRING
+      mode: NULLABLE
+    - name: update_bits_result_partial
+      type: STRING
+      mode: NULLABLE
+    - name: update_can_use_bits_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_can_use_bits_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_can_use_bits_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_cannot_stage_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_cannot_stage_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_cannot_stage_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_check_code_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_check_code_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_check_code_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_check_no_update_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_check_no_update_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_check_no_update_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_download_code_complete
+      type: STRING
+      mode: NULLABLE
+    - name: update_download_code_partial
+      type: STRING
+      mode: NULLABLE
+    - name: update_download_code_unknown
+      type: STRING
+      mode: NULLABLE
+    - name: update_invalid_lastupdatetime_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_invalid_lastupdatetime_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_invalid_lastupdatetime_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_langpack_overtime
+      type: STRING
+      mode: NULLABLE
+    - name: update_last_notify_interval_days_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_last_notify_interval_days_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_last_notify_interval_days_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_not_pref_update_auto_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_not_pref_update_auto_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_not_pref_update_auto_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_not_pref_update_enabled_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_not_pref_update_enabled_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_not_pref_update_service_enabled_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_not_pref_update_service_enabled_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_not_pref_update_service_enabled_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_not_pref_update_staging_enabled_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_not_pref_update_staging_enabled_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_not_pref_update_staging_enabled_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_notification_badge_shown
+      type: STRING
+      mode: NULLABLE
+    - name: update_notification_dismissed
+      type: STRING
+      mode: NULLABLE
+    - name: update_notification_main_action_doorhanger
+      type: STRING
+      mode: NULLABLE
+    - name: update_notification_main_action_menu
+      type: STRING
+      mode: NULLABLE
+    - name: update_notification_shown
+      type: STRING
+      mode: NULLABLE
+    - name: update_ping_count_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_ping_count_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_ping_count_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_pref_service_errors_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_pref_service_errors_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_pref_service_errors_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_pref_update_cancelations_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_pref_update_cancelations_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_pref_update_cancelations_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_service_installed_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_service_installed_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_service_installed_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_service_manually_uninstalled_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_service_manually_uninstalled_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_service_manually_uninstalled_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_state_code_complete_stage
+      type: STRING
+      mode: NULLABLE
+    - name: update_state_code_complete_startup
+      type: STRING
+      mode: NULLABLE
+    - name: update_state_code_partial_stage
+      type: STRING
+      mode: NULLABLE
+    - name: update_state_code_partial_startup
+      type: STRING
+      mode: NULLABLE
+    - name: update_state_code_unknown_stage
+      type: STRING
+      mode: NULLABLE
+    - name: update_state_code_unknown_startup
+      type: STRING
+      mode: NULLABLE
+    - name: update_status_error_code_complete_stage
+      type: STRING
+      mode: NULLABLE
+    - name: update_status_error_code_complete_startup
+      type: STRING
+      mode: NULLABLE
+    - name: update_status_error_code_partial_stage
+      type: STRING
+      mode: NULLABLE
+    - name: update_status_error_code_partial_startup
+      type: STRING
+      mode: NULLABLE
+    - name: update_status_error_code_unknown_stage
+      type: STRING
+      mode: NULLABLE
+    - name: update_status_error_code_unknown_startup
+      type: STRING
+      mode: NULLABLE
+    - name: update_unable_to_apply_external
+      type: STRING
+      mode: NULLABLE
+    - name: update_unable_to_apply_notify
+      type: STRING
+      mode: NULLABLE
+    - name: update_unable_to_apply_subsequent
+      type: STRING
+      mode: NULLABLE
+    - name: update_wiz_last_page_code
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_async_classifylocal_time
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_cl_check_time
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_classifylocal_time
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_completion_error
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_lc_completions
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_lc_prefixes
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_lookup_time_2
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_match_result
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_match_threat_type_result
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_negative_cache_duration
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_positive_cache_duration
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_ps_construct_time
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_ps_fallocate_time
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_ps_fileload_time
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_shutdown_time
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_threathit_network_error
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_threathit_remote_status
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_ui_events
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_update_remote_settings_result
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_vlps_construct_time
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_vlps_fallocate_time
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_vlps_fileload_time
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_vlps_load_corrupt
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_vlps_long_prefixes
+      type: STRING
+      mode: NULLABLE
+    - name: urlclassifier_vlps_metadata_corrupt
+      type: STRING
+      mode: NULLABLE
+    - name: user_chrome_css_loaded
+      type: STRING
+      mode: NULLABLE
+    - name: user_font_families_per_page
+      type: STRING
+      mode: NULLABLE
+    - name: vfc_clearcurrentframe_lock_hold_ms
+      type: STRING
+      mode: NULLABLE
+    - name: vfc_clearfutureframes_lock_hold_ms
+      type: STRING
+      mode: NULLABLE
+    - name: vfc_invalidate_lock_hold_ms
+      type: STRING
+      mode: NULLABLE
+    - name: vfc_invalidate_lock_wait_ms
+      type: STRING
+      mode: NULLABLE
+    - name: vfc_setcurrentframe_lock_hold_ms
+      type: STRING
+      mode: NULLABLE
+    - name: vfc_setimages_lock_hold_ms
+      type: STRING
+      mode: NULLABLE
+    - name: vfc_setvideosegment_lock_hold_ms
+      type: STRING
+      mode: NULLABLE
+    - name: video_as_content_source
+      type: STRING
+      mode: NULLABLE
+    - name: video_as_content_source_in_tree_or_not
+      type: STRING
+      mode: NULLABLE
+    - name: video_can_create_aac_decoder
+      type: STRING
+      mode: NULLABLE
+    - name: video_can_create_h264_decoder
+      type: STRING
+      mode: NULLABLE
+    - name: video_canplaytype_h264_constraint_set_flag
+      type: STRING
+      mode: NULLABLE
+    - name: video_canplaytype_h264_level
+      type: STRING
+      mode: NULLABLE
+    - name: video_canplaytype_h264_profile
+      type: STRING
+      mode: NULLABLE
+    - name: video_cdm_created
+      type: STRING
+      mode: NULLABLE
+    - name: video_chromium_cdm_max_shmems
+      type: STRING
+      mode: NULLABLE
+    - name: video_decoded_h264_sps_constraint_set_flag
+      type: STRING
+      mode: NULLABLE
+    - name: video_decoded_h264_sps_level
+      type: STRING
+      mode: NULLABLE
+    - name: video_decoded_h264_sps_profile
+      type: STRING
+      mode: NULLABLE
+    - name: video_dropped_frames_proportion
+      type: STRING
+      mode: NULLABLE
+    - name: video_eme_play_success
+      type: STRING
+      mode: NULLABLE
+    - name: video_eme_request_failure_latency_ms
+      type: STRING
+      mode: NULLABLE
+    - name: video_eme_request_success_latency_ms
+      type: STRING
+      mode: NULLABLE
+    - name: video_fastseek_used
+      type: STRING
+      mode: NULLABLE
+    - name: video_h264_sps_max_num_ref_frames
+      type: STRING
+      mode: NULLABLE
+    - name: video_hdr_play_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: video_hidden_play_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: video_mft_output_null_samples
+      type: STRING
+      mode: NULLABLE
+    - name: video_play_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: video_unload_state
+      type: STRING
+      mode: NULLABLE
+    - name: video_vp9_benchmark_fps
+      type: STRING
+      mode: NULLABLE
+    - name: view_source_external_result_boolean
+      type: STRING
+      mode: NULLABLE
+    - name: view_source_in_browser_opened_boolean
+      type: STRING
+      mode: NULLABLE
+    - name: view_source_in_window_opened_boolean
+      type: STRING
+      mode: NULLABLE
+    - name: weave_complete_success_count
+      type: STRING
+      mode: NULLABLE
+    - name: weave_configured
+      type: STRING
+      mode: NULLABLE
+    - name: weave_configured_master_password
+      type: STRING
+      mode: NULLABLE
+    - name: weave_device_count_desktop
+      type: STRING
+      mode: NULLABLE
+    - name: weave_device_count_mobile
+      type: STRING
+      mode: NULLABLE
+    - name: weave_login_failed_for
+      type: STRING
+      mode: NULLABLE
+    - name: weave_start_count
+      type: STRING
+      mode: NULLABLE
+    - name: weave_wipe_server_succeeded
+      type: STRING
+      mode: NULLABLE
+    - name: web_audio_autoplay
+      type: STRING
+      mode: NULLABLE
+    - name: web_audio_becomes_audible_time
+      type: STRING
+      mode: NULLABLE
+    - name: web_font_families_per_page
+      type: STRING
+      mode: NULLABLE
+    - name: web_notification_clicked
+      type: STRING
+      mode: NULLABLE
+    - name: web_notification_exceptions_opened
+      type: STRING
+      mode: NULLABLE
+    - name: web_notification_menu
+      type: STRING
+      mode: NULLABLE
+    - name: web_notification_permissions
+      type: STRING
+      mode: NULLABLE
+    - name: web_notification_shown
+      type: STRING
+      mode: NULLABLE
+    - name: webauthn_create_credential_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webauthn_get_assertion_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webcrypto_alg
+      type: STRING
+      mode: NULLABLE
+    - name: webcrypto_extractable_enc
+      type: STRING
+      mode: NULLABLE
+    - name: webcrypto_extractable_generate
+      type: STRING
+      mode: NULLABLE
+    - name: webcrypto_extractable_import
+      type: STRING
+      mode: NULLABLE
+    - name: webcrypto_extractable_sig
+      type: STRING
+      mode: NULLABLE
+    - name: webcrypto_method
+      type: STRING
+      mode: NULLABLE
+    - name: webcrypto_method_secure
+      type: STRING
+      mode: NULLABLE
+    - name: webcrypto_resolved
+      type: STRING
+      mode: NULLABLE
+    - name: webext_background_page_load_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_browseraction_popup_open_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_browseraction_popup_preload_result_count
+      type: STRING
+      mode: NULLABLE
+    - name: webext_content_script_injection_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_dnr_evaluate_rules_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_dnr_startupcache_read_bytes
+      type: STRING
+      mode: NULLABLE
+    - name: webext_dnr_startupcache_read_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_dnr_startupcache_write_bytes
+      type: STRING
+      mode: NULLABLE
+    - name: webext_dnr_startupcache_write_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_dnr_validate_rules_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_eventpage_idle_result_count
+      type: STRING
+      mode: NULLABLE
+    - name: webext_eventpage_running_time_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_extension_startup_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_pageaction_popup_open_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_storage_local_get_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_storage_local_idb_get_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_storage_local_idb_migrate_result_count
+      type: STRING
+      mode: NULLABLE
+    - name: webext_storage_local_idb_set_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_storage_local_set_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webext_user_script_injection_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webfont_compression_woff
+      type: STRING
+      mode: NULLABLE
+    - name: webfont_compression_woff2
+      type: STRING
+      mode: NULLABLE
+    - name: webfont_download_time
+      type: STRING
+      mode: NULLABLE
+    - name: webfont_download_time_after_start
+      type: STRING
+      mode: NULLABLE
+    - name: webfont_fonttype
+      type: STRING
+      mode: NULLABLE
+    - name: webfont_per_page
+      type: STRING
+      mode: NULLABLE
+    - name: webfont_size
+      type: STRING
+      mode: NULLABLE
+    - name: webfont_size_per_page
+      type: STRING
+      mode: NULLABLE
+    - name: webfont_srctype
+      type: STRING
+      mode: NULLABLE
+    - name: webkit_directory_used
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_audio_quality_inbound_bandwidth_kbits
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_audio_quality_inbound_jitter
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_audio_quality_inbound_packetloss_rate
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_audio_quality_outbound_bandwidth_kbits
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_audio_quality_outbound_jitter
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_audio_quality_outbound_packetloss_rate
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_audio_quality_outbound_rtt
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_avsync_when_audio_lags_video_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_avsync_when_video_lags_audio_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_call_count_2
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_call_count_3
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_call_duration
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_call_type
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_datachannel_negotiated
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_dtls_client_abort_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_dtls_client_failure_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_dtls_client_success_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_dtls_server_abort_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_dtls_server_failure_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_dtls_server_success_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_get_user_media_secure_origin
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_get_user_media_type
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_gmp_init_success
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_h264_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_hardware_h264_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_has_h264_hardware
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_hostname_obfuscation_disabled_ice_duration
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_hostname_obfuscation_disabled_ice_duration_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_hostname_obfuscation_enabled_ice_duration
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_hostname_obfuscation_enabled_ice_duration_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_add_candidate_errors_given_failure
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_add_candidate_errors_given_success
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_answerer_abort_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_answerer_failure_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_answerer_success_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_checking_rate
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_failure_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_final_connection_state
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_late_trickle_arrival_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_offerer_abort_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_offerer_failure_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_offerer_success_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_on_time_trickle_arrival_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_success_rate
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_ice_success_time
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_load_state_normal
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_load_state_normal_short
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_load_state_relaxed
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_load_state_relaxed_short
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_load_state_stressed
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_load_state_stressed_short
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_max_audio_receive_track
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_max_audio_send_track
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_max_video_receive_track
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_max_video_send_track
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_renegotiations
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_rtcp_mux
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_software_h264_enabled
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_stun_rate_limit_exceeded_by_type_given_failure
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_stun_rate_limit_exceeded_by_type_given_success
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_decode_error_time_permille
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_decoder_bitrate_avg_per_call_kbps
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_decoder_bitrate_std_dev_per_call_kbps
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_decoder_discarded_packets_per_call_ppm
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_decoder_framerate_10x_std_dev_per_call
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_decoder_framerate_avg_per_call
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_encoder_bitrate_avg_per_call_kbps
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_encoder_bitrate_std_dev_per_call_kbps
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_encoder_dropped_frames_per_call_fpm
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_encoder_framerate_10x_std_dev_per_call
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_encoder_framerate_avg_per_call
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_error_recovery_ms
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_quality_inbound_bandwidth_kbits
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_quality_inbound_jitter
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_quality_inbound_packetloss_rate
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_quality_outbound_bandwidth_kbits
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_quality_outbound_jitter
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_quality_outbound_packetloss_rate
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_quality_outbound_rtt
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_recovery_after_error_per_min
+      type: STRING
+      mode: NULLABLE
+    - name: webrtc_video_recovery_before_error_per_min
+      type: STRING
+      mode: NULLABLE
+    - name: websockets_handshake_type
+      type: STRING
+      mode: NULLABLE
+    - name: webvr_dropped_frames_in_oculus
+      type: STRING
+      mode: NULLABLE
+    - name: webvr_dropped_frames_in_openvr
+      type: STRING
+      mode: NULLABLE
+    - name: webvr_time_spend_for_viewing_in_2d
+      type: STRING
+      mode: NULLABLE
+    - name: webvr_time_spend_for_viewing_in_oculus
+      type: STRING
+      mode: NULLABLE
+    - name: webvr_time_spend_for_viewing_in_openvr
+      type: STRING
+      mode: NULLABLE
+    - name: webvr_time_spent_viewing_in_2d
+      type: STRING
+      mode: NULLABLE
+    - name: webvr_time_spent_viewing_in_oculus
+      type: STRING
+      mode: NULLABLE
+    - name: webvr_time_spent_viewing_in_openvr
+      type: STRING
+      mode: NULLABLE
+    - name: webvr_users_view_in
+      type: STRING
+      mode: NULLABLE
+    - name: webvtt_track_kinds
+      type: STRING
+      mode: NULLABLE
+    - name: webvtt_used_vtt_cues
+      type: STRING
+      mode: NULLABLE
+    - name: webxr_api_mode
+      type: STRING
+      mode: NULLABLE
+    - name: wheel_action
+      type: STRING
+      mode: NULLABLE
+    - name: wheel_index
+      type: STRING
+      mode: NULLABLE
+    - name: window_open_outer_size
+      type: STRING
+      mode: NULLABLE
+    - name: window_remote_subframes_enabled_status
+      type: STRING
+      mode: NULLABLE
+    - name: word_cache_hits_chrome
+      type: STRING
+      mode: NULLABLE
+    - name: word_cache_hits_content
+      type: STRING
+      mode: NULLABLE
+    - name: word_cache_misses_chrome
+      type: STRING
+      mode: NULLABLE
+    - name: word_cache_misses_content
+      type: STRING
+      mode: NULLABLE
+    - name: wr_framebuild_time
+      type: STRING
+      mode: NULLABLE
+    - name: wr_gpu_wait_time
+      type: STRING
+      mode: NULLABLE
+    - name: wr_rasterize_blobs_time
+      type: STRING
+      mode: NULLABLE
+    - name: wr_rasterize_glyphs_time
+      type: STRING
+      mode: NULLABLE
+    - name: wr_render_time
+      type: STRING
+      mode: NULLABLE
+    - name: wr_renderer_time
+      type: STRING
+      mode: NULLABLE
+    - name: wr_renderer_time_no_sc_ms
+      type: STRING
+      mode: NULLABLE
+    - name: wr_scenebuild_time
+      type: STRING
+      mode: NULLABLE
+    - name: wr_sceneswap_time
+      type: STRING
+      mode: NULLABLE
+    - name: wr_texture_cache_update_time
+      type: STRING
+      mode: NULLABLE
+    - name: wr_time_to_frame_build_ms
+      type: STRING
+      mode: NULLABLE
+    - name: wr_time_to_render_start_ms
+      type: STRING
+      mode: NULLABLE
+    - name: xcto_nosniff_block_image
+      type: STRING
+      mode: NULLABLE
+    - name: xcto_nosniff_toplevel_nav_exceptions
+      type: STRING
+      mode: NULLABLE
+    - name: xmlhttprequest_async_or_sync
+      type: STRING
+      mode: NULLABLE
+    - name: xul_cache_disabled
+      type: STRING
+      mode: NULLABLE
+    - name: zoomed_view_enabled
+      type: STRING
+      mode: NULLABLE
+  - name: info
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: addons
+      type: STRING
+      mode: NULLABLE
+    - name: async_plugin_init
+      type: BOOLEAN
+      mode: NULLABLE
+    - name: flash_version
+      type: STRING
+      mode: NULLABLE
+    - name: previous_build_id
+      type: STRING
+      mode: NULLABLE
+    - name: previous_session_id
+      type: STRING
+      mode: NULLABLE
+    - name: previous_subsession_id
+      type: STRING
+      mode: NULLABLE
+    - name: profile_subsession_counter
+      type: INTEGER
+      mode: NULLABLE
+    - name: reason
+      type: STRING
+      mode: NULLABLE
+    - name: revision
+      type: STRING
+      mode: NULLABLE
+    - name: session_id
+      type: STRING
+      mode: NULLABLE
+    - name: session_length
+      type: INTEGER
+      mode: NULLABLE
+    - name: session_start_date
+      type: STRING
+      mode: NULLABLE
+    - name: subsession_counter
+      type: INTEGER
+      mode: NULLABLE
+    - name: subsession_id
+      type: STRING
+      mode: NULLABLE
+    - name: subsession_length
+      type: INTEGER
+      mode: NULLABLE
+    - name: subsession_start_date
+      type: STRING
+      mode: NULLABLE
+    - name: timezone_offset
+      type: INTEGER
+      mode: NULLABLE
+  - name: keyed_histograms
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: addon_content_policy_shim_blocking_loaded_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: addon_content_policy_shim_blocking_loading_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: addon_forbidden_cpow_usage
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: addon_shim_usage
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: application_reputation_server_verdict_2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: audible_play_time_percent
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: autofill_profile_num_uses
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: blocked_on_plugin_instance_destroy_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: blocked_on_plugin_instance_init_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: blocked_on_plugin_module_init_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: blocked_on_plugin_stream_init_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: blocked_on_pluginasyncsurrogate_waitforinit_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: canvas_webgl_accl_failure_id
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: canvas_webgl_failure_id
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: content_js_background_tick_delay_events_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: content_js_foreground_tick_delay_events_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: content_large_paint_phase_weight
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: content_large_paint_phase_weight_full
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: content_large_paint_phase_weight_partial
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: content_signature_verification_errors
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: content_small_paint_phase_weight
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: content_small_paint_phase_weight_full
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: content_small_paint_phase_weight_partial
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: d3d11_compositing_failure_id
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: d3d9_compositing_failure_id
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: decoder_doctor_infobar_stats
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_cold_toolbox_open_delay_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_gcli_commands_keyed
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_javascript_error_displayed
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_memory_breakdown_census_count
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_memory_breakdown_dominator_tree_count
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_perftools_recording_features_used
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_perftools_selected_view_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_toolbox_page_reload_delay_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_warm_toolbox_open_delay_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_webide_connected_runtime_app_type
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_webide_connected_runtime_id
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_webide_connected_runtime_os
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_webide_connected_runtime_platform_version
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_webide_connected_runtime_processor
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_webide_connected_runtime_type
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: devtools_webide_connected_runtime_version
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_lookup_disposition2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_lookup_disposition3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_blacklisted2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_blacklisted3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_disabled2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_disabled3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_first3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_first4
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_http_version2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_lookup_time2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_lookup_time3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_ns_verfified2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_ns_verfified3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_success2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dns_trr_success3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: dom_script_src_encoding
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: downloads_user_action_on_blocked_download
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: email_tracker_embedded_per_tab
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: event_longtask
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: external_protocol_handler_dialog_context_scheme
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: form_filling_required_time_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_bookmarks_import_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_bookmarks_jank_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_bookmarks_quantity
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_bookmarks_roots
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_cards_quantity
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_errors
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_history_import_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_history_jank_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_history_quantity
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_imported_homepage
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_logins_import_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_logins_jank_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_logins_quantity
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_usage
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_session_restore_content_collect_data_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_startup_migration_data_recency
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_startup_migration_undo_bookmarks_errorcount
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_startup_migration_undo_bookmarks_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_startup_migration_undo_logins_errorcount
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_startup_migration_undo_logins_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_startup_migration_undo_reason
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_startup_migration_undo_total_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_startup_migration_undo_visits_errorcount
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_startup_migration_undo_visits_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_startup_migration_used_recent_browser
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_tab_remote_navigation_delay_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_tabletmode_page_load
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_urlbar_selected_result_index_by_type
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_urlbar_selected_result_index_by_type_2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: hsts_priming_request_duration
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_0rtt_state_duration
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_channel_onstart_success
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_complete_load
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_connection_close_code
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_connection_close_code_2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_connection_close_code_3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_connecttion_close_code
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_counts_pto
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_ech_outcome
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_first_sent_to_last_received
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_late_ack
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_late_ack_ratio
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_open_to_first_received
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_open_to_first_sent
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_received_sent_dgrams
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_time_to_reuse_idle_connecttion_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_tls_handshake
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_upload_time
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_upload_time_10m_100m
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http3_upload_time_gt_100m
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http_cache_disposition_3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http_channel_disposition_upgrade
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http_channel_onstart_success_https_rr
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http_channel_onstart_success_trr
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http_channel_onstart_success_trr2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http_channel_page_onstart_success_trr3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http_channel_sub_onstart_success_trr3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http_traffic_analysis
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http_traffic_analysis_2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http_traffic_analysis_3
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: http_upload_bandwidth_mbps
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: https_only_mode_upgrade_time_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: https_only_mode_upgrade_type
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: https_rr_open_to_first_sent
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: https_rr_waiting_time
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: idle_runnable_budget_overuse_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: ipc_read_main_thread_latency_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: ipc_reply_size
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: ipc_sync_main_latency_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: ipc_sync_message_manager_latency_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: ipc_sync_receive_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: ipc_write_main_thread_latency_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: js_telemetry_addon_exceptions
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: l10n_document_initial_translation_time_us
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: main_thread_runnable_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: media_codec_used
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: media_play_time_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: memory_distribution_among_content
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: muted_play_time_percent
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: narrate_content_by_language_2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: network_cache_entry_count
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: network_cache_entry_count_share
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: network_cache_isolation_entry_count_increase
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: network_cache_isolation_size_increase
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: network_cache_isolation_unique_site_access_count
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: network_cache_size
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: network_cache_size_share
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: network_dns_end_to_connect_start_exp_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: network_dns_end_to_connect_start_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: network_http_redirect_to_scheme
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: notify_observers_latency_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: opaque_response_blocking
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: opengl_compositing_failure_id
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: orb_javascript_validation_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: orb_receive_data_for_validation_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: page_load_error
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: permission_request_handling_user_input
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: permission_request_origin_scheme
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: permission_request_third_party_origin
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: places_bookmarks_toolbar_render_delay_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: popup_notification_dismissal_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: popup_notification_main_action_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: popup_notification_stats
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: preferences_file_load_num_prefs
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: preferences_file_load_size_b
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: preferences_file_load_time_us
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: presshell_flushes_per_tick
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: presshell_layout_total_ms_per_tick
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: presshell_reqs_per_layout_flush
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: print_background_task_round_trip_time_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: print_background_task_time_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: print_count
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: print_dialog_opened_count
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: process_crash_submit_attempt
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: process_crash_submit_success
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: pwmgr_manage_sorted
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: qm_first_initialization_attempt
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: qm_init_telemetry_error
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: qm_quota_info_load_time_v0
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: refresh_driver_tick_phase_weight
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: rejected_message_manager_message
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: sandbox_failed_launch_keyed
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: sandbox_rejected_syscalls
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: search_counts
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: search_suggestions_latency_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: service_worker_fetch_event_channel_reset_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: service_worker_fetch_event_channel_reset_ms_2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: service_worker_fetch_event_dispatch_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: service_worker_fetch_event_dispatch_ms_2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: service_worker_fetch_event_finish_synthesized_response_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: service_worker_fetch_event_finish_synthesized_response_ms_2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: service_worker_fetch_interception_duration_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: service_worker_fetch_interception_duration_ms_2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: service_worker_running
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: sqlite_store_open
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: sqlite_store_query
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: ssl_time_until_handshake_finished_keyed_by_ka
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: storage_sync_get_ops_size
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: storage_sync_remove_ops
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: storage_sync_set_ops_size
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: subprocess_abnormal_abort
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: subprocess_crashes_with_dump
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: subprocess_kill_hard
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: subprocess_launch_failure
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: sup_http3_tcp_connection
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: sync_worker_operation
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: telemetry_invalid_ping_type_submitted
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: telemetry_send_failure_type_per_ping
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: thread_wakeup
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: transaction_wait_time_https_rr
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: translated_pages_by_language
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: translation_opportunities_by_language
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: trr_attempt_count
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: trr_relevant_skip_reason_native_failed
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: trr_relevant_skip_reason_native_success
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: trr_relevant_skip_reason_trr_first
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: trr_skip_reason_native_failed
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: trr_skip_reason_native_success
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: trr_skip_reason_retry_failed
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: trr_skip_reason_retry_success
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: trr_skip_reason_strict_mode
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: trr_skip_reason_trr_first2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: update_check_extended_error_external
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: update_check_extended_error_notify
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: update_check_extended_error_subsequent
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: uptake_remote_content_result_1
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: urlclassifier_cl_keyed_update_time
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: urlclassifier_complete_remote_status2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: urlclassifier_complete_server_response_time
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: urlclassifier_complete_timeout2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: urlclassifier_update_error
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: urlclassifier_update_remote_network_error
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: urlclassifier_update_remote_status2
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: urlclassifier_update_server_response_time
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: urlclassifier_update_timeout
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: video_hidden_play_time_percentage
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: video_inferred_decode_suspend_percentage
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: video_inter_keyframe_average_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: video_inter_keyframe_max_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: video_suspend_recovery_time_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: video_visible_play_time_ms
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: weave_engine_sync_errors
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: web_permission_cleared
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_background_page_load_ms_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_browseraction_popup_open_ms_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_browseraction_popup_preload_result_count_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_content_script_injection_ms_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_eventpage_idle_result_count_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_eventpage_running_time_ms_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_extension_startup_ms_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_pageaction_popup_open_ms_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_storage_local_get_ms_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_storage_local_idb_get_ms_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_storage_local_idb_set_ms_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_storage_local_set_ms_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: webext_user_script_injection_ms_by_addonid
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+    - name: fx_migration_extensions_quantity
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: STRING
+        mode: NULLABLE
+  - name: late_writes
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: is_from_terminator_watchdog
+      type: INTEGER
+      mode: NULLABLE
+    - name: memory_map
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: list
+        type: STRING
+        mode: REPEATED
+    - name: stacks
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: list
+        type: RECORD
+        mode: REPEATED
+        fields:
+        - name: list
+          type: INTEGER
+          mode: REPEATED
+  - name: processes
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: content
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: events
+        type: RECORD
+        mode: REPEATED
+        fields:
+        - name: f0_
+          type: INTEGER
+          mode: NULLABLE
+        - name: f1_
+          type: STRING
+          mode: NULLABLE
+        - name: f2_
+          type: STRING
+          mode: NULLABLE
+        - name: f3_
+          type: STRING
+          mode: NULLABLE
+        - name: f4_
+          type: STRING
+          mode: NULLABLE
+        - name: f5_
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: histograms
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: a11y_consumers
+          type: STRING
+          mode: NULLABLE
+        - name: a11y_iatable_usage_flag
+          type: STRING
+          mode: NULLABLE
+        - name: a11y_instantiated_flag
+          type: STRING
+          mode: NULLABLE
+        - name: a11y_isimpledom_usage_flag
+          type: STRING
+          mode: NULLABLE
+        - name: a11y_tree_update_timing_ms
+          type: STRING
+          mode: NULLABLE
+        - name: a11y_update_time
+          type: STRING
+          mode: NULLABLE
+        - name: active_docgroups_per_tabgroup
+          type: STRING
+          mode: NULLABLE
+        - name: active_http_docgroups_per_tabgroup
+          type: STRING
+          mode: NULLABLE
+        - name: addon_manager_upgrade_ui_shown
+          type: STRING
+          mode: NULLABLE
+        - name: addon_signature_verification_status
+          type: STRING
+          mode: NULLABLE
+        - name: alerts_service_dnd_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: alerts_service_dnd_supported_flag
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_allowlist_match
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_binary
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_binary_archive
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_binary_type
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_blocklist_match
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_count
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_hash_length
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_local
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_reason
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_remote_lookup_response_time
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_remote_lookup_timeout
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_server
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_server_2
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_server_verdict
+          type: STRING
+          mode: NULLABLE
+        - name: application_reputation_should_block
+          type: STRING
+          mode: NULLABLE
+        - name: apz_aware_key_listeners
+          type: STRING
+          mode: NULLABLE
+        - name: apz_aware_mousemove_listeners
+          type: STRING
+          mode: NULLABLE
+        - name: apz_zoom_activity
+          type: STRING
+          mode: NULLABLE
+        - name: apz_zoom_activity_rdm
+          type: STRING
+          mode: NULLABLE
+        - name: async_animation_content_too_large_frame_size
+          type: STRING
+          mode: NULLABLE
+        - name: async_animation_content_too_large_percentage
+          type: STRING
+          mode: NULLABLE
+        - name: async_animation_frame_size
+          type: STRING
+          mode: NULLABLE
+        - name: audio_mft_output_null_samples
+          type: STRING
+          mode: NULLABLE
+        - name: audio_track_silence_proportion
+          type: STRING
+          mode: NULLABLE
+        - name: audiostream_backend_used
+          type: STRING
+          mode: NULLABLE
+        - name: audiostream_first_open_ms
+          type: STRING
+          mode: NULLABLE
+        - name: audiostream_later_open_ms
+          type: STRING
+          mode: NULLABLE
+        - name: aushelper_cpu_error_code
+          type: STRING
+          mode: NULLABLE
+        - name: aushelper_cpu_result_code
+          type: STRING
+          mode: NULLABLE
+        - name: aushelper_websense_error_code
+          type: STRING
+          mode: NULLABLE
+        - name: aushelper_websense_reg_exists
+          type: STRING
+          mode: NULLABLE
+        - name: auto_rejected_translation_offers
+          type: STRING
+          mode: NULLABLE
+        - name: autoplay_default_setting_change
+          type: STRING
+          mode: NULLABLE
+        - name: autoplay_sites_setting_change
+          type: STRING
+          mode: NULLABLE
+        - name: avif_a1lx
+          type: STRING
+          mode: NULLABLE
+        - name: avif_a1op
+          type: STRING
+          mode: NULLABLE
+        - name: avif_alpha
+          type: STRING
+          mode: NULLABLE
+        - name: avif_aom_decode_error
+          type: STRING
+          mode: NULLABLE
+        - name: avif_bit_depth
+          type: STRING
+          mode: NULLABLE
+        - name: avif_cicp_cp
+          type: STRING
+          mode: NULLABLE
+        - name: avif_cicp_mc
+          type: STRING
+          mode: NULLABLE
+        - name: avif_cicp_tc
+          type: STRING
+          mode: NULLABLE
+        - name: avif_clap
+          type: STRING
+          mode: NULLABLE
+        - name: avif_colr
+          type: STRING
+          mode: NULLABLE
+        - name: avif_decode_result
+          type: STRING
+          mode: NULLABLE
+        - name: avif_decoder
+          type: STRING
+          mode: NULLABLE
+        - name: avif_grid
+          type: STRING
+          mode: NULLABLE
+        - name: avif_ipro
+          type: STRING
+          mode: NULLABLE
+        - name: avif_ispe
+          type: STRING
+          mode: NULLABLE
+        - name: avif_lsel
+          type: STRING
+          mode: NULLABLE
+        - name: avif_major_brand
+          type: STRING
+          mode: NULLABLE
+        - name: avif_pasp
+          type: STRING
+          mode: NULLABLE
+        - name: avif_pixi
+          type: STRING
+          mode: NULLABLE
+        - name: avif_sequence
+          type: STRING
+          mode: NULLABLE
+        - name: avif_yuv_color_space
+          type: STRING
+          mode: NULLABLE
+        - name: backgroundfilesaver_thread_count
+          type: STRING
+          mode: NULLABLE
+        - name: bad_fallback_font
+          type: STRING
+          mode: NULLABLE
+        - name: base_font_families_per_page
+          type: STRING
+          mode: NULLABLE
+        - name: bfcache_combo
+          type: STRING
+          mode: NULLABLE
+        - name: bfcache_page_restored
+          type: STRING
+          mode: NULLABLE
+        - name: blink_filesystem_used
+          type: STRING
+          mode: NULLABLE
+        - name: blocklist_sync_file_load
+          type: STRING
+          mode: NULLABLE
+        - name: box_align_props_in_blocks_flag
+          type: STRING
+          mode: NULLABLE
+        - name: br_9_2_1_subject_alt_names
+          type: STRING
+          mode: NULLABLE
+        - name: br_9_2_2_subject_common_name
+          type: STRING
+          mode: NULLABLE
+        - name: browser_attribution_errors
+          type: STRING
+          mode: NULLABLE
+        - name: browser_is_assist_default
+          type: STRING
+          mode: NULLABLE
+        - name: browser_is_user_default
+          type: STRING
+          mode: NULLABLE
+        - name: browser_is_user_default_error
+          type: STRING
+          mode: NULLABLE
+        - name: browser_set_default_always_check
+          type: STRING
+          mode: NULLABLE
+        - name: browser_set_default_dialog_prompt_rawcount
+          type: STRING
+          mode: NULLABLE
+        - name: browser_set_default_error
+          type: STRING
+          mode: NULLABLE
+        - name: browser_set_default_result
+          type: STRING
+          mode: NULLABLE
+        - name: browser_set_default_time_to_completion_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: browser_shim_usage_blocked
+          type: STRING
+          mode: NULLABLE
+        - name: browserprovider_xul_import_bookmarks
+          type: STRING
+          mode: NULLABLE
+        - name: bucket_order_errors
+          type: STRING
+          mode: NULLABLE
+        - name: busy_tab_abandoned
+          type: STRING
+          mode: NULLABLE
+        - name: cache_device_search_2
+          type: STRING
+          mode: NULLABLE
+        - name: cache_disk_search_2
+          type: STRING
+          mode: NULLABLE
+        - name: cache_lm_inconsistent
+          type: STRING
+          mode: NULLABLE
+        - name: cache_memory_search_2
+          type: STRING
+          mode: NULLABLE
+        - name: cache_offline_search_2
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_2
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_2
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nsasyncdoomevent_run
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nsblockoncachethreadevent_run
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_close
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_doom
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_doomandfailpendingrequests
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getcacheelement
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getclientid
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getdatasize
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getdeviceid
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getexpirationtime
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getfetchcount
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getfile
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getkey
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getlastfetched
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getlastmodified
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getmetadataelement
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getpredicteddatasize
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getsecurityinfo
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getstoragedatasize
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_getstoragepolicy
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_isstreambased
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_markvalid
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_openinputstream
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_openoutputstream
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_requestdatasizechange
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setcacheelement
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setdatasize
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setexpirationtime
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setmetadataelement
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setpredicteddatasize
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setsecurityinfo
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_setstoragepolicy
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheentrydescriptor_visitmetadata
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_closeallstreams
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_diskdeviceheapsize
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_evictentriesforclient
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_getcacheiotarget
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_isstorageenabledforpolicy
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_onprofilechanged
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_onprofileshutdown
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_opencacheentry
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_processrequest
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_setdiskcachecapacity
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_setdiskcacheenabled
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_setdiskcachemaxentrysize
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_setdisksmartsize
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_setmemorycache
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_setmemorycachemaxentrysize
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_setofflinecachecapacity
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_setofflinecacheenabled
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_shutdown
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscacheservice_visitentries
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nscompressoutputstreamwrapper_release
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nsdecompressinputstreamwrapper_release
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nsinputstreamwrapper_closeinternal
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nsinputstreamwrapper_lazyinit
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nsinputstreamwrapper_release
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nsoutputstreamwrapper_closeinternal
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nsoutputstreamwrapper_lazyinit
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nsoutputstreamwrapper_release
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nsprocessrequestevent_run
+          type: STRING
+          mode: NULLABLE
+        - name: cache_service_lock_wait_mainthread_nssetdisksmartsizecallback_notify
+          type: STRING
+          mode: NULLABLE
+        - name: canvas_2d_used
+          type: STRING
+          mode: NULLABLE
+        - name: canvas_webgl2_success
+          type: STRING
+          mode: NULLABLE
+        - name: canvas_webgl_success
+          type: STRING
+          mode: NULLABLE
+        - name: canvas_webgl_used
+          type: STRING
+          mode: NULLABLE
+        - name: cert_chain_key_size_status
+          type: STRING
+          mode: NULLABLE
+        - name: cert_chain_sha1_policy_status
+          type: STRING
+          mode: NULLABLE
+        - name: cert_ev_status
+          type: STRING
+          mode: NULLABLE
+        - name: cert_ocsp_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: cert_ocsp_required
+          type: STRING
+          mode: NULLABLE
+        - name: cert_pinning_failures_by_ca
+          type: STRING
+          mode: NULLABLE
+        - name: cert_pinning_moz_results
+          type: STRING
+          mode: NULLABLE
+        - name: cert_pinning_moz_results_by_host
+          type: STRING
+          mode: NULLABLE
+        - name: cert_pinning_moz_test_results
+          type: STRING
+          mode: NULLABLE
+        - name: cert_pinning_moz_test_results_by_host
+          type: STRING
+          mode: NULLABLE
+        - name: cert_pinning_results
+          type: STRING
+          mode: NULLABLE
+        - name: cert_pinning_test_results
+          type: STRING
+          mode: NULLABLE
+        - name: cert_validation_http_request_canceled_time
+          type: STRING
+          mode: NULLABLE
+        - name: cert_validation_http_request_failed_time
+          type: STRING
+          mode: NULLABLE
+        - name: cert_validation_http_request_result
+          type: STRING
+          mode: NULLABLE
+        - name: cert_validation_http_request_succeeded_time
+          type: STRING
+          mode: NULLABLE
+        - name: cert_validation_success_by_ca
+          type: STRING
+          mode: NULLABLE
+        - name: changes_of_detected_language
+          type: STRING
+          mode: NULLABLE
+        - name: changes_of_target_language
+          type: STRING
+          mode: NULLABLE
+        - name: charset_override_situation
+          type: STRING
+          mode: NULLABLE
+        - name: charset_override_used
+          type: STRING
+          mode: NULLABLE
+        - name: check_addons_modified_ms
+          type: STRING
+          mode: NULLABLE
+        - name: check_java_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: checkerboard_duration
+          type: STRING
+          mode: NULLABLE
+        - name: checkerboard_peak
+          type: STRING
+          mode: NULLABLE
+        - name: checkerboard_potential_duration
+          type: STRING
+          mode: NULLABLE
+        - name: checkerboard_severity
+          type: STRING
+          mode: NULLABLE
+        - name: components_shim_accessed_by_content
+          type: STRING
+          mode: NULLABLE
+        - name: composite_frame_roundtrip_time
+          type: STRING
+          mode: NULLABLE
+        - name: composite_time
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_duration
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_max_contiguous_drops_apz
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_max_contiguous_drops_chrome
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_max_contiguous_drops_content
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_max_layer_area
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_throughput_apz
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_throughput_chrome
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_throughput_content
+          type: STRING
+          mode: NULLABLE
+        - name: container_used
+          type: STRING
+          mode: NULLABLE
+        - name: content_documents_destroyed
+          type: STRING
+          mode: NULLABLE
+        - name: content_full_paint_time
+          type: STRING
+          mode: NULLABLE
+        - name: content_js_background_tick_delay_total_ms
+          type: STRING
+          mode: NULLABLE
+        - name: content_js_foreground_tick_delay_total_ms
+          type: STRING
+          mode: NULLABLE
+        - name: content_js_known_tick_delay_ms
+          type: STRING
+          mode: NULLABLE
+        - name: content_paint_time
+          type: STRING
+          mode: NULLABLE
+        - name: content_process_launch_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: content_response_duration
+          type: STRING
+          mode: NULLABLE
+        - name: content_signature_verification_status
+          type: STRING
+          mode: NULLABLE
+        - name: cookie_banners_click_handle_duration_ms
+          type: STRING
+          mode: NULLABLE
+        - name: cookie_leave_secure_alone
+          type: STRING
+          mode: NULLABLE
+        - name: cookie_retrieval_samesite_problem
+          type: STRING
+          mode: NULLABLE
+        - name: cookie_scheme_https
+          type: STRING
+          mode: NULLABLE
+        - name: cookie_scheme_security
+          type: STRING
+          mode: NULLABLE
+        - name: cookie_time_moving_ms
+          type: STRING
+          mode: NULLABLE
+        - name: crash_store_compressed_bytes
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_beforeunloadevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_compositionevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_customevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_devicemotionevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_deviceorientationevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_dragevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_errorevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_event
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_events
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_hashchangeevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_htmlevents
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_keyboardevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_keyevents
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_messageevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_mouseevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_mouseevents
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_mousescrollevents
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_mutationevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_mutationevents
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_popstateevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_scrollareaevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_storageevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_svgevents
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_textevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_timeevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_touchevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_uievent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_uievents
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_xulcommandevent
+          type: STRING
+          mode: NULLABLE
+        - name: create_event_xulcommandevents
+          type: STRING
+          mode: NULLABLE
+        - name: csp_documents_count
+          type: STRING
+          mode: NULLABLE
+        - name: csp_referrer_directive
+          type: STRING
+          mode: NULLABLE
+        - name: csp_unsafe_eval_documents_count
+          type: STRING
+          mode: NULLABLE
+        - name: csp_unsafe_inline_documents_count
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_async_snow_white_freeing
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_collected
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_finish_igc
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_full
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_max_pause
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_need_gc
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_oom
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_slice_during_idle
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_sync_skippable
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_time_between
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_visited_gced
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_visited_ref_counted
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_worker
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_worker_collected
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_worker_need_gc
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_worker_oom
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_worker_visited_gced
+          type: STRING
+          mode: NULLABLE
+        - name: cycle_collector_worker_visited_ref_counted
+          type: STRING
+          mode: NULLABLE
+        - name: d3d11_sync_handle_failure
+          type: STRING
+          mode: NULLABLE
+        - name: data_storage_entries
+          type: STRING
+          mode: NULLABLE
+        - name: database_locked_exception
+          type: STRING
+          mode: NULLABLE
+        - name: database_successful_unlock
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_ibm866
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_iso2022jp
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_iso_8859_5
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_koi8r
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_koi8u
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_macarabic
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_macce
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_maccroatian
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_maccyrillic
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_macdevanagari
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_macfarsi
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_macgreek
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_macgujarati
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_macgurmukhi
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_machebrew
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_macicelandic
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_macromanian
+          type: STRING
+          mode: NULLABLE
+        - name: decoder_instantiated_macturkish
+          type: STRING
+          mode: NULLABLE
+        - name: dedicated_worker_destroyed
+          type: STRING
+          mode: NULLABLE
+        - name: dedicated_worker_spawn_gets_queued
+          type: STRING
+          mode: NULLABLE
+        - name: defective_permissions_sql_removed
+          type: STRING
+          mode: NULLABLE
+        - name: deferred_finalize_async
+          type: STRING
+          mode: NULLABLE
+        - name: denied_translation_offers
+          type: STRING
+          mode: NULLABLE
+        - name: deserialize_bytes
+          type: STRING
+          mode: NULLABLE
+        - name: deserialize_items
+          type: STRING
+          mode: NULLABLE
+        - name: deserialize_us
+          type: STRING
+          mode: NULLABLE
+        - name: device_reset_reason
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_aboutdebugging_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_aboutdebugging_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_accessibility_picker_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_accessibility_service_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_accessibility_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_animationinspector_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_animationinspector_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_application_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_browserconsole_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_browserconsole_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_canvasdebugger_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_canvasdebugger_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_changesview_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_compatibilityview_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_compatibilityview_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_computedview_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_computedview_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_custom_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_custom_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_debugger_display_source_local_ms
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_debugger_display_source_remote_ms
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_debugger_load_source_ms
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_developertoolbar_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_developertoolbar_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_dom_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_dom_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_eyedropper_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_flexbox_highlighter_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_fontinspector_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_fontinspector_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_grid_highlighter_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_heap_snapshot_edge_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_heap_snapshot_node_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_inspector_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_inspector_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_jsbrowserdebugger_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_jsbrowserdebugger_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_jsdebugger_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_jsdebugger_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_jsprofiler_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_jsprofiler_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_layoutview_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_layoutview_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_memory_diff_census
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_memory_dominator_tree_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_memory_export_snapshot_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_memory_filter_census
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_memory_import_snapshot_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_memory_inverted_census
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_memory_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_memory_take_snapshot_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_memory_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_menu_eyedropper_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_netmonitor_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_netmonitor_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_number_of_css_grids_in_a_page
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_options_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_options_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_os_enumerated_per_user
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_os_is_64_bits_per_user
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_paintflashing_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_paintflashing_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_perftools_console_recording_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_perftools_recording_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_perftools_recording_duration_ms
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_perftools_recording_export_flag
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_perftools_recording_import_flag
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_picker_eyedropper_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_read_heap_snapshot_ms
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_reload_addon_installed_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_reload_addon_reload_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_responsive_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_responsive_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_ruleview_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_ruleview_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_save_heap_snapshot_ms
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_scratchpad_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_scratchpad_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_scratchpad_window_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_screen_resolution_enumerated_per_user
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_shadereditor_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_shadereditor_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_storage_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_storage_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_styleeditor_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_styleeditor_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_tabs_open_average_linear
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_tabs_open_peak_linear
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_tabs_pinned_average_linear
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_tabs_pinned_peak_linear
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_tilt_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_tilt_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_toolbox_host
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_toolbox_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_toolbox_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webaudioeditor_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webaudioeditor_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webconsole_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webconsole_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_connection_debug_used
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_connection_play_used
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_connection_result
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_connection_time_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_import_project_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_local_connection_result
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_new_project_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_other_connection_result
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_project_editor_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_project_editor_save_count
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_project_editor_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_remote_connection_result
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_simulator_connection_result
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_time_active_seconds
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_usb_connection_result
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_webide_wifi_connection_result
+          type: STRING
+          mode: NULLABLE
+        - name: display_item_usage_count
+          type: STRING
+          mode: NULLABLE
+        - name: display_scaling
+          type: STRING
+          mode: NULLABLE
+        - name: dns_blacklist_count
+          type: STRING
+          mode: NULLABLE
+        - name: dns_cleanup_age
+          type: STRING
+          mode: NULLABLE
+        - name: dns_failed_lookup_time
+          type: STRING
+          mode: NULLABLE
+        - name: dns_lookup_method2
+          type: STRING
+          mode: NULLABLE
+        - name: dns_lookup_time
+          type: STRING
+          mode: NULLABLE
+        - name: dns_renewal_time
+          type: STRING
+          mode: NULLABLE
+        - name: dns_renewal_time_for_ttl
+          type: STRING
+          mode: NULLABLE
+        - name: dns_trr_request_per_conn
+          type: STRING
+          mode: NULLABLE
+        - name: dnt_usage
+          type: STRING
+          mode: NULLABLE
+        - name: document_analytics_tracker_fastblocked
+          type: STRING
+          mode: NULLABLE
+        - name: document_data_uri_loads
+          type: STRING
+          mode: NULLABLE
+        - name: document_preload_image_asyncopen_delay
+          type: STRING
+          mode: NULLABLE
+        - name: document_with_expanded_principal
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_bytecode_size
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_encoding_ms_per_document
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_encoding_status
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_eval_per_document
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_fetch_count
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_inline_size
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_is_streamed
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_kind
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_load_emit_time_percent
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_load_incremental_avg_transfer_rate
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_load_incremental_ratio
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_load_parse_time_percent
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_load_stream_time_percent
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_load_streamparse_estimate_percent
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_loading_source
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_main_thread_decode_exec_ms
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_main_thread_parse_encode_exec_ms
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_main_thread_parse_exec_ms
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_off_thread_decode_exec_ms
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_off_thread_parse_encode_exec_ms
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_off_thread_parse_exec_ms
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_preload_result
+          type: STRING
+          mode: NULLABLE
+        - name: dom_script_source_size
+          type: STRING
+          mode: NULLABLE
+        - name: dwritefont_delayedinitfontlist_collect
+          type: STRING
+          mode: NULLABLE
+        - name: dwritefont_delayedinitfontlist_count
+          type: STRING
+          mode: NULLABLE
+        - name: dwritefont_delayedinitfontlist_total
+          type: STRING
+          mode: NULLABLE
+        - name: dwritefont_init_problem
+          type: STRING
+          mode: NULLABLE
+        - name: e10s_blocked_from_running
+          type: STRING
+          mode: NULLABLE
+        - name: e10s_status
+          type: STRING
+          mode: NULLABLE
+        - name: enable_privilege_ever_called
+          type: STRING
+          mode: NULLABLE
+        - name: encoding_detection_outcome_html
+          type: STRING
+          mode: NULLABLE
+        - name: encoding_detection_outcome_text
+          type: STRING
+          mode: NULLABLE
+        - name: encoding_override_situation
+          type: STRING
+          mode: NULLABLE
+        - name: encoding_override_situation_2
+          type: STRING
+          mode: NULLABLE
+        - name: encoding_override_situation_html
+          type: STRING
+          mode: NULLABLE
+        - name: encoding_override_situation_text
+          type: STRING
+          mode: NULLABLE
+        - name: eventloop_ui_activity_exp_ms
+          type: STRING
+          mode: NULLABLE
+        - name: extension_install_prompt_result
+          type: STRING
+          mode: NULLABLE
+        - name: fallback_to_base_font
+          type: STRING
+          mode: NULLABLE
+        - name: fallback_to_langpack_font
+          type: STRING
+          mode: NULLABLE
+        - name: fallback_to_prefs_font
+          type: STRING
+          mode: NULLABLE
+        - name: fallback_to_user_font
+          type: STRING
+          mode: NULLABLE
+        - name: family_safety
+          type: STRING
+          mode: NULLABLE
+        - name: feed_protocol_usage
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_activity_stream_highlights_loader_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_activity_stream_topsites_loader_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_bookmarks_count
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_custom_homepage
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_distribution_code_category
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_distribution_download_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_distribution_referrer_invalid
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_globalhistory_add_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_globalhistory_update_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_globalhistory_visited_build_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_homepanels_custom
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_load_saved_page
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_loop_other_latency
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_loop_ui_latency
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_orbot_installed
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_reader_view_cache_size
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_reading_list_count
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_restoring_activity
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_search_loader_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sessionstore_all_files_damaged
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sessionstore_damaged_session_file
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sessionstore_restoring_from_backup
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_startup_time_geckoready
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_startup_time_javaui
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sync11_migration_notifications_offered
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sync11_migration_sentinels_seen
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sync11_migrations_completed
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sync11_migrations_failed
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sync11_migrations_succeeded
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sync_number_of_syncs_completed
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sync_number_of_syncs_failed
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sync_number_of_syncs_failed_backoff
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_sync_number_of_syncs_started
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_tabqueue_queuesize
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_topsites_loader_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_tracking_protection_state
+          type: STRING
+          mode: NULLABLE
+        - name: fennec_was_killed
+          type: STRING
+          mode: NULLABLE
+        - name: fetch_is_mainthread
+          type: STRING
+          mode: NULLABLE
+        - name: file_embedded_serviceworkers
+          type: STRING
+          mode: NULLABLE
+        - name: find_plugins
+          type: STRING
+          mode: NULLABLE
+        - name: fips_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: font_cache_hit
+          type: STRING
+          mode: NULLABLE
+        - name: fontlist_bundledfonts_activate
+          type: STRING
+          mode: NULLABLE
+        - name: fontlist_initfacenamelists
+          type: STRING
+          mode: NULLABLE
+        - name: fontlist_initotherfamilynames
+          type: STRING
+          mode: NULLABLE
+        - name: fontlist_initotherfamilynames_no_deferring
+          type: STRING
+          mode: NULLABLE
+        - name: forced_device_reset_reason
+          type: STRING
+          mode: NULLABLE
+        - name: forget_skippable_during_idle
+          type: STRING
+          mode: NULLABLE
+        - name: forget_skippable_frequency
+          type: STRING
+          mode: NULLABLE
+        - name: forget_skippable_max
+          type: STRING
+          mode: NULLABLE
+        - name: form_isindex_used
+          type: STRING
+          mode: NULLABLE
+        - name: fullscreen_change_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fullscreen_transition_black_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_abouthome_cache_construction
+          type: STRING
+          mode: NULLABLE
+        - name: fx_bookmarks_toolbar_init_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_browser_fullscreen_used
+          type: STRING
+          mode: NULLABLE
+        - name: fx_content_crash_dump_unavailable
+          type: STRING
+          mode: NULLABLE
+        - name: fx_content_crash_not_submitted
+          type: STRING
+          mode: NULLABLE
+        - name: fx_content_crash_presented
+          type: STRING
+          mode: NULLABLE
+        - name: fx_gesture_compress_snapshot_of_page
+          type: STRING
+          mode: NULLABLE
+        - name: fx_gesture_install_snapshot_of_page
+          type: STRING
+          mode: NULLABLE
+        - name: fx_migration_entry_point
+          type: STRING
+          mode: NULLABLE
+        - name: fx_migration_source_browser
+          type: STRING
+          mode: NULLABLE
+        - name: fx_new_window_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_page_load_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_page_load_ms_2
+          type: STRING
+          mode: NULLABLE
+        - name: fx_preferences_category_opened
+          type: STRING
+          mode: NULLABLE
+        - name: fx_preferences_category_opened_v2
+          type: STRING
+          mode: NULLABLE
+        - name: fx_preferences_opened_via
+          type: STRING
+          mode: NULLABLE
+        - name: fx_refresh_driver_chrome_frame_delay_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_refresh_driver_content_frame_delay_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_refresh_driver_sync_scroll_frame_delay_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_sanitize_cache
+          type: STRING
+          mode: NULLABLE
+        - name: fx_sanitize_cookies_2
+          type: STRING
+          mode: NULLABLE
+        - name: fx_sanitize_downloads
+          type: STRING
+          mode: NULLABLE
+        - name: fx_sanitize_formdata
+          type: STRING
+          mode: NULLABLE
+        - name: fx_sanitize_history
+          type: STRING
+          mode: NULLABLE
+        - name: fx_sanitize_openwindows
+          type: STRING
+          mode: NULLABLE
+        - name: fx_sanitize_sessions
+          type: STRING
+          mode: NULLABLE
+        - name: fx_sanitize_sitesettings
+          type: STRING
+          mode: NULLABLE
+        - name: fx_sanitize_total
+          type: STRING
+          mode: NULLABLE
+        - name: fx_searchbar_selected_result_method
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_all_files_corrupt
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_auto_restore_duration_until_eager_tabs_restored_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_collect_all_windows_data_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_collect_data_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_corrupt_file
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_dom_storage_size_estimate_chars
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_file_size_bytes
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_manual_restore_duration_until_eager_tabs_restored_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_number_of_eager_tabs_restored
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_number_of_tabs_restored
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_number_of_windows_restored
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_privacy_level
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_read_file_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_restore_window_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_send_update_caused_oom
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_serialize_data_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_startup_init_session_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_startup_onload_initial_window_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_session_restore_write_file_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_startup_migration_automated_import_process_success
+          type: STRING
+          mode: NULLABLE
+        - name: fx_startup_migration_automated_import_undo
+          type: STRING
+          mode: NULLABLE
+        - name: fx_startup_migration_browser_count
+          type: STRING
+          mode: NULLABLE
+        - name: fx_startup_migration_existing_default_browser
+          type: STRING
+          mode: NULLABLE
+        - name: fx_startup_migration_undo_offered
+          type: STRING
+          mode: NULLABLE
+        - name: fx_tab_click_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_tab_close_permit_unload_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_tab_close_time_anim_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_tab_close_time_no_anim_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_tab_switch_spinner_type
+          type: STRING
+          mode: NULLABLE
+        - name: fx_tab_switch_spinner_visible_long_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_tab_switch_spinner_visible_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_tab_switch_total_e10s_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_tab_switch_total_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_tab_switch_update_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_thumbnails_bg_capture_canvas_draw_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_thumbnails_bg_capture_done_reason_2
+          type: STRING
+          mode: NULLABLE
+        - name: fx_thumbnails_bg_capture_page_load_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_thumbnails_bg_capture_queue_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_thumbnails_bg_capture_service_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_thumbnails_bg_queue_size_on_capture
+          type: STRING
+          mode: NULLABLE
+        - name: fx_thumbnails_capture_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_thumbnails_hit_or_miss
+          type: STRING
+          mode: NULLABLE
+        - name: fx_thumbnails_store_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: fx_total_top_visits
+          type: STRING
+          mode: NULLABLE
+        - name: fx_touch_used
+          type: STRING
+          mode: NULLABLE
+        - name: fx_urlbar_selected_result_index
+          type: STRING
+          mode: NULLABLE
+        - name: fx_urlbar_selected_result_method
+          type: STRING
+          mode: NULLABLE
+        - name: fx_urlbar_selected_result_type
+          type: STRING
+          mode: NULLABLE
+        - name: fx_urlbar_selected_result_type_2
+          type: STRING
+          mode: NULLABLE
+        - name: fxa_configured
+          type: STRING
+          mode: NULLABLE
+        - name: gc_animation_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_budget_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_budget_ms_2
+          type: STRING
+          mode: NULLABLE
+        - name: gc_budget_overrun
+          type: STRING
+          mode: NULLABLE
+        - name: gc_budget_was_increased
+          type: STRING
+          mode: NULLABLE
+        - name: gc_compact_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_effectiveness
+          type: STRING
+          mode: NULLABLE
+        - name: gc_in_progress_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_incremental_disabled
+          type: STRING
+          mode: NULLABLE
+        - name: gc_is_compartmental
+          type: STRING
+          mode: NULLABLE
+        - name: gc_mark_gray_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_mark_gray_ms_2
+          type: STRING
+          mode: NULLABLE
+        - name: gc_mark_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_mark_rate
+          type: STRING
+          mode: NULLABLE
+        - name: gc_mark_rate_2
+          type: STRING
+          mode: NULLABLE
+        - name: gc_mark_roots_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_mark_roots_us
+          type: STRING
+          mode: NULLABLE
+        - name: gc_mark_weak_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_max_pause_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_max_pause_ms_2
+          type: STRING
+          mode: NULLABLE
+        - name: gc_minor_reason
+          type: STRING
+          mode: NULLABLE
+        - name: gc_minor_reason_long
+          type: STRING
+          mode: NULLABLE
+        - name: gc_minor_us
+          type: STRING
+          mode: NULLABLE
+        - name: gc_mmu_50
+          type: STRING
+          mode: NULLABLE
+        - name: gc_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_non_incremental
+          type: STRING
+          mode: NULLABLE
+        - name: gc_non_incremental_reason
+          type: STRING
+          mode: NULLABLE
+        - name: gc_nursery_bytes
+          type: STRING
+          mode: NULLABLE
+        - name: gc_nursery_bytes_2
+          type: STRING
+          mode: NULLABLE
+        - name: gc_nursery_promotion_rate
+          type: STRING
+          mode: NULLABLE
+        - name: gc_parallel_mark_interruptions
+          type: STRING
+          mode: NULLABLE
+        - name: gc_parallel_mark_speedup
+          type: STRING
+          mode: NULLABLE
+        - name: gc_parallel_mark_utilization
+          type: STRING
+          mode: NULLABLE
+        - name: gc_prepare_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_pretenure_count
+          type: STRING
+          mode: NULLABLE
+        - name: gc_pretenure_count_2
+          type: STRING
+          mode: NULLABLE
+        - name: gc_reason_2
+          type: STRING
+          mode: NULLABLE
+        - name: gc_reset
+          type: STRING
+          mode: NULLABLE
+        - name: gc_reset_reason
+          type: STRING
+          mode: NULLABLE
+        - name: gc_scc_sweep_max_pause_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_scc_sweep_total_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_slice_count
+          type: STRING
+          mode: NULLABLE
+        - name: gc_slice_during_idle
+          type: STRING
+          mode: NULLABLE
+        - name: gc_slice_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_slice_was_long
+          type: STRING
+          mode: NULLABLE
+        - name: gc_slow_phase
+          type: STRING
+          mode: NULLABLE
+        - name: gc_slow_task
+          type: STRING
+          mode: NULLABLE
+        - name: gc_sweep_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_task_start_delay_us
+          type: STRING
+          mode: NULLABLE
+        - name: gc_tenured_survival_rate
+          type: STRING
+          mode: NULLABLE
+        - name: gc_time_between_s
+          type: STRING
+          mode: NULLABLE
+        - name: gc_time_between_slices_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_wait_for_idle_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gc_zone_count
+          type: STRING
+          mode: NULLABLE
+        - name: gc_zones_collected
+          type: STRING
+          mode: NULLABLE
+        - name: gdi_initfontlist_total
+          type: STRING
+          mode: NULLABLE
+        - name: geolocation_accuracy_exponential
+          type: STRING
+          mode: NULLABLE
+        - name: geolocation_error
+          type: STRING
+          mode: NULLABLE
+        - name: geolocation_getcurrentposition_secure_origin
+          type: STRING
+          mode: NULLABLE
+        - name: geolocation_getcurrentposition_visible
+          type: STRING
+          mode: NULLABLE
+        - name: geolocation_osx_source_is_mls
+          type: STRING
+          mode: NULLABLE
+        - name: geolocation_request_granted
+          type: STRING
+          mode: NULLABLE
+        - name: geolocation_watchposition_secure_origin
+          type: STRING
+          mode: NULLABLE
+        - name: geolocation_watchposition_visible
+          type: STRING
+          mode: NULLABLE
+        - name: geolocation_win8_source_is_mls
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_content_failed_to_acquire_device
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_crash
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_omtp_paint_task_count
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_omtp_paint_time
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_omtp_paint_wait_time
+          type: STRING
+          mode: NULLABLE
+        - name: ghost_windows
+          type: STRING
+          mode: NULLABLE
+        - name: gpu_process_crash_fallbacks
+          type: STRING
+          mode: NULLABLE
+        - name: gpu_process_initialization_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gpu_process_launch_time_ms_2
+          type: STRING
+          mode: NULLABLE
+        - name: gradient_duration
+          type: STRING
+          mode: NULLABLE
+        - name: gradient_retention_time
+          type: STRING
+          mode: NULLABLE
+        - name: graphics_driver_startup_test
+          type: STRING
+          mode: NULLABLE
+        - name: graphics_sanity_test
+          type: STRING
+          mode: NULLABLE
+        - name: graphics_sanity_test_os_snapshot
+          type: STRING
+          mode: NULLABLE
+        - name: graphics_sanity_test_reason
+          type: STRING
+          mode: NULLABLE
+        - name: gv_page_load_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gv_page_load_progress_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gv_page_reload_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gv_startup_runtime_ms
+          type: STRING
+          mode: NULLABLE
+        - name: hidden_viewport_overflow_type
+          type: STRING
+          mode: NULLABLE
+        - name: history_lastvisited_tree_query_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: hpack_bytes_evicted_compressor
+          type: STRING
+          mode: NULLABLE
+        - name: hpack_bytes_evicted_decompressor
+          type: STRING
+          mode: NULLABLE
+        - name: hpack_bytes_evicted_ratio_compressor
+          type: STRING
+          mode: NULLABLE
+        - name: hpack_bytes_evicted_ratio_decompressor
+          type: STRING
+          mode: NULLABLE
+        - name: hpack_elements_evicted_compressor
+          type: STRING
+          mode: NULLABLE
+        - name: hpack_elements_evicted_decompressor
+          type: STRING
+          mode: NULLABLE
+        - name: hpack_peak_count_compressor
+          type: STRING
+          mode: NULLABLE
+        - name: hpack_peak_count_decompressor
+          type: STRING
+          mode: NULLABLE
+        - name: hpack_peak_size_compressor
+          type: STRING
+          mode: NULLABLE
+        - name: hpack_peak_size_decompressor
+          type: STRING
+          mode: NULLABLE
+        - name: htmleditors_overridden_by_beforeinput_listeners
+          type: STRING
+          mode: NULLABLE
+        - name: htmleditors_whose_absolute_positioner_used_by_user
+          type: STRING
+          mode: NULLABLE
+        - name: htmleditors_whose_inline_table_editor_used_by_user
+          type: STRING
+          mode: NULLABLE
+        - name: htmleditors_whose_resizers_used_by_user
+          type: STRING
+          mode: NULLABLE
+        - name: htmleditors_with_absolute_positioner
+          type: STRING
+          mode: NULLABLE
+        - name: htmleditors_with_beforeinput_listeners
+          type: STRING
+          mode: NULLABLE
+        - name: htmleditors_with_inline_table_editor
+          type: STRING
+          mode: NULLABLE
+        - name: htmleditors_with_mutation_listeners_without_beforeinput_listeners
+          type: STRING
+          mode: NULLABLE
+        - name: htmleditors_with_mutation_observers_without_beforeinput_listeners
+          type: STRING
+          mode: NULLABLE
+        - name: htmleditors_with_resizers
+          type: STRING
+          mode: NULLABLE
+        - name: http3_blocked_by_stream_limit_per_conn
+          type: STRING
+          mode: NULLABLE
+        - name: http3_drop_dgrams
+          type: STRING
+          mode: NULLABLE
+        - name: http3_loss_ratio
+          type: STRING
+          mode: NULLABLE
+        - name: http3_request_per_conn
+          type: STRING
+          mode: NULLABLE
+        - name: http3_saved_dgrams
+          type: STRING
+          mode: NULLABLE
+        - name: http3_sending_blocked_by_flow_control_per_trans
+          type: STRING
+          mode: NULLABLE
+        - name: http3_timer_delayed
+          type: STRING
+          mode: NULLABLE
+        - name: http3_trans_blocked_by_stream_limit_per_conn
+          type: STRING
+          mode: NULLABLE
+        - name: http3_trans_sending_blocked_by_flow_control_per_conn
+          type: STRING
+          mode: NULLABLE
+        - name: http_09_info
+          type: STRING
+          mode: NULLABLE
+        - name: http_altsvc_entries_per_header
+          type: STRING
+          mode: NULLABLE
+        - name: http_altsvc_mapping_changed_target
+          type: STRING
+          mode: NULLABLE
+        - name: http_auth_dialog_stats_2
+          type: STRING
+          mode: NULLABLE
+        - name: http_auth_dialog_stats_3
+          type: STRING
+          mode: NULLABLE
+        - name: http_auth_type_stats
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_disposition_2
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_disposition_2_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_entry_alive_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_entry_reload_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_entry_reuse_count
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_io_queue_2_evict
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_io_queue_2_index
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_io_queue_2_management
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_io_queue_2_open
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_io_queue_2_open_priority
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_io_queue_2_read
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_io_queue_2_read_priority
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_io_queue_2_write
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_io_queue_2_write_priority
+          type: STRING
+          mode: NULLABLE
+        - name: http_cache_miss_halflife_experiment_2
+          type: STRING
+          mode: NULLABLE
+        - name: http_channel_disposition
+          type: STRING
+          mode: NULLABLE
+        - name: http_connection_entry_cache_hit_1
+          type: STRING
+          mode: NULLABLE
+        - name: http_content_encoding
+          type: STRING
+          mode: NULLABLE
+        - name: http_disk_cache_disposition_2
+          type: STRING
+          mode: NULLABLE
+        - name: http_disk_cache_overhead
+          type: STRING
+          mode: NULLABLE
+        - name: http_kbread_per_conn
+          type: STRING
+          mode: NULLABLE
+        - name: http_kbread_per_conn2
+          type: STRING
+          mode: NULLABLE
+        - name: http_memory_cache_disposition_2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstart_notrevalidated_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstart_qbig_highpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstart_qbig_normalpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstart_qmed_highpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstart_qmed_normalpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstart_qsmall_highpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstart_qsmall_normalpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstart_revalidated_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstop_large_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstop_notrevalidated_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstop_qbig_highpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstop_qbig_normalpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstop_qmed_highpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstop_qmed_normalpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstop_qsmall_highpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstop_qsmall_normalpri_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstop_revalidated_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_net_vs_cache_onstop_small_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_offline_cache_disposition_2
+          type: STRING
+          mode: NULLABLE
+        - name: http_offline_cache_document_load
+          type: STRING
+          mode: NULLABLE
+        - name: http_onstart_suspend_total_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_cache_read_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_cache_read_time_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_complete_load
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_complete_load_cached
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_complete_load_cached_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_complete_load_net
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_complete_load_net_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_complete_load_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_dns_issue_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_dns_lookup_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_dns_odoh_lookup_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_first_sent_to_last_received
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_open_to_first_from_cache
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_open_to_first_from_cache_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_open_to_first_received
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_open_to_first_sent
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_revalidation
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_tcp_connection
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_tcp_connection_2
+          type: STRING
+          mode: NULLABLE
+        - name: http_page_tls_handshake
+          type: STRING
+          mode: NULLABLE
+        - name: http_pageload_is_ssl
+          type: STRING
+          mode: NULLABLE
+        - name: http_preload_image_startrequest_delay
+          type: STRING
+          mode: NULLABLE
+        - name: http_proxy_type
+          type: STRING
+          mode: NULLABLE
+        - name: http_request_per_conn
+          type: STRING
+          mode: NULLABLE
+        - name: http_request_per_page
+          type: STRING
+          mode: NULLABLE
+        - name: http_request_per_page_from_cache
+          type: STRING
+          mode: NULLABLE
+        - name: http_response_status_code
+          type: STRING
+          mode: NULLABLE
+        - name: http_response_version
+          type: STRING
+          mode: NULLABLE
+        - name: http_saw_quic_alt_protocol
+          type: STRING
+          mode: NULLABLE
+        - name: http_saw_quic_alt_protocol_2
+          type: STRING
+          mode: NULLABLE
+        - name: http_scheme_upgrade
+          type: STRING
+          mode: NULLABLE
+        - name: http_scheme_upgrade_type
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_cache_read_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_cache_read_time_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_complete_load
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_complete_load_cached
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_complete_load_cached_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_complete_load_net
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_complete_load_net_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_complete_load_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_dns_issue_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_dns_lookup_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_dns_odoh_lookup_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_first_sent_to_last_received
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_open_to_first_from_cache
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_open_to_first_from_cache_v2
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_open_to_first_received
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_open_to_first_sent
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_revalidation
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_tcp_connection
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_tcp_connection_2
+          type: STRING
+          mode: NULLABLE
+        - name: http_sub_tls_handshake
+          type: STRING
+          mode: NULLABLE
+        - name: http_subitem_first_byte_latency_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_subitem_open_latency_time
+          type: STRING
+          mode: NULLABLE
+        - name: http_transaction_is_ssl
+          type: STRING
+          mode: NULLABLE
+        - name: http_transaction_use_altsvc
+          type: STRING
+          mode: NULLABLE
+        - name: http_transaction_use_altsvc_oe
+          type: STRING
+          mode: NULLABLE
+        - name: httpconnmgr_total_speculative_conn
+          type: STRING
+          mode: NULLABLE
+        - name: httpconnmgr_unused_speculative_conn
+          type: STRING
+          mode: NULLABLE
+        - name: httpconnmgr_used_speculative_conn
+          type: STRING
+          mode: NULLABLE
+        - name: hyphenation_load_time
+          type: STRING
+          mode: NULLABLE
+        - name: hyphenation_memory
+          type: STRING
+          mode: NULLABLE
+        - name: idb_custom_open_with_options_count
+          type: STRING
+          mode: NULLABLE
+        - name: idle_notify_idle_ms
+          type: STRING
+          mode: NULLABLE
+        - name: image_animated_decode_count
+          type: STRING
+          mode: NULLABLE
+        - name: image_animated_decode_on_draw_latency
+          type: STRING
+          mode: NULLABLE
+        - name: image_animated_decode_time
+          type: STRING
+          mode: NULLABLE
+        - name: image_decode_chunks
+          type: STRING
+          mode: NULLABLE
+        - name: image_decode_count
+          type: STRING
+          mode: NULLABLE
+        - name: image_decode_latency_us
+          type: STRING
+          mode: NULLABLE
+        - name: image_decode_on_draw_latency
+          type: STRING
+          mode: NULLABLE
+        - name: image_decode_speed_avif
+          type: STRING
+          mode: NULLABLE
+        - name: image_decode_speed_gif
+          type: STRING
+          mode: NULLABLE
+        - name: image_decode_speed_jpeg
+          type: STRING
+          mode: NULLABLE
+        - name: image_decode_speed_png
+          type: STRING
+          mode: NULLABLE
+        - name: image_decode_speed_webp
+          type: STRING
+          mode: NULLABLE
+        - name: image_decode_time
+          type: STRING
+          mode: NULLABLE
+        - name: image_request_dispatched
+          type: STRING
+          mode: NULLABLE
+        - name: innerwindows_with_mutation_listeners
+          type: STRING
+          mode: NULLABLE
+        - name: innerwindows_with_text_event_listeners
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_handled_apz_mouse_move_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_handled_apz_touch_move_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_handled_apz_wheel_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_handled_keyboard_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_handled_mouse_down_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_handled_mouse_up_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_queued_apz_mouse_move_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_queued_apz_touch_move_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_queued_apz_wheel_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_queued_click_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_queued_keyboard_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_response_coalesced_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_response_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_response_post_startup_ms
+          type: STRING
+          mode: NULLABLE
+        - name: input_event_response_startup_ms
+          type: STRING
+          mode: NULLABLE
+        - name: ipc_message_size2
+          type: STRING
+          mode: NULLABLE
+        - name: ipc_same_process_message_copy_oom_kb
+          type: STRING
+          mode: NULLABLE
+        - name: ipc_transaction_cancel
+          type: STRING
+          mode: NULLABLE
+        - name: ipv4_and_ipv6_address_connectivity
+          type: STRING
+          mode: NULLABLE
+        - name: js_aot_usage
+          type: STRING
+          mode: NULLABLE
+        - name: js_baseline_compile_proportion
+          type: STRING
+          mode: NULLABLE
+        - name: js_bytecode_caching_time
+          type: STRING
+          mode: NULLABLE
+        - name: js_delazification_proportion
+          type: STRING
+          mode: NULLABLE
+        - name: js_deprecated_array_generics
+          type: STRING
+          mode: NULLABLE
+        - name: js_deprecated_language_extensions_in_addons
+          type: STRING
+          mode: NULLABLE
+        - name: js_deprecated_language_extensions_in_content
+          type: STRING
+          mode: NULLABLE
+        - name: js_deprecated_string_generics
+          type: STRING
+          mode: NULLABLE
+        - name: js_execution_proportion
+          type: STRING
+          mode: NULLABLE
+        - name: js_pageload_baseline_compile_ms
+          type: STRING
+          mode: NULLABLE
+        - name: js_pageload_delazification_ms
+          type: STRING
+          mode: NULLABLE
+        - name: js_pageload_execution_ms
+          type: STRING
+          mode: NULLABLE
+        - name: js_pageload_gc_ms
+          type: STRING
+          mode: NULLABLE
+        - name: js_pageload_parse_ms
+          type: STRING
+          mode: NULLABLE
+        - name: js_pageload_protect_ms
+          type: STRING
+          mode: NULLABLE
+        - name: js_pageload_xdr_encoding_ms
+          type: STRING
+          mode: NULLABLE
+        - name: js_privileged_parser_compile_lazy_after_ms
+          type: STRING
+          mode: NULLABLE
+        - name: js_web_parser_compile_lazy_after_ms
+          type: STRING
+          mode: NULLABLE
+        - name: js_xdr_encoding_proportion
+          type: STRING
+          mode: NULLABLE
+        - name: keypress_present_latency
+          type: STRING
+          mode: NULLABLE
+        - name: langpack_font_families_per_page
+          type: STRING
+          mode: NULLABLE
+        - name: lazyload_image_not_viewport
+          type: STRING
+          mode: NULLABLE
+        - name: lazyload_image_started
+          type: STRING
+          mode: NULLABLE
+        - name: lazyload_image_total
+          type: STRING
+          mode: NULLABLE
+        - name: lazyload_image_viewport_loaded
+          type: STRING
+          mode: NULLABLE
+        - name: lazyload_image_viewport_loading
+          type: STRING
+          mode: NULLABLE
+        - name: link_icon_sizes_attr_dimension
+          type: STRING
+          mode: NULLABLE
+        - name: link_icon_sizes_attr_usage
+          type: STRING
+          mode: NULLABLE
+        - name: load_input_event_response_ms
+          type: STRING
+          mode: NULLABLE
+        - name: localdomstorage_clear_blocking_ms
+          type: STRING
+          mode: NULLABLE
+        - name: localdomstorage_getallkeys_blocking_ms
+          type: STRING
+          mode: NULLABLE
+        - name: localdomstorage_getkey_blocking_ms
+          type: STRING
+          mode: NULLABLE
+        - name: localdomstorage_getlength_blocking_ms
+          type: STRING
+          mode: NULLABLE
+        - name: localdomstorage_getvalue_blocking_ms
+          type: STRING
+          mode: NULLABLE
+        - name: localdomstorage_preload_pending_on_first_access
+          type: STRING
+          mode: NULLABLE
+        - name: localdomstorage_removekey_blocking_ms
+          type: STRING
+          mode: NULLABLE
+        - name: localdomstorage_sessiononly_preload_blocking_ms
+          type: STRING
+          mode: NULLABLE
+        - name: localdomstorage_setvalue_blocking_ms
+          type: STRING
+          mode: NULLABLE
+        - name: localdomstorage_shutdown_database_ms
+          type: STRING
+          mode: NULLABLE
+        - name: localdomstorage_unload_blocking_ms
+          type: STRING
+          mode: NULLABLE
+        - name: login_reputation_login_whitelist_lookup_time
+          type: STRING
+          mode: NULLABLE
+        - name: login_reputation_login_whitelist_result
+          type: STRING
+          mode: NULLABLE
+        - name: long_reflow_interruptible
+          type: STRING
+          mode: NULLABLE
+        - name: low_memory_events_commit_space
+          type: STRING
+          mode: NULLABLE
+        - name: low_memory_events_physical
+          type: STRING
+          mode: NULLABLE
+        - name: low_memory_events_virtual
+          type: STRING
+          mode: NULLABLE
+        - name: mac_initfontlist_total
+          type: STRING
+          mode: NULLABLE
+        - name: master_password_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: media_android_video_tunneling_support
+          type: STRING
+          mode: NULLABLE
+        - name: media_audio_backend
+          type: STRING
+          mode: NULLABLE
+        - name: media_audio_init_failure
+          type: STRING
+          mode: NULLABLE
+        - name: media_control_handle_play_pause_stop_actions
+          type: STRING
+          mode: NULLABLE
+        - name: media_decoder_backend_used
+          type: STRING
+          mode: NULLABLE
+        - name: media_decoding_process_crash
+          type: STRING
+          mode: NULLABLE
+        - name: media_eme_request_deprecated_warnings
+          type: STRING
+          mode: NULLABLE
+        - name: media_eme_secure_context
+          type: STRING
+          mode: NULLABLE
+        - name: media_hls_canplay_requested
+          type: STRING
+          mode: NULLABLE
+        - name: media_hls_canplay_supported
+          type: STRING
+          mode: NULLABLE
+        - name: media_hls_decoder_success
+          type: STRING
+          mode: NULLABLE
+        - name: media_mkv_canplay_requested
+          type: STRING
+          mode: NULLABLE
+        - name: media_mp4_parse_num_sample_description_entries
+          type: STRING
+          mode: NULLABLE
+        - name: media_mp4_parse_sample_description_entries_have_multiple_codecs
+          type: STRING
+          mode: NULLABLE
+        - name: media_mp4_parse_sample_description_entries_have_multiple_crypto
+          type: STRING
+          mode: NULLABLE
+        - name: media_ogg_loaded_is_chained
+          type: STRING
+          mode: NULLABLE
+        - name: media_play_promise_resolution
+          type: STRING
+          mode: NULLABLE
+        - name: media_played_time_after_autoplay_blocked
+          type: STRING
+          mode: NULLABLE
+        - name: media_recorder_recording_duration
+          type: STRING
+          mode: NULLABLE
+        - name: media_recorder_track_encoder_init_timeout_type
+          type: STRING
+          mode: NULLABLE
+        - name: media_rust_mp4parse_error_code
+          type: STRING
+          mode: NULLABLE
+        - name: media_rust_mp4parse_success
+          type: STRING
+          mode: NULLABLE
+        - name: media_rust_mp4parse_track_match_audio
+          type: STRING
+          mode: NULLABLE
+        - name: media_rust_mp4parse_track_match_video
+          type: STRING
+          mode: NULLABLE
+        - name: media_sniffer_mp4_brand_pattern
+          type: STRING
+          mode: NULLABLE
+        - name: media_wmf_decode_error
+          type: STRING
+          mode: NULLABLE
+        - name: mediacache_blockowners_watermark
+          type: STRING
+          mode: NULLABLE
+        - name: mediacache_memory_watermark
+          type: STRING
+          mode: NULLABLE
+        - name: mediacache_watermark_kb
+          type: STRING
+          mode: NULLABLE
+        - name: mediacachestream_length_kb
+          type: STRING
+          mode: NULLABLE
+        - name: mediacachestream_notified_length
+          type: STRING
+          mode: NULLABLE
+        - name: memory_collection_time
+          type: STRING
+          mode: NULLABLE
+        - name: memory_free_purged_pages_ms
+          type: STRING
+          mode: NULLABLE
+        - name: memory_heap_allocated
+          type: STRING
+          mode: NULLABLE
+        - name: memory_heap_committed_unused
+          type: STRING
+          mode: NULLABLE
+        - name: memory_heap_overhead_fraction
+          type: STRING
+          mode: NULLABLE
+        - name: memory_images_content_used_uncompressed
+          type: STRING
+          mode: NULLABLE
+        - name: memory_js_compartments_system
+          type: STRING
+          mode: NULLABLE
+        - name: memory_js_compartments_user
+          type: STRING
+          mode: NULLABLE
+        - name: memory_js_gc_heap
+          type: STRING
+          mode: NULLABLE
+        - name: memory_js_realms_system
+          type: STRING
+          mode: NULLABLE
+        - name: memory_js_realms_user
+          type: STRING
+          mode: NULLABLE
+        - name: memory_resident_fast
+          type: STRING
+          mode: NULLABLE
+        - name: memory_resident_peak
+          type: STRING
+          mode: NULLABLE
+        - name: memory_storage_sqlite
+          type: STRING
+          mode: NULLABLE
+        - name: memory_total
+          type: STRING
+          mode: NULLABLE
+        - name: memory_unique
+          type: STRING
+          mode: NULLABLE
+        - name: memory_unique_content_startup
+          type: STRING
+          mode: NULLABLE
+        - name: memory_vsize
+          type: STRING
+          mode: NULLABLE
+        - name: memory_vsize_max_contiguous
+          type: STRING
+          mode: NULLABLE
+        - name: memoryblockcache_errors
+          type: STRING
+          mode: NULLABLE
+        - name: missing_font
+          type: STRING
+          mode: NULLABLE
+        - name: missing_font_langpack
+          type: STRING
+          mode: NULLABLE
+        - name: missing_font_user
+          type: STRING
+          mode: NULLABLE
+        - name: mixed_content_audio
+          type: STRING
+          mode: NULLABLE
+        - name: mixed_content_downloads
+          type: STRING
+          mode: NULLABLE
+        - name: mixed_content_hsts
+          type: STRING
+          mode: NULLABLE
+        - name: mixed_content_hsts_priming
+          type: STRING
+          mode: NULLABLE
+        - name: mixed_content_hsts_priming_result
+          type: STRING
+          mode: NULLABLE
+        - name: mixed_content_images
+          type: STRING
+          mode: NULLABLE
+        - name: mixed_content_object_subrequest
+          type: STRING
+          mode: NULLABLE
+        - name: mixed_content_page_load
+          type: STRING
+          mode: NULLABLE
+        - name: mixed_content_unblock_counter
+          type: STRING
+          mode: NULLABLE
+        - name: mixed_content_video
+          type: STRING
+          mode: NULLABLE
+        - name: moz_blob_in_xhr
+          type: STRING
+          mode: NULLABLE
+        - name: moz_chunked_arraybuffer_in_xhr
+          type: STRING
+          mode: NULLABLE
+        - name: moz_chunked_text_in_xhr
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_cookies_open_readahead_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_cookies_read_b
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_cookies_read_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_cookies_read_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_cookies_sync_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_cookies_sync_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_cookies_write_b
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_cookies_write_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_cookies_write_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_open_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_open_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_other_read_b
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_other_read_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_other_read_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_other_sync_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_other_sync_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_other_write_b
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_other_write_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_other_write_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_places_read_b
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_places_read_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_places_read_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_places_sync_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_places_sync_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_places_write_b
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_places_write_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_places_write_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_truncate_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_truncate_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_webapps_read_b
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_webapps_read_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_webapps_read_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_webapps_sync_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_webapps_sync_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_webapps_write_b
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_webapps_write_main_thread_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_sqlite_webapps_write_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_storage_async_requests_ms
+          type: STRING
+          mode: NULLABLE
+        - name: moz_storage_async_requests_success
+          type: STRING
+          mode: NULLABLE
+        - name: mse_source_buffer_type
+          type: STRING
+          mode: NULLABLE
+        - name: narrate_content_speaktime_ms
+          type: STRING
+          mode: NULLABLE
+        - name: network_async_open_to_transaction_pending_ms
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_fs_type
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_hash_stats
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_hit_miss_stat_per_cache_size
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_hit_rate_per_cache_size
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_metadata_first_read_size
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_metadata_first_read_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_metadata_second_read_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_metadata_size
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_size_full_fat
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_v1_hit_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_v1_miss_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_v1_truncate_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_v2_hit_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_v2_input_stream_status
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_v2_miss_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: network_cache_v2_output_stream_status
+          type: STRING
+          mode: NULLABLE
+        - name: network_connection_count
+          type: STRING
+          mode: NULLABLE
+        - name: network_disk_cache2_shutdown_clear_private
+          type: STRING
+          mode: NULLABLE
+        - name: network_disk_cache_deletedir
+          type: STRING
+          mode: NULLABLE
+        - name: network_disk_cache_deletedir_shutdown
+          type: STRING
+          mode: NULLABLE
+        - name: network_disk_cache_open
+          type: STRING
+          mode: NULLABLE
+        - name: network_disk_cache_shutdown
+          type: STRING
+          mode: NULLABLE
+        - name: network_disk_cache_shutdown_clear_private
+          type: STRING
+          mode: NULLABLE
+        - name: network_disk_cache_shutdown_v2
+          type: STRING
+          mode: NULLABLE
+        - name: network_disk_cache_trashrename
+          type: STRING
+          mode: NULLABLE
+        - name: network_id
+          type: STRING
+          mode: NULLABLE
+        - name: network_probe_maxcount
+          type: STRING
+          mode: NULLABLE
+        - name: network_race_cache_bandwidth_not_race
+          type: STRING
+          mode: NULLABLE
+        - name: network_race_cache_bandwidth_race_cache_win
+          type: STRING
+          mode: NULLABLE
+        - name: network_race_cache_bandwidth_race_network_win
+          type: STRING
+          mode: NULLABLE
+        - name: network_race_cache_bandwith_not_race
+          type: STRING
+          mode: NULLABLE
+        - name: network_race_cache_bandwith_race_cache_win
+          type: STRING
+          mode: NULLABLE
+        - name: network_race_cache_bandwith_race_network_win
+          type: STRING
+          mode: NULLABLE
+        - name: network_race_cache_with_network_ocec_on_start_diff
+          type: STRING
+          mode: NULLABLE
+        - name: network_race_cache_with_network_saved_time
+          type: STRING
+          mode: NULLABLE
+        - name: network_race_cache_with_network_usage
+          type: STRING
+          mode: NULLABLE
+        - name: network_race_cache_with_network_usage_2
+          type: STRING
+          mode: NULLABLE
+        - name: network_session_at_900fd
+          type: STRING
+          mode: NULLABLE
+        - name: newtab_page_blocked_sites_count
+          type: STRING
+          mode: NULLABLE
+        - name: newtab_page_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: newtab_page_enhanced
+          type: STRING
+          mode: NULLABLE
+        - name: newtab_page_life_span
+          type: STRING
+          mode: NULLABLE
+        - name: newtab_page_life_span_suggested
+          type: STRING
+          mode: NULLABLE
+        - name: newtab_page_pinned_sites_count
+          type: STRING
+          mode: NULLABLE
+        - name: newtab_page_shown
+          type: STRING
+          mode: NULLABLE
+        - name: newtab_page_site_clicked
+          type: STRING
+          mode: NULLABLE
+        - name: ntlm_module_used_2
+          type: STRING
+          mode: NULLABLE
+        - name: number_of_profiles
+          type: STRING
+          mode: NULLABLE
+        - name: onbeforeunload_prompt_action
+          type: STRING
+          mode: NULLABLE
+        - name: onbeforeunload_prompt_count
+          type: STRING
+          mode: NULLABLE
+        - name: osfile_worker_launch_ms
+          type: STRING
+          mode: NULLABLE
+        - name: osfile_worker_ready_ms
+          type: STRING
+          mode: NULLABLE
+        - name: osfile_writeatomic_jank_ms
+          type: STRING
+          mode: NULLABLE
+        - name: page_faults_hard
+          type: STRING
+          mode: NULLABLE
+        - name: page_max_scroll_y
+          type: STRING
+          mode: NULLABLE
+        - name: page_metadata_size
+          type: STRING
+          mode: NULLABLE
+        - name: paint_build_displaylist_time
+          type: STRING
+          mode: NULLABLE
+        - name: paint_build_layers_time
+          type: STRING
+          mode: NULLABLE
+        - name: paint_rasterize_time
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_document_generator
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_document_generator_2
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_document_size_kb
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_document_version
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_document_version_2
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_embed
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_embed_2
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_fallback_error
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_fallback_reason
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_fallback_shown
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_font_types
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_font_types_2
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_form
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_form_2
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_print
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_stream_types
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_stream_types_2
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_tagged
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_time_to_view_ms
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_used
+          type: STRING
+          mode: NULLABLE
+        - name: pending_critical_input_when_timeout
+          type: STRING
+          mode: NULLABLE
+        - name: perf_dom_content_loaded_time_from_responsestart_ms
+          type: STRING
+          mode: NULLABLE
+        - name: perf_dom_content_loaded_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: perf_first_contentful_paint_from_responsestart_ms
+          type: STRING
+          mode: NULLABLE
+        - name: perf_first_contentful_paint_ms
+          type: STRING
+          mode: NULLABLE
+        - name: perf_monitoring_test_cpu_rescheduling_proportion_moved
+          type: STRING
+          mode: NULLABLE
+        - name: perf_page_load_time_from_responsestart_ms
+          type: STRING
+          mode: NULLABLE
+        - name: perf_page_load_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: perf_request_animation_callback_non_pageload_ms
+          type: STRING
+          mode: NULLABLE
+        - name: perf_request_animation_callback_pageload_ms
+          type: STRING
+          mode: NULLABLE
+        - name: permissions_migration_7_error
+          type: STRING
+          mode: NULLABLE
+        - name: permissions_remigration_comparison
+          type: STRING
+          mode: NULLABLE
+        - name: permissions_sql_corrupted
+          type: STRING
+          mode: NULLABLE
+        - name: places_annos_bookmarks_count
+          type: STRING
+          mode: NULLABLE
+        - name: places_annos_pages_count
+          type: STRING
+          mode: NULLABLE
+        - name: places_autocomplete_1st_result_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: places_autocomplete_6_first_results_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: places_autocomplete_urlinline_domain_query_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: places_backups_bookmarkstree_ms
+          type: STRING
+          mode: NULLABLE
+        - name: places_backups_daysfromlast
+          type: STRING
+          mode: NULLABLE
+        - name: places_backups_tojson_ms
+          type: STRING
+          mode: NULLABLE
+        - name: places_bookmarks_count
+          type: STRING
+          mode: NULLABLE
+        - name: places_database_filesize_mb
+          type: STRING
+          mode: NULLABLE
+        - name: places_database_pagesize_b
+          type: STRING
+          mode: NULLABLE
+        - name: places_database_size_per_page_b
+          type: STRING
+          mode: NULLABLE
+        - name: places_expiration_steps_to_clean2
+          type: STRING
+          mode: NULLABLE
+        - name: places_export_tohtml_ms
+          type: STRING
+          mode: NULLABLE
+        - name: places_favicon_bmp_sizes
+          type: STRING
+          mode: NULLABLE
+        - name: places_favicon_gif_sizes
+          type: STRING
+          mode: NULLABLE
+        - name: places_favicon_ico_sizes
+          type: STRING
+          mode: NULLABLE
+        - name: places_favicon_jpeg_sizes
+          type: STRING
+          mode: NULLABLE
+        - name: places_favicon_other_sizes
+          type: STRING
+          mode: NULLABLE
+        - name: places_favicon_png_sizes
+          type: STRING
+          mode: NULLABLE
+        - name: places_favicon_svg_sizes
+          type: STRING
+          mode: NULLABLE
+        - name: places_history_library_search_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: places_idle_frecency_decay_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: places_idle_maintenance_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: places_keywords_count
+          type: STRING
+          mode: NULLABLE
+        - name: places_maintenance_daysfromlast
+          type: STRING
+          mode: NULLABLE
+        - name: places_most_recent_expired_visit_days
+          type: STRING
+          mode: NULLABLE
+        - name: places_pages_count
+          type: STRING
+          mode: NULLABLE
+        - name: places_sorted_bookmarks_perc
+          type: STRING
+          mode: NULLABLE
+        - name: places_tagged_bookmarks_perc
+          type: STRING
+          mode: NULLABLE
+        - name: places_tags_count
+          type: STRING
+          mode: NULLABLE
+        - name: plugin_drawing_model
+          type: STRING
+          mode: NULLABLE
+        - name: plugin_hang_notice_count
+          type: STRING
+          mode: NULLABLE
+        - name: plugin_hang_time
+          type: STRING
+          mode: NULLABLE
+        - name: plugin_hang_ui_dont_ask
+          type: STRING
+          mode: NULLABLE
+        - name: plugin_hang_ui_response_time
+          type: STRING
+          mode: NULLABLE
+        - name: plugin_hang_ui_user_response
+          type: STRING
+          mode: NULLABLE
+        - name: plugin_load_metadata
+          type: STRING
+          mode: NULLABLE
+        - name: plugin_shutdown_ms
+          type: STRING
+          mode: NULLABLE
+        - name: plugins_infobar_allow
+          type: STRING
+          mode: NULLABLE
+        - name: plugins_infobar_block
+          type: STRING
+          mode: NULLABLE
+        - name: plugins_infobar_shown
+          type: STRING
+          mode: NULLABLE
+        - name: plugins_notification_plugin_count
+          type: STRING
+          mode: NULLABLE
+        - name: plugins_notification_shown
+          type: STRING
+          mode: NULLABLE
+        - name: plugins_notification_user_action
+          type: STRING
+          mode: NULLABLE
+        - name: plugins_notification_user_action_2
+          type: STRING
+          mode: NULLABLE
+        - name: prclose_tcp_blocking_time_connectivity_change
+          type: STRING
+          mode: NULLABLE
+        - name: prclose_tcp_blocking_time_link_change
+          type: STRING
+          mode: NULLABLE
+        - name: prclose_tcp_blocking_time_normal
+          type: STRING
+          mode: NULLABLE
+        - name: prclose_tcp_blocking_time_offline
+          type: STRING
+          mode: NULLABLE
+        - name: prclose_tcp_blocking_time_shutdown
+          type: STRING
+          mode: NULLABLE
+        - name: prclose_udp_blocking_time_connectivity_change
+          type: STRING
+          mode: NULLABLE
+        - name: prclose_udp_blocking_time_link_change
+          type: STRING
+          mode: NULLABLE
+        - name: prclose_udp_blocking_time_normal
+          type: STRING
+          mode: NULLABLE
+        - name: prclose_udp_blocking_time_offline
+          type: STRING
+          mode: NULLABLE
+        - name: prclose_udp_blocking_time_shutdown
+          type: STRING
+          mode: NULLABLE
+        - name: prconnect_blocking_time_connectivity_change
+          type: STRING
+          mode: NULLABLE
+        - name: prconnect_blocking_time_link_change
+          type: STRING
+          mode: NULLABLE
+        - name: prconnect_blocking_time_normal
+          type: STRING
+          mode: NULLABLE
+        - name: prconnect_blocking_time_offline
+          type: STRING
+          mode: NULLABLE
+        - name: prconnect_blocking_time_shutdown
+          type: STRING
+          mode: NULLABLE
+        - name: prconnect_fail_blocking_time_connectivity_change
+          type: STRING
+          mode: NULLABLE
+        - name: prconnect_fail_blocking_time_link_change
+          type: STRING
+          mode: NULLABLE
+        - name: prconnect_fail_blocking_time_normal
+          type: STRING
+          mode: NULLABLE
+        - name: prconnect_fail_blocking_time_offline
+          type: STRING
+          mode: NULLABLE
+        - name: prconnect_fail_blocking_time_shutdown
+          type: STRING
+          mode: NULLABLE
+        - name: prconnectcontinue_blocking_time_connectivity_change
+          type: STRING
+          mode: NULLABLE
+        - name: prconnectcontinue_blocking_time_link_change
+          type: STRING
+          mode: NULLABLE
+        - name: prconnectcontinue_blocking_time_normal
+          type: STRING
+          mode: NULLABLE
+        - name: prconnectcontinue_blocking_time_offline
+          type: STRING
+          mode: NULLABLE
+        - name: prconnectcontinue_blocking_time_shutdown
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_base_confidence
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_confidence
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_global_degradation
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_learn_attempts
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_learn_full_queue
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_learn_work_time
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_predict_attempts
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_predict_full_queue
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_predict_time_to_action
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_predict_time_to_inaction
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_predict_work_time
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_predictions_calculated
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_prefetch_time
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_subresource_degradation
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_total_preconnects
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_total_preconnects_created
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_total_preconnects_unused
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_total_preconnects_used
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_total_predictions
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_total_prefetches
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_total_prefetches_used
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_total_preresolves
+          type: STRING
+          mode: NULLABLE
+        - name: predictor_wait_time
+          type: STRING
+          mode: NULLABLE
+        - name: presshell_reqs_per_style_flush
+          type: STRING
+          mode: NULLABLE
+        - name: print_preview_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: print_preview_simplify_page_opened_count
+          type: STRING
+          mode: NULLABLE
+        - name: print_preview_simplify_page_unavailable_count
+          type: STRING
+          mode: NULLABLE
+        - name: push_api_notify
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_blocklist_num_sites
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_form_autofill_result
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_is_username_only_form
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_login_last_used_days
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_login_page_safety
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_manage_copied_password
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_manage_copied_username
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_manage_deleted
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_manage_deleted_all
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_manage_opened
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_manage_visibility_toggled
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_num_form_has_possible_username_event_per_doc
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_num_httpauth_passwords
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_num_passwords_per_hostname
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_num_saved_passwords
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_password_input_in_form
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_prompt_remember_action
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_prompt_update_action
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_saving_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_signup_form_detection_ms
+          type: STRING
+          mode: NULLABLE
+        - name: pwmgr_username_present
+          type: STRING
+          mode: NULLABLE
+        - name: query_stripping_count
+          type: STRING
+          mode: NULLABLE
+        - name: query_stripping_count_by_param
+          type: STRING
+          mode: NULLABLE
+        - name: query_stripping_param_count
+          type: STRING
+          mode: NULLABLE
+        - name: quirks_mode
+          type: STRING
+          mode: NULLABLE
+        - name: range_checksum_errors
+          type: STRING
+          mode: NULLABLE
+        - name: reader_mode_download_result
+          type: STRING
+          mode: NULLABLE
+        - name: reader_mode_parse_result
+          type: STRING
+          mode: NULLABLE
+        - name: refresh_driver_tick
+          type: STRING
+          mode: NULLABLE
+        - name: region_location_services_difference
+          type: STRING
+          mode: NULLABLE
+        - name: rel_preload_miss_ratio
+          type: STRING
+          mode: NULLABLE
+        - name: requests_of_original_content
+          type: STRING
+          mode: NULLABLE
+        - name: safe_mode_usage
+          type: STRING
+          mode: NULLABLE
+        - name: sandbox_broker_initialized
+          type: STRING
+          mode: NULLABLE
+        - name: sandbox_content_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: sandbox_has_seccomp_bpf
+          type: STRING
+          mode: NULLABLE
+        - name: sandbox_has_seccomp_tsync
+          type: STRING
+          mode: NULLABLE
+        - name: sandbox_has_user_namespaces
+          type: STRING
+          mode: NULLABLE
+        - name: sandbox_has_user_namespaces_privileged
+          type: STRING
+          mode: NULLABLE
+        - name: sandbox_media_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: script_block_incorrect_mime
+          type: STRING
+          mode: NULLABLE
+        - name: script_block_incorrect_mime_2
+          type: STRING
+          mode: NULLABLE
+        - name: script_block_incorrect_mime_3
+          type: STRING
+          mode: NULLABLE
+        - name: script_file_protocol_correct_mime
+          type: STRING
+          mode: NULLABLE
+        - name: script_loaded_with_version
+          type: STRING
+          mode: NULLABLE
+        - name: script_preloader_requests
+          type: STRING
+          mode: NULLABLE
+        - name: script_preloader_wait_time
+          type: STRING
+          mode: NULLABLE
+        - name: scroll_anchor_adjustment_count
+          type: STRING
+          mode: NULLABLE
+        - name: scroll_anchor_adjustment_length
+          type: STRING
+          mode: NULLABLE
+        - name: scroll_input_methods
+          type: STRING
+          mode: NULLABLE
+        - name: search_reset_result
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_country_fetch_caused_sync_init
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_country_fetch_result
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_country_fetch_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_country_timeout
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_engine_count
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_init_ms
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_init_sync
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_nonus_country_mismatched_platform_osx
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_nonus_country_mismatched_platform_win
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_us_country_mismatched_platform_osx
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_us_country_mismatched_platform_win
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_us_country_mismatched_timezone
+          type: STRING
+          mode: NULLABLE
+        - name: search_service_us_timezone_mismatched_country
+          type: STRING
+          mode: NULLABLE
+        - name: security_ui
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_controlled_documents
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_destroyed
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_isolated_launch_time
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_launch_time
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_launch_time_2
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_life_time
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_registration_loading
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_registrations
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_request_passthrough
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_spawn_attempts
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_spawn_gets_queued
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_updated
+          type: STRING
+          mode: NULLABLE
+        - name: service_worker_was_spawned
+          type: STRING
+          mode: NULLABLE
+        - name: shared_memory_ua_sheets_mapped_child
+          type: STRING
+          mode: NULLABLE
+        - name: shared_worker_count
+          type: STRING
+          mode: NULLABLE
+        - name: shared_worker_destroyed
+          type: STRING
+          mode: NULLABLE
+        - name: shared_worker_spawn_gets_queued
+          type: STRING
+          mode: NULLABLE
+        - name: should_auto_detect_language
+          type: STRING
+          mode: NULLABLE
+        - name: should_translation_ui_appear
+          type: STRING
+          mode: NULLABLE
+        - name: shutdown_ok
+          type: STRING
+          mode: NULLABLE
+        - name: shutdown_phase_duration_ticks_profile_before_change
+          type: STRING
+          mode: NULLABLE
+        - name: shutdown_phase_duration_ticks_profile_before_change_qm
+          type: STRING
+          mode: NULLABLE
+        - name: shutdown_phase_duration_ticks_profile_change_net_teardown
+          type: STRING
+          mode: NULLABLE
+        - name: shutdown_phase_duration_ticks_profile_change_teardown
+          type: STRING
+          mode: NULLABLE
+        - name: shutdown_phase_duration_ticks_quit_application
+          type: STRING
+          mode: NULLABLE
+        - name: shutdown_phase_duration_ticks_xpcom_shutdown
+          type: STRING
+          mode: NULLABLE
+        - name: shutdown_phase_duration_ticks_xpcom_will_shutdown
+          type: STRING
+          mode: NULLABLE
+        - name: slow_addon_warning_response_time
+          type: STRING
+          mode: NULLABLE
+        - name: slow_addon_warning_states
+          type: STRING
+          mode: NULLABLE
+        - name: slow_script_notice_count
+          type: STRING
+          mode: NULLABLE
+        - name: slow_script_notify_delay
+          type: STRING
+          mode: NULLABLE
+        - name: slow_script_page_count
+          type: STRING
+          mode: NULLABLE
+        - name: social_enabled_on_session
+          type: STRING
+          mode: NULLABLE
+        - name: social_panel_clicks
+          type: STRING
+          mode: NULLABLE
+        - name: social_sidebar_open_duration
+          type: STRING
+          mode: NULLABLE
+        - name: social_sidebar_state
+          type: STRING
+          mode: NULLABLE
+        - name: social_toolbar_buttons
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_chunk_recvd
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_continued_headers
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_goaway_local
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_goaway_peer
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_kbread_per_conn
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_kbread_per_conn2
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_npn_connect
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_npn_join
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_parallel_streams
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_request_per_conn
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_request_per_conn_2
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_request_per_conn_3
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_server_initiated_streams
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_settings_iw
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_settings_max_streams
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_syn_ratio
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_syn_reply_ratio
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_syn_reply_size
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_syn_size
+          type: STRING
+          mode: NULLABLE
+        - name: spdy_version2
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_auth_algorithm_full
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_auth_ecdsa_curve_full
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_auth_rsa_key_size_full
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_bytes_before_cert_callback
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_cert_error_overrides
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_cert_verification_errors
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_cipher_suite_full
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_cipher_suite_resumed
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_ct_policy_compliance_of_ev_certs
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_ct_policy_compliant_connections_by_ca
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_ct_policy_non_compliant_connections_by_ca
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_handshake_result
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_handshake_result_conservative
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_handshake_result_ech
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_handshake_result_ech_grease
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_handshake_result_first_try
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_handshake_type
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_handshake_version
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_initial_failed_cert_validation_time_mozillapkix
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_kea_dhe_key_size_full
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_kea_ecdhe_curve_full
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_kea_rsa_key_size_full
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_key_exchange_algorithm_full
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_key_exchange_algorithm_resumed
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_npn_type
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_observed_end_entity_certificate_lifetime
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_ocsp_may_fetch
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_ocsp_stapling
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_permanent_cert_error_overrides
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_reasons_for_not_false_starting
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_resumed_session
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_scts_origin
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_scts_per_connection
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_scts_verification_status
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_server_auth_eku
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_succesful_cert_validation_time_mozillapkix
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_symmetric_cipher_full
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_symmetric_cipher_resumed
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_time_until_handshake_finished
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_time_until_ready
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_time_until_ready_conservative
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_time_until_ready_ech
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_time_until_ready_ech_grease
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_time_until_ready_first_try
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_tls10_intolerance_reason_post
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_tls10_intolerance_reason_pre
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_tls11_intolerance_reason_post
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_tls11_intolerance_reason_pre
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_tls12_intolerance_reason_post
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_tls12_intolerance_reason_pre
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_tls13_intolerance_reason_post
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_tls13_intolerance_reason_pre
+          type: STRING
+          mode: NULLABLE
+        - name: ssl_version_fallback_inappropriate
+          type: STRING
+          mode: NULLABLE
+        - name: startup_crash_detected
+          type: STRING
+          mode: NULLABLE
+        - name: startup_measurement_errors
+          type: STRING
+          mode: NULLABLE
+        - name: storage_access_api_ui
+          type: STRING
+          mode: NULLABLE
+        - name: storage_access_granted_count
+          type: STRING
+          mode: NULLABLE
+        - name: sts_number_of_onsocketready_calls
+          type: STRING
+          mode: NULLABLE
+        - name: sts_number_of_pending_events
+          type: STRING
+          mode: NULLABLE
+        - name: sts_number_of_pending_events_in_the_last_cycle
+          type: STRING
+          mode: NULLABLE
+        - name: sts_poll_and_event_the_last_cycle
+          type: STRING
+          mode: NULLABLE
+        - name: sts_poll_and_events_cycle
+          type: STRING
+          mode: NULLABLE
+        - name: sts_poll_block_time
+          type: STRING
+          mode: NULLABLE
+        - name: sts_poll_cycle
+          type: STRING
+          mode: NULLABLE
+        - name: stumbler_observations_per_day
+          type: STRING
+          mode: NULLABLE
+        - name: stumbler_time_between_received_locations_sec
+          type: STRING
+          mode: NULLABLE
+        - name: stumbler_time_between_start_sec
+          type: STRING
+          mode: NULLABLE
+        - name: stumbler_time_between_uploads_sec
+          type: STRING
+          mode: NULLABLE
+        - name: stumbler_upload_bytes
+          type: STRING
+          mode: NULLABLE
+        - name: stumbler_upload_cell_count
+          type: STRING
+          mode: NULLABLE
+        - name: stumbler_upload_observation_count
+          type: STRING
+          mode: NULLABLE
+        - name: stumbler_upload_wifi_ap_count
+          type: STRING
+          mode: NULLABLE
+        - name: stumbler_volume_bytes_uploaded_per_sec
+          type: STRING
+          mode: NULLABLE
+        - name: stylo_parallel_restyle_fraction
+          type: STRING
+          mode: NULLABLE
+        - name: stylo_parallel_restyle_fraction_weighted_styled
+          type: STRING
+          mode: NULLABLE
+        - name: stylo_parallel_restyle_fraction_weighted_traversed
+          type: STRING
+          mode: NULLABLE
+        - name: subject_principal_accessed_without_script_on_stack
+          type: STRING
+          mode: NULLABLE
+        - name: system_font_fallback
+          type: STRING
+          mode: NULLABLE
+        - name: system_font_fallback_first
+          type: STRING
+          mode: NULLABLE
+        - name: system_font_fallback_script
+          type: STRING
+          mode: NULLABLE
+        - name: tab_audio_indicator_used
+          type: STRING
+          mode: NULLABLE
+        - name: tab_count
+          type: STRING
+          mode: NULLABLE
+        - name: tab_media_blocking_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: tabchild_paint_time
+          type: STRING
+          mode: NULLABLE
+        - name: tap_to_load_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: tap_to_load_image_size
+          type: STRING
+          mode: NULLABLE
+        - name: tcp_fast_open
+          type: STRING
+          mode: NULLABLE
+        - name: tcp_fast_open_2
+          type: STRING
+          mode: NULLABLE
+        - name: tcp_fast_open_status
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_archive_checking_over_quota_ms
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_archive_directories_count
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_archive_evicted_old_dirs
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_archive_evicted_over_quota
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_archive_evicting_dirs_ms
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_archive_evicting_over_quota_ms
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_archive_oldest_directory_age
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_archive_scan_ping_count
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_archive_session_ping_count
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_archive_size_mb
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_assemble_payload_exception
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_compress
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_discarded_archived_pings_size_mb
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_discarded_content_pings_count
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_discarded_pending_pings_size_mb
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_discarded_send_pings_size_mb
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_event_recording_error
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_invalid_payload_submitted
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_memory_reporter_ms
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_pending_checking_over_quota_ms
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_pending_evicting_over_quota_ms
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_pending_load_failure_parse
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_pending_load_failure_read
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_pending_pings_age
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_pending_pings_evicted_over_quota
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_pending_pings_size_mb
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_ping_evicted_for_server_errors
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_ping_size_exceeded_archived
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_ping_size_exceeded_pending
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_ping_size_exceeded_send
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_ping_submission_waiting_clientid
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_scheduler_tick_exception
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_scheduler_wakeup
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_send_failure
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_send_success
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_sessiondata_failed_load
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_sessiondata_failed_parse
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_sessiondata_failed_save
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_sessiondata_failed_validation
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_stringify
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_success
+          type: STRING
+          mode: NULLABLE
+        - name: thunderbird_conversations_time_to_2nd_gloda_query_ms
+          type: STRING
+          mode: NULLABLE
+        - name: thunderbird_gloda_size_mb
+          type: STRING
+          mode: NULLABLE
+        - name: thunderbird_indexing_rate_msg_per_s
+          type: STRING
+          mode: NULLABLE
+        - name: time_between_unlabeled_runnables_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_dom_complete_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_dom_content_loaded_end_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_dom_content_loaded_start_active_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_dom_content_loaded_start_active_netopt_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_dom_content_loaded_start_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_dom_interactive_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_dom_loading_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_first_click_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_first_contentful_paint_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_first_interaction_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_first_key_input_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_first_mouse_move_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_first_scroll_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_load_event_end_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_load_event_start_active_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_load_event_start_active_netopt_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_load_event_start_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_non_blank_paint_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_non_blank_paint_netopt_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_non_blank_paint_no_netopt_ms
+          type: STRING
+          mode: NULLABLE
+        - name: time_to_response_start_ms
+          type: STRING
+          mode: NULLABLE
+        - name: timeout_execution_bg_ms
+          type: STRING
+          mode: NULLABLE
+        - name: timeout_execution_bg_tracking_ms
+          type: STRING
+          mode: NULLABLE
+        - name: timeout_execution_fg_ms
+          type: STRING
+          mode: NULLABLE
+        - name: timeout_execution_fg_tracking_ms
+          type: STRING
+          mode: NULLABLE
+        - name: tls_early_data_accepted
+          type: STRING
+          mode: NULLABLE
+        - name: tls_early_data_bytes_written
+          type: STRING
+          mode: NULLABLE
+        - name: tls_early_data_negotiated
+          type: STRING
+          mode: NULLABLE
+        - name: tls_error_report_ui
+          type: STRING
+          mode: NULLABLE
+        - name: top_level_content_documents_destroyed
+          type: STRING
+          mode: NULLABLE
+        - name: total_containers_opened
+          type: STRING
+          mode: NULLABLE
+        - name: total_content_page_load_time
+          type: STRING
+          mode: NULLABLE
+        - name: total_count_high_errors
+          type: STRING
+          mode: NULLABLE
+        - name: total_count_low_errors
+          type: STRING
+          mode: NULLABLE
+        - name: total_docgroups_per_tabgroup
+          type: STRING
+          mode: NULLABLE
+        - name: total_http_docgroups_per_tabgroup
+          type: STRING
+          mode: NULLABLE
+        - name: total_scroll_y
+          type: STRING
+          mode: NULLABLE
+        - name: touch_enabled_device
+          type: STRING
+          mode: NULLABLE
+        - name: tracking_protection_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: tracking_protection_events
+          type: STRING
+          mode: NULLABLE
+        - name: tracking_protection_pbm_disabled
+          type: STRING
+          mode: NULLABLE
+        - name: tracking_protection_shield
+          type: STRING
+          mode: NULLABLE
+        - name: transaction_wait_time_http
+          type: STRING
+          mode: NULLABLE
+        - name: transaction_wait_time_http2_sup_http3
+          type: STRING
+          mode: NULLABLE
+        - name: transaction_wait_time_http3
+          type: STRING
+          mode: NULLABLE
+        - name: transaction_wait_time_spdy
+          type: STRING
+          mode: NULLABLE
+        - name: translated_characters
+          type: STRING
+          mode: NULLABLE
+        - name: translated_pages
+          type: STRING
+          mode: NULLABLE
+        - name: translation_opportunities
+          type: STRING
+          mode: NULLABLE
+        - name: types_of_user_clicks
+          type: STRING
+          mode: NULLABLE
+        - name: unique_containers_opened
+          type: STRING
+          mode: NULLABLE
+        - name: update_cannot_stage_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_cannot_stage_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_check_code_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_check_code_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_check_no_update_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_check_no_update_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_download_code_complete
+          type: STRING
+          mode: NULLABLE
+        - name: update_download_code_partial
+          type: STRING
+          mode: NULLABLE
+        - name: update_invalid_lastupdatetime_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_invalid_lastupdatetime_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_last_notify_interval_days_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_last_notify_interval_days_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_not_pref_update_auto_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_not_pref_update_auto_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_not_pref_update_enabled_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_not_pref_update_enabled_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_not_pref_update_service_enabled_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_not_pref_update_service_enabled_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_not_pref_update_staging_enabled_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_not_pref_update_staging_enabled_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_notification_dismissed
+          type: STRING
+          mode: NULLABLE
+        - name: update_notification_main_action_doorhanger
+          type: STRING
+          mode: NULLABLE
+        - name: update_notification_main_action_menu
+          type: STRING
+          mode: NULLABLE
+        - name: update_notification_shown
+          type: STRING
+          mode: NULLABLE
+        - name: update_ping_count_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_ping_count_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_pref_service_errors_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_pref_service_errors_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_pref_update_cancelations_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_pref_update_cancelations_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_service_installed_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_service_installed_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_service_manually_uninstalled_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_service_manually_uninstalled_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_state_code_complete_stage
+          type: STRING
+          mode: NULLABLE
+        - name: update_state_code_complete_startup
+          type: STRING
+          mode: NULLABLE
+        - name: update_state_code_partial_stage
+          type: STRING
+          mode: NULLABLE
+        - name: update_state_code_partial_startup
+          type: STRING
+          mode: NULLABLE
+        - name: update_state_code_unknown_stage
+          type: STRING
+          mode: NULLABLE
+        - name: update_state_code_unknown_startup
+          type: STRING
+          mode: NULLABLE
+        - name: update_status_error_code_complete_stage
+          type: STRING
+          mode: NULLABLE
+        - name: update_status_error_code_complete_startup
+          type: STRING
+          mode: NULLABLE
+        - name: update_status_error_code_partial_stage
+          type: STRING
+          mode: NULLABLE
+        - name: update_status_error_code_partial_startup
+          type: STRING
+          mode: NULLABLE
+        - name: update_status_error_code_unknown_stage
+          type: STRING
+          mode: NULLABLE
+        - name: update_status_error_code_unknown_startup
+          type: STRING
+          mode: NULLABLE
+        - name: update_unable_to_apply_external
+          type: STRING
+          mode: NULLABLE
+        - name: update_unable_to_apply_notify
+          type: STRING
+          mode: NULLABLE
+        - name: update_wiz_last_page_code
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_async_classifylocal_time
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_cl_check_time
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_classifylocal_time
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_completion_error
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_lc_completions
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_lc_prefixes
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_lookup_time_2
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_match_result
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_match_threat_type_result
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_negative_cache_duration
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_positive_cache_duration
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_ps_construct_time
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_ps_fallocate_time
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_ps_fileload_time
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_shutdown_time
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_threathit_network_error
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_threathit_remote_status
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_ui_events
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_vlps_construct_time
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_vlps_fallocate_time
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_vlps_fileload_time
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_vlps_load_corrupt
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_vlps_long_prefixes
+          type: STRING
+          mode: NULLABLE
+        - name: urlclassifier_vlps_metadata_corrupt
+          type: STRING
+          mode: NULLABLE
+        - name: user_font_families_per_page
+          type: STRING
+          mode: NULLABLE
+        - name: vfc_clearcurrentframe_lock_hold_ms
+          type: STRING
+          mode: NULLABLE
+        - name: vfc_clearfutureframes_lock_hold_ms
+          type: STRING
+          mode: NULLABLE
+        - name: vfc_invalidate_lock_hold_ms
+          type: STRING
+          mode: NULLABLE
+        - name: vfc_invalidate_lock_wait_ms
+          type: STRING
+          mode: NULLABLE
+        - name: vfc_setcurrentframe_lock_hold_ms
+          type: STRING
+          mode: NULLABLE
+        - name: vfc_setimages_lock_hold_ms
+          type: STRING
+          mode: NULLABLE
+        - name: vfc_setvideosegment_lock_hold_ms
+          type: STRING
+          mode: NULLABLE
+        - name: video_as_content_source
+          type: STRING
+          mode: NULLABLE
+        - name: video_as_content_source_in_tree_or_not
+          type: STRING
+          mode: NULLABLE
+        - name: video_can_create_aac_decoder
+          type: STRING
+          mode: NULLABLE
+        - name: video_can_create_h264_decoder
+          type: STRING
+          mode: NULLABLE
+        - name: video_canplaytype_h264_constraint_set_flag
+          type: STRING
+          mode: NULLABLE
+        - name: video_canplaytype_h264_level
+          type: STRING
+          mode: NULLABLE
+        - name: video_canplaytype_h264_profile
+          type: STRING
+          mode: NULLABLE
+        - name: video_cdm_created
+          type: STRING
+          mode: NULLABLE
+        - name: video_chromium_cdm_max_shmems
+          type: STRING
+          mode: NULLABLE
+        - name: video_clearkey_play_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: video_decoded_h264_sps_constraint_set_flag
+          type: STRING
+          mode: NULLABLE
+        - name: video_decoded_h264_sps_level
+          type: STRING
+          mode: NULLABLE
+        - name: video_decoded_h264_sps_profile
+          type: STRING
+          mode: NULLABLE
+        - name: video_dropped_compositor_frames_proportion_exponential
+          type: STRING
+          mode: NULLABLE
+        - name: video_dropped_decoded_frames_proportion_exponential
+          type: STRING
+          mode: NULLABLE
+        - name: video_dropped_frames_proportion
+          type: STRING
+          mode: NULLABLE
+        - name: video_dropped_frames_proportion_exponential
+          type: STRING
+          mode: NULLABLE
+        - name: video_dropped_sink_frames_proportion_exponential
+          type: STRING
+          mode: NULLABLE
+        - name: video_eme_play_success
+          type: STRING
+          mode: NULLABLE
+        - name: video_eme_request_failure_latency_ms
+          type: STRING
+          mode: NULLABLE
+        - name: video_eme_request_success_latency_ms
+          type: STRING
+          mode: NULLABLE
+        - name: video_encrypted_play_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: video_fastseek_used
+          type: STRING
+          mode: NULLABLE
+        - name: video_h264_sps_max_num_ref_frames
+          type: STRING
+          mode: NULLABLE
+        - name: video_hdr_play_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: video_hidden_play_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: video_hw_decoder_crash_recovery_time_since_gpu_crashed_ms
+          type: STRING
+          mode: NULLABLE
+        - name: video_hw_decoder_crash_recovery_time_since_mfr_notified_ms
+          type: STRING
+          mode: NULLABLE
+        - name: video_mft_output_null_samples
+          type: STRING
+          mode: NULLABLE
+        - name: video_play_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: video_unload_state
+          type: STRING
+          mode: NULLABLE
+        - name: video_vp9_benchmark_fps
+          type: STRING
+          mode: NULLABLE
+        - name: video_widevine_play_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: view_source_external_result_boolean
+          type: STRING
+          mode: NULLABLE
+        - name: view_source_in_browser_opened_boolean
+          type: STRING
+          mode: NULLABLE
+        - name: view_source_in_window_opened_boolean
+          type: STRING
+          mode: NULLABLE
+        - name: weave_complete_success_count
+          type: STRING
+          mode: NULLABLE
+        - name: weave_configured
+          type: STRING
+          mode: NULLABLE
+        - name: weave_configured_master_password
+          type: STRING
+          mode: NULLABLE
+        - name: weave_device_count_desktop
+          type: STRING
+          mode: NULLABLE
+        - name: weave_device_count_mobile
+          type: STRING
+          mode: NULLABLE
+        - name: weave_start_count
+          type: STRING
+          mode: NULLABLE
+        - name: weave_wipe_server_succeeded
+          type: STRING
+          mode: NULLABLE
+        - name: web_audio_autoplay
+          type: STRING
+          mode: NULLABLE
+        - name: web_audio_becomes_audible_time
+          type: STRING
+          mode: NULLABLE
+        - name: web_font_families_per_page
+          type: STRING
+          mode: NULLABLE
+        - name: web_notification_clicked
+          type: STRING
+          mode: NULLABLE
+        - name: web_notification_exceptions_opened
+          type: STRING
+          mode: NULLABLE
+        - name: web_notification_menu
+          type: STRING
+          mode: NULLABLE
+        - name: web_notification_permissions
+          type: STRING
+          mode: NULLABLE
+        - name: web_notification_shown
+          type: STRING
+          mode: NULLABLE
+        - name: webcrypto_alg
+          type: STRING
+          mode: NULLABLE
+        - name: webcrypto_extractable_enc
+          type: STRING
+          mode: NULLABLE
+        - name: webcrypto_extractable_generate
+          type: STRING
+          mode: NULLABLE
+        - name: webcrypto_extractable_import
+          type: STRING
+          mode: NULLABLE
+        - name: webcrypto_extractable_sig
+          type: STRING
+          mode: NULLABLE
+        - name: webcrypto_method
+          type: STRING
+          mode: NULLABLE
+        - name: webcrypto_method_secure
+          type: STRING
+          mode: NULLABLE
+        - name: webcrypto_resolved
+          type: STRING
+          mode: NULLABLE
+        - name: webext_content_script_injection_ms
+          type: STRING
+          mode: NULLABLE
+        - name: webext_storage_local_get_ms
+          type: STRING
+          mode: NULLABLE
+        - name: webext_storage_local_idb_get_ms
+          type: STRING
+          mode: NULLABLE
+        - name: webext_storage_local_idb_set_ms
+          type: STRING
+          mode: NULLABLE
+        - name: webext_storage_local_set_ms
+          type: STRING
+          mode: NULLABLE
+        - name: webext_user_script_injection_ms
+          type: STRING
+          mode: NULLABLE
+        - name: webfont_compression_woff
+          type: STRING
+          mode: NULLABLE
+        - name: webfont_compression_woff2
+          type: STRING
+          mode: NULLABLE
+        - name: webfont_download_time
+          type: STRING
+          mode: NULLABLE
+        - name: webfont_download_time_after_start
+          type: STRING
+          mode: NULLABLE
+        - name: webfont_fonttype
+          type: STRING
+          mode: NULLABLE
+        - name: webfont_per_page
+          type: STRING
+          mode: NULLABLE
+        - name: webfont_size
+          type: STRING
+          mode: NULLABLE
+        - name: webfont_size_per_page
+          type: STRING
+          mode: NULLABLE
+        - name: webfont_srctype
+          type: STRING
+          mode: NULLABLE
+        - name: webkit_directory_used
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_audio_quality_inbound_bandwidth_kbits
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_audio_quality_inbound_jitter
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_audio_quality_inbound_packetloss_rate
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_audio_quality_outbound_bandwidth_kbits
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_audio_quality_outbound_jitter
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_audio_quality_outbound_packetloss_rate
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_audio_quality_outbound_rtt
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_av_call_duration
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_avsync_when_audio_lags_video_ms
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_avsync_when_video_lags_audio_ms
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_call_count_2
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_call_count_3
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_call_duration
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_call_type
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_datachannel_negotiated
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_dtls_cipher
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_dtls_client_abort_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_dtls_client_failure_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_dtls_client_success_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_dtls_protocol_version
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_dtls_server_abort_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_dtls_server_failure_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_dtls_server_success_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_get_user_media_secure_origin
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_get_user_media_type
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_gmp_init_success
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_h264_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_hardware_h264_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_has_h264_hardware
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_hostname_obfuscation_disabled_ice_duration
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_hostname_obfuscation_disabled_ice_duration_ms
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_hostname_obfuscation_enabled_ice_duration
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_hostname_obfuscation_enabled_ice_duration_ms
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_add_candidate_errors_given_failure
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_add_candidate_errors_given_success
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_answerer_abort_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_answerer_failure_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_answerer_success_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_checking_rate
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_failure_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_final_connection_state
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_late_trickle_arrival_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_nr_ice_gather_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_nr_ice_gather_time_immediate_failure
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_nr_ice_gather_time_immediate_success
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_offerer_abort_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_offerer_failure_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_offerer_success_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_on_time_trickle_arrival_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_success_rate
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_ice_success_time
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_load_state_normal
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_load_state_normal_short
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_load_state_relaxed
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_load_state_relaxed_short
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_load_state_stressed
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_load_state_stressed_short
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_max_audio_receive_track
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_max_audio_send_track
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_max_video_receive_track
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_max_video_send_track
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_renegotiations
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_rtcp_mux
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_software_h264_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_srtp_cipher
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_stun_rate_limit_exceeded_by_type_given_failure
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_stun_rate_limit_exceeded_by_type_given_success
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_decode_error_time_permille
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_decoder_bitrate_avg_per_call_kbps
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_decoder_bitrate_std_dev_per_call_kbps
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_decoder_discarded_packets_per_call_ppm
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_decoder_framerate_10x_std_dev_per_call
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_decoder_framerate_avg_per_call
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_encoder_bitrate_avg_per_call_kbps
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_encoder_bitrate_std_dev_per_call_kbps
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_encoder_dropped_frames_per_call_fpm
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_encoder_framerate_10x_std_dev_per_call
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_encoder_framerate_avg_per_call
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_error_recovery_ms
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_quality_inbound_bandwidth_kbits
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_quality_inbound_jitter
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_quality_inbound_packetloss_rate
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_quality_outbound_bandwidth_kbits
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_quality_outbound_jitter
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_quality_outbound_packetloss_rate
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_quality_outbound_rtt
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_recovery_after_error_per_min
+          type: STRING
+          mode: NULLABLE
+        - name: webrtc_video_recovery_before_error_per_min
+          type: STRING
+          mode: NULLABLE
+        - name: websockets_handshake_type
+          type: STRING
+          mode: NULLABLE
+        - name: webvr_time_spend_for_viewing_in_2d
+          type: STRING
+          mode: NULLABLE
+        - name: webvr_time_spent_viewing_in_2d
+          type: STRING
+          mode: NULLABLE
+        - name: webvr_users_view_in
+          type: STRING
+          mode: NULLABLE
+        - name: webvtt_track_kinds
+          type: STRING
+          mode: NULLABLE
+        - name: webvtt_used_vtt_cues
+          type: STRING
+          mode: NULLABLE
+        - name: webxr_api_mode
+          type: STRING
+          mode: NULLABLE
+        - name: window_open_outer_size
+          type: STRING
+          mode: NULLABLE
+        - name: window_open_type
+          type: STRING
+          mode: NULLABLE
+        - name: word_cache_hits_chrome
+          type: STRING
+          mode: NULLABLE
+        - name: word_cache_hits_content
+          type: STRING
+          mode: NULLABLE
+        - name: word_cache_misses_chrome
+          type: STRING
+          mode: NULLABLE
+        - name: word_cache_misses_content
+          type: STRING
+          mode: NULLABLE
+        - name: xcto_nosniff_block_image
+          type: STRING
+          mode: NULLABLE
+        - name: xcto_nosniff_toplevel_nav_exceptions
+          type: STRING
+          mode: NULLABLE
+        - name: xmlhttprequest_async_or_sync
+          type: STRING
+          mode: NULLABLE
+        - name: xul_cache_disabled
+          type: STRING
+          mode: NULLABLE
+        - name: zoomed_view_enabled
+          type: STRING
+          mode: NULLABLE
+        - name: fingerprinting_protection_canvas_noise_calculate_time_ms
+          type: STRING
+          mode: NULLABLE
+      - name: keyed_histograms
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: addon_content_policy_shim_blocking_loaded_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: addon_content_policy_shim_blocking_loading_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: addon_forbidden_cpow_usage
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: addon_shim_usage
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: application_reputation_server_verdict_2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: audible_play_time_percent
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: blocked_on_plugin_instance_destroy_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: blocked_on_plugin_instance_init_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: blocked_on_plugin_module_init_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: blocked_on_plugin_stream_init_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: blocked_on_pluginasyncsurrogate_waitforinit_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: canvas_webgl_accl_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: canvas_webgl_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: content_js_background_tick_delay_events_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: content_js_foreground_tick_delay_events_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: content_large_paint_phase_weight
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: content_large_paint_phase_weight_full
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: content_large_paint_phase_weight_partial
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: content_signature_verification_errors
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: content_small_paint_phase_weight
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: content_small_paint_phase_weight_full
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: content_small_paint_phase_weight_partial
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: d3d11_compositing_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: d3d9_compositing_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: decoder_doctor_infobar_stats
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_gcli_commands_keyed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_javascript_error_displayed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_memory_breakdown_census_count
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_memory_breakdown_dominator_tree_count
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_perftools_recording_features_used
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_perftools_selected_view_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_webide_connected_runtime_app_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_webide_connected_runtime_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_webide_connected_runtime_os
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_webide_connected_runtime_platform_version
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_webide_connected_runtime_processor
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_webide_connected_runtime_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: devtools_webide_connected_runtime_version
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_perf_first_byte_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_perf_first_contentful_paint_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dom_script_src_encoding
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: eh_perf_first_contentful_paint_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: eh_perf_page_load_time_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: event_longtask
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_bookmarks_import_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_bookmarks_jank_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_bookmarks_quantity
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_errors
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_history_import_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_history_jank_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_history_quantity
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_imported_homepage
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_logins_import_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_logins_jank_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_logins_quantity
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_migration_usage
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_session_restore_content_collect_data_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_startup_migration_data_recency
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_startup_migration_undo_bookmarks_errorcount
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_startup_migration_undo_bookmarks_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_startup_migration_undo_logins_errorcount
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_startup_migration_undo_logins_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_startup_migration_undo_reason
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_startup_migration_undo_total_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_startup_migration_undo_visits_errorcount
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_startup_migration_undo_visits_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_startup_migration_used_recent_browser
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_tab_remote_navigation_delay_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_tabletmode_page_load
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_urlbar_selected_result_index_by_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: fx_urlbar_selected_result_index_by_type_2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: h3p_perf_first_contentful_paint_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: h3p_perf_page_load_time_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: hsts_priming_request_duration
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_channel_onstart_success
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_complete_load
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_connection_close_code
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_connection_close_code_2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_connecttion_close_code
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_counts_pto
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_first_sent_to_last_received
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_late_ack
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_late_ack_ratio
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_open_to_first_received
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_open_to_first_sent
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_perf_first_contentful_paint_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_perf_page_load_time_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_received_sent_dgrams
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_time_to_reuse_idle_connecttion_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_tls_handshake
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_upload_time
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_upload_time_10m_100m
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_upload_time_gt_100m
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http_cache_disposition_3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http_child_omt_stats
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: https_rr_open_to_first_sent
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: idle_runnable_budget_overuse_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_read_main_thread_latency_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_reply_size
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_sync_main_latency_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_sync_message_manager_latency_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_sync_receive_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_write_main_thread_latency_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: js_telemetry_addon_exceptions
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: l10n_document_initial_translation_time_us
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: main_thread_runnable_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: media_codec_used
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: media_play_time_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: memory_distribution_among_content
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: muted_play_time_percent
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: narrate_content_by_language_2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: network_async_open_child_to_transaction_pending_exp_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: network_async_open_child_to_transaction_pending_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: network_response_end_parent_to_content_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: network_response_start_parent_to_content_exp_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: network_response_start_parent_to_content_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: notify_observers_latency_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: opengl_compositing_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: page_load_error
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: popup_notification_dismissal_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: popup_notification_main_action_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: popup_notification_stats
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: preferences_file_load_num_prefs
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: preferences_file_load_size_b
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: preferences_file_load_time_us
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: presshell_flushes_per_tick
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: presshell_layout_total_ms_per_tick
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: presshell_reqs_per_layout_flush
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: print_count
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: print_dialog_opened_count
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: process_crash_submit_attempt
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: process_crash_submit_success
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: pwmgr_manage_sorted
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: refresh_driver_tick_phase_weight
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: rejected_message_manager_message
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: sandbox_rejected_syscalls
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: search_counts
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: service_worker_fetch_event_channel_reset_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: service_worker_fetch_event_channel_reset_ms_2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: service_worker_fetch_event_dispatch_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: service_worker_fetch_event_dispatch_ms_2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: service_worker_fetch_event_finish_synthesized_response_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: service_worker_fetch_event_finish_synthesized_response_ms_2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: service_worker_fetch_interception_duration_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: service_worker_fetch_interception_duration_ms_2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ssl_time_until_handshake_finished_keyed_by_ka
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: storage_sync_get_ops_size
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: storage_sync_remove_ops
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: storage_sync_set_ops_size
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: subprocess_abnormal_abort
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: subprocess_crashes_with_dump
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: subprocess_kill_hard
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: subprocess_launch_failure
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: sup_http3_tcp_connection
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: sync_worker_operation
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: telemetry_invalid_ping_type_submitted
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: thread_wakeup
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: translated_pages_by_language
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: translation_opportunities_by_language
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: update_check_extended_error_external
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: update_check_extended_error_notify
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: uptake_remote_content_result_1
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: urlclassifier_cl_keyed_update_time
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: urlclassifier_complete_remote_status2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: urlclassifier_complete_server_response_time
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: urlclassifier_complete_timeout2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: urlclassifier_update_error
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: urlclassifier_update_remote_network_error
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: urlclassifier_update_remote_status2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: urlclassifier_update_server_response_time
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: urlclassifier_update_timeout
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: video_hidden_play_time_percentage
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: video_inferred_decode_suspend_percentage
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: video_inter_keyframe_average_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: video_inter_keyframe_max_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: video_suspend_recovery_time_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: video_unblackinglisting_dxva_driver_runtime_status
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: video_visible_play_time_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: weave_engine_sync_errors
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: web_permission_cleared
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: webext_content_script_injection_ms_by_addonid
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: webext_storage_local_get_ms_by_addonid
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: webext_storage_local_idb_get_ms_by_addonid
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: webext_storage_local_idb_set_ms_by_addonid
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: webext_storage_local_set_ms_by_addonid
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: webext_user_script_injection_ms_by_addonid
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: keyed_scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: cookie_banners_click_result
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: dom_event_confluence_load_count
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: dom_event_office_online_load_count
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: dom_ipc_rejected_window_actor_message
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: gfx_small_paint_phase_weight
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: images_webp_content_frequency
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: media_audio_process_per_codec_name
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: media_decode_error_per_mime_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: media_video_hardware_decoding_support
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: media_video_hd_hardware_decoding_support
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: pictureinpicture_opened_method
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_cpu_time_per_process_type_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_wakeups_per_process_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: printing_paper_size
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_accumulate_unknown_histogram_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_event_counts
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_keyed_scalars_unknown_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: webrtc_sdp_parser_diff
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: webrtc_video_recv_codec_used
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: webrtc_video_send_codec_used
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+      - name: scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: avif_aom_decode_error
+          type: INTEGER
+          mode: NULLABLE
+        - name: avif_dav1d_decode_error
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_feeds_preview_loaded
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_input_touch_event_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_usage_graphite
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_usage_plugin_instantiated
+          type: INTEGER
+          mode: NULLABLE
+        - name: encoding_override_used
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: encoding_override_used_automatic
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: encoding_override_used_manual
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: formautofill_addresses_detected_sections_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: formautofill_addresses_submitted_sections_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: formautofill_credit_cards_detected_sections_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: formautofill_credit_cards_submitted_sections_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: gfx_omtp_paint_wait_ratio
+          type: INTEGER
+          mode: NULLABLE
+        - name: idb_failure_unknown_objectstore_empty_database
+          type: INTEGER
+          mode: NULLABLE
+        - name: idb_failure_unknown_objectstore_non_empty_database
+          type: INTEGER
+          mode: NULLABLE
+        - name: idb_type_persistent_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: idb_type_temporary_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: images_webp_content_observed
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: images_webp_probe_observed
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: js_run_time_us
+          type: INTEGER
+          mode: NULLABLE
+        - name: mathml_doc_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_allowed_autoplay_no_audio_track_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_autoplay_default_blocked
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: media_autoplay_would_be_allowed_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_autoplay_would_not_be_allowed_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_blocked_autoplay_no_audio_track_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_blocked_no_metadata
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_blocked_no_metadata_endup_no_audio_track
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_page_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_page_had_media_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_page_had_play_revoked_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_wmf_process_usage
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: mediarecorder_recording_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: memoryreporter_max_ghost_windows
+          type: INTEGER
+          mode: NULLABLE
+        - name: navigator_storage_estimate_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: navigator_storage_persist_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_http3_enabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: pdf_viewer_fallback_shown
+          type: INTEGER
+          mode: NULLABLE
+        - name: pdf_viewer_is_attachment
+          type: INTEGER
+          mode: NULLABLE
+        - name: pdf_viewer_print
+          type: INTEGER
+          mode: NULLABLE
+        - name: pdf_viewer_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: pictureinpicture_saw_toggle
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_cpu_time_bogus_values
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_cpu_time_ms
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_thread_wakeups
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_dialog_opened_via_preview
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_dialog_opened_via_preview_tm
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_dialog_opened_without_preview
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_dialog_via_preview_cancelled
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_dialog_via_preview_cancelled_tm
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_dialog_without_preview_cancelled
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_preview_cancelled
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_preview_cancelled_tm
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_preview_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_preview_opened_tm
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_silent_print
+          type: INTEGER
+          mode: NULLABLE
+        - name: script_preloader_mainthread_recompile
+          type: INTEGER
+          mode: NULLABLE
+        - name: sw_alternative_body_used_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: sw_cors_res_for_so_req_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: sw_synthesized_res_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_accumulations
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_child_events
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_keyed_accumulations
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_keyed_scalar_actions
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_scalar_actions
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_process_creation_timestamp_inconsistent
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_profile_directory_scans
+          type: INTEGER
+          mode: NULLABLE
+        - name: wasm_compile_time_baseline_us
+          type: INTEGER
+          mode: NULLABLE
+        - name: wasm_compile_time_ion_us
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_hostnameobfuscation_disabled_failed
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_hostnameobfuscation_disabled_succeeded
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_hostnameobfuscation_enabled_failed
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_hostnameobfuscation_enabled_succeeded
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_nicer_stun_retransmits
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_nicer_turn_401s
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_nicer_turn_403s
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_nicer_turn_438s
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_connected
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_datachannel_created
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_datachannel_max_life_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_datachannel_max_retx_and_life_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_datachannel_max_retx_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_legacy_callback_stats_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_promise_and_callback_stats_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_promise_stats_used
+          type: INTEGER
+          mode: NULLABLE
+    - name: dynamic
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: events
+        type: RECORD
+        mode: REPEATED
+        fields:
+        - name: f0_
+          type: INTEGER
+          mode: NULLABLE
+        - name: f1_
+          type: STRING
+          mode: NULLABLE
+        - name: f2_
+          type: STRING
+          mode: NULLABLE
+        - name: f3_
+          type: STRING
+          mode: NULLABLE
+        - name: f4_
+          type: STRING
+          mode: NULLABLE
+        - name: f5_
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: histograms
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: uptake_remote_content_result_1
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: keyed_histograms
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: uptake_remote_content_result_1
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: keyed_scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: power_cpu_time_per_process_type_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_wakeups_per_process_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_accumulate_unknown_histogram_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_event_counts
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_keyed_scalars_unknown_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+      - name: scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: browser_usage_graphite
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_cpu_time_ms
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_thread_wakeups
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_accumulations
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_child_events
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_keyed_accumulations
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_keyed_scalar_actions
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_scalar_actions
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_profile_directory_scans
+          type: INTEGER
+          mode: NULLABLE
+    - name: extension
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: events
+        type: RECORD
+        mode: REPEATED
+        fields:
+        - name: f0_
+          type: INTEGER
+          mode: NULLABLE
+        - name: f1_
+          type: STRING
+          mode: NULLABLE
+        - name: f2_
+          type: STRING
+          mode: NULLABLE
+        - name: f3_
+          type: STRING
+          mode: NULLABLE
+        - name: f4_
+          type: STRING
+          mode: NULLABLE
+        - name: f5_
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: histograms
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: uptake_remote_content_result_1
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: keyed_histograms
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: uptake_remote_content_result_1
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: keyed_scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: power_cpu_time_per_process_type_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_wakeups_per_process_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_accumulate_unknown_histogram_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_event_counts
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_keyed_scalars_unknown_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+      - name: scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: browser_usage_graphite
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_cpu_time_ms
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_thread_wakeups
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_accumulations
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_child_events
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_keyed_accumulations
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_keyed_scalar_actions
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_scalar_actions
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_profile_directory_scans
+          type: INTEGER
+          mode: NULLABLE
+    - name: gpu
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: events
+        type: RECORD
+        mode: REPEATED
+        fields:
+        - name: f0_
+          type: INTEGER
+          mode: NULLABLE
+        - name: f1_
+          type: STRING
+          mode: NULLABLE
+        - name: f2_
+          type: STRING
+          mode: NULLABLE
+        - name: f3_
+          type: STRING
+          mode: NULLABLE
+        - name: f4_
+          type: STRING
+          mode: NULLABLE
+        - name: f5_
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: histograms
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: apz_zoom_pinchsource
+          type: STRING
+          mode: NULLABLE
+        - name: canvas_webgl_accl_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: checkerboard_duration
+          type: STRING
+          mode: NULLABLE
+        - name: checkerboard_peak
+          type: STRING
+          mode: NULLABLE
+        - name: checkerboard_potential_duration
+          type: STRING
+          mode: NULLABLE
+        - name: checkerboard_severity
+          type: STRING
+          mode: NULLABLE
+        - name: composite_frame_roundtrip_time
+          type: STRING
+          mode: NULLABLE
+        - name: composite_swap_time
+          type: STRING
+          mode: NULLABLE
+        - name: composite_time
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_duration
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_max_contiguous_drops_apz
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_max_contiguous_drops_chrome
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_max_contiguous_drops_content
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_max_layer_area
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_throughput_apz
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_throughput_chrome
+          type: STRING
+          mode: NULLABLE
+        - name: compositor_animation_throughput_content
+          type: STRING
+          mode: NULLABLE
+        - name: content_frame_time
+          type: STRING
+          mode: NULLABLE
+        - name: content_frame_time_reason
+          type: STRING
+          mode: NULLABLE
+        - name: content_frame_time_vsync
+          type: STRING
+          mode: NULLABLE
+        - name: content_frame_time_with_svg
+          type: STRING
+          mode: NULLABLE
+        - name: content_frame_time_without_resource_upload
+          type: STRING
+          mode: NULLABLE
+        - name: content_frame_time_without_upload
+          type: STRING
+          mode: NULLABLE
+        - name: content_full_paint_time
+          type: STRING
+          mode: NULLABLE
+        - name: content_response_duration
+          type: STRING
+          mode: NULLABLE
+        - name: d3d11_compositing_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: d3d11_sync_handle_failure
+          type: STRING
+          mode: NULLABLE
+        - name: device_reset_reason
+          type: STRING
+          mode: NULLABLE
+        - name: forced_device_reset_reason
+          type: STRING
+          mode: NULLABLE
+        - name: fxrpc_entry_method
+          type: STRING
+          mode: NULLABLE
+        - name: fxrpc_ff_installation_from
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_crash
+          type: STRING
+          mode: NULLABLE
+        - name: gpu_process_initialization_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: gpu_wait_time_ms
+          type: STRING
+          mode: NULLABLE
+        - name: idle_runnable_budget_overuse_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_message_size2
+          type: STRING
+          mode: NULLABLE
+        - name: ipc_read_main_thread_latency_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_sync_receive_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_write_main_thread_latency_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: keypress_present_latency
+          type: STRING
+          mode: NULLABLE
+        - name: main_thread_runnable_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: media_decoder_backend_used
+          type: STRING
+          mode: NULLABLE
+        - name: media_wmf_decode_error
+          type: STRING
+          mode: NULLABLE
+        - name: memory_collection_time
+          type: STRING
+          mode: NULLABLE
+        - name: mouseup_followed_by_click_present_latency
+          type: STRING
+          mode: NULLABLE
+        - name: notify_observers_latency_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: opengl_compositing_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: scroll_input_methods
+          type: STRING
+          mode: NULLABLE
+        - name: scroll_present_latency
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_event_recording_error
+          type: STRING
+          mode: NULLABLE
+        - name: uptake_remote_content_result_1
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: webvr_dropped_frames_in_oculus
+          type: STRING
+          mode: NULLABLE
+        - name: webvr_dropped_frames_in_openvr
+          type: STRING
+          mode: NULLABLE
+        - name: webvr_time_spend_for_viewing_in_oculus
+          type: STRING
+          mode: NULLABLE
+        - name: webvr_time_spend_for_viewing_in_openvr
+          type: STRING
+          mode: NULLABLE
+        - name: webvr_time_spent_viewing_in_oculus
+          type: STRING
+          mode: NULLABLE
+        - name: webvr_time_spent_viewing_in_openvr
+          type: STRING
+          mode: NULLABLE
+        - name: webvr_users_view_in
+          type: STRING
+          mode: NULLABLE
+        - name: wr_framebuild_time
+          type: STRING
+          mode: NULLABLE
+        - name: wr_gpu_wait_time
+          type: STRING
+          mode: NULLABLE
+        - name: wr_rasterize_blobs_time
+          type: STRING
+          mode: NULLABLE
+        - name: wr_rasterize_glyphs_time
+          type: STRING
+          mode: NULLABLE
+        - name: wr_render_time
+          type: STRING
+          mode: NULLABLE
+        - name: wr_renderer_time
+          type: STRING
+          mode: NULLABLE
+        - name: wr_renderer_time_no_sc_ms
+          type: STRING
+          mode: NULLABLE
+        - name: wr_scenebuild_time
+          type: STRING
+          mode: NULLABLE
+        - name: wr_sceneswap_time
+          type: STRING
+          mode: NULLABLE
+        - name: wr_texture_cache_update_time
+          type: STRING
+          mode: NULLABLE
+        - name: wr_time_to_frame_build_ms
+          type: STRING
+          mode: NULLABLE
+        - name: wr_time_to_render_start_ms
+          type: STRING
+          mode: NULLABLE
+      - name: keyed_histograms
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: canvas_webgl_accl_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: d3d11_compositing_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: idle_runnable_budget_overuse_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_read_main_thread_latency_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_sync_receive_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: ipc_write_main_thread_latency_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: main_thread_runnable_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: notify_observers_latency_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: opengl_compositing_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: uptake_remote_content_result_1
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: keyed_scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: media_decode_error_per_mime_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_cpu_time_per_process_type_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_gpu_time_per_process_type_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_wakeups_per_process_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_accumulate_unknown_histogram_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_event_counts
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_keyed_scalars_unknown_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+      - name: scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: apz_scrollwheel_overshoot
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_usage_graphite
+          type: INTEGER
+          mode: NULLABLE
+        - name: fxr_pc_is_first_run
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: gfx_canvas_remote_activated
+          type: INTEGER
+          mode: NULLABLE
+        - name: gfx_canvas_remote_deactivated_bad_stream
+          type: INTEGER
+          mode: NULLABLE
+        - name: gfx_canvas_remote_deactivated_no_device
+          type: INTEGER
+          mode: NULLABLE
+        - name: gfx_skipped_composites
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_cpu_time_bogus_values
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_gpu_time_bogus_values
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_cpu_time_ms
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_gpu_time_ms
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_thread_wakeups
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_accumulations
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_child_events
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_keyed_accumulations
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_keyed_scalar_actions
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_scalar_actions
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_profile_directory_scans
+          type: INTEGER
+          mode: NULLABLE
+    - name: parent
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: events
+        type: RECORD
+        mode: REPEATED
+        fields:
+        - name: f0_
+          type: INTEGER
+          mode: NULLABLE
+        - name: f1_
+          type: STRING
+          mode: NULLABLE
+        - name: f2_
+          type: STRING
+          mode: NULLABLE
+        - name: f3_
+          type: STRING
+          mode: NULLABLE
+        - name: f4_
+          type: STRING
+          mode: NULLABLE
+        - name: f5_
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: histograms
+        type: RECORD
+        mode: REPEATED
+        fields:
+        - name: key
+          type: STRING
+          mode: NULLABLE
+        - name: value
+          type: RECORD
+          mode: NULLABLE
+          fields:
+          - name: bucket_count
+            type: INTEGER
+            mode: NULLABLE
+          - name: histogram_type
+            type: INTEGER
+            mode: NULLABLE
+          - name: log_sum
+            type: FLOAT
+            mode: NULLABLE
+          - name: log_sum_squares
+            type: FLOAT
+            mode: NULLABLE
+          - name: range
+            type: INTEGER
+            mode: REPEATED
+          - name: sum
+            type: INTEGER
+            mode: NULLABLE
+          - name: sum_squares_hi
+            type: INTEGER
+            mode: NULLABLE
+          - name: sum_squares_lo
+            type: INTEGER
+            mode: NULLABLE
+          - name: values
+            type: RECORD
+            mode: REPEATED
+            fields:
+            - name: key
+              type: STRING
+              mode: NULLABLE
+            - name: value
+              type: INTEGER
+              mode: NULLABLE
+      - name: keyed_histograms
+        type: RECORD
+        mode: REPEATED
+        fields:
+        - name: key
+          type: STRING
+          mode: NULLABLE
+        - name: value
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: RECORD
+            mode: NULLABLE
+            fields:
+            - name: bucket_count
+              type: INTEGER
+              mode: NULLABLE
+            - name: histogram_type
+              type: INTEGER
+              mode: NULLABLE
+            - name: log_sum
+              type: FLOAT
+              mode: NULLABLE
+            - name: log_sum_squares
+              type: FLOAT
+              mode: NULLABLE
+            - name: range
+              type: INTEGER
+              mode: REPEATED
+            - name: sum
+              type: INTEGER
+              mode: NULLABLE
+            - name: sum_squares_hi
+              type: INTEGER
+              mode: NULLABLE
+            - name: sum_squares_lo
+              type: INTEGER
+              mode: NULLABLE
+            - name: values
+              type: RECORD
+              mode: REPEATED
+              fields:
+              - name: key
+                type: STRING
+                mode: NULLABLE
+              - name: value
+                type: INTEGER
+                mode: NULLABLE
+      - name: keyed_scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: a11y_theme
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: browser_engagement_navigation_about_home
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_engagement_navigation_about_newtab
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_engagement_navigation_contextmenu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_engagement_navigation_searchbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_engagement_navigation_urlbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_engagement_navigation_urlbar_handoff
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_engagement_navigation_urlbar_persisted
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_engagement_navigation_urlbar_searchmode
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_engagement_navigation_webextension
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_engagement_sessionrestore_interstitial
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_errors_collected_count_by_filename
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_ad_clicks
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_about_home
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_about_newtab
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_contextmenu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_reload
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_searchbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_system
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_tabhistory
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_unknown
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_urlbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_urlbar_handoff
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_urlbar_persisted
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_urlbar_searchmode
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_adclicks_webextension
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_about_home
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_about_newtab
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_contextmenu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_reload
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_searchbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_system
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_tabhistory
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_unknown
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_urlbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_urlbar_handoff
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_urlbar_persisted
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_urlbar_searchmode
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_content_webextension
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_data_transferred
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_with_ads
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_about_home
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_about_newtab
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_contextmenu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_reload
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_searchbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_system
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_tabhistory
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_unknown
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_urlbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_urlbar_handoff
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_urlbar_persisted
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_urlbar_searchmode
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_search_withads_webextension
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_searchinit_engine_invalid_webextension
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_customized_widgets
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_all_tabs_panel_entrypoint
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_app_menu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_bookmarks_bar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_content_context
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_keyboard
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_menu_bar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_nav_bar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_overflow_menu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_pageaction_panel
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_pageaction_urlbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_pinned_overflow_menu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_preferences_pane_containers
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_preferences_pane_experimental
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_preferences_pane_general
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_preferences_pane_home
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_preferences_pane_more_from_mozilla
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_preferences_pane_privacy
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_preferences_pane_search
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_preferences_pane_search_results
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_preferences_pane_sync
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_preferences_pane_unknown
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_tabs_bar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_tabs_context
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_tabs_context_entrypoint
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_interaction_unified_extensions_area
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: browser_ui_toolbar_widgets
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_block_dynamic_wikipedia
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_block_nonsponsored
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_block_nonsponsored_bestmatch
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_block_sponsored
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_block_sponsored_bestmatch
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_block_weather
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_click
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_click_dynamic_wikipedia
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_click_nav_notmatched
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_click_nav_shown_heuristic
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_click_nav_shown_nav
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_click_nav_superceded
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_click_nonsponsored
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_click_nonsponsored_bestmatch
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_click_sponsored
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_click_sponsored_bestmatch
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_click_weather
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_exposure_weather
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_help
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_help_dynamic_wikipedia
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_help_nonsponsored
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_help_nonsponsored_bestmatch
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_help_sponsored
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_help_sponsored_bestmatch
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_help_weather
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_impression
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_impression_dynamic_wikipedia
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_impression_nav_notmatched
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_impression_nav_shown
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_impression_nav_superceded
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_impression_nonsponsored
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_impression_nonsponsored_bestmatch
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_impression_sponsored
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_impression_sponsored_bestmatch
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_quicksuggest_impression_weather
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_topsites_click
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: contextual_services_topsites_impression
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: cookie_banners_normal_window_service_mode
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: cookie_banners_private_window_service_mode
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: cookie_banners_rule_lookup_by_domain
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: cookie_banners_rule_lookup_by_load
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: devtools_accessibility_accessible_context_menu_item_activated
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: devtools_accessibility_audit_activated
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: devtools_accessibility_select_accessible_for_node
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: devtools_accessibility_simulation_activated
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: devtools_current_theme
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: devtools_inspector_three_pane_enabled
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: devtools_responsive_open_trigger
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: devtools_tool_registered
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: devtools_toolbox_tabs_reordered
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: devtools_tooltip_shown
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: dom_ipc_rejected_window_actor_message
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: dom_parentprocess_process_launch_errors
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: extensions_apis_dnr_startup_cache_entries
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: extensions_startup_cache_read_errors
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: extensions_updates_rdf
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: gfx_advanced_layers_failure_id
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: identity_fxaccounts_push_state_command_target
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: identity_fxaccounts_push_state_this_device
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: images_webp_content_frequency
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: library_link
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: library_opened
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: library_search
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: media_audio_process_per_codec_name
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: media_control_platform_usage
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: media_video_hardware_decoding_support
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: media_video_hd_hardware_decoding_support
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: migration_discovered_migrators
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: mozstorage_sqlitejsm_transaction_timeout
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: networking_data_transferred
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: networking_data_transferred_kb
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: networking_data_transferred_pb_per_content_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: networking_data_transferred_per_content_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: networking_data_transferred_v3_kb
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: networking_speculative_connect_outcome
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: networking_trr_connection_cycle_count
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: normandy_recipe_freshness
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: notificationbar_crash_subframe_ui
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: notificationbar_testone
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: notificationbar_testtwo
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: os_environment_invoked_to_handle
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: os_environment_is_default_handler
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: os_environment_launched_to_handle
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: pictureinpicture_closed_method
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_cpu_time_per_process_type_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_gpu_time_per_process_type_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_wakeups_per_process_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: preferences_browser_home_page_change
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: preferences_browser_home_page_count
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: preferences_search_query
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: preferences_use_bookmark
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: preferences_use_current_page
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: printing_error
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: printing_settings_changed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: printing_target_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: printing_trigger
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: qm_origin_directory_unexpected_filename
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: quickaction_impression
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: quickaction_picked
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: resistfingerprinting_content_window_size
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: sandbox_no_job
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: security_client_auth_cert_usage
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: security_client_cert
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: security_contentblocker_permissions
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: security_pkcs11_modules_loaded
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: security_psm_ui_interaction
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: security_webauthn_used
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: services_sync_sync_login_state_transitions
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: serviceworker_registrations
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: serviceworker_running_max
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: sidebar_link
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: sidebar_opened
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: sidebar_search
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: storage_sync_api_usage_items_stored
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: storage_sync_api_usage_storage_consumed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_accumulate_clamped_values
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_accumulate_unknown_histogram_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_event_counts
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_keyed_scalars_exceed_limit
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_keyed_scalars_unknown_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: unknowncontenttype_pdf_action
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: update_binarytransparencyresult
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: update_bitshresult
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: update_move_result
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_autofill
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_autofill_about
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_autofill_adaptive
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_autofill_origin
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_autofill_other
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_autofill_preloaded
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_autofill_url
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_bookmark
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_dynamic
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_dynamic_wikipedia
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_extension
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_formhistory
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_history
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_keyword
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_navigational
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_quickaction
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_quicksuggest
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_remotetab
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchengine
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_bookmarkmenu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_handoff
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_historymenu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_keywordoffer
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_oneoff
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_other
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_shortcut
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_tabmenu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_tabtosearch
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_tabtosearch_onboard
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_topsites_newtab
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_topsites_urlbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_touchbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchmode_typed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchsuggestion
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_searchsuggestion_rich
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_switchtab
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_tabtosearch
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_tip
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_topsite
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_trending
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_trending_rich
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_unknown
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_visiturl
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_weather
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_bookmarkmenu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_handoff
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_historymenu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_keywordoffer
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_oneoff
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_other
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_shortcut
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_tabmenu
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_tabtosearch
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_tabtosearch_onboard
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_topsites_newtab
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_topsites_urlbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_touchbar
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_searchmode_typed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_tabtosearch_impressions
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_tabtosearch_impressions_onboarding
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_tips
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: widget_ime_name_on_linux
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: widget_ime_name_on_mac
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: widget_ime_name_on_windows
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: BOOLEAN
+            mode: NULLABLE
+        - name: urlbar_picked_bookmark_adaptive
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: urlbar_picked_history_adaptive
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+      - name: scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: a11y_backplate
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: a11y_hcm_background
+          type: INTEGER
+          mode: NULLABLE
+        - name: a11y_hcm_foreground
+          type: INTEGER
+          mode: NULLABLE
+        - name: a11y_indicator_acted_on
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: a11y_instantiators
+          type: STRING
+          mode: NULLABLE
+        - name: a11y_invert_colors
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: a11y_sitezoom
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: a11y_use_system_colors
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: apz_scrollwheel_overshoot
+          type: INTEGER
+          mode: NULLABLE
+        - name: attribution_provenance_ads_exists
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: attribution_provenance_data_exists
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: attribution_provenance_file_system
+          type: STRING
+          mode: NULLABLE
+        - name: attribution_provenance_host_url_exists
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: attribution_provenance_host_url_is_mozilla
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: attribution_provenance_referrer_url_exists
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: attribution_provenance_referrer_url_is_mozilla
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: attribution_provenance_security_zone
+          type: STRING
+          mode: NULLABLE
+        - name: aushelper_websense_reg_version
+          type: STRING
+          mode: NULLABLE
+        - name: avif_aom_decode_error
+          type: INTEGER
+          mode: NULLABLE
+        - name: avif_dav1d_decode_error
+          type: INTEGER
+          mode: NULLABLE
+        - name: blocklist_last_modified_rs_addons
+          type: STRING
+          mode: NULLABLE
+        - name: blocklist_last_modified_rs_addons_mlbf
+          type: STRING
+          mode: NULLABLE
+        - name: blocklist_last_modified_rs_plugins
+          type: STRING
+          mode: NULLABLE
+        - name: blocklist_last_modified_xml
+          type: STRING
+          mode: NULLABLE
+        - name: blocklist_mlbf_enabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: blocklist_mlbf_generation_time
+          type: STRING
+          mode: NULLABLE
+        - name: blocklist_mlbf_source
+          type: STRING
+          mode: NULLABLE
+        - name: blocklist_mlbf_stash_time_newest
+          type: STRING
+          mode: NULLABLE
+        - name: blocklist_mlbf_stash_time_oldest
+          type: STRING
+          mode: NULLABLE
+        - name: blocklist_mlbf_stashes
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: blocklist_use_xml
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: browser_engagement_active_ticks
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_bookmarks_toolbar_bookmark_added
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_bookmarks_toolbar_bookmark_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_max_concurrent_tab_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_max_concurrent_tab_pinned_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_max_concurrent_window_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_mirror_for_active_ticks
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_mirror_for_uri_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_profile_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_restored_pinned_tabs_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_session_time_excluding_suspend
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_session_time_including_suspend
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_tab_open_event_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_tab_pinned_event_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_tab_reload_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_tab_unload_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_total_uri_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_total_uri_count_normal_and_private_mode
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_unfiltered_uri_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_unique_domains_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_engagement_window_open_event_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_errors_collected_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_errors_collected_with_stack_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_errors_reported_failure_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_errors_reported_success_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_errors_sample_rate
+          type: STRING
+          mode: NULLABLE
+        - name: browser_feeds_feed_subscribed
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_feeds_livebookmark_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_feeds_livebookmark_item_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_feeds_livebookmark_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_feeds_preview_loaded
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_input_touch_event_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_searchinit_engines_cache_corrupted
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: browser_searchinit_init_result_status_code
+          type: STRING
+          mode: NULLABLE
+        - name: browser_searchinit_insecure_opensearch_engine_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_searchinit_insecure_opensearch_update_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_searchinit_secure_opensearch_engine_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_searchinit_secure_opensearch_update_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_session_restore_browser_startup_page
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_session_restore_browser_tabs_restorebutton
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_session_restore_number_of_tabs
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_session_restore_number_of_win
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_session_restore_tabbar_restore_available
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: browser_session_restore_tabbar_restore_clicked
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: browser_session_restore_worker_restart_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_startup_abouthome_cache_result
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_startup_abouthome_cache_shutdownwrite
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: browser_startup_action
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_startup_average_time
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_startup_recorded_time
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_startup_slow_startup_notification_disabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: browser_startup_slow_startup_notified
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: browser_startup_too_new_for_notification
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: browser_timings_last_shutdown
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_ui_interaction_all_tabs_panel_dragstart_tab_event_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_ui_interaction_textrecognition_error
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_usage_graphite
+          type: INTEGER
+          mode: NULLABLE
+        - name: browser_usage_plugin_instantiated
+          type: INTEGER
+          mode: NULLABLE
+        - name: cache_integrity_check_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: content_process_max_precise
+          type: INTEGER
+          mode: NULLABLE
+        - name: contentblocking_category
+          type: INTEGER
+          mode: NULLABLE
+        - name: contentblocking_cryptomining_blocking_enabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: contentblocking_enabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: contentblocking_exceptions
+          type: INTEGER
+          mode: NULLABLE
+        - name: contentblocking_fastblock_enabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: contentblocking_fingerprinting_blocking_enabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: contentblocking_trackers_blocked_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: cookie_banners_service_detect_only
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: corroborate_omnijar_corrupted
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: corroborate_omnijar_mismatch
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: corroborate_system_addons_corrupted
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: datasanitization_network_cookie_lifetime_policy
+          type: INTEGER
+          mode: NULLABLE
+        - name: datasanitization_privacy_clear_on_shutdown_cache
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: datasanitization_privacy_clear_on_shutdown_cookies
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: datasanitization_privacy_clear_on_shutdown_downloads
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: datasanitization_privacy_clear_on_shutdown_formdata
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: datasanitization_privacy_clear_on_shutdown_history
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: datasanitization_privacy_clear_on_shutdown_offline_apps
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: datasanitization_privacy_clear_on_shutdown_open_windows
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: datasanitization_privacy_clear_on_shutdown_sessions
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: datasanitization_privacy_clear_on_shutdown_site_settings
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: datasanitization_privacy_sanitize_sanitize_on_shutdown
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: datasanitization_session_permission_exceptions
+          type: INTEGER
+          mode: NULLABLE
+        - name: deletion_request_context_id
+          type: STRING
+          mode: NULLABLE
+        - name: deletion_request_ecosystem_client_id
+          type: STRING
+          mode: NULLABLE
+        - name: deletion_request_impression_id
+          type: STRING
+          mode: NULLABLE
+        - name: deletion_request_sync_device_id
+          type: STRING
+          mode: NULLABLE
+        - name: devtools_aboutdevtools_installed
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_aboutdevtools_noinstall_exits
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_aboutdevtools_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_accessibility_accessible_context_menu_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_accessibility_node_inspected_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_accessibility_opened_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_accessibility_picker_used_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_accessibility_service_enabled_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_accessibility_tabbing_order_activated
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_application_opened_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_changesview_contextmenu
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_changesview_contextmenu_copy
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_changesview_contextmenu_copy_declaration
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_changesview_contextmenu_copy_rule
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_changesview_copy
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_changesview_copy_all_changes
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_changesview_copy_rule
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_changesview_opened_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_copy_full_css_selector_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_copy_unique_css_selector_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_copy_xpath_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_grid_gridinspector_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_grid_show_grid_areas_overlay_checked
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_grid_show_grid_line_numbers_checked
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_grid_show_infinite_lines_checked
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_inspector_element_picker_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_inspector_node_selection_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_layout_flexboxhighlighter_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_markup_flexboxhighlighter_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_markup_gridinspector_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_markup_scrollable_badge_clicked
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_onboarding_is_devtools_user
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: devtools_responsive_toolbox_opened_first
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_rules_flexboxhighlighter_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_rules_gridinspector_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_shadowdom_reveal_link_clicked
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: devtools_shadowdom_shadow_root_displayed
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: devtools_shadowdom_shadow_root_expanded
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: devtools_toolbar_eyedropper_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_webreplay_load_recording
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_webreplay_new_recording
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_webreplay_reload_recording
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_webreplay_save_recording
+          type: INTEGER
+          mode: NULLABLE
+        - name: devtools_webreplay_stop_recording
+          type: INTEGER
+          mode: NULLABLE
+        - name: dom_contentprocess_build_id_mismatch
+          type: INTEGER
+          mode: NULLABLE
+        - name: dom_contentprocess_build_id_mismatch_false_positive
+          type: INTEGER
+          mode: NULLABLE
+        - name: dom_contentprocess_crash_subframe_ui_presented
+          type: INTEGER
+          mode: NULLABLE
+        - name: dom_contentprocess_crash_tab_ui_presented
+          type: INTEGER
+          mode: NULLABLE
+        - name: dom_contentprocess_os_priority_change_considered
+          type: INTEGER
+          mode: NULLABLE
+        - name: dom_contentprocess_os_priority_lowered
+          type: INTEGER
+          mode: NULLABLE
+        - name: dom_contentprocess_os_priority_raised
+          type: INTEGER
+          mode: NULLABLE
+        - name: dom_contentprocess_troubled_due_to_memory
+          type: INTEGER
+          mode: NULLABLE
+        - name: dom_contentprocess_unsubmitted_ui_presented
+          type: INTEGER
+          mode: NULLABLE
+        - name: dom_midi_has_devices
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: dom_parentprocess_private_window_used
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: downloads_file_opened
+          type: INTEGER
+          mode: NULLABLE
+        - name: downloads_panel_shown
+          type: INTEGER
+          mode: NULLABLE
+        - name: encoding_override_used
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: encoding_override_used_automatic
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: encoding_override_used_manual
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: extensions_apis_dnr_evaluate_rules_count_max
+          type: INTEGER
+          mode: NULLABLE
+        - name: extensions_startup_cache_load_time
+          type: INTEGER
+          mode: NULLABLE
+        - name: extensions_startup_cache_write_byte_length
+          type: INTEGER
+          mode: NULLABLE
+        - name: findbar_find_next
+          type: INTEGER
+          mode: NULLABLE
+        - name: findbar_find_prev
+          type: INTEGER
+          mode: NULLABLE
+        - name: findbar_highlight_all
+          type: INTEGER
+          mode: NULLABLE
+        - name: findbar_match_case
+          type: INTEGER
+          mode: NULLABLE
+        - name: findbar_match_diacritics
+          type: INTEGER
+          mode: NULLABLE
+        - name: findbar_shown
+          type: INTEGER
+          mode: NULLABLE
+        - name: findbar_whole_words
+          type: INTEGER
+          mode: NULLABLE
+        - name: first_startup_elapsed
+          type: INTEGER
+          mode: NULLABLE
+        - name: first_startup_status_code
+          type: INTEGER
+          mode: NULLABLE
+        - name: fog_eval_user_active
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: fog_eval_user_active_error
+          type: INTEGER
+          mode: NULLABLE
+        - name: fog_eval_user_inactive_error
+          type: INTEGER
+          mode: NULLABLE
+        - name: fog_eval_window_raised
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: fog_eval_window_raised_error
+          type: INTEGER
+          mode: NULLABLE
+        - name: formautofill_addresses_autofill_profiles_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: formautofill_addresses_fill_type_autofill
+          type: INTEGER
+          mode: NULLABLE
+        - name: formautofill_addresses_fill_type_autofill_update
+          type: INTEGER
+          mode: NULLABLE
+        - name: formautofill_addresses_fill_type_manual
+          type: INTEGER
+          mode: NULLABLE
+        - name: formautofill_availability
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: formautofill_credit_cards_autofill_profiles_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: formautofill_credit_cards_fill_type_autofill
+          type: INTEGER
+          mode: NULLABLE
+        - name: formautofill_credit_cards_fill_type_autofill_modified
+          type: INTEGER
+          mode: NULLABLE
+        - name: formautofill_credit_cards_fill_type_manual
+          type: INTEGER
+          mode: NULLABLE
+        - name: fullscreen_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: fxr_pc_is_first_run
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: gecko_build_id
+          type: STRING
+          mode: NULLABLE
+        - name: gecko_version
+          type: STRING
+          mode: NULLABLE
+        - name: general_autoconfig_has_filename
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: gfx_adapter_description
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_adapter_device_id
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_adapter_device_id_last_seen
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_adapter_driver_date
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_adapter_driver_files
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_adapter_driver_vendor
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_adapter_driver_version
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_adapter_ram
+          type: INTEGER
+          mode: NULLABLE
+        - name: gfx_adapter_subsystem_id
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_adapter_vendor_id
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_compositor
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_compositor_last_seen
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_display_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: gfx_display_primary_height
+          type: INTEGER
+          mode: NULLABLE
+        - name: gfx_display_primary_width
+          type: INTEGER
+          mode: NULLABLE
+        - name: gfx_feature_webrender
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_hdr_windows_display_colorspace_bitfield
+          type: INTEGER
+          mode: NULLABLE
+        - name: gfx_headless
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: gfx_last_compositor_gecko_version
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_linux_window_protocol
+          type: STRING
+          mode: NULLABLE
+        - name: gfx_os_compositor
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: gfx_skipped_composites
+          type: INTEGER
+          mode: NULLABLE
+        - name: gfx_supports_hdr
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: gifft_validation_main_ping_assembling
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: gifft_validation_mirror_for_main_ping_assembling
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: idb_failure_fileinfo_error
+          type: INTEGER
+          mode: NULLABLE
+        - name: idb_type_persistent_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: idb_type_temporary_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: identity_fxaccounts_missed_commands_fetched
+          type: INTEGER
+          mode: NULLABLE
+        - name: images_webp_content_observed
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: images_webp_probe_observed
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: js_run_time_us
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_allowed_autoplay_no_audio_track_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_autoplay_default_blocked
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: media_autoplay_would_be_allowed_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_autoplay_would_not_be_allowed_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_blocked_autoplay_no_audio_track_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_blocked_no_metadata
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_blocked_no_metadata_endup_no_audio_track
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_element_in_page_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_page_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_page_had_media_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_page_had_play_revoked_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: media_wmf_process_usage
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: mediarecorder_recording_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: migration_uninstaller_profile_refresh
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: navigator_storage_estimate_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: navigator_storage_persist_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: network_http_backup_conn_won
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: network_tcp_overlapped_io_canceled_before_finished
+          type: INTEGER
+          mode: NULLABLE
+        - name: network_tcp_overlapped_result_delayed
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_data_transferred_captive_portal
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_ftp_opened_channels_files
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_ftp_opened_channels_listings
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_http3_enabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: networking_http_connections_captive_portal
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_http_transactions_captive_portal
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_https_rr_prefs_usage
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_loading_certs_task
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_nss_initialization
+          type: INTEGER
+          mode: NULLABLE
+        - name: opaque_response_blocking_cross_origin_opaque_response_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: opaque_response_blocking_javascript_validation_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: opaque_response_blocking_parsing_size_kb
+          type: INTEGER
+          mode: NULLABLE
+        - name: os_environment_allowed_app_sources
+          type: STRING
+          mode: NULLABLE
+        - name: os_environment_is_admin_without_uac
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: os_environment_is_kept_in_dock
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: os_environment_is_taskbar_pinned
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: os_environment_is_taskbar_pinned_private
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: os_environment_launch_method
+          type: STRING
+          mode: NULLABLE
+        - name: pdf_viewer_fallback_shown
+          type: INTEGER
+          mode: NULLABLE
+        - name: pdf_viewer_is_attachment
+          type: INTEGER
+          mode: NULLABLE
+        - name: pdf_viewer_print
+          type: INTEGER
+          mode: NULLABLE
+        - name: pdf_viewer_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: pictureinpicture_most_concurrent_players
+          type: INTEGER
+          mode: NULLABLE
+        - name: pictureinpicture_toggle_enabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: places_pages_need_frecency_recalculation
+          type: INTEGER
+          mode: NULLABLE
+        - name: places_previousday_visits
+          type: INTEGER
+          mode: NULLABLE
+        - name: places_sponsored_visit_no_triggering_url
+          type: INTEGER
+          mode: NULLABLE
+        - name: policies_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: policies_is_enterprise
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: power_cpu_time_bogus_values
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_gpu_time_bogus_values
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_cpu_time_ms
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_gpu_time_ms
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_thread_wakeups
+          type: INTEGER
+          mode: NULLABLE
+        - name: preferences_created_new_user_prefs_file
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: preferences_prefs_file_was_invalid
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: preferences_prevent_accessibility_services
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: preferences_read_user_js
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: printing_dialog_opened_via_preview_tm
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_dialog_via_preview_cancelled_tm
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_preview_cancelled_tm
+          type: INTEGER
+          mode: NULLABLE
+        - name: printing_preview_opened_tm
+          type: INTEGER
+          mode: NULLABLE
+        - name: privacy_dfpi_rollout_enabled_by_default
+          type: INTEGER
+          mode: NULLABLE
+        - name: privacy_dfpi_rollout_tcp_by_default_feature
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: privacy_feature_first_party_isolation_enabled
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: pwmgr_potentially_breached_passwords
+          type: INTEGER
+          mode: NULLABLE
+        - name: qm_repositories_initialization_time
+          type: INTEGER
+          mode: NULLABLE
+        - name: screenshots_copy
+          type: INTEGER
+          mode: NULLABLE
+        - name: screenshots_custom
+          type: INTEGER
+          mode: NULLABLE
+        - name: screenshots_download
+          type: INTEGER
+          mode: NULLABLE
+        - name: screenshots_element
+          type: INTEGER
+          mode: NULLABLE
+        - name: screenshots_full_page
+          type: INTEGER
+          mode: NULLABLE
+        - name: screenshots_upload
+          type: INTEGER
+          mode: NULLABLE
+        - name: screenshots_visible
+          type: INTEGER
+          mode: NULLABLE
+        - name: script_preloader_mainthread_recompile
+          type: INTEGER
+          mode: NULLABLE
+        - name: security_global_privacy_control_enabled
+          type: INTEGER
+          mode: NULLABLE
+        - name: security_https_only_mode_enabled
+          type: INTEGER
+          mode: NULLABLE
+        - name: security_https_only_mode_enabled_pbm
+          type: INTEGER
+          mode: NULLABLE
+        - name: security_intermediate_preloading_num_pending
+          type: INTEGER
+          mode: NULLABLE
+        - name: security_intermediate_preloading_num_preloaded
+          type: INTEGER
+          mode: NULLABLE
+        - name: security_tls_delegated_credentials_txn
+          type: INTEGER
+          mode: NULLABLE
+        - name: services_sync_fxa_verification_method
+          type: STRING
+          mode: NULLABLE
+        - name: startup_first_run_is_from_dmg
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: startup_is_cold
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: startup_is_restored_by_macos
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: startup_is_run_from_app_translocated_location
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: startup_is_run_from_dmg
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: startup_profile_selection_reason
+          type: STRING
+          mode: NULLABLE
+        - name: startup_seconds_since_last_os_restart
+          type: INTEGER
+          mode: NULLABLE
+        - name: startup_skeleton_ui_disabled_reason
+          type: STRING
+          mode: NULLABLE
+        - name: storage_sync_api_usage_extensions_using
+          type: INTEGER
+          mode: NULLABLE
+        - name: sw_alternative_body_used_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: sw_cors_res_for_so_req_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: sw_synthesized_res_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_about_telemetry_pageload
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_data_upload_optin
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: telemetry_ecosystem_new_send_time
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_ecosystem_old_send_time
+          type: STRING
+          mode: NULLABLE
+        - name: telemetry_environment_didnt_change
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_failed_late_write
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_generated_new_client_id
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: telemetry_loaded_client_id_doesnt_match_pref
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_os_shutting_down
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: telemetry_pending_operations_highwatermark_reached
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_persistence_timer_hit_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_process_creation_timestamp_inconsistent
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_profile_directory_scan_date
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_profile_directory_scans
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_removed_client_ids
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_state_file_read_errors
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_state_file_save_errors
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_sync_shutdown_ping_sent
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: telemetry_using_pref_client_id
+          type: INTEGER
+          mode: NULLABLE
+        - name: timestamps_about_home_topsites_first_paint
+          type: INTEGER
+          mode: NULLABLE
+        - name: timestamps_first_paint
+          type: INTEGER
+          mode: NULLABLE
+        - name: timestamps_first_paint_two
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_fix_permissions_attempted
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: update_no_window_auto_restarts
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_downloads_bits_complete_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_downloads_bits_complete_seconds
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_downloads_bits_partial_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_downloads_bits_partial_seconds
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_downloads_internal_complete_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_downloads_internal_complete_seconds
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_downloads_internal_partial_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_downloads_internal_partial_seconds
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_from_app_version
+          type: STRING
+          mode: NULLABLE
+        - name: update_session_intervals_apply_complete
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_intervals_apply_partial
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_intervals_check
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_intervals_download_bits_complete
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_intervals_download_bits_partial
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_intervals_download_internal_complete
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_intervals_download_internal_partial
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_intervals_stage_complete
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_intervals_stage_partial
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_mar_complete_size_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_session_mar_partial_size_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_downloads_bits_complete_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_downloads_bits_complete_seconds
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_downloads_bits_partial_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_downloads_bits_partial_seconds
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_downloads_internal_complete_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_downloads_internal_complete_seconds
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_downloads_internal_partial_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_downloads_internal_partial_seconds
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_from_app_version
+          type: STRING
+          mode: NULLABLE
+        - name: update_startup_intervals_apply_complete
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_intervals_apply_partial
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_intervals_check
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_intervals_download_bits_complete
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_intervals_download_bits_partial
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_intervals_download_internal_complete
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_intervals_download_internal_partial
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_intervals_stage_complete
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_intervals_stage_partial
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_mar_complete_size_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_startup_mar_partial_size_bytes
+          type: INTEGER
+          mode: NULLABLE
+        - name: update_suppress_prompts
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: update_version_pin
+          type: STRING
+          mode: NULLABLE
+        - name: urlbar_abandonment
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_autofill_deletion
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_engagement
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_impression_autofill_about
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_impression_autofill_adaptive
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_impression_autofill_origin
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_impression_autofill_other
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_impression_autofill_preloaded
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_impression_autofill_url
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_persistedsearchterms_revert_by_popup_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_persistedsearchterms_view_count
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_zeroprefix_abandonment
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_zeroprefix_engagement
+          type: INTEGER
+          mode: NULLABLE
+        - name: urlbar_zeroprefix_exposure
+          type: INTEGER
+          mode: NULLABLE
+        - name: wasm_compile_time_baseline_us
+          type: INTEGER
+          mode: NULLABLE
+        - name: wasm_compile_time_cranelift_us
+          type: INTEGER
+          mode: NULLABLE
+        - name: wasm_compile_time_ion_us
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_hostnameobfuscation_disabled_failed
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_hostnameobfuscation_disabled_succeeded
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_hostnameobfuscation_enabled_failed
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_hostnameobfuscation_enabled_succeeded
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_nicer_stun_retransmits
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_nicer_turn_401s
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_nicer_turn_403s
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_nicer_turn_438s
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_connected
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_datachannel_created
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_datachannel_max_life_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_datachannel_max_retx_and_life_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_datachannel_max_retx_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_legacy_callback_stats_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_promise_and_callback_stats_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: webrtc_peerconnection_promise_stats_used
+          type: INTEGER
+          mode: NULLABLE
+        - name: widget_dark_mode
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: widget_gtk_theme_has_scrollbar_buttons
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: widget_gtk_theme_scrollbar_uses_images
+          type: BOOLEAN
+          mode: NULLABLE
+        - name: widget_gtk_version
+          type: STRING
+          mode: NULLABLE
+    - name: socket
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: events
+        type: RECORD
+        mode: REPEATED
+        fields:
+        - name: f0_
+          type: INTEGER
+          mode: NULLABLE
+        - name: f1_
+          type: STRING
+          mode: NULLABLE
+        - name: f2_
+          type: STRING
+          mode: NULLABLE
+        - name: f3_
+          type: STRING
+          mode: NULLABLE
+        - name: f4_
+          type: STRING
+          mode: NULLABLE
+        - name: f5_
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: histograms
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: dns_lookup_disposition3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_blacklisted3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_disabled3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_first4
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_http_version2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_lookup_time3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_ns_verfified3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_success3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_0rtt_state_duration
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_connection_close_code_3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_counts_pto
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_late_ack
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_late_ack_ratio
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_received_sent_dgrams
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_upload_time_10m_100m
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_upload_time_gt_100m
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: https_rr_waiting_time
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: transaction_wait_time_https_rr
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_attempt_count
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_relevant_skip_reason_native_failed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_relevant_skip_reason_native_success
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_relevant_skip_reason_trr_first
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_native_failed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_native_success
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_retry_failed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_retry_success
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_strict_mode
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_trr_first2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: uptake_remote_content_result_1
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: keyed_histograms
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: dns_lookup_disposition3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_blacklisted3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_disabled3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_first4
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_http_version2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_lookup_time3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_ns_verfified3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: dns_trr_success3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_0rtt_state_duration
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_connection_close_code_3
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_counts_pto
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_late_ack
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_late_ack_ratio
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_received_sent_dgrams
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_upload_time_10m_100m
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: http3_upload_time_gt_100m
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: https_rr_waiting_time
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: transaction_wait_time_https_rr
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_attempt_count
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_relevant_skip_reason_native_failed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_relevant_skip_reason_native_success
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_relevant_skip_reason_trr_first
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_native_failed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_native_success
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_retry_failed
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_retry_success
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_strict_mode
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: trr_skip_reason_trr_first2
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+        - name: uptake_remote_content_result_1
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: STRING
+            mode: NULLABLE
+      - name: keyed_scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: networking_trr_connection_cycle_count
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_cpu_time_per_process_type_ms
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: power_wakeups_per_process_type
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_accumulate_unknown_histogram_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_event_counts
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+        - name: telemetry_keyed_scalars_unknown_keys
+          type: RECORD
+          mode: REPEATED
+          fields:
+          - name: key
+            type: STRING
+            mode: NULLABLE
+          - name: value
+            type: INTEGER
+            mode: NULLABLE
+      - name: scalars
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: browser_usage_graphite
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_data_transferred_captive_portal
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_http_connections_captive_portal
+          type: INTEGER
+          mode: NULLABLE
+        - name: networking_http_transactions_captive_portal
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_cpu_time_bogus_values
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_cpu_time_ms
+          type: INTEGER
+          mode: NULLABLE
+        - name: power_total_thread_wakeups
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_accumulations
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_child_events
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_keyed_accumulations
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_keyed_scalar_actions
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_discarded_scalar_actions
+          type: INTEGER
+          mode: NULLABLE
+        - name: telemetry_profile_directory_scans
+          type: INTEGER
+          mode: NULLABLE
+  - name: simple_measurements
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: active_ticks
+      type: INTEGER
+      mode: NULLABLE
+    - name: blank_window_shown
+      type: INTEGER
+      mode: NULLABLE
+    - name: first_paint
+      type: INTEGER
+      mode: NULLABLE
+    - name: main
+      type: INTEGER
+      mode: NULLABLE
+    - name: session_restored
+      type: INTEGER
+      mode: NULLABLE
+    - name: total_time
+      type: INTEGER
+      mode: NULLABLE
+  - name: slow_sql
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: main_thread
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: f0_
+          type: INTEGER
+          mode: NULLABLE
+        - name: f1_
+          type: INTEGER
+          mode: NULLABLE
+    - name: other_threads
+      type: RECORD
+      mode: REPEATED
+      fields:
+      - name: key
+        type: STRING
+        mode: NULLABLE
+      - name: value
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: f0_
+          type: INTEGER
+          mode: NULLABLE
+        - name: f1_
+          type: INTEGER
+          mode: NULLABLE
+  - name: ui_measurements
+    type: RECORD
+    mode: REPEATED
+    fields:
+    - name: action
+      type: STRING
+      mode: NULLABLE
+    - name: extras
+      type: STRING
+      mode: NULLABLE
+    - name: method
+      type: STRING
+      mode: NULLABLE
+    - name: timestamp
+      type: FLOAT
+      mode: NULLABLE
+    - name: type
+      type: STRING
+      mode: NULLABLE
+  - name: ver
+    type: INTEGER
+    mode: NULLABLE
+- name: sample_id
+  type: INTEGER
+  mode: NULLABLE
+- name: submission_timestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: type
+  type: STRING
+  mode: NULLABLE
+- name: version
+  type: FLOAT
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_use_counter_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_use_counter_1pct_v1/metadata.yaml
@@ -1,0 +1,43 @@
+friendly_name: Main Use Counter 1 percent
+description: |-
+  A materialized 1 percent sample of main pings use counters
+  intended as a performance optimization for exploratory queries. It contains
+  only the most recent six months of data. Also see main_nightly for a derived
+  table containing only data where normalized_channel = 'nightly'.
+
+  Queries on this table are logically equivalent to queries on top of `main_use_counter_v4`
+  with a filter on `sample_id = 0`, but this table has a few advantages.
+  First, query estimates will be much more accurate; estimates of bytes scanned
+  can't take into account clustering, so we sometimes see valid queries get
+  rejected by Redash due to appearing expensive when they really aren't.
+  Second, simple queries should complete much more quickly on this table
+  compared to `main_use_counter_v4`; for simple queries on a very wide table like this,
+  the execution time appears to be dominated by BQ simply scanning metadata
+  for all the blocks it might need to touch. Because this table contains
+  only 1% of main ping data, it is likely to have many fewer blocks to
+  scan through.
+
+  An extra-experimental feature here is the addition of subsample_id, an
+  additional clustering field that allows for queries to efficiently filter
+  down to a 0.01% sample. Like sample_id, it ranges from 0 to 99.
+labels:
+  incremental: true
+owners:
+- ascholtz@mozilla.com
+scheduling:
+  dag_name: bqetl_main_summary
+  start_date: '2023-07-01'
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+  referenced_tables: [['moz-fx-data-shared-prod', 'telemetry_stable',
+                       'main_use_counter_v4']]
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_timestamp
+    require_partition_filter: true
+    expiration_days: 180
+  clustering:
+    fields:
+    - normalized_channel
+    - sample_id
+    - subsample_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_use_counter_1pct_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_use_counter_1pct_v1/query.sql
@@ -1,0 +1,17 @@
+SELECT
+  -- subsample_id can allow you to efficiently filter down to a 0.01% sample.
+  -- The choice of implementation here is not particularly well vetted;
+  -- it's simply chosen to be a hash that's stable, has a reasonable
+  -- avalanche effect, and is _different_ from sample_id. We use this same approach
+  -- for choosing id_bucket in exact_mau28 tables.
+  MOD(ABS(FARM_FINGERPRINT(client_id)), 100) AS subsample_id,
+  -- We apply field cleaning at the table level rather than the view level because
+  -- the logic here ends up becoming the bottleneck for simple queries on top of
+  -- this table. The limited size and retention policy on this table makes it feasible
+  -- to perform full backfills as needed if this logic changes.
+  * REPLACE (mozfun.norm.metadata(metadata) AS metadata)
+FROM
+  telemetry_stable.main_use_counter_v4
+WHERE
+  sample_id = 0
+  AND DATE(submission_timestamp) = @submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_use_counter_1pct_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_use_counter_1pct_v1/schema.yaml
@@ -1,0 +1,14635 @@
+fields:
+- name: subsample_id
+  type: INTEGER
+  mode: NULLABLE
+- name: additional_properties
+  type: STRING
+  mode: NULLABLE
+- name: client_id
+  type: STRING
+  mode: NULLABLE
+- name: document_id
+  type: STRING
+  mode: NULLABLE
+- name: metadata
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: geo
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: city
+      type: STRING
+      mode: NULLABLE
+    - name: country
+      type: STRING
+      mode: NULLABLE
+    - name: db_version
+      type: STRING
+      mode: NULLABLE
+    - name: subdivision1
+      type: STRING
+      mode: NULLABLE
+    - name: subdivision2
+      type: STRING
+      mode: NULLABLE
+  - name: header
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: date
+      type: STRING
+      mode: NULLABLE
+    - name: dnt
+      type: STRING
+      mode: NULLABLE
+    - name: x_debug_id
+      type: STRING
+      mode: NULLABLE
+    - name: x_foxsec_ip_reputation
+      type: STRING
+      mode: NULLABLE
+    - name: x_lb_tags
+      type: STRING
+      mode: NULLABLE
+    - name: x_pingsender_version
+      type: STRING
+      mode: NULLABLE
+    - name: x_source_tags
+      type: STRING
+      mode: NULLABLE
+    - name: x_telemetry_agent
+      type: STRING
+      mode: NULLABLE
+    - name: parsed_date
+      type: TIMESTAMP
+      mode: NULLABLE
+    - name: parsed_x_source_tags
+      type: STRING
+      mode: REPEATED
+    - name: parsed_x_lb_tags
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: tls_version
+        type: STRING
+        mode: NULLABLE
+      - name: tls_cipher_hex
+        type: STRING
+        mode: NULLABLE
+  - name: isp
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: db_version
+      type: STRING
+      mode: NULLABLE
+    - name: name
+      type: STRING
+      mode: NULLABLE
+    - name: organization
+      type: STRING
+      mode: NULLABLE
+  - name: uri
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: app_build_id
+      type: STRING
+      mode: NULLABLE
+    - name: app_name
+      type: STRING
+      mode: NULLABLE
+    - name: app_update_channel
+      type: STRING
+      mode: NULLABLE
+    - name: app_version
+      type: STRING
+      mode: NULLABLE
+  - name: user_agent
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: browser
+      type: STRING
+      mode: NULLABLE
+    - name: os
+      type: STRING
+      mode: NULLABLE
+    - name: version
+      type: STRING
+      mode: NULLABLE
+- name: normalized_app_name
+  type: STRING
+  mode: NULLABLE
+- name: normalized_channel
+  type: STRING
+  mode: NULLABLE
+- name: normalized_country_code
+  type: STRING
+  mode: NULLABLE
+- name: normalized_os
+  type: STRING
+  mode: NULLABLE
+- name: normalized_os_version
+  type: STRING
+  mode: NULLABLE
+- name: payload
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: histograms
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: use_counter2_appearance_nonwidget_button_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_button_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_checkbox_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_checkbox_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_innerspinbutton_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_innerspinbutton_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_listbox_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_listbox_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_menulist_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_menulist_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_menulistbutton_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_menulistbutton_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_meter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_meter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_numberinput_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_numberinput_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_progressbar_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_progressbar_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_progressbarvertical_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_progressbarvertical_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_radio_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_radio_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_range_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_range_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_rangethumb_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_rangethumb_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalehorizontal_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalehorizontal_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalethumbend_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalethumbend_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalethumbhorizontal_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalethumbhorizontal_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalethumbstart_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalethumbstart_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalethumbtick_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalethumbtick_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalethumbvertical_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalethumbvertical_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalevertical_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scalevertical_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scrollbarthumbhorizontal_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scrollbarthumbhorizontal_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scrollbarthumbvertical_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scrollbarthumbvertical_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scrollbartrackhorizontal_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scrollbartrackhorizontal_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scrollbartrackvertical_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_scrollbartrackvertical_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_searchfield_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_searchfield_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_textarea_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_textarea_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_textfield_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_nonwidget_textfield_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_overridden_numberinput_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_overridden_numberinput_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_overridden_range_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_overridden_range_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_button_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_button_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_checkbox_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_checkbox_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_innerspinbutton_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_innerspinbutton_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_listbox_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_listbox_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_menulist_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_menulist_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_menulistbutton_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_menulistbutton_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_meter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_meter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_numberinput_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_numberinput_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_progressbar_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_progressbar_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_progressbarvertical_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_progressbarvertical_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_radio_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_radio_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_range_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_range_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_rangethumb_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_rangethumb_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalehorizontal_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalehorizontal_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalethumbend_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalethumbend_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalethumbhorizontal_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalethumbhorizontal_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalethumbstart_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalethumbstart_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalethumbtick_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalethumbtick_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalethumbvertical_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalethumbvertical_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalevertical_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scalevertical_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scrollbarthumbhorizontal_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scrollbarthumbhorizontal_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scrollbarthumbvertical_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scrollbarthumbvertical_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scrollbartrackhorizontal_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scrollbartrackhorizontal_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scrollbartrackvertical_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_scrollbartrackvertical_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_searchfield_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_searchfield_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_textarea_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_textarea_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_textfield_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_appearance_widget_textfield_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_assert_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_assert_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_clear_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_clear_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_count_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_count_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_countreset_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_countreset_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_debug_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_debug_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_dir_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_dir_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_dirxml_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_dirxml_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_error_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_error_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_exception_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_exception_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_group_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_group_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_groupcollapsed_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_groupcollapsed_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_groupend_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_groupend_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_info_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_info_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_log_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_log_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_profile_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_profile_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_profileend_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_profileend_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_table_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_table_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_time_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_time_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_timeend_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_timeend_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_timelog_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_timelog_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_timestamp_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_timestamp_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_trace_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_trace_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_warn_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_console_warn_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_contenturlonimagecontent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_contenturlonimagecontent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_accent_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_accent_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_align_content_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_align_content_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_align_items_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_align_items_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_align_self_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_align_self_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_align_tracks_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_align_tracks_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_alignment_baseline_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_alignment_baseline_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_all_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_all_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_composition_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_composition_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_delay_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_delay_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_direction_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_direction_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_duration_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_duration_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_fill_mode_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_fill_mode_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_iteration_count_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_iteration_count_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_name_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_name_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_play_state_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_play_state_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_timing_function_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_animation_timing_function_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_appearance_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_appearance_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_aspect_ratio_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_aspect_ratio_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_backdrop_filter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_backdrop_filter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_backface_visibility_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_backface_visibility_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_attachment_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_attachment_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_blend_mode_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_blend_mode_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_clip_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_clip_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_image_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_image_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_origin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_origin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_position_x_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_position_x_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_position_y_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_position_y_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_repeat_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_repeat_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_repeat_x_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_repeat_x_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_repeat_y_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_repeat_y_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_background_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_baseline_shift_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_baseline_shift_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_baseline_source_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_baseline_source_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_block_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_block_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_end_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_end_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_end_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_end_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_end_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_end_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_start_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_start_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_start_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_start_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_start_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_start_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_block_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_left_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_left_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_right_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_right_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_bottom_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_collapse_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_collapse_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_end_end_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_end_end_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_end_start_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_end_start_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_outset_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_outset_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_repeat_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_repeat_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_slice_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_slice_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_source_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_source_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_image_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_end_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_end_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_end_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_end_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_end_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_end_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_start_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_start_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_start_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_start_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_start_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_start_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_inline_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_left_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_left_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_left_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_left_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_left_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_left_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_left_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_left_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_right_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_right_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_right_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_right_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_right_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_right_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_right_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_right_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_spacing_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_spacing_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_start_end_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_start_end_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_start_start_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_start_start_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_left_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_left_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_right_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_right_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_top_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_border_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_bottom_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_bottom_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_box_decoration_break_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_box_decoration_break_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_box_shadow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_box_shadow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_box_sizing_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_box_sizing_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_break_after_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_break_after_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_break_before_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_break_before_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_break_inside_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_break_inside_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_buffered_rendering_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_buffered_rendering_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_caption_side_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_caption_side_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_caret_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_caret_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_clear_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_clear_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_clip_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_clip_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_clip_path_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_clip_path_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_clip_rule_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_clip_rule_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_adjust_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_adjust_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_interpolation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_interpolation_filters_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_interpolation_filters_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_interpolation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_rendering_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_rendering_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_scheme_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_color_scheme_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_count_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_count_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_fill_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_fill_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_gap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_gap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_rule_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_rule_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_rule_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_rule_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_rule_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_rule_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_rule_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_rule_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_span_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_span_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_column_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_columns_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_columns_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_intrinsic_block_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_intrinsic_block_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_intrinsic_height_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_intrinsic_height_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_intrinsic_inline_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_intrinsic_inline_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_intrinsic_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_intrinsic_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_intrinsic_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_intrinsic_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_contain_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_container_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_container_name_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_container_name_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_container_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_container_type_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_container_type_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_content_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_content_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_content_visibility_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_content_visibility_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_counter_increment_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_counter_increment_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_counter_reset_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_counter_reset_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_counter_set_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_counter_set_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_cursor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_cursor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_cx_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_cx_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_cy_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_cy_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_d_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_d_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_direction_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_direction_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_display_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_display_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_dominant_baseline_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_dominant_baseline_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_empty_cells_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_empty_cells_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_fill_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_fill_opacity_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_fill_opacity_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_fill_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_fill_rule_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_fill_rule_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_filter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_filter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_basis_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_basis_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_direction_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_direction_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_flow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_flow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_grow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_grow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_shrink_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_shrink_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_wrap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flex_wrap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_float_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_float_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flood_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flood_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flood_opacity_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_flood_opacity_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_family_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_family_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_feature_settings_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_feature_settings_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_kerning_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_kerning_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_language_override_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_language_override_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_optical_sizing_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_optical_sizing_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_palette_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_palette_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_size_adjust_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_size_adjust_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_stretch_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_stretch_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_synthesis_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_synthesis_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_synthesis_small_caps_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_synthesis_small_caps_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_synthesis_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_synthesis_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_synthesis_weight_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_synthesis_weight_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_alternates_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_alternates_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_caps_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_caps_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_east_asian_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_east_asian_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_emoji_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_emoji_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_ligatures_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_ligatures_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_numeric_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_numeric_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variant_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variation_settings_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_variation_settings_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_weight_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_font_weight_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_forced_color_adjust_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_forced_color_adjust_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_gap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_gap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_area_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_area_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_auto_columns_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_auto_columns_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_auto_flow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_auto_flow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_auto_rows_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_auto_rows_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_column_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_column_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_column_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_column_gap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_column_gap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_column_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_column_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_column_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_gap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_gap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_row_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_row_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_row_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_row_gap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_row_gap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_row_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_row_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_row_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_template_areas_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_template_areas_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_template_columns_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_template_columns_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_template_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_template_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_template_rows_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_grid_template_rows_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_height_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_height_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_hyphenate_character_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_hyphenate_character_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_hyphens_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_hyphens_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_image_orientation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_image_orientation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_image_rendering_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_image_rendering_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_ime_mode_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_ime_mode_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inline_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inline_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_block_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_block_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_block_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_block_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_block_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_block_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_inline_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_inline_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_inline_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_inline_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_inline_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_inline_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_inset_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_isolation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_isolation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_justify_content_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_justify_content_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_justify_items_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_justify_items_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_justify_self_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_justify_self_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_justify_tracks_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_justify_tracks_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_left_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_left_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_letter_spacing_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_letter_spacing_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_lighting_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_lighting_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_line_break_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_line_break_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_line_height_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_line_height_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_list_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_list_style_image_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_list_style_image_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_list_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_list_style_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_list_style_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_list_style_type_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_list_style_type_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_block_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_block_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_block_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_block_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_block_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_block_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_bottom_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_bottom_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_inline_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_inline_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_inline_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_inline_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_inline_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_inline_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_left_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_left_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_right_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_right_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_top_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_margin_top_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_marker_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_marker_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_marker_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_marker_mid_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_marker_mid_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_marker_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_marker_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_marker_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_clip_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_clip_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_composite_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_composite_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_image_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_image_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_mode_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_mode_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_origin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_origin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_position_x_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_position_x_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_position_y_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_position_y_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_repeat_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_repeat_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_type_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mask_type_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_masonry_auto_flow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_masonry_auto_flow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_math_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_math_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_max_block_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_max_block_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_max_height_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_max_height_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_max_inline_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_max_inline_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_max_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_max_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_max_zoom_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_max_zoom_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_min_block_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_min_block_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_min_height_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_min_height_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_min_inline_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_min_inline_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_min_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_min_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_min_zoom_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_min_zoom_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mix_blend_mode_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_mix_blend_mode_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_delay_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_delay_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_direction_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_direction_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_duration_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_duration_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_fill_mode_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_fill_mode_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_iteration_count_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_iteration_count_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_name_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_name_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_play_state_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_play_state_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_timing_function_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_animation_timing_function_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_appearance_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_appearance_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_backface_visibility_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_backface_visibility_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_end_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_end_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_end_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_end_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_end_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_end_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_image_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_image_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_start_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_start_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_start_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_start_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_start_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_border_start_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_align_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_align_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_direction_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_direction_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_flex_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_flex_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_ordinal_group_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_ordinal_group_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_orient_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_orient_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_pack_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_pack_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_sizing_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_box_sizing_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_count_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_count_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_fill_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_fill_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_gap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_gap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_rule_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_rule_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_rule_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_rule_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_rule_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_rule_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_rule_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_rule_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_span_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_span_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_column_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_columns_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_columns_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_context_properties_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_context_properties_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_control_character_visibility_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_control_character_visibility_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_float_edge_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_float_edge_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_font_feature_settings_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_font_feature_settings_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_font_language_override_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_font_language_override_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_force_broken_image_icon_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_force_broken_image_icon_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_hyphens_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_hyphens_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_image_region_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_image_region_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_margin_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_margin_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_margin_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_margin_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_orient_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_orient_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_outline_radius_bottomleft_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_outline_radius_bottomleft_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_outline_radius_bottomright_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_outline_radius_bottomright_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_outline_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_outline_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_outline_radius_topleft_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_outline_radius_topleft_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_outline_radius_topright_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_outline_radius_topright_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_padding_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_padding_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_padding_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_padding_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_perspective_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_perspective_origin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_perspective_origin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_perspective_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_stack_sizing_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_stack_sizing_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_tab_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_tab_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_text_size_adjust_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_text_size_adjust_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transform_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transform_origin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transform_origin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transform_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transform_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transform_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transition_delay_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transition_delay_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transition_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transition_duration_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transition_duration_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transition_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transition_property_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transition_property_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transition_timing_function_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_transition_timing_function_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_user_focus_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_user_focus_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_user_input_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_user_input_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_user_modify_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_user_modify_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_user_select_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_user_select_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_window_dragging_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_moz_window_dragging_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_object_fit_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_object_fit_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_object_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_object_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_anchor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_anchor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_distance_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_distance_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_path_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_path_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_rotate_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_offset_rotate_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_opacity_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_opacity_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_order_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_order_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_orientation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_orientation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_orphans_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_orphans_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_outline_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_outline_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_outline_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_outline_offset_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_outline_offset_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_outline_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_outline_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_outline_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_outline_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_outline_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_anchor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_anchor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_block_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_block_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_clip_margin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_clip_margin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_inline_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_inline_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_wrap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_wrap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_x_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_x_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_y_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overflow_y_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overscroll_behavior_block_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overscroll_behavior_block_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overscroll_behavior_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overscroll_behavior_inline_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overscroll_behavior_inline_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overscroll_behavior_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overscroll_behavior_x_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overscroll_behavior_x_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overscroll_behavior_y_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_overscroll_behavior_y_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_block_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_block_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_block_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_block_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_block_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_block_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_bottom_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_bottom_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_inline_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_inline_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_inline_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_inline_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_inline_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_inline_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_left_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_left_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_right_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_right_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_top_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_padding_top_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_page_break_after_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_page_break_after_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_page_break_before_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_page_break_before_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_page_break_inside_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_page_break_inside_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_page_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_page_orientation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_page_orientation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_page_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_paint_order_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_paint_order_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_perspective_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_perspective_origin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_perspective_origin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_perspective_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_place_content_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_place_content_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_place_items_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_place_items_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_place_self_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_place_self_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_pointer_events_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_pointer_events_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_print_color_adjust_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_print_color_adjust_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_quotes_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_quotes_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_r_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_r_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_resize_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_resize_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_right_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_right_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_rotate_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_rotate_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_row_gap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_row_gap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_ruby_align_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_ruby_align_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_ruby_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_ruby_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_rx_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_rx_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_ry_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_ry_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scale_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scale_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_behavior_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_behavior_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_block_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_block_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_block_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_block_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_block_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_block_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_bottom_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_bottom_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_inline_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_inline_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_inline_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_inline_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_inline_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_inline_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_left_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_left_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_right_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_right_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_top_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_margin_top_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_block_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_block_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_block_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_block_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_block_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_block_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_bottom_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_bottom_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_inline_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_inline_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_inline_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_inline_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_inline_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_inline_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_left_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_left_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_right_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_right_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_top_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_padding_top_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_snap_align_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_snap_align_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_snap_stop_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_snap_stop_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_snap_type_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scroll_snap_type_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scrollbar_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scrollbar_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scrollbar_gutter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scrollbar_gutter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scrollbar_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_scrollbar_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_shape_image_threshold_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_shape_image_threshold_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_shape_margin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_shape_margin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_shape_outside_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_shape_outside_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_shape_rendering_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_shape_rendering_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_speak_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_speak_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stop_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stop_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stop_opacity_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stop_opacity_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_dasharray_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_dasharray_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_dashoffset_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_dashoffset_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_linecap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_linecap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_linejoin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_linejoin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_miterlimit_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_miterlimit_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_opacity_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_opacity_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_stroke_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_tab_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_tab_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_table_layout_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_table_layout_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_align_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_align_last_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_align_last_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_align_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_anchor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_anchor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_combine_upright_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_combine_upright_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_line_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_line_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_skip_ink_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_skip_ink_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_thickness_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_decoration_thickness_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_emphasis_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_emphasis_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_emphasis_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_emphasis_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_emphasis_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_emphasis_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_emphasis_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_emphasis_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_indent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_indent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_justify_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_justify_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_orientation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_orientation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_overflow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_overflow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_rendering_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_rendering_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_shadow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_shadow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_size_adjust_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_size_adjust_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_transform_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_transform_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_underline_offset_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_underline_offset_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_underline_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_text_underline_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_top_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_top_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_touch_action_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_touch_action_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transform_box_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transform_box_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transform_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transform_origin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transform_origin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transform_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transform_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transform_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transition_delay_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transition_delay_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transition_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transition_duration_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transition_duration_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transition_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transition_property_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transition_property_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transition_timing_function_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_transition_timing_function_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_translate_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_translate_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_unicode_bidi_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_unicode_bidi_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_user_select_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_user_select_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_user_zoom_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_user_zoom_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_vector_effect_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_vector_effect_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_vertical_align_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_vertical_align_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_visibility_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_visibility_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_align_content_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_align_content_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_align_items_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_align_items_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_align_self_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_align_self_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_delay_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_delay_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_direction_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_direction_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_duration_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_duration_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_fill_mode_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_fill_mode_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_iteration_count_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_iteration_count_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_name_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_name_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_play_state_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_play_state_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_timing_function_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_animation_timing_function_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_app_region_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_app_region_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_appearance_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_appearance_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_backface_visibility_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_backface_visibility_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_background_clip_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_background_clip_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_background_origin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_background_origin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_background_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_background_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_after_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_after_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_after_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_after_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_after_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_after_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_after_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_after_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_before_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_before_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_before_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_before_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_before_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_before_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_before_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_before_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_bottom_left_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_bottom_left_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_bottom_right_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_bottom_right_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_end_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_end_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_end_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_end_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_end_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_end_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_horizontal_spacing_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_horizontal_spacing_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_image_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_image_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_start_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_start_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_start_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_start_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_start_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_start_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_top_left_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_top_left_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_top_right_radius_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_top_right_radius_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_vertical_spacing_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_border_vertical_spacing_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_align_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_align_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_decoration_break_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_decoration_break_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_direction_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_direction_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_flex_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_flex_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_ordinal_group_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_ordinal_group_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_orient_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_orient_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_pack_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_pack_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_reflect_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_reflect_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_shadow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_shadow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_sizing_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_box_sizing_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_clip_path_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_clip_path_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_break_after_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_break_after_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_break_before_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_break_before_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_break_inside_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_break_inside_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_count_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_count_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_gap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_gap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_rule_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_rule_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_rule_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_rule_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_rule_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_rule_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_rule_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_rule_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_span_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_span_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_column_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_columns_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_columns_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_filter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_filter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_basis_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_basis_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_direction_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_direction_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_flow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_flow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_grow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_grow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_shrink_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_shrink_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_wrap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_flex_wrap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_font_feature_settings_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_font_feature_settings_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_font_size_delta_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_font_size_delta_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_font_smoothing_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_font_smoothing_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_highlight_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_highlight_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_hyphenate_character_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_hyphenate_character_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_justify_content_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_justify_content_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_line_break_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_line_break_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_line_clamp_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_line_clamp_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_locale_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_locale_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_logical_height_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_logical_height_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_logical_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_logical_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_after_collapse_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_after_collapse_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_after_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_after_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_before_collapse_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_before_collapse_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_before_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_before_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_bottom_collapse_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_bottom_collapse_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_collapse_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_collapse_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_top_collapse_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_margin_top_collapse_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_outset_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_outset_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_repeat_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_repeat_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_slice_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_slice_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_source_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_source_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_box_image_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_clip_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_clip_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_composite_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_composite_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_image_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_image_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_origin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_origin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_position_x_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_position_x_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_position_y_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_position_y_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_repeat_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_repeat_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_repeat_x_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_repeat_x_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_repeat_y_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_repeat_y_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_size_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_mask_size_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_max_logical_height_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_max_logical_height_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_max_logical_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_max_logical_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_min_logical_height_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_min_logical_height_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_min_logical_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_min_logical_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_opacity_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_opacity_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_order_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_order_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_padding_after_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_padding_after_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_padding_before_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_padding_before_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_padding_end_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_padding_end_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_padding_start_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_padding_start_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_perspective_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_perspective_origin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_perspective_origin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_perspective_origin_x_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_perspective_origin_x_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_perspective_origin_y_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_perspective_origin_y_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_perspective_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_print_color_adjust_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_print_color_adjust_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_rtl_ordering_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_rtl_ordering_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_ruby_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_ruby_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_shape_image_threshold_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_shape_image_threshold_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_shape_margin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_shape_margin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_shape_outside_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_shape_outside_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_tap_highlight_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_tap_highlight_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_combine_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_combine_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_decorations_in_effect_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_decorations_in_effect_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_emphasis_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_emphasis_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_emphasis_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_emphasis_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_emphasis_position_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_emphasis_position_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_emphasis_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_emphasis_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_fill_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_fill_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_orientation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_orientation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_security_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_security_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_size_adjust_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_size_adjust_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_stroke_color_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_stroke_color_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_stroke_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_stroke_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_stroke_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_text_stroke_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_origin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_origin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_origin_x_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_origin_x_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_origin_y_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_origin_y_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_origin_z_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_origin_z_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transform_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transition_delay_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transition_delay_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transition_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transition_duration_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transition_duration_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transition_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transition_property_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transition_property_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transition_timing_function_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_transition_timing_function_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_user_drag_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_user_drag_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_user_modify_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_user_modify_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_user_select_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_user_select_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_writing_mode_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_webkit_writing_mode_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_white_space_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_white_space_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_widows_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_widows_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_width_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_width_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_will_change_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_will_change_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_word_break_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_word_break_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_word_spacing_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_word_spacing_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_word_wrap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_word_wrap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_writing_mode_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_writing_mode_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_x_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_x_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_y_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_y_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_z_index_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_z_index_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_zoom_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_zoom_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_customelementregistry_define_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_customelementregistry_define_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_customizedbuiltin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_customizedbuiltin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_addelement_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_addelement_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozcleardataat_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozcleardataat_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozcursor_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozcursor_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozcursor_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozcursor_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozgetdataat_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozgetdataat_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozitemcount_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozitemcount_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozitemcount_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozitemcount_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozsetdataat_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozsetdataat_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozsourcenode_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozsourcenode_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozsourcenode_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozsourcenode_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_moztypesat_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_moztypesat_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozusercancelled_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozusercancelled_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozusercancelled_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_datatransfer_mozusercancelled_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_ambient_light_event_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_ambient_light_event_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_app_cache_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_app_cache_insecure_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_app_cache_insecure_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_app_cache_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_chrome_use_of_dom3_load_method_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_chrome_use_of_dom3_load_method_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_components_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_components_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_create_attribute_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_create_attribute_ns_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_create_attribute_ns_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_create_attribute_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_create_image_bitmap_canvas_rendering_context2_d_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_create_image_bitmap_canvas_rendering_context2_d_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_data_container_event_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_data_container_event_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_deprecated_testing_attribute_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_deprecated_testing_attribute_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_deprecated_testing_interface_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_deprecated_testing_interface_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_deprecated_testing_method_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_deprecated_testing_method_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_document_release_capture_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_document_release_capture_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_dom_attr_modified_event_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_dom_attr_modified_event_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_dom_exception_code_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_dom_exception_code_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_dom_quad_bounds_attr_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_dom_quad_bounds_attr_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_draw_window_canvas_rendering_context2_d_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_draw_window_canvas_rendering_context2_d_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_element_release_capture_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_element_release_capture_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_element_set_capture_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_element_set_capture_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_enable_privilege_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_enable_privilege_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_external_add_search_provider_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_external_add_search_provider_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_file_last_modified_date_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_file_last_modified_date_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_form_submission_untrusted_event_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_form_submission_untrusted_event_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_get_attribute_node_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_get_attribute_node_ns_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_get_attribute_node_ns_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_get_attribute_node_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_get_prevent_default_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_get_prevent_default_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_get_property_css_value_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_get_property_css_value_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_get_set_user_data_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_get_set_user_data_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_idb_database_create_mutable_file_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_idb_database_create_mutable_file_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_idb_mutable_file_open_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_idb_mutable_file_open_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_idb_open_db_options_storage_type_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_idb_open_db_options_storage_type_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_image_bitmap_rendering_context_transfer_image_bitmap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_image_bitmap_rendering_context_transfer_image_bitmap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_import_xul_into_content_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_import_xul_into_content_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_input_encoding_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_input_encoding_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_install_trigger_deprecated_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_install_trigger_deprecated_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_install_trigger_install_deprecated_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_install_trigger_install_deprecated_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_lenient_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_lenient_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_lenient_this_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_lenient_this_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_alignment_attributes_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_alignment_attributes_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_bevelled_attribute_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_bevelled_attribute_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_line_thickness_value_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_line_thickness_value_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_math_size_value_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_math_size_value_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_math_space_value_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_math_space_value_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_menclose_notation_radical_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_menclose_notation_radical_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_mfenced_element_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_mfenced_element_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_script_shift_attributes_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_script_shift_attributes_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_scriptminsize_attribute_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_scriptminsize_attribute_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_scriptsizemultiplier_attribute_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_scriptsizemultiplier_attribute_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_stixgeneral_operator_stretching_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_stixgeneral_operator_stretching_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_style_attribute_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_style_attribute_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_x_link_attribute_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_x_link_attribute_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_mixed_display_object_subrequest_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_mixed_display_object_subrequest_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_motion_event_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_motion_event_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_mouse_event_moz_pressure_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_mouse_event_moz_pressure_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_before_paint_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_before_paint_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_box_or_inline_box_display_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_box_or_inline_box_display_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_current_transform_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_current_transform_inverse_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_current_transform_inverse_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_current_transform_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_get_as_file_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_get_as_file_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_preserves_pitch_deprecated_prefix_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_preserves_pitch_deprecated_prefix_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_request_full_screen_deprecated_prefix_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_request_full_screen_deprecated_prefix_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_text_style_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_text_style_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_mozfullscreenchange_deprecated_prefix_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_mozfullscreenchange_deprecated_prefix_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_mozfullscreenerror_deprecated_prefix_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_mozfullscreenerror_deprecated_prefix_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_mutation_event_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_mutation_event_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_navigator_battery_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_navigator_battery_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_navigator_get_user_media_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_navigator_get_user_media_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_no_exposed_props_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_no_exposed_props_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_node_iterator_detach_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_node_iterator_detach_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_node_value_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_node_value_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_offscreen_canvas_to_blob_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_offscreen_canvas_to_blob_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_orientation_event_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_orientation_event_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_owner_element_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_owner_element_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_panner_node_doppler_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_panner_node_doppler_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_prefixed_fullscreen_api_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_prefixed_fullscreen_api_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_prefixed_image_smoothing_enabled_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_prefixed_image_smoothing_enabled_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_prefixed_visibility_api_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_prefixed_visibility_api_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_proximity_event_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_proximity_event_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_register_protocol_handler_insecure_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_register_protocol_handler_insecure_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_remove_attribute_node_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_remove_attribute_node_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_rtc_peer_connection_get_streams_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_rtc_peer_connection_get_streams_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_send_as_binary_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_send_as_binary_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_set_attribute_node_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_set_attribute_node_ns_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_set_attribute_node_ns_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_set_attribute_node_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_show_modal_dialog_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_show_modal_dialog_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_svg_farthest_viewport_element_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_svg_farthest_viewport_element_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_svg_nearest_viewport_element_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_svg_nearest_viewport_element_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_sync_xml_http_request_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_sync_xml_http_request_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_text_content_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_text_content_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_u2f_register_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_u2f_register_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_u2f_sign_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_u2f_sign_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_url_create_object_url_media_stream_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_url_create_object_url_media_stream_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_use_of_capture_events_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_use_of_capture_events_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_use_of_dom3_load_method_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_use_of_dom3_load_method_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_use_of_release_events_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_use_of_release_events_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_webrtc_deprecated_prefix_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_webrtc_deprecated_prefix_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_window_cc_ontrollers_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_window_cc_ontrollers_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_window_content_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_window_content_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_window_content_untrusted_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_window_content_untrusted_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_window_controllers_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_window_controllers_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_xml_base_attribute_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_xml_base_attribute_for_style_attr_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_xml_base_attribute_for_style_attr_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_xml_base_attribute_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_xml_base_attribute_with_styled_element_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_xml_base_attribute_with_styled_element_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_document_mozsetimageelement_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_document_mozsetimageelement_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentexeccommandcontentreadonly_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentexeccommandcontentreadonly_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentexeccommanddecreasefontsize_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentexeccommanddecreasefontsize_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentexeccommandheading_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentexeccommandheading_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentexeccommandincreasefontsize_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentexeccommandincreasefontsize_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentexeccommandreadonly_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentexeccommandreadonly_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentopen_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentopen_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentopenreplace_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentopenreplace_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandstateorvaluecontentreadonly_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandstateorvaluecontentreadonly_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandstateorvaluegethtml_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandstateorvaluegethtml_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandstateorvalueheading_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandstateorvalueheading_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandstateorvalueinsertbronreturn_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandstateorvalueinsertbronreturn_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandstateorvaluereadonly_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandstateorvaluereadonly_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledcontentreadonly_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledcontentreadonly_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenableddecreasefontsize_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenableddecreasefontsize_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledgethtml_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledgethtml_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledheading_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledheading_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledincreasefontsize_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledincreasefontsize_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledinsertbronreturn_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledinsertbronreturn_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledreadonly_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_documentquerycommandsupportedorenabledreadonly_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domerror_message_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domerror_message_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domerror_message_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domerror_message_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domerror_name_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domerror_name_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domerror_name_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domerror_name_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domerrorconstructor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domerrorconstructor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domparser_parsefromstring_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_domparser_parsefromstring_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_attachshadow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_attachshadow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_releasecapture_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_releasecapture_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_releasepointercapture_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_releasepointercapture_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_setcapture_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_setcapture_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_sethtml_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_sethtml_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_setpointercapture_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_element_setpointercapture_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_enumeratedevicesinsec_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_enumeratedevicesinsec_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_enumeratedevicesunfocused_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_enumeratedevicesunfocused_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_external_addsearchengine_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_external_addsearchengine_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_external_addsearchprovider_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_external_addsearchprovider_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feblend_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feblend_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fecolormatrix_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fecolormatrix_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fecomponenttransfer_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fecomponenttransfer_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fecomposite_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fecomposite_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feconvolvematrix_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feconvolvematrix_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fediffuselighting_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fediffuselighting_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fedisplacementmap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fedisplacementmap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feflood_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feflood_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fegaussianblur_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fegaussianblur_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feimage_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feimage_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_femerge_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_femerge_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_femorphology_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_femorphology_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feoffset_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feoffset_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fespecularlighting_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fespecularlighting_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fetile_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_fetile_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feturbulence_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_feturbulence_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_filteredcrossoriginiframe_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_filteredcrossoriginiframe_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_getdisplaymediaxorigin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_getdisplaymediaxorigin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_getusermediainsec_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_getusermediainsec_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_getusermediaunfocused_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_getusermediaunfocused_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_getusermediaxorigin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_getusermediaxorigin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_adoptedstylesheets_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_adoptedstylesheets_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_caretrangefrompoint_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_caretrangefrompoint_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_clear_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_clear_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_exitpictureinpicture_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_exitpictureinpicture_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_featurepolicy_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_featurepolicy_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onbeforecopy_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onbeforecopy_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onbeforecut_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onbeforecut_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onbeforepaste_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onbeforepaste_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_oncancel_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_oncancel_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onfreeze_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onfreeze_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onmousewheel_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onmousewheel_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onresume_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onresume_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onsearch_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onsearch_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onsecuritypolicyviolation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onsecuritypolicyviolation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onwebkitfullscreenchange_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onwebkitfullscreenchange_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onwebkitfullscreenerror_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_onwebkitfullscreenerror_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_pictureinpictureelement_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_pictureinpictureelement_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_pictureinpictureenabled_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_pictureinpictureenabled_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_registerelement_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_registerelement_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_wasdiscarded_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_wasdiscarded_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitcancelfullscreen_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitcancelfullscreen_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitcurrentfullscreenelement_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitcurrentfullscreenelement_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitexitfullscreen_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitexitfullscreen_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitfullscreenelement_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitfullscreenelement_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitfullscreenenabled_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitfullscreenenabled_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkithidden_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkithidden_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitisfullscreen_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitisfullscreen_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitvisibilitystate_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_webkitvisibilitystate_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_xmlencoding_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_xmlencoding_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_xmlstandalone_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_xmlstandalone_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_xmlversion_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocument_xmlversion_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocumentnamedgetterhit_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_htmldocumentnamedgetterhit_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_idbdatabase_createmutablefile_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_idbdatabase_createmutablefile_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_idbdatabase_mozcreatefilehandle_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_idbdatabase_mozcreatefilehandle_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_idbmutablefile_getfile_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_idbmutablefile_getfile_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_idbmutablefile_open_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_idbmutablefile_open_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_js_asmjs_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_js_asmjs_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_js_wasm_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_js_wasm_duplicate_imports_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_js_wasm_duplicate_imports_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_js_wasm_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_mediadevices_enumeratedevices_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_mediadevices_enumeratedevices_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_mediadevices_getdisplaymedia_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_mediadevices_getdisplaymedia_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_mediadevices_getusermedia_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_mediadevices_getusermedia_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_mozgetusermediainsec_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_mozgetusermediainsec_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_mozgetusermediaxorigin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_mozgetusermediaxorigin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_navigator_mozgetusermedia_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_navigator_mozgetusermedia_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_no_data_url_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_no_data_url_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_oncached_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_oncached_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_oncached_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_oncached_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onchecking_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onchecking_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onchecking_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onchecking_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_ondownloading_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_ondownloading_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_ondownloading_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_ondownloading_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onerror_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onerror_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onerror_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onerror_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onnoupdate_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onnoupdate_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onnoupdate_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onnoupdate_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onobsolete_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onobsolete_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onobsolete_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onobsolete_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onprogress_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onprogress_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onprogress_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onprogress_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onupdateready_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onupdateready_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onupdateready_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_onupdateready_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_status_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_status_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_status_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_status_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_swapcache_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_swapcache_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_update_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_offlineresourcelist_update_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onbounce_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onbounce_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_ondommousescroll_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_ondommousescroll_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onfinish_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onfinish_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onmozmousepixelscroll_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onmozmousepixelscroll_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onoverflow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onoverflow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onstart_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onstart_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onunderflow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_onunderflow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_percentagestrokewidthinsvg_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_percentagestrokewidthinsvg_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_percentagestrokewidthinsvgtext_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_percentagestrokewidthinsvgtext_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingcachesdelete_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingcachesdelete_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingcacheshas_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingcacheshas_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingcacheskeys_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingcacheskeys_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingcachesmatch_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingcachesmatch_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingcachesopen_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingcachesopen_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingidbfactorydeletedatabase_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingidbfactorydeletedatabase_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingidbfactoryopen_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingidbfactoryopen_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingnavigatorserviceworker_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_privatebrowsingnavigatorserviceworker_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_property_fill_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_property_fill_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_property_fillopacity_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_property_fillopacity_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_pushmanager_subscribe_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_pushmanager_subscribe_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_pushsubscription_unsubscribe_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_pushsubscription_unsubscribe_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_range_createcontextualfragment_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_range_createcontextualfragment_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_sanitizer_constructor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_sanitizer_constructor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_sanitizer_sanitize_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_sanitizer_sanitize_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_sanitizer_sanitizefor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_sanitizer_sanitizefor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_scheduler_posttask_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_scheduler_posttask_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_svgsvgelement_currentscale_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_svgsvgelement_currentscale_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_svgsvgelement_currentscale_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_svgsvgelement_currentscale_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_svgsvgelement_getelementbyid_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_svgsvgelement_getelementbyid_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_absoluteorientationsensor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_absoluteorientationsensor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_accelerometer_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_accelerometer_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_applicationcache_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_applicationcache_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_applicationcacheerrorevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_applicationcacheerrorevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_atomics_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_atomics_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_audioparammap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_audioparammap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_audioworklet_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_audioworklet_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_audioworkletnode_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_audioworkletnode_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_backgroundfetchmanager_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_backgroundfetchmanager_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_backgroundfetchrecord_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_backgroundfetchrecord_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_backgroundfetchregistration_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_backgroundfetchregistration_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_beforeinstallpromptevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_beforeinstallpromptevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetooth_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetooth_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothcharacteristicproperties_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothcharacteristicproperties_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothdevice_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothdevice_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothremotegattcharacteristic_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothremotegattcharacteristic_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothremotegattdescriptor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothremotegattdescriptor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothremotegattserver_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothremotegattserver_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothremotegattservice_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothremotegattservice_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothuuid_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_bluetoothuuid_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_canvascapturemediastreamtrack_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_canvascapturemediastreamtrack_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_chrome_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_chrome_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_clientinformation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_clientinformation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_clipboarditem_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_clipboarditem_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssimagevalue_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssimagevalue_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_csskeywordvalue_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_csskeywordvalue_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathinvert_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathinvert_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathmax_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathmax_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathmin_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathmin_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathnegate_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathnegate_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathproduct_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathproduct_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathsum_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathsum_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathvalue_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmathvalue_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmatrixcomponent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssmatrixcomponent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssnumericarray_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssnumericarray_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssnumericvalue_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssnumericvalue_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssperspective_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssperspective_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_csspositionvalue_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_csspositionvalue_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssrotate_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssrotate_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssscale_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssscale_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssskew_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssskew_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssskewx_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssskewx_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssskewy_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssskewy_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssstylevalue_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssstylevalue_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_csstransformcomponent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_csstransformcomponent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_csstransformvalue_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_csstransformvalue_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_csstranslate_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_csstranslate_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssunitvalue_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssunitvalue_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssunparsedvalue_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssunparsedvalue_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssvariablereferencevalue_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_cssvariablereferencevalue_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_defaultstatus_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_defaultstatus_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_devicemotioneventacceleration_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_devicemotioneventacceleration_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_devicemotioneventrotationrate_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_devicemotioneventrotationrate_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_domerror_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_domerror_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_enterpictureinpictureevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_enterpictureinpictureevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_external_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_external_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_federatedcredential_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_federatedcredential_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_gyroscope_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_gyroscope_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_htmlcontentelement_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_htmlcontentelement_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_htmldialogelement_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_htmldialogelement_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_htmlshadowelement_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_htmlshadowelement_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_imagecapture_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_imagecapture_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_inputdevicecapabilities_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_inputdevicecapabilities_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_inputdeviceinfo_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_inputdeviceinfo_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_keyboard_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_keyboard_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_keyboardlayoutmap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_keyboardlayoutmap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_linearaccelerationsensor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_linearaccelerationsensor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_lock_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_lock_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_lockmanager_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_lockmanager_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_mediametadata_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_mediametadata_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_mediasession_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_mediasession_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_mediasettingsrange_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_mediasettingsrange_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midiaccess_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midiaccess_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midiconnectionevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midiconnectionevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midiinput_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midiinput_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midiinputmap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midiinputmap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midimessageevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midimessageevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midioutput_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midioutput_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midioutputmap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midioutputmap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midiport_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_midiport_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_navigationpreloadmanager_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_navigationpreloadmanager_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_networkinformation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_networkinformation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_offscreenbuffering_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_offscreenbuffering_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_offscreencanvas_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_offscreencanvas_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_offscreencanvasrenderingcontext2d_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_offscreencanvasrenderingcontext2d_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_onappinstalled_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_onappinstalled_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_onbeforeinstallprompt_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_onbeforeinstallprompt_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_oncancel_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_oncancel_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_ondeviceorientationabsolute_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_ondeviceorientationabsolute_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_onmousewheel_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_onmousewheel_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_onsearch_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_onsearch_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_onselectionchange_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_onselectionchange_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_opendatabase_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_opendatabase_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_orientationsensor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_orientationsensor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_overconstrainederror_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_overconstrainederror_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_passwordcredential_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_passwordcredential_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentaddress_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentaddress_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentinstruments_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentinstruments_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentmanager_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentmanager_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentmethodchangeevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentmethodchangeevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentrequest_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentrequest_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentrequestupdateevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentrequestupdateevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentresponse_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_paymentresponse_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_performanceeventtiming_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_performanceeventtiming_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_performancelongtasktiming_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_performancelongtasktiming_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_performancepainttiming_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_performancepainttiming_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_photocapabilities_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_photocapabilities_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_pictureinpicturewindow_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_pictureinpicturewindow_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationavailability_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationavailability_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationconnection_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationconnection_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationconnectionavailableevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationconnectionavailableevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationconnectioncloseevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationconnectioncloseevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationconnectionlist_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationconnectionlist_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationreceiver_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationreceiver_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationrequest_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_presentationrequest_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_relativeorientationsensor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_relativeorientationsensor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_remoteplayback_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_remoteplayback_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_reportingobserver_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_reportingobserver_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_rtcdtlstransport_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_rtcdtlstransport_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_rtcerror_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_rtcerror_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_rtcerrorevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_rtcerrorevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_rtcicetransport_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_rtcicetransport_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_rtcsctptransport_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_rtcsctptransport_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_sensor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_sensor_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_sensorerrorevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_sensorerrorevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_sharedarraybuffer_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_sharedarraybuffer_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_sidebar_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_sidebar_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_sidebar_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_sidebar_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_stylemedia_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_stylemedia_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_stylepropertymap_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_stylepropertymap_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_stylepropertymapreadonly_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_stylepropertymapreadonly_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_svgdiscardelement_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_svgdiscardelement_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_syncmanager_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_syncmanager_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_taskattributiontiming_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_taskattributiontiming_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_textdecoderstream_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_textdecoderstream_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_textencoderstream_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_textencoderstream_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_textevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_textevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_touch_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_touch_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_touchevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_touchevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_touchlist_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_touchlist_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_transformstream_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_transformstream_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usb_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usb_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbalternateinterface_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbalternateinterface_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbconfiguration_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbconfiguration_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbconnectionevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbconnectionevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbdevice_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbdevice_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbendpoint_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbendpoint_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbinterface_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbinterface_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbintransferresult_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbintransferresult_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbisochronousintransferpacket_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbisochronousintransferpacket_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbisochronousintransferresult_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbisochronousintransferresult_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbisochronousouttransferpacket_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbisochronousouttransferpacket_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbisochronousouttransferresult_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbisochronousouttransferresult_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbouttransferresult_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_usbouttransferresult_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_useractivation_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_useractivation_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_visualviewport_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_visualviewport_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitcancelanimationframe_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitcancelanimationframe_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitmediastream_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitmediastream_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitmutationobserver_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitmutationobserver_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitrequestanimationframe_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitrequestanimationframe_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitrequestfilesystem_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitrequestfilesystem_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitresolvelocalfilesystemurl_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitresolvelocalfilesystemurl_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitrtcpeerconnection_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitrtcpeerconnection_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitspeechgrammar_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitspeechgrammar_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitspeechgrammarlist_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitspeechgrammarlist_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitspeechrecognition_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitspeechrecognition_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitspeechrecognitionerror_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitspeechrecognitionerror_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitspeechrecognitionevent_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitspeechrecognitionevent_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitstorageinfo_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_webkitstorageinfo_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_worklet_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_worklet_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_writablestream_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_window_writablestream_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_windowopenemptyurl_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_windowopenemptyurl_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_wrfilterfallback_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_wrfilterfallback_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_xmldocument_async_getter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_xmldocument_async_getter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_xmldocument_async_setter_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_xmldocument_async_setter_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_xslstylesheet_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_xslstylesheet_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_xsltprocessor_constructor_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_xsltprocessor_constructor_page
+      type: STRING
+      mode: NULLABLE
+  - name: processes
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: content
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: histograms
+        type: RECORD
+        mode: NULLABLE
+        fields:
+        - name: use_counter2_appearance_nonwidget_button_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_button_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_checkbox_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_checkbox_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_innerspinbutton_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_innerspinbutton_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_listbox_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_listbox_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_menulist_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_menulist_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_menulistbutton_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_menulistbutton_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_meter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_meter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_numberinput_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_numberinput_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_progressbar_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_progressbar_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_progressbarvertical_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_progressbarvertical_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_radio_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_radio_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_range_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_range_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_rangethumb_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_rangethumb_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalehorizontal_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalehorizontal_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalethumbend_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalethumbend_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalethumbhorizontal_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalethumbhorizontal_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalethumbstart_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalethumbstart_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalethumbtick_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalethumbtick_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalethumbvertical_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalethumbvertical_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalevertical_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scalevertical_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scrollbarthumbhorizontal_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scrollbarthumbhorizontal_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scrollbarthumbvertical_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scrollbarthumbvertical_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scrollbartrackhorizontal_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scrollbartrackhorizontal_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scrollbartrackvertical_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_scrollbartrackvertical_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_searchfield_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_searchfield_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_textarea_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_textarea_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_textfield_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_nonwidget_textfield_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_overridden_numberinput_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_overridden_numberinput_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_overridden_range_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_overridden_range_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_button_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_button_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_checkbox_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_checkbox_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_innerspinbutton_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_innerspinbutton_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_listbox_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_listbox_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_menulist_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_menulist_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_menulistbutton_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_menulistbutton_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_meter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_meter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_numberinput_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_numberinput_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_progressbar_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_progressbar_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_progressbarvertical_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_progressbarvertical_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_radio_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_radio_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_range_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_range_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_rangethumb_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_rangethumb_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalehorizontal_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalehorizontal_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalethumbend_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalethumbend_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalethumbhorizontal_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalethumbhorizontal_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalethumbstart_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalethumbstart_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalethumbtick_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalethumbtick_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalethumbvertical_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalethumbvertical_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalevertical_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scalevertical_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scrollbarthumbhorizontal_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scrollbarthumbhorizontal_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scrollbarthumbvertical_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scrollbarthumbvertical_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scrollbartrackhorizontal_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scrollbartrackhorizontal_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scrollbartrackvertical_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_scrollbartrackvertical_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_searchfield_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_searchfield_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_textarea_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_textarea_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_textfield_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_appearance_widget_textfield_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_assert_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_assert_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_clear_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_clear_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_count_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_count_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_countreset_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_countreset_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_debug_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_debug_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_dir_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_dir_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_dirxml_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_dirxml_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_error_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_error_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_exception_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_exception_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_group_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_group_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_groupcollapsed_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_groupcollapsed_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_groupend_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_groupend_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_info_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_info_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_log_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_log_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_profile_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_profile_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_profileend_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_profileend_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_table_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_table_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_time_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_time_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_timeend_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_timeend_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_timelog_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_timelog_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_timestamp_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_timestamp_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_trace_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_trace_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_warn_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_console_warn_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_contenturlonimagecontent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_contenturlonimagecontent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_accent_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_accent_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_align_content_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_align_content_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_align_items_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_align_items_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_align_self_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_align_self_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_align_tracks_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_align_tracks_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_alignment_baseline_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_alignment_baseline_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_all_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_all_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_composition_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_composition_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_delay_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_delay_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_direction_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_direction_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_duration_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_duration_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_fill_mode_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_fill_mode_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_iteration_count_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_iteration_count_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_name_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_name_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_play_state_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_play_state_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_timing_function_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_animation_timing_function_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_appearance_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_appearance_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_aspect_ratio_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_aspect_ratio_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_backdrop_filter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_backdrop_filter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_backface_visibility_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_backface_visibility_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_attachment_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_attachment_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_blend_mode_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_blend_mode_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_clip_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_clip_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_image_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_image_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_origin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_origin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_position_x_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_position_x_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_position_y_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_position_y_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_repeat_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_repeat_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_repeat_x_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_repeat_x_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_repeat_y_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_repeat_y_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_background_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_baseline_shift_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_baseline_shift_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_baseline_source_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_baseline_source_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_block_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_block_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_end_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_end_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_end_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_end_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_end_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_end_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_start_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_start_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_start_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_start_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_start_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_start_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_block_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_left_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_left_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_right_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_right_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_bottom_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_collapse_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_collapse_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_end_end_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_end_end_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_end_start_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_end_start_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_outset_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_outset_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_repeat_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_repeat_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_slice_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_slice_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_source_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_source_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_image_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_end_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_end_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_end_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_end_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_end_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_end_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_start_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_start_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_start_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_start_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_start_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_start_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_inline_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_left_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_left_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_left_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_left_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_left_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_left_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_left_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_left_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_right_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_right_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_right_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_right_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_right_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_right_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_right_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_right_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_spacing_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_spacing_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_start_end_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_start_end_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_start_start_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_start_start_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_left_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_left_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_right_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_right_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_top_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_border_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_bottom_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_bottom_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_box_decoration_break_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_box_decoration_break_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_box_shadow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_box_shadow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_box_sizing_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_box_sizing_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_break_after_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_break_after_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_break_before_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_break_before_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_break_inside_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_break_inside_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_buffered_rendering_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_buffered_rendering_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_caption_side_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_caption_side_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_caret_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_caret_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_clear_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_clear_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_clip_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_clip_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_clip_path_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_clip_path_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_clip_rule_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_clip_rule_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_adjust_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_adjust_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_interpolation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_interpolation_filters_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_interpolation_filters_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_interpolation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_rendering_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_rendering_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_scheme_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_color_scheme_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_count_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_count_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_fill_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_fill_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_gap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_gap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_rule_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_rule_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_rule_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_rule_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_rule_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_rule_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_rule_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_rule_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_span_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_span_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_column_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_columns_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_columns_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_intrinsic_block_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_intrinsic_block_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_intrinsic_height_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_intrinsic_height_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_intrinsic_inline_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_intrinsic_inline_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_intrinsic_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_intrinsic_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_intrinsic_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_intrinsic_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_contain_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_container_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_container_name_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_container_name_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_container_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_container_type_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_container_type_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_content_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_content_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_content_visibility_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_content_visibility_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_counter_increment_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_counter_increment_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_counter_reset_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_counter_reset_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_counter_set_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_counter_set_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_cursor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_cursor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_cx_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_cx_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_cy_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_cy_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_d_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_d_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_direction_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_direction_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_display_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_display_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_dominant_baseline_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_dominant_baseline_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_empty_cells_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_empty_cells_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_fill_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_fill_opacity_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_fill_opacity_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_fill_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_fill_rule_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_fill_rule_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_filter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_filter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_basis_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_basis_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_direction_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_direction_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_flow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_flow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_grow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_grow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_shrink_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_shrink_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_wrap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flex_wrap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_float_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_float_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flood_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flood_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flood_opacity_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_flood_opacity_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_family_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_family_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_feature_settings_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_feature_settings_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_kerning_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_kerning_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_language_override_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_language_override_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_optical_sizing_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_optical_sizing_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_palette_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_palette_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_size_adjust_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_size_adjust_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_stretch_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_stretch_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_synthesis_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_synthesis_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_synthesis_small_caps_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_synthesis_small_caps_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_synthesis_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_synthesis_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_synthesis_weight_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_synthesis_weight_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_alternates_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_alternates_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_caps_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_caps_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_east_asian_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_east_asian_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_emoji_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_emoji_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_ligatures_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_ligatures_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_numeric_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_numeric_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variant_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variation_settings_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_variation_settings_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_weight_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_font_weight_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_forced_color_adjust_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_forced_color_adjust_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_gap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_gap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_area_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_area_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_auto_columns_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_auto_columns_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_auto_flow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_auto_flow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_auto_rows_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_auto_rows_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_column_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_column_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_column_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_column_gap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_column_gap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_column_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_column_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_column_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_gap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_gap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_row_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_row_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_row_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_row_gap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_row_gap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_row_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_row_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_row_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_template_areas_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_template_areas_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_template_columns_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_template_columns_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_template_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_template_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_template_rows_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_grid_template_rows_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_height_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_height_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_hyphenate_character_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_hyphenate_character_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_hyphens_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_hyphens_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_image_orientation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_image_orientation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_image_rendering_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_image_rendering_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_ime_mode_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_ime_mode_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inline_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inline_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_block_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_block_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_block_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_block_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_block_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_block_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_inline_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_inline_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_inline_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_inline_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_inline_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_inline_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_inset_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_isolation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_isolation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_justify_content_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_justify_content_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_justify_items_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_justify_items_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_justify_self_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_justify_self_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_justify_tracks_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_justify_tracks_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_left_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_left_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_letter_spacing_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_letter_spacing_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_lighting_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_lighting_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_line_break_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_line_break_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_line_height_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_line_height_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_list_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_list_style_image_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_list_style_image_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_list_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_list_style_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_list_style_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_list_style_type_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_list_style_type_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_block_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_block_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_block_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_block_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_block_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_block_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_bottom_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_bottom_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_inline_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_inline_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_inline_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_inline_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_inline_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_inline_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_left_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_left_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_right_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_right_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_top_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_margin_top_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_marker_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_marker_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_marker_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_marker_mid_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_marker_mid_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_marker_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_marker_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_marker_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_clip_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_clip_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_composite_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_composite_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_image_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_image_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_mode_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_mode_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_origin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_origin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_position_x_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_position_x_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_position_y_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_position_y_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_repeat_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_repeat_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_type_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mask_type_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_masonry_auto_flow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_masonry_auto_flow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_math_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_math_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_max_block_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_max_block_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_max_height_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_max_height_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_max_inline_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_max_inline_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_max_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_max_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_max_zoom_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_max_zoom_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_min_block_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_min_block_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_min_height_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_min_height_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_min_inline_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_min_inline_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_min_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_min_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_min_zoom_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_min_zoom_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mix_blend_mode_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_mix_blend_mode_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_delay_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_delay_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_direction_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_direction_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_duration_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_duration_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_fill_mode_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_fill_mode_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_iteration_count_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_iteration_count_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_name_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_name_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_play_state_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_play_state_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_timing_function_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_animation_timing_function_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_appearance_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_appearance_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_backface_visibility_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_backface_visibility_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_end_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_end_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_end_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_end_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_end_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_end_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_image_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_image_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_start_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_start_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_start_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_start_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_start_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_border_start_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_align_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_align_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_direction_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_direction_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_flex_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_flex_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_ordinal_group_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_ordinal_group_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_orient_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_orient_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_pack_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_pack_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_sizing_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_box_sizing_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_count_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_count_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_fill_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_fill_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_gap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_gap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_rule_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_rule_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_rule_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_rule_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_rule_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_rule_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_rule_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_rule_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_span_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_span_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_column_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_columns_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_columns_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_context_properties_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_context_properties_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_control_character_visibility_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_control_character_visibility_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_float_edge_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_float_edge_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_font_feature_settings_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_font_feature_settings_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_font_language_override_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_font_language_override_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_force_broken_image_icon_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_force_broken_image_icon_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_hyphens_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_hyphens_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_image_region_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_image_region_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_margin_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_margin_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_margin_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_margin_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_orient_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_orient_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_outline_radius_bottomleft_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_outline_radius_bottomleft_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_outline_radius_bottomright_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_outline_radius_bottomright_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_outline_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_outline_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_outline_radius_topleft_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_outline_radius_topleft_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_outline_radius_topright_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_outline_radius_topright_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_padding_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_padding_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_padding_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_padding_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_perspective_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_perspective_origin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_perspective_origin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_perspective_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_stack_sizing_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_stack_sizing_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_tab_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_tab_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_text_size_adjust_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_text_size_adjust_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transform_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transform_origin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transform_origin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transform_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transform_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transform_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transition_delay_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transition_delay_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transition_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transition_duration_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transition_duration_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transition_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transition_property_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transition_property_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transition_timing_function_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_transition_timing_function_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_user_focus_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_user_focus_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_user_input_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_user_input_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_user_modify_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_user_modify_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_user_select_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_user_select_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_window_dragging_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_moz_window_dragging_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_object_fit_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_object_fit_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_object_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_object_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_anchor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_anchor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_distance_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_distance_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_path_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_path_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_rotate_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_offset_rotate_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_opacity_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_opacity_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_order_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_order_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_orientation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_orientation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_orphans_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_orphans_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_outline_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_outline_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_outline_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_outline_offset_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_outline_offset_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_outline_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_outline_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_outline_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_outline_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_outline_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_anchor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_anchor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_block_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_block_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_clip_margin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_clip_margin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_inline_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_inline_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_wrap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_wrap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_x_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_x_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_y_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overflow_y_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overscroll_behavior_block_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overscroll_behavior_block_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overscroll_behavior_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overscroll_behavior_inline_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overscroll_behavior_inline_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overscroll_behavior_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overscroll_behavior_x_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overscroll_behavior_x_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overscroll_behavior_y_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_overscroll_behavior_y_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_block_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_block_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_block_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_block_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_block_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_block_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_bottom_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_bottom_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_inline_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_inline_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_inline_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_inline_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_inline_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_inline_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_left_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_left_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_right_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_right_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_top_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_padding_top_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_page_break_after_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_page_break_after_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_page_break_before_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_page_break_before_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_page_break_inside_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_page_break_inside_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_page_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_page_orientation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_page_orientation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_page_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_paint_order_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_paint_order_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_perspective_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_perspective_origin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_perspective_origin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_perspective_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_place_content_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_place_content_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_place_items_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_place_items_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_place_self_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_place_self_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_pointer_events_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_pointer_events_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_print_color_adjust_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_print_color_adjust_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_quotes_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_quotes_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_r_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_r_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_resize_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_resize_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_right_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_right_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_rotate_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_rotate_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_row_gap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_row_gap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_ruby_align_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_ruby_align_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_ruby_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_ruby_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_rx_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_rx_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_ry_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_ry_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scale_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scale_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_behavior_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_behavior_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_block_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_block_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_block_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_block_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_block_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_block_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_bottom_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_bottom_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_inline_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_inline_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_inline_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_inline_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_inline_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_inline_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_left_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_left_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_right_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_right_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_top_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_margin_top_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_block_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_block_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_block_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_block_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_block_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_block_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_bottom_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_bottom_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_inline_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_inline_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_inline_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_inline_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_inline_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_inline_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_left_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_left_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_right_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_right_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_top_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_padding_top_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_snap_align_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_snap_align_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_snap_stop_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_snap_stop_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_snap_type_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scroll_snap_type_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scrollbar_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scrollbar_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scrollbar_gutter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scrollbar_gutter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scrollbar_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_scrollbar_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_shape_image_threshold_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_shape_image_threshold_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_shape_margin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_shape_margin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_shape_outside_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_shape_outside_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_shape_rendering_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_shape_rendering_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_speak_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_speak_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stop_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stop_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stop_opacity_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stop_opacity_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_dasharray_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_dasharray_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_dashoffset_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_dashoffset_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_linecap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_linecap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_linejoin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_linejoin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_miterlimit_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_miterlimit_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_opacity_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_opacity_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_stroke_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_tab_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_tab_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_table_layout_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_table_layout_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_align_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_align_last_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_align_last_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_align_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_anchor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_anchor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_combine_upright_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_combine_upright_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_line_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_line_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_skip_ink_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_skip_ink_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_thickness_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_decoration_thickness_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_emphasis_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_emphasis_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_emphasis_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_emphasis_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_emphasis_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_emphasis_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_emphasis_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_emphasis_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_indent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_indent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_justify_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_justify_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_orientation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_orientation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_overflow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_overflow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_rendering_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_rendering_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_shadow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_shadow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_size_adjust_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_size_adjust_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_transform_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_transform_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_underline_offset_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_underline_offset_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_underline_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_text_underline_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_top_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_top_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_touch_action_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_touch_action_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transform_box_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transform_box_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transform_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transform_origin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transform_origin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transform_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transform_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transform_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transition_delay_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transition_delay_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transition_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transition_duration_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transition_duration_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transition_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transition_property_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transition_property_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transition_timing_function_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_transition_timing_function_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_translate_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_translate_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_unicode_bidi_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_unicode_bidi_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_user_select_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_user_select_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_user_zoom_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_user_zoom_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_vector_effect_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_vector_effect_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_vertical_align_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_vertical_align_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_visibility_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_visibility_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_align_content_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_align_content_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_align_items_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_align_items_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_align_self_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_align_self_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_delay_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_delay_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_direction_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_direction_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_duration_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_duration_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_fill_mode_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_fill_mode_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_iteration_count_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_iteration_count_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_name_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_name_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_play_state_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_play_state_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_timing_function_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_animation_timing_function_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_app_region_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_app_region_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_appearance_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_appearance_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_backface_visibility_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_backface_visibility_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_background_clip_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_background_clip_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_background_origin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_background_origin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_background_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_background_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_after_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_after_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_after_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_after_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_after_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_after_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_after_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_after_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_before_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_before_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_before_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_before_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_before_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_before_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_before_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_before_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_bottom_left_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_bottom_left_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_bottom_right_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_bottom_right_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_end_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_end_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_end_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_end_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_end_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_end_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_horizontal_spacing_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_horizontal_spacing_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_image_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_image_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_start_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_start_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_start_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_start_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_start_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_start_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_top_left_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_top_left_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_top_right_radius_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_top_right_radius_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_vertical_spacing_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_border_vertical_spacing_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_align_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_align_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_decoration_break_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_decoration_break_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_direction_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_direction_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_flex_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_flex_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_ordinal_group_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_ordinal_group_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_orient_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_orient_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_pack_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_pack_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_reflect_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_reflect_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_shadow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_shadow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_sizing_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_box_sizing_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_clip_path_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_clip_path_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_break_after_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_break_after_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_break_before_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_break_before_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_break_inside_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_break_inside_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_count_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_count_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_gap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_gap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_rule_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_rule_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_rule_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_rule_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_rule_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_rule_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_rule_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_rule_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_span_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_span_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_column_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_columns_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_columns_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_filter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_filter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_basis_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_basis_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_direction_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_direction_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_flow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_flow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_grow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_grow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_shrink_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_shrink_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_wrap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_flex_wrap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_font_feature_settings_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_font_feature_settings_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_font_size_delta_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_font_size_delta_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_font_smoothing_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_font_smoothing_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_highlight_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_highlight_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_hyphenate_character_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_hyphenate_character_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_justify_content_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_justify_content_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_line_break_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_line_break_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_line_clamp_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_line_clamp_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_locale_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_locale_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_logical_height_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_logical_height_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_logical_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_logical_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_after_collapse_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_after_collapse_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_after_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_after_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_before_collapse_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_before_collapse_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_before_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_before_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_bottom_collapse_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_bottom_collapse_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_collapse_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_collapse_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_top_collapse_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_margin_top_collapse_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_outset_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_outset_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_repeat_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_repeat_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_slice_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_slice_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_source_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_source_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_box_image_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_clip_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_clip_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_composite_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_composite_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_image_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_image_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_origin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_origin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_position_x_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_position_x_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_position_y_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_position_y_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_repeat_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_repeat_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_repeat_x_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_repeat_x_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_repeat_y_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_repeat_y_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_size_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_mask_size_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_max_logical_height_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_max_logical_height_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_max_logical_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_max_logical_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_min_logical_height_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_min_logical_height_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_min_logical_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_min_logical_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_opacity_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_opacity_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_order_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_order_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_padding_after_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_padding_after_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_padding_before_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_padding_before_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_padding_end_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_padding_end_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_padding_start_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_padding_start_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_perspective_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_perspective_origin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_perspective_origin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_perspective_origin_x_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_perspective_origin_x_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_perspective_origin_y_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_perspective_origin_y_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_perspective_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_print_color_adjust_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_print_color_adjust_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_rtl_ordering_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_rtl_ordering_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_ruby_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_ruby_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_shape_image_threshold_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_shape_image_threshold_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_shape_margin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_shape_margin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_shape_outside_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_shape_outside_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_tap_highlight_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_tap_highlight_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_combine_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_combine_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_decorations_in_effect_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_decorations_in_effect_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_emphasis_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_emphasis_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_emphasis_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_emphasis_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_emphasis_position_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_emphasis_position_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_emphasis_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_emphasis_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_fill_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_fill_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_orientation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_orientation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_security_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_security_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_size_adjust_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_size_adjust_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_stroke_color_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_stroke_color_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_stroke_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_stroke_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_stroke_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_text_stroke_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_origin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_origin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_origin_x_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_origin_x_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_origin_y_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_origin_y_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_origin_z_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_origin_z_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transform_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transition_delay_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transition_delay_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transition_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transition_duration_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transition_duration_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transition_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transition_property_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transition_property_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transition_timing_function_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_transition_timing_function_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_user_drag_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_user_drag_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_user_modify_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_user_modify_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_user_select_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_user_select_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_writing_mode_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_webkit_writing_mode_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_white_space_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_white_space_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_widows_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_widows_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_width_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_width_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_will_change_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_will_change_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_word_break_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_word_break_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_word_spacing_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_word_spacing_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_word_wrap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_word_wrap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_writing_mode_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_writing_mode_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_x_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_x_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_y_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_y_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_z_index_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_z_index_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_zoom_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_zoom_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_customelementregistry_define_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_customelementregistry_define_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_customizedbuiltin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_customizedbuiltin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_addelement_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_addelement_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozcleardataat_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozcleardataat_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozcursor_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozcursor_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozcursor_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozcursor_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozgetdataat_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozgetdataat_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozitemcount_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozitemcount_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozitemcount_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozitemcount_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozsetdataat_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozsetdataat_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozsourcenode_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozsourcenode_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozsourcenode_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozsourcenode_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_moztypesat_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_moztypesat_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozusercancelled_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozusercancelled_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozusercancelled_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_datatransfer_mozusercancelled_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_ambient_light_event_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_ambient_light_event_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_app_cache_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_app_cache_insecure_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_app_cache_insecure_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_app_cache_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_chrome_use_of_dom3_load_method_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_chrome_use_of_dom3_load_method_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_components_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_components_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_create_attribute_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_create_attribute_ns_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_create_attribute_ns_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_create_attribute_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_create_image_bitmap_canvas_rendering_context2_d_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_create_image_bitmap_canvas_rendering_context2_d_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_data_container_event_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_data_container_event_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_deprecated_testing_attribute_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_deprecated_testing_attribute_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_deprecated_testing_interface_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_deprecated_testing_interface_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_deprecated_testing_method_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_deprecated_testing_method_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_document_release_capture_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_document_release_capture_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_dom_attr_modified_event_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_dom_attr_modified_event_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_dom_exception_code_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_dom_exception_code_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_dom_quad_bounds_attr_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_dom_quad_bounds_attr_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_draw_window_canvas_rendering_context2_d_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_draw_window_canvas_rendering_context2_d_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_element_release_capture_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_element_release_capture_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_element_set_capture_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_element_set_capture_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_enable_privilege_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_enable_privilege_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_external_add_search_provider_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_external_add_search_provider_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_file_last_modified_date_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_file_last_modified_date_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_form_submission_untrusted_event_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_form_submission_untrusted_event_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_get_attribute_node_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_get_attribute_node_ns_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_get_attribute_node_ns_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_get_attribute_node_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_get_prevent_default_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_get_prevent_default_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_get_property_css_value_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_get_property_css_value_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_get_set_user_data_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_get_set_user_data_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_idb_database_create_mutable_file_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_idb_database_create_mutable_file_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_idb_mutable_file_open_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_idb_mutable_file_open_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_idb_open_db_options_storage_type_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_idb_open_db_options_storage_type_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_image_bitmap_rendering_context_transfer_image_bitmap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_image_bitmap_rendering_context_transfer_image_bitmap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_import_xul_into_content_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_import_xul_into_content_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_input_encoding_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_input_encoding_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_install_trigger_deprecated_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_install_trigger_deprecated_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_install_trigger_install_deprecated_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_install_trigger_install_deprecated_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_lenient_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_lenient_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_lenient_this_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_lenient_this_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_alignment_attributes_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_alignment_attributes_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_bevelled_attribute_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_bevelled_attribute_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_line_thickness_value_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_line_thickness_value_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_math_size_value_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_math_size_value_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_math_space_value_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_math_space_value_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_menclose_notation_radical_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_menclose_notation_radical_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_mfenced_element_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_mfenced_element_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_script_shift_attributes_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_script_shift_attributes_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_scriptminsize_attribute_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_scriptminsize_attribute_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_scriptsizemultiplier_attribute_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_scriptsizemultiplier_attribute_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_stixgeneral_operator_stretching_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_stixgeneral_operator_stretching_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_style_attribute_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_style_attribute_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_x_link_attribute_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_x_link_attribute_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_mixed_display_object_subrequest_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_mixed_display_object_subrequest_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_motion_event_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_motion_event_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_mouse_event_moz_pressure_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_mouse_event_moz_pressure_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_before_paint_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_before_paint_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_box_or_inline_box_display_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_box_or_inline_box_display_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_current_transform_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_current_transform_inverse_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_current_transform_inverse_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_current_transform_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_get_as_file_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_get_as_file_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_preserves_pitch_deprecated_prefix_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_preserves_pitch_deprecated_prefix_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_request_full_screen_deprecated_prefix_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_request_full_screen_deprecated_prefix_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_text_style_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_text_style_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_mozfullscreenchange_deprecated_prefix_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_mozfullscreenchange_deprecated_prefix_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_mozfullscreenerror_deprecated_prefix_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_mozfullscreenerror_deprecated_prefix_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_mutation_event_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_mutation_event_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_navigator_battery_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_navigator_battery_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_navigator_get_user_media_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_navigator_get_user_media_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_no_exposed_props_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_no_exposed_props_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_node_iterator_detach_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_node_iterator_detach_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_node_value_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_node_value_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_offscreen_canvas_to_blob_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_offscreen_canvas_to_blob_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_orientation_event_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_orientation_event_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_owner_element_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_owner_element_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_panner_node_doppler_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_panner_node_doppler_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_prefixed_fullscreen_api_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_prefixed_fullscreen_api_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_prefixed_image_smoothing_enabled_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_prefixed_image_smoothing_enabled_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_prefixed_visibility_api_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_prefixed_visibility_api_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_proximity_event_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_proximity_event_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_register_protocol_handler_insecure_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_register_protocol_handler_insecure_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_remove_attribute_node_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_remove_attribute_node_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_rtc_peer_connection_get_streams_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_rtc_peer_connection_get_streams_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_send_as_binary_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_send_as_binary_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_set_attribute_node_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_set_attribute_node_ns_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_set_attribute_node_ns_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_set_attribute_node_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_show_modal_dialog_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_show_modal_dialog_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_svg_farthest_viewport_element_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_svg_farthest_viewport_element_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_svg_nearest_viewport_element_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_svg_nearest_viewport_element_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_sync_xml_http_request_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_sync_xml_http_request_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_text_content_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_text_content_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_u2f_register_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_u2f_register_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_u2f_sign_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_u2f_sign_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_url_create_object_url_media_stream_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_url_create_object_url_media_stream_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_use_of_capture_events_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_use_of_capture_events_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_use_of_dom3_load_method_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_use_of_dom3_load_method_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_use_of_release_events_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_use_of_release_events_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_webrtc_deprecated_prefix_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_webrtc_deprecated_prefix_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_window_cc_ontrollers_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_window_cc_ontrollers_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_window_content_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_window_content_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_window_content_untrusted_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_window_content_untrusted_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_window_controllers_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_window_controllers_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_xml_base_attribute_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_xml_base_attribute_for_style_attr_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_xml_base_attribute_for_style_attr_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_xml_base_attribute_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_xml_base_attribute_with_styled_element_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_xml_base_attribute_with_styled_element_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_document_mozsetimageelement_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_document_mozsetimageelement_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentexeccommandcontentreadonly_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentexeccommandcontentreadonly_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentexeccommanddecreasefontsize_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentexeccommanddecreasefontsize_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentexeccommandheading_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentexeccommandheading_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentexeccommandincreasefontsize_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentexeccommandincreasefontsize_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentexeccommandreadonly_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentexeccommandreadonly_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentopen_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentopen_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentopenreplace_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentopenreplace_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandstateorvaluecontentreadonly_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandstateorvaluecontentreadonly_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandstateorvaluegethtml_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandstateorvaluegethtml_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandstateorvalueheading_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandstateorvalueheading_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandstateorvalueinsertbronreturn_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandstateorvalueinsertbronreturn_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandstateorvaluereadonly_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandstateorvaluereadonly_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledcontentreadonly_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledcontentreadonly_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenableddecreasefontsize_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenableddecreasefontsize_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledgethtml_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledgethtml_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledheading_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledheading_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledincreasefontsize_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledincreasefontsize_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledinsertbronreturn_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledinsertbronreturn_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledreadonly_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_documentquerycommandsupportedorenabledreadonly_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domerror_message_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domerror_message_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domerror_message_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domerror_message_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domerror_name_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domerror_name_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domerror_name_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domerror_name_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domerrorconstructor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domerrorconstructor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domparser_parsefromstring_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_domparser_parsefromstring_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_attachshadow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_attachshadow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_releasecapture_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_releasecapture_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_releasepointercapture_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_releasepointercapture_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_setcapture_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_setcapture_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_sethtml_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_sethtml_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_setpointercapture_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_element_setpointercapture_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_enumeratedevicesinsec_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_enumeratedevicesinsec_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_enumeratedevicesunfocused_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_enumeratedevicesunfocused_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_external_addsearchengine_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_external_addsearchengine_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_external_addsearchprovider_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_external_addsearchprovider_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feblend_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feblend_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fecolormatrix_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fecolormatrix_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fecomponenttransfer_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fecomponenttransfer_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fecomposite_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fecomposite_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feconvolvematrix_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feconvolvematrix_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fediffuselighting_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fediffuselighting_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fedisplacementmap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fedisplacementmap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feflood_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feflood_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fegaussianblur_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fegaussianblur_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feimage_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feimage_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_femerge_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_femerge_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_femorphology_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_femorphology_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feoffset_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feoffset_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fespecularlighting_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fespecularlighting_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fetile_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_fetile_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feturbulence_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_feturbulence_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_filteredcrossoriginiframe_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_filteredcrossoriginiframe_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_getdisplaymediaxorigin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_getdisplaymediaxorigin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_getusermediainsec_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_getusermediainsec_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_getusermediaunfocused_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_getusermediaunfocused_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_getusermediaxorigin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_getusermediaxorigin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_adoptedstylesheets_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_adoptedstylesheets_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_caretrangefrompoint_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_caretrangefrompoint_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_clear_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_clear_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_exitpictureinpicture_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_exitpictureinpicture_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_featurepolicy_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_featurepolicy_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onbeforecopy_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onbeforecopy_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onbeforecut_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onbeforecut_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onbeforepaste_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onbeforepaste_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_oncancel_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_oncancel_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onfreeze_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onfreeze_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onmousewheel_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onmousewheel_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onresume_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onresume_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onsearch_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onsearch_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onsecuritypolicyviolation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onsecuritypolicyviolation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onwebkitfullscreenchange_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onwebkitfullscreenchange_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onwebkitfullscreenerror_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_onwebkitfullscreenerror_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_pictureinpictureelement_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_pictureinpictureelement_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_pictureinpictureenabled_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_pictureinpictureenabled_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_registerelement_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_registerelement_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_wasdiscarded_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_wasdiscarded_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitcancelfullscreen_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitcancelfullscreen_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitcurrentfullscreenelement_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitcurrentfullscreenelement_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitexitfullscreen_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitexitfullscreen_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitfullscreenelement_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitfullscreenelement_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitfullscreenenabled_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitfullscreenenabled_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkithidden_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkithidden_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitisfullscreen_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitisfullscreen_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitvisibilitystate_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_webkitvisibilitystate_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_xmlencoding_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_xmlencoding_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_xmlstandalone_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_xmlstandalone_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_xmlversion_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocument_xmlversion_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocumentnamedgetterhit_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_htmldocumentnamedgetterhit_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_idbdatabase_createmutablefile_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_idbdatabase_createmutablefile_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_idbdatabase_mozcreatefilehandle_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_idbdatabase_mozcreatefilehandle_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_idbmutablefile_getfile_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_idbmutablefile_getfile_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_idbmutablefile_open_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_idbmutablefile_open_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_js_asmjs_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_js_asmjs_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_js_wasm_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_js_wasm_duplicate_imports_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_js_wasm_duplicate_imports_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_js_wasm_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_mediadevices_enumeratedevices_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_mediadevices_enumeratedevices_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_mediadevices_getdisplaymedia_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_mediadevices_getdisplaymedia_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_mediadevices_getusermedia_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_mediadevices_getusermedia_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_mozgetusermediainsec_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_mozgetusermediainsec_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_mozgetusermediaxorigin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_mozgetusermediaxorigin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_navigator_mozgetusermedia_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_navigator_mozgetusermedia_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_no_data_url_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_no_data_url_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_oncached_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_oncached_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_oncached_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_oncached_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onchecking_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onchecking_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onchecking_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onchecking_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_ondownloading_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_ondownloading_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_ondownloading_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_ondownloading_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onerror_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onerror_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onerror_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onerror_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onnoupdate_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onnoupdate_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onnoupdate_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onnoupdate_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onobsolete_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onobsolete_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onobsolete_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onobsolete_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onprogress_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onprogress_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onprogress_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onprogress_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onupdateready_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onupdateready_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onupdateready_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_onupdateready_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_status_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_status_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_status_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_status_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_swapcache_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_swapcache_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_update_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_offlineresourcelist_update_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onbounce_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onbounce_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_ondommousescroll_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_ondommousescroll_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onfinish_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onfinish_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onmozmousepixelscroll_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onmozmousepixelscroll_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onoverflow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onoverflow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onstart_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onstart_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onunderflow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_onunderflow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_percentagestrokewidthinsvg_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_percentagestrokewidthinsvg_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_percentagestrokewidthinsvgtext_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_percentagestrokewidthinsvgtext_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingcachesdelete_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingcachesdelete_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingcacheshas_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingcacheshas_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingcacheskeys_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingcacheskeys_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingcachesmatch_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingcachesmatch_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingcachesopen_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingcachesopen_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingidbfactorydeletedatabase_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingidbfactorydeletedatabase_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingidbfactoryopen_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingidbfactoryopen_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingnavigatorserviceworker_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_privatebrowsingnavigatorserviceworker_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_property_fill_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_property_fill_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_property_fillopacity_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_property_fillopacity_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_pushmanager_subscribe_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_pushmanager_subscribe_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_pushsubscription_unsubscribe_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_pushsubscription_unsubscribe_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_range_createcontextualfragment_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_range_createcontextualfragment_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_sanitizer_constructor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_sanitizer_constructor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_sanitizer_sanitize_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_sanitizer_sanitize_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_sanitizer_sanitizefor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_sanitizer_sanitizefor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_scheduler_posttask_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_scheduler_posttask_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_svgsvgelement_currentscale_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_svgsvgelement_currentscale_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_svgsvgelement_currentscale_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_svgsvgelement_currentscale_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_svgsvgelement_getelementbyid_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_svgsvgelement_getelementbyid_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_absoluteorientationsensor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_absoluteorientationsensor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_accelerometer_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_accelerometer_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_applicationcache_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_applicationcache_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_applicationcacheerrorevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_applicationcacheerrorevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_atomics_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_atomics_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_audioparammap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_audioparammap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_audioworklet_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_audioworklet_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_audioworkletnode_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_audioworkletnode_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_backgroundfetchmanager_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_backgroundfetchmanager_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_backgroundfetchrecord_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_backgroundfetchrecord_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_backgroundfetchregistration_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_backgroundfetchregistration_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_beforeinstallpromptevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_beforeinstallpromptevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetooth_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetooth_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothcharacteristicproperties_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothcharacteristicproperties_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothdevice_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothdevice_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothremotegattcharacteristic_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothremotegattcharacteristic_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothremotegattdescriptor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothremotegattdescriptor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothremotegattserver_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothremotegattserver_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothremotegattservice_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothremotegattservice_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothuuid_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_bluetoothuuid_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_canvascapturemediastreamtrack_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_canvascapturemediastreamtrack_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_chrome_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_chrome_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_clientinformation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_clientinformation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_clipboarditem_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_clipboarditem_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssimagevalue_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssimagevalue_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_csskeywordvalue_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_csskeywordvalue_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathinvert_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathinvert_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathmax_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathmax_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathmin_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathmin_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathnegate_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathnegate_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathproduct_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathproduct_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathsum_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathsum_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathvalue_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmathvalue_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmatrixcomponent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssmatrixcomponent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssnumericarray_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssnumericarray_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssnumericvalue_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssnumericvalue_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssperspective_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssperspective_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_csspositionvalue_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_csspositionvalue_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssrotate_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssrotate_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssscale_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssscale_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssskew_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssskew_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssskewx_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssskewx_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssskewy_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssskewy_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssstylevalue_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssstylevalue_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_csstransformcomponent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_csstransformcomponent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_csstransformvalue_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_csstransformvalue_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_csstranslate_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_csstranslate_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssunitvalue_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssunitvalue_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssunparsedvalue_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssunparsedvalue_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssvariablereferencevalue_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_cssvariablereferencevalue_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_defaultstatus_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_defaultstatus_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_devicemotioneventacceleration_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_devicemotioneventacceleration_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_devicemotioneventrotationrate_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_devicemotioneventrotationrate_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_domerror_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_domerror_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_enterpictureinpictureevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_enterpictureinpictureevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_external_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_external_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_federatedcredential_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_federatedcredential_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_gyroscope_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_gyroscope_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_htmlcontentelement_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_htmlcontentelement_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_htmldialogelement_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_htmldialogelement_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_htmlshadowelement_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_htmlshadowelement_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_imagecapture_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_imagecapture_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_inputdevicecapabilities_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_inputdevicecapabilities_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_inputdeviceinfo_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_inputdeviceinfo_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_keyboard_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_keyboard_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_keyboardlayoutmap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_keyboardlayoutmap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_linearaccelerationsensor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_linearaccelerationsensor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_lock_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_lock_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_lockmanager_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_lockmanager_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_mediametadata_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_mediametadata_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_mediasession_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_mediasession_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_mediasettingsrange_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_mediasettingsrange_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midiaccess_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midiaccess_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midiconnectionevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midiconnectionevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midiinput_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midiinput_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midiinputmap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midiinputmap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midimessageevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midimessageevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midioutput_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midioutput_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midioutputmap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midioutputmap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midiport_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_midiport_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_navigationpreloadmanager_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_navigationpreloadmanager_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_networkinformation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_networkinformation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_offscreenbuffering_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_offscreenbuffering_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_offscreencanvas_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_offscreencanvas_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_offscreencanvasrenderingcontext2d_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_offscreencanvasrenderingcontext2d_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_onappinstalled_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_onappinstalled_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_onbeforeinstallprompt_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_onbeforeinstallprompt_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_oncancel_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_oncancel_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_ondeviceorientationabsolute_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_ondeviceorientationabsolute_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_onmousewheel_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_onmousewheel_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_onsearch_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_onsearch_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_onselectionchange_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_onselectionchange_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_opendatabase_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_opendatabase_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_orientationsensor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_orientationsensor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_overconstrainederror_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_overconstrainederror_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_passwordcredential_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_passwordcredential_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentaddress_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentaddress_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentinstruments_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentinstruments_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentmanager_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentmanager_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentmethodchangeevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentmethodchangeevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentrequest_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentrequest_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentrequestupdateevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentrequestupdateevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentresponse_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_paymentresponse_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_performanceeventtiming_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_performanceeventtiming_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_performancelongtasktiming_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_performancelongtasktiming_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_performancepainttiming_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_performancepainttiming_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_photocapabilities_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_photocapabilities_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_pictureinpicturewindow_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_pictureinpicturewindow_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationavailability_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationavailability_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationconnection_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationconnection_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationconnectionavailableevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationconnectionavailableevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationconnectioncloseevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationconnectioncloseevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationconnectionlist_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationconnectionlist_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationreceiver_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationreceiver_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationrequest_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_presentationrequest_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_relativeorientationsensor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_relativeorientationsensor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_remoteplayback_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_remoteplayback_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_reportingobserver_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_reportingobserver_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_rtcdtlstransport_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_rtcdtlstransport_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_rtcerror_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_rtcerror_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_rtcerrorevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_rtcerrorevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_rtcicetransport_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_rtcicetransport_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_rtcsctptransport_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_rtcsctptransport_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_sensor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_sensor_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_sensorerrorevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_sensorerrorevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_sharedarraybuffer_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_sharedarraybuffer_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_sidebar_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_sidebar_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_sidebar_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_sidebar_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_stylemedia_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_stylemedia_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_stylepropertymap_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_stylepropertymap_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_stylepropertymapreadonly_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_stylepropertymapreadonly_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_svgdiscardelement_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_svgdiscardelement_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_syncmanager_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_syncmanager_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_taskattributiontiming_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_taskattributiontiming_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_textdecoderstream_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_textdecoderstream_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_textencoderstream_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_textencoderstream_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_textevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_textevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_touch_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_touch_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_touchevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_touchevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_touchlist_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_touchlist_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_transformstream_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_transformstream_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usb_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usb_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbalternateinterface_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbalternateinterface_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbconfiguration_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbconfiguration_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbconnectionevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbconnectionevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbdevice_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbdevice_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbendpoint_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbendpoint_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbinterface_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbinterface_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbintransferresult_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbintransferresult_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbisochronousintransferpacket_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbisochronousintransferpacket_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbisochronousintransferresult_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbisochronousintransferresult_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbisochronousouttransferpacket_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbisochronousouttransferpacket_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbisochronousouttransferresult_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbisochronousouttransferresult_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbouttransferresult_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_usbouttransferresult_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_useractivation_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_useractivation_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_visualviewport_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_visualviewport_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitcancelanimationframe_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitcancelanimationframe_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitmediastream_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitmediastream_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitmutationobserver_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitmutationobserver_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitrequestanimationframe_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitrequestanimationframe_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitrequestfilesystem_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitrequestfilesystem_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitresolvelocalfilesystemurl_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitresolvelocalfilesystemurl_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitrtcpeerconnection_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitrtcpeerconnection_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitspeechgrammar_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitspeechgrammar_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitspeechgrammarlist_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitspeechgrammarlist_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitspeechrecognition_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitspeechrecognition_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitspeechrecognitionerror_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitspeechrecognitionerror_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitspeechrecognitionevent_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitspeechrecognitionevent_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitstorageinfo_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_webkitstorageinfo_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_worklet_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_worklet_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_writablestream_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_window_writablestream_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_windowopenemptyurl_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_windowopenemptyurl_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_wrfilterfallback_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_wrfilterfallback_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_xmldocument_async_getter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_xmldocument_async_getter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_xmldocument_async_setter_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_xmldocument_async_setter_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_xslstylesheet_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_xslstylesheet_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_xsltprocessor_constructor_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_xsltprocessor_constructor_page
+          type: STRING
+          mode: NULLABLE
+- name: sample_id
+  type: INTEGER
+  mode: NULLABLE
+- name: submission_timestamp
+  type: TIMESTAMP
+  mode: NULLABLE

--- a/sql_generators/feature_usage/templating.yaml
+++ b/sql_generators/feature_usage/templating.yaml
@@ -288,7 +288,7 @@ sources:
         type: INT64
   ### Main ###
   - name: main
-    ref: telemetry.main_1pct
+    ref: telemetry.main_remainder_1pct
     group_by: ["submission_date", "client_id"]
     filters:
       - sql: DATE(submission_timestamp) = @submission_date


### PR DESCRIPTION
See discussion in https://mozilla.slack.com/archives/C01E8GDG80N/p1688570552377059

We've reached the point where `main_1pct` can no longer be populated by querying `telemetry_stable.main_v4`. The best way going forward is to split `main_1pct` much like we have split `main_v4` (into separate tables for use counters and the rest of the data).

The `telemetry.main_1pct` view will point to `telemetry.main_remainder_1pct` for now. I'll check if there are any dashboards that query use counter data from the old view version (no scheduled queries are affected by this).

For backfilling the `main_remainder_1pct_v1` and `main_use_counter_1pct_v1` we'll use the existing data in `main_1pct_v1` and generate a query that excludes the columns that are no longer part of the new tables. The underlying tables `telemetry_stable.main_remainder_v1` and `telemetry_stable.main_use_counter_v1` only have data that goes back a few weeks, so they can't be used for backfilling.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1112)
