### PR TITLE
Fix typo on dependency task name

### DIFF
--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_beta_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_beta_aggregates_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_glam_refresh_aggregates
   date_partition_parameter: null
   depends_on:
-  - task_id: export_org_mozila_fenix_glam_beta
+  - task_id: export_org_mozilla_fenix_glam_beta
     dag_name: glam_fenix
     execution_delta: 6h

--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_nightly_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_nightly_aggregates_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_glam_refresh_aggregates
   date_partition_parameter: null
   depends_on:
-  - task_id: export_org_mozila_fenix_glam_nightly
+  - task_id: export_org_mozilla_fenix_glam_nightly
     dag_name: glam_fenix
     execution_delta: 6h

--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_release_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_release_aggregates_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_glam_refresh_aggregates
   date_partition_parameter: null
   depends_on:
-  - task_id: export_org_mozila_fenix_glam_release
+  - task_id: export_org_mozilla_fenix_glam_release
     dag_name: glam_fenix
     execution_delta: 6h


### PR DESCRIPTION
I spelled mozilla with one "L"
Soon enough I'll be writing GLLAM

