### PR TITLE
fixing DENG-2219 DENG-2220 DENG-2221

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_derived/firefox_major_release_dates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_derived/firefox_major_release_dates_v1/metadata.yaml
@@ -8,3 +8,4 @@ labels:
   owner1: leli@mozilla.com
 scheduling:
   dag_name: bqetl_telemetry_dev_cycle
+  date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_derived/glean_metrics_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_derived/glean_metrics_stats_v1/metadata.yaml
@@ -8,3 +8,4 @@ labels:
   owner1: leli@mozilla.com
 scheduling:
   dag_name: bqetl_telemetry_dev_cycle
+  date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_derived/telemetry_probes_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_derived/telemetry_probes_stats_v1/metadata.yaml
@@ -8,3 +8,4 @@ labels:
   owner1: leli@mozilla.com
 scheduling:
   dag_name: bqetl_telemetry_dev_cycle
+  date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_external/experiments_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_external/experiments_stats_v1/metadata.yaml
@@ -10,3 +10,4 @@ labels:
   owner1: leli@mozilla.com
 scheduling:
   dag_name: bqetl_telemetry_dev_cycle
+  date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_external/glean_metrics_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_external/glean_metrics_stats_v1/metadata.yaml
@@ -9,3 +9,4 @@ labels:
   owner1: leli@mozilla.com
 scheduling:
   dag_name: bqetl_telemetry_dev_cycle
+  date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_external/telemetry_probes_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_external/telemetry_probes_stats_v1/metadata.yaml
@@ -9,3 +9,4 @@ labels:
   owner1: leli@mozilla.com
 scheduling:
   dag_name: bqetl_telemetry_dev_cycle
+  date_partition_parameter: null


### PR DESCRIPTION
Airflow is complaining about missing partition .. so adding it to aaaall the metadata now 

```
Cannot read partition
[2023-12-22, 17:46:54 UTC] {pod_manager.py:437} INFO - [base] information from a table that is not partitioned: moz-fx-data-shared-
[2023-12-22, 17:46:54 UTC] {pod_manager.py:437} INFO - [base] prod:telemetry_dev_cycle_derived.firefox_major_release_dates_v1$20231222
```

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2260)
