### PR TITLE
[Bug 1821784] Be explicit about skipping generation for certain Glean artifacts

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -363,6 +363,9 @@ view:
     - sql/glam-fenix-dev/glam_etl/**/view.sql
     # tests
     - sql/moz-fx-data-test-project/test/simple_view/view.sql
+  override: # Skip automatically updating the following views
+    skip:
+    - sql/moz-fx-data-shared-prod/mozilla_vpn/**/view.sql
 
 schema:
   mozilla_pipeline_schemas_uri: https://github.com/mozilla-services/mozilla-pipeline-schemas

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -389,7 +389,9 @@ render:
   # uses {%s} which results in unknown tag exception
   - sql/mozfun/hist/string_to_json/udf.sql
 
-glean_usage:
-  override: # Skip automatically updating the following artifacts
-    skip:
-    - sql/moz-fx-data-shared-prod/mozilla_vpn/**
+generate:
+  glean_usage:
+    skip_existing: # Skip automatically updating the following artifacts
+    - sql/moz-fx-data-shared-prod/mozilla_vpn/deletion_request/**
+    - sql/moz-fx-data-shared-prod/mozilla_vpn/events/**
+    - sql/moz-fx-data-shared-prod/mozilla_vpn/main/**

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -363,9 +363,6 @@ view:
     - sql/glam-fenix-dev/glam_etl/**/view.sql
     # tests
     - sql/moz-fx-data-test-project/test/simple_view/view.sql
-  override: # Skip automatically updating the following views
-    skip:
-    - sql/moz-fx-data-shared-prod/mozilla_vpn/**/view.sql
 
 schema:
   mozilla_pipeline_schemas_uri: https://github.com/mozilla-services/mozilla-pipeline-schemas
@@ -391,3 +388,8 @@ render:
   skip:
   # uses {%s} which results in unknown tag exception
   - sql/mozfun/hist/string_to_json/udf.sql
+
+glean_usage:
+  override: # Skip automatically updating the following artifacts
+    skip:
+    - sql/moz-fx-data-shared-prod/mozilla_vpn/**

--- a/sql_generators/glean_usage/glean_app_ping_views.py
+++ b/sql_generators/glean_usage/glean_app_ping_views.py
@@ -77,6 +77,8 @@ class GleanAppPingViews(GleanTable):
         env = Environment(loader=FileSystemLoader(PATH / "templates"))
         view_template = env.get_template("app_ping_view.view.sql")
 
+        skip_existing = self.skip_existing()
+
         p = GleanPing(repo)
         # generate views for all available pings
         for ping_name in p.get_pings():
@@ -163,7 +165,7 @@ class GleanAppPingViews(GleanTable):
                     "view.sql",
                     rendered_view,
                     skip_existing=get_table_dir(output_dir, full_view_id) / "view.sql"
-                    in self.override_skip(),
+                    in skip_existing,
                 )
 
                 app_channels = [
@@ -181,7 +183,7 @@ class GleanAppPingViews(GleanTable):
                     ),
                     skip_existing=get_table_dir(output_dir, full_view_id)
                     / "metadata.yaml"
-                    in self.override_skip(),
+                    in skip_existing,
                 )
 
                 schema_dir = get_table_dir(output_dir, full_view_id)

--- a/sql_generators/glean_usage/glean_app_ping_views.py
+++ b/sql_generators/glean_usage/glean_app_ping_views.py
@@ -162,7 +162,8 @@ class GleanAppPingViews(GleanTable):
                     full_view_id,
                     "view.sql",
                     rendered_view,
-                    skip_existing=True,
+                    skip_existing=get_table_dir(output_dir, full_view_id) / "view.sql"
+                    in self.override_skip(),
                 )
 
                 app_channels = [
@@ -178,7 +179,9 @@ class GleanAppPingViews(GleanTable):
                         app_name=release_app["canonical_app_name"],
                         app_channels=", ".join(app_channels),
                     ),
-                    skip_existing=True,
+                    skip_existing=get_table_dir(output_dir, full_view_id)
+                    / "metadata.yaml"
+                    in self.override_skip(),
                 )
 
                 schema_dir = get_table_dir(output_dir, full_view_id)


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1821784

Instead of skipping existing files during Glean generation processes, we should be explicit in what files should be skipped. This prevents us from breaking artifact deploys.

This is a less significant change than the alternative option of writing generated sql to a separate directory, which would also solve this issue: https://github.com/mozilla/bigquery-etl/issues/4068
This is something still worth considering, but this PR is a quicker fix for an issue that has been happening on a weekly basis now.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1183)
