### PR TITLE
Completing onboarding_v2 backfill 2023-09-18

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/onboarding_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/onboarding_v2/backfill.yaml
@@ -5,4 +5,4 @@
   watchers:
   - gleonard@mozilla.com
   - chutten@mozilla.com
-  status: Validated
+  status: Complete


### PR DESCRIPTION
Completing backfill for `moz-fx-data-shared-prod.firefox_desktop_derived.onboarding_v2` - 2023-09-18

Data from backfill location: `moz-fx-data-shared-prod.backfills_staging_derived.onboarding_v2_2023_09_18` has been copied to production location: `moz-fx-data-shared-prod.firefox_desktop_derived.onboarding_v2`.

A backup (clone) of the previous production data is located at `moz-fx-data-shared-prod.backfills_staging_derived.onboarding_v2_backup_2023_09_18` and will expire in 30 days.

Please merge this pull request once you confirm that your production data is as expected.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1610)
