### PR TITLE
Remove dryrun from view validation in CI

### DIFF
--- a/bigquery_etl/cli/view.py
+++ b/bigquery_etl/cli/view.py
@@ -11,13 +11,11 @@ from traceback import print_exc
 import rich_click as click
 
 from ..cli.utils import (
-    no_dryrun_option,
     parallelism_option,
     paths_matching_name_pattern,
     project_id_option,
     respect_dryrun_skip_option,
     sql_dir_option,
-    use_cloud_function_option,
 )
 from ..config import ConfigLoader
 from ..dryrun import DryRun
@@ -25,7 +23,6 @@ from ..metadata.parse_metadata import METADATA_FILE, Metadata
 from ..util.bigquery_id import sql_table_id
 from ..util.client_queue import ClientQueue
 from ..view import View, broken_views
-from .dryrun import dryrun
 
 VIEW_NAME_RE = re.compile(r"(?P<dataset>[a-zA-z0-9_]+)\.(?P<name>[a-zA-z0-9_]+)")
 
@@ -93,28 +90,12 @@ def create(name, sql_dir, project_id, owner):
 @click.argument("name", required=False)
 @sql_dir_option
 @project_id_option(default=None)
-@use_cloud_function_option
-@click.option(
-    "--validate_schemas",
-    "--validate-schemas",
-    help="Require dry run schema to match destination table and file if present.",
-    is_flag=True,
-    default=False,
-)
 @parallelism_option()
-@respect_dryrun_skip_option()
-@no_dryrun_option(default=False)
-@click.pass_context
 def validate(
-    ctx,
     name,
     sql_dir,
     project_id,
-    use_cloud_function,
-    validate_schemas,
     parallelism,
-    respect_dryrun_skip,
-    no_dryrun,
 ):
     """Validate the view definition."""
     view_files = paths_matching_name_pattern(
@@ -127,24 +108,11 @@ def validate(
     if not all(result):
         sys.exit(1)
 
-    # dryrun views
-    if not no_dryrun:
-        ctx.invoke(
-            dryrun,
-            paths=[str(f) for f in view_files],
-            use_cloud_function=use_cloud_function,
-            project=project_id,
-            validate_schemas=validate_schemas,
-            respect_skip=respect_dryrun_skip,
-        )
-    else:
-        click.echo("Dry run skipped for view files.")
-
     click.echo("All views are valid.")
 
 
-def _view_is_valid(view):
-    return view.is_valid()
+def _view_is_valid(v: View) -> bool:
+    return v.is_valid()
 
 
 @view.command(

--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -150,7 +150,7 @@ class View:
             )
         }
 
-    def is_valid(self):
+    def is_valid(self) -> bool:
         """Validate the SQL view definition."""
         if any(str(self.path).endswith(p) for p in self.skip_validation()):
             print(f"Skipped validation for {self.path}")

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -377,25 +377,6 @@ view:
     skip:
     # tests
     - sql/moz-fx-data-test-project/test/simple_view/view.sql
-    # Access Denied
-    - sql/moz-fx-data-shared-prod/ads/nt_visits_to_sessions_conversion_factors_daily/view.sql
-    - sql/moz-fx-data-shared-prod/telemetry/experiment_enrollment_cumulative_population_estimate/view.sql
-    - sql/moz-fx-data-shared-prod/mlhackweek_search/events/view.sql
-    - sql/moz-fx-data-shared-prod/regrets_reporter_ucs/deletion_request/view.sql
-    - sql/moz-fx-data-shared-prod/mlhackweek_search/custom/view.sql
-    - sql/moz-fx-data-shared-prod/regrets_reporter_ucs/regret_details/view.sql
-    - sql/moz-fx-data-shared-prod/regrets_reporter_ucs/video_data/view.sql
-    - sql/moz-fx-data-shared-prod/mlhackweek_search/deletion_request/view.sql
-    - sql/moz-fx-data-shared-prod/mlhackweek_search/baseline/view.sql
-    - sql/moz-fx-data-shared-prod/telemetry/regrets_reporter_update/view.sql
-    - sql/moz-fx-data-shared-prod/regrets_reporter_ucs/video_index/view.sql
-    - sql/moz-fx-data-shared-prod/telemetry/xfocsp_error_report/view.sql
-    - sql/moz-fx-data-shared-prod/mlhackweek_search/metrics/view.sql
-    - sql/moz-fx-data-shared-prod/regrets_reporter_ucs/main_events/view.sql
-    - sql/moz-fx-data-shared-prod/mlhackweek_search/action/view.sql
-    - sql/moz-fx-data-shared-prod/**/client_deduplication/view.sql
-    - sql/moz-fx-data-shared-prod/stripe/itemized_tax_transactions/view.sql
-    - sql/moz-fx-data-shared-prod/accounts_db/fxa_oauth_clients/view.sql
   publish:
     skip:
     - sql/moz-fx-data-shared-prod/activity_stream/tile_id_types/view.sql


### PR DESCRIPTION
There's no need to dryrun views during view validation. Views can be dryrun directly from the dryrun CLI, and are already in CI part of the `dry-run-sql` CI job.

The view validation skips under "access_denied" in `bqetl_project.yaml` are really dryrun skips.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2300)
