### PR TITLE
Validating onboarding_v2 backfill 2023-09-18

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/onboarding_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/onboarding_v2/backfill.yaml
@@ -5,4 +5,4 @@
   watchers:
   - gleonard@mozilla.com
   - chutten@mozilla.com
-  status: Drafting
+  status: Validated


### PR DESCRIPTION
Validating backfill for `moz-fx-data-shared-prod.firefox_desktop_derived.onboarding_v2` - 2023-09-18

Please merge this pull request once the backfill data at location: `moz-fx-data-shared-prod.backfills_staging_derived.onboarding_v2_2023_09_18` has been validated.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1604)
