### PR TITLE
Unschedule `fxa_content_events_v1` ETL (bug 1872186)

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/metadata.yaml
@@ -7,10 +7,12 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-scheduling:
-  dag_name: bqetl_fxa_events
-  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
-  referenced_tables: []
+# This is no longer scheduled because the underlying FxA tables have been removed.
+# FxA content server events are now included in the fxa_gcp_stdout_events_v1 ETL.
+#scheduling:
+#  dag_name: bqetl_fxa_events
+#  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+#  referenced_tables: []
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/query.sql
@@ -1,3 +1,12 @@
+/*
+This query is deprecated and no longer scheduled. The underlying tables
+on the FxA side have been removed and the relevant events are now included
+in the fxa_gcp_stdout_events_v1 ETL instead.
+
+We keep this query here basically just to document the fact that this table
+still exists and is referenced in views. If we need to backfill downstream
+ETL, the historical data in this table is still relevant.
+*/
 SELECT
   * REPLACE (
     (


### PR DESCRIPTION
Because the underlying FxA tables have been removed.

This shouldn't be an issue since the FxA content server events are now included in the `fxa_gcp_stdout_events_v1` ETL ([DENG-722](https://mozilla-hub.atlassian.net/browse/DENG-722)).

This should resolve [bug 1872186](https://bugzilla.mozilla.org/show_bug.cgi?id=1872186) "Airflow task bqetl_fxa_events.firefox_accounts_derived__fxa_content_events__v1 failing since exec_date 2023-12-25".

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DENG-722]: https://mozilla-hub.atlassian.net/browse/DENG-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2298)
