### PR TITLE
Consistently call `bqetl query render` when generating SQL in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,6 +447,10 @@ jobs:
             PATH="venv/bin:$PATH" script/bqetl generate all \
               --output-dir /tmp/workspace/private-generated-sql/sql/ \
               --target-project moz-fx-data-shared-prod
+            PATH="venv/bin:$PATH" script/bqetl query render \
+              --sql-dir /tmp/workspace/private-generated-sql/sql/ \
+              --output-dir /tmp/workspace/private-generated-sql/sql/ \
+              /tmp/workspace/private-generated-sql/sql/
             PATH="venv/bin:$PATH" script/bqetl dependency record \
               --skip-existing \
               "/tmp/workspace/private-generated-sql/sql/"
@@ -513,6 +517,9 @@ jobs:
             export PATH="venv/bin:$PATH"
             ./script/bqetl generate all \
               --target-project moz-fx-data-shared-prod
+            ./script/bqetl query render \
+              --output-dir sql/ \
+              sql/
             ./script/bqetl dependency record \
               --skip-existing \
               "sql/"


### PR DESCRIPTION
The `bqetl query render` subcommand to support Jinja in SQL files was added in #3691, at which time the `generate-sql` CI job was updated to call `bqetl query render`.  However, the `private-generate-sql` and `generate-diff` CI jobs weren't updated to match.  One side effect of this is that SQL diffs on PRs currently erroneously show differences that are simply due to Jinja expressions getting rendered/replaced.

This updates the CI jobs that generate SQL to consistently call `bqetl query render`.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1513)
