### PR TITLE
Have `bqetl query` commands fail if they don't find a matching query

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -64,7 +64,6 @@ from ..util.common import random_str
 from ..util.common import render as render_template
 from ..util.parallel_topological_sorter import ParallelTopologicalSorter
 from .dryrun import dryrun
-from .generate import generate_all
 
 QUERY_NAME_RE = re.compile(r"(?P<dataset>[a-zA-z0-9_]+)\.(?P<name>[a-zA-z0-9_]+)")
 VERSION_RE = re.compile(r"_v[0-9]+")
@@ -419,13 +418,7 @@ def info(ctx, name, sql_dir, project_id, cost, last_updated):
 
     query_files = paths_matching_name_pattern(name, sql_dir, project_id)
     if query_files == []:
-        # run SQL generators if no matching query has been found
-        ctx.invoke(
-            generate_all,
-            output_dir=ctx.obj["TMP_DIR"],
-            ignore=["derived_view_schemas", "stable_views"],
-        )
-        query_files = paths_matching_name_pattern(name, ctx.obj["TMP_DIR"], project_id)
+        raise click.ClickException(f"No query matching `{name}` was found.")
 
     for query_file in query_files:
         query_file_path = Path(query_file)
@@ -712,13 +705,7 @@ def backfill(
 
     query_files = paths_matching_name_pattern(name, sql_dir, project_id)
     if query_files == []:
-        # run SQL generators if no matching query has been found
-        ctx.invoke(
-            generate_all,
-            output_dir=ctx.obj["TMP_DIR"],
-            ignore=["derived_view_schemas", "stable_views", "country_code_lookup"],
-        )
-        query_files = paths_matching_name_pattern(name, ctx.obj["TMP_DIR"], project_id)
+        raise click.ClickException(f"No query matching `{name}` was found.")
 
     for query_file in query_files:
         query_file_path = Path(query_file)
@@ -888,13 +875,7 @@ def run(
 
     query_files = paths_matching_name_pattern(name, sql_dir, project_id)
     if query_files == []:
-        # run SQL generators if no matching query has been found
-        ctx.invoke(
-            generate_all,
-            output_dir=ctx.obj["TMP_DIR"],
-            ignore=["derived_view_schemas", "stable_views", "country_code_lookup"],
-        )
-        query_files = paths_matching_name_pattern(name, ctx.obj["TMP_DIR"], project_id)
+        raise click.ClickException(f"No query matching `{name}` was found.")
 
     _run_query(
         query_files,
@@ -1983,15 +1964,7 @@ def deploy(
 
     query_files = paths_matching_name_pattern(name, sql_dir, project_id, ["query.*"])
     if not query_files:
-        # run SQL generators if no matching query has been found
-        ctx.invoke(
-            generate_all,
-            output_dir=ctx.obj["TMP_DIR"],
-            ignore=["derived_view_schemas", "stable_views"],
-        )
-        query_files = paths_matching_name_pattern(
-            name, ctx.obj["TMP_DIR"], project_id, ["query.*"]
-        )
+        raise click.ClickException(f"No query matching `{name}` was found.")
 
     def _deploy(query_file):
         if respect_dryrun_skip and str(query_file) in DryRun.skipped_files():
@@ -2246,13 +2219,7 @@ def validate_schema(
     """Validate the defined query schema with the query and the destination table."""
     query_files = paths_matching_name_pattern(name, sql_dir, project_id)
     if query_files == []:
-        # run SQL generators if no matching query has been found
-        ctx.invoke(
-            generate_all,
-            output_dir=ctx.obj["TMP_DIR"],
-            ignore=["derived_view_schemas", "stable_views"],
-        )
-        query_files = paths_matching_name_pattern(name, ctx.obj["TMP_DIR"], project_id)
+        raise click.ClickException(f"No query matching `{name}` was found.")
 
     _validate_schema = partial(
         _validate_schema_from_path,


### PR DESCRIPTION
Rather than running all SQL generators and silently doing nothing if a matching query still isn't found.

IMO automatically running all SQL generators when a specified query isn't found is never desirable:
- In the production environment all SQL generation should have been done already, so re-running SQL generation won't help.
- In a local dev environment running all SQL generators takes a long time and messes with your local working copy.  I'd rather have it fail fast and then leave it up to the developer whether to run a particular SQL generator if they want.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
