### PR TITLE
Use mozfun.glean.parse_datetime to parse ping_info fields

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fenix_events_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fenix_events_v1/view.sql
@@ -5,7 +5,7 @@ SELECT
     client_info.client_id AS device_id,
     CONCAT(document_id, CAST(event.timestamp AS STRING)) AS insert_id,
     CONCAT(event.category, '.', event.name) AS event_type,
-    TIMESTAMP_ADD(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M%Ez', ping_info.start_time), INTERVAL event.timestamp SECOND) AS timestamp,
+    TIMESTAMP_ADD(mozfun.glean.parse_datetime(ping_info.start_time), INTERVAL event.timestamp SECOND) AS timestamp,
     client_info.app_display_version AS app_version,
     client_info.os AS platform,
     client_info.os AS os_name,

--- a/sql/mozfun/norm/glean_ping_info/udf.sql
+++ b/sql/mozfun/norm/glean_ping_info/udf.sql
@@ -8,8 +8,8 @@ CREATE OR REPLACE FUNCTION norm.glean_ping_info(ping_info ANY TYPE) AS (
   (
     SELECT AS STRUCT
       ping_info.*,
-      SAFE.PARSE_TIMESTAMP('%FT%H:%M%Ez', ping_info.start_time) AS parsed_start_time,
-      SAFE.PARSE_TIMESTAMP('%FT%H:%M%Ez', ping_info.end_time) AS parsed_end_time
+      mozfun.glean.parse_datetime(ping_info.start_time) AS parsed_start_time,
+      mozfun.glean.parse_datetime(ping_info.end_time) AS parsed_end_time
   )
 );
 
@@ -30,5 +30,11 @@ SELECT
   assert.null(
     norm.glean_ping_info(
       STRUCT('2019-12-01T20:22+11:00' AS start_time, '2019-12-01T21:24:00+11:00' AS end_time)
+    ).parsed_end_time
+  ),
+  assert.equals(
+    TIMESTAMP '2019-12-01 10:24:03.17',
+    norm.glean_ping_info(
+      STRUCT('2019-12-01T20:22:03.17+11:00' AS start_time, '2019-12-01T21:24:03.17+11:00' AS end_time)
     ).parsed_end_time
   );

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
@@ -20,7 +20,7 @@ WITH base AS (
     LOWER(client_info.client_id) AS client_id,
     sample_id,
     SAFE.PARSE_DATE('%F', SUBSTR(client_info.first_run_date, 1, 10)) AS first_run_date,
-    SAFE.PARSE_TIMESTAMP('%FT%H:%M%Ez', ping_info.end_time) AS parsed_end_time,
+    mozfun.glean.parse_datetime(ping_info.end_time) AS parsed_end_time,
     udf.glean_timespan_seconds(metrics.timespan.glean_baseline_duration) AS duration,
     client_info.android_sdk_version,
     client_info.app_build,


### PR DESCRIPTION
In future versions of Glean that timestamp can be more precise, so we need to ensure we correctly parse it.

Re-push of #4459 directly to this repository

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1832)
