### PR TITLE
Add Monitor Plus to SubPlat consolidated reporting config (DENG-972)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/services_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/services_v1/query.sql
@@ -59,6 +59,13 @@ WITH services AS (
             STRUCT('8c3e3e6de4ee9731' AS id, 'mozilla-hubs' AS name),
             STRUCT('34bc0d0a6add7329' AS id, 'mozilla-hubs-dev' AS name)
           ] AS subplat_oauth_clients
+        ),
+        STRUCT(
+          'Monitor' AS id,
+          'Mozilla Monitor Plus' AS name,
+          ARRAY<STRUCT<name STRING, subplat_capabilities ARRAY<STRING>>>[] AS tiers,
+          ['monitor'] AS subplat_capabilities,
+          [STRUCT('802d56ef2a9af9fa' AS id, 'fx-monitor' AS name)] AS subplat_oauth_clients
         )
       ]
     )


### PR DESCRIPTION
## [DENG-972](https://mozilla-hub.atlassian.net/browse/DENG-972): SubPlat consolidated reporting ETL

Monitor Plus is a new subscription product being released this month.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DENG-972]: https://mozilla-hub.atlassian.net/browse/DENG-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2345)
