### PR TITLE
feat(): updated fenix_derived.funnel_retention_clients_* to use clients view instead of table directly

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_2_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_2_v1/query.sql
@@ -22,8 +22,7 @@ clients_first_seen AS (
     adjust_creative,
     adjust_network,
   FROM
-    -- TODO: once the view is updated, this should be updated to point to the viev rather than the table directly.
-    fenix_derived.firefox_android_clients_v2
+    fenix.firefox_android_clients
   WHERE
     -- Two weeks need to elapse before calculating the week 2 retention
     first_seen_date = DATE_SUB(@submission_date, INTERVAL 13 DAY)

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/query.sql
@@ -22,8 +22,7 @@ clients_first_seen AS (
     adjust_creative,
     adjust_network,
   FROM
-    -- TODO: once the view is updated, this should be updated to point to the viev rather than the table directly.
-    fenix_derived.firefox_android_clients_v2
+    fenix.firefox_android_clients
   WHERE
     -- 28 days need to elapse before calculating the week 4 and day 28 retention metrics
     first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)


### PR DESCRIPTION
# feat(): updated fenix_derived.funnel_retention_clients_* to use clients view instead of table directly

This can be merged once PR: https://github.com/mozilla/bigquery-etl/pull/4562 has been merged.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1976)
