### PR TITLE
bug(1870691): fixed spelling mistake and added missing filter for focus android check

### DIFF
--- a/sql_generators/active_users/templates/desktop_checks.sql
+++ b/sql_generators/active_users/templates/desktop_checks.sql
@@ -97,7 +97,7 @@ SELECT
     ABS((SELECT * FROM qdau_sum) - (SELECT * FROM live_table_qdau_count)) > 10,
     ERROR(
       CONCAT(
-        "QDAU mismatch between the live (`telemetry_live.main_v5`) and active_users_aggregates (`{{ dataset_id }}.{{ table_name }}`) tables is greated than 10.",
+        "QDAU mismatch between the live (`telemetry_live.main_v5`) and active_users_aggregates (`{{ dataset_id }}.{{ table_name }}`) tables is greater than 10.",
         " Live table count: ",
         (SELECT * FROM live_table_qdau_count),
         " | active_users_aggregates (QDAU): ",
@@ -155,7 +155,7 @@ SELECT
     ABS((SELECT * FROM dau_sum) - (SELECT * FROM distinct_client_count)) > 10,
     ERROR(
       CONCAT(
-        "DAU mismatch between the live (`telemetry_live.main_v5`) and active_users_aggregates (`{{ dataset_id }}.{{ table_name }}`) tables is greated than 10.",
+        "DAU mismatch between the live (`telemetry_live.main_v5`) and active_users_aggregates (`{{ dataset_id }}.{{ table_name }}`) tables is greater than 10.",
         " Live table count: ",
         (SELECT * FROM distinct_client_count),
         " | active_users_aggregates (DAU): ",

--- a/sql_generators/active_users/templates/fenix_checks.sql
+++ b/sql_generators/active_users/templates/fenix_checks.sql
@@ -124,7 +124,7 @@ SELECT
     ABS((SELECT * FROM dau_sum) - (SELECT * FROM distinct_client_count)) > 10,
     ERROR(
       CONCAT(
-        "DAU mismatch between the firefox_ios live (`org_mozilla_firefox_live`, `org_mozilla_fenix_live.baseline_v1`,`org_mozilla_firefox_beta_live.baseline_v1`,`org_mozilla_fenix_nightly_live.baseline_v1`, `org_mozilla_fennec_aurora_live.baseline_v1`) and active_users_aggregates (`fenix_derived.active_users_aggregates_v2`) tables is greated than 10.",
+        "DAU mismatch between the firefox_ios live (`org_mozilla_firefox_live`, `org_mozilla_fenix_live.baseline_v1`,`org_mozilla_firefox_beta_live.baseline_v1`,`org_mozilla_fenix_nightly_live.baseline_v1`, `org_mozilla_fennec_aurora_live.baseline_v1`) and active_users_aggregates (`fenix_derived.active_users_aggregates_v2`) tables is greater than 10.",
         " Live table count: ",
         (SELECT * FROM distinct_client_count),
         " | active_users_aggregates (DAU): ",

--- a/sql_generators/active_users/templates/mobile_checks.sql
+++ b/sql_generators/active_users/templates/mobile_checks.sql
@@ -17,15 +17,15 @@ WITH dau_sum AS (
     `{{ project_id }}.{{ dataset_id }}.{{ table_name }}` {%- endraw %}
   WHERE
     submission_date = @submission_date
+    {% if app_name == "focus_android" -%}
+    AND app_name IN ('Focus Android Glean', 'Focus Android Glean BrowserStack')
+    {% endif -%}
 ),
 distinct_client_count_base AS (
   {%- for channel in channels %}
   {%- if not loop.first -%}
   UNION ALL
     {%- endif %}
-    {% if channel.name -%}
-  -- {{ channel.name }} channel
-    {% endif -%}
   SELECT
     COUNT(DISTINCT client_info.client_id) AS distinct_client_count,
   FROM
@@ -46,7 +46,7 @@ SELECT
     ABS((SELECT * FROM dau_sum) - (SELECT * FROM distinct_client_count)) > 10,
     ERROR(
       CONCAT(
-        "DAU mismatch between the {{ app_name }} live across all channels ({%- for channel in channels %}{{ channel.table }},{% endfor -%}) and active_users_aggregates ({%- raw %}`{{ dataset_id }}.{{ table_name }}`{%- endraw %}) tables is greated than 10.",
+        "DAU mismatch between the {{ app_name }} live across all channels ({%- for channel in channels %}{{ channel.table }},{% endfor -%}) and active_users_aggregates ({%- raw %}`{{ dataset_id }}.{{ table_name }}`{%- endraw %}) tables is greater than 10.",
         " Live table count: ",
         (SELECT * FROM distinct_client_count),
         " | active_users_aggregates (DAU): ",

--- a/sql_generators/active_users/templates/mobile_checks.sql
+++ b/sql_generators/active_users/templates/mobile_checks.sql
@@ -18,7 +18,7 @@ WITH dau_sum AS (
   WHERE
     submission_date = @submission_date
     {% if app_name == "focus_android" -%}
-    AND app_name IN ('Focus Android Glean', 'Focus Android Glean BrowserStack')
+      AND app_name IN ('Focus Android Glean', 'Focus Android Glean BrowserStack')
     {% endif -%}
 ),
 distinct_client_count_base AS (

--- a/tests/checks/matches_pattern.jinja
+++ b/tests/checks/matches_pattern.jinja
@@ -1,6 +1,6 @@
 {% macro matches_pattern(column, pattern, where, threshold_fail_percentage, message) %}
   {% set threshold_fail_percentage = threshold_fail_percentage|default(0) %}
-  {% set message = message|default('The rate of fields that failed to match the pattern for column: `' ~ column ~ '` is greated than the `threshold_fail_percentage` (set to: ' ~ threshold_fail_percentage ~ '). Expected pattern: `' ~ pattern ~ '`.') %}
+  {% set message = message|default('The rate of fields that failed to match the pattern for column: `' ~ column ~ '` is greater than the `threshold_fail_percentage` (set to: ' ~ threshold_fail_percentage ~ '). Expected pattern: `' ~ pattern ~ '`.') %}
 
   SELECT
     IF(


### PR DESCRIPTION
# bug(1870691): fixed spelling mistake and added missing filter for focus android check

As per discussion with the owner of this dataset, the check needs filter out non-glean data in order to get the correct numbers. See the discussion inside the related bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1870691

Also, fixed a typo.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2236)
