### PR TITLE
feat(DENG-2083): added firefox_ios_derived.clients_activation_v1 and corresponding view

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -161,7 +161,9 @@ DELETE_TARGETS: DeleteIndex = {
     client_id_target(table="fenix_derived.new_profile_activation_v1"): FENIX_SRC,
     client_id_target(table="fenix_derived.firefox_android_clients_v1"): FENIX_SRC,
     client_id_target(table="search_derived.acer_cohort_v1"): DESKTOP_SRC,
-    client_id_target(table="firefox_ios_derived.clients_activation_v1"): FIREFOX_IOS_SRC,
+    client_id_target(
+        table="firefox_ios_derived.clients_activation_v1"
+    ): FIREFOX_IOS_SRC,
     client_id_target(
         table="search_derived.mobile_search_clients_daily_v1"
     ): DESKTOP_SRC,

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -161,6 +161,7 @@ DELETE_TARGETS: DeleteIndex = {
     client_id_target(table="fenix_derived.new_profile_activation_v1"): FENIX_SRC,
     client_id_target(table="fenix_derived.firefox_android_clients_v1"): FENIX_SRC,
     client_id_target(table="search_derived.acer_cohort_v1"): DESKTOP_SRC,
+    client_id_target(table="firefox_ios_derived.clients_activation_v1"): FIREFOX_IOS_SRC,
     client_id_target(
         table="search_derived.mobile_search_clients_daily_v1"
     ): DESKTOP_SRC,

--- a/sql/moz-fx-data-shared-prod/firefox_ios/clients_activation/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/clients_activation/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_ios.clients_activation`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_ios_derived.clients_activation_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
@@ -7,7 +7,6 @@ WITH upstream_clients_count AS (
   SELECT COUNT(*)
   FROM `{{ project_id }}.firefox_ios.firefox_ios_clients`
   WHERE first_seen_date = DATE_SUB(@submission_date, INTERVAL 6 DAY)
-  AND NOT is_suspicious_device_client
 ),
 activations_clients_count AS (
   SELECT COUNT(*)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
@@ -19,7 +19,7 @@ SELECT
     (SELECT * FROM upstream_clients_count) <> (SELECT * FROM activations_clients_count),
     ERROR("Number of client records should match for the same first_seen_date."),
     NULL
-  )
+  );
 #fail
 SELECT
   IF(

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
@@ -1,0 +1,31 @@
+#fail
+{{ is_unique(["client_id"]) }}
+#fail
+{{ min_row_count(1, "`submission_date` = @submission_date") }}
+#fail
+WITH upstream_clients_count AS (
+  SELECT COUNT(*)
+  FROM `{{ project_id }}.firefox_ios.firefox_ios_clients`
+  WHERE first_seen_date = DATE_SUB(@submission_date, INTERVAL 6 DAY)
+  AND NOT is_suspicious_device_client
+),
+activations_clients_count AS (
+  SELECT COUNT(*)
+  FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+  WHERE submission_date = @submission_date
+)
+SELECT
+  IF(
+    (SELECT * FROM upstream_clients_count) <> (SELECT * FROM activations_clients_count),
+    ERROR("Number of client records should match for the same first_seen_date."),
+    NULL
+  )
+#fail
+SELECT
+  IF(
+    DATE_DIFF(submission_date, first_seen_date, DAY) <> 6,
+    ERROR("Day difference between values inside first_seen_date and submission_date fields should be 6."),
+    NULL
+  )
+FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+WHERE `submission_date` = @submission_date;

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/metadata.yaml
@@ -1,0 +1,26 @@
+friendly_name: Clients Activation (Firefox iOS)
+description: |-
+  Mobile activation metric used for Marketing campaign performance.
+  A records per client indicating whether they became activated.
+
+  Activated means, a week has elapsed since the client was first seen
+  and within days 2 and 7 they had at least one instance of activity along
+  along with at least 1 search count.
+owners:
+- vsabino@mozilla.com
+- kik@mozilla.com
+labels:
+  incremental: true
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  clustering:
+    fields:
+    - sample_id
+scheduling:
+  dag_name: bqetl_firefox_ios
+  date_partition_parameter: submission_date
+  depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/query.sql
@@ -53,7 +53,7 @@ SELECT
   first_seen_date,
   client_id,
   sample_id,
-  IF(days_2_7 > 1 AND COALESCE(search_count, 0) > 0, TRUE, FALSE) AS is_activated,
+  (days_2_7 > 1 AND COALESCE(search_count, 0) > 0) AS is_activated,
 FROM
   new_clients
 LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/query.sql
@@ -14,7 +14,6 @@ WITH new_clients AS (
   FROM firefox_ios.firefox_ios_clients
   WHERE
     first_seen_date = DATE_SUB(@submission_date, INTERVAL 6 DAY)
-    AND NOT is_suspicious_device_client
 ),
 new_clients_activity AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/query.sql
@@ -11,7 +11,8 @@ WITH new_clients AS (
     first_seen_date,
     sample_id,
     channel,
-  FROM firefox_ios.firefox_ios_clients
+  FROM
+    firefox_ios.firefox_ios_clients
   WHERE
     first_seen_date = DATE_SUB(@submission_date, INTERVAL 6 DAY)
 ),
@@ -43,7 +44,9 @@ clients_search AS (
     AND os = 'iOS'
     AND normalized_app_name = 'Fennec'
   GROUP BY
-    client_id, sample_id, channel
+    client_id,
+    sample_id,
+    channel
 )
 SELECT
   @submission_date AS submission_date,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/query.sql
@@ -1,0 +1,64 @@
+-- This table implements the Mobile activation metric defined in June 2022
+-- Based on data from the first seven days since profile creation, we select
+-- clients with at least three days of use (first open plus two) and who
+-- perform a search on the later half of the week. As such, this table will
+-- always lag new profiles by seven days and the CTEs are filtered for
+-- corresponding periods.
+-- Each entry in this table corresponds to a new_profile
+WITH new_clients AS (
+  SELECT
+    client_id,
+    first_seen_date,
+    sample_id,
+    channel,
+  FROM firefox_ios.firefox_ios_clients
+  WHERE
+    first_seen_date = DATE_SUB(@submission_date, INTERVAL 6 DAY)
+    AND NOT is_suspicious_device_client
+),
+new_clients_activity AS (
+  SELECT
+    client_id,
+    first_seen_date,
+    sample_id,
+    normalized_channel AS channel,
+    ARRAY_LENGTH(
+      mozfun.bits28.to_dates(mozfun.bits28.range(days_seen_bits, -5, 6), submission_date)
+    ) AS days_2_7,
+  FROM
+    firefox_ios.baseline_clients_last_seen
+  WHERE
+    submission_date = @submission_date
+    AND DATE_DIFF(submission_date, first_seen_date, DAY) = 6
+),
+clients_search AS (
+  SELECT
+    client_id,
+    sample_id,
+    channel,
+    SUM(search_count) AS search_count
+  FROM
+    search_derived.mobile_search_clients_daily_v1
+  WHERE
+    (submission_date BETWEEN DATE_SUB(@submission_date, INTERVAL 3 DAY) AND @submission_date)
+    AND os = 'iOS'
+    AND normalized_app_name = 'Fennec'
+  GROUP BY
+    client_id, sample_id, channel
+)
+SELECT
+  @submission_date AS submission_date,
+  first_seen_date,
+  client_id,
+  sample_id,
+  IF(days_2_7 > 1 AND COALESCE(search_count, 0) > 0, TRUE, FALSE) AS is_activated,
+FROM
+  new_clients
+LEFT JOIN
+  new_clients_activity
+USING
+  (client_id, first_seen_date, sample_id, channel)
+LEFT JOIN
+  clients_search
+USING
+  (client_id, sample_id, channel)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/schema.yaml
@@ -1,0 +1,31 @@
+fields:
+
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: |
+    Date when a client activated.
+
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+  description: |
+    Date when the app first reported a baseline ping for the client.
+
+- mode: NULLABLE
+  name: client_id
+  type: STRING
+  description: |
+    Unique ID for the client installation.
+
+- mode: NULLABLE
+  name: sample_id
+  type: INTEGER
+  description: |
+    Sample ID to limit query results during an analysis.
+
+- mode: NULLABLE
+  name: is_activated
+  type: BOOLEAN
+  description: |
+    Determines if a client is activated based on the activation metric and a 7 day lag.


### PR DESCRIPTION
# feat(DENG-2083): added firefox_ios_derived.clients_activation_v1 and corresponding view

The purpose of this change is to avoid the activations table diverging away from the clients table. This is currently possible, as both the clients and activations table are built independently using different sources. Naturally, this resulted us observing unexpected differences in the client counts between the two tables. This should not be the case and is something that is addressed by this change.

This change aims to improve the two following aspects of this data model:

1. Make the data lineage simpler and representative of the expected stage in the data lifecycle (there should be no activation for a client, unless they are recorded as a client in the clients table).
2. Remove the self (previous state) dependency from this model. This simplifies the logic and makes each partition idempotent making it much easier to rebuild specific partitions if necessary.

----

depends on: https://github.com/mozilla/bigquery-etl/pull/4638


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2103)
