### PR TITLE
Bug 1868674 - Ignore certain fields in internet outage checks

### DIFF
--- a/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/checks.sql
@@ -5,6 +5,15 @@
 {{ is_unique(columns=["datetime", "city", "country"], where="DATE(`datetime`) = @submission_date") }}
 
 #fail
+/*
+  This statement used to contain the following fields,
+  but these are sometimes missing from country/city combinations
+  See https://sql.telemetry.mozilla.org/queries/96541/source
+  and bug 1868674
+
+  "avg_tls_handshake_time"
+  "count_dns_failure"
+*/
 {{ not_null(columns=[
   "datetime",
   "city",
@@ -19,9 +28,7 @@
   "missing_dns_success",
   "avg_dns_failure_time",
   "missing_dns_failure",
-  "count_dns_failure",
   "ssl_error_prop",
-  "avg_tls_handshake_time"
 
 ], where="DATE(`datetime`) = @submission_date") }}
 


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [x] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [x] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [x] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2200)
