### PR TITLE
DENG-1705 - Add startup_profile_selection_reason from first ping to clients_daily, clients_first_seen_v2 and downstream

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
@@ -2375,3 +2375,6 @@ fields:
 - name: min_subsession_counter
   type: INTEGER
   mode: NULLABLE
+- name: startup_profile_selection_first_ping_only
+  type: STRING
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
@@ -1453,6 +1453,9 @@ aggregates AS (
     ARRAY_AGG(startup_profile_selection_reason ORDER BY submission_timestamp ASC)[
       OFFSET(0)
     ] AS startup_profile_selection_reason_first,
+    mozfun.stats.mode_last(
+        ARRAY_AGG(IF(subsession_counter = 1, startup_profile_selection_reason, NULL) ORDER BY submission_timestamp)
+    ) as startup_profile_selection_first_ping_only,
     SUM(
       scalar_parent_browser_ui_interaction_textrecognition_error
     ) AS scalar_parent_browser_ui_interaction_textrecognition_error_sum,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
@@ -1454,7 +1454,7 @@ aggregates AS (
       OFFSET(0)
     ] AS startup_profile_selection_reason_first,
     mozfun.stats.mode_last(
-        ARRAY_AGG(IF(subsession_counter = 1, startup_profile_selection_reason, NULL) ORDER BY submission_timestamp)
+        ARRAY_AGG(IF(subsession_counter = 1, startup_profile_selection_reason, NULL) ORDER BY submission_timestamp ASC)
     ) as startup_profile_selection_first_ping_only,
     SUM(
       scalar_parent_browser_ui_interaction_textrecognition_error

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
@@ -2339,3 +2339,6 @@ fields:
 - name: min_subsession_counter
   type: INTEGER
   mode: NULLABLE
+- name: startup_profile_selection_first_ping_only
+  type: STRING
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/query.sql
@@ -16,7 +16,7 @@ WITH clients_first_seen_28_days_ago AS (
     attribution_experiment,
     attribution_dltoken,
     attribution_dlsource,
-    -- startup_profile_selection_reason, when startup_profile_selection_reason is available
+    startup_profile_selection_reason,
     first_seen_date,
   FROM
     telemetry_derived.clients_first_seen_v2
@@ -38,24 +38,20 @@ clients_first_seen_28_days_ago_with_days_seen AS (
     AND cls.submission_date = @submission_date
 )
 SELECT
-  client_id,
-  sample_id,
-  first_seen_date,
-  @submission_date AS submission_date,
-  country_code,
-  channel,
-  build_id,
-  os,
-  os_version,
-  distribution_id,
-  attribution_source,
-  attribution_ua,
-  attribution_medium,
-  attribution_campaign,
-  attribution_content,
-  attribution_experiment,
-  attribution_dltoken,
-  attribution_dlsource,
+  * REPLACE (
+    COALESCE(
+      days_seen_bits,
+      mozfun.bits28.from_string('0000000000000000000000000000')
+    ) AS days_seen_bits,
+    COALESCE(
+      days_visited_1_uri_bits,
+      mozfun.bits28.from_string('0000000000000000000000000000')
+    ) AS days_visited_1_uri_bits,
+    COALESCE(
+      days_interacted_bits,
+      mozfun.bits28.from_string('0000000000000000000000000000')
+    ) AS days_interacted_bits
+  ),
   COALESCE(
     BIT_COUNT(mozfun.bits28.from_string('1111111000000000000000000000') & days_seen_bits) >= 5,
     FALSE
@@ -84,17 +80,6 @@ SELECT
     ) > 0,
     FALSE
   ) AS qualified_week4,
-  COALESCE(
-    days_seen_bits,
-    mozfun.bits28.from_string('0000000000000000000000000000')
-  ) AS days_seen_bits,
-  COALESCE(
-    days_visited_1_uri_bits,
-    mozfun.bits28.from_string('0000000000000000000000000000')
-  ) AS days_visited_1_uri_bits,
-  COALESCE(
-    days_interacted_bits,
-    mozfun.bits28.from_string('0000000000000000000000000000')
-  ) AS days_interacted_bits,
+  @submission_date AS submission_date,
 FROM
   clients_first_seen_28_days_ago_with_days_seen

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/schema.yaml
@@ -85,3 +85,7 @@ fields:
 - name: days_interacted_bits
   type: INTEGER
   mode: NULLABLE
+- name: startup_profile_selection_reason
+  type: STRING
+  mode: NULLABLE
+  description: Client's first startup_profile_selection reason.

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/schema.yaml
@@ -88,4 +88,4 @@ fields:
 - name: startup_profile_selection_reason
   type: STRING
   mode: NULLABLE
-  description: Client's first startup_profile_selection reason.
+  description: How the profile was selected during startup, as reported by the first ping received.

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -2341,3 +2341,6 @@ fields:
 - name: min_subsession_counter
   type: INTEGER
   mode: NULLABLE
+- name: startup_profile_selection_first_ping_only
+  type: STRING
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/query.sql
@@ -374,7 +374,7 @@ main_ping AS (
     ARRAY_AGG(normalized_os_version RESPECT NULLS ORDER BY submission_date)[
       SAFE_OFFSET(0)
     ] AS normalized_os_version,
-    ARRAY_AGG(startup_profile_selection_reason_first RESPECT NULLS ORDER BY submission_date)[
+    ARRAY_AGG(startup_profile_selection_reason_first_ping_only RESPECT NULLS ORDER BY submission_date)[
       SAFE_OFFSET(0)
     ] AS startup_profile_selection_reason,
     ARRAY_AGG(attribution.dltoken RESPECT NULLS ORDER BY submission_date)[

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/query.sql
@@ -374,9 +374,9 @@ main_ping AS (
     ARRAY_AGG(normalized_os_version RESPECT NULLS ORDER BY submission_date)[
       SAFE_OFFSET(0)
     ] AS normalized_os_version,
-    CAST(
-      NULL AS STRING
-    ) AS startup_profile_selection_reason, -- main_v5:payload.processes.parent.scalars.startup_profile_selection_reason
+    ARRAY_AGG(startup_profile_selection_reason_first RESPECT NULLS ORDER BY submission_date)[
+      SAFE_OFFSET(0)
+    ] AS startup_profile_selection_reason,
     ARRAY_AGG(attribution.dltoken RESPECT NULLS ORDER BY submission_date)[
       SAFE_OFFSET(0)
     ] AS attribution_dltoken,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_joined_v1/schema.yaml
@@ -2110,6 +2110,9 @@ fields:
 - name: startup_profile_selection_reason_first
   type: STRING
   mode: NULLABLE
+- name: startup_profile_selection_reason_first_ping_only
+  type: STRING
+  mode: NULLABLE
 - name: first_document_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/schema.yaml
@@ -2388,3 +2388,6 @@ fields:
 - name: min_subsession_counter
   type: INTEGER
   mode: NULLABLE
+- name: startup_profile_selection_first_ping_only
+  type: STRING
+  mode: NULLABLE

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/moz-fx-data-shared-prod.telemetry_derived.clients_daily_v6.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/moz-fx-data-shared-prod.telemetry_derived.clients_daily_v6.schema.json
@@ -160,5 +160,9 @@
   {
     "type": "STRING",
     "name": "normalized_os_version"
+  },
+  {
+    "type": "STRING",
+    "name": "startup_profile_selection_reason_first"
   }
 ]

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/moz-fx-data-shared-prod.telemetry_derived.clients_daily_v6.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/moz-fx-data-shared-prod.telemetry_derived.clients_daily_v6.schema.json
@@ -163,6 +163,6 @@
   },
   {
     "type": "STRING",
-    "name": "startup_profile_selection_reason_first"
+    "name": "startup_profile_selection_reason_first_ping_only"
   }
 ]


### PR DESCRIPTION
Follow up to https://github.com/mozilla/bigquery-etl/pull/4473. Small refactor to cfs_28_days_later

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1865)
