### PR TITLE
DENG-2263 - Adding try catch to udf_js.decodeURIComponent

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf_js/decode_uri_attribution/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/decode_uri_attribution/udf.sql
@@ -30,6 +30,7 @@ const columns = [
   'ua',
   'variation',
 ];
+try { 
 return decodeURIComponent(decodeURIComponent(attribution))
   .split('&')
   .map((kv) => kv.split(/=(.*)/s))
@@ -40,7 +41,10 @@ return decodeURIComponent(decodeURIComponent(attribution))
     }
     return acc;
   }, {});
-
+} 
+catch {
+  return {};
+}
 """;
 
 -- Tests


### PR DESCRIPTION
- https://mozilla-hub.atlassian.net/browse/DENG-2263

- There are occasionally rows where the URI decode function fails, and this makes the view unusable (throws an error if you try to query that row) - so we added a try / catch to return null if the decoding fails.

- Once this is in place, will be easier to look at examples of where the decoding is failing, so we can make any changes to that as needed in the future

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2265)
