### PR TITLE
feat(): firefox_ios_clients_v1 table partitoning and clustering settings update + filtering out "suspicious ios" users

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_ios.firefox_ios_clients`
 AS
 SELECT
-  * REPLACE (
+  * EXCEPT (is_suspicious_device_client) REPLACE (
     CASE
       WHEN adjust_network IS NULL
         THEN 'Unknown'
@@ -17,3 +17,6 @@ SELECT
   ),
 FROM
   `moz-fx-data-shared-prod.firefox_ios_derived.firefox_ios_clients_v1`
+WHERE
+  -- filtering out suspicious devices on iOS, for more info see: bug-1846554
+  NOT is_suspicious_device_client

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/init.sql
@@ -25,6 +25,8 @@ WITH first_seen AS (
   WHERE
     submission_date < CURRENT_DATE
     AND client_id IS NOT NULL
+    -- filtering out suspicious devices on iOS, for more info see: bug-1846554
+    AND NOT (app_display_version = '107.2' AND submission_date >= '2023-02-01')
 ),
 -- Find the most recent activation record per client_id.
 activations AS (

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
@@ -36,6 +36,11 @@ scheduling:
   parameters:
   - submission_date:DATE:{{ds}}
 bigquery:
+  time_partitioning:
+    field: first_seen_date
+    type: day
+    require_partition_filter: false
+    expiration_days: null
   clustering:
     fields:
     - channel

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -11,14 +11,12 @@ WITH first_seen AS (
     device_manufacturer,
     device_model,
     normalized_os_version AS os_version,
-    app_display_version AS app_version
+    app_display_version AS app_version,
   FROM
     firefox_ios.baseline_clients_first_seen
   WHERE
     submission_date = @submission_date
     AND client_id IS NOT NULL
-    -- filtering out suspicious devices on iOS, for more info see: bug-1846554
-    AND NOT (app_display_version = '107.2' AND submission_date >= '2023-02-01')
 ),
 -- Find the most recent activation record per client_id.
 activations AS (
@@ -143,7 +141,9 @@ _current AS (
           THEN "metrics"
         ELSE NULL
       END AS adjust_info__source_ping
-    ) AS metadata
+    ) AS metadata,
+    -- field to help us identify suspicious devices on iOS, for more info see: bug-1846554
+    (app_version = '107.2' AND submission_date >= '2023-02-01') AS is_suspicious_device_client,
   FROM
     first_seen
   FULL OUTER JOIN
@@ -210,6 +210,7 @@ SELECT
       _current.metadata.adjust_info__source_ping
     ) AS adjust_info__source_ping
   ) AS metadata,
+  COALESCE(_previous.is_suspicious_device_client, _current.is_suspicious_device_client) AS is_suspicious_device_client,
 FROM
   _current
 FULL OUTER JOIN

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -17,6 +17,8 @@ WITH first_seen AS (
   WHERE
     submission_date = @submission_date
     AND client_id IS NOT NULL
+    -- filtering out suspicious devices on iOS, for more info see: bug-1846554
+    AND NOT (app_display_version = '107.2' AND submission_date >= '2023-02-01')
 ),
 -- Find the most recent activation record per client_id.
 activations AS (

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
@@ -120,3 +120,9 @@ fields:
     type: STRING
     description: |
       Ping from which the adjust_info values originate.
+
+- mode: NULLABLE
+  name: is_suspicious_device_client
+  type: BOOLEAN
+  description: |
+    Flag to identify suspicious device users, see bug-1846554 for more info.


### PR DESCRIPTION
# feat(): firefox_ios_clients_v1 table partitoning and clustering settings update + filtering out "suspicious ios" users 

filtering out "suspicious ios" users due to bug-1846554

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1674)
