### PR TITLE
feat(DENG-2156): added value_length check and updated some of the ETL checks to use the macro

### DIFF
--- a/docs/reference/data_checks.md
+++ b/docs/reference/data_checks.md
@@ -186,7 +186,7 @@ Example:
 {{ row_count_within_past_partitions_avg(7, 5, "submission_date") }}
 ```
 
-### row_count_within_past_partitions_avg([source](../../tests/checks/value_length.jinja))
+### value_length([source](../../tests/checks/value_length.jinja))
 
 Checks that the columns have values of specific character length.
 
@@ -203,7 +203,7 @@ where: Optional[str]: Any additional filtering rules that should be applied when
 Example:
 ```sql
 #warn
-{{ value_length(columns=["country"], expected_length=2, where="submission_date = @submission_date") }}
+{{ value_length(column="country", expected_length=2, where="submission_date = @submission_date") }}
 ```
 
 

--- a/docs/reference/data_checks.md
+++ b/docs/reference/data_checks.md
@@ -167,6 +167,7 @@ Please keep in mind the below checks can be combined and specified in the same `
 ```
 
 ### row_count_within_past_partitions_avg([source](../../tests/checks/row_count_within_past_partitions_avg.jinja))
+
 Compares the row count of the current partition to the average of `number_of_days` past partitions and checks if the row count is within the average +- `threshold_percentage` %
 
 Usage:
@@ -183,6 +184,26 @@ Example:
 ```sql
 #fail
 {{ row_count_within_past_partitions_avg(7, 5, "submission_date") }}
+```
+
+### row_count_within_past_partitions_avg([source](../../tests/checks/value_length.jinja))
+
+Checks that the columns have values of specific character length.
+
+Usage:
+
+```
+Arguments:
+
+columns: List[str] - Columns which will be checked against the `expected_length`.
+expected_length: int - Describes the expected character length of the value inside the specified columns.
+where: Optional[str]: Any additional filtering rules that should be applied when retrieving the data to run the check against.
+```
+
+Example:
+```sql
+#warn
+{{ value_length(columns=["country"], expected_length=2, where="submission_date = @submission_date") }}
 ```
 
 

--- a/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/checks.sql
@@ -25,11 +25,5 @@
 
 ], where="DATE(`datetime`) = @submission_date") }}
 
-#fail
-SELECT IF(
-  COUNTIF(LENGTH(country) <> 2) > 0,
-  ERROR("Some values in this field do not adhere to the ISO 3166-1 specification (2 character country code)."),
-  null
-)
-FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
-WHERE DATE(`datetime`) = @submission_date;
+#warn
+{{ value_length(columns=["country"], expected_length=2, where="DATE(`datetime`) = @submission_date") }}

--- a/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/checks.sql
@@ -26,4 +26,4 @@
 ], where="DATE(`datetime`) = @submission_date") }}
 
 #warn
-{{ value_length(columns=["country"], expected_length=2, where="DATE(`datetime`) = @submission_date") }}
+{{ value_length(column="country", expected_length=2, where="DATE(`datetime`) = @submission_date") }}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
@@ -8,7 +8,7 @@
 {{ row_count_within_past_partitions_avg(number_of_days=7, threshold_percentage=5) }}
 
 #fail
-{{ value_length(columns=["client_id"], expected_length=36, where="submission_date = @submission_date") }}
+{{ value_length(column="client_id", expected_length=36, where="submission_date = @submission_date") }}
 
 #warn
 {{ is_unique(columns=["client_id"], where="submission_date = @submission_date") }}
@@ -32,7 +32,7 @@
 ], where="submission_date = @submission_date") }}
 
 #warn
-{{ value_length(columns=["country"], expected_length=2, where="submission_date = @submission_date") }}
+{{ value_length(column="country", expected_length=2, where="submission_date = @submission_date") }}
 
 #warn
 SELECT IF(

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
@@ -8,13 +8,7 @@
 {{ row_count_within_past_partitions_avg(number_of_days=7, threshold_percentage=5) }}
 
 #fail
-SELECT IF(
-  COUNTIF(LENGTH(client_id) <> 36) > 0,
-  ERROR("client_id is expected to be 36 characters in length."),
-  null
-)
-FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
-WHERE submission_date = @submission_date;
+{{ value_length(columns=["client_id"], expected_length=36, where="submission_date = @submission_date") }}
 
 #warn
 {{ is_unique(columns=["client_id"], where="submission_date = @submission_date") }}
@@ -38,13 +32,7 @@ WHERE submission_date = @submission_date;
 ], where="submission_date = @submission_date") }}
 
 #warn
-SELECT IF(
-  COUNTIF(LENGTH(country) <> 2) > 0,
-  ERROR("Some values in this field do not adhere to the ISO 3166-1 specification (2 character country code)."),
-  null
-)
-FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
-WHERE submission_date = @submission_date;
+{{ value_length(columns=["country"], expected_length=2, where="submission_date = @submission_date") }}
 
 #warn
 SELECT IF(

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
@@ -65,5 +65,8 @@
   FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
   WHERE submission_date = @submission_date;
 
+#warn
+{{ value_length(columns=["client_id"], expected_length=36, where="submission_date = @submission_date") }}
+
 {% endraw %}
 

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
@@ -66,7 +66,7 @@
   WHERE submission_date = @submission_date;
 
 #warn
-{{ value_length(columns=["client_id"], expected_length=36, where="submission_date = @submission_date") }}
+{{ value_length(column="client_id", expected_length=36, where="submission_date = @submission_date") }}
 
 {% endraw %}
 

--- a/tests/checks/value_length.jinja
+++ b/tests/checks/value_length.jinja
@@ -1,12 +1,7 @@
-{% macro value_length(columns, expected_length, where) %}
-  {% if columns is string %}
-    {% set columns = [columns] %}
-  {% endif %}
+{% macro value_length(column, expected_length, where) %}
   WITH value_length_checks AS (
     SELECT [
-      {% for col in columns %}
-        IF(COUNTIF(LENGTH({{ col }}) <> {{ expected_length }}) > 0, "{{ col }}", NULL){% if not loop.last -%},{% endif -%}
-      {% endfor %}
+      IF(COUNTIF(LENGTH({{ column }}) <> {{ expected_length }}) > 0, "{{ column }}", NULL)
     ] AS checks
     FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
     {% if where %}

--- a/tests/checks/value_length.jinja
+++ b/tests/checks/value_length.jinja
@@ -1,18 +1,12 @@
 {% macro value_length(column, expected_length, where) %}
-  WITH value_length_checks AS (
-    SELECT [
-      IF(COUNTIF(LENGTH({{ column }}) <> {{ expected_length }}) > 0, "{{ column }}", NULL)
-    ] AS checks
-    FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
-    {% if where %}
-    WHERE {{ where }}
-    {% endif %}
-  ), failed_columns AS (
-    SELECT ARRAY_AGG(u IGNORE NULLS) AS checks FROM value_length_checks, UNNEST(checks) AS u
-  )
-  SELECT IF(
-   (SELECT ARRAY_LENGTH(checks) FROM failed_columns) > 0,
-   ERROR(CONCAT("Columns with unexpected value length: ", (SELECT ARRAY_TO_STRING(checks, ", ") FROM failed_columns))),
-   NULL
-  );
+  SELECT
+    IF(
+    COUNTIF(LENGTH({{ column }}) <> {{ expected_length }}) > 0,
+    ERROR("Column: `{{ column }}` has values of unexpected length."),
+    NULL
+    )
+  FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+  {% if where %}
+  WHERE {{ where }}
+  {% endif %};
 {% endmacro %}

--- a/tests/checks/value_length.jinja
+++ b/tests/checks/value_length.jinja
@@ -1,0 +1,23 @@
+{% macro value_length(columns, expected_length, where) %}
+  {% if columns is string %}
+    {% set columns = [columns] %}
+  {% endif %}
+  WITH value_length_checks AS (
+    SELECT [
+      {% for col in columns %}
+        IF(COUNTIF(LENGTH({{ col }}) <> {{ expected_length }}) > 0, "{{ col }}", NULL){% if not loop.last -%},{% endif -%}
+      {% endfor %}
+    ] AS checks
+    FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+    {% if where %}
+    WHERE {{ where }}
+    {% endif %}
+  ), failed_columns AS (
+    SELECT ARRAY_AGG(u IGNORE NULLS) AS checks FROM value_length_checks, UNNEST(checks) AS u
+  )
+  SELECT IF(
+   (SELECT ARRAY_LENGTH(checks) FROM failed_columns) > 0,
+   ERROR(CONCAT("Columns with unexpected value length: ", (SELECT ARRAY_TO_STRING(checks, ", ") FROM failed_columns))),
+   NULL
+  );
+{% endmacro %}


### PR DESCRIPTION
# feat(DENG-2156): added value_length check and updated some of the ETL checks to use the macro

Example render command:
`$ ./bqetl check render --sql_dir=sql --project_id=moz-fx-data-shared-prod internet_outages.global_outages_v1 --parameter=submission_date:DATE:2023-12-03`

Output:
```
[...]

#warn
WITH value_length_checks AS (
  SELECT
    [IF(COUNTIF(LENGTH(country) <> 2) > 0, "country", NULL)] AS checks
  FROM
    `moz-fx-data-shared-prod.internet_outages.global_outages_v1`
  WHERE
    DATE(`datetime`) = "2023-12-03"
),
failed_columns AS (
  SELECT
    ARRAY_AGG(u IGNORE NULLS) AS checks
  FROM
    value_length_checks,
    UNNEST(checks) AS u
)
SELECT
  IF(
    (SELECT ARRAY_LENGTH(checks) FROM failed_columns) > 0,
    ERROR(
      CONCAT(
        "Columns with unexpected value length: ",
        (SELECT ARRAY_TO_STRING(checks, ", ") FROM failed_columns)
      )
    ),
    NULL
  );
```

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2157)
