### PR TITLE
# bug(): wrapping commented out test in jinja comment to exclude it from the final output

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
@@ -10,13 +10,13 @@
 #fail
 {{ value_length(column="client_id", expected_length=36, where="submission_date = @submission_date") }}
 
-{% raw -%}
+{#
 -- Commented out due to upstream duplication issue inside Fenix data
 -- which will cause this check to fail, see: bug(1803609).
 -- Once the duplication issue has been resolved, this check can be uncommented.
 -- #fail
 -- {{ is_unique(columns=["client_id"], where="submission_date = @submission_date") }}
-{% endraw %}
+#}
 #warn
 {{ not_null(columns=[
   "activity_segment",

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
@@ -10,11 +10,13 @@
 #fail
 {{ value_length(column="client_id", expected_length=36, where="submission_date = @submission_date") }}
 
+{% raw -%}
 -- Commented out due to upstream duplication issue inside Fenix data
 -- which will cause this check to fail, see: bug(1803609).
 -- Once the duplication issue has been resolved, this check can be uncommented.
 -- #fail
 -- {{ is_unique(columns=["client_id"], where="submission_date = @submission_date") }}
+{% endraw %}
 #warn
 {{ not_null(columns=[
   "activity_segment",


### PR DESCRIPTION
# bug(): wrapping commented out test in jinja comment to exclude it from the final output

This is causing part of our ETL execution flow to be blocked unintentionally.

This is a follow up to this commit https://github.com/mozilla/bigquery-etl/commit/8fc3567ad48292efd6594fde990d9e7c0d8e56c8 which accidentally introduced this bug.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2377)
