### PR TITLE
GROWTH-101 - Update gclid_conversions view to 1-row per conversion

### DIFF
--- a/bigquery_etl/dependency.py
+++ b/bigquery_etl/dependency.py
@@ -25,9 +25,8 @@ def _raw_table_name(table: sqlglot.exp.Table) -> str:
         .split(" AS ", 1)[0]
         # remove quotes
         .replace("`", "")
-        # remove PIVOT/UNPIVOT
-        # .replace("UNPIVOT
     )
+    # remove PIVOT/UNPIVOT
     removed_pivots = re.sub(" (?:UN)?PIVOT.*$", "", with_replacements)
 
     return removed_pivots

--- a/bigquery_etl/dependency.py
+++ b/bigquery_etl/dependency.py
@@ -19,13 +19,18 @@ stable_views = None
 
 
 def _raw_table_name(table: sqlglot.exp.Table) -> str:
-    return (
+    with_replacements = (
         table.sql("bigquery", comments=False)
         # remove alias
         .split(" AS ", 1)[0]
         # remove quotes
         .replace("`", "")
+        # remove PIVOT/UNPIVOT
+        # .replace("UNPIVOT
     )
+    removed_pivots = re.sub(" (?:UN)?PIVOT.*$", "", with_replacements)
+
+    return removed_pivots
 
 
 def extract_table_references(sql: str) -> List[str]:

--- a/sql/moz-fx-data-shared-prod/mozilla_org/gclid_conversions/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/gclid_conversions/view.sql
@@ -19,7 +19,7 @@ SELECT
     ELSE NULL
   END AS conversion_name,
 FROM
-  mozilla_org_derived.gclid_conversions_v1 UNPIVOT(
+  `moz-fx-data-shared-prod`.mozilla_org_derived.gclid_conversions_v1 UNPIVOT(
     did_conversion FOR conversion_name IN (
       did_firefox_first_run,
       did_search,

--- a/sql/moz-fx-data-shared-prod/mozilla_org/gclid_conversions/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/gclid_conversions/view.sql
@@ -2,6 +2,30 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.mozilla_org.gclid_conversions`
 AS
 SELECT
-  *
+  FORMAT_DATETIME("%F %T", DATETIME(activity_date, TIME(23, 59, 59))) AS activity_date,
+  gclid,
+  -- Names as represented in Google Ads
+  -- https://docs.google.com/spreadsheets/d/1YzhhvbpOlqPLORRJUZ55BIb0H20hwFqQFApR-r0UMfI
+  CASE
+    conversion_name
+    WHEN "did_firefox_first_run"
+      THEN "firefox_first_run"
+    WHEN "did_search"
+      THEN "firefox_first_search"
+    WHEN "did_click_ad"
+      THEN "firefox_first_ad_click"
+    WHEN "did_returned_second_day"
+      THEN "firefox_second_run"
+    ELSE NULL
+  END AS conversion_name,
 FROM
-  `moz-fx-data-shared-prod.mozilla_org_derived.gclid_conversions_v1`
+  mozilla_org_derived.gclid_conversions_v1 UNPIVOT(
+    did_conversion FOR conversion_name IN (
+      did_firefox_first_run,
+      did_search,
+      did_click_ad,
+      did_returned_second_day
+    )
+  )
+WHERE
+  did_conversion

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -1,0 +1,26 @@
+from bigquery_etl.dependency import extract_table_references
+
+
+class TestDependency:
+    def test_extract_table_refs_correctly_ignores_unpivot(self):
+        unpivot_query = "SELECT * FROM a UNPIVOT(b FOR c IN (d, e, f))"
+        refs = extract_table_references(unpivot_query)
+
+        assert refs == ["a"]
+
+    def test_extract_table_refs_correctly_ignores_pivot(self):
+        pivot_query = """SELECT * FROM Produce
+          PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2', 'Q3', 'Q4'))
+        """
+        refs = extract_table_references(pivot_query)
+
+        assert refs == ["Produce"]
+
+    def test_extract_table_refs_pivot_and_join(self):
+        pivot_query = """SELECT * FROM Produce
+          PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2', 'Q3', 'Q4'))
+          JOIN Perishable_Mints USING (name)
+        """
+        refs = extract_table_references(pivot_query)
+
+        assert set(refs) == {"Produce", "Perishable_Mints"}


### PR DESCRIPTION
Census, the reverse ETL tool, requires a 1:1 mapping from source to destination. Because we're sending conversion events, we need 1 row per-conversion event.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [x] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [x] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2075)
