### PR TITLE
Override `--replace=true` from `.bigqueryrc` for `stripe_external.customers_changelog_v1` (DENG-974)

### DIFF
--- a/dags/bqetl_subplat.py
+++ b/dags/bqetl_subplat.py
@@ -739,7 +739,7 @@ with DAG(
         date_partition_parameter=None,
         depends_on_past=False,
         task_concurrency=1,
-        arguments=["--append_table"],
+        arguments=["--append_table", "--noreplace"],
     )
 
     stripe_external__invoice__v1 = bigquery_etl_query(

--- a/sql/moz-fx-data-shared-prod/stripe_external/customers_changelog_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/customers_changelog_v1/metadata.yaml
@@ -18,6 +18,7 @@ scheduling:
   date_partition_parameter: null
   arguments:
   - --append_table
+  - --noreplace
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## [DENG-974](https://mozilla-hub.atlassian.net/browse/DENG-974): Stripe subscriptions ETL v2

Fixup for #4035.

The goal was to append to the `stripe_external.customers_changelog_v1` table, but since [`.bigqueryrc` specifies `--replace=true`](https://github.com/mozilla/bigquery-etl/blob/91882dd150169f045cceac48b87ad0267ce81026/.bigqueryrc#L6) the table is getting erased each time.  This should fix that.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1145)


[DENG-974]: https://mozilla-hub.atlassian.net/browse/DENG-974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ