### PR TITLE
Account for NULL handling in joins

### DIFF
--- a/sql/moz-fx-data-shared-prod/stub_attribution_service/dl_token_ga_attribution_lookup/view.sql
+++ b/sql/moz-fx-data-shared-prod/stub_attribution_service/dl_token_ga_attribution_lookup/view.sql
@@ -2,6 +2,10 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.stub_attribution_service.dl_token_ga_attribution_lookup`
 AS
 SELECT
-  *
+  * REPLACE (
+    mozfun.ga.nullify_string(dl_token) AS dl_token,
+    mozfun.ga.nullify_string(ga_client_id) AS ga_client_id,
+    mozfun.ga.nullify_string(stub_session_id) AS stub_session_id
+  )
 FROM
   `moz-fx-data-shared-prod.stub_attribution_service_derived.dl_token_ga_attribution_lookup_v1`

--- a/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dl_token_ga_attribution_lookup_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dl_token_ga_attribution_lookup_v1/query.sql
@@ -1,17 +1,17 @@
 WITH historical_triplets AS (
   SELECT
-    dl_token,
-    ga_client_id,
-    stub_session_id,
+    IFNULL(dl_token, "") AS dl_token,
+    IFNULL(ga_client_id, "") AS ga_client_id,
+    IFNULL(stub_session_id, "") AS stub_session_id,
     first_seen_date,
   FROM
     stub_attribution_service_derived.dl_token_ga_attribution_lookup_v1
 ),
 new_downloads AS (
   SELECT DISTINCT
-    mozfun.ga.nullify_string(jsonPayload.fields.dltoken) AS dl_token,
-    mozfun.ga.nullify_string(jsonPayload.fields.visit_id) AS ga_client_id,
-    mozfun.ga.nullify_string(jsonPayload.fields.session_id) AS stub_session_id,
+    IFNULL(mozfun.ga.nullify_string(jsonPayload.fields.dltoken), "") AS dl_token,
+    IFNULL(mozfun.ga.nullify_string(jsonPayload.fields.visit_id), "") AS ga_client_id,
+    IFNULL(mozfun.ga.nullify_string(jsonPayload.fields.session_id), "") AS stub_session_id,
     @download_date AS first_seen_date,
   FROM
     `moz-fx-stubattribut-prod-32a5`.stubattribution_prod.stdout
@@ -19,6 +19,8 @@ new_downloads AS (
     DATE(timestamp) = @download_date
 )
 SELECT
+  -- We can't store these as NULL, since joins on NULL keys don't match.
+  -- Since they don't match, we end up with dupes
   dl_token,
   ga_client_id,
   stub_session_id,

--- a/tests/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dl_token_ga_attribution_lookup_v1/test_single_day/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dl_token_ga_attribution_lookup_v1/test_single_day/expect.yaml
@@ -10,3 +10,11 @@
   ga_client_id: only_present_historically
   stub_session_id: stub_session_id_3
   first_seen_date: 2023-01-01
+- dl_token: testNullJoins
+  ga_client_id: ""
+  stub_session_id: ""
+  first_seen_date: 2023-01-01
+- dl_token: testEmptyStringWithNullJoins
+  ga_client_id: ""
+  stub_session_id: ""
+  first_seen_date: 2023-01-01

--- a/tests/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dl_token_ga_attribution_lookup_v1/test_single_day/moz-fx-stubattribut-prod-32a5.stubattribution_prod.stdout.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dl_token_ga_attribution_lookup_v1/test_single_day/moz-fx-stubattribut-prod-32a5.stubattribution_prod.stdout.yaml
@@ -19,3 +19,17 @@
       session_id: stub_session_id_2
       log_type: download_started
   timestamp: '2023-03-31 01:16:43.101135 UTC'
+- jsonPayload:
+    fields:
+      visit_id: NULL
+      dltoken: testNullJoins
+      session_id: NULL
+      log_type: download_started
+  timestamp: '2023-03-31 01:16:43.101135 UTC'
+- jsonPayload:
+    fields:
+      visit_id: NULL
+      dltoken: testEmptyStringWithNullJoins
+      session_id: NULL
+      log_type: download_started
+  timestamp: '2023-03-31 01:16:43.101135 UTC'

--- a/tests/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dl_token_ga_attribution_lookup_v1/test_single_day/stub_attribution_service_derived.dl_token_ga_attribution_lookup_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dl_token_ga_attribution_lookup_v1/test_single_day/stub_attribution_service_derived.dl_token_ga_attribution_lookup_v1.yaml
@@ -6,3 +6,11 @@
   ga_client_id: also_present_today
   stub_session_id: stub_session_id_2
   first_seen_date: 2023-01-01
+- dl_token: testNullJoins
+  ga_client_id: NULL
+  stub_session_id: NULL
+  first_seen_date: 2023-01-01
+- dl_token: testEmptyStringWithNullJoins
+  ga_client_id: ""
+  stub_session_id: ""
+  first_seen_date: 2023-01-01


### PR DESCRIPTION
Previously, NULL values in the join keys didn't join, resulting in duplicate rows. This change will coalesce those to empty strings and NULLIFY them in the view.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2006)
