### PR TITLE
Bug 1852630 - Override default main-like tables to pin v4

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/first_shutdown/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/first_shutdown/view.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.first_shutdown`
+AS
+SELECT
+  * REPLACE (
+    mozfun.norm.metadata(metadata) AS metadata,
+    `moz-fx-data-shared-prod`.udf.normalize_main_payload(payload) AS payload
+  )
+FROM
+  `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_v4`

--- a/sql/moz-fx-data-shared-prod/telemetry/main/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/main/view.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.main`
+AS
+SELECT
+  * REPLACE (
+    mozfun.norm.metadata(metadata) AS metadata,
+    `moz-fx-data-shared-prod`.udf.normalize_main_payload(payload) AS payload
+  )
+FROM
+  `moz-fx-data-shared-prod.telemetry_stable.main_v4`

--- a/sql/moz-fx-data-shared-prod/telemetry/saved_session/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/saved_session/view.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.saved_session`
+AS
+SELECT
+  * REPLACE (
+    mozfun.norm.metadata(metadata) AS metadata,
+    `moz-fx-data-shared-prod`.udf.normalize_main_payload(payload) AS payload
+  )
+FROM
+  `moz-fx-data-shared-prod.telemetry_stable.saved_session_v4`


### PR DESCRIPTION
and rename main_remainder_v4 references to main_v5

[Bug 1852630](https://bugzilla.mozilla.org/show_bug.cgi?id=1852630)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1538)
