### PR TITLE
Update partitioning bigquery usage v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/metadata.yaml
@@ -12,5 +12,5 @@ scheduling:
 bigquery:
   time_partitioning:
     type: day
-    field: creation_date
+    field: submission_date
     require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.py
@@ -21,7 +21,7 @@ parser.add_argument("--destination_table", default="bigquery_usage_v2")
 
 def create_query(date, project):
     """Create query with filter for source projects."""
-    return """
+    return f"""
         WITH jobs_by_org AS (
       SELECT
         t1.project_id AS source_project,
@@ -72,7 +72,7 @@ def create_query(date, project):
       )
       SELECT
         jo.source_project,
-        jo.creation_date,
+        jo.creation_date as job_creation_date,
         jo.job_id,
         jo.job_type,
         jo.reservation_id,
@@ -95,7 +95,8 @@ def create_query(date, project):
         jo.error_location,
         jo.error_reason,
         jo.error_message,
-        jo.resource_warning
+        jo.resource_warning,
+        DATE('{date}') AS submission_date,
       FROM jobs_by_org jo
       LEFT JOIN jobs_by_project jp
       USING(source_project,

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.py
@@ -72,7 +72,7 @@ def create_query(date, project):
       )
       SELECT
         jo.source_project,
-        jo.creation_date as job_creation_date,
+        jo.creation_date,
         jo.job_id,
         jo.job_type,
         jo.reservation_id,

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/schema.yaml
@@ -128,4 +128,4 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
-  description: Date bigquery_usage_v2 table refreshed
+  description: Date Airflow DAG is executed

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/schema.yaml
@@ -124,3 +124,8 @@ fields:
   name: resource_warning
   type: STRING
   description: The warning message that appears if the resource usage is above the internal threshold of the system
+
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Date bigquery_usage_v2 table refreshed


### PR DESCRIPTION
Checklist for reviewer:

Error in running previous version where data wasn't going into the right partition - Creation date was different from the date the job was run.

Added DATE when DAG was run as submission_date and made this the partition date. Kept the creation_date as this will be used later in the bigquery_tables_inventory_v1 query

Deleted the old table because a new column was added. Backfill to March 16, 2023 will need to happen after merging

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1641)
