### PR TITLE
feat(): firefox_ios source added to shredder config

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -97,6 +97,9 @@ CONTEXTUAL_SERVICES_SRC = DeleteSource(
     field="payload.scalars.parent.deletion_request_context_id",
 )
 FENIX_SRC = DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID)
+FIREFOX_IOS_SRC = DeleteSource(
+    table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID
+)
 FXA_HMAC_SRC = DeleteSource(
     table="firefox_accounts_derived.fxa_delete_events_v1", field="hmac_user_id"
 )


### PR DESCRIPTION
feat(): firefox_ios source added to shredder config

This is to enable us to add firefox_ios client level tables to the shredder configuration for "Shredding"

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2111)
