### PR TITLE
Glam public - update source tbl 

### DIFF
--- a/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_beta_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_beta_v1/query.sql
@@ -1,7 +1,7 @@
 SELECT
-  * EXCEPT (channel)
+  *
 FROM
-  `moz-fx-data-shared-prod.telemetry_derived.client_probe_counts_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.glam_extract_firefox_beta_v1`
 WHERE
   -- filter based on https://github.com/mozilla/python_mozaggregator/blob/6c0119bfd0b535346c37cb3f707d998039d3e24b/mozaggregator/service.py#L51
   (
@@ -12,4 +12,3 @@ WHERE
     AND metric NOT LIKE "%manager_message_size%"
     AND metric NOT LIKE "%dropped_frames_proportion%"
   )
-  AND channel = "beta"

--- a/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_beta_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_beta_v1/schema.yaml
@@ -1,41 +1,43 @@
 fields:
-- name: os
-  type: STRING
-  mode: NULLABLE
 - name: app_version
   type: INTEGER
   mode: NULLABLE
+- name: os
+  type: STRING
+  mode: NULLABLE
 - name: app_build_id
-  type: STRING
-  mode: NULLABLE
-- name: metric
-  type: STRING
-  mode: NULLABLE
-- name: metric_type
-  type: STRING
-  mode: NULLABLE
-- name: key
   type: STRING
   mode: NULLABLE
 - name: process
   type: STRING
   mode: NULLABLE
+- name: metric
+  type: STRING
+  mode: NULLABLE
+- name: key
+  type: STRING
+  mode: NULLABLE
 - name: client_agg_type
   type: STRING
   mode: NULLABLE
-- name: agg_type
+- name: metric_type
   type: STRING
   mode: NULLABLE
 - name: total_users
   type: INTEGER
   mode: NULLABLE
-- name: aggregates
-  type: RECORD
-  mode: REPEATED
-  fields:
-  - name: key
-    type: STRING
-    mode: NULLABLE
-  - name: value
-    type: FLOAT
-    mode: NULLABLE
+- name: histogram
+  type: STRING
+  mode: NULLABLE
+- name: percentiles
+  type: STRING
+  mode: NULLABLE
+- name: total_sample
+  type: BIGNUMERIC
+  mode: NULLABLE
+- name: non_norm_histogram
+  type: STRING
+  mode: NULLABLE
+- name: non_norm_percentiles
+  type: STRING
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_nightly_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_nightly_v1/query.sql
@@ -1,7 +1,7 @@
 SELECT
-  * EXCEPT (channel)
+  *
 FROM
-  `moz-fx-data-shared-prod.telemetry_derived.client_probe_counts_v1`
+  `moz-fx-data-shared-prod.telemetry_derived.glam_extract_firefox_nightly_v1`
 WHERE
   -- filter based on https://github.com/mozilla/python_mozaggregator/blob/6c0119bfd0b535346c37cb3f707d998039d3e24b/mozaggregator/service.py#L51
   (
@@ -12,4 +12,3 @@ WHERE
     AND metric NOT LIKE "%manager_message_size%"
     AND metric NOT LIKE "%dropped_frames_proportion%"
   )
-  AND channel = "nightly"

--- a/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_nightly_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_nightly_v1/schema.yaml
@@ -1,41 +1,43 @@
 fields:
-- name: os
-  type: STRING
-  mode: NULLABLE
 - name: app_version
   type: INTEGER
   mode: NULLABLE
+- name: os
+  type: STRING
+  mode: NULLABLE
 - name: app_build_id
-  type: STRING
-  mode: NULLABLE
-- name: metric
-  type: STRING
-  mode: NULLABLE
-- name: metric_type
-  type: STRING
-  mode: NULLABLE
-- name: key
   type: STRING
   mode: NULLABLE
 - name: process
   type: STRING
   mode: NULLABLE
+- name: metric
+  type: STRING
+  mode: NULLABLE
+- name: key
+  type: STRING
+  mode: NULLABLE
 - name: client_agg_type
   type: STRING
   mode: NULLABLE
-- name: agg_type
+- name: metric_type
   type: STRING
   mode: NULLABLE
 - name: total_users
   type: INTEGER
   mode: NULLABLE
-- name: aggregates
-  type: RECORD
-  mode: REPEATED
-  fields:
-  - name: key
-    type: STRING
-    mode: NULLABLE
-  - name: value
-    type: FLOAT
-    mode: NULLABLE
+- name: histogram
+  type: STRING
+  mode: NULLABLE
+- name: percentiles
+  type: STRING
+  mode: NULLABLE
+- name: total_sample
+  type: BIGNUMERIC
+  mode: NULLABLE
+- name: non_norm_histogram
+  type: STRING
+  mode: NULLABLE
+- name: non_norm_percentiles
+  type: STRING
+  mode: NULLABLE


### PR DESCRIPTION
I recently noticed that GLAM public dataset is outdated (latest version is 78) and this is due to the query reading from a deprecated table. I suggest that we use the following tables to fix it, because they're the last state of the data before importing data into into glam.

