### PR TITLE
Fix mobile_search udf

### DIFF
--- a/sql/mozfun/mobile_search/normalize_app_name/udf.sql
+++ b/sql/mozfun/mobile_search/normalize_app_name/udf.sql
@@ -49,9 +49,9 @@ AS
 SELECT
   assert.equals(
     STRUCT('Firefox' AS normalized_app_name, 'Firefox Android' AS normalized_app_name_os),
-    normalize_app_name('Fenix', 'Android')
+    mobile_search.normalize_app_name('Fenix', 'Android')
   ),
   assert.equals(
     STRUCT('Firefox Lite' AS normalized_app_name, 'Firefox Lite Android' AS normalized_app_name_os),
-    normalize_app_name('Zerda', 'Android')
+    mobile_search.normalize_app_name('Zerda', 'Android')
   ),;


### PR DESCRIPTION
The test sql is failing due to no mention of namespace in the udf name.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
