### PR TITLE
Grant ads dataset to ads workgroup

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads/dataset_metadata.yaml
@@ -4,4 +4,7 @@ description: |-
 dataset_base_acl: view_restricted
 user_facing: true
 labels: {}
-workgroup_access: []
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:ads

--- a/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
@@ -4,4 +4,7 @@ description: |-
 dataset_base_acl: derived_restricted
 user_facing: false
 labels: {}
-workgroup_access: []
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:ads

--- a/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
@@ -4,7 +4,4 @@ description: |-
 dataset_base_acl: derived_restricted
 user_facing: false
 labels: {}
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:ads
+workgroup_access: []


### PR DESCRIPTION
Members of the `ads` workgroup should have view access to everything in the `ads` dataset. There are some tables in `ads_derived` that are further restricted, so I didn't add this access to that dataset as well. The ads team is working on some changes to their permissioning/workgroup structure so this is likely to change in the future, but this should provide the essential access for now.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2291)
