### PR TITLE
feat(): updating fxa android funnel to support install_source filtering downstream

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix/funnel_retention_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/funnel_retention_clients/view.sql
@@ -17,6 +17,7 @@ SELECT
   COALESCE(retention_week_4.adjust_campaign, retention_week_2.adjust_campaign) AS adjust_campaign,
   COALESCE(retention_week_4.adjust_creative, retention_week_2.adjust_creative) AS adjust_creative,
   COALESCE(retention_week_4.adjust_network, retention_week_2.adjust_network) AS adjust_network,
+  COALESCE(retention_week_4.install_source, retention_week_2.install_source) AS install_source,
   retention_week_2.retained_week_2,
   retention_week_4.retained_week_4,
   retention_week_4.days_seen_in_first_28_days,

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_2_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_2_v1/query.sql
@@ -21,13 +21,13 @@ clients_first_seen AS (
     adjust_campaign,
     adjust_creative,
     adjust_network,
+    install_source,
   FROM
     fenix.firefox_android_clients
   WHERE
     -- Two weeks need to elapse before calculating the week 2 retention
     first_seen_date = DATE_SUB(@submission_date, INTERVAL 13 DAY)
     AND channel = "release"
-    AND install_source = "com.android.vending"
 ),
 retention_calculation AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_2_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_2_v1/query.sql
@@ -27,6 +27,7 @@ clients_first_seen AS (
     -- Two weeks need to elapse before calculating the week 2 retention
     first_seen_date = DATE_SUB(@submission_date, INTERVAL 13 DAY)
     AND channel = "release"
+    AND install_source = "com.android.vending"
 ),
 retention_calculation AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_2_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_2_v1/schema.yaml
@@ -61,6 +61,11 @@ fields:
     The type of source of a client installation.
 
 - mode: NULLABLE
+  name: install_source
+  type: STRING
+  description:
+
+- mode: NULLABLE
   name: retained_week_2
   type: BOOLEAN
   description: |

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/query.sql
@@ -21,13 +21,13 @@ clients_first_seen AS (
     adjust_campaign,
     adjust_creative,
     adjust_network,
+    install_source,
   FROM
     fenix.firefox_android_clients
   WHERE
     -- 28 days need to elapse before calculating the week 4 and day 28 retention metrics
     first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
     AND channel = "release"
-    AND install_source = "com.android.vending"
 ),
 retention_calculation AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/query.sql
@@ -27,7 +27,7 @@ clients_first_seen AS (
     -- 28 days need to elapse before calculating the week 4 and day 28 retention metrics
     first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
     AND channel = "release"
-    AND install_source = 'com.android.vending'
+    AND install_source = "com.android.vending"
 ),
 retention_calculation AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/query.sql
@@ -27,6 +27,7 @@ clients_first_seen AS (
     -- 28 days need to elapse before calculating the week 4 and day 28 retention metrics
     first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
     AND channel = "release"
+    AND install_source = 'com.android.vending'
 ),
 retention_calculation AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/schema.yaml
@@ -61,6 +61,11 @@ fields:
     The type of source of a client installation.
 
 - mode: NULLABLE
+  name: install_source
+  type: STRING
+  description:
+
+- mode: NULLABLE
   name: days_seen_in_first_28_days
   type: INTEGER
   description: |

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_week_4_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_week_4_v1/query.sql
@@ -7,6 +7,7 @@ SELECT
   adjust_campaign,
   adjust_creative,
   adjust_network,
+  install_source,
   COUNT(*) AS new_profiles,
   COUNTIF(repeat_first_month_user) AS repeat_user,
   COUNTIF(retained_week_4) AS retained_week_4,
@@ -22,4 +23,5 @@ GROUP BY
   adjust_ad_group,
   adjust_campaign,
   adjust_creative,
-  adjust_network
+  adjust_network,
+  install_source

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_week_4_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_week_4_v1/schema.yaml
@@ -49,6 +49,11 @@ fields:
     The type of source of a client installation.
 
 - mode: NULLABLE
+  name: install_source
+  type: STRING
+  description:
+
+- mode: NULLABLE
   name: new_profiles
   type: INTEGER
   description: |


### PR DESCRIPTION
# feat(): updating fxa android funnel to support install_source filtering downstream

The following tables will need to be redeployed and rebuild in order to update the schemas:

- [ ] `funnel_retention_clients_week_2_v1`
- [ ] `funnel_retention_clients_week_4_v1`
- [ ] `funnel_retention_week_4_v1`

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1974)
