### PR TITLE
bug(): tweaking the min_rows data check macro as currently it does not error when expected

### DIFF
--- a/tests/checks/min_rows.jinja
+++ b/tests/checks/min_rows.jinja
@@ -9,7 +9,7 @@
     {% endif %}
   )
   SELECT IF(
-   (SELECT total_rows FROM min_rows WHERE total_rows < {{ threshold }}) > 0,
+   (SELECT COUNTIF(total_rows < {{ threshold }}) FROM min_rows) > 0,
    ERROR(CONCAT("Less than ", (SELECT total_rows FROM min_rows), " rows found (expected more than {{ threshold }})")),
    NULL
   );


### PR DESCRIPTION
# bug(): tweaking the min_rows data check macro as currently it does not error when expected

An example of a rendered check query before the change:

```sql
WITH min_rows AS (
  SELECT
    COUNT(*) AS total_rows
  FROM
    `moz-fx-data-shared-prod.firefox_ios_derived.app_store_funnel_v1`
  WHERE
    `date` = DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
)
SELECT
  IF(
    (SELECT total_rows FROM min_rows WHERE total_rows < 1) > 0,
    ERROR(
      CONCAT("Less than ", (SELECT total_rows FROM min_rows), " rows found (expected more than 1)")
    ),
    NULL
  );
```
Currently, the above results in `null` being returned even though we know there is missing data in the table.

Rendered query after the change:

```sql
WITH min_rows AS (
  SELECT
    COUNT(*) AS total_rows
  FROM
    `moz-fx-data-shared-prod.firefox_ios_derived.app_store_funnel_v1`
  WHERE
    `date` = DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
)
SELECT
  IF(
    (SELECT COUNTIF(total_rows < 1) FROM min_rows) > 0,
    ERROR(
      CONCAT("Less than ", (SELECT total_rows FROM min_rows), " rows found (expected more than 1)")
    ),
    NULL
  );
```
Now we correctly get an error, as expected.



┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1492)
