### PR TITLE
Shred four more FxA tables

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -271,6 +271,8 @@ DELETE_TARGETS: DeleteIndex = {
     DeleteTarget(table="telemetry_stable.sync_v4", field=SYNC_IDS): SYNC_SOURCES,
     DeleteTarget(table="telemetry_stable.sync_v5", field=SYNC_IDS): SYNC_SOURCES,
     # fxa
+    client_id_target(table="firefox_accounts_derived.events_daily_v1"): FXA_SRC,
+    client_id_target(table="firefox_accounts_derived.funnel_events_source_v1"): FXA_SRC,
     user_id_target(
         table="firefox_accounts_derived.fxa_amplitude_export_v1"
     ): FXA_HMAC_SRC,
@@ -288,6 +290,12 @@ DELETE_TARGETS: DeleteIndex = {
     fxa_user_id_target(
         table="firefox_accounts_derived.fxa_gcp_stdout_events_v1"
     ): FXA_SRC,
+    user_id_target(
+        table="firefox_accounts_derived.fxa_log_device_command_events_v1"
+    ): FXA_HMAC_SRC,
+    user_id_target(
+        table="firefox_accounts_derived.fxa_log_device_command_events_v2"
+    ): FXA_HMAC_SRC,
     fxa_user_id_target(table="firefox_accounts_derived.fxa_oauth_events_v1"): FXA_SRC,
     fxa_user_id_target(table="firefox_accounts_derived.fxa_stdout_events_v1"): FXA_SRC,
     user_id_target(table="firefox_accounts_derived.fxa_users_daily_v1"): FXA_SRC,


### PR DESCRIPTION
  * `moz-fx-data-shared-prod.firefox_accounts_derived.events_daily_v1`
    * Added in June 2021 by #2114.
  * `moz-fx-data-shared-prod.firefox_accounts_derived.funnel_events_source_v1`
    * Added in June 2021 by #2126.
  * `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_log_device_command_events_v1`
    * Added in July 2020 by #1150.
  * `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_log_device_command_events_v2`
    * Added in September 2023 by #4308.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)