### PR TITLE
Bug 1868850 - Remove failing warn checks from UM

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
@@ -11,8 +11,6 @@
 {{ value_length(column="client_id", expected_length=36, where="submission_date = @submission_date") }}
 
 #warn
--- The following field is sometimes NULL
--- "normalized_os_version"
 {{ not_null(columns=[
   "activity_segment",
   "normalized_app_name",

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
@@ -10,6 +10,11 @@
 #fail
 {{ value_length(column="client_id", expected_length=36, where="submission_date = @submission_date") }}
 
+-- Commented out due to upstream duplication issue inside Fenix data
+-- which will cause this check to fail, see: bug(1803609).
+-- Once the duplication issue has been resolved, this check can be uncommented.
+-- #fail
+-- {{ is_unique(columns=["client_id"], where="submission_date = @submission_date") }}
 #warn
 {{ not_null(columns=[
   "activity_segment",

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
@@ -11,9 +11,8 @@
 {{ value_length(column="client_id", expected_length=36, where="submission_date = @submission_date") }}
 
 #warn
-{{ is_unique(columns=["client_id"], where="submission_date = @submission_date") }}
-
-#warn
+-- The following field is sometimes NULL
+-- "normalized_os_version"
 {{ not_null(columns=[
   "activity_segment",
   "normalized_app_name",
@@ -24,7 +23,6 @@
   "days_since_seen",
   "is_new_profile",
   "normalized_os",
-  "normalized_os_version",
   "app_version",
   "os_version_major",
   "os_version_minor",


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [x] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [x] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [x] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2201)
