### PR TITLE
DS-3281 - Add client adclicks history table

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix/client_adclicks_history/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/client_adclicks_history/metadata.yaml
@@ -1,0 +1,15 @@
+friendly_name: Client Adclicks History
+description: |-
+  Contains the full history of ad-clicks for each client.
+
+  This should only be used for the LTV project.
+  To calculate LTV for any client, we add together two things -
+  1. Predicted future Ad Clicks
+  2. Total historical ad clicks
+
+  This table provides 2.
+  The full history of each client's ad_clicks
+  are available as a MAP, keyed by date,
+  where the value is the number of ad clicks.
+owners:
+- frank@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fenix/client_adclicks_history/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/client_adclicks_history/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.fenix.client_adclicks_history`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.fenix_derived.client_adclicks_history_v1`

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/checks.sql
@@ -1,0 +1,6 @@
+#fail
+-- Grain is: client_id
+{{ is_unique(["client_id"]) }}
+#fail
+{{ min_row_count(100000) }}
+

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/metadata.yaml
@@ -18,6 +18,7 @@ labels:
   owner1: frank@mozilla.com
 scheduling:
   dag_name: bqetl_org_mozilla_firefox_derived
+  date_partition_parameter: null
 bigquery:
   clustering:
     fields: [sample_id]

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/metadata.yaml
@@ -1,0 +1,25 @@
+friendly_name: Client Adclicks History
+description: |-
+  Contains the full history of ad-clicks for each client.
+
+  This should only be used for the LTV project.
+  To calculate LTV for any client, we add together two things -
+  1. Predicted future Ad Clicks
+  2. Total historical ad clicks
+
+  This table provides 2.
+  The full history of each client's ad_clicks
+  are available as a MAP, keyed by date,
+  where the value is the number of ad clicks.
+owners:
+- frank@mozilla.com
+labels:
+  incremental: true
+  owner1: frank@mozilla.com
+scheduling:
+  dag_name: bqetl_org_mozilla_firefox_derived
+bigquery:
+  clustering:
+    fields: [sample_id]
+references: {}
+deprecated: false

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/query.sql
@@ -1,0 +1,29 @@
+WITH new_data AS (
+  SELECT
+    client_id,
+    sample_id,
+    ad_clicks,
+  FROM
+    `moz-fx-data-shared-prod`.fenix_derived.attributable_clients_v2
+  WHERE
+    submission_date = @submission_date
+    AND ad_clicks > 0
+),
+existing_data AS (
+  SELECT
+    client_id,
+    sample_id,
+    ad_click_history
+  FROM
+    `moz-fx-data-shared-prod`.fenix_derived.client_adclicks_history_v1
+)
+SELECT
+  client_id,
+  sample_id,
+  mozfun.map.set_key(ad_click_history, @submission_date, ad_clicks)
+FROM
+  existing_data
+FULL OUTER JOIN
+  new_data
+USING
+  (sample_id, client_id)

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/query.sql
@@ -20,7 +20,7 @@ existing_data AS (
 SELECT
   client_id,
   sample_id,
-  mozfun.map.set_key(ad_click_history, @submission_date, ad_clicks)
+  mozfun.map.set_key(ad_click_history, @submission_date, ad_clicks) AS ad_click_history
 FROM
   existing_data
 FULL OUTER JOIN

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_adclicks_history_v1/schema.yaml
@@ -1,0 +1,22 @@
+fields:
+- description: Unique ID for the client installation.
+  mode: NULLABLE
+  name: client_id
+  type: STRING
+- description: Sample ID to limit query results during an analysis.
+  mode: NULLABLE
+  name: sample_id
+  type: INTEGER
+- description: History of ad_clicks for a user, by submission_date
+  fields:
+  - description: The date associated with the ad_click value
+    mode: NULLABLE
+    name: key
+    type: DATE
+  - description: The total number of ad_clicks for the submission_date
+    mode: NULLABLE
+    name: value
+    type: INTEGER
+  mode: REPEATED
+  name: ad_click_history
+  type: RECORD


### PR DESCRIPTION
This creates a table with 1-row per-client, clustered on `sample_id`, with the full history of days and ad_clicks for that client.

This was the most efficient way to create this kind of table while still keeping the job idempotent.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [x] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [x] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [x] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1929)
