### PR TITLE
tweak(): submission_date hardcoded to avoid having to specify submission_date when using the first_seen_view

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen.view.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen.view.sql
@@ -9,3 +9,4 @@ FROM
   `{{ project_id }}.{{ daily_table }}`
 WHERE
   is_new_profile
+  AND submission_date > "2010-01-01"


### PR DESCRIPTION
tweak(): submission_date hardcoded to avoid having to specify submission_date when using the first_seen_view

This simplifies the downstream usage of the per product first_seen view which requires submission_date filter making it more tricky to filter for a specific first_seen_date value.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1651)
