### PR TITLE
Split Facebook from Other in Adjust Network field

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix/firefox_android_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/firefox_android_clients/view.sql
@@ -18,7 +18,7 @@ SELECT
         'Untrusted Devices',
         'Product Marketing (Owned media)',
         'Google Ads ACI',
-        'Facebook'
+        'Facebook Installs'
       )
       THEN 'Other'
     ELSE adjust_network

--- a/sql/moz-fx-data-shared-prod/fenix/firefox_android_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/firefox_android_clients/view.sql
@@ -17,7 +17,8 @@ SELECT
         'Google Organic Search',
         'Untrusted Devices',
         'Product Marketing (Owned media)',
-        'Google Ads ACI'
+        'Google Ads ACI',
+        'Facebook'
       )
       THEN 'Other'
     ELSE adjust_network


### PR DESCRIPTION
With the new Marketing campaigns that are running, we'd like to have more visibility on new profiles attributed to Facebook, and therefore split it from "Others" in the view.
 
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1443)
