### PR TITLE
Add user-facing view to fxa_accounts

### DIFF
--- a/sql/moz-fx-data-shared-prod/accounts_db/fxa_accounts/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_db/fxa_accounts/metadata.yaml
@@ -1,0 +1,17 @@
+---
+friendly_name: Accounts table from production FxA database
+description: |-
+  An authorized view on top of the `accounts_db_external.fxa_accounts_v1` table
+  that only includes non-sensitive fields.
+  Some fields in this table are converted to a more user-friendly, BigQuery-native format:
+    - `uid` is converted from bytes to a hex string
+    - boolean integer columns are converted to BOOL
+    - timestamp columns are converted to TIMESTAMP
+
+  See https://mozilla.github.io/ecosystem-platform/reference/database-structure#database-fxa
+labels:
+  authorized: true
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/accounts_db/fxa_accounts/view.sql
+++ b/sql/moz-fx-data-shared-prod/accounts_db/fxa_accounts/view.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.accounts_db.fxa_accounts`
+AS
+SELECT
+  uid,
+  emailVerified,
+  verifierVersion,
+  verifierSetAt,
+  createdAt,
+  locale,
+  lockedAt,
+  profileChangedAt,
+  keysChangedAt,
+  ecosystemAnonId,
+  disabledAt,
+  metricsOptOutAt,
+FROM
+  `moz-fx-data-shared-prod.accounts_db_external.fxa_accounts_v1`


### PR DESCRIPTION
Follow up to https://github.com/mozilla/bigquery-etl/pull/4578

This adds a new user-facing view to accounts table. After this lands we'll be able to remove `accounts_backend.accounts` and its underlying table. 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2251)
