### PR TITLE
DENG-476 - Remove unnecessary reference to main_v4 from ssl ratios

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -15,7 +15,3 @@ labels:
   incremental_export: false
 scheduling:
   dag_name: bqetl_ssl_ratios
-  # provide this value so that DAG generation does not have to dry run the
-  # query to get it, and that would be slow because main_v4 is referenced
-  referenced_tables: [['moz-fx-data-shared-prod', 'telemetry_stable',
-                       'main_v4']]


### PR DESCRIPTION


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1791)
