### PR TITLE
DS-3361. Update documentation of initialize command.

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1281,13 +1281,18 @@ def _initialize_in_parallel(
 
 
 @query.command(
-    help="""Create and initialize the destination table for the query.
-    Only for queries that have an `init.sql` file.
+    help="""Run a full backfill on the destination table for the query.
+       Using this command will:
+        - Create the table if it doesn't exist and run a full backfill.
+        - Run a full backfill if the table exists and is empty.
+        - Raise an exception if the table exists and has data, or if the table exists and the schema doesn't match the query.
+       It supports `query.sql` files that use the is_init() pattern, and `init.sql` files.
+       To run in parallel per sample_id, include a @sample_id parameter in the query.
 
-    Examples:
-
-    ./bqetl query initialize telemetry_derived.ssl_ratios_v1
-    """,
+       Examples:
+       - For init.sql files: ./bqetl query initialize telemetry_derived.ssl_ratios_v1
+       - For query.sql files and parallel run: ./bqetl query initialize sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/query.sql
+       """,
 )
 @click.argument("name")
 @sql_dir_option


### PR DESCRIPTION
[DS-3361](https://mozilla-hub.atlassian.net/browse/DS-3361)
Documentation after changes to the `bqetl query initialize` command.

The [documentation for this command](https://mozilla.github.io/bigquery-etl/bqetl/#initialize) is updated with the docs generation.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2011)


[DS-3361]: https://mozilla-hub.atlassian.net/browse/DS-3361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ