### PR TITLE
feat(DENG-722): updated fxa views to point to fxa_all_events view

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
@@ -19,93 +19,50 @@
 ---  'content',
 ---  'auth'
 --- )
+--------
+-- In the meantime, this view points to the fxa_all_events view
+-- while maintaining filtering rules to only include certain events for backward compatibility.
 -----
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_accounts.fxa_content_auth_events`
 AS
-WITH content AS (
-  SELECT
-    jsonPayload.logger,
-    jsonPayload.fields.event_type,
-    jsonPayload.fields.app_version,
-    jsonPayload.fields.os_name,
-    jsonPayload.fields.os_version,
-    jsonPayload.fields.country,
-    jsonPayload.fields.language,
-    jsonPayload.fields.user_id,
-    jsonPayload.fields.user_properties,
-    jsonPayload.fields.event_properties,
-    `timestamp`,
-    receiveTimestamp,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_content_events_v1`
-),
-  --
-auth AS (
-  SELECT
-    jsonPayload.logger,
-    jsonPayload.fields.event_type,
-    jsonPayload.fields.app_version,
-    jsonPayload.fields.os_name,
-    jsonPayload.fields.os_version,
-    jsonPayload.fields.country,
-    jsonPayload.fields.language,
-    jsonPayload.fields.user_id,
-    jsonPayload.fields.user_properties,
-    jsonPayload.fields.event_properties,
-    `timestamp`,
-    receiveTimestamp,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_auth_events_v1`
-),
-  --
-unioned AS (
-  SELECT
-    *
-  FROM
-    auth
-  UNION ALL
-  SELECT
-    *
-  FROM
-    content
-)
-  --
 SELECT
-  * EXCEPT (user_properties, event_properties),
-  JSON_VALUE(user_properties, "$.utm_term") AS utm_term,
-  JSON_VALUE(user_properties, "$.utm_source") AS utm_source,
-  JSON_VALUE(user_properties, "$.utm_medium") AS utm_medium,
-  JSON_VALUE(user_properties, "$.utm_campaign") AS utm_campaign,
-  JSON_VALUE(user_properties, "$.utm_content") AS utm_content,
-  JSON_VALUE(user_properties, "$.ua_version") AS ua_version,
-  JSON_VALUE(user_properties, "$.ua_browser") AS ua_browser,
-  JSON_VALUE(user_properties, "$.entrypoint") AS entrypoint,
-  JSON_VALUE(user_properties, "$.entrypoint_experiment") AS entrypoint_experiment,
-  JSON_VALUE(user_properties, "$.entrypoint_variation") AS entrypoint_variation,
-  JSON_VALUE(user_properties, "$.flow_id") AS flow_id,
-  JSON_VALUE(event_properties, "$.service") AS service,
-  JSON_VALUE(event_properties, "$.email_type") AS email_type,
-  JSON_VALUE(event_properties, "$.email_provider") AS email_provider,
-  JSON_VALUE(event_properties, "$.oauth_client_id") AS oauth_client_id,
-  JSON_VALUE(event_properties, "$.connect_device_flow") AS connect_device_flow,
-  JSON_VALUE(event_properties, "$.connect_device_os") AS connect_device_os,
-  JSON_VALUE(user_properties, "$.sync_device_count") AS sync_device_count,
-  JSON_VALUE(user_properties, "$.sync_active_devices_day") AS sync_active_devices_day,
-  JSON_VALUE(user_properties, "$.sync_active_devices_week") AS sync_active_devices_week,
-  JSON_VALUE(user_properties, "$.sync_active_devices_month") AS sync_active_devices_month,
-  JSON_VALUE(event_properties, "$.email_sender") AS email_sender,
-  JSON_VALUE(event_properties, "$.email_service") AS email_service,
-  JSON_VALUE(event_properties, "$.email_template") AS email_template,
-  JSON_VALUE(event_properties, "$.email_version") AS email_version,
+  logger,
+  event_type,
+  app_version,
+  os_name,
+  os_version,
+  country,
+  LANGUAGE,
+  user_id,
+  `timestamp`,
+  receiveTimestamp,
+  utm_term,
+  utm_source,
+  utm_medium,
+  utm_campaign,
+  utm_content,
+  ua_version,
+  ua_browser,
+  entrypoint,
+  entrypoint_experiment,
+  entrypoint_variation,
+  flow_id,
+  service,
+  email_type,
+  email_provider,
+  oauth_client_id,
+  connect_device_flow,
+  connect_device_os,
+  sync_device_count,
+  sync_active_devices_day,
+  sync_active_devices_week,
+  sync_active_devices_month,
+  email_sender,
+  email_service,
+  email_template,
+  email_version,
 FROM
-  unioned
--- Commented out for now, to restore FxA Looker dashboards
--- Once dashboards have been migrated to use fxa_all_events view
--- this will be uncommented to see if we can pick up any other usage
--- of this view.
--- See DENG-582 for more info.
--- WHERE
---   ERROR(
---     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `fxa_log` instead. See DENG-582 for more info.'
---   )
+  `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
+WHERE
+  fxa_log IN ("content", "auth")

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
@@ -20,117 +20,49 @@
 ---  'auth',
 --   'oauth'
 --- )
+--------
+-- In the meantime, this view points to the fxa_all_events view
+-- while maintaining filtering rules to only include certain events for backward compatibility.
 -----
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_accounts.fxa_content_auth_oauth_events`
 AS
-WITH content AS (
-  SELECT
-    jsonPayload.logger,
-    jsonPayload.fields.event_type,
-    jsonPayload.fields.app_version,
-    jsonPayload.fields.os_name,
-    jsonPayload.fields.os_version,
-    jsonPayload.fields.country,
-    jsonPayload.fields.language,
-    jsonPayload.fields.user_id,
-    jsonPayload.fields.user_properties,
-    jsonPayload.fields.event_properties,
-    jsonPayload.fields.device_id,
-    `timestamp`,
-    receiveTimestamp,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_content_events_v1`
-),
-    --
-auth AS (
-  SELECT
-    jsonPayload.logger,
-    jsonPayload.fields.event_type,
-    jsonPayload.fields.app_version,
-    jsonPayload.fields.os_name,
-    jsonPayload.fields.os_version,
-    jsonPayload.fields.country,
-    jsonPayload.fields.language,
-    jsonPayload.fields.user_id,
-    jsonPayload.fields.user_properties,
-    jsonPayload.fields.event_properties,
-    jsonPayload.fields.device_id,
-    `timestamp`,
-    receiveTimestamp,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_auth_events_v1`
-),
-    --
-oauth AS (
-  SELECT
-    jsonPayload.logger,
-    jsonPayload.fields.event_type,
-    jsonPayload.fields.app_version,
-    CAST(NULL AS STRING) AS os_name,
-    CAST(NULL AS STRING) AS os_version,
-    CAST(NULL AS STRING) AS country,
-    CAST(NULL AS STRING) AS language,
-    jsonPayload.fields.user_id,
-    jsonPayload.fields.user_properties,
-    jsonPayload.fields.event_properties,
-    CAST(NULL AS STRING) AS device_id,
-    `timestamp`,
-    receiveTimestamp,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_oauth_events_v1`
-),
-    --
-unioned AS (
-  SELECT
-    *
-  FROM
-    auth
-  UNION ALL
-  SELECT
-    *
-  FROM
-    content
-  UNION ALL
-  SELECT
-    *
-  FROM
-    oauth
-)
-    --
 SELECT
-  * EXCEPT (user_properties, event_properties),
-  JSON_VALUE(user_properties, "$.utm_term") AS utm_term,
-  JSON_VALUE(user_properties, "$.utm_source") AS utm_source,
-  JSON_VALUE(user_properties, "$.utm_medium") AS utm_medium,
-  JSON_VALUE(user_properties, "$.utm_campaign") AS utm_campaign,
-  JSON_VALUE(user_properties, "$.utm_content") AS utm_content,
-  JSON_VALUE(user_properties, "$.ua_version") AS ua_version,
-  JSON_VALUE(user_properties, "$.ua_browser") AS ua_browser,
-  JSON_VALUE(user_properties, "$.entrypoint") AS entrypoint,
-  JSON_VALUE(user_properties, "$.flow_id") AS flow_id,
-  JSON_VALUE(event_properties, "$.service") AS service,
-  JSON_VALUE(event_properties, "$.email_type") AS email_type,
-  JSON_VALUE(event_properties, "$.email_provider") AS email_provider,
-  JSON_VALUE(event_properties, "$.oauth_client_id") AS oauth_client_id,
-  JSON_VALUE(event_properties, "$.connect_device_flow") AS connect_device_flow,
-  JSON_VALUE(event_properties, "$.connect_device_os") AS connect_device_os,
-  JSON_VALUE(user_properties, "$.sync_device_count") AS sync_device_count,
-  JSON_VALUE(user_properties, "$.sync_active_devices_day") AS sync_active_devices_day,
-  JSON_VALUE(user_properties, "$.sync_active_devices_week") AS sync_active_devices_week,
-  JSON_VALUE(user_properties, "$.sync_active_devices_month") AS sync_active_devices_month,
-  JSON_VALUE(event_properties, "$.email_sender") AS email_sender,
-  JSON_VALUE(event_properties, "$.email_service") AS email_service,
-  JSON_VALUE(event_properties, "$.email_template") AS email_template,
-  JSON_VALUE(event_properties, "$.email_version") AS email_version,
+  logger,
+  event_type,
+  app_version,
+  os_name,
+  os_version,
+  country,
+  LANGUAGE,
+  user_id,
+  device_id,
+  `timestamp`,
+  receiveTimestamp,
+  utm_term,
+  utm_source,
+  utm_medium,
+  utm_campaign,
+  utm_content,
+  ua_version,
+  ua_browser,
+  entrypoint,
+  flow_id,
+  service,
+  email_type,
+  email_provider,
+  oauth_client_id,
+  connect_device_flow,
+  connect_device_os,
+  sync_device_count,
+  sync_active_devices_day,
+  sync_active_devices_week,
+  sync_active_devices_month,
+  email_sender,
+  email_service,
+  email_template,
+  email_version,
 FROM
-  unioned
--- Commented out for now, to restore FxA Looker dashboards
--- Once dashboards have been migrated to use fxa_all_events view
--- this will be uncommented to see if we can pick up any other usage
--- of this view.
--- See DENG-582 for more info.
--- WHERE
---   ERROR(
---     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `fxa_log` instead. See DENG-582 for more info.'
---   )
+  `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
+WHERE
+  fxa_log IN ("content", "auth", "oauth")

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
@@ -20,147 +20,54 @@
 ---  'auth',
 --   'stdout'
 --- )
+--------
+-- In the meantime, this view points to the fxa_all_events view
+-- while maintaining filtering rules to only include certain events for backward compatibility.
 -----
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_accounts.fxa_content_auth_stdout_events`
 AS
-WITH content AS (
-  SELECT
-    jsonPayload.logger,
-    jsonPayload.fields.event_type,
-    jsonPayload.fields.app_version,
-    jsonPayload.fields.os_name,
-    jsonPayload.fields.os_version,
-    jsonPayload.fields.country,
-    CAST(NULL AS STRING) AS country_code,
-    jsonPayload.fields.language,
-    jsonPayload.fields.user_id,
-    jsonPayload.fields.device_id,
-    jsonPayload.fields.user_properties,
-    jsonPayload.fields.event_properties,
-    `timestamp`,
-    receiveTimestamp,
-    TIMESTAMP_MILLIS(CAST(jsonPayload.fields.time AS INT64)) AS event_time,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_content_events_v1`
-),
-  --
-auth AS (
-  SELECT
-    jsonPayload.logger,
-    jsonPayload.fields.event_type,
-    jsonPayload.fields.app_version,
-    jsonPayload.fields.os_name,
-    jsonPayload.fields.os_version,
-    jsonPayload.fields.country,
-    JSON_VALUE(jsonPayload.fields.event_properties, "$.country_code") AS country_code,
-    jsonPayload.fields.language,
-    jsonPayload.fields.user_id,
-    jsonPayload.fields.device_id,
-    jsonPayload.fields.user_properties,
-    jsonPayload.fields.event_properties,
-    `timestamp`,
-    receiveTimestamp,
-    TIMESTAMP_MILLIS(CAST(jsonPayload.fields.time AS INT64)) AS event_time,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_auth_events_v1`
-),
-  --
-stdout AS (
-  SELECT
-    jsonPayload.logger,
-    jsonPayload.fields.event_type,
-    jsonPayload.fields.app_version,
-    jsonPayload.fields.os_name,
-    jsonPayload.fields.os_version,
-    CAST(NULL AS STRING) AS country,
-    jsonPayload.fields.country_code,
-    jsonPayload.fields.language,
-    jsonPayload.fields.user_id,
-    jsonPayload.fields.device_id,
-    jsonPayload.fields.user_properties,
-    jsonPayload.fields.event_properties,
-    `timestamp`,
-    receiveTimestamp,
-    TIMESTAMP_MILLIS(CAST(jsonPayload.fields.time AS INT64)) AS event_time,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_stdout_events_v1`
-),
-  --
-unioned AS (
-  SELECT
-    *
-  FROM
-    auth
-  UNION ALL
-  SELECT
-    *
-  FROM
-    content
-  UNION ALL
-  SELECT
-    *
-  FROM
-    stdout
-)
-  --
 SELECT
-  * EXCEPT (user_properties, event_properties),
-  JSON_VALUE(user_properties, "$.utm_term") AS utm_term,
-  JSON_VALUE(user_properties, "$.utm_source") AS utm_source,
-  JSON_VALUE(user_properties, "$.utm_medium") AS utm_medium,
-  JSON_VALUE(user_properties, "$.utm_campaign") AS utm_campaign,
-  JSON_VALUE(user_properties, "$.utm_content") AS utm_content,
-  JSON_VALUE(user_properties, "$.ua_version") AS ua_version,
-  JSON_VALUE(user_properties, "$.ua_browser") AS ua_browser,
-  JSON_VALUE(user_properties, "$.entrypoint") AS entrypoint,
-  JSON_VALUE(user_properties, "$.entrypoint_experiment") AS entrypoint_experiment,
-  JSON_VALUE(user_properties, "$.entrypoint_variation") AS entrypoint_variation,
-  JSON_VALUE(user_properties, "$.flow_id") AS flow_id,
-  JSON_VALUE(event_properties, "$.service") AS service,
-  JSON_VALUE(event_properties, "$.email_type") AS email_type,
-  JSON_VALUE(event_properties, "$.email_provider") AS email_provider,
-  JSON_VALUE(event_properties, "$.oauth_client_id") AS oauth_client_id,
-  JSON_VALUE(event_properties, "$.connect_device_flow") AS connect_device_flow,
-  JSON_VALUE(event_properties, "$.connect_device_os") AS connect_device_os,
-  JSON_VALUE(user_properties, "$.sync_device_count") AS sync_device_count,
-  JSON_VALUE(user_properties, "$.sync_active_devices_day") AS sync_active_devices_day,
-  JSON_VALUE(user_properties, "$.sync_active_devices_week") AS sync_active_devices_week,
-  JSON_VALUE(user_properties, "$.sync_active_devices_month") AS sync_active_devices_month,
-  JSON_VALUE(event_properties, "$.email_sender") AS email_sender,
-  JSON_VALUE(event_properties, "$.email_service") AS email_service,
-  JSON_VALUE(event_properties, "$.email_template") AS email_template,
-  JSON_VALUE(event_properties, "$.email_version") AS email_version,
-  JSON_VALUE(event_properties, "$.subscription_id") AS subscription_id,
-  JSON_VALUE(event_properties, "$.plan_id") AS plan_id,
-  JSON_VALUE(event_properties, "$.previous_plan_id") AS previous_plan_id,
-  JSON_VALUE(event_properties, "$.subscribed_plan_ids") AS subscribed_plan_ids,
-  JSON_VALUE(event_properties, "$.product_id") AS product_id,
-  JSON_VALUE(event_properties, "$.previous_product_id") AS previous_product_id,
-  -- `promotionCode` was renamed `promotion_code` in stdout logs.
-  COALESCE(
-    JSON_VALUE(event_properties, "$.promotion_code"),
-    JSON_VALUE(event_properties, "$.promotionCode")
-  ) AS promotion_code,
-  JSON_VALUE(event_properties, "$.payment_provider") AS payment_provider,
-  JSON_VALUE(event_properties, "$.provider_event_id") AS provider_event_id,
-  JSON_VALUE(event_properties, "$.checkout_type") AS checkout_type,
-  JSON_VALUE(event_properties, "$.source_country") AS source_country,
-  -- `source_country` was renamed `country_code_source` in stdout logs.
-  COALESCE(
-    JSON_VALUE(event_properties, "$.country_code_source"),
-    JSON_VALUE(event_properties, "$.source_country")
-  ) AS country_code_source,
-  JSON_VALUE(event_properties, "$.error_id") AS error_id,
-  CAST(JSON_VALUE(event_properties, "$.voluntary_cancellation") AS BOOL) AS voluntary_cancellation,
+  utm_term,
+  utm_source,
+  utm_medium,
+  utm_campaign,
+  utm_content,
+  ua_version,
+  ua_browser,
+  entrypoint,
+  entrypoint_experiment,
+  entrypoint_variation,
+  flow_id,
+  service,
+  email_type,
+  email_provider,
+  oauth_client_id,
+  connect_device_flow,
+  connect_device_os,
+  sync_device_count,
+  sync_active_devices_day,
+  sync_active_devices_week,
+  sync_active_devices_month,
+  email_sender,
+  email_service,
+  email_template,
+  email_version,
+  subscription_id,
+  plan_id,
+  previous_plan_id,
+  subscribed_plan_ids,
+  product_id,
+  previous_product_id,
+  promotion_code,
+  payment_provider,
+  provider_event_id,
+  checkout_type,
+  source_country,
+  country_code_source,
+  error_id,
+  voluntary_cancellation,
 FROM
-  unioned
--- Commented out for now, to restore FxA Looker dashboards
--- Once dashboards have been migrated to use fxa_all_events view
--- this will be uncommented to see if we can pick up any other usage
--- of this view.
--- See DENG-582 for more info.
--- WHERE
---   ERROR(
---     'VIEW DEPRECATED - This view will be completely deleted after 9th of February 2023, please use `fxa_all_events` with filter on `fxa_log` instead. See DENG-582 for more info.'
---   )
+  `moz-fx-data-shared-prod.firefox_accounts.fxa_all_events`
+WHERE
+  fxa_log IN ("content", "auth", "stdout")

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/nonprod_fxa_all_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/nonprod_fxa_all_events/view.sql
@@ -115,7 +115,7 @@ unioned AS (
     server_events
 )
 SELECT
-  fxa_server,
+  fxa_server AS fxa_log,
   `timestamp`,
   receiveTimestamp,
   event_time,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/nonprod_fxa_content_auth_stdout_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/nonprod_fxa_content_auth_stdout_events/view.sql
@@ -6,134 +6,60 @@ AS
   -- to access nonprod fxa event data.
   -- Keeping this around until we can ensure all downstream
   -- tools are updated to use the new view (see: DENG-627).
-WITH content AS (
-  SELECT
-    jsonPayload.logger,
-    jsonPayload.fields.event_type,
-    jsonPayload.fields.app_version,
-    jsonPayload.fields.os_name,
-    jsonPayload.fields.os_version,
-    jsonPayload.fields.country,
-    CAST(NULL AS STRING) AS country_code,
-    jsonPayload.fields.language,
-    jsonPayload.fields.user_id,
-    jsonPayload.fields.device_id,
-    jsonPayload.fields.user_properties,
-    jsonPayload.fields.event_properties,
-    `timestamp`,
-    receiveTimestamp,
-    TIMESTAMP_MILLIS(CAST(jsonPayload.fields.time AS INT64)) AS event_time,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts_derived.nonprod_fxa_content_events_v1`
-),
-  --
-auth AS (
-  SELECT
-    jsonPayload.logger,
-    jsonPayload.fields.event_type,
-    jsonPayload.fields.app_version,
-    jsonPayload.fields.os_name,
-    jsonPayload.fields.os_version,
-    jsonPayload.fields.country,
-    JSON_VALUE(jsonPayload.fields.event_properties, "$.country_code") AS country_code,
-    jsonPayload.fields.language,
-    jsonPayload.fields.user_id,
-    jsonPayload.fields.device_id,
-    jsonPayload.fields.user_properties,
-    jsonPayload.fields.event_properties,
-    `timestamp`,
-    receiveTimestamp,
-    TIMESTAMP_MILLIS(CAST(jsonPayload.fields.time AS INT64)) AS event_time,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts_derived.nonprod_fxa_auth_events_v1`
-),
-  --
-stdout AS (
-  SELECT
-    jsonPayload.logger,
-    jsonPayload.fields.event_type,
-    jsonPayload.fields.app_version,
-    jsonPayload.fields.os_name,
-    jsonPayload.fields.os_version,
-    CAST(NULL AS STRING) AS country,
-    jsonPayload.fields.country_code,
-    CAST(NULL AS STRING) AS language,
-    jsonPayload.fields.user_id,
-    jsonPayload.fields.device_id,
-    jsonPayload.fields.user_properties,
-    jsonPayload.fields.event_properties,
-    `timestamp`,
-    receiveTimestamp,
-    TIMESTAMP_MILLIS(CAST(jsonPayload.fields.time AS INT64)) AS event_time,
-  FROM
-    `moz-fx-data-shared-prod.firefox_accounts_derived.nonprod_fxa_stdout_events_v1`
-),
-  --
-unioned AS (
-  SELECT
-    *
-  FROM
-    auth
-  UNION ALL
-  SELECT
-    *
-  FROM
-    content
-  UNION ALL
-  SELECT
-    *
-  FROM
-    stdout
-)
-  --
 SELECT
-  * EXCEPT (user_properties, event_properties),
-  JSON_VALUE(user_properties, "$.utm_term") AS utm_term,
-  JSON_VALUE(user_properties, "$.utm_source") AS utm_source,
-  JSON_VALUE(user_properties, "$.utm_medium") AS utm_medium,
-  JSON_VALUE(user_properties, "$.utm_campaign") AS utm_campaign,
-  JSON_VALUE(user_properties, "$.utm_content") AS utm_content,
-  JSON_VALUE(user_properties, "$.ua_version") AS ua_version,
-  JSON_VALUE(user_properties, "$.ua_browser") AS ua_browser,
-  JSON_VALUE(user_properties, "$.entrypoint") AS entrypoint,
-  JSON_VALUE(user_properties, "$.entrypoint_experiment") AS entrypoint_experiment,
-  JSON_VALUE(user_properties, "$.entrypoint_variation") AS entrypoint_variation,
-  JSON_VALUE(user_properties, "$.flow_id") AS flow_id,
-  JSON_VALUE(event_properties, "$.service") AS service,
-  JSON_VALUE(event_properties, "$.email_type") AS email_type,
-  JSON_VALUE(event_properties, "$.email_provider") AS email_provider,
-  JSON_VALUE(event_properties, "$.oauth_client_id") AS oauth_client_id,
-  JSON_VALUE(event_properties, "$.connect_device_flow") AS connect_device_flow,
-  JSON_VALUE(event_properties, "$.connect_device_os") AS connect_device_os,
-  JSON_VALUE(user_properties, "$.sync_device_count") AS sync_device_count,
-  JSON_VALUE(user_properties, "$.sync_active_devices_day") AS sync_active_devices_day,
-  JSON_VALUE(user_properties, "$.sync_active_devices_week") AS sync_active_devices_week,
-  JSON_VALUE(user_properties, "$.sync_active_devices_month") AS sync_active_devices_month,
-  JSON_VALUE(event_properties, "$.email_sender") AS email_sender,
-  JSON_VALUE(event_properties, "$.email_service") AS email_service,
-  JSON_VALUE(event_properties, "$.email_template") AS email_template,
-  JSON_VALUE(event_properties, "$.email_version") AS email_version,
-  JSON_VALUE(event_properties, "$.subscription_id") AS subscription_id,
-  JSON_VALUE(event_properties, "$.plan_id") AS plan_id,
-  JSON_VALUE(event_properties, "$.previous_plan_id") AS previous_plan_id,
-  JSON_VALUE(event_properties, "$.subscribed_plan_ids") AS subscribed_plan_ids,
-  JSON_VALUE(event_properties, "$.product_id") AS product_id,
-  JSON_VALUE(event_properties, "$.previous_product_id") AS previous_product_id,
-  -- `promotionCode` was renamed `promotion_code` in stdout logs.
-  COALESCE(
-    JSON_VALUE(event_properties, "$.promotion_code"),
-    JSON_VALUE(event_properties, "$.promotionCode")
-  ) AS promotion_code,
-  JSON_VALUE(event_properties, "$.payment_provider") AS payment_provider,
-  JSON_VALUE(event_properties, "$.provider_event_id") AS provider_event_id,
-  JSON_VALUE(event_properties, "$.checkout_type") AS checkout_type,
-  JSON_VALUE(event_properties, "$.source_country") AS source_country,
-  -- `source_country` was renamed `country_code_source` in stdout logs.
-  COALESCE(
-    JSON_VALUE(event_properties, "$.country_code_source"),
-    JSON_VALUE(event_properties, "$.source_country")
-  ) AS country_code_source,
-  JSON_VALUE(event_properties, "$.error_id") AS error_id,
-  CAST(JSON_VALUE(event_properties, "$.voluntary_cancellation") AS BOOL) AS voluntary_cancellation,
+  logger,
+  event_type,
+  app_version,
+  os_name,
+  os_version,
+  country,
+  country_code,
+  LANGUAGE,
+  user_id,
+  device_id,
+  `timestamp`,
+  receiveTimestamp,
+  event_time,
+  utm_term,
+  utm_source,
+  utm_medium,
+  utm_campaign,
+  utm_content,
+  ua_version,
+  ua_browser,
+  entrypoint,
+  entrypoint_experiment,
+  entrypoint_variation,
+  flow_id,
+  service,
+  email_type,
+  email_provider,
+  oauth_client_id,
+  connect_device_flow,
+  connect_device_os,
+  sync_device_count,
+  sync_active_devices_day,
+  sync_active_devices_week,
+  sync_active_devices_month,
+  email_sender,
+  email_service,
+  email_template,
+  email_version,
+  subscription_id,
+  plan_id,
+  previous_plan_id,
+  subscribed_plan_ids,
+  product_id,
+  previous_product_id,
+  promotion_code,
+  payment_provider,
+  provider_event_id,
+  checkout_type,
+  source_country,
+  country_code_source,
+  error_id,
+  voluntary_cancellation,
 FROM
-  unioned
+  `moz-fx-data-shared-prod.firefox_accounts.nonprod_fxa_all_events`
+WHERE
+  fxa_log IN ("content", "auth", "stdout")


### PR DESCRIPTION
# feat(DENG-722): updated fxa views to point to fxa_all_events view

This change is required in order to make the data post migration available inside the existing Looker dashboards without requiring any effort on the Looker side.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1560)
