### PR TITLE
Fix processing follow up items in ParallelTopologicalSorter

### DIFF
--- a/bigquery_etl/util/parallel_topological_sorter.py
+++ b/bigquery_etl/util/parallel_topological_sorter.py
@@ -74,15 +74,15 @@ class ParallelTopologicalSorter:
             ts.done(task)
             finalized_tasks_queue.task_done()
 
-            # add follow up tasks to be processed
-            if followup_queue:
-                while not followup_queue.empty():
-                    follow_up_item = followup_queue.get()
-                    ts.add(follow_up_item)
-                    self.visited[follow_up_item] = False
-
         task_queue.join()
         finalized_tasks_queue.join()
+
+        # followup items cannot be added to the topological sorter after prepare() is called
+        # processing them here sequentially
+        if followup_queue:
+            while not followup_queue.empty():
+                follow_up_item = followup_queue.get()
+                callback(follow_up_item, followup_queue)
 
         # check that all dependencies have been processed
         for task, _ in self.visited.items():


### PR DESCRIPTION
This fixes an issue when using `ParallelTopologicalSorter` with followup items getting added dynamically. Items can't get added to `TopologicalSorter` after `prepare()` has been called, so we need to process the followup items separately

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
