### PR TITLE
Remove remaining mentions of no_partition

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -700,13 +700,6 @@ def _get_partition(
     help="How many threads to run backfill in parallel",
 )
 @click.option(
-    "--no_partition",
-    "--no-partition",
-    is_flag=True,
-    default=False,
-    help="Disable writing results to a partition. Overwrites entire destination table.",
-)
-@click.option(
     "--destination_table",
     "--destination-table",
     required=False,
@@ -730,7 +723,6 @@ def backfill(
     dry_run,
     max_rows,
     parallelism,
-    no_partition,
     destination_table,
     checks,
 ):

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/metadata.yaml
@@ -12,8 +12,8 @@ description: |-
   effectively appeared on that date. The submission_date indicates
   when the server received the data.
 
-  The query for this table overwrites the whole table instead of writing to
-  a single partition, so manual backfills must use parameter --no_partition.
+  Note that the query for this table overwrites the whole table instead of writing to
+  a single partition.
 
   Proposal:
   https://docs.google.com/document/d/12bj4DhCybelqHVgOVq8KJlzgtbbUw3f68palNrv-gaM/.

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/metadata.yaml
@@ -11,8 +11,8 @@ description: |-
   For analysis purposes, use first_seen_date to query clients that
   effectively appeared on that date.
 
-  The query for this table overwrites the whole table instead of writing to
-  a single partition, so manual backfills must use parameter --no_partition.
+  Note that the query for this table overwrites the whole table instead of writing to
+  a single partition.
 
   Proposal:
   https://docs.google.com/document/d/12bj4DhCybelqHVgOVq8KJlzgtbbUw3f68palNrv-gaM/.


### PR DESCRIPTION
After https://github.com/mozilla/bigquery-etl/pull/4769, `no_partition` is no longer needed to backfill unpartitioned tables. PR removes mentions

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2356)
