### PR TITLE
fix(ci): sync-dags-repo uses wrong branch for private-bigquery-etl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,6 +413,8 @@ jobs:
     parameters:
       repo-to-sync:
         type: string
+      target-branch:
+        type: string
     steps:
       - checkout
       - add_ssh_keys:
@@ -429,7 +431,7 @@ jobs:
             cd ~/project/telemetry-airflow-dags
             git submodule update --init --recursive --depth 1
             cd << parameters.repo-to-sync >>
-            git pull origin generated-sql
+            git pull origin << parameters.target-branch >>
             cd ..
             git add << parameters.repo-to-sync >>
             git commit --allow-empty -m "Automatic commit from ${CIRCLE_PROJECT_REPONAME} commit ${CIRCLE_SHA1:0:9} build ${CIRCLE_BUILD_NUM} [skip ci]"
@@ -731,6 +733,7 @@ workflows:
       - sync-dags-repo:
           name: 🔃 Synchronize bigquery-etl submodule
           repo-to-sync: ${CIRCLE_PROJECT_REPONAME}
+          target-branch: generated-sql
           requires:
             - push-generated-sql
           filters:
@@ -776,6 +779,7 @@ workflows:
       - sync-dags-repo:
           name: 🔃 Synchronize private-bigquery-etl submodule
           repo-to-sync: private-bigquery-etl
+          target-branch: private-generated-sql
           requires:
             - push-private-generated-sql
           filters:


### PR DESCRIPTION
private-bigquery-etl uses branch `private-generated-sql` instead of `generated-sql`.

![image](https://github.com/mozilla/bigquery-etl/assets/1668835/856aac0c-9b08-410d-aa8d-d7a1ccef743b)


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1757)
