### PR TITLE
Bug 1852630 - Rename main_remainder_v4 to main_v5

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -140,8 +140,26 @@ EXTERNAL_TASKS = {
         schedule_interval="0 1 * * *",
     ): [
         "telemetry_stable.main_v4",
+        "telemetry_stable.main_v5",
         "telemetry_stable.main_use_counter_v4",
-        "telemetry_stable.main_remainder_v4",
+    ],
+    TaskRef(
+        dag_name="copy_deduplicate",
+        task_id="copy_deduplicate_first_shutdown_ping",
+        schedule_interval="0 1 * * *",
+    ): [
+        "telemetry_stable.first_shutdown_v4",
+        "telemetry_stable.first_shutdown_v5",
+        "telemetry_stable.first_shutdown_use_counter_v4",
+    ],
+    TaskRef(
+        dag_name="copy_deduplicate",
+        task_id="copy_deduplicate_saved_session_ping",
+        schedule_interval="0 1 * * *",
+    ): [
+        "telemetry_stable.saved_session_v4",
+        "telemetry_stable.saved_session_v5",
+        "telemetry_stable.saved_session_use_counter_v4",
     ],
     TaskRef(
         dag_name="copy_deduplicate",

--- a/dags/bqetl_analytics_tables.py
+++ b/dags/bqetl_analytics_tables.py
@@ -104,6 +104,19 @@ with DAG(
     )
 
     clients_first_seen_v2.set_upstream(wait_for_copy_deduplicate_all)
+    wait_for_copy_deduplicate_first_shutdown_ping = ExternalTaskSensor(
+        task_id="wait_for_copy_deduplicate_first_shutdown_ping",
+        external_dag_id="copy_deduplicate",
+        external_task_id="copy_deduplicate_first_shutdown_ping",
+        execution_delta=datetime.timedelta(seconds=3600),
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    clients_first_seen_v2.set_upstream(wait_for_copy_deduplicate_first_shutdown_ping)
     wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskSensor(
         task_id="wait_for_telemetry_derived__clients_daily__v6",
         external_dag_id="bqetl_main_summary",

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/query.sql
@@ -24,9 +24,9 @@ extracted AS (
       'main_v4',
       'saved_session_v4',
       'first_shutdown_v4',
-      'main_remainder_v4',
-      'saved_session_remainder_v4',
-      'first_shutdown_remainder_v4'
+      'main_v5',
+      'saved_session_v5',
+      'first_shutdown_v5'
     )
     AND _TABLE_SUFFIX NOT IN (SELECT * FROM placeholder_table_names)
 ),

--- a/sql/moz-fx-data-shared-prod/telemetry/main_1pct/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_1pct/metadata.yaml
@@ -5,13 +5,13 @@ description: |-
   intended as a performance optimization for exploratory queries.
   It contains only the most recent six months of data.
 
-  Queries on this table are logically equivalent to queries on top of `main_remainder_v4`
+  Queries on this table are logically equivalent to queries on top of `main_v4`
   with a filter on `sample_id = 0`, but this table has a few advantages.
   First, query estimates will be much more accurate; estimates of bytes scanned
   can't take into account clustering, so we sometimes see valid queries get
   rejected by Redash due to appearing expensive when they really aren't.
   Second, simple queries should complete much more quickly on this table
-  compared to `main_remainder_v4`; for simple queries on a very wide table like this,
+  compared to `main_v4`; for simple queries on a very wide table like this,
   the execution time appears to be dominated by BQ simply scanning metadata
   for all the blocks it might need to touch. Because this table contains
   only 1% of main ping data, it is likely to have many fewer blocks to

--- a/sql/moz-fx-data-shared-prod/telemetry/main_remainder_1pct/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_remainder_1pct/metadata.yaml
@@ -5,13 +5,13 @@ description: |-
   intended as a performance optimization for exploratory queries. It contains
   only the most recent six months of data.
 
-  Queries on this table are logically equivalent to queries on top of `main_remainder_v4`
+  Queries on this table are logically equivalent to queries on top of `main_v5`
   with a filter on `sample_id = 0`, but this table has a few advantages.
   First, query estimates will be much more accurate; estimates of bytes scanned
   can't take into account clustering, so we sometimes see valid queries get
   rejected by Redash due to appearing expensive when they really aren't.
   Second, simple queries should complete much more quickly on this table
-  compared to `main_remainder_v4`; for simple queries on a very wide table like this,
+  compared to `main_v5`; for simple queries on a very wide table like this,
   the execution time appears to be dominated by BQ simply scanning metadata
   for all the blocks it might need to touch. Because this table contains
   only 1% of main ping data, it is likely to have many fewer blocks to

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/metadata.yaml
@@ -5,13 +5,13 @@ description: |-
   only the most recent six months of data. Also see main_nightly for a derived
   table containing only data where normalized_channel = 'nightly'.
 
-  Queries on this table are logically equivalent to queries on top of `main_remainder_v4`
+  Queries on this table are logically equivalent to queries on top of `main_v5`
   with a filter on `sample_id = 0`, but this table has a few advantages.
   First, query estimates will be much more accurate; estimates of bytes scanned
   can't take into account clustering, so we sometimes see valid queries get
   rejected by Redash due to appearing expensive when they really aren't.
   Second, simple queries should complete much more quickly on this table
-  compared to `main_remainder_v4`; for simple queries on a very wide table like this,
+  compared to `main_v5`; for simple queries on a very wide table like this,
   the execution time appears to be dominated by BQ simply scanning metadata
   for all the blocks it might need to touch. Because this table contains
   only 1% of main ping data, it is likely to have many fewer blocks to
@@ -29,7 +29,7 @@ scheduling:
   start_date: '2023-07-01'
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
   referenced_tables: [['moz-fx-data-shared-prod', 'telemetry_stable',
-                       'main_remainder_v4']]
+                       'main_v5']]
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/query.sql
@@ -14,7 +14,7 @@ SELECT
     `moz-fx-data-shared-prod.udf.normalize_main_payload`(payload) AS payload
   )
 FROM
-  telemetry_stable.main_remainder_v4
+  telemetry_stable.main_v5
 WHERE
   sample_id = 0
   AND DATE(submission_timestamp) = @submission_date


### PR DESCRIPTION
and point at new copy_deduplicate tasks for similar pings

[Bug 1852630](https://bugzilla.mozilla.org/show_bug.cgi?id=1852630)
requires https://github.com/mozilla/telemetry-airflow/pull/1825

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
