### PR TITLE
Fix test for `norm.fenix_app_info` UDF

### DIFF
--- a/sql/mozfun/norm/fenix_app_info/udf.sql
+++ b/sql/mozfun/norm/fenix_app_info/udf.sql
@@ -42,7 +42,7 @@ SELECT
       'nightly' AS channel,
       'org.mozilla.fenix.nightly' AS app_id
     ),
-    norm.fenix_app_info('org.mozilla.fenix.nightly', '2015718419')
+    norm.fenix_app_info('org_mozilla_fenix_nightly', '2015718419')
   );
 
 WITH build_id AS (


### PR DESCRIPTION
This incorrect test just happened to work before because of unescaped underscores in the UDF's `LIKE` patterns, but the underscores were properly escaped in #4810.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2390)
