### PR TITLE
Add opt-in to running checks for backfill

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -514,6 +514,7 @@ def _backfill_query(
     partitioning_type,
     backfill_date,
     destination_table,
+    run_checks,
 ):
     """Run a query backfill for a specific date."""
     project, dataset, table = extract_from_query_path(query_file_path)
@@ -570,7 +571,7 @@ def _backfill_query(
 
         # Run checks on the query
         checks_file = query_file_path.parent / "checks.sql"
-        if checks_file.exists():
+        if run_checks and checks_file.exists():
             table_name = checks_file.parent.name
             # query_args have things like format, which we don't want to push
             # to the check; so we just take the query parameters
@@ -675,6 +676,9 @@ def _backfill_query(
         + "If not set, determines destination table based on query."
     ),
 )
+@click.option(
+    "--checks/--no-checks", help="Whether to run checks during backfill", default=False
+)
 @click.pass_context
 def backfill(
     ctx,
@@ -689,6 +693,7 @@ def backfill(
     parallelism,
     no_partition,
     destination_table,
+    checks,
 ):
     """Run a backfill."""
     if not is_authenticated():
@@ -787,6 +792,7 @@ def backfill(
             ctx.args,
             partitioning_type,
             destination_table=destination_table,
+            run_checks=checks,
         )
 
         if not depends_on_past:


### PR DESCRIPTION
Tested this locally. `bqetl backfill` now defaults to not running checks.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [x] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [x] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [x] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1814)
