### PR TITLE
Handle Fivetran changing Stripe columns to JSON data type (DENG-1818)

### DIFF
--- a/sql/moz-fx-data-shared-prod/stripe_external/charge_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/charge_v1/schema.yaml
@@ -82,7 +82,7 @@ fields:
   type: STRING
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: on_behalf_of
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/coupon_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/coupon_v1/schema.yaml
@@ -28,7 +28,7 @@ fields:
   type: INTEGER
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: name
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/customer_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/customer_v1/schema.yaml
@@ -25,7 +25,7 @@ fields:
   type: STRING
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: shipping_carrier
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/customers_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/customers_changelog_v1/query.sql
@@ -41,7 +41,7 @@ customer_latest_discounts AS (
           coupons.currency,
           coupons.duration,
           coupons.duration_in_months,
-          metadata,
+          coupons.metadata,
           coupons.name,
           coupons.percent_off,
           coupons.redeem_by

--- a/sql/moz-fx-data-shared-prod/stripe_external/customers_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/customers_changelog_v1/query.sql
@@ -9,7 +9,7 @@ WITH customers AS (
     created,
     default_card_id,
     is_deleted,
-    PARSE_JSON(metadata) AS metadata,
+    metadata,
     shipping_address_country,
     shipping_address_postal_code,
     shipping_address_state,
@@ -41,7 +41,7 @@ customer_latest_discounts AS (
           coupons.currency,
           coupons.duration,
           coupons.duration_in_months,
-          PARSE_JSON(coupons.metadata) AS metadata,
+          metadata,
           coupons.name,
           coupons.percent_off,
           coupons.redeem_by

--- a/sql/moz-fx-data-shared-prod/stripe_external/invoice_line_item_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/invoice_line_item_v1/schema.yaml
@@ -24,7 +24,7 @@ fields:
   type: STRING
   mode: NULLABLE
 - name: metadata
-  type: STRING
+  type: JSON
   mode: NULLABLE
 - name: period_end
   type: TIMESTAMP

--- a/sql/moz-fx-data-shared-prod/stripe_external/invoice_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/invoice_v1/schema.yaml
@@ -70,7 +70,7 @@ fields:
   type: BOOLEAN
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: next_payment_attempt
   type: TIMESTAMP

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_charge_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_charge_v1/schema.yaml
@@ -91,7 +91,7 @@ fields:
   type: STRING
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: on_behalf_of
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_coupon_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_coupon_v1/schema.yaml
@@ -28,7 +28,7 @@ fields:
   type: INTEGER
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: name
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_customer_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_customer_v1/schema.yaml
@@ -25,7 +25,7 @@ fields:
   type: STRING
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: shipping_carrier
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_invoice_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_invoice_v1/schema.yaml
@@ -73,7 +73,7 @@ fields:
   type: BOOLEAN
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: next_payment_attempt
   type: TIMESTAMP

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_plan_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_plan_v1/schema.yaml
@@ -34,7 +34,7 @@ fields:
   type: BOOLEAN
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: nickname
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_product_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_product_v1/schema.yaml
@@ -22,7 +22,7 @@ fields:
   type: BOOLEAN
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: name
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_promotion_code_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_promotion_code_v1/schema.yaml
@@ -31,7 +31,7 @@ fields:
   type: INTEGER
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: minimum_amount
   type: INTEGER

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_refund_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_refund_v1/schema.yaml
@@ -34,7 +34,7 @@ fields:
   type: STRING
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: payment_intent_id
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_subscription_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_subscription_history_v1/schema.yaml
@@ -67,7 +67,7 @@ fields:
   type: STRING
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: pause_collection_behavior
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_subscription_item_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_subscription_item_v1/schema.yaml
@@ -19,7 +19,7 @@ fields:
   type: TIMESTAMP
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: plan_id
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/plan_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/plan_v1/schema.yaml
@@ -34,7 +34,7 @@ fields:
   type: BOOLEAN
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: nickname
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/product_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/product_v1/schema.yaml
@@ -22,7 +22,7 @@ fields:
   type: BOOLEAN
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: name
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/promotion_code_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/promotion_code_v1/schema.yaml
@@ -31,7 +31,7 @@ fields:
   type: INTEGER
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: minimum_amount
   type: INTEGER

--- a/sql/moz-fx-data-shared-prod/stripe_external/refund_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/refund_v1/schema.yaml
@@ -34,7 +34,7 @@ fields:
   type: STRING
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: payment_intent_id
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/subscription_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/subscription_history_v1/schema.yaml
@@ -67,7 +67,7 @@ fields:
   type: STRING
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: pause_collection_behavior
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/subscription_item_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/subscription_item_v1/schema.yaml
@@ -19,7 +19,7 @@ fields:
   type: TIMESTAMP
 - mode: NULLABLE
   name: metadata
-  type: STRING
+  type: JSON
 - mode: NULLABLE
   name: plan_id
   type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/query.sql
@@ -21,7 +21,7 @@ WITH subscriptions_history AS (
     default_source_id,
     ended_at,
     latest_invoice_id,
-    PARSE_JSON(metadata) AS metadata,
+    metadata,
     pending_setup_intent_id,
     start_date,
     status,
@@ -40,7 +40,7 @@ subscription_items AS (
   SELECT
     id,
     created,
-    PARSE_JSON(metadata) AS metadata,
+    metadata,
     plan_id,
     quantity,
     subscription_id,
@@ -56,7 +56,7 @@ products AS (
     id,
     created,
     description,
-    PARSE_JSON(metadata) AS metadata,
+    metadata,
     name,
     statement_descriptor,
     updated,
@@ -73,7 +73,7 @@ plans AS (
     currency,
     `interval`,
     interval_count,
-    PARSE_JSON(metadata) AS metadata,
+    metadata,
     nickname,
     product_id,
     tiers_mode,
@@ -142,7 +142,7 @@ subscriptions_history_tax_rates AS (
         tax_rates.display_name,
         tax_rates.inclusive,
         tax_rates.jurisdiction,
-        PARSE_JSON(tax_rates.metadata) AS metadata,
+        metadata,
         tax_rates.percentage
       )
       ORDER BY
@@ -175,7 +175,7 @@ subscriptions_history_latest_discounts AS (
           coupons.currency,
           coupons.duration,
           coupons.duration_in_months,
-          PARSE_JSON(coupons.metadata) AS metadata,
+          metadata,
           coupons.name,
           coupons.percent_off,
           coupons.redeem_by

--- a/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/query.sql
@@ -142,7 +142,7 @@ subscriptions_history_tax_rates AS (
         tax_rates.display_name,
         tax_rates.inclusive,
         tax_rates.jurisdiction,
-        metadata,
+        tax_rates.metadata,
         tax_rates.percentage
       )
       ORDER BY
@@ -175,7 +175,7 @@ subscriptions_history_latest_discounts AS (
           coupons.currency,
           coupons.duration,
           coupons.duration_in_months,
-          metadata,
+          coupons.metadata,
           coupons.name,
           coupons.percent_off,
           coupons.redeem_by

--- a/sql/moz-fx-data-shared-prod/stripe_external/tax_rate_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/tax_rate_v1/schema.yaml
@@ -24,7 +24,7 @@ fields:
   type: STRING
   mode: NULLABLE
 - name: metadata
-  type: STRING
+  type: JSON
   mode: NULLABLE
 - name: percentage
   type: FLOAT

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_history_v1/query.sql
@@ -145,7 +145,7 @@ product_capabilities AS (
   FROM
     `moz-fx-data-shared-prod`.stripe_external.nonprod_product_v1 AS products
   JOIN
-    UNNEST(mozfun.json.js_extract_string_map(metadata)) AS metadata_items
+    UNNEST(mozfun.json.js_extract_string_map(TO_JSON_STRING(metadata))) AS metadata_items
   ON
     metadata_items.key LIKE 'capabilities%'
   JOIN
@@ -162,7 +162,7 @@ plan_capabilities AS (
   FROM
     `moz-fx-data-shared-prod`.stripe_external.nonprod_plan_v1 AS plans
   JOIN
-    UNNEST(mozfun.json.js_extract_string_map(metadata)) AS metadata_items
+    UNNEST(mozfun.json.js_extract_string_map(TO_JSON_STRING(metadata))) AS metadata_items
   ON
     metadata_items.key LIKE 'capabilities%'
   JOIN

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_plans_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_plans_v1/query.sql
@@ -10,7 +10,7 @@ SELECT
   currency,
   `interval`,
   interval_count,
-  PARSE_JSON(metadata) AS metadata,
+  metadata,
   nickname,
   tiers_mode,
   trial_period_days,

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_products_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_products_v1/query.sql
@@ -5,7 +5,7 @@ SELECT
   is_deleted,
   active,
   description,
-  PARSE_JSON(metadata) AS metadata,
+  metadata,
   name,
   statement_descriptor,
 FROM

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v1/query.sql
@@ -145,7 +145,7 @@ product_capabilities AS (
   FROM
     `moz-fx-data-shared-prod`.stripe_external.product_v1 AS products
   JOIN
-    UNNEST(mozfun.json.js_extract_string_map(metadata)) AS metadata_items
+    UNNEST(mozfun.json.js_extract_string_map(TO_JSON_STRING(metadata))) AS metadata_items
   ON
     metadata_items.key LIKE 'capabilities%'
   JOIN
@@ -162,7 +162,7 @@ plan_capabilities AS (
   FROM
     `moz-fx-data-shared-prod`.stripe_external.plan_v1 AS plans
   JOIN
-    UNNEST(mozfun.json.js_extract_string_map(metadata)) AS metadata_items
+    UNNEST(mozfun.json.js_extract_string_map(TO_JSON_STRING(metadata))) AS metadata_items
   ON
     metadata_items.key LIKE 'capabilities%'
   JOIN


### PR DESCRIPTION
## [DENG-1818](https://mozilla-hub.atlassian.net/browse/DENG-1818): Handle Fivetran changing Stripe columns to JSON data type

Fivetran is planning to change some Stripe columns to [BigQuery’s JSON data type](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#json_type) sometime between Nov 16-30.

This PR should not be merged until Fivetran actually changes the Stripe column types.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DENG-1818]: https://mozilla-hub.atlassian.net/browse/DENG-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ