### PR TITLE
Bug 1865716 - Include errorGroups in legacy docker_fxa_admin_server_sanitized query

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts/docker_fxa_admin_server_sanitized/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/docker_fxa_admin_server_sanitized/view.sql
@@ -38,7 +38,8 @@ SELECT
         jsonPayload.fields.search_type
       ) AS fields
     ) AS jsonPayload
-  )
+  ),
+  NULL AS errorGroups
 FROM
   `moz-fx-data-shared-prod.firefox_accounts_derived.docker_fxa_admin_server_sanitized_v1`
 UNION ALL

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/docker_fxa_admin_server_sanitized/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/docker_fxa_admin_server_sanitized/view.sql
@@ -39,7 +39,7 @@ SELECT
       ) AS fields
     ) AS jsonPayload
   ),
-  NULL AS errorGroups
+  CAST(NULL AS ARRAY<STRUCT<id STRING>>) AS errorGroups
 FROM
   `moz-fx-data-shared-prod.firefox_accounts_derived.docker_fxa_admin_server_sanitized_v1`
 UNION ALL

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v2/schema.yaml
@@ -485,3 +485,10 @@ fields:
   - name: totalSplits
     type: INTEGER
     mode: NULLABLE
+- name: errorGroups
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: id
+    type: STRING
+    mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v2/schema.yaml
@@ -487,7 +487,7 @@ fields:
     mode: NULLABLE
 - name: errorGroups
   type: RECORD
-  mode: NULLABLE
+  mode: REPEATED
   fields:
   - name: id
     type: STRING


### PR DESCRIPTION
`errorGroups` field was added in `docker_fxa_admin_server_sanitized_v2` and breaks the UNION.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2005)
