### PR TITLE
DENG-1187 Added reported baseline ping column to fenix android

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
@@ -198,6 +198,11 @@ _current AS (
           THEN FALSE
         ELSE TRUE
       END AS reported_metrics_ping,
+      CASE
+        WHEN baseline.client_id IS NULL
+          THEN FALSE
+        ELSE TRUE
+      END AS reported_baseline_ping
       DATE(first_session.min_submission_datetime) AS min_first_session_ping_submission_date,
       DATE(first_session.first_run_datetime) AS min_first_session_ping_run_date,
       DATE(metrics.min_submission_datetime) AS min_metrics_ping_submission_date,
@@ -337,6 +342,8 @@ SELECT
     ) AS reported_first_session_ping,
     COALESCE(_previous.metadata.reported_metrics_ping, FALSE)
     OR COALESCE(_current.metadata.reported_metrics_ping, FALSE) AS reported_metrics_ping,
+    COALESCE(_previous.metadata.reported_baseline_ping, FALSE)
+    OR COALESCE(_current.metadata.reported_baseline_ping, FALSE) AS reported_baseline_ping,
     CASE
       WHEN _previous.metadata.min_first_session_ping_submission_date IS NOT NULL
         AND _current.metadata.min_first_session_ping_submission_date IS NOT NULL

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/schema.yaml
@@ -121,6 +121,10 @@ fields:
     mode: NULLABLE
     name: reported_metrics_ping
     type: BOOLEAN
+  - description: True if the client ever reported a baseline ping.
+    mode: NULLABLE
+    name: reported_baseline_ping
+    type: BOOLEAN
   - description: Date when the first reported first_sessin ping is received by the
       server.
     mode: NULLABLE


### PR DESCRIPTION
[DENG-1187](https://mozilla-hub.atlassian.net/browse/DENG-1187):

This new column was requested by DS to capture if baseline ping was present.