### PR TITLE
feat(): adding firefox ios retention week 4 aggregates query

### DIFF
--- a/dags/bqetl_analytics_aggregations.py
+++ b/dags/bqetl_analytics_aggregations.py
@@ -156,20 +156,6 @@ with DAG(
         parameters=["submission_date:DATE:{{macros.ds_add(ds, -1)}}"],
     )
 
-    with TaskGroup(
-        "firefox_ios_active_users_aggregates_external"
-    ) as firefox_ios_active_users_aggregates_external:
-        ExternalTaskMarker(
-            task_id="bqetl_firefox_ios__wait_for_firefox_ios_active_users_aggregates",
-            external_dag_id="bqetl_firefox_ios",
-            external_task_id="wait_for_firefox_ios_active_users_aggregates",
-            execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=84600)).isoformat() }}",
-        )
-
-        firefox_ios_active_users_aggregates_external.set_upstream(
-            firefox_ios_active_users_aggregates
-        )
-
     focus_android_active_users_aggregates = bigquery_etl_query(
         task_id="focus_android_active_users_aggregates",
         destination_table='active_users_aggregates_v2${{ macros.ds_format(macros.ds_add(ds, -1), "%Y-%m-%d", "%Y%m%d") }}',

--- a/dags/bqetl_analytics_aggregations.py
+++ b/dags/bqetl_analytics_aggregations.py
@@ -156,6 +156,20 @@ with DAG(
         parameters=["submission_date:DATE:{{macros.ds_add(ds, -1)}}"],
     )
 
+    with TaskGroup(
+        "firefox_ios_active_users_aggregates_external"
+    ) as firefox_ios_active_users_aggregates_external:
+        ExternalTaskMarker(
+            task_id="bqetl_firefox_ios__wait_for_firefox_ios_active_users_aggregates",
+            external_dag_id="bqetl_firefox_ios",
+            external_task_id="wait_for_firefox_ios_active_users_aggregates",
+            execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=84600)).isoformat() }}",
+        )
+
+        firefox_ios_active_users_aggregates_external.set_upstream(
+            firefox_ios_active_users_aggregates
+        )
+
     focus_android_active_users_aggregates = bigquery_etl_query(
         task_id="focus_android_active_users_aggregates",
         destination_table='active_users_aggregates_v2${{ macros.ds_format(macros.ds_add(ds, -1), "%Y-%m-%d", "%Y%m%d") }}',

--- a/dags/bqetl_firefox_ios.py
+++ b/dags/bqetl_firefox_ios.py
@@ -324,6 +324,21 @@ with DAG(
     firefox_ios_derived__app_store_funnel__v1.set_upstream(
         wait_for_app_store_external__firefox_downloads_territory_source_type_report__v1
     )
+    wait_for_firefox_ios_active_users_aggregates = ExternalTaskSensor(
+        task_id="wait_for_firefox_ios_active_users_aggregates",
+        external_dag_id="bqetl_analytics_aggregations",
+        external_task_id="firefox_ios_active_users_aggregates",
+        execution_delta=datetime.timedelta(seconds=1800),
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    firefox_ios_derived__app_store_funnel__v1.set_upstream(
+        wait_for_firefox_ios_active_users_aggregates
+    )
 
     firefox_ios_derived__attributable_clients__v1.set_upstream(
         wait_for_baseline_clients_daily

--- a/dags/bqetl_firefox_ios.py
+++ b/dags/bqetl_firefox_ios.py
@@ -110,6 +110,19 @@ with DAG(
         retries=0,
     )
 
+    checks__fail_firefox_ios_derived__funnel_retention_week_4_aggregates__v1 = bigquery_dq_check(
+        task_id="checks__fail_firefox_ios_derived__funnel_retention_week_4_aggregates__v1",
+        source_table="funnel_retention_week_4_aggregates_v1",
+        dataset_id="firefox_ios_derived",
+        project_id="moz-fx-data-shared-prod",
+        is_dq_check_fail=True,
+        owner="kik@mozilla.com",
+        email=["kik@mozilla.com", "telemetry-alerts@mozilla.com"],
+        depends_on_past=False,
+        parameters=["submission_date:DATE:{{ds}}"],
+        retries=0,
+    )
+
     checks__warn_firefox_ios_derived__app_store_funnel__v1 = bigquery_dq_check(
         task_id="checks__warn_firefox_ios_derived__app_store_funnel__v1",
         source_table="app_store_funnel_v1",
@@ -195,6 +208,17 @@ with DAG(
         depends_on_past=False,
     )
 
+    firefox_ios_derived__funnel_retention_week_4_aggregates__v1 = bigquery_etl_query(
+        task_id="firefox_ios_derived__funnel_retention_week_4_aggregates__v1",
+        destination_table="funnel_retention_week_4_aggregates_v1",
+        dataset_id="firefox_ios_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="kik@mozilla.com",
+        email=["kik@mozilla.com", "telemetry-alerts@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+    )
+
     firefox_ios_derived__new_profile_activation__v2 = bigquery_etl_query(
         task_id="firefox_ios_derived__new_profile_activation__v2",
         destination_table="new_profile_activation_v2",
@@ -254,6 +278,10 @@ with DAG(
         firefox_ios_derived__funnel_retention_week_4__v1
     )
 
+    checks__fail_firefox_ios_derived__funnel_retention_week_4_aggregates__v1.set_upstream(
+        firefox_ios_derived__funnel_retention_week_4_aggregates__v1
+    )
+
     checks__warn_firefox_ios_derived__app_store_funnel__v1.set_upstream(
         firefox_ios_derived__app_store_funnel__v1
     )
@@ -295,21 +323,6 @@ with DAG(
 
     firefox_ios_derived__app_store_funnel__v1.set_upstream(
         wait_for_app_store_external__firefox_downloads_territory_source_type_report__v1
-    )
-    wait_for_firefox_ios_active_users_aggregates = ExternalTaskSensor(
-        task_id="wait_for_firefox_ios_active_users_aggregates",
-        external_dag_id="bqetl_analytics_aggregations",
-        external_task_id="firefox_ios_active_users_aggregates",
-        execution_delta=datetime.timedelta(seconds=1800),
-        check_existence=True,
-        mode="reschedule",
-        allowed_states=ALLOWED_STATES,
-        failed_states=FAILED_STATES,
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
-    )
-
-    firefox_ios_derived__app_store_funnel__v1.set_upstream(
-        wait_for_firefox_ios_active_users_aggregates
     )
 
     firefox_ios_derived__attributable_clients__v1.set_upstream(
@@ -364,6 +377,10 @@ with DAG(
 
     firefox_ios_derived__funnel_retention_week_2__v1.set_upstream(
         checks__fail_firefox_ios_derived__firefox_ios_clients__v1
+    )
+
+    firefox_ios_derived__funnel_retention_week_4_aggregates__v1.set_upstream(
+        checks__fail_firefox_ios_derived__funnel_retention_week_4__v1
     )
 
     firefox_ios_derived__new_profile_activation__v2.set_upstream(

--- a/sql/moz-fx-data-shared-prod/firefox_ios/funnel_retention_week_4_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/funnel_retention_week_4_aggregates/view.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_ios.funnel_retention_week_4_aggregates`
+AS
+SELECT
+  *
+FROM `moz-fx-data-shared-prod.firefox_ios_derived.funnel_retention_week_4_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
@@ -46,6 +46,8 @@ store_stats AS (
   ON
     country_names.name = views_data.country_name
 ),
+-- TODO: we may need to consider updating the source for new profiles to be firefox_ios.firefox_ios_clients
+-- instead to avoid the other funnel query using a different source.
 _new_profiles AS (
   SELECT
     submission_date AS `date`,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/checks.sql
@@ -2,4 +2,11 @@
 {{ is_unique(["client_id"]) }}
 #fail
 {{ min_row_count(1, "submission_date = @submission_date") }}
+#fail
+SELECT
+  IF(
+    DATE_DIFF(submission_date, first_seen_date, DAY) <> 13,
+    ERROR("Day difference between submission_date and first_seen_date is not equal to 13 as expected"),
+    NULL
+  );
 

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/checks.sql
@@ -1,5 +1,5 @@
 #fail
 {{ is_unique(["client_id"]) }}
 #fail
-{{ min_row_count(1, "first_seen_date = DATE_SUB(@submission_date, INTERVAL 13 DAY)") }}
+{{ min_row_count(1, "submission_date = @submission_date") }}
 

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/checks.sql
@@ -1,0 +1,69 @@
+#fail
+{{ is_unique([
+  "first_seen_date", "first_reported_country", "first_reported_isp",
+  "adjust_ad_group", "adjust_campaign", "adjust_creative", "adjust_network"
+], "submission_date = @submission_date") }}
+#fail
+{{ not_null(["first_seen_date", "adjust_network"], "submission_date = @submission_date") }}
+#fail
+{{ min_row_count(1, "submission_date = @submission_date") }}
+#fail
+WITH new_profile_count AS (
+  SELECT SUM(new_profiles) FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}` WHERE submission_date = @submission_date
+),
+new_profile_upstream_count AS (
+  SELECT COUNT(*) FROM `{{ project_id }}.{{ dataset_id }}.funnel_retention_week_4_v1` WHERE submission_date = @submission_date
+)
+SELECT IF(
+  (SELECT * FROM new_profile_count) <> (SELECT * FROM new_profile_upstream_count),
+  ERROR(
+    CONCAT(
+      "New profile count mismatch between this (",
+      (SELECT * FROM new_profile_count),
+      ") and upstream (",
+      (SELECT * FROM new_profile_upstream_count),
+      ") tables"
+    )
+  ),
+  NULL
+);
+#fail
+WITH repeat_user_count AS (
+  SELECT SUM(repeat_user) FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}` WHERE submission_date = @submission_date
+),
+repeat_user_upstream_count AS (
+  SELECT COUNTIF(repeat_first_month_user) FROM `{{ project_id }}.{{ dataset_id }}.funnel_retention_week_4_v1` WHERE submission_date = @submission_date
+)
+SELECT IF(
+  (SELECT * FROM repeat_user_count) <> (SELECT * FROM repeat_user_upstream_count),
+  ERROR(
+    CONCAT(
+      "New profile count mismatch between this (",
+      (SELECT * FROM repeat_user_count),
+      ") and upstream (",
+      (SELECT * FROM repeat_user_upstream_count),
+      ") tables"
+    )
+  ),
+  NULL
+);
+#fail
+WITH retained_week_4_count AS (
+  SELECT SUM(retained_week_4) FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}` WHERE submission_date = @submission_date
+),
+retained_week_4_upstream_count AS (
+  SELECT COUNTIF(retained_week_4) FROM `{{ project_id }}.{{ dataset_id }}.funnel_retention_week_4_v1` WHERE submission_date = @submission_date
+)
+SELECT IF(
+  (SELECT * FROM retained_week_4_count) <> (SELECT * FROM retained_week_4_upstream_count),
+  ERROR(
+    CONCAT(
+      "New profile count mismatch between this (",
+      (SELECT * FROM retained_week_4_count),
+      ") and upstream (",
+      (SELECT * FROM retained_week_4_upstream_count),
+      ") tables"
+    )
+  ),
+  NULL
+);

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/checks.sql
@@ -67,3 +67,10 @@ SELECT IF(
   ),
   NULL
 );
+#fail
+SELECT
+  IF(
+    DATE_DIFF(submission_date, first_seen_date, DAY) <> 27,
+    ERROR("Day difference between submission_date and first_seen_date is not equal to 27 as expected"),
+    NULL
+  );

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/metadata.yaml
@@ -16,5 +16,5 @@ bigquery:
     require_partition_filter: false
   clustering:
     fields:
-    - first_seen_country
+    - first_reported_country
     - adjust_network

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: User Retention Aggregations - Firefox iOS (Week 4)
+description: |
+  Aggregated dataset for Firefox iOS retention analysis.
+owners:
+- kik@mozilla.com
+labels:
+  schedule: daily
+  incremental: true
+scheduling:
+  dag_name: bqetl_firefox_ios
+  depends_on_past: false
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+  clustering:
+    fields:
+    - first_seen_country
+    - adjust_network

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/query.sql
@@ -1,0 +1,25 @@
+SELECT
+  submission_date,
+  first_seen_date,
+  first_reported_country,
+  first_reported_isp,
+  adjust_ad_group,
+  adjust_campaign,
+  adjust_creative,
+  adjust_network,
+  COUNT(*) AS new_profiles,
+  COUNTIF(repeat_first_month_user) AS repeat_user,
+  COUNTIF(retained_week_4) AS retained_week_4,
+FROM
+  firefox_ios_derived.funnel_retention_week_4_v1
+WHERE
+  submission_date = @submission_date
+GROUP BY
+  submission_date,
+  first_seen_date,
+  first_reported_country,
+  first_reported_isp,
+  adjust_ad_group,
+  adjust_campaign,
+  adjust_creative,
+  adjust_network

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_aggregates_v1/schema.yaml
@@ -1,0 +1,67 @@
+fields:
+
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: |
+    Partition field, also corresponds to internal execution date of the job (first_seen_date + 28 days).
+
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+  description: |
+    Date of when the user was first seen.
+
+- mode: NULLABLE
+  name: first_reported_country
+  type: STRING
+  description: |
+    First reported country for the client installation.
+
+- mode: NULLABLE
+  name: first_reported_isp
+  type: STRING
+  description: |
+    Name of the first reported isp (Internet Service Provider).
+
+- mode: NULLABLE
+  name: adjust_ad_group
+  type: STRING
+  description: |
+    Structure parameter for the the ad group of a campaign.
+
+- mode: NULLABLE
+  name: adjust_campaign
+  type: STRING
+  description: |
+    Structure parameter for the campaign name.
+
+- mode: NULLABLE
+  name: adjust_creative
+  type: STRING
+  description: |
+    Structure parameter for the creative content of a campaign.
+
+- mode: NULLABLE
+  name: adjust_network
+  type: STRING
+  description: |
+    The type of source of a client installation.
+
+- mode: NULLABLE
+  name: new_profiles
+  type: INTEGER
+  description: |
+    Count of new_profiles for the given grouping.
+
+- mode: NULLABLE
+  name: repeat_user
+  type: INTEGER
+  description: |
+    Count of users categorised as "repeat_first_month_user" for the grouping.
+
+- mode: NULLABLE
+  name: retained_week_4
+  type: INTEGER
+  description: |
+    Count of users categorised as "retained_week_4" for the grouping.

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/checks.sql
@@ -1,7 +1,7 @@
 #fail
 {{ is_unique(["client_id"]) }}
 #fail
-{{ min_row_count(1, "first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)") }}
+{{ min_row_count(1, "submission_date = @submission_date") }}
 #fail
 -- Here we're checking that the retention_week_2 generated inside funnel_retention_week_2_v1
 -- matches that reported by this table (generated 2 weeks later).

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/checks.sql
@@ -34,4 +34,11 @@ SELECT
       )
     ),
     NULL
-  )
+  );
+#fail
+SELECT
+  IF(
+    DATE_DIFF(submission_date, first_seen_date, DAY) <> 27,
+    ERROR("Day difference between submission_date and first_seen_date is not equal to 27 as expected"),
+    NULL
+  );


### PR DESCRIPTION
feat(): adding firefox ios retention week 4 aggregates query

This means that unless we decide to "backfill" this table the numbers reported by it should not be affected by Shredder.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1695)
