### PR TITLE
Don't nest SQL generated from `main` branch in extra `sql` directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -586,7 +586,7 @@ jobs:
             ./script/bqetl metadata update \
               sql/
 
-            mkdir -p /tmp/workspace/main-generated-sql/sql
+            mkdir -p /tmp/workspace/main-generated-sql
             cp -r sql/ /tmp/workspace/main-generated-sql/sql
             mkdir -p /tmp/workspace/main-generated-sql/dags
             ./script/bqetl dag generate --output-dir /tmp/workspace/main-generated-sql/dags


### PR DESCRIPTION
This has been breaking the SQL diff CI since this problem was introduced by #4512, due to the contents of `/tmp/workspace/generated-sql/` and `/tmp/workspace/main-generated-sql/sql/` not being consistent:
```
Only in /tmp/workspace/generated-sql/sql/: glam-fenix-dev
Only in /tmp/workspace/generated-sql/sql/: moz-fx-cjms-nonprod-9a36
Only in /tmp/workspace/generated-sql/sql/: moz-fx-cjms-prod-f3c7
Only in /tmp/workspace/generated-sql/sql/: moz-fx-data-bq-performance
Only in /tmp/workspace/generated-sql/sql/: moz-fx-data-experiments
Only in /tmp/workspace/generated-sql/sql/: moz-fx-data-marketing-prod
Only in /tmp/workspace/generated-sql/sql/: moz-fx-data-shared-prod
Only in /tmp/workspace/generated-sql/sql/: mozfun
Only in /tmp/workspace/main-generated-sql/sql/: sql
```

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
