### PR TITLE
bug(1840419): org_mozilla_ios_firefox.unified_metrics_v1 query fixing invalid query view generation

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/unified_metrics_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/unified_metrics_v1/query.py
@@ -157,7 +157,12 @@ def main():
     update_schema(bq, legacy_core, schema)
     update_schema(bq, legacy_event, schema)
 
-    stripped = [c.split()[0].lstrip("root.") for c in column_summary]
+    # these columns needs to be excluded due to a change in view generation (metrics)
+    # for more details, see: https://github.com/mozilla/bigquery-etl/pull/4029
+    # and https://bugzilla.mozilla.org/show_bug.cgi?id=1741487
+    columns_to_exclude = ("root.metrics.text RECORD", "root.metrics.url RECORD", "root.metrics.jwe RECORD", "root.metrics.labeled_rate RECORD",)
+    stripped = [c.split()[0].lstrip("root.") for c in column_summary if c not in columns_to_exclude]
+
     query_glean = generate_query(
         ['"glean" as telemetry_system', *stripped],
         "moz-fx-data-shared-prod.org_mozilla_ios_firefox.metrics",


### PR DESCRIPTION
# bug(1840419): org_mozilla_ios_firefox.unified_metrics_v1 query fixing invalid query view generation

We're excluding fields from the generated view sql code:

- jwe
- text
- url
- labeled_rate

caused by: https://github.com/mozilla/bigquery-etl/pull/4029

More context can be found in bug 1840419.

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1241)
