### PR TITLE
fix DENG-1091: automatically add triage/confidential to private DAGs

### DIFF
--- a/bigquery_etl/query_scheduling/dag.py
+++ b/bigquery_etl/query_scheduling/dag.py
@@ -21,6 +21,8 @@ AIRFLOW_DAG_TEMPLATE = "airflow_dag.j2"
 PUBLIC_DATA_JSON_DAG_TEMPLATE = "public_data_json_airflow_dag.j2"
 PUBLIC_DATA_JSON_DAG = "bqetl_public_data_json"
 
+CONFIDENTIAL_TAG = "triage/confidential"
+
 
 class DagParseException(Exception):
     """Raised when DAG config is invalid."""
@@ -197,6 +199,12 @@ class Dag:
             tags: set[str] = set(d[name].get("tags", []))
             if not any(tag.startswith("repo/") for tag in tags):
                 tags.add("repo/" + d[name].get("repo", "bigquery-etl"))
+
+            if name.startswith("private_") and CONFIDENTIAL_TAG not in tags:
+                tags.add(
+                    CONFIDENTIAL_TAG,
+                )
+
             d[name]["tags"] = sorted(tags)
 
             if name == PUBLIC_DATA_JSON_DAG:


### PR DESCRIPTION
For https://mozilla-hub.atlassian.net/browse/DENG-1091 (https://bugzilla.mozilla.org/show_bug.cgi?id=1841129)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1676)
