### PR TITLE
Add sampling to glam-fog

### DIFF
--- a/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
@@ -31,7 +31,7 @@ sampled_data AS (
     OR (
         channel = "release" AND
         os = "Windows" AND
-        sample_id <= 10)
+        sample_id < 10)
 ),
 histograms AS (
   SELECT

--- a/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
@@ -18,6 +18,21 @@ WITH extracted AS (
     DATE(submission_timestamp) = {{ submission_date }}
     AND client_info.client_id IS NOT NULL
 ),
+sampled_data AS (
+  SELECT
+    *
+  FROM
+    extracted
+  WHERE
+    -- If you're changing this, then you'll also need to change probe_counts_v1,
+    -- where sampling is taken into account for counting clients.
+    channel IN ("nightly", "beta")
+    OR (channel = "release" AND os != "Windows")
+    OR (
+        channel = "release" AND
+        os = "Windows" AND
+        sample_id <= 10)
+),
 histograms AS (
   SELECT
     {{ attributes }},
@@ -29,7 +44,7 @@ histograms AS (
       >
     >[{{ histograms }}] AS metadata
   FROM
-    extracted
+    sampled_data
 ),
 flattened_histograms AS (
   SELECT

--- a/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
@@ -31,7 +31,7 @@ sampled_data AS (
     OR (
         channel = "release" AND
         os = "Windows" AND
-        sample_id <= 10)
+        sample_id < 10)
 ),
 unlabeled_metrics AS (
   SELECT

--- a/bigquery_etl/glam/templates/probe_counts_v1.sql
+++ b/bigquery_etl/glam/templates/probe_counts_v1.sql
@@ -38,15 +38,13 @@ RETURNS ARRAY<INT64> AS (
 SELECT
     {{ attributes }},
     {{ aggregate_attributes }},
-    -- Logic to count clients based on sampled windows release data.
-    -- If you're changing this, then you'll also need to change
-    -- clients_daily_[scalar | histogram]_aggregates
-    os = 'Windows'
-    AND channel = 'release' AS sampled,
     {% if is_scalar %}
         client_agg_type,
         agg_type,
-        IF(sampled,
+        -- Logic to count clients based on sampled windows release data.
+        -- If you're changing this, then you'll also need to change
+        -- clients_daily_[scalar | histogram]_aggregates
+        IF(os = 'Windows' AND channel = 'release',
           SUM(count) * 10,
           SUM(count)
         ) AS total_users,
@@ -66,7 +64,10 @@ SELECT
     {% else %}
         agg_type AS client_agg_type,
         'histogram' as agg_type,
-        IF(sampled,
+        -- Logic to count clients based on sampled windows release data.
+        -- If you're changing this, then you'll also need to change
+        -- clients_daily_[scalar | histogram]_aggregates
+        IF(os = 'Windows' AND channel = 'release',
           CAST(ROUND(SUM(record.value)) AS INT64) * 10,
           CAST(ROUND(SUM(record.value)) AS INT64)
         ) AS total_users,


### PR DESCRIPTION
Samples (10%) `Windows` probes in `Release` for FOG, following what's done in Legacy Telemetry.
This is in response to a linear increase in BQ processing costs for the `glam_fog` dag since mid June 2023.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1747)
