### PR TITLE
Change VPN subscriptions attribution from first touch to last touch (DENG-2259)

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/schema.yaml
@@ -20,9 +20,6 @@ fields:
 - name: event_timestamp
   type: TIMESTAMP
   mode: NULLABLE
-- name: customer_start_date
-  type: TIMESTAMP
-  mode: NULLABLE
 - name: subscription_start_date
   type: TIMESTAMP
   mode: NULLABLE
@@ -59,9 +56,6 @@ fields:
 - name: ended_reason
   type: STRING
   mode: NULLABLE
-- name: end_date
-  type: TIMESTAMP
-  mode: NULLABLE
 - name: fxa_uid
   type: STRING
   mode: NULLABLE
@@ -76,27 +70,6 @@ fields:
   mode: NULLABLE
 - name: user_registration_date
   type: TIMESTAMP
-  mode: NULLABLE
-- name: entrypoint_experiment
-  type: STRING
-  mode: NULLABLE
-- name: entrypoint_variation
-  type: STRING
-  mode: NULLABLE
-- name: utm_campaign
-  type: STRING
-  mode: NULLABLE
-- name: utm_content
-  type: STRING
-  mode: NULLABLE
-- name: utm_medium
-  type: STRING
-  mode: NULLABLE
-- name: utm_source
-  type: STRING
-  mode: NULLABLE
-- name: utm_term
-  type: STRING
   mode: NULLABLE
 - name: provider
   type: STRING
@@ -146,6 +119,30 @@ fields:
 - name: promotion_discounts_amount
   type: INTEGER
   mode: NULLABLE
+- name: attribution_timestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: entrypoint_experiment
+  type: STRING
+  mode: NULLABLE
+- name: entrypoint_variation
+  type: STRING
+  mode: NULLABLE
+- name: utm_campaign
+  type: STRING
+  mode: NULLABLE
+- name: utm_content
+  type: STRING
+  mode: NULLABLE
+- name: utm_medium
+  type: STRING
+  mode: NULLABLE
+- name: utm_source
+  type: STRING
+  mode: NULLABLE
+- name: utm_term
+  type: STRING
+  mode: NULLABLE
 - name: normalized_acquisition_channel
   type: STRING
   mode: NULLABLE
@@ -163,6 +160,12 @@ fields:
   mode: NULLABLE
 - name: website_channel_group
   type: STRING
+  mode: NULLABLE
+- name: customer_start_date
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: end_date
+  type: TIMESTAMP
   mode: NULLABLE
 - name: months_retained
   type: INTEGER


### PR DESCRIPTION
## [DENG-2259](https://mozilla-hub.atlassian.net/browse/DENG-2259): Change VPN ETL to use last touch attribution

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DENG-2259]: https://mozilla-hub.atlassian.net/browse/DENG-2259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2310)
