### PR TITLE
bug(DENG-1622): app_store_funnel_v1 country mapping table updated + check tweak

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
@@ -3,7 +3,7 @@
 -- min_row_count helps us detect if we're seeing delays in the data arriving
 -- could also be an indicator of an upstream issue.
 #fail
-{{ min_row_count(1, "`date` = DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)") }}
+{{ min_row_count(1, "`date` = DATE_SUB(@submission_date, INTERVAL 1 DAY)") }}
 #fail
 WITH _aua_new_profiles AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
@@ -30,7 +30,7 @@ downloads_data AS (
 store_stats AS (
   SELECT
     DATE(`date`) AS `date`,
-    code AS country,
+    country_names.code AS country,
     views,
     total_downloads,
     first_time_downloads,
@@ -41,10 +41,10 @@ store_stats AS (
     downloads_data
   USING
     (`date`, country_name)
-  LEFT OUTER JOIN
-    static.country_codes_v1
+  LEFT JOIN
+    static.country_names_v1 AS country_names
   ON
-    country_name = name
+    country_names.name = views_data.country_name
 ),
 _new_profiles AS (
   SELECT


### PR DESCRIPTION
# bug(DENG-1622): app_store_funnel_v1 country mapping table updated

Updated the country mapping table to use country_names table instead as the previous table was incorrectly used which resulted in a bunch of countries incorrectly being categorised as `null` and resulting in the granuality of the table (date, country) being violated. This change addresses this issue.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1623)
