### PR TITLE
Set depend_on_past=False for warn checks

### DIFF
--- a/bigquery_etl/cli/check.py
+++ b/bigquery_etl/cli/check.py
@@ -70,17 +70,7 @@ def _parse_check_output(output: str) -> str:
 @click.group(
     help="""
         Commands for managing and running bqetl data checks.
-
-        ––––––––––––––––––––––––––––––––––––––––––––––
-
-        IN ACTIVE DEVELOPMENT
-
-        The current progress can be found under:
-
-        \thttps://mozilla-hub.atlassian.net/browse/DENG-919
-
-        ––––––––––––––––––––––––––––––––––––––––––––––
-        """
+    """
 )
 @click.pass_context
 def check(ctx):

--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -488,6 +488,7 @@ class Task:
         task.query_file_path = query_file
         task.is_dq_check = True
         task.is_dq_check_fail = is_check_fail
+        task.depends_on_past = False
         task.retries = 0
         task.depends_on_fivetran = []
         if task.is_dq_check_fail:


### PR DESCRIPTION
This should fix issues we are seeing in https://workflow.telemetry.mozilla.org/dags/bqetl_firefox_ios/grid?dag_run_id=scheduled__2023-10-24T04%3A00%3A00%2B00%3A00&task_id=checks__warn_firefox_ios_derived__firefox_ios_clients__v1

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1925)
