### PR TITLE
Fix event monitoring template

### DIFF
--- a/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
@@ -116,9 +116,9 @@
         ) * 60
       ) MINUTE
     ) AS window_end,
-    NULL AS event_category,
+    CAST(NULL AS STRING) AS event_category,
     metrics.string.event_name,
-    NULL AS event_extra_key,
+    CAST(NULL AS STRING) AS event_extra_key,
     normalized_country_code AS country,
     "{{ dataset['canonical_app_name'] }}" AS normalized_app_name,
     normalized_channel,


### PR DESCRIPTION
Nulls need to be casted to string to make the union work.

This will fix https://workflow.telemetry.mozilla.org/log?execution_date=2023-11-09T02%3A00%3A00%2B00%3A00&task_id=monitoring_derived__event_monitoring_aggregates__v1&dag_id=bqetl_monitoring&map_index=-1

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1954)
