### PR TITLE
DENG-476 - Update internet outages to reference main_v5

### DIFF
--- a/dags/bqetl_internet_outages.py
+++ b/dags/bqetl_internet_outages.py
@@ -84,10 +84,10 @@ with DAG(
     internet_outages__global_outages__v1.set_upstream(
         wait_for_copy_deduplicate_main_ping
     )
-    wait_for_telemetry_derived__clients_daily__v6 = ExternalTaskSensor(
-        task_id="wait_for_telemetry_derived__clients_daily__v6",
+    wait_for_telemetry_derived__clients_daily_joined__v1 = ExternalTaskSensor(
+        task_id="wait_for_telemetry_derived__clients_daily_joined__v1",
         external_dag_id="bqetl_main_summary",
-        external_task_id="telemetry_derived__clients_daily__v6",
+        external_task_id="telemetry_derived__clients_daily_joined__v1",
         execution_delta=datetime.timedelta(seconds=18000),
         check_existence=True,
         mode="reschedule",
@@ -97,5 +97,5 @@ with DAG(
     )
 
     internet_outages__global_outages__v1.set_upstream(
-        wait_for_telemetry_derived__clients_daily__v6
+        wait_for_telemetry_derived__clients_daily_joined__v1
     )

--- a/dags/bqetl_main_summary.py
+++ b/dags/bqetl_main_summary.py
@@ -140,13 +140,6 @@ with DAG(
         )
 
         ExternalTaskMarker(
-            task_id="bqetl_internet_outages__wait_for_telemetry_derived__clients_daily__v6",
-            external_dag_id="bqetl_internet_outages",
-            external_task_id="wait_for_telemetry_derived__clients_daily__v6",
-            execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=68400)).isoformat() }}",
-        )
-
-        ExternalTaskMarker(
             task_id="jetstream__wait_for_clients_daily",
             external_dag_id="jetstream",
             external_task_id="wait_for_clients_daily",
@@ -220,6 +213,13 @@ with DAG(
             external_dag_id="bqetl_review_checker",
             external_task_id="wait_for_telemetry_derived__clients_daily_joined__v1",
             execution_date="{{ (execution_date - macros.timedelta(seconds=7200)).isoformat() }}",
+        )
+
+        ExternalTaskMarker(
+            task_id="bqetl_internet_outages__wait_for_telemetry_derived__clients_daily_joined__v1",
+            external_dag_id="bqetl_internet_outages",
+            external_task_id="wait_for_telemetry_derived__clients_daily_joined__v1",
+            execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=68400)).isoformat() }}",
         )
 
         ExternalTaskMarker(

--- a/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/metadata.yaml
@@ -62,18 +62,6 @@ labels:
   - '1640204'
 scheduling:
   dag_name: bqetl_internet_outages
-  # provide this value so that DAG generation does not have to dry run the
-  # query to get it, and that would be slow because main_v4 is referenced
-  referenced_tables:
-  - - moz-fx-data-shared-prod
-    - telemetry_stable
-    - main_v4
-  - - moz-fx-data-shared-prod
-    - telemetry_derived
-    - clients_daily_v6
-  - - moz-fx-data-shared-prod
-    - telemetry_stable
-    - health_v4
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/query.sql
@@ -229,7 +229,7 @@ histogram_data_sample AS (
       payload.processes.content.histograms.http_page_tls_handshake
     ).values AS tls_handshake,
   FROM
-    telemetry_stable.main_v4
+    telemetry_stable.main_v5
   WHERE
     DATE(submission_timestamp) = @submission_date
     -- Restrict to Firefox.


### PR DESCRIPTION
also fixes dags waiting for the wrong upstream tables

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1786)
