### PR TITLE
DENG1546 - Fix bqetl serp DAG failure due to missing parameter

### DIFF
--- a/dags/bqetl_serp.py
+++ b/dags/bqetl_serp.py
@@ -57,6 +57,9 @@ with DAG(
         ],
         date_partition_parameter=None,
         depends_on_past=False,
+        parameters=[
+            'submission_date:DATE:{{ (execution_date - macros.timedelta(hours=24)).strftime("%Y%m%d") }}'
+        ],
         sql_file_path="sql/moz-fx-data-shared-prod/firefox_desktop_derived/serp_events_v1/query.sql",
     )
 

--- a/dags/bqetl_serp.py
+++ b/dags/bqetl_serp.py
@@ -57,9 +57,7 @@ with DAG(
         ],
         date_partition_parameter=None,
         depends_on_past=False,
-        parameters=[
-            'submission_date:DATE:{{ (execution_date - macros.timedelta(hours=24)).strftime("%Y%m%d") }}'
-        ],
+        parameters=['submission_date:DATE:{{ (execution_date).strftime("%Y%m%d") }}'],
         sql_file_path="sql/moz-fx-data-shared-prod/firefox_desktop_derived/serp_events_v1/query.sql",
     )
 

--- a/sql_generators/serp_events/templates/metadata.yaml
+++ b/sql_generators/serp_events/templates/metadata.yaml
@@ -16,12 +16,12 @@ scheduling:
     >-
     {% raw %}serp_events_v1${{
     (execution_date - macros.timedelta(hours=24)).strftime("%Y%m%d")
-    }}{% endraw%}
+    }}{% endraw %}
   parameters:
-    >-
-    {% raw %}submission_date:DATE:{{
-    (execution_date - macros.timedelta(hours=24)).strftime("%Y%m%d")
-    }}{% endraw %}s
+    - >-
+      {% raw %}submission_date:DATE:{{
+      (execution_date - macros.timedelta(hours=24)).strftime("%Y%m%d")
+      }}{% endraw %}
   query_file_path:
     # explicit query file path is necessary because the destination table
     # includes a partition identifier that is not in the path

--- a/sql_generators/serp_events/templates/metadata.yaml
+++ b/sql_generators/serp_events/templates/metadata.yaml
@@ -17,6 +17,11 @@ scheduling:
     {% raw %}serp_events_v1${{
     (execution_date - macros.timedelta(hours=24)).strftime("%Y%m%d")
     }}{% endraw%}
+  parameters:
+    >-
+    {% raw %}submission_date:DATE:{{
+    (execution_date - macros.timedelta(hours=24)).strftime("%Y%m%d")
+    }}{% endraw %}s
   query_file_path:
     # explicit query file path is necessary because the destination table
     # includes a partition identifier that is not in the path

--- a/sql_generators/serp_events/templates/metadata.yaml
+++ b/sql_generators/serp_events/templates/metadata.yaml
@@ -20,7 +20,7 @@ scheduling:
   parameters:
     - >-
       {% raw %}submission_date:DATE:{{
-      (execution_date - macros.timedelta(hours=24)).strftime("%Y%m%d")
+      (execution_date).strftime("%Y%m%d")
       }}{% endraw %}
   query_file_path:
     # explicit query file path is necessary because the destination table


### PR DESCRIPTION
The bqetl_serp DAG is failing due to the below error 
Error in query string: Error processing job 'moz-fx-data-shared-
```Query parameter - 'submission_date' not found at [13:48]```

Error logs - https://workflow.telemetry.mozilla.org/dags/bqetl_serp/grid?dag_run_id=scheduled__2023-10-13T00%3A00%3A00%2B00%3A00&task_id=firefox_desktop_serp_events__v1&tab=logs

This should fix the issue
