### PR TITLE
feat(): moved out the is_suspicious_client_device filter from clients view to retention queries

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_ios.firefox_ios_clients`
 AS
 SELECT
-  * EXCEPT (is_suspicious_device_client) REPLACE (
+  * REPLACE (
     CASE
       WHEN adjust_network IS NULL
         THEN 'Unknown'
@@ -17,6 +17,3 @@ SELECT
   ),
 FROM
   `moz-fx-data-shared-prod.firefox_ios_derived.firefox_ios_clients_v1`
-WHERE
-  -- filtering out suspicious devices on iOS, for more info see: bug-1846554
-  NOT is_suspicious_device_client

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_2_v1/query.sql
@@ -27,6 +27,8 @@ clients_first_seen AS (
     -- Two weeks need to elapse before calculating the week 2 retention
     first_seen_date = DATE_SUB(@submission_date, INTERVAL 13 DAY)
     AND channel = "release"
+    -- filtering out suspicious devices on iOS, for more info see: bug-1846554
+    AND NOT is_suspicious_device_client
 ),
 retention_calculation AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/query.sql
@@ -27,6 +27,8 @@ clients_first_seen AS (
     -- 28 days need to elapse before calculating the week 4 and day 28 retention metrics
     first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
     AND channel = "release"
+    -- filtering out suspicious devices on iOS, for more info see: bug-1846554
+    AND NOT is_suspicious_device_client
 ),
 retention_calculation AS (
   SELECT


### PR DESCRIPTION
feat(): moved out the is_suspicious_client_device filter from clients view to retention queries

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1709)
