### PR TITLE
DENG1546 - Fix bqetl_serp DAG failure

### DIFF
--- a/dags/bqetl_serp.py
+++ b/dags/bqetl_serp.py
@@ -57,7 +57,7 @@ with DAG(
         ],
         date_partition_parameter=None,
         depends_on_past=False,
-        parameters=['submission_date:DATE:{{ (execution_date).strftime("%Y%m%d") }}'],
+        parameters=["submission_date:DATE:{{ds}}"],
         sql_file_path="sql/moz-fx-data-shared-prod/firefox_desktop_derived/serp_events_v1/query.sql",
     )
 

--- a/sql_generators/serp_events/templates/metadata.yaml
+++ b/sql_generators/serp_events/templates/metadata.yaml
@@ -19,9 +19,7 @@ scheduling:
     }}{% endraw %}
   parameters:
     - >-
-      {% raw %}submission_date:DATE:{{
-      (execution_date).strftime("%Y%m%d")
-      }}{% endraw %}
+      {% raw %}submission_date:DATE:{{ds}}{% endraw %}
   query_file_path:
     # explicit query file path is necessary because the destination table
     # includes a partition identifier that is not in the path


### PR DESCRIPTION
The dag bqetl_serp failed with error 
```Unparseable query parameter  `submission_date` in type `TYPE_DATE`, Invalid date: '20231015' value: - '20231015'```

Error logs - https://workflow.telemetry.mozilla.org/dags/bqetl_serp/grid?dag_run_id=scheduled__2023-10-15T00%3A00%3A00%2B00%3A00&task_id=firefox_desktop_serp_events__v1&tab=logs



Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1783)
