### PR TITLE
Deng 1662 move google ads to ads google mmc connector

### DIFF
--- a/sql/moz-fx-data-shared-prod/google_ads_derived/accounts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/accounts_v1/metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: Accounts
+description: |-
+  Account information for different Google Ads accounts
+owners:
+- lschiestl@mozilla.com
+labels: {}
+scheduling:
+  scheduling:
+  dag_name: bqetl_fivetran_google_ads
+  depends_on_past: false
+  date_partition_parameter: null
+bigquery: null
+references: {}
+deprecated: false

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/accounts_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/accounts_v1/query.sql
@@ -1,0 +1,4 @@
+SELECT
+  *
+FROM
+  `moz-fx-data-bq-fivetran.ads_google_mmc_google_ads_source.stg_google_ads__account_history`

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_conversions_by_date_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_conversions_by_date_v1/query.sql
@@ -1,7 +1,7 @@
 WITH conversion_counts AS (
   SELECT
     date,
-    customer_id as account_id,
+    customer_id AS account_id,
     campaign_id,
     SUM(biddable_app_install_conversions) AS installs,
     SUM(biddable_app_post_install_conversions) AS conversions,

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_conversions_by_date_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_conversions_by_date_v1/query.sql
@@ -1,17 +1,21 @@
 WITH conversion_counts AS (
   SELECT
     date,
+    customer_id as account_id,
     campaign_id,
     SUM(biddable_app_install_conversions) AS installs,
     SUM(biddable_app_post_install_conversions) AS conversions,
   FROM
-    `moz-fx-data-bq-fivetran`.google_ads.campaign_conversions_by_date
+    `moz-fx-data-bq-fivetran`.ads_google_mmc.campaign_conversions_by_date
   GROUP BY
     date,
+    account_id,
     campaign_id
 )
 SELECT
   date,
+  account_name,
+  account_id,
   campaign_name,
   campaign_id,
   installs,
@@ -21,4 +25,4 @@ FROM
 JOIN
   `moz-fx-data-shared-prod`.google_ads_derived.campaign_names_map_v1
 USING
-  (campaign_id)
+  (campaign_id, account_id)

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_names_map_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_names_map_v1/query.sql
@@ -1,14 +1,22 @@
 WITH campaign_names AS (
   SELECT
+    customer_id,
     id AS campaign_id,
     name AS campaign_name,
     ROW_NUMBER() OVER (PARTITION BY id ORDER BY updated_at DESC) = 1 AS is_most_recent_record,
   FROM
-    `moz-fx-data-bq-fivetran`.google_ads.campaign_history
+    `moz-fx-data-bq-fivetran`.ads_google_mmc.campaign_history
 )
 SELECT
-  *
+  accounts.account_name,
+  accounts.account_id,
+  campaign_names.campaign_id,
+  campaign_names.campaign_name,
+  campaign_names.is_most_recent_record
+
 FROM
   campaign_names
+JOIN `moz-fx-data-shared`.google_ads_derived.accounts_v1 as accounts
+ON accounts.account_id = campaign_names.customer_id
 WHERE
-  is_most_recent_record
+  campaign_names.is_most_recent_record

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_names_map_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/campaign_names_map_v1/query.sql
@@ -13,10 +13,11 @@ SELECT
   campaign_names.campaign_id,
   campaign_names.campaign_name,
   campaign_names.is_most_recent_record
-
 FROM
   campaign_names
-JOIN `moz-fx-data-shared`.google_ads_derived.accounts_v1 as accounts
-ON accounts.account_id = campaign_names.customer_id
+JOIN
+  `moz-fx-data-shared`.google_ads_derived.accounts_v1 AS accounts
+ON
+  accounts.account_id = campaign_names.customer_id
 WHERE
   campaign_names.is_most_recent_record

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_ad_group_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_ad_group_stats_v1/query.sql
@@ -2,4 +2,4 @@ SELECT
   date_day AS `date`,
   * EXCEPT (date_day)
 FROM
-  `moz-fx-data-bq-fivetran.google_ads_google_ads.google_ads__ad_group_report`
+  `moz-fx-data-bq-fivetran.ads_google_mmc_google_ads.google_ads__ad_group_report`

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/query.sql
@@ -2,4 +2,4 @@ SELECT
   date_day AS `date`,
   * EXCEPT (date_day)
 FROM
-  `moz-fx-data-bq-fivetran.google_ads_google_ads.google_ads__campaign_report`
+  `moz-fx-data-bq-fivetran.ads_google_mmc_google_ads.google_ads__campaign_report`


### PR DESCRIPTION
At the current state this is a draft, but I would appreciate feedback on it.

This will move all tables from the `google_ads` connector to `ads_google_mmc` fivetran connector where all accounts are synced.

It is currently not filtering to only show the one account that is synced with `google_ads` connector. I added an account_id and account_name field to all tables, so that one can easily add that filter for the views if wanted. 
(not sure on how to set this up in regards to permissions but we could always do row level permissions for the accounts)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
