### PR TITLE
remove adjust view from skip list after fixing it

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -163,7 +163,6 @@ dry_run:
   - sql/moz-fx-data-shared-prod/messaging_system_derived/snippets_users_last_seen_v1/init.sql
   - sql/moz-fx-data-shared-prod/messaging_system_derived/whats_new_panel_users_last_seen_v1/init.sql
   # Reference table not found
-  - sql/moz-fx-data-shared-prod/adjust/adjust_kpi_deliverables/view.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/structured_detailed_error_counts_v1/view.sql
   - sql/moz-fx-data-shared-prod/monitoring/structured_detailed_error_counts/view.sql
   - sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/migrated_clients_v1/query.sql


### PR DESCRIPTION
This PR is a reminder to remove the adjust view from the skip list once the table is build
PR #4046 was adding it to the skip list to try to unblock the circleCI

Once the [Bug 1841267](https://bugzilla.mozilla.org/show_bug.cgi?id=1841267) is closed please merge this @Marlene-M-Hirose 

Don't merge this just yet!

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1154)
