### PR TITLE
feat(DENG-1599): added ETL checks related to firefox_ios_derived.new_profile_activation_v2

### DIFF
--- a/dags/bqetl_firefox_ios.py
+++ b/dags/bqetl_firefox_ios.py
@@ -122,6 +122,23 @@ with DAG(
         retries=0,
     )
 
+    checks__fail_firefox_ios_derived__new_profile_activation__v2 = bigquery_dq_check(
+        task_id="checks__fail_firefox_ios_derived__new_profile_activation__v2",
+        source_table="new_profile_activation_v2",
+        dataset_id="firefox_ios_derived",
+        project_id="moz-fx-data-shared-prod",
+        is_dq_check_fail=True,
+        owner="vsabino@mozilla.com",
+        email=[
+            "kik@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+            "vsabino@mozilla.com",
+        ],
+        depends_on_past=True,
+        parameters=["submission_date:DATE:{{ds}}"],
+        retries=0,
+    )
+
     checks__warn_firefox_ios_derived__app_store_funnel__v1 = bigquery_dq_check(
         task_id="checks__warn_firefox_ios_derived__app_store_funnel__v1",
         source_table="app_store_funnel_v1",
@@ -278,6 +295,10 @@ with DAG(
         firefox_ios_derived__funnel_retention_week_4__v1
     )
 
+    checks__fail_firefox_ios_derived__new_profile_activation__v2.set_upstream(
+        firefox_ios_derived__new_profile_activation__v2
+    )
+
     checks__warn_firefox_ios_derived__app_store_funnel__v1.set_upstream(
         firefox_ios_derived__app_store_funnel__v1
     )
@@ -351,12 +372,12 @@ with DAG(
     firefox_ios_derived__firefox_ios_clients__v1.set_upstream(
         wait_for_baseline_clients_daily
     )
-    firefox_ios_derived__firefox_ios_clients__v1.set_upstream(
-        wait_for_copy_deduplicate_all
-    )
 
     firefox_ios_derived__firefox_ios_clients__v1.set_upstream(
-        firefox_ios_derived__new_profile_activation__v2
+        checks__fail_firefox_ios_derived__new_profile_activation__v2
+    )
+    firefox_ios_derived__firefox_ios_clients__v1.set_upstream(
+        wait_for_copy_deduplicate_all
     )
 
     wait_for_baseline_clients_last_seen = ExternalTaskSensor(

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/checks.sql
@@ -12,6 +12,23 @@ SELECT
     NULL
   )
 FROM
-  `moz-fx-data-shared-prod.firefox_ios_derived.firefox_ios_clients_v1`
+  `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
 WHERE
   first_seen_date = @submission_date;
+#warn
+WITH base AS (
+  SELECT COUNTIF(is_activated)
+  FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+  WHERE first_seen_date = @submission_date
+),
+upstream AS (
+  SELECT COUNTIF(is_activated)
+  FROM `{{ project_id }}.{{ dataset_id }}.new_profile_activation_v2`
+  WHERE first_seen_date = @submission_date
+)
+SELECT
+  IF(
+    (SELECT * FROM base) <> (SELECT * FROM upstream),
+    ERROR(CONCAT("Number of activations does not match up that of the upstream table. Upstream count: ", (SELECT * FROM upstream), ", base count: ", (SELECT * FROM base))),
+    NULL
+  );

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v2/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v2/checks.sql
@@ -1,0 +1,22 @@
+#fail
+{{ is_unique(["client_id"]) }}
+#fail
+{{ min_row_count(1, "`date` = @submission_date") }}
+#fail
+SELECT
+  IF(
+    COUNTIF(is_new_profile) <> COUNT(*),
+    ERROR("Number of is_new_profile TRUE values should be the same as the row count."),
+    NULL
+  )
+FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+WHERE `date` = @submission_date;
+#fail
+SELECT
+  IF(
+    DATE_DIFF(`date`, first_seen_date, DAY) <> 6,
+    ERROR("Day difference between values inside `date` and submission_date fields should be 6."),
+    NULL
+  )
+FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+WHERE `date` = @submission_date;


### PR DESCRIPTION
# feat(DENG-1599): added ETL checks related to firefox_ios_derived.new_profile_activation_v2

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1749)
