### PR TITLE
bug(1844385): bqetl_acoustic_contact_export contacts_raw_v1 failing due to invalid schema update error.

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -760,7 +760,7 @@ bqetl_acoustic_contact_export:
     owner: kignasiak@mozilla.com
     start_date: "2021-03-01"
     email: ["telemetry-alerts@mozilla.com", "kignasiak@mozilla.com"]
-    retries: 2
+    retries: 1
     retry_delay: 5m
   tags:
     - impact/tier_3
@@ -775,7 +775,7 @@ bqetl_acoustic_raw_recipient_export:
     owner: kignasiak@mozilla.com
     start_date: "2022-03-01"
     email: ["telemetry-alerts@mozilla.com", "kignasiak@mozilla.com"]
-    retries: 2
+    retries: 1
     retry_delay: 5m
   tags:
     - impact/tier_3

--- a/dags/bqetl_acoustic_contact_export.py
+++ b/dags/bqetl_acoustic_contact_export.py
@@ -34,7 +34,7 @@ default_args = {
     "retry_delay": datetime.timedelta(seconds=300),
     "email_on_failure": True,
     "email_on_retry": True,
-    "retries": 0,
+    "retries": 2,
 }
 
 tags = ["impact/tier_3", "repo/bigquery-etl"]

--- a/dags/bqetl_acoustic_contact_export.py
+++ b/dags/bqetl_acoustic_contact_export.py
@@ -78,6 +78,7 @@ with DAG(
         email=["kignasiak@mozilla.com", "telemetry-alerts@mozilla.com"],
         date_partition_parameter="submission_date",
         depends_on_past=False,
+        retries=0,
     )
 
     acoustic__contact__v1.set_upstream(acoustic__contact_raw__v1)

--- a/dags/bqetl_acoustic_contact_export.py
+++ b/dags/bqetl_acoustic_contact_export.py
@@ -34,7 +34,7 @@ default_args = {
     "retry_delay": datetime.timedelta(seconds=300),
     "email_on_failure": True,
     "email_on_retry": True,
-    "retries": 2,
+    "retries": 0,
 }
 
 tags = ["impact/tier_3", "repo/bigquery-etl"]

--- a/dags/bqetl_acoustic_contact_export.py
+++ b/dags/bqetl_acoustic_contact_export.py
@@ -34,7 +34,7 @@ default_args = {
     "retry_delay": datetime.timedelta(seconds=300),
     "email_on_failure": True,
     "email_on_retry": True,
-    "retries": 2,
+    "retries": 1,
 }
 
 tags = ["impact/tier_3", "repo/bigquery-etl"]
@@ -78,7 +78,6 @@ with DAG(
         email=["kignasiak@mozilla.com", "telemetry-alerts@mozilla.com"],
         date_partition_parameter="submission_date",
         depends_on_past=False,
-        retries=0,
     )
 
     acoustic__contact__v1.set_upstream(acoustic__contact_raw__v1)

--- a/dags/bqetl_acoustic_raw_recipient_export.py
+++ b/dags/bqetl_acoustic_raw_recipient_export.py
@@ -34,7 +34,7 @@ default_args = {
     "retry_delay": datetime.timedelta(seconds=300),
     "email_on_failure": True,
     "email_on_retry": True,
-    "retries": 2,
+    "retries": 1,
 }
 
 tags = ["impact/tier_3", "repo/bigquery-etl"]

--- a/sql/moz-fx-data-marketing-prod/acoustic/contact_raw_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/contact_raw_v1/metadata.yaml
@@ -21,6 +21,7 @@ owners:
 scheduling:
   dag_name: bqetl_acoustic_contact_export
   date_partition_parameter: submission_date
+  retries: 0
   referenced_tables:
     - [
       'moz-fx-data-bq-fivetran',

--- a/sql/moz-fx-data-marketing-prod/acoustic/contact_raw_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/contact_raw_v1/metadata.yaml
@@ -21,7 +21,6 @@ owners:
 scheduling:
   dag_name: bqetl_acoustic_contact_export
   date_partition_parameter: submission_date
-  retries: 0
   referenced_tables:
     - [
       'moz-fx-data-bq-fivetran',

--- a/sql/moz-fx-data-marketing-prod/acoustic/contact_raw_v1/query.sql
+++ b/sql/moz-fx-data-marketing-prod/acoustic/contact_raw_v1/query.sql
@@ -1,5 +1,19 @@
+CREATE TEMP FUNCTION yes_no_to_int(val STRING) AS (
+  CASE
+    WHEN LOWER(val) = "no"
+      THEN 0
+    WHEN LOWER(val) = "yes"
+      THEN 1
+    ELSE CAST(val AS INTEGER)
+  END
+);
+
 SELECT
-  * EXCEPT (_file, _line, _fivetran_synced, _modified, last_modified_date),
+  * EXCEPT (_file, _line, _fivetran_synced, _modified, last_modified_date) REPLACE(
+    yes_no_to_int(double_opt_in) AS double_opt_in,
+    yes_no_to_int(fxa_account_deleted) AS fxa_account_deleted,
+    yes_no_to_int(has_opted_out_of_email) AS has_opted_out_of_email
+  ),
   DATE(@submission_date) AS last_modified_date,
 FROM
   `moz-fx-data-bq-fivetran.acoustic_sftp.contact_export_v_1`


### PR DESCRIPTION
# bug(1844385): bqetl_acoustic_contact_export contacts_raw_v1 failing due to invalid schema update error.

As we started getting unexpected values (`yes` and `no` for some fields we previously assumed to be of numeric value only):

- ensuring the `double_opt_in` field is of type `INTEGER`, this includes conversion of `Yes` to `1` and `No` to `0`.
- ensuring the `fxa_account_deleted` field is of type `INTEGER`, this includes conversion of `Yes` to `1` and `No` to `0`.
- ensuring the `has_opted_out_of_email` field is of type `INTEGER`, this includes conversion of `Yes` to `1` and `No` to `0`.


Additionally, to avoid wasted cost by attempting to re-run the query (if the query is invalid, retrying is pointless)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1318)
