### PR TITLE
DENG-1714 - Create clients_first_seen_28_days_later

### DIFF
--- a/dags/bqetl_analytics_tables.py
+++ b/dags/bqetl_analytics_tables.py
@@ -203,6 +203,22 @@ with DAG(
 
         firefox_android_clients_external.set_upstream(firefox_android_clients)
 
+    telemetry_derived__clients_first_seen_28_days_later__v1 = bigquery_etl_query(
+        task_id="telemetry_derived__clients_first_seen_28_days_later__v1",
+        destination_table="clients_first_seen_28_days_later_v1",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="loines@mozilla.com",
+        email=[
+            "gkaberere@mozilla.com",
+            "loines@mozilla.com",
+            "lvargas@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+    )
+
     checks__fail_fenix_derived__funnel_retention_clients_week_2__v1.set_upstream(
         fenix_derived__funnel_retention_clients_week_2__v1
     )
@@ -291,3 +307,21 @@ with DAG(
     )
 
     firefox_android_clients.set_upstream(wait_for_baseline_clients_daily)
+
+    telemetry_derived__clients_first_seen_28_days_later__v1.set_upstream(
+        clients_first_seen_v2
+    )
+    wait_for_telemetry_derived__clients_last_seen__v1 = ExternalTaskSensor(
+        task_id="wait_for_telemetry_derived__clients_last_seen__v1",
+        external_dag_id="bqetl_main_summary",
+        external_task_id="telemetry_derived__clients_last_seen__v1",
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    telemetry_derived__clients_first_seen_28_days_later__v1.set_upstream(
+        wait_for_telemetry_derived__clients_last_seen__v1
+    )

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -317,6 +317,12 @@ with DAG(
         )
 
         ExternalTaskMarker(
+            task_id="bqetl_analytics_tables__wait_for_telemetry_derived__clients_last_seen__v1",
+            external_dag_id="bqetl_analytics_tables",
+            external_task_id="wait_for_telemetry_derived__clients_last_seen__v1",
+        )
+
+        ExternalTaskMarker(
             task_id="bqetl_desktop_funnel__wait_for_telemetry_derived__clients_last_seen__v1",
             external_dag_id="bqetl_desktop_funnel",
             external_task_id="wait_for_telemetry_derived__clients_last_seen__v1",

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_first_seen_28_days_later/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_first_seen_28_days_later/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.clients_first_seen_28_days_later`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.clients_first_seen_28_days_later_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/metadata.yaml
@@ -1,0 +1,19 @@
+friendly_name: Clients First Seen 28 Days Later
+description: |-
+  Client cohorts 28 days after their first seen date with relevant retention indicators.
+owners:
+  - loines@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_analytics_tables
+bigquery:
+  time_partitioning:
+    type: day
+    field: first_seen_date
+    require_partition_filter: true
+    expiration_days: null
+  clustering:
+    fields:
+      - sample_id
+deprecated: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/query.sql
@@ -1,0 +1,88 @@
+WITH clients_first_seen_28_days_ago AS (
+  SELECT
+    client_id,
+    sample_id,
+    country AS country_code,
+    normalized_channel AS channel,
+    app_build_id AS build_id,
+    normalized_os AS os,
+    mozfun.norm.truncate_version(normalized_os_version, "minor") AS os_version,
+    attribution_source,
+    distribution_id,
+    attribution_ua,
+    -- startup_profile_selection_reason, when startup_profile_selection_reason is available
+    first_seen_date,
+  FROM
+    telemetry_derived.clients_first_seen_v2
+  WHERE
+    first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 day)
+),
+clients_first_seen_28_days_ago_with_days_seen AS (
+  SELECT
+    clients_first_seen_28_days_ago.*,
+    cls.days_seen_bits,
+    cls.days_visited_1_uri_bits,
+    cls.days_interacted_bits,
+  FROM
+    clients_first_seen_28_days_ago
+  LEFT JOIN
+    telemetry.clients_last_seen cls
+  ON
+    clients_first_seen_28_days_ago.client_id = cls.client_id
+    AND cls.submission_date = @submission_date
+)
+SELECT
+  client_id,
+  sample_id,
+  first_seen_date,
+  @submission_date AS submission_date,
+  country_code,
+  channel,
+  build_id,
+  os,
+  os_version,
+  attribution_source,
+  distribution_id,
+  attribution_ua,
+  COALESCE(
+    BIT_COUNT(mozfun.bits28.from_string('1111111000000000000000000000') & days_seen_bits) >= 5,
+    FALSE
+  ) AS activated,
+  COALESCE(
+    BIT_COUNT(mozfun.bits28.from_string('0111111111111111111111111111') & days_seen_bits) > 0,
+    FALSE
+  ) AS returned_second_day,
+  COALESCE(
+    BIT_COUNT(
+      mozfun.bits28.from_string(
+        '0111111111111111111111111111'
+      ) & days_visited_1_uri_bits & days_interacted_bits
+    ) > 0,
+    FALSE
+  ) AS qualified_second_day,
+  COALESCE(
+    BIT_COUNT(mozfun.bits28.from_string('0000000000000000000001111111') & days_seen_bits) > 0,
+    FALSE
+  ) AS retained_week4,
+  COALESCE(
+    BIT_COUNT(
+      mozfun.bits28.from_string(
+        '0000000000000000000001111111'
+      ) & days_visited_1_uri_bits & days_interacted_bits
+    ) > 0,
+    FALSE
+  ) AS qualified_week4,
+  COALESCE(
+    days_seen_bits,
+    mozfun.bits28.from_string('0000000000000000000000000000')
+  ) AS days_seen_bits,
+  COALESCE(
+    days_visited_1_uri_bits,
+    mozfun.bits28.from_string('0000000000000000000000000000')
+  ) AS days_visited_1_uri_bits,
+  COALESCE(
+    days_interacted_bits,
+    mozfun.bits28.from_string('0000000000000000000000000000')
+  ) AS days_interacted_bits,
+FROM
+  clients_first_seen_28_days_ago_with_days_seen

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/query.sql
@@ -7,9 +7,15 @@ WITH clients_first_seen_28_days_ago AS (
     app_build_id AS build_id,
     normalized_os AS os,
     mozfun.norm.truncate_version(normalized_os_version, "minor") AS os_version,
-    attribution_source,
     distribution_id,
+    attribution_source,
     attribution_ua,
+    attribution_medium,
+    attribution_campaign,
+    attribution_content,
+    attribution_experiment,
+    attribution_dltoken,
+    attribution_dlsource,
     -- startup_profile_selection_reason, when startup_profile_selection_reason is available
     first_seen_date,
   FROM
@@ -41,9 +47,15 @@ SELECT
   build_id,
   os,
   os_version,
-  attribution_source,
   distribution_id,
+  attribution_source,
   attribution_ua,
+  attribution_medium,
+  attribution_campaign,
+  attribution_content,
+  attribution_experiment,
+  attribution_dltoken,
+  attribution_dlsource,
   COALESCE(
     BIT_COUNT(mozfun.bits28.from_string('1111111000000000000000000000') & days_seen_bits) >= 5,
     FALSE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/schema.yaml
@@ -1,0 +1,69 @@
+fields:
+- name: client_id
+  type: STRING
+  mode: NULLABLE
+- name: sample_id
+  type: INTEGER
+  mode: NULLABLE
+- name: first_seen_date
+  type: DATE
+  mode: NULLABLE
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+- name: country_code
+  type: STRING
+  mode: NULLABLE
+- name: channel
+  type: STRING
+  mode: NULLABLE
+- name: build_id
+  type: STRING
+  mode: NULLABLE
+- name: os
+  type: STRING
+  mode: NULLABLE
+- name: os_version
+  type: NUMERIC
+  mode: NULLABLE
+- name: attribution_source
+  type: STRING
+  mode: NULLABLE
+- name: distribution_id
+  type: STRING
+  mode: NULLABLE
+- name: attribution_ua
+  type: STRING
+  mode: NULLABLE
+- name: activated
+  description: Whether the profile sent a main ping in at least 5 of their first 7
+    days.
+  type: BOOLEAN
+  mode: NULLABLE
+- name: returned_second_day
+  description: Whether the profile sent a main ping on any day after their first day
+    during their first 28 days.
+  type: BOOLEAN
+  mode: NULLABLE
+- name: qualified_second_day
+  description: Whether the profile qualified as DAU on any day after their first day
+    during their first 28 days.
+  type: BOOLEAN
+  mode: NULLABLE
+- name: retained_week4
+  description: Whether the profile sent a main ping on any day in their 4th week.
+  type: BOOLEAN
+  mode: NULLABLE
+- name: qualified_week4
+  description: Whether the profile qualified as DAU on any day in their 4th week.
+  type: BOOLEAN
+  mode: NULLABLE
+- name: days_seen_bits
+  type: INTEGER
+  mode: NULLABLE
+- name: days_visited_1_uri_bits
+  type: INTEGER
+  mode: NULLABLE
+- name: days_interacted_bits
+  type: INTEGER
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/schema.yaml
@@ -26,13 +26,31 @@ fields:
 - name: os_version
   type: NUMERIC
   mode: NULLABLE
-- name: attribution_source
-  type: STRING
-  mode: NULLABLE
 - name: distribution_id
   type: STRING
   mode: NULLABLE
+- name: attribution_source
+  type: STRING
+  mode: NULLABLE
 - name: attribution_ua
+  type: STRING
+  mode: NULLABLE
+- name: attribution_medium
+  type: STRING
+  mode: NULLABLE
+- name: attribution_campaign
+  type: STRING
+  mode: NULLABLE
+- name: attribution_content
+  type: STRING
+  mode: NULLABLE
+- name: attribution_experiment
+  type: STRING
+  mode: NULLABLE
+- name: attribution_dltoken
+  type: STRING
+  mode: NULLABLE
+- name: attribution_dlsource
   type: STRING
   mode: NULLABLE
 - name: activated


### PR DESCRIPTION
Creates `clients_first_seen_28_days_later` query and view. 

More or less copy-paste from https://github.com/mozilla/bigquery-etl/pull/4358 and https://docs.google.com/document/d/1l-m7-WS51qo8V_29ArN4VYV-GX4U5YmV2UQtcDPL5LY/edit#heading=h.k926msualmu4. I'll highlight key differences in files changed.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [x] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
