### PR TITLE
DAG docs - fix broken links and add tags to docs

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -36,7 +36,7 @@ Built from {{ repo }} repo, [`dags/{{ name }}.py`](https://github.com/mozilla/{{
 #### Tags
 {% for tag in tags %}
 * {{ tag }}
-{% endfor %}
+{%- endfor %}
 """
 
 

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -21,7 +21,7 @@ from utils.callbacks import retry_tasks_callback
 docs = """
 ### {{ name }}
 
-Built from {{ repo }} repo, [`dags/{{ name }}.py`](https://github.com/mozilla/{{ repo }}/blob/main/dags/{{ name }}.py)
+Built from {{ repo }} repo, [`dags/{{ name }}.py`](https://github.com/mozilla/{{ repo }}/blob/generated-sql/dags/{{ name }}.py)
 
 {% if description != "" -%}
 #### Description
@@ -32,6 +32,11 @@ Built from {{ repo }} repo, [`dags/{{ name }}.py`](https://github.com/mozilla/{{
 #### Owner
 
 {{ default_args.owner }}
+
+#### Tags
+{% for tag in tags %}
+* {{ tag }}
+{% endfor %}
 """
 
 

--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -11,7 +11,7 @@ from utils.gcp import gke_command
 docs = """
 ### {{ name }}
 
-Built from bigquery-etl repo, [`dags/{{ name }}.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/{{ name }}.py)
+Built from bigquery-etl repo, [`dags/{{ name }}.py`](https://github.com/mozilla/bigquery-etl/blob/generated-sql/dags/{{ name }}.py)
 
 {% if description != "" -%}
 #### Description
@@ -22,6 +22,11 @@ Built from bigquery-etl repo, [`dags/{{ name }}.py`](https://github.com/mozilla/
 #### Owner
 
 {{ default_args.owner }}
+
+#### Tags
+{% for tag in tags %}
+* {{ tag }}
+{%- endfor %}
 """
 
 

--- a/tests/data/dags/python_script_test_dag
+++ b/tests/data/dags/python_script_test_dag
@@ -11,11 +11,15 @@ from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
 docs = """
 ### bqetl_test_dag
 
-Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/bqetl_test_dag.py)
+Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/generated-sql/dags/bqetl_test_dag.py)
 
 #### Owner
 
 test@example.org
+
+#### Tags
+
+* repo/bigquery-etl
 """
 
 

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -15,11 +15,15 @@ from utils.callbacks import retry_tasks_callback
 docs = """
 ### bqetl_test_dag
 
-Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/bqetl_test_dag.py)
+Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/generated-sql/dags/bqetl_test_dag.py)
 
 #### Owner
 
 test@example.org
+
+#### Tags
+
+* repo/bigquery-etl
 """
 
 

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -11,11 +11,15 @@ from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
 docs = """
 ### bqetl_test_dag
 
-Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/bqetl_test_dag.py)
+Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/generated-sql/dags/bqetl_test_dag.py)
 
 #### Owner
 
 test@example.org
+
+#### Tags
+
+* repo/bigquery-etl
 """
 
 

--- a/tests/data/dags/test_dag_external_check_dependency
+++ b/tests/data/dags/test_dag_external_check_dependency
@@ -17,7 +17,7 @@ Built from bigquery-etl repo, [`dags/bqetl_external_test_dag.py`](https://github
 
 test@example.org
 
-# Tags
+#### Tags
 
 * repo/bigquery-etl
 """

--- a/tests/data/dags/test_dag_external_check_dependency
+++ b/tests/data/dags/test_dag_external_check_dependency
@@ -11,11 +11,15 @@ from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
 docs = """
 ### bqetl_external_test_dag
 
-Built from bigquery-etl repo, [`dags/bqetl_external_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/bqetl_external_test_dag.py)
+Built from bigquery-etl repo, [`dags/bqetl_external_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/generated-sql/dags/bqetl_external_test_dag.py)
 
 #### Owner
 
 test@example.org
+
+# Tags
+
+* repo/bigquery-etl
 """
 
 

--- a/tests/data/dags/test_dag_external_dependency
+++ b/tests/data/dags/test_dag_external_dependency
@@ -11,11 +11,15 @@ from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
 docs = """
 ### bqetl_external_test_dag
 
-Built from bigquery-etl repo, [`dags/bqetl_external_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/bqetl_external_test_dag.py)
+Built from bigquery-etl repo, [`dags/bqetl_external_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/generated-sql/dags/bqetl_external_test_dag.py)
 
 #### Owner
 
 test@example.org
+
+#### Tags
+
+* repo/bigquery-etl
 """
 
 

--- a/tests/data/dags/test_dag_with_check_dependencies
+++ b/tests/data/dags/test_dag_with_check_dependencies
@@ -11,11 +11,15 @@ from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
 docs = """
 ### bqetl_test_dag
 
-Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/bqetl_test_dag.py)
+Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/generated-sql/dags/bqetl_test_dag.py)
 
 #### Owner
 
 test@example.org
+
+#### Tags
+
+* repo/bigquery-etl
 """
 
 

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -11,11 +11,15 @@ from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
 docs = """
 ### bqetl_test_dag
 
-Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/bqetl_test_dag.py)
+Built from bigquery-etl repo, [`dags/bqetl_test_dag.py`](https://github.com/mozilla/bigquery-etl/blob/generated-sql/dags/bqetl_test_dag.py)
 
 #### Owner
 
 test@example.org
+
+#### Tags
+
+* repo/bigquery-etl
 """
 
 

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -11,11 +11,15 @@ from utils.gcp import gke_command
 docs = """
 ### bqetl_public_data_json
 
-Built from bigquery-etl repo, [`dags/bqetl_public_data_json.py`](https://github.com/mozilla/bigquery-etl/blob/main/dags/bqetl_public_data_json.py)
+Built from bigquery-etl repo, [`dags/bqetl_public_data_json.py`](https://github.com/mozilla/bigquery-etl/blob/generated-sql/dags/bqetl_public_data_json.py)
 
 #### Owner
 
 test@example.org
+
+#### Tags
+
+* repo/bigquery-etl
 """
 
 


### PR DESCRIPTION
At the moment the link in the Airflow DAG docs leads to the dag-file in `main` that no longer exists.
So switching the link to point to the file in the `generated-sql` branch should fix this.

And while I was here I thought it might be nice to add the tags to the docs, because inside the DAG in airflow one can't see what the impact is, which is annoying during triage.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2303)
