### PR TITLE
DENG-1379 Remove app_name from search filter and use join by client_id

### DIFF
--- a/sql_generators/active_users/templates/focus_android_query.sql
+++ b/sql_generators/active_users/templates/focus_android_query.sql
@@ -74,7 +74,6 @@ search_clients AS (
     `moz-fx-data-shared-prod.search_derived.mobile_search_clients_daily_v1`
   WHERE
     submission_date = @submission_date
-    AND app_name = '{{ app_value }}'
 ),
 search_metrics AS (
   SELECT

--- a/sql_generators/active_users/templates/mobile_query.sql
+++ b/sql_generators/active_users/templates/mobile_query.sql
@@ -43,7 +43,6 @@ search_clients AS (
     `moz-fx-data-shared-prod.search_derived.mobile_search_clients_daily_v1`
   WHERE
     submission_date = @submission_date
-    AND app_name = '{{ app_value }}'
 ),
 search_metrics AS (
   SELECT

--- a/sql_generators/active_users_deletion_requests/templates/mobile_deletion_request_query.sql
+++ b/sql_generators/active_users_deletion_requests/templates/mobile_deletion_request_query.sql
@@ -56,7 +56,6 @@ search_clients AS (
     AND DATE(request.submission_timestamp)
     BETWEEN @start_date
     AND @end_date
-    AND app_name = '{{ app_value }}'
 ),
 search_metrics AS (
   SELECT


### PR DESCRIPTION
Fixes [DENG-1379](https://mozilla-hub.atlassian.net/browse/DENG-1379) and reported bug of null values in search counts for mobile.

[Validation query](https://sql.telemetry.mozilla.org/queries/93988/source).

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DENG-1379]: https://mozilla-hub.atlassian.net/browse/DENG-1379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1380)
