### PR TITLE
ci-fix Ignore dataset.update required permissions when dryrunning authorized views

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -17,7 +17,7 @@ import re
 from enum import Enum
 from os.path import basename, dirname, exists
 from pathlib import Path
-from typing import Set
+from typing import Optional, Set
 from urllib.request import Request, urlopen
 
 import click
@@ -352,29 +352,29 @@ class DryRun:
             return []
         return self.dry_run_result.get("errors", [])
 
-    def get_error(self):
+    def get_error(self) -> Optional[Errors]:
         """Get specific errors for edge case handling."""
-        errors = self.dry_run_result.get("errors", None)
-        if errors and len(errors) == 1:
-            error = errors[0]
-        else:
-            error = None
-        if error and error.get("code", None) in [400, 403]:
+        errors = self.errors()
+        if len(errors) != 1:
+            return None
+
+        error = errors[0]
+        if error and error.get("code") in [400, 403]:
+            error_message = error.get("message", "")
             if (
                 "does not have bigquery.tables.create permission for dataset"
-                in error.get("message", "")
-                or "Permission bigquery.tables.create denied"
-                in error.get("message", "")
+                in error_message
+                or "Permission bigquery.tables.create denied" in error_message
             ):
                 return Errors.READ_ONLY
-            if "without a filter over column(s)" in error.get("message", ""):
+            if "without a filter over column(s)" in error_message:
                 return Errors.DATE_FILTER_NEEDED
             if (
                 "Syntax error: Expected end of input but got keyword WHERE"
-                in error.get("message", "")
+                in error_message
             ):
                 return Errors.DATE_FILTER_NEEDED_AND_SYNTAX
-        return error
+        return None
 
     def validate_schema(self):
         """Check whether schema is valid."""

--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -365,6 +365,7 @@ class DryRun:
                 "does not have bigquery.tables.create permission for dataset"
                 in error_message
                 or "Permission bigquery.tables.create denied" in error_message
+                or "Permission bigquery.datasets.update denied" in error_message
             ):
                 return Errors.READ_ONLY
             if "without a filter over column(s)" in error_message:


### PR DESCRIPTION
Running `CREATE OR REPLACE VIEW ...` on authorized views requires `datasets.update` permissions (which CI does not have). 
See current CI failure:
```
sql/moz-fx-data-shared-prod/telemetry/socorro_crash/view.sql ERROR
 [{'code': 403, 'errors': [{'message': 'Access Denied: Dataset moz-fx-data-shared-prod:telemetry: Permission bigquery.datasets.update denied on dataset moz-fx-data-shared-prod:telemetry (or it may not exist).', 'domain': 'global', 'reason': 'accessDenied'}], 'response': {'headers': {'alt-svc': 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000', 'cache-control': 'private', 'content-encoding': 'gzip', 'content-type': 'application/json; charset=UTF-8', 'date': 'Mon, 11 Dec 2023 15:49:05 GMT', 'server': 'ESF', 'transfer-encoding': 'chunked', 'vary': 'Origin, X-Origin, Referer', 'x-content-type-options': 'nosniff', 'x-frame-options': 'SAMEORIGIN', 'x-xss-protection': '0'}}, 'message': 'Access Denied: Dataset moz-fx-data-shared-prod:telemetry: Permission bigquery.datasets.update denied on dataset moz-fx-data-shared-prod:telemetry (or it may not exist).'}]
```

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2170)
