### PR TITLE
Update telemetry_derived.histogram_percentiles_v1 schema

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/histogram_percentiles_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/histogram_percentiles_v1/schema.yaml
@@ -54,7 +54,7 @@ fields:
 
 - fields:
   - mode: NULLABLE
-    name: key
+    name: KEY
     type: STRING
   - mode: NULLABLE
     name: value
@@ -65,7 +65,7 @@ fields:
 
 - fields:
   - mode: NULLABLE
-    name: key
+    name: KEY
     type: STRING
   - mode: NULLABLE
     name: value
@@ -73,3 +73,7 @@ fields:
   mode: REPEATED
   name: non_norm_aggregates
   type: RECORD
+
+- name: os
+  type: STRING
+  mode: NULLABLE


### PR DESCRIPTION
Follow up to #3873 - looks like the checked-in schema doesn't match the deployed schema in some incompatible ways:

`[2023-07-25, 02:21:19 UTC] {pod_manager.py:235} INFO - google.api_core.exceptions.BadRequest: 400 PATCH https://bigquery.googleapis.com/bigquery/v2/projects/moz-fx-data-shared-prod/datasets/telemetry_derived/tables/histogram_percentiles_v1?prettyPrint=false: Field aggregates.KEY already exists in schema`