### PR TITLE
feat(): added an option to matches_pattern to be able to specify percentage threshold / tolerance for failures for the check

### DIFF
--- a/docs/reference/data_checks.md
+++ b/docs/reference/data_checks.md
@@ -236,13 +236,14 @@ Arguments:
 column: str - Column which values will be checked against the regex.
 pattern: str - Regex pattern specifying the expected shape / pattern of the values inside the column.
 where: Optional[str]: Any additional filtering rules that should be applied when retrieving the data to run the check against.
+threshold_fail_percentage: Optional[int] - Percentage of how many rows can fail the check before causing it to fail.
 message: Optional[str]: Custom error message.
 ```
 
 Example:
 ```sql
 #warn
-{{ matches_pattern(column="country", pattern="^[A-Z]{2}$", where="submission_date = @submission_date", message="Oops") }}
+{{ matches_pattern(column="country", pattern="^[A-Z]{2}$", where="submission_date = @submission_date", threshold_fail_percentage=10, message="Oops") }}
 ```
 
 

--- a/tests/checks/matches_pattern.jinja
+++ b/tests/checks/matches_pattern.jinja
@@ -1,9 +1,10 @@
-{% macro matches_pattern(column, pattern, where, message) %}
-  {% set message = message|default('Some values inside the `' ~ column ~ '` column do not match the expected pattern: `' ~ pattern ~ '`') %}
+{% macro matches_pattern(column, pattern, where, threshold_fail_percentage, message) %}
+  {% set threshold_fail_percentage = threshold_fail_percentage|default(0) %}
+  {% set message = message|default('The rate of fields that failed to match the pattern for column: `' ~ column ~ '` is greated than the `threshold_fail_percentage` (set to: ' ~ threshold_fail_percentage ~ '). Expected pattern: `' ~ pattern ~ '`.') %}
 
   SELECT
     IF(
-      COUNTIF(NOT REGEXP_CONTAINS({{ column }}, r"{{ pattern }}")) > 0,
+      ROUND((COUNTIF(NOT REGEXP_CONTAINS({{ column }}, r"{{ pattern }}"))) / COUNT(*) * 100, 2) > {{ threshold_fail_percentage }},
       ERROR("{{ message }}"),
       NULL
     )


### PR DESCRIPTION
# feat(): added an option to matches_pattern to be able to specify percentage threshold / tolerance for failures for the check

Now we can specify how many percent of rows can fail the check before causing the check to fail.

Example rendered check with a default:

```
#warn
{{ matches_pattern(column="country", pattern="^[A-Z]{2}$", where="submission_date = @submission_date", message="Some values in this field do not adhere to the ISO 3166-1 specification (2 character country code, for example: DE).") }}

```

```
#warn
SELECT
  IF(
    ROUND((COUNTIF(NOT REGEXP_CONTAINS(country, r"^[A-Z]{2}$"))) / COUNT(*) * 100, 2) > 0,
    ERROR(
      "Some values in this field do not adhere to the ISO 3166-1 specification (2 character country code, for example: DE)."
    ),
    NULL
  )
FROM
  `moz-fx-data-shared-prod.telemetry_derived.unified_metrics_v1`
WHERE
  submission_date = "2023-12-13";
```

---

Example rendered check with a default overwrite:

```
#warn
{{ matches_pattern(column="country", pattern="^[A-Z]{2}$", where="submission_date = @submission_date", threshold_fail_percentage=10, message="Some values in this field do not adhere to the ISO 3166-1 specification (2 character country code, for example: DE).") }}
```

```
#warn
SELECT
  IF(
    ROUND((COUNTIF(NOT REGEXP_CONTAINS(country, r"^[A-Z]{2}$"))) / COUNT(*) * 100, 2) > 10,
    ERROR(
      "Some values in this field do not adhere to the ISO 3166-1 specification (2 character country code, for example: DE)."
    ),
    NULL
  )
FROM
  `moz-fx-data-shared-prod.telemetry_derived.unified_metrics_v1`
WHERE
  submission_date = "2023-12-13";
```

In both cases the following command was used to render the checks:

```
./bqetl check render --sql_dir=sql --project_id=moz-fx-data-shared-prod telemetry_derived.unified_metrics_v1 --parameter=submission_date:DATE:2023-12-13
```

Both of the outputs have been manually tested via the BigQuery Console and executed without failures.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2212)
