### PR TITLE
# bug(1859232): removed check for firefox_ios_clients_v1 which used different filtering settings causing result mismatch

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/checks.sql
@@ -1,9 +1,9 @@
 #fail
 {{ is_unique(columns=["client_id"]) }}
 #fail
-{{ not_null(columns=["client_id"]) }}
+{{ not_null(columns=["client_id"], where="first_seen_date = @submission_date") }}
 #fail
-{{ min_row_count(1, "first_seen_date = @submission_date") }}
+{{ min_row_count(1, where="first_seen_date = @submission_date") }}
 #warn
 SELECT
   IF(
@@ -15,20 +15,3 @@ FROM
   `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
 WHERE
   first_seen_date = @submission_date;
-#warn
-WITH base AS (
-  SELECT COUNTIF(is_activated)
-  FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
-  WHERE first_seen_date = @submission_date
-),
-upstream AS (
-  SELECT COUNTIF(is_activated)
-  FROM `{{ project_id }}.{{ dataset_id }}.new_profile_activation_v2`
-  WHERE first_seen_date = @submission_date
-)
-SELECT
-  IF(
-    (SELECT * FROM base) <> (SELECT * FROM upstream),
-    ERROR(CONCAT("Number of activations does not match up that of the upstream table. Upstream count: ", (SELECT * FROM upstream), ", base count: ", (SELECT * FROM base))),
-    NULL
-  );


### PR DESCRIPTION
# bug(1859232): removed check for firefox_ios_clients_v1 which used different filtering settings causing result mismatch

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1955)
