### PR TITLE
Fix Glean usage generation; don't skip query generation when tables don't exist

### DIFF
--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -234,22 +234,23 @@ class GleanTable:
                     **render_kwargs,
                 )
 
+        # generated files to update
+        Artifact = namedtuple("Artifact", "table_id basename sql")
+        artifacts = [
+            Artifact(view, "metadata.yaml", view_metadata),
+            Artifact(table, "metadata.yaml", table_metadata),
+            Artifact(table, "query.sql", query_sql),
+        ]
+
         if not (referenced_table_exists(view_sql)):
             logging.info("Skipping view for table which doesn't exist:" f" {table}")
-            return
+        else:
+            artifacts.append(
+                Artifact(view, "view.sql", view_sql))
 
         skip_existing_artifact = self.skip_existing(output_dir, project_id)
 
         if output_dir:
-            # generated files to update
-            Artifact = namedtuple("Artifact", "table_id basename sql")
-            artifacts = [
-                Artifact(view, "metadata.yaml", view_metadata),
-                Artifact(view, "view.sql", view_sql),
-                Artifact(table, "metadata.yaml", table_metadata),
-                Artifact(table, "query.sql", query_sql),
-            ]
-
             if not self.no_init:
                 artifacts.append(Artifact(table, "init.sql", init_sql))
 


### PR DESCRIPTION
This should fix the artifact deploys.

`glean_usage` is generating various queries and corresponding views for each Glean application. The logic seems to skip the generation if a table that is referenced by a view does not exist. However, this is initially the case when a new app gets added. This PR fixes this behaviour.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1804)
