### PR TITLE
Added new_profile_activation_v1 to shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -96,7 +96,7 @@ CONTEXTUAL_SERVICES_SRC = DeleteSource(
     table="telemetry_stable.deletion_request_v4",
     field="payload.scalars.parent.deletion_request_context_id",
 )
-FENIX_SRC = DeleteSource(table="fenix.deletion_request", field=CLIENT_ID)
+FENIX_SRC = DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID)
 FXA_HMAC_SRC = DeleteSource(
     table="firefox_accounts_derived.fxa_delete_events_v1", field="hmac_user_id"
 )


### PR DESCRIPTION
It was discovered in #4093 that the following table contain `client_id` but are not currently being shredded:
- `moz-fx-data-shared-prod.fenix_derived.new_profile_activation_v1`

This PR adds it to the delete target list so it will also be shredded.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1310)
