### PR TITLE
Update CJMS nonprod flows view to use FxA GCP log tables (bug 1872185)

### DIFF
--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_live/view.sql
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_live/view.sql
@@ -3,26 +3,28 @@ CREATE OR REPLACE VIEW
 AS
 WITH fxa_content_auth_stdout_events_live AS (
   SELECT
-    PARSE_DATE('%y%m%d', _TABLE_SUFFIX) AS submission_date,
+    DATE(_PARTITIONTIME) AS submission_date,
     JSON_VALUE(jsonPayload.fields.user_properties, '$.flow_id') AS flow_id,
     `timestamp`,
     TO_HEX(SHA256(jsonPayload.fields.user_id)) AS fxa_uid,
   FROM
-    `moz-fx-fxa-nonprod-375e.fxa_stage_logs.docker_fxa_auth_20*`
+    `moz-fx-fxa-nonprod.gke_fxa_stage_log.stderr`
   WHERE
-    jsonPayload.type = 'amplitudeEvent'
+    jsonPayload.logger = 'fxa-auth-server'
+    AND jsonPayload.type = 'amplitudeEvent'
     AND jsonPayload.fields.event_type IS NOT NULL
     AND jsonPayload.fields.user_id IS NOT NULL
   UNION ALL
   SELECT
-    PARSE_DATE('%y%m%d', _TABLE_SUFFIX) AS submission_date,
+    DATE(_PARTITIONTIME) AS submission_date,
     JSON_VALUE(jsonPayload.fields.user_properties, '$.flow_id') AS flow_id,
     `timestamp`,
     TO_HEX(SHA256(jsonPayload.fields.user_id)) AS fxa_uid,
   FROM
-    `moz-fx-fxa-nonprod-375e.fxa_stage_logs.docker_fxa_content_20*`
+    `moz-fx-fxa-nonprod.gke_fxa_stage_log.stdout`
   WHERE
-    jsonPayload.type = 'amplitudeEvent'
+    jsonPayload.logger = 'fxa-content-server'
+    AND jsonPayload.type = 'amplitudeEvent'
     AND jsonPayload.fields.event_type IS NOT NULL
   UNION ALL
   SELECT


### PR DESCRIPTION
The old FxA AWS log tables no longer exist.

This should resolve [bug 1872185](https://bugzilla.mozilla.org/show_bug.cgi?id=1872185) "Airflow task bqetl_cjms_nonprod.cjms_bigquery__flows__v1 failing since exec_date 2023-12-25 20:00:00".

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2299)
