### PR TITLE
Updated main_remainder schema.yaml

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/schema.yaml
@@ -22404,6 +22404,21 @@ fields:
         - name: widget_gtk_version
           type: STRING
           mode: NULLABLE
+        - name: extensions_quarantined_domains_listsize
+          type: INTEGER
+          mode: NULLABLE
+        - name: first_startup_delete_tasks_time
+          type: INTEGER
+          mode: NULLABLE
+        - name: first_startup_normandy_init_time
+          type: INTEGER
+          mode: NULLABLE
+        - name: migration_time_to_produce_legacy_migrator_list
+          type: INTEGER
+          mode: NULLABLE
+        - name: migration_time_to_produce_migrator_list
+          type: INTEGER
+          mode: NULLABLE
     - name: socket
       type: RECORD
       mode: NULLABLE


### PR DESCRIPTION
Dry-run failing:
```
Schema defined in sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/schema.yaml incompatible with query sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/query.sql
```

The metadata has `--schema_update_option=ALLOW_FIELD_ADDITION` but this doesn't affect the yaml file on disk. PR updates the file on disk. 


About `--schema_update_option=ALLOW_FIELD_ADDITION` - personally I tend not to use this option since having explicit schemas leads to less confusion in my experience. If we want to support it with the current tooling though, should we consider some sort of schema-update auto-PR or something here?
