### PR TITLE
Set ConfigLoader's project directory on module initialization

### DIFF
--- a/bigquery_etl/__init__.py
+++ b/bigquery_etl/__init__.py
@@ -1,5 +1,6 @@
 """BigQuery ETL."""
 from pathlib import Path
+
 from .config import ConfigLoader
 
 # We need to set the project dir before this module is imported from cli.__init__.py

--- a/bigquery_etl/__init__.py
+++ b/bigquery_etl/__init__.py
@@ -1,1 +1,7 @@
 """BigQuery ETL."""
+from pathlib import Path
+from .config import ConfigLoader
+
+# We need to set the project dir before this module is imported from cli.__init__.py
+if __name__ == "bigquery_etl":
+    ConfigLoader.set_project_dir(Path().absolute())


### PR DESCRIPTION
This should fix the following error we hit in `copy_deduplicate.baseline_clients_first_seen`:

```
  File "/usr/local/bin/bqetl", line 5, in <module>
    from bigquery_etl.cli import cli
  File "/usr/local/lib/python3.10/site-packages/bigquery_etl/cli/__init__.py", line 13, in <module>
    from ..cli.backfill import backfill
  File "/usr/local/lib/python3.10/site-packages/bigquery_etl/cli/backfill.py", line 31, in <module>
    from ..cli.query import backfill as query_backfill
  File "/usr/local/lib/python3.10/site-packages/bigquery_etl/cli/query.py", line 29, in <module>
    from ..cli.utils import (
  File "/usr/local/lib/python3.10/site-packages/bigquery_etl/cli/utils.py", line 147, in <module>
    default=ConfigLoader.get("default", "sql_dir", fallback="sql"),
  File "/usr/local/lib/python3.10/site-packages/bigquery_etl/config.py", line 30, in get
    conf = self.config
  File "/usr/local/lib/python3.10/site-packages/bigquery_etl/config.py", line 21, in config
    self._config = yaml.safe_load((self.project_dir / self.config_file).read_text())
  File "/usr/local/lib/python3.10/pathlib.py", line 1134, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/usr/local/lib/python3.10/pathlib.py", line 1119, in open
    return self._accessor.open(self, mode, buffering, encoding, errors,
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.10/site-packages/bqetl_project.yaml'

```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)