### PR TITLE
bug(1867537): fixing broken test for firefox_ios_derived.baseline_clients_yearly_v1

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -583,6 +583,7 @@ bqetl_firefox_ios:
     depends_on_past: false
     email:
       - kik@mozilla.com
+      - frank@mozilla.com
       - telemetry-alerts@mozilla.com
     email_on_failure: true
     email_on_retry: true

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/baseline_clients_yearly_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/baseline_clients_yearly_v1/checks.sql
@@ -7,7 +7,7 @@
 
 #fail
 -- Should have clients who were active on that date present
-{{ min_row_count(10000, "days_since_seen = 0 AND submission_date = @submission_date") }}
+{{ min_row_count(10000, "`moz-fx-data-shared-prod`.udf.bits_to_days_since_seen(days_seen_bytes) = 0 AND submission_date = @submission_date") }}
 
 #fail
 -- Should have a bunch of new profiles each date


### PR DESCRIPTION
# bug(1867537): fixing broken test for firefox_ios_derived.baseline_clients_yearly_v1

This is currently causing the `bqetl_firefox_ios` DAG to fail.

Now the render command appears to render a valid query that can be executed:

```
$ ./bqetl check render --sql_dir=sql --project_id=moz-fx-data-shared-prod firefox_ios_derived.baseline_clients_yearly_v1 --parameter=submission_date:DATE:2023-
11-30

# outputs:

#fail
WITH non_unique AS (
  SELECT
    COUNT(*) AS total_count
  FROM
    `moz-fx-data-shared-prod.firefox_ios_derived.baseline_clients_yearly_v1`
  WHERE
    submission_date = "2023-11-30"
  GROUP BY
    client_id
  HAVING
    total_count > 1
)
SELECT
  IF(
    (SELECT COUNT(*) FROM non_unique) > 0,
    ERROR(
      "Duplicates detected (Expected combined set of values for columns ['client_id'] to be unique.)"
    ),
    NULL
  );

#fail
-- Should have a partition with rows for each date
WITH min_row_count AS (
  SELECT
    COUNT(*) AS total_rows
  FROM
    `moz-fx-data-shared-prod.firefox_ios_derived.baseline_clients_yearly_v1`
  WHERE
    submission_date = "2023-11-30"
)
SELECT
  IF(
    (SELECT COUNTIF(total_rows < 10000) FROM min_row_count) > 0,
    ERROR(
      CONCAT(
        "Min Row Count Error: ",
        (SELECT total_rows FROM min_row_count),
        " rows found, expected more than 10000 rows"
      )
    ),
    NULL
  );

#fail
-- Should have clients who were active on that date present
WITH min_row_count AS (
  SELECT
    COUNT(*) AS total_rows
  FROM
    `moz-fx-data-shared-prod.firefox_ios_derived.baseline_clients_yearly_v1`
  WHERE
    `moz-fx-data-shared-prod`.udf.bits_to_days_since_seen(days_seen_bytes) = 0
    AND submission_date = "2023-11-30"
)
SELECT
  IF(
    (SELECT COUNTIF(total_rows < 10000) FROM min_row_count) > 0,
    ERROR(
      CONCAT(
        "Min Row Count Error: ",
        (SELECT total_rows FROM min_row_count),
        " rows found, expected more than 10000 rows"
      )
    ),
    NULL
  );

#fail
-- Should have a bunch of new profiles each date
WITH min_row_count AS (
  SELECT
    COUNT(*) AS total_rows
  FROM
    `moz-fx-data-shared-prod.firefox_ios_derived.baseline_clients_yearly_v1`
  WHERE
    first_seen_date = "2023-11-30"
    AND submission_date = "2023-11-30"
)
SELECT
  IF(
    (SELECT COUNTIF(total_rows < 10000) FROM min_row_count) > 0,
    ERROR(
      CONCAT(
        "Min Row Count Error: ",
        (SELECT total_rows FROM min_row_count),
        " rows found, expected more than 10000 rows"
      )
    ),
    NULL
  );
```