### PR TITLE
feat(DENG-1697): Descheduled all FxA queries using the old AWS based tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/metadata.yaml
@@ -7,10 +7,12 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-scheduling:
-  dag_name: bqetl_fxa_events
-  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
-  referenced_tables: []
+# Query descheduled as a direct result of AWS migration to GCP
+# on 27th September 2023 the last AWS instances were spun down.
+# scheduling:
+#   dag_name: bqetl_fxa_events
+#   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+#   referenced_tables: []
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_auth_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_auth_events_v1/metadata.yaml
@@ -11,9 +11,11 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-scheduling:
-  dag_name: bqetl_fxa_events
-  referenced_tables: []
+# Query descheduled as a direct result of AWS migration to GCP
+# on 27th September 2023 the last AWS instances were spun down.
+# scheduling:
+#   dag_name: bqetl_fxa_events
+#   referenced_tables: []
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_content_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_content_events_v1/metadata.yaml
@@ -11,9 +11,11 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-scheduling:
-  dag_name: bqetl_fxa_events
-  referenced_tables: []
+# Query descheduled as a direct result of AWS migration to GCP
+# on 27th September 2023 the last AWS instances were spun down.
+# scheduling:
+#   dag_name: bqetl_fxa_events
+#   referenced_tables: []
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/metadata.yaml
@@ -16,10 +16,10 @@ labels:
 # descheduled due to source table change. v2 of the query retrieves the data from the new source.
 # scheduling:
 #   dag_name: bqetl_fxa_events
-#   This query references secret keys that are not available for dry runs,
-#   so we must explicitly write out dependencies. In this case, the query
-#   depends only on fxa logs produced via Stackdriver integration, so no other
-#   scheduled tasks are involved and the referenced_tables list is empty.
+#   # This query references secret keys that are not available for dry runs,
+#   # so we must explicitly write out dependencies. In this case, the query
+#   # depends only on fxa logs produced via Stackdriver integration, so no other
+#   # scheduled tasks are involved and the referenced_tables list is empty.
 #   referenced_tables: []
 bigquery:
   time_partitioning:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/metadata.yaml
@@ -13,14 +13,14 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-scheduling:
-  # descheduled due to source table change. v2 of the query retrieves the data from the new source.
-  # dag_name: bqetl_fxa_events
-  # This query references secret keys that are not available for dry runs,
-  # so we must explicitly write out dependencies. In this case, the query
-  # depends only on fxa logs produced via Stackdriver integration, so no other
-  # scheduled tasks are involved and the referenced_tables list is empty.
-  referenced_tables: []
+# descheduled due to source table change. v2 of the query retrieves the data from the new source.
+# scheduling:
+#   dag_name: bqetl_fxa_events
+#   This query references secret keys that are not available for dry runs,
+#   so we must explicitly write out dependencies. In this case, the query
+#   depends only on fxa logs produced via Stackdriver integration, so no other
+#   scheduled tasks are involved and the referenced_tables list is empty.
+#   referenced_tables: []
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
@@ -7,11 +7,13 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-# Query descheduled as a direct result of AWS migration to GCP
-# on 27th September 2023 the last AWS instances were spun down.
-# scheduling:
-#   dag_name: bqetl_fxa_events
-#   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+# This table is still being populated with data from the payments server
+# due to the fact that it was deployed in GCP prior to the AWS -> GCP migration
+# and was set up to route its data to the fxa_prod_logs.stdout inside the old FxA GCP project.
+# Until this routing is not updated, we need to keep this task running.
+scheduling:
+  dag_name: bqetl_fxa_events
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
@@ -7,9 +7,11 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-scheduling:
-  dag_name: bqetl_fxa_events
-  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+# Query descheduled as a direct result of AWS migration to GCP
+# on 27th September 2023 the last AWS instances were spun down.
+# scheduling:
+#   dag_name: bqetl_fxa_events
+#   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/metadata.yaml
@@ -10,7 +10,7 @@ labels:
 # This table is still being populated with data from the payments server
 # due to the fact that it was deployed in GCP prior to the AWS -> GCP migration
 # and was set up to route its data to the fxa_prod_logs.stdout inside the old FxA GCP project.
-# Until this routing is not updated, we need to keep this task running.
+# Until this routing is updated, we need to keep this task running.
 scheduling:
   dag_name: bqetl_fxa_events
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_auth_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_auth_events_v1/metadata.yaml
@@ -8,10 +8,12 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-scheduling:
-  dag_name: bqetl_fxa_events
-  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
-  referenced_tables: []
+# Query descheduled as a direct result of AWS migration to GCP
+# on 27th September 2023 the last AWS instances were spun down.
+# scheduling:
+#   dag_name: bqetl_fxa_events
+#   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+#   referenced_tables: []
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_content_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_content_events_v1/metadata.yaml
@@ -8,10 +8,12 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-scheduling:
-  dag_name: bqetl_fxa_events
-  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
-  referenced_tables: []
+# Query descheduled as a direct result of AWS migration to GCP
+# on 27th September 2023 the last AWS instances were spun down.
+# scheduling:
+#   dag_name: bqetl_fxa_events
+#   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+#   referenced_tables: []
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/metadata.yaml
@@ -8,11 +8,13 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-# Query descheduled as a direct result of AWS migration to GCP
-# on 27th September 2023 the last AWS instances were spun down.
-# scheduling:
-#   dag_name: bqetl_fxa_events
-#   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+# This table is still being populated with data from the payments server
+# due to the fact that it was deployed in GCP prior to the AWS -> GCP migration
+# and was set up to route its data to the fxa_prod_logs.stdout inside the old FxA GCP project.
+# Until this routing is not updated, we need to keep this task running.
+scheduling:
+  dag_name: bqetl_fxa_events
+  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/metadata.yaml
@@ -8,9 +8,11 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-scheduling:
-  dag_name: bqetl_fxa_events
-  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
+# Query descheduled as a direct result of AWS migration to GCP
+# on 27th September 2023 the last AWS instances were spun down.
+# scheduling:
+#   dag_name: bqetl_fxa_events
+#   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/metadata.yaml
@@ -11,7 +11,7 @@ labels:
 # This table is still being populated with data from the payments server
 # due to the fact that it was deployed in GCP prior to the AWS -> GCP migration
 # and was set up to route its data to the fxa_prod_logs.stdout inside the old FxA GCP project.
-# Until this routing is not updated, we need to keep this task running.
+# Until this routing is updated, we need to keep this task running.
 scheduling:
   dag_name: bqetl_fxa_events
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']


### PR DESCRIPTION
# feat(DENG-1697): Descheduled all FxA queries using the old AWS based tables

This change removing scheduling configuration for FxA queries which use log tables coming from the AWS version of the service. This service is no longer active and has been fully migrated over to GCP.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2398)
