### PR TITLE
feat(DENG-2175): added matches_pattern etl checks macro and updated tests to use it

### DIFF
--- a/docs/reference/data_checks.md
+++ b/docs/reference/data_checks.md
@@ -188,14 +188,14 @@ Example:
 
 ### value_length([source](../../tests/checks/value_length.jinja))
 
-Checks that the columns have values of specific character length.
+Checks that the column has values of specific character length.
 
 Usage:
 
 ```
 Arguments:
 
-columns: List[str] - Columns which will be checked against the `expected_length`.
+column: str - Column which will be checked against the `expected_length`.
 expected_length: int - Describes the expected character length of the value inside the specified columns.
 where: Optional[str]: Any additional filtering rules that should be applied when retrieving the data to run the check against.
 ```
@@ -204,6 +204,27 @@ Example:
 ```sql
 #warn
 {{ value_length(column="country", expected_length=2, where="submission_date = @submission_date") }}
+```
+
+### matches_pattern([source](../../tests/checks/matches_pattern.jinja))
+
+Checks that the column values adhere to a pattern based on a regex expression.
+
+Usage:
+
+```
+Arguments:
+
+column: str - Column which values will be checked against the regex.
+pattern: str - Regex pattern specifying the expected shape / pattern of the values inside the column.
+where: Optional[str]: Any additional filtering rules that should be applied when retrieving the data to run the check against.
+message: Optional[str]: Custom error message.
+```
+
+Example:
+```sql
+#warn
+{{ matches_pattern(column="country", pattern="^[A-Z]{2}$", where="submission_date = @submission_date", message="Oops") }}
 ```
 
 

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
@@ -87,10 +87,4 @@ FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
 WHERE submission_date = @submission_date;
 
 #warn
-SELECT IF(
-  COUNTIF(NOT REGEXP_CONTAINS(CAST(country AS STRING), r"^[A-Z]{2}|\?\?$")) > 0,
-  ERROR("Unexpected values for field normalized_channel detected."),
-  null
-)
-FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
-WHERE submission_date = @submission_date;
+{{ matches_pattern(column="country", pattern="^[A-Z]{2}$", where="submission_date = @submission_date", message="Some values in this field do not adhere to the ISO 3166-1 specification (2 character country code, for example: DE).") }}

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
@@ -1,0 +1,60 @@
+{{ header }}
+
+{#
+   We use raw here b/c the first pass is rendered to create the checks.sql
+   files, and the second pass is rendering of the checks themselves.
+
+   For example, the header above is rendered for every checks file
+   when we create the checks file, when `bqetl generate glean_usage`
+   is called.
+
+   However the second part, where we render the check is_unique() below,
+   is rendered when we _run_ the check, during `bqetl query backfill`
+   (you can also run them locally with `bqetl check run`).
+#}
+{% raw -%}
+#warn
+{{ is_unique(["client_id"], where="submission_date = @submission_date") }}
+
+#warn
+{{ min_row_count(1, where="submission_date = @submission_date") }}
+
+# warn
+{{ not_null([
+  "submission_date",
+  "client_id",
+  "sample_id",
+  "first_seen_date",
+  "days_seen_bits",
+  "days_created_profile_bits",
+  "days_seen_session_start_bits",
+  "days_seen_session_end_bits"
+  ], where="submission_date = @submission_date") }}
+
+#warn
+SELECT IF(
+  COUNTIF(normalized_channel NOT IN (
+    "nightly",
+    "aurora",
+    "release",
+    "Other",
+    "beta",
+    "esr"
+  )) > 0,
+  ERROR("Unexpected values for field normalized_channel detected."),
+  null
+)
+FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+WHERE submission_date = @submission_date;
+
+#warn
+{{ matches_pattern(column="country", pattern="^[A-Z]{2}$", where="submission_date = @submission_date") }}
+
+#warn
+{{ matches_pattern(column="telemetry_sdk_build", pattern="^\d+\.\d+\.\d+$", where="submission_date = @submission_date", message="Values inside field telemetry_sdk_build not adhere to the expected format. Example: 23.43.33") }}
+
+#warn
+{{ value_length(column="client_id", expected_length=36, where="submission_date = @submission_date") }}
+
+{% endraw %}
+

--- a/tests/checks/matches_pattern.jinja
+++ b/tests/checks/matches_pattern.jinja
@@ -1,0 +1,14 @@
+{% macro matches_pattern(column, pattern, where, message) %}
+  {% set message = message|default('Some values inside the `' ~ column ~ '` column do not match the expected pattern: `' ~ pattern ~ '`') %}
+
+  SELECT
+    IF(
+      COUNTIF(NOT REGEXP_CONTAINS({{ column }}, r"{{ pattern }}")) > 0,
+      ERROR("{{ message }}"),
+      NULL
+    )
+  FROM `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+  {% if where %}
+  WHERE {{ where }}
+  {% endif %};
+{% endmacro %}


### PR DESCRIPTION
# feat(DENG-2175): added matches_pattern etl checks macro and updated tests to use it


This introduced `matches_pattern` etl check macro which allows us to specify a regex expression to test that values inside a column adhere to the regex defined pattern.

Checks already doing this via SQL have been updated to use the macro instead.

Example command:

`./bqetl check render --sql_dir=sql --project_id=moz-fx-data-shared-prod org_mozilla_fenix_derived.baseline_clients_last_seen_v1 --parameter=submission_date:DATE:2023-12-03`

Output:

```
[...]
#warn
SELECT
  IF(
    COUNTIF(normalized_channel NOT IN ("nightly", "aurora", "release", "Other", "beta", "esr")) > 0,
    ERROR("Unexpected values for field normalized_channel detected."),
    NULL
  )
FROM
  `moz-fx-data-shared-prod.org_mozilla_fenix_derived.baseline_clients_last_seen_v1`
WHERE
  submission_date = "2023-12-03";

#warn
SELECT
  IF(
    COUNTIF(NOT REGEXP_CONTAINS(country, r"^[A-Z]{2}$")) > 0,
    ERROR(
      "Some values inside the `country` column do not match the expected pattern: `^[A-Z]{2}$`"
    ),
    NULL
  )
FROM
  `moz-fx-data-shared-prod.org_mozilla_fenix_derived.baseline_clients_last_seen_v1`
WHERE
  submission_date = "2023-12-03";

#warn
SELECT
  IF(
    COUNTIF(NOT REGEXP_CONTAINS(telemetry_sdk_build, r"^\d+\.\d+\.\d+$")) > 0,
    ERROR(
      "Values inside field telemetry_sdk_build not adhere to the expected format. Example: 23.43.33"
    ),
    NULL
  )
FROM
  `moz-fx-data-shared-prod.org_mozilla_fenix_derived.baseline_clients_last_seen_v1`
WHERE
  submission_date = "2023-12-03";

#warn
SELECT
  IF(
    COUNTIF(LENGTH(client_id) <> 36) > 0,
    ERROR("Column: `client_id` has values of unexpected length."),
    NULL
  )
FROM
  `moz-fx-data-shared-prod.org_mozilla_fenix_derived.baseline_clients_last_seen_v1`
WHERE
  submission_date = "2023-12-03";
```

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2176)
