### PR TITLE
Publish private-bigquery-etl DAGs to private-generated-sql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,10 +441,18 @@ jobs:
                           git@github.com:mozilla/private-bigquery-etl.git \
                           ~/private-bigquery-etl
             rsync --archive ~/private-bigquery-etl/sql/ sql/
+            rsync --archive ~/private-bigquery-etl/dags.yaml dags.yaml
       - run:
           name: Generate SQL content
           command: |
             mkdir -p /tmp/workspace/private-generated-sql
+
+            mkdir -p /tmp/workspace/private-generated-sql/dags
+            PATH="venv/bin:$PATH" script/bqetl dag generate \
+              --dags-config dags.yaml \
+              --sql-dir ~/private-bigquery-etl/sql/ \
+              --output-dir /tmp/workspace/private-generated-sql/dags/
+
             cp -r sql/ /tmp/workspace/private-generated-sql/sql
             # Don't depend on dry run for PRs
             PATH="venv/bin:$PATH" script/bqetl generate all \

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -379,10 +379,10 @@ def schedule(name, sql_dir, project_id, dag, depends_on_past, task_name):
             )
 
             # update dags since new task has been added
-            dags = get_dags(None, sql_dir.parent / "dags.yaml")
+            dags = get_dags(None, sql_dir.parent / "dags.yaml", sql_dir=sql_dir)
             dags_to_be_generated.add(dag)
         else:
-            dags = get_dags(None, sql_dir.parent / "dags.yaml")
+            dags = get_dags(None, sql_dir.parent / "dags.yaml", sql_dir=sql_dir)
             if metadata.scheduling == {}:
                 click.echo(f"No scheduling information for: {query_file}", err=True)
                 sys.exit(1)

--- a/bigquery_etl/query_scheduling/generate_airflow_dags.py
+++ b/bigquery_etl/query_scheduling/generate_airflow_dags.py
@@ -49,11 +49,11 @@ parser.add_argument(
 standard_args.add_log_level(parser)
 
 
-def get_dags(project_id, dags_config):
+def get_dags(project_id, dags_config, sql_dir=None):
     """Return all configured DAGs including associated tasks."""
     tasks = []
     dag_collection = DagCollection.from_file(dags_config)
-    for project_dir in project_dirs(project_id):
+    for project_dir in project_dirs(project_id, sql_dir=sql_dir):
         # parse metadata.yaml to retrieve scheduling information
         if os.path.isdir(project_dir):
             for root, dirs, files in os.walk(project_dir):

--- a/bigquery_etl/util/common.py
+++ b/bigquery_etl/util/common.py
@@ -44,9 +44,10 @@ def snake_case(line: str) -> str:
     return "_".join([w.lower() for w in words if w.strip()])[::-1]
 
 
-def project_dirs(project_id=None) -> List[str]:
+def project_dirs(project_id=None, sql_dir=None) -> List[str]:
     """Return all project directories."""
-    sql_dir = ConfigLoader.get("default", "sql_dir", fallback="sql")
+    if sql_dir is None:
+        sql_dir = ConfigLoader.get("default", "sql_dir", fallback="sql")
     if project_id is None:
         return [
             os.path.join(sql_dir, project_dir) for project_dir in os.listdir(sql_dir)


### PR DESCRIPTION
This adds a step to CI to publish generated DAGs from `private-bigquery-etl` to the `private-generated-sql` branch in the same repository. We already generate and publish DAGs in bigquery-etl to the `generated-sql` branch and need to do the same in the private repo to support loading DAGs from these branches instead of `main`


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1595)
