### PR TITLE
chore(ci): update private-bigquery-etl git submodule in telemetry-airflow-dags repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,6 +407,9 @@ jobs:
               || echo "Skipping push since it looks like there were no changes"
   sync-dags-repo:
     executor: docker/machine
+    parameters:
+      repo-to-sync:
+        type: string
     steps:
       - checkout
       - add_ssh_keys:
@@ -421,10 +424,10 @@ jobs:
             git clone --branch main git@github.com:mozilla/telemetry-airflow-dags.git
             cd ~/project/telemetry-airflow-dags
             git submodule update --init --recursive --depth 1
-            cd ${CIRCLE_PROJECT_REPONAME}
+            cd << parameters.repo-to-sync >>
             git pull origin generated-sql
             cd ..
-            git add ${CIRCLE_PROJECT_REPONAME}
+            git add << parameters.repo-to-sync >>
             git commit --allow-empty -m "Automatic commit from ${CIRCLE_PROJECT_REPONAME} commit ${CIRCLE_SHA1:0:9} build ${CIRCLE_BUILD_NUM} [skip ci]"
             git push origin main
   deploy:
@@ -721,6 +724,7 @@ workflows:
                 - main
       - sync-dags-repo:
           name: 🔃 Synchronize DAGs repository
+          repo-to-sync: ${CIRCLE_PROJECT_REPONAME}
           requires:
             - push-generated-sql
           filters:
@@ -759,6 +763,15 @@ workflows:
       - push-private-generated-sql:
           requires:
             - private-generate-sql
+          filters:
+            branches:
+              only:
+                - main
+      - sync-dags-repo:
+          name: 🔃 Synchronize DAGs repository
+          repo-to-sync: private-bigquery-etl
+          requires:
+            - push-private-generated-sql
           filters:
             branches:
               only:


### PR DESCRIPTION
# Description
Add CI step to update the submodule reference for `private-bigquery-etl`'s `private-generated-sql` branch in [telemetry-airflow-dags](https://github.com/mozilla/telemetry-airflow-dags).

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1755)
