### PR TITLE
Bug 1865706 - Glam etl drops keys longer than 200 characters instead of truncating

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/query.sql
@@ -6,7 +6,7 @@ WITH
       COALESCE(app_build_id, "*") AS app_build_id,
       process,
       metric,
-      SUBSTR(REPLACE(KEY, r"\x00", ""), 0, 200) AS KEY,
+      REPLACE(KEY, r"\x00", "") AS KEY,
       client_agg_type,
       metric_type,
       total_users,
@@ -29,6 +29,7 @@ WITH
       channel = @channel
       AND app_version IS NOT NULL
       AND total_users > 375
+      AND CHAR_LEN(KEY) <= 200
     GROUP BY
       channel,
       app_version,


### PR DESCRIPTION
fixes 1865706

GLAM has been truncating keys to 200 characters and this has become a problem now that it encountered more than one key that's longer than 200 chars and are made entirely of a single character, for the same probe. We believe such keys are garbage data, because they're all made of `�`, therefore we are getting rid of them.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2242)
