### PR TITLE
Add map.set_key to mozfun

### DIFF
--- a/sql/mozfun/map/set_key/README.md
+++ b/sql/mozfun/map/set_key/README.md
@@ -1,0 +1,8 @@
+`map.set_key`
+
+Set a key to a specific value in a map.
+We represent maps as Arrays of Key/Value structs:
+`ARRAY<STRUCT<key ANY TYPE, value ANY TYPE>>`.
+
+The type of the key and value you are setting must
+match the types in the map itself.

--- a/sql/mozfun/map/set_key/metadata.yaml
+++ b/sql/mozfun/map/set_key/metadata.yaml
@@ -1,0 +1,5 @@
+description: |
+  Set a key to a value in a map.
+  If you call map.get_key after setting,
+  the value you set will be returned.
+friendly_name: Set Key

--- a/sql/mozfun/map/set_key/udf.sql
+++ b/sql/mozfun/map/set_key/udf.sql
@@ -1,36 +1,45 @@
-CREATE OR REPLACE FUNCTION map.set_key(map ANY TYPE, new_key ANY TYPE, new_value ANY TYPE)
-AS (
-  ARRAY(
-    SELECT
-      STRUCT(
-        key,
-        COALESCE(new_value, value)
-      )
-    FROM (
-      SELECT new_key AS key, new_value
+CREATE OR REPLACE FUNCTION map.set_key(map ANY TYPE, new_key ANY TYPE, new_value ANY TYPE) AS (
+  IF(
+    new_key IS NULL,
+    ERROR(
+      "mozfun.map.set_key: Cannot insert NULL keys into map, tried to insert: (key=" || CAST(
+        new_key AS STRING
+      ) || ", value=" || CAST(new_value AS STRING) || ")"
+    ),
+    ARRAY(
+      SELECT
+        STRUCT(key, COALESCE(new_data.value, existing_data.value) AS value)
+      FROM
+        (SELECT new_key AS key, new_value AS value) AS new_data
+      FULL OUTER JOIN
+        -- BQ doesn't allow you to FULL OUTER JOIN an
+        -- unnested array directly, so we use a subquery
+        (SELECT * FROM UNNEST(map)) AS existing_data
+      USING
+        (key)
     )
-    FULL OUTER JOIN
-      -- BQ doesn't allow you to FULL OUTER JOIN an
-      -- unnested array directly, so we use a subquery
-      (SELECT * FROM UNNEST(map)) AS existing_data
-      USING (key)
   )
 );
-
 
 -- Tests
 SELECT
   -- No current map
-  assert.map_entries_equals(map.set_key(CAST(NULL AS ARRAY<STRUCT<key STRING, value INT64>>), "a", 1), [STRUCT("a" AS key, 1 AS value)]),
-
+  mozfun.assert.map_entries_equals(
+    map.set_key(CAST([] AS ARRAY<STRUCT<key STRING, value INT64>>), "a", 1),
+    [STRUCT("a" AS key, 1 AS value)]
+  ),
+  -- Null current map
+  mozfun.assert.map_entries_equals(
+    map.set_key(CAST(NULL AS ARRAY<STRUCT<key STRING, value INT64>>), "a", 1),
+    [STRUCT("a" AS key, 1 AS value)]
+  ),
   -- Have current map, key is not present
-  assert.map_entries_equals(map.set_key([STRUCT("b" AS key, 2 AS value)], "a", 1), [STRUCT("a" AS key, 1 AS value), STRUCT("b", 2)]),
-
+  mozfun.assert.map_entries_equals(
+    map.set_key([STRUCT("b" AS key, 2 AS value)], "a", 1),
+    [STRUCT("a" AS key, 1 AS value), STRUCT("b", 2)]
+  ),
   -- Have current map, key is present
-  assert.map_entries_equals(map.set_key([STRUCT("a" AS key, 2 AS value)], "a", 1), [STRUCT("a" AS key, 1 AS value)]),
-
-  -- Null values for keys in map
-  assert.map_entries_equals(map.set_key([STRUCT(CAST(NULL AS STRING) AS key, 1 AS value)], "a", 1), [STRUCT("a" AS key, 1 AS value), STRUCT(CAST(NULL AS STRING), 1)]),
-
-  -- Null values for new key
-  assert.map_entries_equals(map.set_key([STRUCT("a" AS key, 1 AS value)], CAST(NULL AS STRING), 1), [STRUCT("a" AS key, 1 AS value), STRUCT(CAST(NULL AS STRING), 1)])
+  mozfun.assert.map_entries_equals(
+    map.set_key([STRUCT("a" AS key, 2 AS value)], "a", 1),
+    [STRUCT("a" AS key, 1 AS value)]
+  ),

--- a/sql/mozfun/map/set_key/udf.sql
+++ b/sql/mozfun/map/set_key/udf.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE FUNCTION map.set_key(map ANY TYPE, new_key ANY TYPE, new_value ANY TYPE)
+AS (
+  ARRAY(
+    SELECT
+      STRUCT(
+        key,
+        COALESCE(new_value, value)
+      )
+    FROM (
+      SELECT new_key AS key, new_value
+    )
+    FULL OUTER JOIN
+      -- BQ doesn't allow you to FULL OUTER JOIN an
+      -- unnested array directly, so we use a subquery
+      (SELECT * FROM UNNEST(map)) AS existing_data
+      USING (key)
+  )
+);
+
+
+-- Tests
+SELECT
+  -- No current map
+  assert.map_entries_equals(map.set_key(CAST(NULL AS ARRAY<STRUCT<key STRING, value INT64>>), "a", 1), [STRUCT("a" AS key, 1 AS value)]),
+
+  -- Have current map, key is not present
+  assert.map_entries_equals(map.set_key([STRUCT("b" AS key, 2 AS value)], "a", 1), [STRUCT("a" AS key, 1 AS value), STRUCT("b", 2)]),
+
+  -- Have current map, key is present
+  assert.map_entries_equals(map.set_key([STRUCT("a" AS key, 2 AS value)], "a", 1), [STRUCT("a" AS key, 1 AS value)]),
+
+  -- Null values for keys in map
+  assert.map_entries_equals(map.set_key([STRUCT(CAST(NULL AS STRING) AS key, 1 AS value)], "a", 1), [STRUCT("a" AS key, 1 AS value), STRUCT(CAST(NULL AS STRING), 1)]),
+
+  -- Null values for new key
+  assert.map_entries_equals(map.set_key([STRUCT("a" AS key, 1 AS value)], CAST(NULL AS STRING), 1), [STRUCT("a" AS key, 1 AS value), STRUCT(CAST(NULL AS STRING), 1)])


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1926)
