### PR TITLE
Speed up glean_usage generation by caching the table getter

### DIFF
--- a/sql_generators/glean_usage/__init__.py
+++ b/sql_generators/glean_usage/__init__.py
@@ -1,5 +1,5 @@
 """GLEAN Usage."""
-from functools import partial
+from functools import cache, partial
 from pathlib import Path
 
 import click
@@ -99,6 +99,7 @@ def generate(
     elif exclude:
         table_filter = partial(table_matches_patterns, exclude, True)
 
+    @cache
     def get_tables(table_name="baseline_v1"):
         baseline_tables = list_tables(
             project_id=target_project,


### PR DESCRIPTION
`get_tables` is deterministic under the assumption that the tables don't change in between invocations. Which I hope holds here. We therefore can just cache that value so that subsequent runs quickly return without needing a roundtrip to BigQuery again.

Same as #4619 (and rebased), but pushed to this repository directly so that tests just work.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2119)
