### PR TITLE
bug(): readded fileds to the fxa_content_auth_stdout_events removed by an accident

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_events/view.sql
@@ -33,7 +33,7 @@ SELECT
   os_name,
   os_version,
   country,
-  LANGUAGE,
+  `language`,
   user_id,
   `timestamp`,
   receiveTimestamp,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_oauth_events/view.sql
@@ -34,7 +34,7 @@ SELECT
   os_name,
   os_version,
   country,
-  LANGUAGE,
+  `language`,
   user_id,
   device_id,
   `timestamp`,

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_content_auth_stdout_events/view.sql
@@ -28,6 +28,19 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_accounts.fxa_content_auth_stdout_events`
 AS
 SELECT
+  logger,
+  event_type,
+  app_version,
+  os_name,
+  os_version,
+  country,
+  country_code,
+  `language`,
+  user_id,
+  device_id,
+  `timestamp`,
+  receiveTimestamp,
+  event_time,
   utm_term,
   utm_source,
   utm_medium,


### PR DESCRIPTION
# bug(): readded fileds to the fxa_content_auth_stdout_events removed by an accident

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1575)
