### PR TITLE
DS-3104 Create version 2 of Clients Last Seen

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -228,6 +228,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/query.sql
+  - sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/latest_versions/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/italy_covid19_outage_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/init.sql

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
@@ -1,0 +1,54 @@
+friendly_name: Clients Last Seen
+description: |-
+  Aggregations that show a rolling 28-day per-client summary on top of
+  `clients_daily_*` tables.
+  It also performs a join with `clients_first_seen_v1`
+  in order to provide fields related to client activation that fall outside
+  the 28-day window. From Q4 2023, the query join with
+  `clients_first_seen_v2`, based on the redefinition of New Profiles:
+  https://docs.google.com/document/d/1B-zTNwschQgljij19Ez104qRV5RUC9zwjSN9tc1C8vc/edit#heading=h.gcjj37lkgqer
+  It should normally be accessed through the user-facing
+  view `telemetry.clients_last_seen`. Note that by end of Q1 2021, that view
+  start referencing the downstream table `clients_last_seen_joined_v1`
+  which merges in fields based on the `event` ping.
+  See https://github.com/mozilla/bigquery-etl/issues/1761
+owners:
+- dthorn@mozilla.com
+labels:
+  application: firefox
+  schedule: daily
+  dag: bqetl_main_summary
+  owner1: dthorn
+scheduling:
+  dag_name: bqetl_main_summary
+  priority: 85
+  start_date: '2023-09-15'
+  email:
+  - dthorn@mozilla.com
+  depends_on_past: true
+  external_downstream_tasks:
+  - task_id: wait_for_clients_last_seen
+    dag_name: taar_daily
+    execution_delta: 2h
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  clustering:
+    fields:
+    - normalized_channel
+    - sample_id
+schema:
+  derived_from:
+  - table:
+    - moz-fx-data-shared-prod
+    - telemetry_derived
+    - clients_daily_v6
+    exclude: null
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/taar
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
@@ -13,18 +13,18 @@ description: |-
   which merges in fields based on the `event` ping.
   See https://github.com/mozilla/bigquery-etl/issues/1761
 owners:
-- dthorn@mozilla.com
+- ascholtz@mozilla.com
 labels:
   application: firefox
   schedule: daily
   dag: bqetl_main_summary
-  owner1: dthorn
+  owner1: ascholtz
 scheduling:
   dag_name: bqetl_main_summary
   priority: 85
   start_date: '2023-09-15'
   email:
-  - dthorn@mozilla.com
+  - ascholtz@mozilla.com
   depends_on_past: true
   external_downstream_tasks:
   - task_id: wait_for_clients_last_seen

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
@@ -13,18 +13,18 @@ description: |-
   which merges in fields based on the `event` ping.
   See https://github.com/mozilla/bigquery-etl/issues/1761
 owners:
-- ascholtz@mozilla.com
+- anicholson@mozilla.com
 labels:
   application: firefox
   schedule: daily
   dag: bqetl_main_summary
-  owner1: ascholtz
+  owner1: anicholson
 scheduling:
   dag_name: bqetl_main_summary
   priority: 85
   start_date: '2023-09-15'
   email:
-  - ascholtz@mozilla.com
+  - anicholson@mozilla.com
   depends_on_past: true
   external_downstream_tasks:
   - task_id: wait_for_clients_last_seen

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/query.sql
@@ -1,0 +1,164 @@
+-- Note that this query runs in the telemetry_derived dataset, so sees derived tables
+-- rather than the user-facing views (so key_value structs haven't been eliminated, etc.)
+WITH _current AS (
+  SELECT
+    -- In this raw table, we capture the history of activity over the past
+    -- 28 days for each usage criterion as a single 64-bit integer. The
+    -- rightmost bit represents whether the user was active in the current day.
+    CAST(TRUE AS INT64) AS days_seen_bits,
+    -- For measuring Active MAU, where this is the days since this
+    -- client_id was an Active User as defined by
+    -- https://docs.telemetry.mozilla.org/cookbooks/active_dau.html
+    CAST(
+      COALESCE(
+        scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum,
+        scalar_parent_browser_engagement_total_uri_count_sum
+      ) >= 1 AS INT64
+    ) AS days_visited_1_uri_bits,
+    CAST(
+      COALESCE(
+        scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum,
+        scalar_parent_browser_engagement_total_uri_count_sum
+      ) >= 5 AS INT64
+    ) AS days_visited_5_uri_bits,
+    CAST(
+      COALESCE(
+        scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum,
+        scalar_parent_browser_engagement_total_uri_count_sum
+      ) >= 10 AS INT64
+    ) AS days_visited_10_uri_bits,
+    CAST(active_hours_sum >= 0.011 AS INT64) AS days_had_8_active_ticks_bits,
+    CAST(devtools_toolbox_opened_count_sum > 0 AS INT64) AS days_opened_dev_tools_bits,
+    CAST(active_hours_sum > 0 AS INT64) AS days_interacted_bits,
+    CAST(
+      scalar_parent_browser_engagement_total_uri_count_sum >= 1 AS INT64
+    ) AS days_visited_1_uri_normal_mode_bits,
+    -- This field is only available after version 84, see the definition in clients_daily_v6 view
+    CAST(
+      IF(
+        mozfun.norm.extract_version(app_display_version, 'major') < 84,
+        NULL,
+        scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum - COALESCE(
+          scalar_parent_browser_engagement_total_uri_count_sum,
+          0
+        )
+      ) >= 1 AS INT64
+    ) AS days_visited_1_uri_private_mode_bits,
+    -- We only trust profile_date if it is within one week of the ping submission,
+    -- so we ignore any value more than seven days old.
+    udf.days_since_created_profile_as_28_bits(
+      DATE_DIFF(submission_date, SAFE.PARSE_DATE("%F", SUBSTR(profile_creation_date, 0, 10)), DAY)
+    ) AS days_created_profile_bits,
+    -- Experiments are an array, so we keep track of a usage bit pattern per experiment.
+    ARRAY(
+      SELECT AS STRUCT
+        key AS experiment,
+        value AS branch,
+        1 AS bits
+      FROM
+        UNNEST(experiments)
+    ) AS days_seen_in_experiment,
+    * EXCEPT (submission_date)
+  FROM
+    clients_daily_v6
+  WHERE
+    submission_date = @submission_date
+),
+--
+_previous AS (
+  SELECT
+    days_seen_bits,
+    days_visited_1_uri_bits,
+    days_visited_5_uri_bits,
+    days_visited_10_uri_bits,
+    days_had_8_active_ticks_bits,
+    days_opened_dev_tools_bits,
+    days_interacted_bits,
+    days_visited_1_uri_normal_mode_bits,
+    days_visited_1_uri_private_mode_bits,
+    days_created_profile_bits,
+    days_seen_in_experiment,
+    * EXCEPT (
+      days_seen_bits,
+      days_visited_1_uri_bits,
+      days_visited_5_uri_bits,
+      days_visited_10_uri_bits,
+      days_had_8_active_ticks_bits,
+      days_opened_dev_tools_bits,
+      days_interacted_bits,
+      days_visited_1_uri_normal_mode_bits,
+      days_visited_1_uri_private_mode_bits,
+      days_created_profile_bits,
+      days_seen_in_experiment,
+      submission_date,
+      first_seen_date,
+      second_seen_date
+    )
+  FROM
+    clients_last_seen_v2
+  WHERE
+    submission_date = DATE_SUB(@submission_date, INTERVAL 1 DAY)
+    -- Filter out rows from yesterday that have now fallen outside the 28-day window.
+    AND udf.shift_28_bits_one_day(days_seen_bits) > 0
+)
+--
+SELECT
+  @submission_date AS submission_date,
+  IF(cfs.first_seen_date > @submission_date, NULL, cfs.first_seen_date) AS first_seen_date,
+  IF(cfs.second_seen_date > @submission_date, NULL, cfs.second_seen_date) AS second_seen_date,
+  IF(_current.client_id IS NOT NULL, _current, _previous).* REPLACE (
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_seen_bits,
+      _current.days_seen_bits
+    ) AS days_seen_bits,
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_visited_1_uri_bits,
+      _current.days_visited_1_uri_bits
+    ) AS days_visited_1_uri_bits,
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_visited_5_uri_bits,
+      _current.days_visited_5_uri_bits
+    ) AS days_visited_5_uri_bits,
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_visited_10_uri_bits,
+      _current.days_visited_10_uri_bits
+    ) AS days_visited_10_uri_bits,
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_had_8_active_ticks_bits,
+      _current.days_had_8_active_ticks_bits
+    ) AS days_had_8_active_ticks_bits,
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_opened_dev_tools_bits,
+      _current.days_opened_dev_tools_bits
+    ) AS days_opened_dev_tools_bits,
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_interacted_bits,
+      _current.days_interacted_bits
+    ) AS days_interacted_bits,
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_visited_1_uri_normal_mode_bits,
+      _current.days_visited_1_uri_normal_mode_bits
+    ) AS days_visited_1_uri_normal_mode_bits,
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_visited_1_uri_private_mode_bits,
+      _current.days_visited_1_uri_private_mode_bits
+    ) AS days_visited_1_uri_private_mode_bits,
+    udf.coalesce_adjacent_days_28_bits(
+      _previous.days_created_profile_bits,
+      _current.days_created_profile_bits
+    ) AS days_created_profile_bits,
+    udf.combine_experiment_days(
+      _previous.days_seen_in_experiment,
+      _current.days_seen_in_experiment
+    ) AS days_seen_in_experiment
+  )
+FROM
+  _current
+FULL JOIN
+  _previous
+USING
+  (client_id)
+LEFT JOIN
+  clients_first_seen_v2 AS cfs
+USING
+  (client_id)

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/query.sql
@@ -156,9 +156,7 @@ FROM
   _current
 FULL JOIN
   _previous
-USING
-  (client_id)
+  USING (client_id)
 LEFT JOIN
   clients_first_seen_v2 AS cfs
-USING
-  (client_id)
+  USING (client_id)

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/schema.yaml
@@ -1,0 +1,2348 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: null
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+- mode: NULLABLE
+  name: second_seen_date
+  type: DATE
+- mode: NULLABLE
+  name: days_seen_bits
+  type: INTEGER
+- mode: NULLABLE
+  name: days_visited_1_uri_bits
+  type: INTEGER
+- mode: NULLABLE
+  name: days_visited_5_uri_bits
+  type: INTEGER
+- mode: NULLABLE
+  name: days_visited_10_uri_bits
+  type: INTEGER
+- mode: NULLABLE
+  name: days_had_8_active_ticks_bits
+  type: INTEGER
+- mode: NULLABLE
+  name: days_opened_dev_tools_bits
+  type: INTEGER
+- mode: NULLABLE
+  name: days_interacted_bits
+  type: INTEGER
+- mode: NULLABLE
+  name: days_visited_1_uri_normal_mode_bits
+  type: INTEGER
+- mode: NULLABLE
+  name: days_visited_1_uri_private_mode_bits
+  type: INTEGER
+- mode: NULLABLE
+  name: days_created_profile_bits
+  type: INTEGER
+- fields:
+  - mode: NULLABLE
+    name: experiment
+    type: STRING
+  - mode: NULLABLE
+    name: branch
+    type: STRING
+  - mode: NULLABLE
+    name: bits
+    type: INTEGER
+  mode: REPEATED
+  name: days_seen_in_experiment
+  type: RECORD
+- mode: NULLABLE
+  name: client_id
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: aborts_content_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: aborts_gmplugin_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: aborts_plugin_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: active_addons_count_mean
+  type: FLOAT
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: addon_id
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: blocklisted
+    type: BOOLEAN
+    description: null
+  - mode: NULLABLE
+    name: name
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: user_disabled
+    type: BOOLEAN
+    description: null
+  - mode: NULLABLE
+    name: app_disabled
+    type: BOOLEAN
+    description: null
+  - mode: NULLABLE
+    name: version
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: scope
+    type: INTEGER
+    description: null
+  - mode: NULLABLE
+    name: type
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: foreign_install
+    type: BOOLEAN
+    description: null
+  - mode: NULLABLE
+    name: has_binary_components
+    type: BOOLEAN
+    description: null
+  - mode: NULLABLE
+    name: install_day
+    type: INTEGER
+    description: null
+  - mode: NULLABLE
+    name: update_day
+    type: INTEGER
+    description: null
+  - mode: NULLABLE
+    name: signed_state
+    type: INTEGER
+    description: null
+  - mode: NULLABLE
+    name: is_system
+    type: BOOLEAN
+    description: null
+  - mode: NULLABLE
+    name: is_web_extension
+    type: BOOLEAN
+    description: null
+  - mode: NULLABLE
+    name: multiprocess_compatible
+    type: BOOLEAN
+    description: null
+  mode: REPEATED
+  name: active_addons
+  type: RECORD
+  description: null
+- mode: NULLABLE
+  name: active_experiment_branch
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: active_experiment_id
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: active_hours_sum
+  type: FLOAT
+  description: null
+- mode: NULLABLE
+  name: addon_compatibility_check_enabled
+  type: BOOLEAN
+  description: null
+- mode: NULLABLE
+  name: app_build_id
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: app_display_version
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: app_name
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: app_version
+  type: STRING
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: source
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: medium
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: campaign
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: content
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: experiment
+    type: STRING
+  - mode: NULLABLE
+    name: variation
+    type: STRING
+  - mode: NULLABLE
+    name: dltoken
+    type: STRING
+  mode: NULLABLE
+  name: attribution
+  type: RECORD
+  description: null
+- mode: NULLABLE
+  name: blocklist_enabled
+  type: BOOLEAN
+  description: null
+- mode: NULLABLE
+  name: channel
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: client_clock_skew_mean
+  type: FLOAT
+  description: null
+- mode: NULLABLE
+  name: client_submission_latency_mean
+  type: FLOAT
+  description: null
+- mode: NULLABLE
+  name: cpu_cores
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: cpu_count
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: cpu_family
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: cpu_l2_cache_kb
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: cpu_l3_cache_kb
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: cpu_model
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: cpu_speed_mhz
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: cpu_stepping
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: cpu_vendor
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: crashes_detected_content_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: crashes_detected_gmplugin_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: crashes_detected_plugin_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: crash_submit_attempt_content_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: crash_submit_attempt_main_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: crash_submit_attempt_plugin_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: crash_submit_success_content_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: crash_submit_success_main_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: crash_submit_success_plugin_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: default_search_engine
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: default_search_engine_data_load_path
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: default_search_engine_data_name
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: default_search_engine_data_origin
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: default_search_engine_data_submission_url
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: devtools_toolbox_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: distribution_id
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: e10s_enabled
+  type: BOOLEAN
+  description: null
+- mode: NULLABLE
+  name: env_build_arch
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: env_build_id
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: env_build_version
+  type: STRING
+  description: null
+- mode: REPEATED
+  name: environment_settings_intl_accept_languages
+  type: STRING
+  description: null
+- mode: REPEATED
+  name: environment_settings_intl_app_locales
+  type: STRING
+  description: null
+- mode: REPEATED
+  name: environment_settings_intl_available_locales
+  type: STRING
+  description: null
+- mode: REPEATED
+  name: environment_settings_intl_requested_locales
+  type: STRING
+  description: null
+- mode: REPEATED
+  name: environment_settings_intl_system_locales
+  type: STRING
+  description: null
+- mode: REPEATED
+  name: environment_settings_intl_regional_prefs_locales
+  type: STRING
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: STRING
+    description: null
+  mode: REPEATED
+  name: experiments
+  type: RECORD
+  description: null
+- mode: NULLABLE
+  name: first_paint_mean
+  type: FLOAT
+  description: null
+- mode: NULLABLE
+  name: flash_version
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: city
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: geo_subdivision1
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: geo_subdivision2
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: isp_name
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: isp_organization
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: gfx_features_advanced_layers_status
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: gfx_features_d2d_status
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: gfx_features_d3d11_status
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: gfx_features_gpu_process_status
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_aboutdebugging_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_animationinspector_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_browserconsole_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_canvasdebugger_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_computedview_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_custom_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_developertoolbar_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_dom_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_eyedropper_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_fontinspector_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_inspector_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_jsbrowserdebugger_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_jsdebugger_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_jsprofiler_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_layoutview_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_memory_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_menu_eyedropper_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_netmonitor_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_options_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_paintflashing_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_picker_eyedropper_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_responsive_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_ruleview_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_scratchpad_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_scratchpad_window_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_shadereditor_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_storage_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_styleeditor_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_webaudioeditor_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_webconsole_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: histogram_parent_devtools_webide_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: install_year
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: is_default_browser
+  type: BOOLEAN
+  description: null
+- mode: NULLABLE
+  name: is_wow64
+  type: BOOLEAN
+  description: null
+- mode: NULLABLE
+  name: locale
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: memory_mb
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: normalized_channel
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: normalized_os_version
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: os
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: os_service_pack_major
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: os_service_pack_minor
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: os_version
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: pings_aggregated_by_this_row
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: places_bookmarks_count_mean
+  type: FLOAT
+  description: null
+- mode: NULLABLE
+  name: places_pages_count_mean
+  type: FLOAT
+  description: null
+- mode: NULLABLE
+  name: plugin_hangs_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: plugins_infobar_allow_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: plugins_infobar_block_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: plugins_infobar_shown_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: plugins_notification_shown_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: previous_build_id
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: profile_age_in_days
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: profile_creation_date
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: push_api_notify_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: sample_id
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: sandbox_effective_content_process_level
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_combined_webrtc_nicer_stun_retransmits_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_combined_webrtc_nicer_turn_401s_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_combined_webrtc_nicer_turn_403s_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_combined_webrtc_nicer_turn_438s_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_content_navigator_storage_estimate_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_content_navigator_storage_persist_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_aushelper_websense_reg_version
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_browser_engagement_max_concurrent_tab_count_max
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_browser_engagement_max_concurrent_window_count_max
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_browser_engagement_tab_open_event_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_browser_engagement_total_uri_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_browser_engagement_unfiltered_uri_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_browser_engagement_unique_domains_count_max
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_browser_engagement_unique_domains_count_mean
+  type: FLOAT
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_browser_engagement_window_open_event_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_devtools_accessibility_node_inspected_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_devtools_accessibility_opened_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_devtools_accessibility_picker_used_count_sum
+  type: INTEGER
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_devtools_accessibility_select_accessible_for_node_sum
+  type: RECORD
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_devtools_accessibility_service_enabled_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_devtools_copy_full_css_selector_opened_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_devtools_copy_unique_css_selector_opened_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_devtools_toolbar_eyedropper_opened_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_dom_contentprocess_troubled_due_to_memory_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_navigator_storage_estimate_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_navigator_storage_persist_count_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_storage_sync_api_usage_extensions_using_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_cohort
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: search_count_abouthome
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_count_contextmenu
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_count_newtab
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_count_searchbar
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_count_system
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_count_urlbar
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_count_all
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_count_tagged_sap
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_count_tagged_follow_on
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_count_organic
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_count_urlbar_handoff
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_urlbar_persisted
+  type: INTEGER
+- mode: NULLABLE
+  name: session_restored_mean
+  type: FLOAT
+  description: null
+- mode: NULLABLE
+  name: sessions_started_on_this_day
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: shutdown_kill_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: subsession_hours_sum
+  type: NUMERIC
+  description: null
+- mode: NULLABLE
+  name: ssl_handshake_result_failure_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: ssl_handshake_result_success_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: sync_configured
+  type: BOOLEAN
+  description: null
+- mode: NULLABLE
+  name: sync_count_desktop_mean
+  type: FLOAT
+  description: null
+- mode: NULLABLE
+  name: sync_count_mobile_mean
+  type: FLOAT
+  description: null
+- mode: NULLABLE
+  name: sync_count_desktop_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: sync_count_mobile_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: telemetry_enabled
+  type: BOOLEAN
+  description: null
+- mode: NULLABLE
+  name: timezone_offset
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: total_hours_sum
+  type: NUMERIC
+  description: null
+- mode: NULLABLE
+  name: update_auto_download
+  type: BOOLEAN
+  description: null
+- mode: NULLABLE
+  name: update_channel
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: update_enabled
+  type: BOOLEAN
+  description: null
+- mode: NULLABLE
+  name: vendor
+  type: STRING
+  description: null
+- mode: NULLABLE
+  name: web_notification_shown_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: windows_build_number
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: windows_ubr
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: fxa_configured
+  type: BOOLEAN
+  description: null
+- mode: NULLABLE
+  name: trackers_blocked_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: submission_timestamp_min
+  type: TIMESTAMP
+  description: null
+- mode: NULLABLE
+  name: ad_clicks_count_all
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: search_with_ads_count_all
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_urlbar_impression_autofill_about_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_urlbar_impression_autofill_adaptive_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_urlbar_impression_autofill_origin_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_urlbar_impression_autofill_other_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_urlbar_impression_autofill_preloaded_sum
+  type: INTEGER
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_urlbar_impression_autofill_url_sum
+  type: INTEGER
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_telemetry_event_counts_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_content_telemetry_event_counts_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_bookmarkmenu_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_handoff_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_keywordoffer_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_oneoff_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_other_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_shortcut_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_tabmenu_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_tabtosearch_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_tabtosearch_onboard_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_topsites_newtab_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_topsites_urlbar_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_touchbar_sum
+  type: RECORD
+  description: null
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+    description: null
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+    description: null
+  mode: REPEATED
+  name: scalar_parent_urlbar_searchmode_typed_sum
+  type: RECORD
+  description: null
+- mode: NULLABLE
+  name: scalar_parent_os_environment_is_taskbar_pinned
+  type: BOOLEAN
+- mode: NULLABLE
+  name: scalar_parent_os_environment_launched_via_desktop
+  type: BOOLEAN
+- mode: NULLABLE
+  name: scalar_parent_os_environment_launched_via_start_menu
+  type: BOOLEAN
+- mode: NULLABLE
+  name: scalar_parent_os_environment_launched_via_taskbar
+  type: BOOLEAN
+- mode: NULLABLE
+  name: scalar_parent_os_environment_launched_via_other_shortcut
+  type: BOOLEAN
+- mode: NULLABLE
+  name: scalar_parent_os_environment_launched_via_other
+  type: BOOLEAN
+- mode: NULLABLE
+  name: search_count_webextension
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_alias
+  type: INTEGER
+- mode: NULLABLE
+  name: search_count_urlbar_searchmode
+  type: INTEGER
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_browser_ui_interaction_preferences_pane_home_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_autofill_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_autofill_about_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_autofill_adaptive_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_autofill_origin_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_autofill_other_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_autofill_preloaded_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_autofill_url_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_bookmark_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_dynamic_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_extension_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_formhistory_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_history_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_keyword_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_remotetab_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_searchengine_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_searchsuggestion_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_switchtab_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_tabtosearch_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_tip_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_topsite_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_unknown_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_urlbar_picked_visiturl_sum
+  type: RECORD
+- mode: NULLABLE
+  name: default_private_search_engine
+  type: STRING
+- mode: NULLABLE
+  name: default_private_search_engine_data_load_path
+  type: STRING
+- mode: NULLABLE
+  name: default_private_search_engine_data_name
+  type: STRING
+- mode: NULLABLE
+  name: default_private_search_engine_data_origin
+  type: STRING
+- mode: NULLABLE
+  name: default_private_search_engine_data_submission_url
+  type: STRING
+- fields:
+  - mode: NULLABLE
+    name: engine
+    type: STRING
+  - mode: NULLABLE
+    name: source
+    type: STRING
+  - mode: NULLABLE
+    name: count
+    type: INTEGER
+  mode: REPEATED
+  name: search_counts
+  type: RECORD
+- mode: NULLABLE
+  name: user_pref_browser_search_region
+  type: STRING
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_with_ads
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: ad_clicks
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_urlbar_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_urlbar_persisted_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_urlbar_searchmode_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_contextmenu_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_about_home_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_about_newtab_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_searchbar_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_system_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_webextension_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_tabhistory_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_reload_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_content_unknown_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_urlbar_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_urlbar_persisted_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_urlbar_searchmode_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_contextmenu_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_about_home_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_about_newtab_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_searchbar_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_system_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_webextension_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_tabhistory_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_reload_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_withads_unknown_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_urlbar_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_urlbar_handoff_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_urlbar_persisted_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_urlbar_searchmode_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_contextmenu_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_about_home_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_about_newtab_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_searchbar_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_system_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_webextension_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_tabhistory_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_reload_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: search_adclicks_unknown_sum
+  type: RECORD
+- mode: NULLABLE
+  name: update_background
+  type: BOOLEAN
+- mode: NULLABLE
+  name: user_pref_browser_search_suggest_enabled
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_widget_in_navbar
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_searches
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_show_search_suggestions_first
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest_sponsored
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_quicksuggest_onboarding_dialog_choice
+  type: STRING
+- mode: NULLABLE
+  name: scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum
+  type: INTEGER
+- mode: NULLABLE
+  name: user_pref_browser_newtabpage_enabled
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_app_shield_optoutstudies_enabled
+  type: STRING
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_click_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_impression_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_help_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_topsites_click_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_topsites_impression_sum
+  type: RECORD
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_quicksuggest_nonsponsored
+  type: STRING
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_quicksuggest_data_collection_enabled
+  type: STRING
+- mode: NULLABLE
+  name: scalar_a11y_hcm_foreground
+  type: INTEGER
+- mode: NULLABLE
+  name: scalar_a11y_hcm_background
+  type: INTEGER
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: BOOLEAN
+  mode: REPEATED
+  name: a11y_theme
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_help_nonsponsored_bestmatch_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_help_sponsored_bestmatch_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_block_nonsponsored_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_block_sponsored_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_block_sponsored_bestmatch_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_block_nonsponsored_bestmatch_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_click_sponsored_bestmatch_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_click_nonsponsored_bestmatch_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_impression_sponsored_bestmatch_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_impression_nonsponsored_bestmatch_sum
+  type: RECORD
+- mode: NULLABLE
+  name: user_pref_browser_urlbar_suggest_bestmatch
+  type: STRING
+- mode: NULLABLE
+  name: scalar_parent_browser_ui_interaction_textrecognition_error_sum
+  type: INTEGER
+- mode: NULLABLE
+  name: text_recognition_interaction_timing_sum
+  type: INTEGER
+- mode: NULLABLE
+  name: text_recognition_interaction_timing_count_sum
+  type: INTEGER
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_browser_ui_interaction_content_context_sum
+  type: RECORD
+- mode: NULLABLE
+  name: text_recognition_api_performance_sum
+  type: INTEGER
+- mode: NULLABLE
+  name: text_recognition_api_performance_count_sum
+  type: INTEGER
+- mode: NULLABLE
+  name: text_recognition_text_length_sum
+  type: INTEGER
+- mode: NULLABLE
+  name: text_recognition_text_length_count_sum
+  type: INTEGER
+- mode: NULLABLE
+  name: places_searchbar_cumulative_searches_sum
+  type: INTEGER
+- mode: NULLABLE
+  name: places_searchbar_cumulative_filter_count_sum
+  type: INTEGER
+- mode: NULLABLE
+  name: scalar_parent_os_environment_launched_via_taskbar_private
+  type: BOOLEAN
+- mode: NULLABLE
+  name: dom_parentprocess_private_window_used
+  type: BOOLEAN
+- mode: NULLABLE
+  name: os_environment_is_taskbar_pinned_any
+  type: BOOLEAN
+- mode: NULLABLE
+  name: os_environment_is_taskbar_pinned_private_any
+  type: BOOLEAN
+- mode: NULLABLE
+  name: os_environment_is_taskbar_pinned_private
+  type: BOOLEAN
+- mode: NULLABLE
+  name: bookmark_migrations_quantity_chrome
+  type: INTEGER
+- mode: NULLABLE
+  name: bookmark_migrations_quantity_edge
+  type: INTEGER
+- mode: NULLABLE
+  name: bookmark_migrations_quantity_safari
+  type: INTEGER
+- mode: NULLABLE
+  name: bookmark_migrations_quantity_all
+  type: INTEGER
+- mode: NULLABLE
+  name: history_migrations_quantity_chrome
+  type: INTEGER
+- mode: NULLABLE
+  name: history_migrations_quantity_edge
+  type: INTEGER
+- mode: NULLABLE
+  name: history_migrations_quantity_safari
+  type: INTEGER
+- mode: NULLABLE
+  name: history_migrations_quantity_all
+  type: INTEGER
+- mode: NULLABLE
+  name: logins_migrations_quantity_chrome
+  type: INTEGER
+- mode: NULLABLE
+  name: logins_migrations_quantity_edge
+  type: INTEGER
+- mode: NULLABLE
+  name: logins_migrations_quantity_safari
+  type: INTEGER
+- mode: NULLABLE
+  name: logins_migrations_quantity_all
+  type: INTEGER
+- mode: NULLABLE
+  name: media_play_time_ms_audio_sum
+  type: INTEGER
+- mode: NULLABLE
+  name: media_play_time_ms_video_sum
+  type: INTEGER
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_block_dynamic_wikipedia_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_block_weather_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_click_dynamic_wikipedia_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_click_nonsponsored_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_click_sponsored_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_click_weather_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_help_dynamic_wikipedia_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_help_nonsponsored_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_help_sponsored_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_help_weather_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_impression_dynamic_wikipedia_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_impression_nonsponsored_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_impression_sponsored_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: contextual_services_quicksuggest_impression_weather_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_sidebar_opened_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_sidebar_search_sum
+  type: RECORD
+- fields:
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: scalar_parent_sidebar_link_sum
+  type: RECORD
+- name: places_previousday_visits_mean
+  type: FLOAT
+  mode: NULLABLE
+- name: places_library_cumulative_bookmark_searches_sum
+  type: INTEGER
+  mode: NULLABLE
+- name: places_library_cumulative_history_searches_sum
+  type: INTEGER
+  mode: NULLABLE
+- name: places_bookmarks_searchbar_cumulative_searches_sum
+  type: INTEGER
+  mode: NULLABLE
+- name: scalar_parent_library_link_sum
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: key
+    type: STRING
+    mode: NULLABLE
+  - name: value
+    type: INTEGER
+    mode: NULLABLE
+- name: scalar_parent_library_opened_sum
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: key
+    type: STRING
+    mode: NULLABLE
+  - name: value
+    type: INTEGER
+    mode: NULLABLE
+- name: scalar_parent_library_search_sum
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: key
+    type: STRING
+    mode: NULLABLE
+  - name: value
+    type: INTEGER
+    mode: NULLABLE


### PR DESCRIPTION
Create query for version 2 of table clients_last_seen. This PR queries clients_first_seen_v2 directly, therefore **it should only be merged AFTER** its [backfill DS-3101](https://mozilla-hub.atlassian.net/browse/DS-3101) and [validation DS-3102](https://mozilla-hub.atlassian.net/browse/DS-3102).

The schema needs to be deployed.

This PR doesn't impact any other tables. --The view and DAG changes are moved to a separate PR to enable running the backfill and validations of this new version first.