### PR TITLE
add triage/confidential tag to docs

### DIFF
--- a/docs/reference/airflow_tags.md
+++ b/docs/reference/airflow_tags.md
@@ -24,3 +24,5 @@ This tag is meant to provide guidance to a triage engineer on how to respond to 
 - **triage/record_only**: Failures should _only_ be recorded and the job owner informed without taking any active steps to fix the failure.
 
 - **triage/no_triage**: No triage should be performed on this job. Should only be used in a limited number of cases, like this is still WIP, where no production processes are affected.
+
+- **triage/confidential** - Failures should be recorded by the triage engineer as normal, and bug should be marked **Confidential**.


### PR DESCRIPTION
Adding `triage/confidential` to the Airflow Tags docs.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2164)
