### PR TITLE
Support offset backfills, require metadata 

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -507,8 +507,9 @@ def _backfill_query(
     run_checks,
 ):
     """Run a query backfill for a specific date."""
-    if backfill_date in exclude:
-        click.echo(f"Skip {query_file_path} backfill for run date {backfill_date}")
+    backfill_date_str = backfill_date.strftime("%Y-%m-%d")
+    if backfill_date_str in exclude:
+        click.echo(f"Skip {query_file_path} backfill for run date {backfill_date_str}")
         return True
 
     project, dataset, table = extract_from_query_path(query_file_path)
@@ -520,12 +521,10 @@ def _backfill_query(
         case PartitionType.MONTH:
             if date_partition_parameter != 0:
                 # TODO: Support offsets here e.g. desktop_mobile_search_clients_monthly_v1
-                raise ValueError("TODO: Can't set offset for month partitions.")
+                raise ValueError("Unsupported offset for month partitions.")
             partition = backfill_date.strftime("%Y%m")
         case _:
             raise ValueError(f"Unsupported partitioning type: {partitioning_type}")
-
-    backfill_date_str = backfill_date.strftime("%Y-%m-%d")
 
     if destination_table is None:
         destination_table = f"{project}.{dataset}.{table}"
@@ -764,7 +763,7 @@ def backfill(
             case _:
                 raise ValueError(f"Unsupported partitioning type: {partitioning_type}")
 
-        if depends_on_past and exclude != []:
+        if depends_on_past and exclude:
             click.echo(
                 f"Warning: depends_on_past = True for {query_file_path} but the"
                 f"following dates will be excluded from the backfill: {exclude}"

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -509,7 +509,7 @@ def _backfill_query(
     """Run a query backfill for a specific date."""
     backfill_date_str = backfill_date.strftime("%Y-%m-%d")
     if backfill_date_str in exclude:
-        click.echo(f"Skip {query_file_path} backfill for run date {backfill_date_str}")
+        click.echo(f"Skipping {query_file_path} backfill for run date {backfill_date_str}")
         return True
 
     project, dataset, table = extract_from_query_path(query_file_path)
@@ -519,9 +519,9 @@ def _backfill_query(
             partition_date = backfill_date + timedelta(days=date_partition_offset)
             partition = partition_date.strftime("%Y%m%d")
         case PartitionType.MONTH:
-            if date_partition_parameter != 0:
+            if date_partition_offset != 0:
                 # TODO: Support offsets here e.g. desktop_mobile_search_clients_monthly_v1
-                raise ValueError("Unsupported offset for month partitions.")
+                raise ValueError("Offsets are unsupported for non-daily partitions (found date_partition_offset={date_partition_offset}).")
             partition = backfill_date.strftime("%Y%m")
         case _:
             raise ValueError(f"Unsupported partitioning type: {partitioning_type}")

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -792,7 +792,7 @@ def backfill(
             run_checks=checks,
         )
 
-        if not depends_on_past:
+        if not depends_on_past and parallelism > 0:
             # run backfill for dates in parallel if depends_on_past is false
             with Pool(parallelism) as p:
                 result = p.map(backfill_query, dates, chunksize=1)

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -509,7 +509,9 @@ def _backfill_query(
     """Run a query backfill for a specific date."""
     backfill_date_str = backfill_date.strftime("%Y-%m-%d")
     if backfill_date_str in exclude:
-        click.echo(f"Skipping {query_file_path} backfill for run date {backfill_date_str}")
+        click.echo(
+            f"Skipping {query_file_path} backfill for run date {backfill_date_str}"
+        )
         return True
 
     project, dataset, table = extract_from_query_path(query_file_path)
@@ -521,7 +523,9 @@ def _backfill_query(
         case PartitionType.MONTH:
             if date_partition_offset != 0:
                 # TODO: Support offsets here e.g. desktop_mobile_search_clients_monthly_v1
-                raise ValueError("Offsets are unsupported for non-daily partitions (found date_partition_offset={date_partition_offset}).")
+                raise ValueError(
+                    "Offsets are unsupported for non-daily partitions (found date_partition_offset={date_partition_offset})."
+                )
             partition = backfill_date.strftime("%Y%m")
         case _:
             raise ValueError(f"Unsupported partitioning type: {partitioning_type}")


### PR DESCRIPTION
Add support for `dataset_partition_offset` for `bqetl query backfill`. Also require a `metadata.yaml` file for backfilling a table

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2098)
