### PR TITLE
bug(DENG-1558): firefox_ios_derived.app_store_funnel_v1 updated the source of new profiles

### DIFF
--- a/dags/bqetl_analytics_aggregations.py
+++ b/dags/bqetl_analytics_aggregations.py
@@ -156,6 +156,20 @@ with DAG(
         parameters=["submission_date:DATE:{{macros.ds_add(ds, -1)}}"],
     )
 
+    with TaskGroup(
+        "firefox_ios_active_users_aggregates_external"
+    ) as firefox_ios_active_users_aggregates_external:
+        ExternalTaskMarker(
+            task_id="bqetl_firefox_ios__wait_for_firefox_ios_active_users_aggregates",
+            external_dag_id="bqetl_firefox_ios",
+            external_task_id="wait_for_firefox_ios_active_users_aggregates",
+            execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=84600)).isoformat() }}",
+        )
+
+        firefox_ios_active_users_aggregates_external.set_upstream(
+            firefox_ios_active_users_aggregates
+        )
+
     focus_android_active_users_aggregates = bigquery_etl_query(
         task_id="focus_android_active_users_aggregates",
         destination_table='active_users_aggregates_v2${{ macros.ds_format(macros.ds_add(ds, -1), "%Y-%m-%d", "%Y%m%d") }}',

--- a/dags/bqetl_firefox_ios.py
+++ b/dags/bqetl_firefox_ios.py
@@ -149,11 +149,11 @@ with DAG(
     firefox_ios_derived__app_store_funnel__v1.set_upstream(
         wait_for_app_store_external__firefox_downloads_territory_source_type_report__v1
     )
-    wait_for_firefox_ios_derived__new_profile_activation__v1 = ExternalTaskSensor(
-        task_id="wait_for_firefox_ios_derived__new_profile_activation__v1",
-        external_dag_id="bqetl_mobile_activation",
-        external_task_id="firefox_ios_derived__new_profile_activation__v1",
-        execution_delta=datetime.timedelta(seconds=14400),
+    wait_for_firefox_ios_active_users_aggregates = ExternalTaskSensor(
+        task_id="wait_for_firefox_ios_active_users_aggregates",
+        external_dag_id="bqetl_analytics_aggregations",
+        external_task_id="firefox_ios_active_users_aggregates",
+        execution_delta=datetime.timedelta(seconds=1800),
         check_existence=True,
         mode="reschedule",
         allowed_states=ALLOWED_STATES,
@@ -162,7 +162,7 @@ with DAG(
     )
 
     firefox_ios_derived__app_store_funnel__v1.set_upstream(
-        wait_for_firefox_ios_derived__new_profile_activation__v1
+        wait_for_firefox_ios_active_users_aggregates
     )
 
     wait_for_baseline_clients_daily = ExternalTaskSensor(

--- a/dags/bqetl_mobile_activation.py
+++ b/dags/bqetl_mobile_activation.py
@@ -65,20 +65,6 @@ with DAG(
         depends_on_past=False,
     )
 
-    with TaskGroup(
-        "firefox_ios_derived__new_profile_activation__v1_external"
-    ) as firefox_ios_derived__new_profile_activation__v1_external:
-        ExternalTaskMarker(
-            task_id="bqetl_firefox_ios__wait_for_firefox_ios_derived__new_profile_activation__v1",
-            external_dag_id="bqetl_firefox_ios",
-            external_task_id="wait_for_firefox_ios_derived__new_profile_activation__v1",
-            execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=72000)).isoformat() }}",
-        )
-
-        firefox_ios_derived__new_profile_activation__v1_external.set_upstream(
-            firefox_ios_derived__new_profile_activation__v1
-        )
-
     wait_for_baseline_clients_last_seen = ExternalTaskSensor(
         task_id="wait_for_baseline_clients_last_seen",
         external_dag_id="copy_deduplicate",

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
@@ -1,3 +1,2 @@
 {{ is_unique(["`date`", "country"]) }}
  {{ min_row_count(1, "`date` = DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)") }}
-

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
@@ -54,9 +54,8 @@ _new_profiles AS (
   FROM
     firefox_ios.firefox_ios_clients
   WHERE
-    DATE(submission_timestamp) >= '2022-01-01'
-    AND first_seen_date >= '2022-01-01'
-    -- TODO: do we need to filter here for "release" channel only?
+    first_seen_date >= '2022-01-01'
+    AND channel = "release"
   GROUP BY
     `date`,
     country

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
@@ -48,13 +48,13 @@ store_stats AS (
 ),
 _new_profiles AS (
   SELECT
-    first_seen_date AS `date`,
-    first_reported_country AS country,
-    COUNT(*) AS new_profiles,
+    submission_date AS `date`,
+    country,
+    SUM(new_profiles) AS new_profiles,
   FROM
-    firefox_ios.firefox_ios_clients
+    firefox_ios.active_users_aggregates
   WHERE
-    first_seen_date >= '2022-01-01'
+    submission_date >= '2022-01-01'
     AND channel = "release"
   GROUP BY
     `date`,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
@@ -46,20 +46,17 @@ store_stats AS (
   ON
     country_name = name
 ),
-new_profiles_and_activations AS (
+_new_profiles AS (
   SELECT
     first_seen_date AS `date`,
-    country,
-    SUM(new_profile) AS new_profiles,
-    SUM(activated) AS activations,
+    first_reported_country AS country,
+    COUNT(*) AS new_profiles,
   FROM
-    firefox_ios.new_profile_activation
+    firefox_ios.firefox_ios_clients
   WHERE
-    submission_date >= '2022-01-01'
+    DATE(submission_timestamp) >= '2022-01-01'
     AND first_seen_date >= '2022-01-01'
-     -- below filter required due to untrusted devices anomaly,
-     -- more information can be found in this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1846554
-    AND NOT (app_display_version = '107.2' AND submission_date >= '2023-02-01')
+    -- TODO: do we need to filter here for "release" channel only?
   GROUP BY
     `date`,
     country
@@ -72,10 +69,9 @@ SELECT
   COALESCE(first_time_downloads, 0) AS first_time_downloads,
   COALESCE(redownloads, 0) AS redownloads,
   COALESCE(new_profiles, 0) AS new_profiles,
-  COALESCE(activations, 0) AS activations,
 FROM
   store_stats
 FULL OUTER JOIN
-  new_profiles_and_activations
+  _new_profiles
 USING
   (`date`, country)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/schema.yaml
@@ -41,9 +41,3 @@ fields:
   type: INTEGER
   description: |
     Number of new profiles on the date.
-
-- mode: NULLABLE
-  name: activations
-  type: INTEGER
-  description: |
-    Number of users that ended up activating that were first seen on the date.


### PR DESCRIPTION
# bug(DENG-1558): firefox_ios_derived.app_store_funnel_v1 updated the source of new profiles

Previously, the query has been using an incorrect source for getting new_profile numbers. This changes updated the query to use the new more recent table for getting this information.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1592)
