### PR TITLE
Fix `mozilla_vpn.main` view generated SQL

### DIFF
--- a/sql_generators/glean_usage/glean_app_ping_views.py
+++ b/sql_generators/glean_usage/glean_app_ping_views.py
@@ -250,12 +250,11 @@ class GleanAppPingViews(GleanTable):
                             # unnest repeated record
                             select_expr.append(
                                 f"""
-                                    (
-                                        SELECT ARRAY_AGG(
+                                    ARRAY(
+                                        SELECT
                                             STRUCT(
                                                 {self._generate_select_expression(node['fields'], app_schema_nodes[node_name]['fields'], [node_name])}
                                             )
-                                        )
                                         FROM UNNEST({'.'.join(path + [node_name])}) AS `{node_name}`
                                     ) AS `{node_name}`
                                 """

--- a/sql_generators/glean_usage/glean_app_ping_views.py
+++ b/sql_generators/glean_usage/glean_app_ping_views.py
@@ -256,8 +256,8 @@ class GleanAppPingViews(GleanTable):
                                                 {self._generate_select_expression(node['fields'], app_schema_nodes[node_name]['fields'], [node_name])}
                                             )
                                         )
-                                        FROM UNNEST({'.'.join(path + [node_name])}) AS {node_name}
-                                    ) AS {node_name}
+                                        FROM UNNEST({'.'.join(path + [node_name])}) AS `{node_name}`
+                                    ) AS `{node_name}`
                                 """
                             )
                         else:
@@ -266,21 +266,21 @@ class GleanAppPingViews(GleanTable):
                                 f"""
                                     STRUCT(
                                         {self._generate_select_expression(node['fields'], app_schema_nodes[node_name]['fields'], path + [node_name])}
-                                    ) AS {node_name}
+                                    ) AS `{node_name}`
                                 """
                             )
                     else:
                         if node.get("mode", None) == "REPEATED":
                             select_expr.append(
-                                f"SAFE_CAST(NULL AS ARRAY<{dtype}>) AS {node_name}"
+                                f"SAFE_CAST(NULL AS ARRAY<{dtype}>) AS `{node_name}`"
                             )
                         else:
                             select_expr.append(
-                                f"SAFE_CAST(NULL AS {dtype}) AS {node_name}"
+                                f"SAFE_CAST(NULL AS {dtype}) AS `{node_name}`"
                             )
             else:
                 select_expr.append(
-                    f"CAST(NULL AS {self._type_info(node)}) AS {node_name}"
+                    f"CAST(NULL AS {self._type_info(node)}) AS `{node_name}`"
                 )
 
         return ", ".join(select_expr)
@@ -292,7 +292,7 @@ class GleanAppPingViews(GleanTable):
             dtype = (
                 "STRUCT<"
                 + ", ".join(
-                    f"{field['name']} {self._type_info(field)}"
+                    f"`{field['name']}` {self._type_info(field)}"
                     for field in node["fields"]
                 )
                 + ">"

--- a/sql_generators/glean_usage/glean_app_ping_views.py
+++ b/sql_generators/glean_usage/glean_app_ping_views.py
@@ -270,14 +270,9 @@ class GleanAppPingViews(GleanTable):
                                 """
                             )
                     else:
-                        if node.get("mode", None) == "REPEATED":
-                            select_expr.append(
-                                f"SAFE_CAST(NULL AS ARRAY<{dtype}>) AS `{node_name}`"
-                            )
-                        else:
-                            select_expr.append(
-                                f"SAFE_CAST(NULL AS {dtype}) AS `{node_name}`"
-                            )
+                        select_expr.append(
+                            f"CAST(NULL AS {self._type_info(node)}) AS `{node_name}`"
+                        )
             else:
                 select_expr.append(
                     f"CAST(NULL AS {self._type_info(node)}) AS `{node_name}`"
@@ -297,6 +292,8 @@ class GleanAppPingViews(GleanTable):
                 )
                 + ">"
             )
+        elif dtype == "FLOAT":
+            dtype = "FLOAT64"
         if node.get("mode") == "REPEATED":
             return f"ARRAY<{dtype}>"
         return dtype


### PR DESCRIPTION
When the Glean app for the Mozilla VPN iOS network extension was added in mozilla/probe-scraper#628 this caused the `glean_usage` SQL generator to try to generate the `mozilla_vpn.main` view with some invalid SQL:
- A struct type definition contained an unqualified `range` field name, but `RANGE` is a [reserved keyword in BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#reserved_keywords).
- A struct type definition contained a `FLOAT` data type reference, but [BigQuery requires it to be `FLOAT64`](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#floating_point_types) (I've asked Google if they have any plans to support `FLOAT` without the `64` suffix).

This PR adds workarounds for both of those issues in the `glean_usage` SQL generator code.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1693)
