### PR TITLE
Diff DAGs first in `generate-diff` CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,10 +577,10 @@ jobs:
           name: Generate diff
           command: |
             diff -bur --no-dereference \
-              /tmp/workspace/main-generated-sql/sql/ /tmp/workspace/generated-sql/sql/ \
+              /tmp/workspace/main-generated-sql/dags/ /tmp/workspace/generated-sql/dags/ \
               > /tmp/workspace/generated-sql/sql.diff || true
             diff -bur --no-dereference \
-              /tmp/workspace/main-generated-sql/dags/ /tmp/workspace/generated-sql/dags/ \
+              /tmp/workspace/main-generated-sql/sql/ /tmp/workspace/generated-sql/sql/ \
               >> /tmp/workspace/generated-sql/sql.diff || true
       - persist_to_workspace:
           root: /tmp/workspace


### PR DESCRIPTION
With DAGs [soon to be completely auto-generated](https://mozilla.slack.com/archives/C01E8GDG80N/p1695225705737459?thread_ts=1695225273.715379&cid=C01E8GDG80N) and not checked in as part of PRs it'll be critical to understand how PRs are changing the DAGs.  We already have CI jobs that diff the generated code with what's in the `main` branch and attach the diff output to the PR as comments, but that currently diffs the SQL first and then the DAGs, and it only shows the first 65k characters of the diff, so the DAG diffs might not be shown.

This PR diffs the DAGs first so the DAG diffs should always be shown in the CI's generated diff PR comments.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1619)
