### PR TITLE
DENG-797 change monitoring_airflow DAG schedule

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -412,7 +412,7 @@ bqetl_monitoring:
     - impact/tier_1
 
 bqetl_monitoring_airflow:
-  schedule_interval: 0 2 * * *
+  schedule_interval: 0 10 * * *
   description: |
     This DAG schedules queries and scripts for populating datasets
     used for monitoring of Airflow DAGs.

--- a/dags/bqetl_monitoring_airflow.py
+++ b/dags/bqetl_monitoring_airflow.py
@@ -45,7 +45,7 @@ tags = ["impact/tier_2", "repo/bigquery-etl"]
 with DAG(
     "bqetl_monitoring_airflow",
     default_args=default_args,
-    schedule_interval="0 2 * * *",
+    schedule_interval="0 10 * * *",
     doc_md=docs,
     tags=tags,
 ) as dag:


### PR DESCRIPTION
changing the timing on the airflow monitoring DAG so that it runs after more of the other DAGs ran ... because at currently 2 am most haven't finished yet. Open for other suggestions on the timing

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1508)
