### PR TITLE
Fix test for mozfun.norm.result_type_to_product_name

### DIFF
--- a/sql/mozfun/norm/result_type_to_product_name/udf.sql
+++ b/sql/mozfun/norm/result_type_to_product_name/udf.sql
@@ -27,4 +27,4 @@ RETURNS STRING AS (
 
                 -- Tests
 SELECT
-  assert.null(norm.result_type_to_product_name("not a valid type"))
+  assert.equals("other", norm.result_type_to_product_name("not a valid type"))


### PR DESCRIPTION
fixes bug introduced in https://github.com/mozilla/bigquery-etl/pull/4373

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1870)
