### PR TITLE
Add rust result types to product mapping

### DIFF
--- a/sql/mozfun/norm/result_type_to_product_name/udf.sql
+++ b/sql/mozfun/norm/result_type_to_product_name/udf.sql
@@ -5,22 +5,23 @@ RETURNS STRING AS (
     CASE
     WHEN res IN ('autofill_origin', 'autofill_url') THEN 'autofill'
     WHEN res IN ('addon') THEN 'xchannels_add_on'
-    WHEN res IN ('rs_amo') THEN 'suggest_add_on'
+    WHEN res IN ('rs_amo', 'rust_amo') THEN 'suggest_add_on'
     WHEN res IN ('search_suggest', 'search_history', 'search_suggest_rich') THEN 'default_partner_search_suggestion'
     WHEN res IN ('search_engine') THEN 'search_engine'
     WHEN res IN ('trending_search', 'trending_search_rich') THEN 'trending_suggestion'
     WHEN res IN ('history') THEN 'history'
     WHEN res IN ('bookmark', 'keyword') THEN 'bookmark'
     WHEN res IN ('tab') THEN 'open_tab'
-    WHEN res IN ('merino_adm_sponsored', 'rs_adm_sponsored', 'suggest_sponsor') THEN 'admarketplace_sponsored'
+    WHEN res IN ('merino_adm_sponsored', 'rs_adm_sponsored', 'suggest_sponsor', 'rust_adm_sponsored') THEN 'admarketplace_sponsored'
     WHEN res IN ('merino_top_picks') THEN 'navigational'
     WHEN res IN ('rs_adm_nonsponsored',
     'merino_adm_nonsponsored',
-    'suggest_non_sponsor') THEN 'wikipedia_enhanced'
+    'suggest_non_sponsor',
+    'rust_adm_nonsponsored') THEN 'wikipedia_enhanced'
     WHEN res IN ('dynamic_wikipedia', 'merino_wikipedia') THEN 'wikipedia_dynamic'
     WHEN res IN ('weather') THEN 'weather'
     WHEN res IN ( 'action', 'intervention_clear', 'intervention_refresh', 'intervention_unknown', 'intervention_update' ) THEN 'quick_action'
-    WHEN res IN ('rs_pocket') THEN 'pocket_collection'
+    WHEN res IN ('rs_pocket', 'rust_pocket') THEN 'pocket_collection'
     ELSE 'other'
     END
 );


### PR DESCRIPTION
These result types are being added in relation to the new Rust backend for Suggest (https://docs.google.com/document/d/1JTSR4oVjSke0qKRe1s6nFvk3LHE01__dO2L8a20AhLg/edit#bookmark=id.b4zo4jx5g68i)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1952)
