### PR TITLE
remove unused deprecated field from branch

### DIFF
--- a/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
@@ -7,7 +7,7 @@ import json
 import sys
 import time
 from argparse import ArgumentParser
-from typing import Any, Dict, List, Optional, Union
+from typing import List, Optional
 
 import attr
 import cattrs
@@ -38,7 +38,6 @@ class Branch:
 
     slug: str
     ratio: int
-    value: Union[str, Dict[Any, Any]]
 
 
 @attr.s(auto_attribs=True)
@@ -114,8 +113,7 @@ class ExperimentV1:
     def to_experiment(self) -> "Experiment":
         """Convert to Experiment."""
         branches = [
-            Branch(slug=variant.slug, ratio=variant.ratio, value=variant.value)
-            for variant in self.variants
+            Branch(slug=variant.slug, ratio=variant.ratio) for variant in self.variants
         ]
         control_slug = None
 
@@ -175,9 +173,7 @@ class ExperimentV6:
         )
         converter.register_structure_hook(
             Branch,
-            lambda b, _: Branch(
-                slug=b["slug"], ratio=b["ratio"], value=b["feature"]["value"]
-            ),
+            lambda b, _: Branch(slug=b["slug"], ratio=b["ratio"]),
         )
         return converter.structure(d, cls)
 
@@ -282,7 +278,6 @@ def main():
             fields=[
                 bigquery.SchemaField("slug", "STRING"),
                 bigquery.SchemaField("ratio", "INTEGER"),
-                bigquery.SchemaField("value", "JSON"),
             ],
         ),
         bigquery.SchemaField("app_id", "STRING"),


### PR DESCRIPTION
Removes the `value` field from experiment branches because it has not been used by Experimenter in over a year and is causing an issue on a new experiment because it is missing.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1718)
