### PR TITLE
DENG-1705 - Add startup_profile_selection_reason_first to clients_daily_v6

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
@@ -2336,3 +2336,6 @@ fields:
   - name: value
     type: INTEGER
     mode: NULLABLE
+- name: startup_profile_selection_reason_first
+  type: STRING
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
@@ -558,6 +558,7 @@ clients_summary AS (
     payload.processes.parent.keyed_scalars.library_opened AS scalar_parent_library_opened,
     payload.processes.parent.keyed_scalars.library_search AS scalar_parent_library_search,
     payload.processes.parent.scalars.places_previousday_visits AS places_previousday_visits,
+    payload.processes.parent.scalars.startup_profile_selection_reason AS startup_profile_selection_reason,
     -- CAUTION: the order of fields here must match the order defined in
     -- count_histograms above and offsets must increment on each line.
     count_histograms[OFFSET(0)].histogram AS histogram_parent_devtools_aboutdebugging_opened_count,
@@ -1424,6 +1425,9 @@ aggregates AS (
     ARRAY_AGG(user_pref_browser_urlbar_suggest_bestmatch ORDER BY submission_timestamp DESC)[
       OFFSET(0)
     ] AS user_pref_browser_urlbar_suggest_bestmatch,
+    ARRAY_AGG(startup_profile_selection_reason ORDER BY submission_timestamp ASC)[
+      OFFSET(0)
+    ] AS startup_profile_selection_reason_first,
     SUM(
       scalar_parent_browser_ui_interaction_textrecognition_error
     ) AS scalar_parent_browser_ui_interaction_textrecognition_error_sum,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
@@ -2300,3 +2300,6 @@ fields:
   - name: value
     type: INTEGER
     mode: NULLABLE
+- name: startup_profile_selection_reason_first
+  type: STRING
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -152,6 +152,9 @@ fields:
   - mode: NULLABLE
     name: dltoken
     type: STRING
+  - name: dlsource
+    type: STRING
+    mode: NULLABLE
   mode: NULLABLE
   name: attribution
   type: RECORD
@@ -2299,3 +2302,6 @@ fields:
   - name: value
     type: INTEGER
     mode: NULLABLE
+- name: startup_profile_selection_reason_first
+  type: STRING
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
@@ -2349,3 +2349,6 @@ fields:
   - name: value
     type: INTEGER
     mode: NULLABLE
+- name: startup_profile_selection_reason_first
+  type: STRING
+  mode: NULLABLE


### PR DESCRIPTION
See https://github.com/mozilla/bigquery-etl/pull/3962#discussion_r1332186267 - get the first value for a client's `startup_profile_selection_reason`