### PR TITLE
Fix typo in open tab count

### DIFF
--- a/sql_generators/urlbar_events/templates/desktop_query.sql
+++ b/sql_generators/urlbar_events/templates/desktop_query.sql
@@ -120,7 +120,7 @@ events_summary AS (
     COUNTIF(res = 'trending_suggestion') AS num_trending_suggestion_impressions,
     COUNTIF(res = 'history') AS num_history_impressions,
     COUNTIF(res = 'bookmark') AS num_bookmark_impressions,
-    COUNTIF(res = 'open_tabs') AS num_open_tab_impressions,
+    COUNTIF(res = 'open_tab') AS num_open_tab_impressions,
     COUNTIF(res = 'admarketplace_sponsored') AS num_admarketplace_sponsored_impressions,
     COUNTIF(res = 'navigational') AS num_navigational_impressions,
     COUNTIF(res = 'add_on') AS num_add_on_impressions,


### PR DESCRIPTION
Fixes a typo that caused the `num_open_tab_impressions` column to be all 0.

As discussed, this will need a backfill, but we can probably do this when we soon land new columns in the table.

@alekhyamoz Do I need to update `sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_v1/query.sql` as well, or will that happen automatically?

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1608)
