### PR TITLE
fix(ci): Add missing SSH key in sync-dags-repo step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,7 +774,7 @@ workflows:
               only:
                 - main
       - sync-dags-repo:
-          name: 🔃 Synchronize DAGs repository
+          name: 🔃 Synchronize private-bigquery-etl submodule
           repo-to-sync: private-bigquery-etl
           requires:
             - push-private-generated-sql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,8 @@ jobs:
       - *build
       - *attach_generated_sql
       - add_ssh_keys:
-          fingerprints: "22:b9:3c:1b:82:ab:3f:e4:b5:79:70:d1:7b:b9:28:d2"
+          fingerprints:
+            - "22:b9:3c:1b:82:ab:3f:e4:b5:79:70:d1:7b:b9:28:d2"
       - run:
           name: Build and deploy docs
           command: |
@@ -351,7 +352,8 @@ jobs:
       - *attach_generated_sql
       - *copy_generated_sql
       - add_ssh_keys:
-          fingerprints: "22:b9:3c:1b:82:ab:3f:e4:b5:79:70:d1:7b:b9:28:d2"
+          fingerprints:
+            - "22:b9:3c:1b:82:ab:3f:e4:b5:79:70:d1:7b:b9:28:d2"
       - run:
           name: Pull in generated-sql branch from remote
           command: |
@@ -386,7 +388,8 @@ jobs:
     steps:
       - *attach_generated_sql
       - add_ssh_keys:
-          fingerprints: "22:b9:3c:1b:82:ab:3f:e4:b5:79:70:d1:7b:b9:28:d2"
+          fingerprints:
+            - "22:b9:3c:1b:82:ab:3f:e4:b5:79:70:d1:7b:b9:28:d2"
       - run:
           name: Push to generated-sql branch
           command: |
@@ -410,11 +413,13 @@ jobs:
     parameters:
       repo-to-sync:
         type: string
+      ssh_key_fingerprint:
+        type: string
     steps:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "e4:30:50:41:53:f0:d6:3a:bb:c9:38:54:2d:ca:56:41"
+            - << parameters.ssh_key_fingerprint >>
       - run:
           name: 🤖 Update DAGs repository
           command: |
@@ -452,7 +457,8 @@ jobs:
       - *build
       - add_ssh_keys:
           # deploy key to private-bigquery-etl
-          fingerprints: "9d:1e:af:52:78:2c:e8:ec:33:4c:db:cd:5a:ff:70:0a"
+          fingerprints:
+            - "9d:1e:af:52:78:2c:e8:ec:33:4c:db:cd:5a:ff:70:0a"
       - run:
           name: Install rsync
           command: |
@@ -502,7 +508,8 @@ jobs:
     steps:
       - *attach_generated_sql
       - add_ssh_keys:
-          fingerprints: "9d:1e:af:52:78:2c:e8:ec:33:4c:db:cd:5a:ff:70:0a"
+          fingerprints:
+            - "9d:1e:af:52:78:2c:e8:ec:33:4c:db:cd:5a:ff:70:0a"
       - run:
           name: Push to private-generated-sql branch
           # yamllint disable rule:line-length
@@ -723,8 +730,9 @@ workflows:
               only:
                 - main
       - sync-dags-repo:
-          name: 🔃 Synchronize DAGs repository
+          name: 🔃 Synchronize bigquery-etl submodule
           repo-to-sync: ${CIRCLE_PROJECT_REPONAME}
+          ssh_key_fingerprint: "e4:30:50:41:53:f0:d6:3a:bb:c9:38:54:2d:ca:56:41"
           requires:
             - push-generated-sql
           filters:
@@ -770,6 +778,7 @@ workflows:
       - sync-dags-repo:
           name: 🔃 Synchronize DAGs repository
           repo-to-sync: private-bigquery-etl
+          ssh_key_fingerprint: "9d:1e:af:52:78:2c:e8:ec:33:4c:db:cd:5a:ff:70:0a"
           requires:
             - push-private-generated-sql
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,13 +413,12 @@ jobs:
     parameters:
       repo-to-sync:
         type: string
-      ssh_key_fingerprint:
-        type: string
     steps:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - << parameters.ssh_key_fingerprint >>
+            - "9d:1e:af:52:78:2c:e8:ec:33:4c:db:cd:5a:ff:70:0a"
+            - "e4:30:50:41:53:f0:d6:3a:bb:c9:38:54:2d:ca:56:41"
       - run:
           name: 🤖 Update DAGs repository
           command: |
@@ -732,7 +731,6 @@ workflows:
       - sync-dags-repo:
           name: 🔃 Synchronize bigquery-etl submodule
           repo-to-sync: ${CIRCLE_PROJECT_REPONAME}
-          ssh_key_fingerprint: "e4:30:50:41:53:f0:d6:3a:bb:c9:38:54:2d:ca:56:41"
           requires:
             - push-generated-sql
           filters:
@@ -778,7 +776,6 @@ workflows:
       - sync-dags-repo:
           name: 🔃 Synchronize DAGs repository
           repo-to-sync: private-bigquery-etl
-          ssh_key_fingerprint: "9d:1e:af:52:78:2c:e8:ec:33:4c:db:cd:5a:ff:70:0a"
           requires:
             - push-private-generated-sql
           filters:


### PR DESCRIPTION
# Description
Adds missing key to sync private-bigquery-etl repo in the sync-dags-repo step.

Also fix linting issue where fingerprints were defined as strings but should be arrays.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
