### PR TITLE
Bug 1844886: Add non-norm cols to scalar tbls

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -226,6 +226,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/histogram_percentiles_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
+  - sql/moz-fx-data-shared-prod/telemetry/client_probe_counts/view.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_sql_run_check_v1/query.sql
   # Dataset sql/glam-fenix-dev:glam_etl was not found
   - sql/glam-fenix-dev/glam_etl/**/*.sql
@@ -296,7 +297,7 @@ format:
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_non_norm_histogram_bucket_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
-  - sql/moz-fx-data-shared-prod/telemetry_derived/client_probe_counts/view.sql
+  - sql/moz-fx-data-shared-prod/telemetry/client_probe_counts/view.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_daily_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/init.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/query.sql

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -220,6 +220,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_non_norm_histogram_bucket_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql
+  - sql/moz-fx-data-shared-prod/telemetry_derived/client_probe_counts/view.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/glam_sample_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/glam_user_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/query.sql
@@ -295,6 +296,7 @@ format:
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_non_norm_histogram_bucket_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/query.sql
+  - sql/moz-fx-data-shared-prod/telemetry_derived/client_probe_counts/view.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_daily_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/init.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/query.sql

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/query.sql
@@ -79,11 +79,18 @@ percentiles AS (
     metric_type,
     key,
     process,
-    client_agg_type)
-
-SELECT *
-REPLACE(mozfun.glam.map_from_array_offsets_precise(
-  [0.1, 1.0, 5.0, 25.0, 50.0, 75.0, 95.0, 99.0, 99.9],
-  aggregates
-) AS aggregates)
-FROM percentiles
+    client_agg_type
+),
+aggregated AS (
+  SELECT *
+  REPLACE(mozfun.glam.map_from_array_offsets_precise(
+    [0.1, 1.0, 5.0, 25.0, 50.0, 75.0, 95.0, 99.0, 99.9],
+    aggregates
+  ) AS aggregates)
+  FROM percentiles
+)
+SELECT
+  *,
+  aggregates AS non_norm_aggregates
+FROM
+  aggregated

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/scalar_percentiles_v1/schema.yaml
@@ -1,0 +1,78 @@
+fields:
+- mode: NULLABLE
+  name: os
+  type: STRING
+
+- mode: NULLABLE
+  name: app_version
+  type: INTEGER
+
+- mode: NULLABLE
+  name: app_build_id
+  type: STRING
+
+- mode: NULLABLE
+  name: channel
+  type: STRING
+
+- mode: NULLABLE
+  name: metric
+  type: STRING
+
+- mode: NULLABLE
+  name: metric_type
+  type: STRING
+
+- mode: NULLABLE
+  name: key
+  type: STRING
+
+- mode: NULLABLE
+  name: process
+  type: STRING
+
+- mode: NULLABLE
+  name: first_bucket
+  type: INTEGER
+
+- mode: NULLABLE
+  name: last_bucket
+  type: INTEGER
+
+- mode: NULLABLE
+  name: num_buckets
+  type: INTEGER
+
+- mode: NULLABLE
+  name: client_agg_type
+  type: STRING
+
+- mode: NULLABLE
+  name: agg_type
+  type: STRING
+
+- mode: NULLABLE
+  name: total_users
+  type: INTEGER
+
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: FLOAT
+  mode: REPEATED
+  name: aggregates
+  type: RECORD
+
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: FLOAT
+  mode: REPEATED
+  name: non_norm_aggregates
+  type: RECORD

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/test_aggregation/expect.ndjson
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_probe_counts_v1/test_aggregation/expect.ndjson
@@ -1,2 +1,2 @@
-{"agg_type":"histogram","aggregates":[],"app_build_id":"first","app_version":75,"channel":"nightly","client_agg_type":"min","key":"","metric":"some_metric","metric_type":"scalar","os":"first","process":"parent","total_users":400}
-{"agg_type":"histogram","aggregates":[],"app_build_id":"first","app_version":75,"channel":"nightly","client_agg_type":"min","key":"","metric":"some_metric","metric_type":"scalar","process":"parent","total_users":400}
+{"agg_type":"histogram","aggregates":[],"non_norm_aggregates":[],"app_build_id":"first","app_version":75,"channel":"nightly","client_agg_type":"min","key":"","metric":"some_metric","metric_type":"scalar","os":"first","process":"parent","total_users":400}
+{"agg_type":"histogram","aggregates":[],"non_norm_aggregates":[],"app_build_id":"first","app_version":75,"channel":"nightly","client_agg_type":"min","key":"","metric":"some_metric","metric_type":"scalar","process":"parent","total_users":400}


### PR DESCRIPTION
Fixes 1844886

This brings `non_norm_aggregates` cols to scalar percentiles/aggregates tables so said tables match the schema of counterpart histogram tables, allowing downstream processes to `UNION` them.
Before those columns were being added to `telemetry_derived.client_probe_counts` view, prior to export.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1272)
