### PR TITLE
Skip accounts_db.fxa_oauth_clients dryrun

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -54,6 +54,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/accounts_backend/accounts/view.sql
   - sql/moz-fx-data-shared-prod/accounts_db_external/**/*.sql
   - sql/moz-fx-data-shared-prod/accounts_db_nonprod_external/**/*.sql
+  - sql/moz-fx-data-shared-prod/accounts_db/fxa_oauth_clients/view.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/query.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_bounce_events_v1/query.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql


### PR DESCRIPTION
Follow up to https://github.com/mozilla/bigquery-etl/pull/4667 because CI is still failing. 

Two things from this:
1. Does view validation besides the dryrun actually access any resources? At a glance I see most of the views in the view validation section part of `bqetl_project.yaml` in the dryrun skip section
2. If (1) is true then should view validation skips also skip dryrun?