### PR TITLE
Fix parallel schema updates

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1591,7 +1591,7 @@ def _update_query_schema(
         click.echo(f"{query_file} dry runs are skipped. Cannot update schemas.")
         return
 
-    tmp_tables = copy.copy(tmp_tables)
+    tmp_tables = copy.deepcopy(tmp_tables)
     query_file_path = Path(query_file)
     existing_schema_path = query_file_path.parent / SCHEMA_FILE
     project_name, dataset_name, table_name = extract_from_query_path(query_file_path)

--- a/bigquery_etl/util/parallel_topological_sorter.py
+++ b/bigquery_etl/util/parallel_topological_sorter.py
@@ -1,7 +1,6 @@
 """Threaded TopologialSorter."""
 
 import multiprocessing
-import queue
 from copy import deepcopy
 from graphlib import TopologicalSorter
 from typing import Dict, Set
@@ -42,7 +41,7 @@ class ParallelTopologicalSorter:
         processes = []
 
         if self.with_follow_up:
-            followup_queue = queue.Queue()
+            followup_queue = multiprocessing.Queue()
         else:
             followup_queue = None
 


### PR DESCRIPTION
Fixes https://mozilla.slack.com/archives/C4D5ZA91B/p1689588833802629

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1237)
