### PR TITLE
Remove buildhub2 filter in GLAM templates

### DIFF
--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -111,11 +111,6 @@ def main():
         + (" --no-parameterize" if args.no_parameterize else "")
     )
 
-    # This enables build_id filtering against Buildhub data
-    # and filtering out of an erroneous version "1024" (see query template for details).
-    # Only the desktop builds are reported to Buildhub
-    filter_desktop_builds = True if args.product == "firefox_desktop" else False
-
     schema = get_schema(args.source_table)
     distributions = get_distribution_metrics(schema)
     metrics_sql = get_metrics_sql(distributions).strip()
@@ -126,7 +121,6 @@ def main():
     print(
         render_main(
             header=header,
-            filter_desktop_builds=filter_desktop_builds,
             source_table=args.source_table,
             submission_date=submission_date,
             attributes=ATTRIBUTES,

--- a/bigquery_etl/glam/clients_daily_scalar_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_scalar_aggregates.py
@@ -146,11 +146,6 @@ def main():
         + (" --no-parameterize" if args.no_parameterize else "")
     )
 
-    # This enables build_id filtering against Buildhub data
-    # and filtering out of an erroneous version "1024" (see query template for details).
-    # Only the desktop builds are reported to Buildhub
-    filter_desktop_builds = True if args.product == "firefox_desktop" else False
-
     schema = get_schema(args.source_table)
     unlabeled_metric_names = get_scalar_metrics(schema, "unlabeled")
     labeled_metric_names = get_scalar_metrics(schema, "labeled")
@@ -164,7 +159,6 @@ def main():
     print(
         render_main(
             header=header,
-            filter_desktop_builds=filter_desktop_builds,
             source_table=args.source_table,
             submission_date=submission_date,
             attributes=ATTRIBUTES,

--- a/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
@@ -1,14 +1,5 @@
 {{ header }}
-WITH
-{% if filter_desktop_builds %}
-valid_builds AS (
-  SELECT DISTINCT
-    build.build.id AS build_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry.buildhub2`
-),
-{% endif %}
-extracted AS (
+WITH extracted AS (
   SELECT
     *,
     DATE(submission_timestamp) AS submission_date,
@@ -23,20 +14,9 @@ extracted AS (
     client_info.app_channel AS channel
   FROM
     `moz-fx-data-shared-prod.{{ source_table }}`
-  {% if filter_desktop_builds %}
-  INNER JOIN
-    valid_builds
-  ON
-    client_info.app_build = build_id
-  {% endif %}
   WHERE
     DATE(submission_timestamp) = {{ submission_date }}
     AND client_info.client_id IS NOT NULL
-    {% if filter_desktop_builds %}
-    -- some FOG clients on Windows are sending version "1024.0.0"
-    -- see https://bugzilla.mozilla.org/show_bug.cgi?id=1768187
-    AND client_info.app_display_version != '1024.0.0'
-    {% endif %}
 ),
 histograms AS (
   SELECT

--- a/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
@@ -1,14 +1,5 @@
 {{ header }}
-WITH
-{% if filter_desktop_builds %}
-valid_builds AS (
-  SELECT DISTINCT
-    build.build.id AS build_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry.buildhub2`
-),
-{% endif %}
-extracted AS (
+WITH extracted AS (
   SELECT
     *,
     DATE(submission_timestamp) AS submission_date,
@@ -23,20 +14,9 @@ extracted AS (
     client_info.app_channel AS channel
   FROM
     `moz-fx-data-shared-prod.{{ source_table }}`
-  {% if filter_desktop_builds %}
-  INNER JOIN
-    valid_builds
-  ON
-    client_info.app_build = build_id
-  {% endif %}
   WHERE
     DATE(submission_timestamp) = {{ submission_date }}
     AND client_info.client_id IS NOT NULL
-    {% if filter_desktop_builds %}
-    -- some FOG clients on Windows are sending version "1024.0.0"
-    -- see https://bugzilla.mozilla.org/show_bug.cgi?id=1768187
-    AND client_info.app_display_version != '1024.0.0'
-    {% endif %}
 ),
 unlabeled_metrics AS (
   SELECT


### PR DESCRIPTION
Due to historical incidents of bad version number getting in that broke the ETL, we added a filter that only accepts build IDs that match buildhub2 builds. However, [this query](https://sql.telemetry.mozilla.org/queries/93349/source) shows many FOG builds with substantial client count are being filtered out because they do not exist in buildhub2. This affects the client count we see in GLAM. 

Considering that we already have [a guardrail to ensure only valid version numbers get in](https://github.com/mozilla/bigquery-etl/pull/3933), we should remove the buildhub2 filter. Potentially will fix https://github.com/mozilla/glam/issues/2003.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1239)
