### PR TITLE
DS-3103. Update view clients_first_seen to query v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/clients_first_seen/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_first_seen/metadata.yaml
@@ -1,9 +1,11 @@
 ---
 friendly_name: Clients First Seen
 description: |-
-  Identical in schema to `clients_daily` except that each client appears only
-  once over all time; includes fields `first_seen_date` and `second_seen_date`
-  for determining user "activation".
+  First observations of Firefox Desktop clients based on the ping that reports
+  first: main, new_profile or first_shutdown.
+  Previously, this view reflected only clients based on main ping. From Q4 2023
+  these three pings are used to determine first_seen_date, second_seen date and
+  other attributes. See https://mozilla-hub.atlassian.net/browse/DS-2929.
 
   Note that `first_seen_date` and `second_seen_date` are also pulled into
   `clients_last_seen` to avoid needing to join with this view. Use this view
@@ -13,6 +15,7 @@ description: |-
 
   See also: `clients_daily`, `clients_last_seen`
 owners:
-  - jklukas@mozilla.com
+  - lvargas@mozilla.com
+  - rzhao@mozilla.com
 labels:
   application: firefox

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_first_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_first_seen/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-shared-prod.telemetry_derived.clients_first_seen_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.clients_first_seen_v2`


### PR DESCRIPTION
Update view `telemetry.clients_first_seen` to query version 2 of the table.

This PR **should only be merged** after running all validations in the table and the closing [DS-3102](https://mozilla-hub.atlassian.net/browse/DS-3102).

[DS-3102]: https://mozilla-hub.atlassian.net/browse/DS-3102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1466)
