### PR TITLE
Update clients_first_seen_28_days_later metadata to write to correct partition

### DIFF
--- a/dags/bqetl_analytics_tables.py
+++ b/dags/bqetl_analytics_tables.py
@@ -151,7 +151,7 @@ with DAG(
 
     telemetry_derived__clients_first_seen_28_days_later__v1 = bigquery_etl_query(
         task_id="telemetry_derived__clients_first_seen_28_days_later__v1",
-        destination_table="clients_first_seen_28_days_later_v1",
+        destination_table='clients_first_seen_28_days_later_v1${{ macros.ds_format(macros.ds_add(ds, -27), "%Y-%m-%d", "%Y%m%d") }}',
         dataset_id="telemetry_derived",
         project_id="moz-fx-data-shared-prod",
         owner="loines@mozilla.com",
@@ -161,8 +161,10 @@ with DAG(
             "lvargas@mozilla.com",
             "telemetry-alerts@mozilla.com",
         ],
-        date_partition_parameter="submission_date",
+        date_partition_parameter=None,
         depends_on_past=False,
+        task_concurrency=1,
+        parameters=["submission_date:DATE:{{ds}}"],
     )
 
     wait_for_copy_deduplicate_all = ExternalTaskSensor(

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/metadata.yaml
@@ -7,6 +7,10 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_analytics_tables
+  date_partition_offset: -27
+  date_partition_parameter: null
+  parameters:
+    - submission_date:DATE:{{ds}}
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
This is currently trying to write to the current days partition, update to match the query's `DATE_SUB(27 DAY)`

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1839)
