### PR TITLE
Increase no_output_timeout for long-running CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,8 @@ jobs:
           # yamllint disable rule:line-length
           command: |
             PATH="venv/bin:$PATH" script/entrypoint -m 'integration' -n 8
+          # workaround for job failing with `Too long with no output (exceeded 10m0s): context deadline exceeded` error
+          no_output_timeout: 30m
   generate-dags:
     docker: *docker
     steps:
@@ -368,6 +370,8 @@ jobs:
               --dataset-suffix=$CIRCLE_SHA1 \
               --remove-updated-artifacts \
               $PATHS
+          # workaround for job failing with `Too long with no output (exceeded 10m0s): context deadline exceeded` error
+          no_output_timeout: 30m
       - run:
           name: Copy generated SQL to temporary stage directory
           command: |


### PR DESCRIPTION
This is a workaround for CI jobs timing out with `Too long with no output (exceeded 10m0s): context deadline exceeded` error.

Integration tests seem to especially prone to this failure because they are executed in parallel with pytest-xdist which captures test output during the run.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2023)
