### PR TITLE
Add `syndication` as possible metadata field

### DIFF
--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -420,6 +420,7 @@ class DatasetMetadata:
     labels: Dict = attr.ib({})
     default_table_workgroup_access: Optional[List[Dict[str, Any]]] = attr.ib(None)
     workgroup_access: list = attr.ib(DEFAULT_WORKGROUP_ACCESS)
+    syndication: Dict = attr.ib({})
 
     def __attrs_post_init__(self):
         """Set default table workgroup access to workgroup access."""


### PR DESCRIPTION
91acdfce70318b2f49e7a4ce22322dc9e820ce38 (in #4663) added this, which in turn broke (at least) doc generation.
See failure in https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/27883/workflows/c2e70f7c-268e-44d3-8763-4ffd8ea237ef/jobs/297400

This adds it as an optional field, which makes everything parse again.
Tested by running locally:

```
PATH="venv/bin:$PATH" script/bqetl docs generate --output_dir=generated_docs/
```

(with stuff from the `generated-sql` branch included in the `sql` dir for completeness)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2211)
