### PR TITLE
Correct DAG description as DAG is currently active.

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1167,11 +1167,6 @@ bqetl_kpis_shredder:
     retry_delay: 30m
     start_date: '2023-05-16'
   description: |
-    Currently paused due to a bug causing the DAG upstream dependencies completion
-    not being detected correctly.
-    for more info, see:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1852517
-      - https://github.com/mozilla/bigquery-etl/pull/4239
     This DAG calculates KPIs for shredder client_ids
   repo: bigquery-etl
   schedule_interval: 0 2 */28 * *


### PR DESCRIPTION
This DAG is [active and running since Oct, 2023](https://workflow.telemetry.mozilla.org/dags/bqetl_kpis_shredder/grid?search=bqetl_kpis_shredder). 
