### PR TITLE
chore(): prefixing schema error message inside dryrun to "ERROR" to make it easier to find the error in logs

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -436,7 +436,7 @@ class DryRun:
             if not existing_schema.equal(query_schema):
                 click.echo(
                     click.style(
-                        f"Schema defined in {existing_schema_path} "
+                        f"ERROR: Schema defined in {existing_schema_path} "
                         f"incompatible with query {query_file_path}",
                         fg="red",
                     ),


### PR DESCRIPTION
# chore(): prefixing schema error message inside dryrun to "ERROR" to make it easier to find the error in logs

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1919)
