### PR TITLE
chore(): updated bqetl_kpis_shredder DAG description to indicate why it is paused

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1152,7 +1152,13 @@ bqetl_kpis_shredder:
     retries: 2
     retry_delay: 30m
     start_date: '2023-05-16'
-  description: This DAG calculates KPIs for shredder client_ids
+  description: |
+    Currently paused due to a bug causing the DAG upstream dependencies completion
+    not being detected correctly.
+    for more info, see:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1852517
+      - https://github.com/mozilla/bigquery-etl/pull/4239
+    This DAG calculates KPIs for shredder client_ids
   repo: bigquery-etl
   schedule_interval: 0 0 */28 * *
   tags:

--- a/dags/bqetl_kpis_shredder.py
+++ b/dags/bqetl_kpis_shredder.py
@@ -15,7 +15,13 @@ Built from bigquery-etl repo, [`dags/bqetl_kpis_shredder.py`](https://github.com
 
 #### Description
 
+Currently paused due to a bug causing the DAG upstream dependencies completion
+not being detected correctly.
+for more info, see:
+  - https://bugzilla.mozilla.org/show_bug.cgi?id=1852517
+  - https://github.com/mozilla/bigquery-etl/pull/4239
 This DAG calculates KPIs for shredder client_ids
+
 #### Owner
 
 lvargas@mozilla.com


### PR DESCRIPTION
# chore(): updated bqetl_kpis_shredder DAG description to indicate why it is paused

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1542)
