### PR TITLE
DENG1546 - Fix BQ partition by day issue.

### DIFF
--- a/sql_generators/serp_events/__init__.py
+++ b/sql_generators/serp_events/__init__.py
@@ -1,0 +1,90 @@
+"""Generate serp events aggregates per app."""
+import os
+from enum import Enum
+from pathlib import Path
+
+import click
+from jinja2 import Environment, FileSystemLoader
+
+from bigquery_etl.cli.utils import use_cloud_function_option
+from bigquery_etl.format_sql.formatter import reformat
+from bigquery_etl.util.common import render, write_sql
+
+THIS_PATH = Path(os.path.dirname(__file__))
+TABLE_NAME = "urlbar_events"
+
+
+class Browsers(Enum):
+    """Enumeration with browser names and equivalent dataset names."""
+
+    firefox_desktop = "Firefox Desktop"
+
+
+@click.command()
+@click.option(
+    "--output-dir",
+    "--output_dir",
+    help="Output directory generated SQL is written to",
+    type=click.Path(file_okay=False),
+    default="sql",
+)
+@click.option(
+    "--target-project",
+    "--target_project",
+    help="Google Cloud project ID",
+    default="moz-fx-data-shared-prod",
+)
+@use_cloud_function_option
+def generate(target_project, output_dir, use_cloud_function):
+    """Generate per-app queries, views and metadata for urlbar events aggregates.
+
+    The parent folders will be created if not existing and existing files will be overwritten.
+    """
+    env = Environment(loader=FileSystemLoader(str(THIS_PATH / "templates")))
+    desktop_query_template = env.get_template("desktop_query.sql")
+    metadata_template = "metadata.yaml"
+    view_template = env.get_template("view.sql")
+    output_dir = Path(output_dir) / target_project
+    browser = Browsers["firefox_desktop"]
+    query_sql = reformat(
+        desktop_query_template.render(
+            project_id=target_project,
+            app_value=browser.value,
+            app_name=browser.name,
+        )
+    )
+
+    write_sql(
+        output_dir=output_dir,
+        full_table_id=f"{target_project}.{browser.name}_derived.{TABLE_NAME}_v1",
+        basename="query.sql",
+        sql=query_sql,
+        skip_existing=False,
+    )
+
+    write_sql(
+        output_dir=output_dir,
+        full_table_id=f"{target_project}.{browser.name}_derived.{TABLE_NAME}_v1",
+        basename="metadata.yaml",
+        sql=render(
+            metadata_template,
+            template_folder=THIS_PATH / "templates",
+            app_value=browser.value,
+            app_name=browser.name,
+            format=False,
+        ),
+        skip_existing=False,
+    )
+
+    write_sql(
+        output_dir=output_dir,
+        full_table_id=f"{target_project}.{browser.name}.{TABLE_NAME}",
+        basename="view.sql",
+        sql=reformat(
+            view_template.render(
+                project_id=target_project,
+                app_name=browser.name,
+            )
+        ),
+        skip_existing=False,
+    )

--- a/sql_generators/serp_events/templates/desktop_query.sql
+++ b/sql_generators/serp_events/templates/desktop_query.sql
@@ -1,0 +1,331 @@
+WITH raw_serp_events AS (
+  SELECT
+    *,
+    DATE(submission_timestamp) AS submission_date,
+    mozfun.map.get_key(event.extra, 'impression_id') AS impression_id,
+    event
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_stable.events_v1`,
+    UNNEST(events) AS event
+  WHERE
+    event.category = 'serp'
+    AND DATE(submission_timestamp) >= '2023-09-01'
+    AND TIMESTAMP_DIFF(submission_timestamp, timestamp '2023-09-01', DAY) IN (0, 1)
+  -- output limiting for testing
+    AND sample_id = 3
+    AND normalized_channel = 'release'
+),
+serp_event_counts AS (
+  SELECT
+    impression_id,
+    COUNTIF(event.name = 'impression') AS n_impressions,
+    COUNTIF(event.name = 'engagement') AS n_engagements,
+    COUNTIF(event.name = 'abandonment') AS n_abandonments,
+  FROM
+    raw_serp_events
+  GROUP BY
+    impression_id
+),
+filtered_impression_ids AS (
+  -- select serp sessions/impression IDs with the expected combinations of events
+  SELECT
+    impression_id
+  FROM
+    serp_event_counts
+  WHERE
+    n_impressions = 1
+    AND ((n_engagements >= 1 AND n_abandonments = 0) OR (n_engagements = 0 AND n_abandonments = 1))
+),
+serp_events AS (
+  SELECT
+    *
+  FROM
+    raw_serp_events
+  INNER JOIN
+    filtered_impression_ids
+  USING
+    (impression_id)
+),
+impressions AS (
+  -- pull top-level fields from the impression event
+  SELECT
+    impression_id,
+    submission_date,
+    client_info.client_id AS glean_client_id,
+    metrics.uuid.legacy_telemetry_client_id AS legacy_telemetry_client_id,
+    event.timestamp AS event_timestamp,
+    normalized_channel,
+    normalized_country_code,
+    client_info.os,
+    mozfun.norm.browser_version_info(client_info.app_display_version) AS browser_version_info,
+    sample_id,
+    ping_info.experiments,
+    CAST(mozfun.map.get_key(event.extra, 'is_shopping_page') AS bool) AS is_shopping_page,
+    mozfun.map.get_key(event.extra, 'provider') AS search_engine,
+    mozfun.map.get_key(event.extra, 'source') AS sap_source,
+    CAST(mozfun.map.get_key(event.extra, 'tagged') AS bool) AS is_tagged
+  FROM
+    serp_events
+  WHERE
+    event.name = 'impression'
+    AND submission_date = '2023-09-01'
+),
+abandonments AS (
+  SELECT
+    impression_id,
+    mozfun.map.get_key(event.extra, 'reason') AS abandon_reason
+  FROM
+    serp_events
+  WHERE
+    event.name = 'abandonment'
+),
+engagement_counts AS (
+  SELECT
+    impression_id,
+    COUNTIF(action = 'clicked' AND target = 'ad_carousel') AS num_ad_carousel_clicks,
+    COUNTIF(action = 'clicked' AND target = 'ad_link') AS num_ad_link_clicks,
+    COUNTIF(action = 'clicked' AND target = 'ad_sitelink') AS num_ad_sitelink_clicks,
+    COUNTIF(action = 'clicked' AND target = 'ad_sidebar') AS num_ad_sidebar_clicks,
+    COUNTIF(
+      action = 'clicked'
+      AND target = 'refined_search_buttons'
+    ) AS num_refined_search_buttons_clicks,
+    COUNTIF(action = 'clicked' AND target = 'shopping_tab') AS num_shopping_tab_clicks,
+    COUNTIF(action = 'clicked' AND target = 'non_ads_link') AS num_non_ads_link_clicks,
+    COUNTIF(
+      action = 'clicked'
+      AND target = 'incontent_searchbox'
+    ) AS num_incontent_searchbox_clicks,
+    COUNTIF(action = 'expanded' AND target = 'ad_carousel') AS num_ad_carousel_expansions,
+    COUNTIF(
+      action = 'expanded'
+      AND target = 'refined_search_buttons'
+    ) AS num_refined_search_buttons_expansions,
+    COUNTIF(
+      action = 'submitted'
+      AND target = 'incontent_searchbox'
+    ) AS num_incontent_searchbox_submits,
+    COUNT(*) AS num_engagements
+  FROM
+    (
+      SELECT
+        impression_id,
+        mozfun.map.get_key(event.extra, 'action') AS action,
+        mozfun.map.get_key(event.extra, 'target') AS target,
+      FROM
+        serp_events
+      WHERE
+        event.name = 'engagement'
+    )
+  GROUP BY
+    impression_id
+),
+ad_impression_counts AS (
+  SELECT
+    impression_id,
+    SUM(
+      CASE
+        WHEN component = 'ad_carousel'
+          THEN ads_loaded
+        ELSE 0
+      END
+    ) AS num_ad_carousel_ads_loaded,
+    SUM(
+      CASE
+        WHEN component = 'ad_carousel'
+          THEN ads_visible
+        ELSE 0
+      END
+    ) AS num_ad_carousel_ads_visible,
+    SUM(
+      CASE
+        WHEN component = 'ad_carousel'
+          THEN ads_hidden
+        ELSE 0
+      END
+    ) AS num_ad_carousel_ads_hidden,
+    SUM(CASE WHEN component = 'ad_link' THEN ads_loaded ELSE 0 END) AS num_ad_link_ads_loaded,
+    SUM(CASE WHEN component = 'ad_link' THEN ads_visible ELSE 0 END) AS num_ad_link_ads_visible,
+    SUM(CASE WHEN component = 'ad_link' THEN ads_hidden ELSE 0 END) AS num_ad_link_ads_hidden,
+    SUM(CASE WHEN component = 'ad_sidebar' THEN ads_loaded ELSE 0 END) AS num_ad_sidebar_ads_loaded,
+    SUM(
+      CASE
+        WHEN component = 'ad_sidebar'
+          THEN ads_visible
+        ELSE 0
+      END
+    ) AS num_ad_sidebar_ads_visible,
+    SUM(CASE WHEN component = 'ad_sidebar' THEN ads_hidden ELSE 0 END) AS num_ad_sidebar_ads_hidden,
+    SUM(
+      CASE
+        WHEN component = 'ad_sitelink'
+          THEN ads_loaded
+        ELSE 0
+      END
+    ) AS num_ad_sitelink_ads_loaded,
+    SUM(
+      CASE
+        WHEN component = 'ad_sitelink'
+          THEN ads_visible
+        ELSE 0
+      END
+    ) AS num_ad_sitelink_ads_visible,
+    SUM(
+      CASE
+        WHEN component = 'ad_sitelink'
+          THEN ads_hidden
+        ELSE 0
+      END
+    ) AS num_ad_sitelink_ads_hidden,
+    SUM(
+      CASE
+        WHEN component = 'refined_search_buttons'
+          THEN ads_loaded
+        ELSE 0
+      END
+    ) AS num_refined_search_buttons_ads_loaded,
+    SUM(
+      CASE
+        WHEN component = 'refined_search_buttons'
+          THEN ads_visible
+        ELSE 0
+      END
+    ) AS num_refined_search_buttons_ads_visible,
+    SUM(
+      CASE
+        WHEN component = 'refined_search_buttons'
+          THEN ads_hidden
+        ELSE 0
+      END
+    ) AS num_refined_search_buttons_ads_hidden,
+    SUM(
+      CASE
+        WHEN component = 'shopping_tab'
+          THEN ads_loaded
+        ELSE 0
+      END
+    ) AS num_shopping_tab_ads_loaded,
+    SUM(
+      CASE
+        WHEN component = 'shopping_tab'
+          THEN ads_visible
+        ELSE 0
+      END
+    ) AS num_shopping_tab_ads_visible,
+    SUM(
+      CASE
+        WHEN component = 'shopping_tab'
+          THEN ads_hidden
+        ELSE 0
+      END
+    ) AS num_shopping_tab_ads_hidden,
+    SUM(ads_loaded) AS num_ads_loaded
+  FROM
+    (
+      SELECT
+        impression_id,
+        mozfun.map.get_key(event.extra, 'component') AS component,
+        CAST(mozfun.map.get_key(event.extra, 'ads_loaded') AS int) AS ads_loaded,
+        CAST(mozfun.map.get_key(event.extra, 'ads_visible') AS int) AS ads_visible,
+        CAST(mozfun.map.get_key(event.extra, 'ads_hidden') AS int) AS ads_hidden,
+      FROM
+        serp_events
+      WHERE
+        event.name = 'ad_impression'
+    )
+  GROUP BY
+    impression_id
+),
+serp_summary AS (
+  SELECT
+    impression_id,
+    submission_date,
+    glean_client_id,
+    legacy_telemetry_client_id,
+    event_timestamp,
+    normalized_channel,
+    normalized_country_code,
+    os,
+    browser_version_info,
+    sample_id,
+    experiments,
+    is_shopping_page,
+    search_engine,
+    sap_source,
+    is_tagged,
+    COALESCE(num_engagements, 0) > 0 AS is_engaged,
+    COALESCE(num_ads_loaded, 0) > 0 AS ads_loaded,
+    -- engagement counts
+    COALESCE(num_ad_carousel_clicks, 0) AS num_ad_carousel_clicks,
+    COALESCE(num_ad_link_clicks, 0) AS num_ad_link_clicks,
+    COALESCE(num_ad_sitelink_clicks, 0) AS num_ad_sitelink_clicks,
+    COALESCE(num_ad_sidebar_clicks, 0) AS num_ad_sidebar_clicks,
+    COALESCE(num_refined_search_buttons_clicks, 0) AS num_refined_search_buttons_clicks,
+    COALESCE(num_shopping_tab_clicks, 0) AS num_shopping_tab_clicks,
+    COALESCE(num_non_ads_link_clicks, 0) AS num_non_ads_link_clicks,
+    COALESCE(num_incontent_searchbox_clicks, 0) AS num_incontent_searchbox_clicks,
+    COALESCE(num_ad_carousel_expansions, 0) AS num_ad_carousel_expansions,
+    COALESCE(num_refined_search_buttons_expansions, 0) AS num_refined_search_buttons_expansions,
+    COALESCE(num_incontent_searchbox_submits, 0) AS num_incontent_searchbox_submits,
+    -- abandonment reason
+    abandon_reason,
+    -- ad impression counts
+    -- for each component, ads_visible + ads_blocked + ads_notshowing = ads_loaded
+    COALESCE(num_ad_carousel_ads_visible, 0) AS num_ad_carousel_ads_visible,
+    COALESCE(num_ad_carousel_ads_hidden, 0) AS num_ad_carousel_ads_blocked,
+    COALESCE(
+      num_ad_carousel_ads_loaded - num_ad_carousel_ads_visible - num_ad_carousel_ads_hidden,
+      0
+    ) AS num_ad_carousel_ads_notshowing,
+    COALESCE(num_ad_link_ads_visible, 0) AS num_ad_link_ads_visible,
+    COALESCE(num_ad_link_ads_hidden, 0) AS num_ad_link_ads_blocked,
+    COALESCE(
+      num_ad_link_ads_loaded - num_ad_link_ads_visible - num_ad_link_ads_hidden,
+      0
+    ) AS num_ad_link_ads_notshowing,
+    COALESCE(num_ad_sidebar_ads_visible, 0) AS num_ad_sidebar_ads_visible,
+    COALESCE(num_ad_sidebar_ads_hidden, 0) AS num_ad_sidebar_ads_blocked,
+    COALESCE(
+      num_ad_sidebar_ads_loaded - num_ad_sidebar_ads_visible - num_ad_sidebar_ads_hidden,
+      0
+    ) AS num_ad_sidebar_ads_notshowing,
+    COALESCE(num_ad_sitelink_ads_visible, 0) AS num_ad_sitelink_ads_visible,
+    COALESCE(num_ad_sitelink_ads_hidden, 0) AS num_ad_sitelink_ads_blocked,
+    COALESCE(
+      num_ad_sitelink_ads_loaded - num_ad_sitelink_ads_visible - num_ad_sitelink_ads_hidden,
+      0
+    ) AS num_ad_sitelink_ads_notshowing,
+    COALESCE(num_refined_search_buttons_ads_visible, 0) AS num_refined_search_buttons_ads_visible,
+    COALESCE(num_refined_search_buttons_ads_hidden, 0) AS num_refined_search_buttons_ads_blocked,
+    COALESCE(
+      num_refined_search_buttons_ads_loaded - num_refined_search_buttons_ads_visible - num_refined_search_buttons_ads_hidden,
+      0
+    ) AS num_ad_link_ads_notshowing,
+    COALESCE(num_shopping_tab_ads_visible, 0) AS num_shopping_tab_ads_visible,
+    COALESCE(num_shopping_tab_ads_hidden, 0) AS num_shopping_tab_ads_blocked,
+    COALESCE(
+      num_shopping_tab_ads_loaded - num_shopping_tab_ads_visible - num_shopping_tab_ads_hidden,
+      0
+    ) AS num_ad_link_ads_notshowing,
+  FROM
+    impressions
+  LEFT JOIN
+    engagement_counts
+  USING
+    (impression_id)
+  LEFT JOIN
+    abandonments
+  USING
+    (impression_id)
+  LEFT JOIN
+    ad_impression_counts
+  USING
+    (impression_id)
+)
+SELECT
+  * EXCEPT (experiments)
+FROM
+  serp_summary
+-- order by impression_id
+LIMIT
+  100

--- a/sql_generators/serp_events/templates/desktop_query.sql
+++ b/sql_generators/serp_events/templates/desktop_query.sql
@@ -1,19 +1,18 @@
 WITH raw_serp_events AS (
   SELECT
     *,
-    DATE(submission_timestamp) AS submission_date,
     mozfun.map.get_key(event.extra, 'impression_id') AS impression_id,
-    event
+    event,
+    @submission_date as submission_date
   FROM
     `moz-fx-data-shared-prod.firefox_desktop_stable.events_v1`,
     UNNEST(events) AS event
   WHERE
     event.category = 'serp'
-    AND DATE(submission_timestamp) >= '2023-09-01'
-    AND TIMESTAMP_DIFF(submission_timestamp, timestamp '2023-09-01', DAY) IN (0, 1)
-  -- output limiting for testing
-    AND sample_id = 3
-    AND normalized_channel = 'release'
+    -- allow events related to an impression_id to span 2 submission dates
+    -- we restrict to event sequences started on a single date below
+    AND DATE(submission_timestamp) >= DATE_SUB(@submission_date, INTERVAL 1 DAY)
+    AND DATE(submission_timestamp) <= @submission_date
 ),
 serp_event_counts AS (
   SELECT
@@ -50,9 +49,11 @@ impressions AS (
   -- pull top-level fields from the impression event
   SELECT
     impression_id,
+    submission_timestamp AS impression_submission_timestamp,
     submission_date,
     client_info.client_id AS glean_client_id,
     metrics.uuid.legacy_telemetry_client_id AS legacy_telemetry_client_id,
+    ping_info.seq AS ping_seq,
     event.timestamp AS event_timestamp,
     normalized_channel,
     normalized_country_code,
@@ -60,6 +61,7 @@ impressions AS (
     mozfun.norm.browser_version_info(client_info.app_display_version) AS browser_version_info,
     sample_id,
     ping_info.experiments,
+    -- SERP session characteristics
     CAST(mozfun.map.get_key(event.extra, 'is_shopping_page') AS bool) AS is_shopping_page,
     mozfun.map.get_key(event.extra, 'provider') AS search_engine,
     mozfun.map.get_key(event.extra, 'source') AS sap_source,
@@ -68,7 +70,8 @@ impressions AS (
     serp_events
   WHERE
     event.name = 'impression'
-    AND submission_date = '2023-09-01'
+    -- restrict to sessions that started on the target submission date
+    AND DATE(submission_timestamp) = DATE_SUB(@submission_date, INTERVAL 1 DAY)
 ),
 abandonments AS (
   SELECT
@@ -82,144 +85,43 @@ abandonments AS (
 engagement_counts AS (
   SELECT
     impression_id,
-    COUNTIF(action = 'clicked' AND target = 'ad_carousel') AS num_ad_carousel_clicks,
-    COUNTIF(action = 'clicked' AND target = 'ad_link') AS num_ad_link_clicks,
-    COUNTIF(action = 'clicked' AND target = 'ad_sitelink') AS num_ad_sitelink_clicks,
-    COUNTIF(action = 'clicked' AND target = 'ad_sidebar') AS num_ad_sidebar_clicks,
-    COUNTIF(
-      action = 'clicked'
-      AND target = 'refined_search_buttons'
-    ) AS num_refined_search_buttons_clicks,
-    COUNTIF(action = 'clicked' AND target = 'shopping_tab') AS num_shopping_tab_clicks,
-    COUNTIF(action = 'clicked' AND target = 'non_ads_link') AS num_non_ads_link_clicks,
-    COUNTIF(
-      action = 'clicked'
-      AND target = 'incontent_searchbox'
-    ) AS num_incontent_searchbox_clicks,
-    COUNTIF(action = 'expanded' AND target = 'ad_carousel') AS num_ad_carousel_expansions,
-    COUNTIF(
-      action = 'expanded'
-      AND target = 'refined_search_buttons'
-    ) AS num_refined_search_buttons_expansions,
-    COUNTIF(
-      action = 'submitted'
-      AND target = 'incontent_searchbox'
-    ) AS num_incontent_searchbox_submits,
-    COUNT(*) AS num_engagements
+    component,
+    COUNTIF(action = 'clicked') AS num_clicks,
+    COUNTIF(action = 'expanded') AS num_expands,
+    COUNTIF(action = 'submitted') AS num_submits,
   FROM
     (
+    -- 1 row per engagement event
       SELECT
         impression_id,
         mozfun.map.get_key(event.extra, 'action') AS action,
-        mozfun.map.get_key(event.extra, 'target') AS target,
+        mozfun.map.get_key(event.extra, 'target') AS component,
       FROM
         serp_events
       WHERE
         event.name = 'engagement'
     )
   GROUP BY
+    impression_id,
+    component
+),
+engaged_sessions AS (
+  -- indicator for sessions with overall nonzero engagements
+  SELECT DISTINCT
+    impression_id,
+    TRUE AS is_engaged
+  FROM
+    engagement_counts
+  GROUP BY
     impression_id
 ),
 ad_impression_counts AS (
   SELECT
     impression_id,
-    SUM(
-      CASE
-        WHEN component = 'ad_carousel'
-          THEN ads_loaded
-        ELSE 0
-      END
-    ) AS num_ad_carousel_ads_loaded,
-    SUM(
-      CASE
-        WHEN component = 'ad_carousel'
-          THEN ads_visible
-        ELSE 0
-      END
-    ) AS num_ad_carousel_ads_visible,
-    SUM(
-      CASE
-        WHEN component = 'ad_carousel'
-          THEN ads_hidden
-        ELSE 0
-      END
-    ) AS num_ad_carousel_ads_hidden,
-    SUM(CASE WHEN component = 'ad_link' THEN ads_loaded ELSE 0 END) AS num_ad_link_ads_loaded,
-    SUM(CASE WHEN component = 'ad_link' THEN ads_visible ELSE 0 END) AS num_ad_link_ads_visible,
-    SUM(CASE WHEN component = 'ad_link' THEN ads_hidden ELSE 0 END) AS num_ad_link_ads_hidden,
-    SUM(CASE WHEN component = 'ad_sidebar' THEN ads_loaded ELSE 0 END) AS num_ad_sidebar_ads_loaded,
-    SUM(
-      CASE
-        WHEN component = 'ad_sidebar'
-          THEN ads_visible
-        ELSE 0
-      END
-    ) AS num_ad_sidebar_ads_visible,
-    SUM(CASE WHEN component = 'ad_sidebar' THEN ads_hidden ELSE 0 END) AS num_ad_sidebar_ads_hidden,
-    SUM(
-      CASE
-        WHEN component = 'ad_sitelink'
-          THEN ads_loaded
-        ELSE 0
-      END
-    ) AS num_ad_sitelink_ads_loaded,
-    SUM(
-      CASE
-        WHEN component = 'ad_sitelink'
-          THEN ads_visible
-        ELSE 0
-      END
-    ) AS num_ad_sitelink_ads_visible,
-    SUM(
-      CASE
-        WHEN component = 'ad_sitelink'
-          THEN ads_hidden
-        ELSE 0
-      END
-    ) AS num_ad_sitelink_ads_hidden,
-    SUM(
-      CASE
-        WHEN component = 'refined_search_buttons'
-          THEN ads_loaded
-        ELSE 0
-      END
-    ) AS num_refined_search_buttons_ads_loaded,
-    SUM(
-      CASE
-        WHEN component = 'refined_search_buttons'
-          THEN ads_visible
-        ELSE 0
-      END
-    ) AS num_refined_search_buttons_ads_visible,
-    SUM(
-      CASE
-        WHEN component = 'refined_search_buttons'
-          THEN ads_hidden
-        ELSE 0
-      END
-    ) AS num_refined_search_buttons_ads_hidden,
-    SUM(
-      CASE
-        WHEN component = 'shopping_tab'
-          THEN ads_loaded
-        ELSE 0
-      END
-    ) AS num_shopping_tab_ads_loaded,
-    SUM(
-      CASE
-        WHEN component = 'shopping_tab'
-          THEN ads_visible
-        ELSE 0
-      END
-    ) AS num_shopping_tab_ads_visible,
-    SUM(
-      CASE
-        WHEN component = 'shopping_tab'
-          THEN ads_hidden
-        ELSE 0
-      END
-    ) AS num_shopping_tab_ads_hidden,
-    SUM(ads_loaded) AS num_ads_loaded
+    component,
+    ads_loaded AS num_ads_loaded_reported,
+    ads_visible AS num_ads_visible_reported,
+    ads_hidden AS num_ads_hidden_reported,
   FROM
     (
       SELECT
@@ -228,104 +130,136 @@ ad_impression_counts AS (
         CAST(mozfun.map.get_key(event.extra, 'ads_loaded') AS int) AS ads_loaded,
         CAST(mozfun.map.get_key(event.extra, 'ads_visible') AS int) AS ads_visible,
         CAST(mozfun.map.get_key(event.extra, 'ads_hidden') AS int) AS ads_hidden,
+      -- there should be at most 1 ad_impression event per component
+      -- if there are multiple, it would be an edge case where events got duplicated
+      -- enforce 1 row per session/component for data cleanliness
+        RANK() OVER (
+          PARTITION BY
+            impression_id,
+            mozfun.map.get_key(event.extra, 'component')
+          ORDER BY
+            event.timestamp
+        ) AS i
       FROM
         serp_events
       WHERE
         event.name = 'ad_impression'
     )
+  WHERE
+    i = 1
+),
+ad_sessions AS (
+  -- indicator for sessions with overall nonzero ad impressions
+  SELECT DISTINCT
+    impression_id,
+    TRUE AS has_ads_loaded
+  FROM
+    ad_impression_counts
   GROUP BY
     impression_id
 ),
-serp_summary AS (
+component_counts AS (
+  -- join engagements and ad impressions into a single table
+  -- 1 row for each session/component that had either an impression or an engagement
   SELECT
     impression_id,
-    submission_date,
-    glean_client_id,
-    legacy_telemetry_client_id,
-    event_timestamp,
-    normalized_channel,
-    normalized_country_code,
-    os,
-    browser_version_info,
-    sample_id,
-    experiments,
-    is_shopping_page,
-    search_engine,
-    sap_source,
-    is_tagged,
-    COALESCE(num_engagements, 0) > 0 AS is_engaged,
-    COALESCE(num_ads_loaded, 0) > 0 AS ads_loaded,
-    -- engagement counts
-    COALESCE(num_ad_carousel_clicks, 0) AS num_ad_carousel_clicks,
-    COALESCE(num_ad_link_clicks, 0) AS num_ad_link_clicks,
-    COALESCE(num_ad_sitelink_clicks, 0) AS num_ad_sitelink_clicks,
-    COALESCE(num_ad_sidebar_clicks, 0) AS num_ad_sidebar_clicks,
-    COALESCE(num_refined_search_buttons_clicks, 0) AS num_refined_search_buttons_clicks,
-    COALESCE(num_shopping_tab_clicks, 0) AS num_shopping_tab_clicks,
-    COALESCE(num_non_ads_link_clicks, 0) AS num_non_ads_link_clicks,
-    COALESCE(num_incontent_searchbox_clicks, 0) AS num_incontent_searchbox_clicks,
-    COALESCE(num_ad_carousel_expansions, 0) AS num_ad_carousel_expansions,
-    COALESCE(num_refined_search_buttons_expansions, 0) AS num_refined_search_buttons_expansions,
-    COALESCE(num_incontent_searchbox_submits, 0) AS num_incontent_searchbox_submits,
-    -- abandonment reason
-    abandon_reason,
-    -- ad impression counts
-    -- for each component, ads_visible + ads_blocked + ads_notshowing = ads_loaded
-    COALESCE(num_ad_carousel_ads_visible, 0) AS num_ad_carousel_ads_visible,
-    COALESCE(num_ad_carousel_ads_hidden, 0) AS num_ad_carousel_ads_blocked,
+    component,
+    COALESCE(num_clicks, 0) AS num_clicks,
+    COALESCE(num_expands, 0) AS num_expands,
+    COALESCE(num_submits, 0) AS num_submits,
+    COALESCE(num_ads_loaded_reported, 0) AS num_ads_loaded_reported,
+    COALESCE(num_ads_visible_reported, 0) AS num_ads_visible_reported,
+    COALESCE(num_ads_hidden_reported, 0) AS num_ads_hidden_reported,
+    -- ad blocker usage is inferred when all ads are hidden
     COALESCE(
-      num_ad_carousel_ads_loaded - num_ad_carousel_ads_visible - num_ad_carousel_ads_hidden,
-      0
-    ) AS num_ad_carousel_ads_notshowing,
-    COALESCE(num_ad_link_ads_visible, 0) AS num_ad_link_ads_visible,
-    COALESCE(num_ad_link_ads_hidden, 0) AS num_ad_link_ads_blocked,
-    COALESCE(
-      num_ad_link_ads_loaded - num_ad_link_ads_visible - num_ad_link_ads_hidden,
-      0
-    ) AS num_ad_link_ads_notshowing,
-    COALESCE(num_ad_sidebar_ads_visible, 0) AS num_ad_sidebar_ads_visible,
-    COALESCE(num_ad_sidebar_ads_hidden, 0) AS num_ad_sidebar_ads_blocked,
-    COALESCE(
-      num_ad_sidebar_ads_loaded - num_ad_sidebar_ads_visible - num_ad_sidebar_ads_hidden,
-      0
-    ) AS num_ad_sidebar_ads_notshowing,
-    COALESCE(num_ad_sitelink_ads_visible, 0) AS num_ad_sitelink_ads_visible,
-    COALESCE(num_ad_sitelink_ads_hidden, 0) AS num_ad_sitelink_ads_blocked,
-    COALESCE(
-      num_ad_sitelink_ads_loaded - num_ad_sitelink_ads_visible - num_ad_sitelink_ads_hidden,
-      0
-    ) AS num_ad_sitelink_ads_notshowing,
-    COALESCE(num_refined_search_buttons_ads_visible, 0) AS num_refined_search_buttons_ads_visible,
-    COALESCE(num_refined_search_buttons_ads_hidden, 0) AS num_refined_search_buttons_ads_blocked,
-    COALESCE(
-      num_refined_search_buttons_ads_loaded - num_refined_search_buttons_ads_visible - num_refined_search_buttons_ads_hidden,
-      0
-    ) AS num_ad_link_ads_notshowing,
-    COALESCE(num_shopping_tab_ads_visible, 0) AS num_shopping_tab_ads_visible,
-    COALESCE(num_shopping_tab_ads_hidden, 0) AS num_shopping_tab_ads_blocked,
-    COALESCE(
-      num_shopping_tab_ads_loaded - num_shopping_tab_ads_visible - num_shopping_tab_ads_hidden,
-      0
-    ) AS num_ad_link_ads_notshowing,
+      num_ads_loaded_reported > 0
+      AND num_ads_hidden_reported = num_ads_loaded_reported,
+      FALSE
+    ) AS ad_blocker_inferred,
   FROM
-    impressions
-  LEFT JOIN
     engagement_counts
-  USING
-    (impression_id)
-  LEFT JOIN
-    abandonments
-  USING
-    (impression_id)
-  LEFT JOIN
+  FULL JOIN
     ad_impression_counts
   USING
-    (impression_id)
+    (impression_id, component)
 )
 SELECT
-  * EXCEPT (experiments)
+  impression_id,
+  submission_date,
+  impression_submission_timestamp,
+  glean_client_id,
+  legacy_telemetry_client_id,
+  ping_seq,
+  event_timestamp,
+  normalized_channel,
+  normalized_country_code,
+  os,
+  browser_version_info,
+  sample_id,
+  experiments,
+  is_shopping_page,
+  search_engine,
+  sap_source,
+  is_tagged,
+  COALESCE(is_engaged, FALSE) AS is_engaged,
+  COALESCE(has_ads_loaded, FALSE) AS has_ads_loaded,
+  abandon_reason,
+  component,
+  -- indicator for components that can have ad impressions
+  -- engagements are recorded for these and other components
+  component IN (
+    'ad_carousel',
+    'ad_image_row',
+    'ad_link',
+    'ad_sidebar',
+    'ad_sitelink',
+    'refined_search_buttons',
+    'shopping_tab'
+  ) AS is_ad_component,
+  COALESCE(num_clicks, 0) AS num_clicks,
+  COALESCE(num_expands, 0) AS num_expands,
+  COALESCE(num_submits, 0) AS num_submits,
+  COALESCE(num_ads_loaded_reported, 0) AS num_ads_loaded_reported,
+  COALESCE(num_ads_visible_reported, 0) AS num_ads_visible_reported,
+  COALESCE(num_ads_hidden_reported, 0) AS num_ads_hidden_reported,
+  COALESCE(ad_blocker_inferred, FALSE) AS ad_blocker_inferred,
+  COALESCE(
+    CASE
+    -- when an ad blocker is active, this should be 0
+      WHEN ad_blocker_inferred
+        THEN num_ads_visible_reported
+      ELSE
+    -- when no ad blocker is active, count ads reported as 'hidden' as visible
+    -- this is an edge case where the hidden count may not be reliable
+        num_ads_visible_reported + num_ads_hidden_reported
+    END,
+    0
+  ) AS num_ads_showing,
+  -- ads that are not visible but not blocked by an ad blocker are considered 'not showing'
+  COALESCE(
+    num_ads_loaded_reported - num_ads_visible_reported - num_ads_hidden_reported,
+    0
+  ) AS num_ads_notshowing,
 FROM
-  serp_summary
--- order by impression_id
-LIMIT
-  100
+  -- 1 row per impression_id
+  impressions
+LEFT JOIN
+  -- 1 row per impression_id with nonzero engagements
+  engaged_sessions
+USING
+  (impression_id)
+LEFT JOIN
+  -- 1 row per impression_id with nonzero ad impressions
+  ad_sessions
+USING
+  (impression_id)
+LEFT JOIN
+  -- 1 row per impression_id with an abandonment
+  abandonments
+USING
+  (impression_id)
+LEFT JOIN
+  -- expands to 1 row per impression_id per component that had either an engagement or an ad impression
+  component_counts
+USING
+  (impression_id)

--- a/sql_generators/serp_events/templates/metadata.yaml
+++ b/sql_generators/serp_events/templates/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Serp Events
+description: |-
+  TODO
+owners:
+- akommasani@mozilla.com
+- pissac@mozilla.com
+- dzeber@mozilla.com
+labels:
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_serp
+  task_name: {{ app_name }}_serp_events__v1
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+  clustering:
+    fields:
+      - normalized_channel
+      - sample_id

--- a/sql_generators/serp_events/templates/view.sql
+++ b/sql_generators/serp_events/templates/view.sql
@@ -1,0 +1,8 @@
+--- User-facing view. Generated via sql_generators.active_users.
+CREATE OR REPLACE VIEW
+  `{{ project_id }}.{{ app_name }}.serp_events`
+AS
+SELECT
+  *
+FROM
+  `{{ project_id }}.{{ app_name }}_derived.serp_events_v1`


### PR DESCRIPTION

The bqetl_serp dag has been failing with the error - ```Some rows belong to different partitions rather than destination partition ```
Further logs - https://workflow.telemetry.mozilla.org/log?dag_id=bqetl_serp&task_id=firefox_desktop_serp_events__v1&execution_date=2023-10-12T00%3A00%3A00%2B00%3A00&map_index=-1

This is happening since we are populating 2 different `submission_dates` for each run.
**Fix** - I have added a column `submission_date` which will refer to the run date and renamed the impression submission timestamp to `impression_submission_timestamp` instead of submission_date



Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1758)
