### PR TITLE
fix(): tweaks to partitioning settings for firefox_ios_derived.funnel_retention tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/metadata.yaml
@@ -13,8 +13,9 @@ scheduling:
 bigquery:
   time_partitioning:
     type: day
-    field: first_seen_date
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:
     - sample_id
+    - first_seen_date

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/query.sql
@@ -40,6 +40,7 @@ retention_calculation AS (
     (client_id, sample_id)
 )
 SELECT
+  @submission_date AS submission_date,
   * EXCEPT (retention) REPLACE(
   -- metric date should align with first_seen_date, if that is not the case then the query will fail.
     IF(

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/schema.yaml
@@ -1,6 +1,12 @@
 fields:
 
 - mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: |
+    Partition field, also corresponds to internal execution date of the job (first_seen_date + 28 days).
+
+- mode: NULLABLE
   name: first_seen_date
   type: DATE
   description: |

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/metadata.yaml
@@ -17,8 +17,9 @@ scheduling:
 bigquery:
   time_partitioning:
     type: day
-    field: first_seen_date
+    field: submission_date
     require_partition_filter: false
   clustering:
     fields:
     - sample_id
+    - first_seen_date

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/query.sql
@@ -41,6 +41,7 @@ retention_calculation AS (
     (client_id, sample_id)
 )
 SELECT
+  @submission_date AS submission_date,
   * EXCEPT (retention) REPLACE(
     -- metric date should align with first_seen_date, if that is not the case then the query will fail.
     IF(

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/schema.yaml
@@ -1,6 +1,12 @@
 fields:
 
 - mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: |
+    Partition field, also corresponds to internal execution date of the job (first_seen_date + 28 days).
+
+- mode: NULLABLE
   name: first_seen_date
   type: DATE
   description: |


### PR DESCRIPTION
fix(): tweaks to partitioning settings for firefox_ios_derived.funnel_retention tables

This is to correctly work with the bqetl mechanism when inserting data into a specific data partition of a table:
https://github.com/mozilla/telemetry-airflow/blob/2048f039c6c68bf99254cb9721bc35923232cd82/dags/utils/gcp.py#L197

Otherwise, when running the query we get an error trying to insert the data into a "wrong partition"