### PR TITLE
missing-mobile-fields-review-checker

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/serp_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/serp_events/view.sql
@@ -1,8 +1,0 @@
---- User-facing view. Generated via sql_generators.active_users.
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.firefox_desktop.serp_events`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.firefox_desktop_derived.serp_events_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/serp_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/serp_events/view.sql
@@ -1,0 +1,8 @@
+--- User-facing view. Generated via sql_generators.active_users.
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.serp_events`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.serp_events_v1`

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/review_checker_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/review_checker_clients_v1/query.sql
@@ -1,6 +1,4 @@
 WITH shopping_metrics AS (
-  --we're missing fx_dau, user_has_onboarded, and nimbus_disabled_shopping in looker
-  --for android and possibly also iOS
   SELECT
     client_info.client_id AS client_id,
     DATE(submission_timestamp) AS submission_date,
@@ -64,6 +62,20 @@ active AS (
     client_info.client_id,
     submission_date
 ),
+fx_dau AS (
+  SELECT
+    client_info.client_id,
+    DATE(submission_timestamp) AS submission_date,
+    CASE
+      WHEN LOWER(metadata.isp.name) != 'browserstack'
+        THEN 1
+      ELSE 0
+    END AS is_fx_dau
+  FROM
+    `moz-fx-data-shared-prod.fenix.baseline`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+),
 search AS (
   SELECT
     submission_date,
@@ -89,7 +101,8 @@ joined_data AS (
     sm.is_opt_out,
     s.sap,
     s.ad_click,
-    active.active_hours AS active_hours_sum
+    active.active_hours AS active_hours_sum,
+    fx_dau.is_fx_dau
   FROM
     shopping_metrics sm
   LEFT JOIN
@@ -102,6 +115,11 @@ joined_data AS (
   ON
     s.client_id = sm.client_id
     AND s.submission_date = sm.submission_date
+  LEFT JOIN
+    fx_dau
+  ON
+    fx_dau.client_id = sm.client_id
+    AND fx_dau.submission_date = sm.submission_date
 )
 SELECT
   *

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/review_checker_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/review_checker_clients_v1/query.sql
@@ -102,6 +102,8 @@ joined_data AS (
     s.sap,
     s.ad_click,
     active.active_hours AS active_hours_sum,
+    sm.is_onboarded,
+    sm.is_nimbus_disabled,
     fx_dau.is_fx_dau
   FROM
     shopping_metrics sm

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/review_checker_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/review_checker_clients_v1/query.sql
@@ -1,4 +1,6 @@
 WITH shopping_metrics AS (
+  --we're missing fx_dau, user_has_onboarded, and nimbus_disabled_shopping in looker
+  --for android and possibly also iOS
   SELECT
     client_info.client_id AS client_id,
     DATE(submission_timestamp) AS submission_date,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/review_checker_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/review_checker_clients_v1/schema.yaml
@@ -56,3 +56,12 @@ fields:
 - name: active_hours_sum
   type: FLOAT
   mode: NULLABLE
+- name: is_onboarded
+  type: INTEGER
+  mode: NULLABLE
+- name: is_nimbus_disabled
+  type: INTEGER
+  mode: NULLABLE
+- name: is_fx_dau
+  type: INTEGER
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/review_checker_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/review_checker_clients_v1/query.sql
@@ -62,6 +62,20 @@ active AS (
     client_info.client_id,
     submission_date
 ),
+fx_dau AS (
+  SELECT
+    client_info.client_id,
+    DATE(submission_timestamp) AS submission_date,
+    CASE
+      WHEN LOWER(metadata.isp.name) != 'browserstack'
+        THEN 1
+      ELSE 0
+    END AS is_fx_dau
+  FROM
+    `moz-fx-data-shared-prod.firefox_ios.baseline`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+),
 search AS (
   SELECT
     submission_date,
@@ -88,7 +102,8 @@ joined_data AS (
     sm.is_opt_out,
     s.sap,
     s.ad_click,
-    active.active_hours AS active_hours_sum
+    active.active_hours AS active_hours_sum,
+    fx_dau.is_fx_dau
   FROM
     shopping_metrics sm
   LEFT JOIN
@@ -101,6 +116,11 @@ joined_data AS (
   ON
     s.client_id = sm.client_id
     AND s.submission_date = sm.submission_date
+  LEFT JOIN
+    fx_dau
+  ON
+    fx_dau.client_id = sm.client_id
+    AND fx_dau.submission_date = sm.submission_date
 )
 SELECT
   *

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/review_checker_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/review_checker_clients_v1/query.sql
@@ -103,6 +103,8 @@ joined_data AS (
     s.sap,
     s.ad_click,
     active.active_hours AS active_hours_sum,
+    sm.is_onboarded,
+    sm.is_nimbus_disabled,
     fx_dau.is_fx_dau
   FROM
     shopping_metrics sm

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/review_checker_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/review_checker_clients_v1/schema.yaml
@@ -56,3 +56,12 @@ fields:
 - name: active_hours_sum
   type: FLOAT
   mode: NULLABLE
+- name: is_onboarded
+  type: INTEGER
+  mode: NULLABLE
+- name: is_nimbus_disabled
+  type: INTEGER
+  mode: NULLABLE
+- name: is_fx_dau
+  type: INTEGER
+  mode: NULLABLE


### PR DESCRIPTION
android and (possibly) iOS review checker clients tables are missing metrics/dimensions for fx_dau, user_has_onboarded, and nimbus_disabled_shopping.  this is a PR to kick off making those changes

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1962)
