### PR TITLE
Fix null casting in script

### DIFF
--- a/sql_generators/glean_usage/templates/event_flow_monitoring_aggregates_v1.script.sql
+++ b/sql_generators/glean_usage/templates/event_flow_monitoring_aggregates_v1.script.sql
@@ -35,7 +35,7 @@ CREATE TEMP TABLE
             "{{ app['canonical_app_name'] }}" AS normalized_app_name,
             client_info.app_channel AS channel
           FROM
-            `moz-fx-data-shared-prod.{{ app['bq_dataset_family'] }}.events_unnested`,
+            `moz-fx-data-shared-prod.{{ app['app_name'] }}.events_unnested`,
             UNNEST(event_extra) AS ext
           WHERE
             DATE(submission_timestamp) = @submission_date
@@ -44,13 +44,13 @@ CREATE TEMP TABLE
           SELECT DISTINCT
             @submission_date AS submission_date,
             metrics.string.session_flow_id AS flow_id,
-            NULL AS category,
+            CAST(NULL AS STRING) AS category,
             metrics.string.event_name AS name,
             submission_timestamp AS timestamp,
             "{{ app['canonical_app_name'] }}" AS normalized_app_name,
             client_info.app_channel AS channel
           FROM
-            `moz-fx-data-shared-prod.{{ app['bq_dataset_family'] }}.accounts_events`
+            `moz-fx-data-shared-prod.{{ app['app_name'] }}.accounts_events`
           WHERE
             DATE(submission_timestamp) = @submission_date
             AND metrics.string.session_flow_id != ""


### PR DESCRIPTION
Fix null casting error and use app datasets

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2396)
