### PR TITLE
Speed up GLAM histogram bucket counts

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql
@@ -26,23 +26,6 @@ WITH filtered_data AS (
     AND sample_id >= @min_sample_id
     AND sample_id <= @max_sample_id
 ),
-static_combos AS (
-  SELECT
-    NULL AS os,
-    NULL AS app_build_id
-  UNION ALL
-  SELECT
-    NULL AS os,
-    '*' AS app_build_id
-  UNION ALL
-  SELECT
-    '*' AS os,
-    NULL AS app_build_id
-  UNION ALL
-  SELECT
-    '*' AS os,
-    '*' AS app_build_id
-),
 build_ids AS (
   SELECT
     app_build_id,
@@ -57,27 +40,23 @@ build_ids AS (
     -- for context see https://github.com/mozilla/glam/issues/1575#issuecomment-946880387
     CASE
       WHEN channel = 'release'
-        THEN COUNT(DISTINCT client_id) > 625000/(@max_sample_id - @min_sample_id + 1)
+        THEN COUNT(DISTINCT client_id) > 625000 / (@max_sample_id - @min_sample_id + 1)
       WHEN channel = 'beta'
-        THEN COUNT(DISTINCT client_id) > 9000/(@max_sample_id - @min_sample_id + 1)
+        THEN COUNT(DISTINCT client_id) > 9000 / (@max_sample_id - @min_sample_id + 1)
       WHEN channel = 'nightly'
-        THEN COUNT(DISTINCT client_id) > 375/(@max_sample_id - @min_sample_id + 1)
-      ELSE COUNT(DISTINCT client_id) > 100/(@max_sample_id - @min_sample_id + 1)
+        THEN COUNT(DISTINCT client_id) > 375 / (@max_sample_id - @min_sample_id + 1)
+      ELSE COUNT(DISTINCT client_id) > 100 / (@max_sample_id - @min_sample_id + 1)
     END
 ),
-all_combos AS (
+data_with_enough_wau AS (
   SELECT
-    * EXCEPT (os, app_build_id),
-    COALESCE(combo.os, table.os) AS os,
-    COALESCE(combo.app_build_id, table.app_build_id) AS app_build_id
+    *
   FROM
     filtered_data table
   INNER JOIN
     build_ids
   USING
     (app_build_id, channel)
-  CROSS JOIN
-    static_combos combo
 ),
 normalized_histograms AS (
   SELECT
@@ -88,10 +67,102 @@ normalized_histograms AS (
       mozfun.glam.histogram_normalized_sum(
         mozfun.map.sum(ARRAY_CONCAT_AGG(aggregates)),
         IF(MAX(sampled), 10.0, 1.0)
-      ) AS aggregates
+      ) AS aggregates,
+      COALESCE(CAST(NULL AS STRING), os) AS os,
+      COALESCE(CAST(NULL AS STRING), app_build_id) AS app_build_id
     )
   FROM
-    all_combos
+    data_with_enough_wau
+  GROUP BY
+    sample_id,
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    first_bucket,
+    last_bucket,
+    num_buckets,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type
+  UNION ALL
+  SELECT
+    * EXCEPT (sampled) REPLACE(
+    -- This returns true if at least 1 row has sampled=true.
+    -- ~0.0025% of the population uses more than 1 os for the same set of dimensions
+    -- and in this case we treat them as Windows+Release users when fudging numbers
+      mozfun.glam.histogram_normalized_sum(
+        mozfun.map.sum(ARRAY_CONCAT_AGG(aggregates)),
+        IF(MAX(sampled), 10.0, 1.0)
+      ) AS aggregates,
+      "*" AS os,
+      COALESCE(CAST(NULL AS STRING), app_build_id) AS app_build_id
+    )
+  FROM
+    data_with_enough_wau
+  GROUP BY
+    sample_id,
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    first_bucket,
+    last_bucket,
+    num_buckets,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type
+  UNION ALL
+  SELECT
+    * EXCEPT (sampled) REPLACE(
+    -- This returns true if at least 1 row has sampled=true.
+    -- ~0.0025% of the population uses more than 1 os for the same set of dimensions
+    -- and in this case we treat them as Windows+Release users when fudging numbers
+      mozfun.glam.histogram_normalized_sum(
+        mozfun.map.sum(ARRAY_CONCAT_AGG(aggregates)),
+        IF(MAX(sampled), 10.0, 1.0)
+      ) AS aggregates,
+      COALESCE(CAST(NULL AS STRING), os) AS os,
+      "*" AS app_build_id
+    )
+  FROM
+    data_with_enough_wau
+  GROUP BY
+    sample_id,
+    client_id,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    first_bucket,
+    last_bucket,
+    num_buckets,
+    metric,
+    metric_type,
+    key,
+    process,
+    agg_type
+  UNION ALL
+  SELECT
+    * EXCEPT (sampled) REPLACE(
+    -- This returns true if at least 1 row has sampled=true.
+    -- ~0.0025% of the population uses more than 1 os for the same set of dimensions
+    -- and in this case we treat them as Windows+Release users when fudging numbers
+      mozfun.glam.histogram_normalized_sum(
+        mozfun.map.sum(ARRAY_CONCAT_AGG(aggregates)),
+        IF(MAX(sampled), 10.0, 1.0)
+      ) AS aggregates,
+      "*" AS os,
+      "*" AS app_build_id
+    )
+  FROM
+    data_with_enough_wau
   GROUP BY
     sample_id,
     client_id,


### PR DESCRIPTION
Rewriting the `CROSS JOIN` in `telemetry_derived.clients_histogram_bucket_counts_v1` as `UNION ALL`. This reduced execution time by about 40% for some sampled data I tested it on.

The thing that is different with the `UNION`ed queries is that it can aggregate data for each of the `os` and `app_build_id` combinations in parallel on smaller datasets. Before, BigQuery ran the aggregations in a single step on a larger dataset which had all the combinations. 

One thing to note is that while the elapsed/felt time is 40% lower, this query is technically less efficient and consumes slightly more slot time and shuffles more bytes. I don't think that will be an issue, since it doesn't affect the cost and having these jobs finish quite a bit faster is desirable.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1445)
