### PR TITLE
update schema.yaml to match query.py using Adjust API and not the dow…

### DIFF
--- a/sql/moz-fx-data-shared-prod/adjust_derived/adjust_deliverables_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/adjust_derived/adjust_deliverables_v1/schema.yaml
@@ -1,65 +1,71 @@
 fields:
 
 - mode: NULLABLE
-  name: app_name_dashboard
+  name: date
+  type: DATE
+- mode: NULLABLE
+  name: app
   type: STRING
 - mode: NULLABLE
-  name: created_at
-  type: TIMESTAMP
-- mode: NULLABLE
-  name: install_begin_time
-  type: TIMESTAMP
-- mode: NULLABLE
-  name: installed_at
-  type: TIMESTAMP
-- mode: NULLABLE
-  name: conversion_duration
-  type: integer
-- mode: NULLABLE
-  name: app_name
+  name: app_token
   type: STRING
 - mode: NULLABLE
-  name: app_version
+  name: network
   type: STRING
 - mode: NULLABLE
-  name: network_name
+  name: network_token
   type: STRING
 - mode: NULLABLE
-  name: network_type
+  name: campaign
   type: STRING
 - mode: NULLABLE
-  name: ad_revenue_network
+  name: campaign_token
   type: STRING
 - mode: NULLABLE
-  name: campaign_name
+  name: adgroup
   type: STRING
 - mode: NULLABLE
-  name: adgroup_name
+  name: adgroup_token
   type: STRING
 - mode: NULLABLE
-  name: creative_name
+  name: creative
+  type: STRING
+- mode: NULLABLE
+  name: creative_token
   type: STRING
 - mode: NULLABLE
   name: country
   type: STRING
 - mode: NULLABLE
-  name: os_name
+  name: os
   type: STRING
 - mode: NULLABLE
-  name: adid
+  name: device
   type: STRING
 - mode: NULLABLE
-  name: device_manufacturer
-  type: STRING
+  name: clicks
+  type: INTEGER
 - mode: NULLABLE
-  name: device_type
-  type: STRING
+  name: installs
+  type: INTEGER
 - mode: NULLABLE
-  name: store
-  type: STRING
+  name: limit_ad_tracking_install_rate
+  type: FLOAT
 - mode: NULLABLE
-  name: activity_type
-  type: STRING
+  name: click_conversion_rate
+  type: FLOAT
 - mode: NULLABLE
-  name: date
-  type: DATE
+  name: impression_conversion_rate
+  type: FLOAT
+- mode: NULLABLE
+  name: sessions
+  type: INTEGER
+- mode: NULLABLE
+  name: daus
+  type: INTEGER
+- mode: NULLABLE
+  name: waus
+  type: INTEGER
+- mode: NULLABLE
+  name: maus
+  type: INTEGER


### PR DESCRIPTION
…nload from Adjust UI

Original schema.yaml file matched the download from the Adjust UI, not the download from the Adjust API. This needed to be updated to match

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)