### PR TITLE
Use canonical app name for event flow monitoring

### DIFF
--- a/sql_generators/glean_usage/event_flow_monitoring.py
+++ b/sql_generators/glean_usage/event_flow_monitoring.py
@@ -39,7 +39,7 @@ class EventFlowMonitoring(GleanTable):
         if not self.across_apps_enabled:
             return
 
-        apps = [app[0]["app_name"] for app in apps]
+        apps = [app[0] for app in apps]
 
         render_kwargs = dict(
             project_id=project_id,

--- a/sql_generators/glean_usage/templates/event_flow_monitoring_aggregates_v1.script.sql
+++ b/sql_generators/glean_usage/templates/event_flow_monitoring_aggregates_v1.script.sql
@@ -21,7 +21,7 @@ CREATE TEMP TABLE
         {% if not loop.first -%}
           UNION ALL
         {% endif %}
-        {% if dataset_id not in ["telemetry", "accounts_frontend", "accounts_backend"] %}
+        {% if app['bq_dataset_family'] not in ["telemetry", "accounts_frontend", "accounts_backend"] %}
           SELECT DISTINCT
             @submission_date AS submission_date,
             ext.value AS flow_id,
@@ -32,25 +32,25 @@ CREATE TEMP TABLE
           -- limit event.timestamp, otherwise this will cause an overflow
               INTERVAL LEAST(event_timestamp, 20000000000000) MILLISECOND
             ) AS timestamp,
-            "{{ app }}" AS normalized_app_name,
+            "{{ app['canonical_app_name'] }}" AS normalized_app_name,
             client_info.app_channel AS channel
           FROM
-            `moz-fx-data-shared-prod.{{ app }}.events_unnested`,
+            `moz-fx-data-shared-prod.{{ app['bq_dataset_family'] }}.events_unnested`,
             UNNEST(event_extra) AS ext
           WHERE
             DATE(submission_timestamp) = @submission_date
             AND ext.key = "flow_id"
-        {% elif dataset_id in ["accounts_frontend", "accounts_backend"] %}
+        {% elif app['bq_dataset_family'] in ["accounts_frontend", "accounts_backend"] %}
           SELECT DISTINCT
             @submission_date AS submission_date,
             metrics.string.session_flow_id AS flow_id,
             NULL AS category,
             metrics.string.event_name AS name,
             submission_timestamp AS timestamp,
-            "{{ app }}" AS normalized_app_name,
+            "{{ app['canonical_app_name'] }}" AS normalized_app_name,
             client_info.app_channel AS channel
           FROM
-            `moz-fx-data-shared-prod.{{ app }}.accounts_events`
+            `moz-fx-data-shared-prod.{{ app['bq_dataset_family'] }}.accounts_events`
           WHERE
             DATE(submission_timestamp) = @submission_date
             AND metrics.string.session_flow_id != ""


### PR DESCRIPTION
We have some other event monitoring datasets that use the canonical app name, instead of the app dataset name. This PR updates the event flow monitoring dataset to do the same

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
