### PR TITLE
Update tests for UDF norm.glean_ping_info when parsing timestamp.

### DIFF
--- a/sql/mozfun/norm/glean_ping_info/udf.sql
+++ b/sql/mozfun/norm/glean_ping_info/udf.sql
@@ -27,7 +27,8 @@ SELECT
       STRUCT('2019-12-01T20:22+11:00' AS start_time, '2019-12-01T21:24+11:00' AS end_time)
     ).parsed_end_time
   ),
-  assert.null(
+  assert.equals(
+    TIMESTAMP '2019-12-01 10:24:00',
     norm.glean_ping_info(
       STRUCT('2019-12-01T20:22+11:00' AS start_time, '2019-12-01T21:24:00+11:00' AS end_time)
     ).parsed_end_time


### PR DESCRIPTION
This PR resolves failing tests in dependabot to upgrade [sqlglot in PR-4500](https://github.com/mozilla/bigquery-etl/pull/4500) and [black in PR-4499](https://github.com/mozilla/bigquery-etl/pull/4499).

The function [parse_timestamp](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#parse_timestamp) returns the date instead of NULL when parsing a timestamp with seconds.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1894)
