### PR TITLE
Bug 1815242 - Update bqetl_pocket triage notes

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -556,6 +556,11 @@ bqetl_pocket:
 
     Originally created for [Bug 1695336](
     https://bugzilla.mozilla.org/show_bug.cgi?id=1695336).
+
+    *Triage notes*
+
+    As long as the most recent DAG run is successful this job can be considered healthy.
+    In such case, past DAG failures can be ignored.
   schedule_interval: 0 12 * * *
   tags:
     - impact/tier_2


### PR DESCRIPTION
From bug, only most recent success matters