### PR TITLE
Skip accounts_db.fxa_oauth_clients in view validation

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -391,6 +391,7 @@ view:
     - sql/moz-fx-data-shared-prod/mlhackweek_search/action/view.sql
     - sql/moz-fx-data-shared-prod/**/client_deduplication/view.sql
     - sql/moz-fx-data-shared-prod/stripe/itemized_tax_transactions/view.sql
+    - sql/moz-fx-data-shared-prod/accounts_db/fxa_oauth_clients/view.sql
   publish:
     skip:
     - sql/moz-fx-data-shared-prod/activity_stream/tile_id_types/view.sql


### PR DESCRIPTION
We skip `accounts_db_external.fxa_oauth_clients_v1` (`sql/moz-fx-data-shared-prod/accounts_db/**/*.sql`) in dry-run also for permissions reasons