### PR TITLE
feat(DENG-2120): migrated over checks defined in DIM for baseline_clients_last_seen fenix.

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
@@ -13,7 +13,7 @@
    (you can also run them locally with `bqetl check run`).
 #}
 {% raw -%}
-  #fail
+  #warn
   {{ is_unique(["client_id"], where="submission_date = @submission_date") }}
 
   #warn
@@ -50,7 +50,7 @@
   #warn
   SELECT IF(
     COUNTIF(NOT REGEXP_CONTAINS(CAST(country AS STRING), r"^[A-Z]{2}|\?\?$")) > 0,
-    ERROR("Unexpected values for field normalized_channel detected."),
+    ERROR("Some values in this field do not adhere to the ISO 3166-1 specification (2 character country code, for example: DE)."),
     null
   )
   FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
@@ -59,7 +59,7 @@
   #warn
   SELECT IF(
     COUNTIF(NOT REGEXP_CONTAINS(CAST(telemetry_sdk_build AS STRING), r"^\d+\.\d+\.\d+$")) > 0,
-    ERROR("Unexpected values for field normalized_channel detected."),
+    ERROR("Values inside field telemetry_sdk_build not adhere to the expected format. Example: 23.43.33"),
     null
   )
   FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
@@ -1,6 +1,5 @@
 {{ header }}
 
-#fail
 {#
    We use raw here b/c the first pass is rendered to create the checks.sql
    files, and the second pass is rendering of the checks themselves.
@@ -14,5 +13,57 @@
    (you can also run them locally with `bqetl check run`).
 #}
 {% raw -%}
-  {{ is_unique(["client_id"], "submission_date = @submission_date") }}
+  #fail
+  {{ is_unique(["client_id"], where="submission_date = @submission_date") }}
+
+  #warn
+  {{ min_row_count(1, where="submission_date = @submission_date") }}
+
+  # warn
+  {{ not_null([
+    "submission_date",
+    "client_id",
+    "sample_id",
+    "first_seen_date",
+    "days_seen_bits",
+    "days_created_profile_bits",
+    "days_seen_session_start_bits",
+    "days_seen_session_end_bits"
+    ], where="submission_date = @submission_date") }}
+
+  #warn
+  SELECT IF(
+    COUNTIF(normalized_channel NOT IN (
+      "nightly",
+      "aurora",
+      "release",
+      "Other",
+      "beta",
+      "esr"
+    )) > 0,
+    ERROR("Unexpected values for field normalized_channel detected."),
+    null
+  )
+  FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+  WHERE submission_date = @submission_date;
+
+  #warn
+  SELECT IF(
+    COUNTIF(NOT REGEXP_CONTAINS(CAST(country AS STRING), r"^[A-Z]{2}|\?\?$")) > 0,
+    ERROR("Unexpected values for field normalized_channel detected."),
+    null
+  )
+  FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+  WHERE submission_date = @submission_date;
+
+  #warn
+  SELECT IF(
+    COUNTIF(NOT REGEXP_CONTAINS(CAST(telemetry_sdk_build AS STRING), r"^\d+\.\d+\.\d+$")) > 0,
+    ERROR("Unexpected values for field normalized_channel detected."),
+    null
+  )
+  FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+  WHERE submission_date = @submission_date;
+
 {% endraw %}
+


### PR DESCRIPTION
# feat(DENG-2120): migrated over checks defined in DIM for baseline_clients_last_seen fenix.

## small tweak

All checks are turned into warning checks to avoid potentially breaking the pipeline tomorrow. Over time we can promote some of these to be fail checks.

---


This will also add the checks for all products using this specific sql generator template.

Example rendered output for org_mozilla_fenix_nightly_derived.baseline_clients_last_seen_v1 for submission_date `2023-12-03`:

```
#fail
WITH non_unique AS (
  SELECT
    COUNT(*) AS total_count
  FROM
    `moz-fx-data-shared-prod.org_mozilla_fenix_nightly_derived.baseline_clients_last_seen_v1`
  WHERE
    submission_date = "2023-12-03"
  GROUP BY
    client_id
  HAVING
    total_count > 1
)
SELECT
  IF(
    (SELECT COUNT(*) FROM non_unique) > 0,
    ERROR(
      "Duplicates detected (Expected combined set of values for columns ['client_id'] to be unique.)"
    ),
    NULL
  );

  #fail
WITH min_row_count AS (
  SELECT
    COUNT(*) AS total_rows
  FROM
    `moz-fx-data-shared-prod.org_mozilla_fenix_nightly_derived.baseline_clients_last_seen_v1`
  WHERE
    submission_date = "2023-12-03"
)
SELECT
  IF(
    (SELECT COUNTIF(total_rows < 1) FROM min_row_count) > 0,
    ERROR(
      CONCAT(
        "Min Row Count Error: ",
        (SELECT total_rows FROM min_row_count),
        " rows found, expected more than 10 rows"
      )
    ),
    NULL
  );

  # warn
WITH null_checks AS (
  SELECT
    [
      IF(COUNTIF(submission_date IS NULL) > 0, "submission_date", NULL),
      IF(COUNTIF(client_id IS NULL) > 0, "client_id", NULL),
      IF(COUNTIF(sample_id IS NULL) > 0, "sample_id", NULL),
      IF(COUNTIF(first_seen_date IS NULL) > 0, "first_seen_date", NULL),
      IF(COUNTIF(days_seen_bits IS NULL) > 0, "days_seen_bits", NULL),
      IF(COUNTIF(days_created_profile_bits IS NULL) > 0, "days_created_profile_bits", NULL),
      IF(COUNTIF(days_seen_session_start_bits IS NULL) > 0, "days_seen_session_start_bits", NULL),
      IF(COUNTIF(days_seen_session_end_bits IS NULL) > 0, "days_seen_session_end_bits", NULL)
    ] AS checks
  FROM
    `moz-fx-data-shared-prod.org_mozilla_fenix_nightly_derived.baseline_clients_last_seen_v1`
  WHERE
    submission_date = "2023-12-03"
),
non_null_checks AS (
  SELECT
    ARRAY_AGG(u IGNORE NULLS) AS checks
  FROM
    null_checks,
    UNNEST(checks) AS u
)
SELECT
  IF(
    (SELECT ARRAY_LENGTH(checks) FROM non_null_checks) > 0,
    ERROR(
      CONCAT(
        "Columns with NULL values: ",
        (SELECT ARRAY_TO_STRING(checks, ", ") FROM non_null_checks)
      )
    ),
    NULL
  );

  #warn
SELECT
  IF(
    COUNTIF(normalized_channel NOT IN ("nightly", "aurora", "release", "Other", "beta", "esr")) > 0,
    ERROR("Unexpected values for field normalized_channel detected."),
    NULL
  )
FROM
  `moz-fx-data-shared-prod.org_mozilla_fenix_nightly_derived.baseline_clients_last_seen_v1`
WHERE
  submission_date = "2023-12-03";

  #warn
SELECT
  IF(
    COUNTIF(NOT REGEXP_CONTAINS(CAST(country AS STRING), r"^[A-Z]{2}|\?\?$")) > 0,
    ERROR("Unexpected values for field normalized_channel detected."),
    NULL
  )
FROM
  `moz-fx-data-shared-prod.org_mozilla_fenix_nightly_derived.baseline_clients_last_seen_v1`
WHERE
  submission_date = "2023-12-03";

  #warn
SELECT
  IF(
    COUNTIF(NOT REGEXP_CONTAINS(CAST(telemetry_sdk_build AS STRING), r"^\d+\.\d+\.\d+$")) > 0,
    ERROR("Unexpected values for field normalized_channel detected."),
    NULL
  )
FROM
  `moz-fx-data-shared-prod.org_mozilla_fenix_nightly_derived.baseline_clients_last_seen_v1`
WHERE
  submission_date = "2023-12-03";
```

All of these checks on this dataset for this submission_date appear to pass.


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2138)
