### PR TITLE
fix(): udated schema.yaml files for main_remainder_1pct_v1 and main_use_counter_1pct_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/schema.yaml
@@ -22419,6 +22419,12 @@ fields:
         - name: migration_time_to_produce_migrator_list
           type: INTEGER
           mode: NULLABLE
+        - name: extensions_quarantined_domains_listhash
+          type: STRING
+          mode: NULLABLE
+        - name: extensions_quarantined_domains_remotehash
+          type: STRING
+          mode: NULLABLE
     - name: socket
       type: RECORD
       mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_use_counter_1pct_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_use_counter_1pct_v1/schema.yaml
@@ -7385,6 +7385,42 @@ fields:
     - name: use_counter2_deprecated_size_to_content_page
       type: STRING
       mode: NULLABLE
+    - name: use_counter2_css_property_math_depth_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_css_property_math_depth_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_init_mouse_event_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_init_mouse_event_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_init_ns_mouse_event_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_init_ns_mouse_event_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_input_source_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_moz_input_source_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_sync_xml_http_request_deprecated_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_sync_xml_http_request_deprecated_page
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_math_variant_document
+      type: STRING
+      mode: NULLABLE
+    - name: use_counter2_deprecated_math_ml_deprecated_math_variant_page
+      type: STRING
+      mode: NULLABLE
   - name: processes
     type: RECORD
     mode: NULLABLE
@@ -14637,6 +14673,42 @@ fields:
           type: STRING
           mode: NULLABLE
         - name: use_counter2_deprecated_size_to_content_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_math_depth_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_css_property_math_depth_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_init_mouse_event_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_init_mouse_event_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_init_ns_mouse_event_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_init_ns_mouse_event_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_input_source_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_moz_input_source_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_sync_xml_http_request_deprecated_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_sync_xml_http_request_deprecated_page
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_math_variant_document
+          type: STRING
+          mode: NULLABLE
+        - name: use_counter2_deprecated_math_ml_deprecated_math_variant_page
           type: STRING
           mode: NULLABLE
 - name: sample_id


### PR DESCRIPTION
fix(): udated schema.yaml files for main_remainder_1pct_v1 and main_use_counter_1pct_v1

Bigquery ETL main branch started failing on the `dry-run-sql` step with the following error:

```
Schema defined in sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/schema.yaml incompatible with query sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/query.sql
```

Both schema files have been updated by running:

```
./bqetl query schema update telemetry_derived.main_remainder_1pct_v1
./bqetl query schema update telemetry_derived.main_use_counter_1pct_v1
```

The reason both have been updated that locally when running:

```
./bqetl dryrun --validate-schemas sql/moz-fx-data-shared-prod/telemetry_derived
```

Both were reporting this error.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1347)
