### PR TITLE
Generate normal task dependencies from `depends_on` if the task is in the same DAG

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -238,7 +238,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
 {% set fivetran_seen = [] -%}
 {% for task in tasks | sort(attribute='task_name') %}
     {% for dependency in (task.upstream_dependencies + task.depends_on) | sort(attribute='task_id') -%}
-    {% if dependency.dag_name == name and dependency not in task.depends_on -%}
+    {% if dependency.dag_name == name and dependency.get_execution_delta(schedule_interval) in [none, '0h', '0m', '0s'] -%}
     {% if dependency.task_id != task.task_name %}
     {{ task.task_name }}.set_upstream({{ dependency.task_id }})
     {% endif -%}

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/metadata.yaml
@@ -12,7 +12,7 @@ scheduling:
   - - 'moz-fx-data-shared-prod'
     - 'monitoring_derived'
     - 'job_by_organization_v1'
-  upstream_dependencies:
+  depends_on:
   - task_id: monitoring_derived__jobs_by_organization__v1
     dag_name: bqetl_monitoring
   arguments: ["--date", "{{ ds }}"]


### PR DESCRIPTION
For manual task dependencies specified in `metadata.yaml` files via `depends_on`, if the referenced task is in the same DAG with no execution delta then we should generate a normal intra-DAG task dependency, not an external task sensor.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-1982)
