### PR TITLE
Link to full diff in git comments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -608,6 +608,9 @@ jobs:
           root: /tmp/workspace
           paths:
             - generated-sql
+      - store_artifacts:
+          path: /tmp/workspace/generated-sql/sql.diff
+          destination: sql.diff
   post-diff:
     docker:
       - image: circleci/node:8.10.0
@@ -617,9 +620,6 @@ jobs:
           at: /tmp/workspace
       - run: npm i circle-github-bot
       - run: .circleci/post-diff.js
-      - store_artifacts:
-          path: /tmp/integration
-          destination: /app/integration
   reset-stage-env:
     docker: *docker
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,10 +598,10 @@ jobs:
       - run:
           name: Generate diff
           command: |
-            diff -bur --no-dereference \
+            diff -bur --no-dereference --new-file \
               /tmp/workspace/main-generated-sql/dags/ /tmp/workspace/generated-sql/dags/ \
               > /tmp/workspace/generated-sql/sql.diff || true
-            diff -bur --no-dereference \
+            diff -bur --no-dereference --new-file \
               /tmp/workspace/main-generated-sql/sql/ /tmp/workspace/generated-sql/sql/ \
               >> /tmp/workspace/generated-sql/sql.diff || true
       - persist_to_workspace:

--- a/.circleci/post-diff.js
+++ b/.circleci/post-diff.js
@@ -42,4 +42,6 @@ ${warnings}
 bot.comment(process.env.GH_AUTH_TOKEN, `
 ### Integration report for "${bot.env.commitMessage}"
 ${diff()}
+
+[Link to full diff](https://output.circle-artifacts.com/output/job/${process.env.CIRCLE_WORKFLOW_JOB_ID}/artifacts/${process.env.CIRCLE_NODE_INDEX}/sql.diff)
 `);


### PR DESCRIPTION
This adds a link to PR diff comment to link to the full diff that is now stored as a CircleCI artifact

This also addresses https://github.com/mozilla/bigquery-etl/issues/4573 by adding the `--new-file` option

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2012)
