### PR TITLE
Fix skipping client_dedup

### DIFF
--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -257,7 +257,7 @@ class GleanTable:
                 destination = (
                     get_table_dir(output_dir, artifact.table_id) / artifact.basename
                 )
-                skip_existing = destination in skip_existing_artifact
+                skip_existing = str(destination) in skip_existing_artifact
 
                 write_sql(
                     output_dir,
@@ -325,7 +325,7 @@ class GleanTable:
 
             if output_dir:
                 skip_existing = (
-                    get_table_dir(output_dir, view) / "view.sql"
+                    str(get_table_dir(output_dir, view) / "view.sql")
                     in skip_existing_artifacts
                 )
                 write_sql(

--- a/sql_generators/glean_usage/glean_app_ping_views.py
+++ b/sql_generators/glean_usage/glean_app_ping_views.py
@@ -164,7 +164,9 @@ class GleanAppPingViews(GleanTable):
                     full_view_id,
                     "view.sql",
                     rendered_view,
-                    skip_existing=get_table_dir(output_dir, full_view_id) / "view.sql"
+                    skip_existing=str(
+                        get_table_dir(output_dir, full_view_id) / "view.sql"
+                    )
                     in skip_existing,
                 )
 
@@ -181,8 +183,9 @@ class GleanAppPingViews(GleanTable):
                         app_name=release_app["canonical_app_name"],
                         app_channels=", ".join(app_channels),
                     ),
-                    skip_existing=get_table_dir(output_dir, full_view_id)
-                    / "metadata.yaml"
+                    skip_existing=str(
+                        get_table_dir(output_dir, full_view_id) / "metadata.yaml"
+                    )
                     in skip_existing,
                 )
 


### PR DESCRIPTION
This should fix errors related to fenix.client_deduplication. The issue was comparing Path objects to str (which for some reason works for me locally but not in CI)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1259)
