### PR TITLE
Use correct app_version field

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attributable_clients_v1/query.sql
@@ -8,7 +8,9 @@ WITH client_days AS (
     DATE(submission_timestamp) AS submission_date,
     sample_id,
     client_info.client_id,
-    LOGICAL_OR(mozfun.norm.extract_version(app_version, 'major') >= 108) AS has_search_data,
+    LOGICAL_OR(
+      mozfun.norm.extract_version(client_info.app_display_version, 'major') >= 108
+    ) AS has_search_data,
     SUM(sum_map_values(metrics.labeled_counter.search_in_content)) AS searches,
     SUM(sum_map_values(metrics.labeled_counter.browser_search_with_ads)) AS searches_with_ads,
     SUM(sum_map_values(metrics.labeled_counter.browser_search_ad_clicks)) AS ad_clicks,


### PR DESCRIPTION
I actually tried backfilling this one locally, and it runs.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1960)
