### PR TITLE
Allow running multiple checks

### DIFF
--- a/bigquery_etl/cli/check.py
+++ b/bigquery_etl/cli/check.py
@@ -114,19 +114,18 @@ def render(
     ctx: click.Context, dataset: str, project_id: Optional[str], sql_dir: Optional[str]
 ) -> None:
     """Render a check's Jinja template."""
-    checks_file, project_id, dataset_id, table = paths_matching_checks_pattern(
+    for checks_file, project_id, dataset_id, table in paths_matching_checks_pattern(
         dataset, sql_dir, project_id=project_id
-    )
-
-    click.echo(
-        _render(
-            checks_file,
-            dataset_id,
-            table,
-            project_id=project_id,
-            query_arguments=ctx.args[:],
+    ):
+        click.echo(
+            _render(
+                checks_file,
+                dataset_id,
+                table,
+                project_id=project_id,
+                query_arguments=ctx.args[:],
+            )
         )
-    )
 
     return None
 
@@ -214,19 +213,18 @@ def run(ctx, dataset, project_id, sql_dir, marker, dry_run):
         )
         sys.exit(1)
 
-    checks_file, project_id, dataset_id, table = paths_matching_checks_pattern(
+    for checks_file, project_id, dataset_id, table in paths_matching_checks_pattern(
         dataset, sql_dir, project_id=project_id
-    )
-
-    _run_check(
-        checks_file,
-        project_id,
-        dataset_id,
-        table,
-        ctx.args,
-        dry_run=dry_run,
-        marker=marker,
-    )
+    ):
+        _run_check(
+            checks_file,
+            project_id,
+            dataset_id,
+            table,
+            ctx.args,
+            dry_run=dry_run,
+            marker=marker,
+        )
 
 
 def _run_check(

--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -96,7 +96,6 @@ def paths_matching_checks_pattern(
         yield checks_file, project, dataset, table
     else:
         print(f"No checks.sql file found in {sql_path}/{project_id}/{pattern}")
-        return None, None, None, None
 
 
 def paths_matching_name_pattern(


### PR DESCRIPTION
This has been very useful for checking e.g. all `baseline_clients_first_seen` tables for errors.

Another nice improvement would be parallelization, but that is not required.
Also added some typing.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [x] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [x] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [x] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
