### PR TITLE
fix DENG-1510: add dryrun flag to schema update command

### DIFF
--- a/docs/cookbooks/common_workflows.md
+++ b/docs/cookbooks/common_workflows.md
@@ -114,8 +114,9 @@ The following is an example to update a new field in `telemetry_derived.clients_
 1. Open the `clients_daily_v6` `query.sql` file and add new field definitions.
 1. Run `./bqetl format sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql`
 1. Run `./bqetl query validate telemetry_derived.clients_daily_v6`.
-1. Run `./bqetl query schema update telemetry_derived.clients_daily_v6 --update_downstream`.
+1. Run `./bqetl query schema update telemetry_derived.clients_daily_v6 --update_downstream --ignore-dryrun-skip`.
    * [x] `schema.yaml` files of downstream dependencies, like `clients_last_seen_v1` are updated.
+   * If the schema has no changes, we do not run schema updates on any of its downstream dependencies.
 1. Open a PR with these changes.
 1. PR is reviewed and approved.
 1. Merge pull-request.


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/DENG-1510 or https://bugzilla.mozilla.org/show_bug.cgi?id=1852117 for context.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1512)
