### PR TITLE
Add init logic to new incremental Stripe ETLs (DENG-974)

### DIFF
--- a/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/query.sql
@@ -30,7 +30,11 @@ WITH subscriptions_history AS (
   FROM
     `moz-fx-data-shared-prod`.stripe_external.subscription_history_v1
   WHERE
-    DATE(_fivetran_start) >= @date
+    {% if is_init() %}
+      TRUE
+    {% else %}
+      DATE(_fivetran_start) >= @date
+    {% endif %}
 ),
 subscription_items AS (
   SELECT
@@ -263,4 +267,8 @@ LEFT JOIN
 ON
   subscriptions_history.id = subscriptions_history_latest_discounts.subscription_history_id
 WHERE
-  DATE(subscriptions_history._fivetran_start) = @date
+  {% if is_init() %}
+    DATE(subscriptions_history._fivetran_start) < CURRENT_DATE()
+  {% else %}
+    DATE(subscriptions_history._fivetran_start) = @date
+  {% endif %}

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/query.sql
@@ -442,4 +442,8 @@ SELECT
 FROM
   changelog_union
 WHERE
-  DATE(`timestamp`) = @date
+  {% if is_init() %}
+    DATE(`timestamp`) < CURRENT_DATE()
+  {% else %}
+    DATE(`timestamp`) = @date
+  {% endif %}


### PR DESCRIPTION
## [DENG-974](https://mozilla-hub.atlassian.net/browse/DENG-974): Stripe subscriptions ETL v2

Going forward I want to use the new `is_init()` Jinja macro logic to make it easier to deploy all the new incremental SubPlat consolidated reporting ETLs, so for consistency, this PR adds such `is_init()` logic to the associated incremental Stripe ETLs that have already been deployed.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DENG-974]: https://mozilla-hub.atlassian.net/browse/DENG-974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1159)
