### PR TITLE
feat(DENG-2083): updated the source of is_activated inside the firefox_ios_clients view

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
@@ -1,3 +1,6 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_ios.firefox_ios_clients`
+AS
 SELECT
   clients.* EXCEPT(is_activated) REPLACE (
     CASE

--- a/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
@@ -1,8 +1,5 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.firefox_ios.firefox_ios_clients`
-AS
 SELECT
-  * REPLACE (
+  clients.* EXCEPT(is_activated) REPLACE (
     CASE
       WHEN adjust_network IS NULL
         THEN 'Unknown'
@@ -15,5 +12,12 @@ SELECT
       ELSE adjust_network
     END AS adjust_network
   ),
+  -- We need to pull is_activated from clients_activation which correctly
+  -- determines if a specific client is activated or not.
+  -- see: DENG-2083 for more info.
+  activation.is_activated,
 FROM
-  `moz-fx-data-shared-prod.firefox_ios_derived.firefox_ios_clients_v1`
+  `moz-fx-data-shared-prod.firefox_ios_derived.firefox_ios_clients_v1` AS clients
+LEFT JOIN
+  `moz-fx-data-shared-prod.firefox_ios.clients_activation` AS activation
+USING(client_id, first_seen_date)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
@@ -64,7 +64,7 @@ fields:
   name: is_activated
   type: BOOLEAN
   description: |
-    Determines if a client is activated based on the activation metric and a 7 day lag.
+    !!! INVALID !!! Please use firefox_ios.clients_activation instead.
 
 - mode: NULLABLE
   name: submission_timestamp


### PR DESCRIPTION
# feat(DENG-2083): updated the source of is_activated inside the firefox_ios_clients view

This is because is_activated is incorrectly generated inside the firefox_ios_clients table.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2397)
