### PR TITLE
Don't generate glean_usage tables for deprecated apps

### DIFF
--- a/sql_generators/glean_usage/__init__.py
+++ b/sql_generators/glean_usage/__init__.py
@@ -3,6 +3,7 @@ from functools import partial
 from pathlib import Path
 
 import click
+import requests
 from pathos.multiprocessing import ProcessingPool
 
 from bigquery_etl.cli.utils import (
@@ -10,6 +11,7 @@ from bigquery_etl.cli.utils import (
     table_matches_patterns,
     use_cloud_function_option,
 )
+from bigquery_etl.schema.stable_table_schema import get_stable_table_schemas
 from sql_generators.glean_usage import (
     baseline_clients_daily,
     baseline_clients_first_seen,
@@ -20,7 +22,6 @@ from sql_generators.glean_usage import (
     metrics_clients_daily,
     metrics_clients_last_seen,
 )
-from sql_generators.glean_usage.common import get_app_info, list_baseline_tables
 
 # list of methods for generating queries
 GLEAN_TABLES = [
@@ -34,11 +35,74 @@ GLEAN_TABLES = [
     clients_last_seen_joined.ClientsLastSeenJoined(),
 ]
 
-# * mlhackweek_search was an experiment that we don't want to generate tables
-# for
-# * regrets_reporter currently refers to two applications, skip the glean
+# regrets_reporter currently refers to two applications, skip the glean
 # one to avoid confusion: https://github.com/mozilla/bigquery-etl/issues/2499
-SKIP_APPS = ["mlhackweek_search", "regrets_reporter", "regrets_reporter_ucs"]
+SKIP_APPS = ["regrets_reporter", "regrets_reporter_ucs"]
+APP_LISTINGS_URL = "https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings"
+
+
+def get_app_info():
+    """Return a list of applications from the probeinfo API."""
+    resp = requests.get(APP_LISTINGS_URL)
+    resp.raise_for_status()
+    apps_json = resp.json()
+    app_info = {}
+
+    for app_variant_info in apps_json:
+        app_name = app_variant_info["app_name"]
+        if app_variant_info.get("deprecated", False):
+            print(f"{app_name} is deprecated")
+            continue
+        if app_name in SKIP_APPS:
+            print(f"{app_name} is skipped")
+            continue
+        elif app_name not in app_info:
+            app_info[app_name] = []
+        app_info[app_name].append(app_variant_info)
+
+    return app_info
+
+
+def _contains_glob(patterns):
+    return any({"*", "?", "["}.intersection(pattern) for pattern in patterns)
+
+
+def _extract_dataset_from_glob(pattern):
+    # Assumes globs are in <dataset>.<table> form without a project specified.
+    return pattern.split(".", 1)[0]
+
+
+def list_baseline_tables(project_id, only_tables, table_filter):
+    """Return names of all matching baseline tables in shared-prod."""
+    prod_baseline_tables = [
+        s.stable_table
+        for s in get_stable_table_schemas()
+        if s.schema_id == "moz://mozilla.org/schemas/glean/ping/1"
+        and s.bq_table == "baseline_v1"
+    ]
+    prod_datasets_with_baseline = [t.split(".")[0] for t in prod_baseline_tables]
+    stable_datasets = prod_datasets_with_baseline
+    if only_tables and not _contains_glob(only_tables):
+        # skip list calls when only_tables exists and contains no globs
+        return [
+            f"{project_id}.{t}"
+            for t in only_tables
+            if table_filter(t) and t in prod_baseline_tables
+        ]
+    if only_tables and not _contains_glob(
+        _extract_dataset_from_glob(t) for t in only_tables
+    ):
+        stable_datasets = {_extract_dataset_from_glob(t) for t in only_tables}
+        stable_datasets = {
+            d
+            for d in stable_datasets
+            if d.endswith("_stable") and d in prod_datasets_with_baseline
+        }
+    return [
+        f"{project_id}.{d}.baseline_v1"
+        for d in stable_datasets
+        if table_filter(f"{d}.baseline_v1")
+    ]
 
 
 @click.command()
@@ -95,28 +159,29 @@ def generate(
     elif exclude:
         table_filter = partial(table_matches_patterns, exclude, True)
 
-    baseline_tables = list_baseline_tables(
+    app_info = get_app_info()
+    if app_name:
+        app_info = {name: info for name, info in app_info.items() if name == app_name}
+
+    non_deprecated_app_id_datasets = [
+        f"{variant['bq_dataset_family']}_stable"
+        for name, variants in app_info.items()
+        for variant in variants
+    ]
+
+    all_baseline_tables = list_baseline_tables(
         project_id=target_project,
         only_tables=[only] if only else None,
         table_filter=table_filter,
     )
 
-    # filter out skipped apps
-    baseline_tables = [
+    non_deprecated_baseline_app_id_tables = [
         baseline_table
-        for baseline_table in baseline_tables
-        if baseline_table.split(".")[1]
-        not in [f"{skipped_app}_stable" for skipped_app in SKIP_APPS]
+        for baseline_table in all_baseline_tables
+        if baseline_table.split(".")[1] in non_deprecated_app_id_datasets
     ]
 
     output_dir = Path(output_dir) / target_project
-
-    # per app specific datasets
-    app_info = get_app_info()
-    if app_name:
-        app_info = {name: info for name, info in app_info.items() if name == app_name}
-
-    app_info = [info for name, info in app_info.items() if name not in SKIP_APPS]
 
     # Prepare parameters so that generation of all Glean datasets can be done in parallel
 
@@ -132,7 +197,7 @@ def generate(
             ),
             baseline_table,
         )
-        for baseline_table in baseline_tables
+        for baseline_table in non_deprecated_baseline_app_id_tables
         for table in GLEAN_TABLES
     ]
 
@@ -148,7 +213,7 @@ def generate(
             ),
             info,
         )
-        for info in app_info
+        for name, info in app_info.items()
         for table in GLEAN_TABLES
     ]
 


### PR DESCRIPTION
- Deprecated app_variants will no longer have their glean_usage tables updated (for the app-id tables/views)
- Deprecated apps will have all app_variants marked as deprecated, and will then not be updated (for the app tables/views)

See the difference in the `generate-sql` branch here: https://github.com/mozilla/bigquery-etl/compare/generated-sql...generated-sql-skip-deprecated?expand=1

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
