### PR TITLE
1866834 - update use counters views

### DIFF
--- a/sql_generators/use_counters/__init__.py
+++ b/sql_generators/use_counters/__init__.py
@@ -9,7 +9,6 @@ from jinja2 import Environment, FileSystemLoader
 
 from bigquery_etl.cli.utils import use_cloud_function_option
 from bigquery_etl.format_sql.formatter import reformat
-from bigquery_etl.schema import SCHEMA_FILE, Schema
 from bigquery_etl.util.common import write_sql
 
 FILE_PATH = Path(os.path.dirname(__file__))
@@ -49,7 +48,7 @@ def generate_view(project: str, dataset: str, destination_table: str, write_dir:
         SELECT
             *
         FROM
-            `{project}.{dataset}.{destination_table}`
+            `mozilla-public-data.{dataset}.{destination_table}`
     """
     )
 
@@ -80,6 +79,7 @@ def generate_metadata(
 def generate_schema(
     project: str, dataset: str, destination_table: str, write_dir: Path
 ):
+    """Generate schema"""
     shutil.copyfile(
         FILE_PATH / "templates" / "schema.yaml",
         write_dir / project / dataset / destination_table / "schema.yaml",


### PR DESCRIPTION
After making the BQ table public, I need to update the generated views to point to the new, updating public tables instead of the old ones, since the old ones will be deprecated.

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2388)
