### PR TITLE
GLAM avoid scientific notation for big sample counts

### DIFF
--- a/bigquery_etl/glam/templates/view_sample_counts_v1.sql
+++ b/bigquery_etl/glam/templates/view_sample_counts_v1.sql
@@ -77,9 +77,9 @@ SELECT
     '' AS key,
     agg_type,
     {% if channel == 'release' %}
-      SUM(value) * MAX(sample_mult) as total_sample
+      CAST(SUM(value) * MAX(sample_mult) as numeric) as total_sample
     {% else %}
-      SUM(value) as total_sample
+      CAST(SUM(value) as numeric) as total_sample
     {% endif %}
 FROM
     all_combos
@@ -98,9 +98,9 @@ SELECT
     key,
     agg_type,
     {% if channel == 'release' %}
-      SUM(value) * MAX(sample_mult) as total_sample
+      CAST(SUM(value) * MAX(sample_mult) as numeric) as total_sample
     {% else %}
-      SUM(value) as total_sample
+      CAST(SUM(value) as numeric) as total_sample
     {% endif %}
 FROM
     all_combos

--- a/bigquery_etl/glam/templates/view_sample_counts_v1.sql
+++ b/bigquery_etl/glam/templates/view_sample_counts_v1.sql
@@ -77,9 +77,9 @@ SELECT
     '' AS key,
     agg_type,
     {% if channel == 'release' %}
-      CAST(SUM(value) * MAX(sample_mult) as numeric) as total_sample
+      CAST(SUM(value) * MAX(sample_mult) as BIGNUMERIC) as total_sample
     {% else %}
-      CAST(SUM(value) as numeric) as total_sample
+      CAST(SUM(value) as BIGNUMERIC) as total_sample
     {% endif %}
 FROM
     all_combos
@@ -98,9 +98,9 @@ SELECT
     key,
     agg_type,
     {% if channel == 'release' %}
-      CAST(SUM(value) * MAX(sample_mult) as numeric) as total_sample
+      CAST(SUM(value) * MAX(sample_mult) as BIGNUMERIC) as total_sample
     {% else %}
-      CAST(SUM(value) as numeric) as total_sample
+      CAST(SUM(value) as BIGNUMERIC) as total_sample
     {% endif %}
 FROM
     all_combos

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql
@@ -84,7 +84,7 @@ SELECT
   CASE
     WHEN client_agg_type = '' THEN 0
   ELSE
-    total_sample
+    CAST(total_sample as numeric)
   END
   AS total_sample,
   non_norm_histogram,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql
@@ -84,7 +84,7 @@ SELECT
   CASE
     WHEN client_agg_type = '' THEN 0
   ELSE
-    CAST(total_sample as numeric)
+    CAST(total_sample as BIGNUMERIC)
   END
   AS total_sample,
   non_norm_histogram,


### PR DESCRIPTION
Fixes [GLAM Desktop imports](https://workflow.telemetry.mozilla.org/dags/glam_glean_imports/grid?tab=graph&dag_run_id=scheduled__2023-12-03T05%3A00%3A00%2B00%3A00&task_id=Prod_glam.glam_import_desktop_aggs_release) failure that happen today: 
```psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type bigint: "1.01033992827342e+15"```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2124)
