### PR TITLE
Add output_dir to command dag generate.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,11 +581,10 @@ jobs:
               "sql/"
             ./script/bqetl metadata update \
               sql/
-            ./script/bqetl dag generate --output-dir /tmp/workspace/private-generated-sql/dags/
 
             mkdir -p /tmp/workspace/main-generated-sql
+            ./script/bqetl dag generate --output-dir /tmp/workspace/main-generated-sql/dags
             cp -r sql/ /tmp/workspace/main-generated-sql/sql
-            cp -r dags/ /tmp/workspace/main-generated-sql/dags
       - persist_to_workspace:
           root: /tmp/workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,7 +581,7 @@ jobs:
               "sql/"
             ./script/bqetl metadata update \
               sql/
-            ./script/bqetl dag generate
+            ./script/bqetl dag generate --output-dir /tmp/workspace/private-generated-sql/dags/
 
             mkdir -p /tmp/workspace/main-generated-sql
             cp -r sql/ /tmp/workspace/main-generated-sql/sql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,9 +582,10 @@ jobs:
             ./script/bqetl metadata update \
               sql/
 
-            mkdir -p /tmp/workspace/main-generated-sql
-            ./script/bqetl dag generate --output-dir /tmp/workspace/main-generated-sql/dags
+            mkdir -p /tmp/workspace/main-generated-sql/sql
             cp -r sql/ /tmp/workspace/main-generated-sql/sql
+            mkdir -p /tmp/workspace/main-generated-sql/dags
+            ./script/bqetl dag generate --output-dir /tmp/workspace/main-generated-sql/dags
       - persist_to_workspace:
           root: /tmp/workspace
           paths:


### PR DESCRIPTION
[ci/circleci: main-generate-sql-and-dags is failing](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/26277/workflows/882f9402-d4d6-4c36-8eb7-0a99621b00dc/jobs/276045?invite=true#step-106-1696361_89) because the command `dag generate` is missing the output directory.


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1906)
