### PR TITLE
fix(bug-1852517): bqetl kpis shredder sensor failing to detect upstream completion

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1154,7 +1154,7 @@ bqetl_kpis_shredder:
     start_date: '2023-05-16'
   description: This DAG calculates KPIs for shredder client_ids
   repo: bigquery-etl
-  schedule_interval: 0 0 */28 * *
+  schedule_interval: 0 1 */28 * *
   tags:
     - impact/tier_3
     - repo/bigquery-etl

--- a/dags/bqetl_kpis_shredder.py
+++ b/dags/bqetl_kpis_shredder.py
@@ -39,7 +39,7 @@ tags = ["impact/tier_3", "repo/bigquery-etl"]
 with DAG(
     "bqetl_kpis_shredder",
     default_args=default_args,
-    schedule_interval="0 0 */28 * *",
+    schedule_interval="0 1 */28 * *",
     doc_md=docs,
     tags=tags,
 ) as dag:

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
@@ -1,2 +1,3 @@
 {{ is_unique(["`date`", "country"]) }}
+ {{ min_rows(1, "`date` = DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)") }}
 


### PR DESCRIPTION
fix(bug-1852517): bqetl kpis shredder sensor failing to detect upstream completion

This change updates the scheduling for `bqetl_kpis_shredder` DAG to run at 1AM UTC to match that of the `copy_deduplicate` DAG.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1517)
