### PR TITLE
Revert "[RS-768] Add default engine & engagement info to revenue levers table"

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/query.sql
@@ -7,16 +7,7 @@ desktop_data_google AS (
     IF(country = 'US', 'US', 'RoW') AS country,
     COUNT(DISTINCT client_id) AS dau,
     COUNT(
-      DISTINCT IF(default_search_engine LIKE '%google%', client_id, NULL)
-    ) AS dau_w_engine_as_default,
-    COUNT(
-      DISTINCT IF(
-        sap > 0
-        AND normalized_engine = 'Google'
-        AND default_search_engine LIKE '%google%',
-        client_id,
-        NULL
-      )
+      DISTINCT IF(sap > 0 AND normalized_engine = 'Google', client_id, NULL)
     ) AS dau_engaged_w_sap,
     SUM(IF(normalized_engine = 'Google', sap, 0)) AS sap,
     SUM(IF(normalized_engine = 'Google', tagged_sap, 0)) AS tagged_sap,
@@ -47,16 +38,7 @@ desktop_data_bing AS (
     submission_date,
     COUNT(DISTINCT client_id) AS dau,
     COUNT(
-      DISTINCT IF(default_search_engine LIKE '%bing%', client_id, NULL)
-    ) AS dau_w_engine_as_default,
-    COUNT(
-      DISTINCT IF(
-        sap > 0
-        AND normalized_engine = 'Bing'
-        AND default_search_engine LIKE '%bing%',
-        client_id,
-        NULL
-      )
+      DISTINCT IF(sap > 0 AND normalized_engine = 'Bing', client_id, NULL)
     ) AS dau_engaged_w_sap,
     SUM(IF(normalized_engine = 'Bing', sap, 0)) AS sap,
     SUM(IF(normalized_engine = 'Bing', tagged_sap, 0)) AS tagged_sap,
@@ -84,28 +66,7 @@ desktop_data_ddg AS (
     submission_date,
     COUNT(DISTINCT client_id) AS dau,
     COUNT(
-      DISTINCT IF(
-        (
-          default_search_engine LIKE('%ddg%')
-          OR default_search_engine LIKE('%duckduckgo%')
-          AND NOT default_search_engine LIKE('%addon%')
-        ),
-        client_id,
-        NULL
-      )
-    ) AS ddg_dau_w_engine_as_default,
-    COUNT(
-      DISTINCT IF(
-        (engine) IN ('ddg', 'duckduckgo')
-        AND sap > 0
-        AND (
-          default_search_engine LIKE('%ddg%')
-          OR default_search_engine LIKE('%duckduckgo%')
-          AND NOT default_search_engine LIKE('%addon%')
-        ),
-        client_id,
-        NULL
-      )
+      DISTINCT IF((engine) IN ('ddg', 'duckduckgo') AND sap > 0, client_id, NULL)
     ) AS ddg_dau_engaged_w_sap,
     SUM(IF(engine IN ('ddg', 'duckduckgo'), sap, 0)) AS ddg_sap,
     SUM(IF(engine IN ('ddg', 'duckduckgo'), tagged_sap, 0)) AS ddg_tagged_sap,
@@ -120,16 +81,7 @@ desktop_data_ddg AS (
     SUM(IF(engine IN ('ddg', 'duckduckgo') AND is_sap_monetizable, sap, 0)) AS ddg_monetizable_sap,
     -- in-content probes not available for addon so these metrics although being here will be zero
     COUNT(
-      DISTINCT IF(default_search_engine LIKE('ddg%addon'), client_id, NULL)
-    ) AS ddgaddon_dau_w_engine_as_default,
-    COUNT(
-      DISTINCT IF(
-        engine = 'ddg-addon'
-        AND sap > 0
-        AND default_search_engine LIKE('ddg%addon'),
-        client_id,
-        NULL
-      )
+      DISTINCT IF(engine = 'ddg-addon' AND sap > 0, client_id, NULL)
     ) AS ddgaddon_dau_engaged_w_sap,
     SUM(IF(engine IN ('ddg-addon'), sap, 0)) AS ddgaddon_sap,
     SUM(IF(engine IN ('ddg-addon'), tagged_sap, 0)) AS ddgaddon_tagged_sap,
@@ -177,16 +129,7 @@ mobile_data_google AS (
     IF(country = 'US', 'US', 'RoW') AS country,
     IF(country = 'US', dau.US_dau_eligible_google, dau.RoW_dau_eligible_google) AS dau,
     COUNT(
-      DISTINCT IF(default_search_engine LIKE '%google%', client_id, NULL)
-    ) AS dau_w_engine_as_default,
-    COUNT(
-      DISTINCT IF(
-        sap > 0
-        AND normalized_engine = 'Google'
-        AND default_search_engine LIKE '%google%',
-        client_id,
-        NULL
-      )
+      DISTINCT IF(sap > 0 AND normalized_engine = 'Google', client_id, NULL)
     ) AS dau_engaged_w_sap,
     SUM(IF(normalized_engine = 'Google', sap, 0)) AS sap,
     SUM(IF(normalized_engine = 'Google', tagged_sap, 0)) AS tagged_sap,
@@ -207,10 +150,7 @@ mobile_data_google AS (
   WHERE
     submission_date = @submission_date
     AND country NOT IN ('RU', 'UA', 'BY', 'TR', 'KZ', 'CN')
-    AND (
-      app_name IN ('Fenix', 'Firefox Preview', 'Focus Android Glean', 'Focus iOS Glean')
-      OR (app_name = 'Fennec' AND os = 'iOS')
-    )
+    AND normalized_app_name IN ('Focus', 'Fenix', 'Fennec')
   GROUP BY
     submission_date,
     country,
@@ -228,33 +168,10 @@ mobile_data_bing_ddg AS (
     submission_date,
     dau.dau,
     COUNT(
-      DISTINCT IF(default_search_engine LIKE '%bing%', client_id, NULL)
-    ) AS bing_dau_w_engine_as_default,
-    COUNT(
-      DISTINCT IF(
-        sap > 0
-        AND normalized_engine = 'Bing'
-        AND default_search_engine LIKE '%bing%',
-        client_id,
-        NULL
-      )
+      DISTINCT IF(sap > 0 AND normalized_engine = 'Bing', client_id, NULL)
     ) AS bing_dau_engaged_w_sap,
     COUNT(
-      DISTINCT IF(
-        default_search_engine LIKE('%ddg%')
-        OR default_search_engine LIKE('%duckduckgo%'),
-        client_id,
-        NULL
-      )
-    ) AS ddg_dau_w_engine_as_default,
-    COUNT(
-      DISTINCT IF(
-        (engine) IN ('ddg', 'duckduckgo')
-        AND sap > 0
-        AND (default_search_engine LIKE('%ddg%') OR default_search_engine LIKE('%duckduckgo%')),
-        client_id,
-        NULL
-      )
+      DISTINCT IF(sap > 0 AND normalized_engine = 'DuckDuckGo', client_id, NULL)
     ) AS ddg_dau_engaged_w_sap,
     SUM(IF(normalized_engine = 'Bing', sap, 0)) AS bing_sap,
     SUM(IF(normalized_engine = 'Bing', tagged_sap, 0)) AS bing_tagged_sap,
@@ -284,10 +201,7 @@ mobile_data_bing_ddg AS (
     (submission_date)
   WHERE
     submission_date = @submission_date
-    AND (
-      app_name IN ('Fenix', 'Firefox Preview', 'Focus Android Glean', 'Focus iOS Glean')
-      OR (app_name = 'Fennec' AND os = 'iOS')
-    )
+    AND normalized_app_name IN ('Focus', 'Fenix', 'Fennec')
   GROUP BY
     submission_date,
     dau
@@ -312,8 +226,7 @@ SELECT
   organic,
   ad_click_organic,
   search_with_ads_organic,
-  monetizable_sap,
-  dau_w_engine_as_default
+  monetizable_sap
 FROM
   desktop_data_google
 UNION ALL
@@ -333,8 +246,7 @@ SELECT
   organic,
   ad_click_organic,
   search_with_ads_organic,
-  monetizable_sap,
-  dau_w_engine_as_default
+  monetizable_sap
 FROM
   desktop_data_bing
 UNION ALL
@@ -354,8 +266,7 @@ SELECT
   ddg_organic AS organic,
   ddg_ad_click_organic AS ad_click_organic,
   ddg_search_with_ads_organic AS search_with_ads_organic,
-  ddg_monetizable_sap AS monetizable_sap,
-  ddg_dau_w_engine_as_default AS dau_w_engine_as_default
+  ddg_monetizable_sap AS monetizable_sap
 FROM
   desktop_data_ddg
 UNION ALL
@@ -375,8 +286,7 @@ SELECT
   ddgaddon_organic AS organic,
   ddgaddon_ad_click_organic AS ad_click_organic,
   ddgaddon_search_with_ads_organic AS search_with_ads_organic,
-  ddgaddon_monetizable_sap AS monetizable_sap,
-  ddgaddon_dau_w_engine_as_default AS dau_w_engine_as_default
+  ddgaddon_monetizable_sap AS monetizable_sap
 FROM
   desktop_data_ddg
 UNION ALL
@@ -396,8 +306,7 @@ SELECT
   organic,
   ad_click_organic,
   search_with_ads_organic,
-  monetizable_sap,
-  dau_w_engine_as_default
+  monetizable_sap
 FROM
   mobile_data_google
 UNION ALL
@@ -417,8 +326,7 @@ SELECT
   bing_organic,
   bing_ad_click_organic,
   bing_search_with_ads_organic,
-  bing_monetizable_sap,
-  bing_dau_w_engine_as_default AS dau_w_engine_as_default
+  bing_monetizable_sap
 FROM
   mobile_data_bing_ddg
 UNION ALL
@@ -438,7 +346,6 @@ SELECT
   ddg_organic,
   ddg_ad_click_organic,
   ddg_search_with_ads_organic,
-  ddg_monetizable_sap,
-  ddg_dau_w_engine_as_default AS dau_w_engine_as_default
+  ddg_monetizable_sap
 FROM
   mobile_data_bing_ddg

--- a/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/schema.yaml
@@ -47,6 +47,3 @@ fields:
   - mode: NULLABLE
     name: monetizable_sap
     type: INTEGER
-  - mode: NULLABLE
-    name: dau_w_engine_as_default
-    type: INTEGER


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#4283

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1580)
