### PR TITLE
docs(DENG-961): added data checks docs to mkdocs.yml

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Common workflows: cookbooks/common_workflows.md
       - Creating a derived dataset: cookbooks/creating_a_derived_dataset.md
       - Testing: cookbooks/testing.md
+      - Adding Data Checks: cookbooks/adding_data_checks.md
   - Reference:
       - bqetl CLI: bqetl.md
       - Recommended practices: reference/recommended_practices.md
@@ -47,3 +48,4 @@ nav:
       - Scheduling: reference/scheduling.md
       - Public data: reference/public_data.md
       - Airflow Tags: reference/airflow_tags.md
+      - Data Checks: reference/data_checks.md


### PR DESCRIPTION
# docs(DENG-961): added data checks docs to mkdocs.yml

This is to ensure they are included in our docs page. This inclusion was missed in PR: #4162

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1403)
