### PR TITLE
[Bug 1873276] Add references materialized views to bigquery_usage tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
@@ -36,7 +36,13 @@ def create_query(date, project):
           priority,
           project_id,
           project_number,
-          referenced_tables,
+          ARRAY_CONCAT(referenced_tables, (SELECT ARRAY_AGG(
+            STRUCT(
+              materialized_view.table_reference.project_id AS project_id,
+              materialized_view.table_reference.dataset_id AS dataset_id,
+              materialized_view.table_reference.table_id AS table_id
+            )
+          ) FROM UNNEST(materialized_view_statistics.materialized_view) AS materialized_view)) AS referenced_tables,
           reservation_id,
           start_time,
           state,


### PR DESCRIPTION
Needed for monitoring materialized views (https://bugzilla.mozilla.org/show_bug.cgi?id=1873276).
Materialized view references are in a separate field `materialized_view_statistics.materialized_view` in the `INFROMATION_SCHEMA.JOBS` views. This PR adds them to the `referenced_tables` field. I think it's fine to treat them as referenced tables for the purpose of monitoring

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2321)
