### PR TITLE
fix(ci): Manually set SSH configuration for multiple SSH keys.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,8 +446,8 @@ jobs:
             git pull origin << parameters.target-branch >>
             cd ..
             git add << parameters.repo-to-sync >>
-            git commit --allow-empty -m "Automatic commit from ${CIRCLE_PROJECT_REPONAME} commit ${CIRCLE_SHA1:0:9} build ${CIRCLE_BUILD_NUM} [skip ci]"
-            git push origin main
+#            git commit --allow-empty -m "Automatic commit from ${CIRCLE_PROJECT_REPONAME} commit ${CIRCLE_SHA1:0:9} build ${CIRCLE_BUILD_NUM} [skip ci]"
+#            git push origin main
   deploy:
     executor: ubuntu-machine-executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,11 +423,23 @@ jobs:
             - "e4:30:50:41:53:f0:d6:3a:bb:c9:38:54:2d:ca:56:41"
       - run:
           name: 🤖 Update DAGs repository
+          # ~/.ssh/config needs to be manually configured to support cloning a private
+          # repository through submodules and writing to another repository.
           command: |
+            cat <<'EOT' > ~/.ssh/config
+            Host github.com
+              IdentitiesOnly yes
+              IdentityFile /home/circleci/.ssh/id_rsa_9d1eaf52782ce8ec334cdbcd5aff700a
+            Host git-telemetry-airflow-dags
+              HostName github.com
+              User git
+              IdentitiesOnly yes
+              IdentityFile /home/circleci/.ssh/id_rsa_e430504153f0d63abbc938542dca5641
+            EOT
             ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
             git config --global user.email "dataops@mozilla.com"
             git config --global user.name "CircleCI Job"
-            git clone --branch main git@github.com:mozilla/telemetry-airflow-dags.git
+            git clone --branch main git@git-telemetry-airflow-dags:mozilla/telemetry-airflow-dags.git
             cd ~/project/telemetry-airflow-dags
             git submodule update --init --recursive --depth 1
             cd << parameters.repo-to-sync >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,8 +446,8 @@ jobs:
             git pull origin << parameters.target-branch >>
             cd ..
             git add << parameters.repo-to-sync >>
-#            git commit --allow-empty -m "Automatic commit from ${CIRCLE_PROJECT_REPONAME} commit ${CIRCLE_SHA1:0:9} build ${CIRCLE_BUILD_NUM} [skip ci]"
-#            git push origin main
+            git commit --allow-empty -m "Automatic commit from ${CIRCLE_PROJECT_REPONAME} commit ${CIRCLE_SHA1:0:9} build ${CIRCLE_BUILD_NUM} [skip ci]"
+            git push origin main
   deploy:
     executor: ubuntu-machine-executor
     steps:
@@ -746,12 +746,12 @@ workflows:
           name: 🔃 Synchronize bigquery-etl submodule
           repo-to-sync: ${CIRCLE_PROJECT_REPONAME}
           target-branch: generated-sql
-#          requires:
-#            - push-generated-sql
-#          filters:
-#            branches:
-#              only:
-#                - main
+          requires:
+            - push-generated-sql
+          filters:
+            branches:
+              only:
+                - main
       - reset-stage-env:
           requires:
             - push-generated-sql
@@ -792,12 +792,12 @@ workflows:
           name: 🔃 Synchronize private-bigquery-etl submodule
           repo-to-sync: private-bigquery-etl
           target-branch: private-generated-sql
-#          requires:
-#            - push-private-generated-sql
-#          filters:
-#            branches:
-#              only:
-#                - main
+          requires:
+            - push-private-generated-sql
+          filters:
+            branches:
+              only:
+                - main
       - deploy-to-private-gcr:
           context: data-eng-airflow-gcr
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,8 +446,8 @@ jobs:
             git pull origin << parameters.target-branch >>
             cd ..
             git add << parameters.repo-to-sync >>
-            git commit --allow-empty -m "Automatic commit from ${CIRCLE_PROJECT_REPONAME} commit ${CIRCLE_SHA1:0:9} build ${CIRCLE_BUILD_NUM} [skip ci]"
-            git push origin main
+#            git commit --allow-empty -m "Automatic commit from ${CIRCLE_PROJECT_REPONAME} commit ${CIRCLE_SHA1:0:9} build ${CIRCLE_BUILD_NUM} [skip ci]"
+#            git push origin main
   deploy:
     executor: ubuntu-machine-executor
     steps:
@@ -746,12 +746,12 @@ workflows:
           name: 🔃 Synchronize bigquery-etl submodule
           repo-to-sync: ${CIRCLE_PROJECT_REPONAME}
           target-branch: generated-sql
-          requires:
-            - push-generated-sql
-          filters:
-            branches:
-              only:
-                - main
+#          requires:
+#            - push-generated-sql
+#          filters:
+#            branches:
+#              only:
+#                - main
       - reset-stage-env:
           requires:
             - push-generated-sql
@@ -792,12 +792,12 @@ workflows:
           name: 🔃 Synchronize private-bigquery-etl submodule
           repo-to-sync: private-bigquery-etl
           target-branch: private-generated-sql
-          requires:
-            - push-private-generated-sql
-          filters:
-            branches:
-              only:
-                - main
+#          requires:
+#            - push-private-generated-sql
+#          filters:
+#            branches:
+#              only:
+#                - main
       - deploy-to-private-gcr:
           context: data-eng-airflow-gcr
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,7 @@ jobs:
           # ~/.ssh/config needs to be manually configured to support cloning a private
           # repository through submodules and writing to another repository.
           command: |
-            cat <<'EOT' > ~/.ssh/config
+            cat \<<'EOT' > ~/.ssh/config
             Host github.com
               IdentitiesOnly yes
               IdentityFile /home/circleci/.ssh/id_rsa_9d1eaf52782ce8ec334cdbcd5aff700a

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,8 +446,8 @@ jobs:
             git pull origin << parameters.target-branch >>
             cd ..
             git add << parameters.repo-to-sync >>
-#            git commit --allow-empty -m "Automatic commit from ${CIRCLE_PROJECT_REPONAME} commit ${CIRCLE_SHA1:0:9} build ${CIRCLE_BUILD_NUM} [skip ci]"
-#            git push origin main
+            git commit --allow-empty -m "Automatic commit from ${CIRCLE_PROJECT_REPONAME} commit ${CIRCLE_SHA1:0:9} build ${CIRCLE_BUILD_NUM} [skip ci]"
+            git push origin main
   deploy:
     executor: ubuntu-machine-executor
     steps:


### PR DESCRIPTION
# Description
Should fix CI failures on main. The issue is that we need two different SSH keys, for writer on telemetry-airflow-dags and for reader on private-bigquery-etl, and CircleCI does not support loading keys with different hosts for the same hostname.

By manually changing the SSH configuration, we can use those two keys without issues.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1760)
