### PR TITLE
DENG-899 - Add json write functionality to bqetl schedule command

### DIFF
--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -1,8 +1,9 @@
 """bigquery-etl CLI backfill command."""
-
+import json
 import sys
 import tempfile
 from datetime import date, datetime, timedelta
+from pathlib import Path
 
 import click
 import yaml
@@ -290,8 +291,9 @@ def info(ctx, qualified_table_name, sql_dir, project_id, status):
 @project_id_option(
     ConfigLoader.get("default", "project", fallback="moz-fx-data-shared-prod")
 )
+@click.option("--json_path", type=click.Path())
 @click.pass_context
-def scheduled(ctx, qualified_table_name, sql_dir, project_id):
+def scheduled(ctx, qualified_table_name, sql_dir, project_id, json_path=None):
     """Return list of backfill(s) that require processing."""
     total_backfills_count = 0
 
@@ -310,6 +312,10 @@ def scheduled(ctx, qualified_table_name, sql_dir, project_id):
     click.echo(
         f"\nThere are a total of {total_backfills_count} backfill(s) that require processing."
     )
+
+    if backfills_to_process_dict and json_path is not None:
+        scheduled_backfills_json = json.dumps(list(backfills_to_process_dict.keys()))
+        Path(json_path).write_text(scheduled_backfills_json)
 
 
 @backfill.command(


### PR DESCRIPTION
In preparation for using this as an XCOM in Airflow. We'll read this JSON in downstream Airflow tasks to process backfills.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
~- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.~
~- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.~
~- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).~

~For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):~
- [x] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)~

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1313)
