### PR TITLE
docs(DENG-961): Added reference doc for data checks and a cookbook for adding new data checks

### DIFF
--- a/docs/cookbooks/adding_data_checks.md
+++ b/docs/cookbooks/adding_data_checks.md
@@ -1,0 +1,32 @@
+# Adding data checks
+
+> Before adding a check to a query, please remember that the current implementation will result in an Airflow task being added to the DAG which will be executed immediately after the query task completes. If any of the defined checks fail, all downstream tasks from the query task will fail (`checks` act as a "circuit-breaker"). This means all downstream tasks and DAGs will not be executed!
+
+## Create checks.sql
+
+Inside the query directory, which usually contains `query.sql` or `query.py`, `metadata.yaml` and `schema.yaml`, create a new file called `checks.sql` (unless already exists).
+
+Once checks have been added, we need to `regenerate the DAG` responsible for scheduling the query.
+
+## Update checks.sql
+
+If `checks.sql` already exists for the query, you can always add additional checks to the file by appending it to the list of already defined checks.
+
+When adding additional checks there should be no need to have to regenerate the DAG responsible for scheduling the query as all checks are executed using a single Airflow task.
+
+## Removing checks.sql
+
+All checks can be removed by deleleting the `checks.sql` file and regenerating the DAG responsible for scheduling the query.
+
+Alternatively, specific checks can be removed by deleting them from the `checks.sql` file.
+
+## Example checks.sql
+
+Example of what a `checks.sql` may look like:
+
+```sql
+{{ not_null(["submission_date", "os"], "submission_date = @submission_date") }}
+ {{ min_rows(1, "submission_date = @submission_date") }}
+ {{ is_unique(["submission_date", "os", "country"], "submission_date = @submission_date")}}
+ {{ in_range(["non_ssl_loads", "ssl_loads", "reporting_ratio"], 0, none, "submission_date = @submission_date") }}
+```

--- a/docs/reference/data_checks.md
+++ b/docs/reference/data_checks.md
@@ -4,13 +4,15 @@
 
 ## Background
 
-To create more confidence and trust in our data is crucial to provide some form of data checks. These checks should uncover problems as soon as possible, ideally as part of the data process creating the data. This includes checking that the data produced follows certain "assumptions" determined by the dataset owner. These "assumptions" need to be easy to define, but at the same time flexible enough to encode more complex business logic. For example, checks for null columns, for range/size properties, duplicates, table grain etc.
+To create more confidence and trust in our data is crucial to provide some form of data checks. These checks should uncover problems as soon as possible, ideally as part of the data process creating the data. This includes checking that the data produced follows certain assumptions determined by the dataset owner. These assumptions need to be easy to define, but at the same time flexible enough to encode more complex business logic. For example, checks for null columns, for range/size properties, duplicates, table grain etc.
 
 ## bqetl data checks to the rescue
 
 bqetl data checks aim to provide this ability by providing a simple interface for specifying our "assumptions" about the data the query should produce and checking them against the actual result.
 
-This easy interface is achieved by providing a number of jinja templates providing "out-of-the-box" logic for performing a number of common checks without having to rewrite the logic. For example, checking if any nulls are present in a specific column. These templates can be found [here](../../tests/checks/) and are available as jinja macros inside the `checks.sql` files. This allows to "configure" the logic by passing some details relevant to our specific dataset. Take a look at the examples below for practical examples.
+This easy interface is achieved by providing a number of jinja templates providing "out-of-the-box" logic for performing a number of common checks without having to rewrite the logic. For example, checking if any nulls are present in a specific column. These templates can be found [here](../../tests/checks/) and are available as jinja macros inside the `checks.sql` files. This allows to "configure" the logic by passing some details relevant to our specific dataset. Check templates will get rendered as raw SQL expressions. Take a look at the examples below for practical examples.
+
+It is also possible to write checks using raw SQL by using assertions. This is, for example, useful when writing checks for custom business logic.
 
 ## data checks available with examples
 

--- a/docs/reference/data_checks.md
+++ b/docs/reference/data_checks.md
@@ -1,0 +1,94 @@
+# bqetl data checks
+
+> Instructions on how to add data checks can be found under the [Adding data checks](../cookbooks/adding_data_checks.md) cookbook.
+
+## Background
+
+To create more confidence and trust in our data is crucial to provide some form of data checks. These checks should uncover problems as soon as possible, ideally as part of the data process creating the data. This includes checking that the data produced follows certain "assumptions" determined by the dataset owner. These "assumptions" need to be easy to define, but at the same time flexible enough to encode more complex business logic. For example, checks for null columns, for range/size properties, duplicates, table grain etc.
+
+## bqetl data checks to the rescue
+
+bqetl data checks aim to provide this ability by providing a simple interface for specifying our "assumptions" about the data the query should produce and checking them against the actual result.
+
+This easy interface is achieved by providing a number of jinja templates providing "out-of-the-box" logic for performing a number of common checks without having to rewrite the logic. For example, checking if any nulls are present in a specific column. These templates can be found [here](../../tests/checks/) and are available as jinja macros inside the `checks.sql` files. This allows to "configure" the logic by passing some details relevant to our specific dataset. Take a look at the examples below for practical examples.
+
+## data checks available with examples
+
+### in_range ([source](../../tests/checks/in_range.jinja))
+
+Usage:
+
+```
+Arguments:
+
+columns: List[str] - A list of columns which we want to check the values of.
+min: Optional[int] - Minimum value we should observe in the specified columns.
+max: Optional[int] - Maximum value we should observe in the specified columns.
+where: Optional[str] - A condition that will be injected into the `WHERE` clause of the check. For example, "submission_date = @submission_date" so that the check is only executed against a specific partition.
+```
+
+Example:
+
+```sql
+{{ in_range(["non_ssl_loads", "ssl_loads", "reporting_ratio"], 0, none, "submission_date = @submission_date") }}
+```
+
+### is_unique ([source](../../tests/checks/is_unique.jinja))
+
+Usage:
+
+```
+Arguments:
+
+columns: List[str] - A list of columns which should produce a unique record.
+where: Optional[str] - A condition that will be injected into the `WHERE` clause of the check. For example, "submission_date = @submission_date" so that the check is only executed against a specific partition.
+```
+
+Example:
+
+```sql
+{{ is_unique(["submission_date", "os", "country"], "submission_date = @submission_date")}}
+```
+
+### min_rows ([source](../../tests/checks/min_rows.jinja))
+
+Usage:
+
+```
+Arguments:
+
+threshold: Optional[int] - What is the minimum number of rows we expect (default: 1)
+where: Optional[str] - A condition that will be injected into the `WHERE` clause of the check. For example, "submission_date = @submission_date" so that the check is only executed against a specific partition.
+```
+
+Example:
+
+```sql
+{{ min_rows(1, "submission_date = @submission_date") }}
+```
+
+### not_null ([source](../../tests/checks/not_null.jinja))
+
+Usage:
+
+```
+Arguments:
+
+columns: List[str] - A list of columns which should not contain a null value.
+where: Optional[str] - A condition that will be injected into the `WHERE` clause of the check. For example, "submission_date = @submission_date" so that the check is only executed against a specific partition.
+```
+
+Example:
+
+```sql
+{{ not_null(["submission_date", "os"], "submission_date = @submission_date") }}
+```
+
+Please keep in mind the below checks can be combined and specified in the same `checks.sql` file. For example:
+
+```sql
+{{ not_null(["submission_date", "os"], "submission_date = @submission_date") }}
+ {{ min_rows(1, "submission_date = @submission_date") }}
+ {{ is_unique(["submission_date", "os", "country"], "submission_date = @submission_date")}}
+ {{ in_range(["non_ssl_loads", "ssl_loads", "reporting_ratio"], 0, none, "submission_date = @submission_date") }}
+```


### PR DESCRIPTION
# docs(DENG-961): Added reference doc for data checks and a cookbook for adding new data checks

This includes two docs:

- `cookbooks/adding_data_checks.md` - a guide to adding checks to a query.
- `reference/data_checks.md` - an overview of data checks and what checks are available.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1356)
