### PR TITLE
bug(): fixing airflow_task_instance query and correcting job_id type

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_instance_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_instance_v1/query.sql
@@ -7,7 +7,7 @@ SELECT
   start_date,
   end_date,
   duration,
-  updated_at AS job_id,
+  job_id,
   executor_config,
   external_executor_id,
   hostname,

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_instance_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/airflow_task_instance_v1/schema.yaml
@@ -34,7 +34,7 @@ fields:
 - description:
   mode: NULLABLE
   name: job_id
-  type: TIMESTAMP
+  type: INTEGER
 - description:
   mode: NULLABLE
   name: executor_config


### PR DESCRIPTION
# bug(): fixing airflow_task_instance query and correcting job_id type

It appears due to an incorrect aliasing inside the `query.sql` we ended up with an incorrect field being used to populate the `job_id` field. This PR aims to fix this.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1475)
