### PR TITLE
Add `fxa_delete_events_v2` ETL based on FxA logs from GCP

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -101,11 +101,9 @@ FIREFOX_IOS_SRC = DeleteSource(
     table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID
 )
 FXA_HMAC_SRC = DeleteSource(
-    table="firefox_accounts_derived.fxa_delete_events_v1", field="hmac_user_id"
+    table="firefox_accounts.fxa_delete_events", field="hmac_user_id"
 )
-FXA_SRC = DeleteSource(
-    table="firefox_accounts_derived.fxa_delete_events_v1", field=USER_ID
-)
+FXA_SRC = DeleteSource(table="firefox_accounts.fxa_delete_events", field=USER_ID)
 REGRETS_SRC = DeleteSource(
     table="regrets_reporter_stable.regrets_reporter_update_v1",
     field="data_deletion_request.extension_installation_uuid",
@@ -118,7 +116,7 @@ SYNC_SOURCES = (
         field="payload.scalars.parent.deletion_request_sync_device_id",
     ),
     DeleteSource(
-        table="firefox_accounts_derived.fxa_delete_events_v1",
+        table="firefox_accounts.fxa_delete_events",
         field="SUBSTR(hmac_user_id, 0, 32)",
     ),
 )

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -62,6 +62,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/query.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/init.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/query.sql
+  - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v2/query.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_oauth_events_v1/query.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_auth_events_v1/query.sql
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_content_events_v1/query.sql

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_delete_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_delete_events/view.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_accounts.fxa_delete_events`
+AS
+SELECT
+  submission_timestamp,
+  user_id,
+  hmac_user_id
+FROM
+  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_delete_events_v1`
+UNION ALL
+SELECT
+  submission_timestamp,
+  user_id,
+  hmac_user_id
+FROM
+  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_delete_events_v2`

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/schema.yaml
@@ -1,0 +1,10 @@
+fields:
+- name: submission_timestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: user_id
+  type: STRING
+  mode: NULLABLE
+- name: hmac_user_id
+  type: STRING
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v2/metadata.yaml
@@ -1,0 +1,23 @@
+---
+friendly_name: FxA Delete Events
+description: Deletion events extracted from FxA auth server logs
+ used as signal for Mozilla to delete analysis data associated with
+ the user
+owners:
+  - kik@mozilla.com
+labels:
+  application: fxa
+  incremental: true
+  schedule: daily
+scheduling:
+  dag_name: bqetl_fxa_events
+  # This query references secret keys that are not available for dry runs,
+  # so we must explicitly write out dependencies. In this case, the query
+  # depends only on fxa logs produced via Stackdriver integration, so no other
+  # scheduled tasks are involved and the referenced_tables list is empty.
+  referenced_tables: []
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_timestamp
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v2/metadata.yaml
@@ -13,7 +13,7 @@ scheduling:
   dag_name: bqetl_fxa_events
   # This query references secret keys that are not available for dry runs,
   # so we must explicitly write out dependencies. In this case, the query
-  # depends only on fxa logs produced via Stackdriver integration, so no other
+  # depends only on fxa logs produced via Cloud Monitoring integration, so no other
   # scheduled tasks are involved and the referenced_tables list is empty.
   referenced_tables: []
 bigquery:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v2/query.sql
@@ -1,0 +1,30 @@
+WITH hmac_key AS (
+  SELECT
+    AEAD.DECRYPT_BYTES(
+      (SELECT keyset FROM `moz-fx-dataops-secrets.airflow_query_keys.fxa_prod`),
+      ciphertext,
+      CAST(key_id AS BYTES)
+    ) AS value
+  FROM
+    `moz-fx-data-shared-prod.firefox_accounts_derived.encrypted_keys_v1`
+  WHERE
+    key_id = 'fxa_hmac_prod'
+)
+SELECT
+  `timestamp` AS submission_timestamp,
+  TO_HEX(SHA256(jsonPayload.fields.uid)) AS user_id,
+  TO_HEX(
+    udf.hmac_sha256((SELECT * FROM hmac_key), CAST(jsonPayload.fields.uid AS BYTES))
+  ) AS hmac_user_id,
+FROM
+  `moz-fx-fxa-prod.gke_fxa_prod_log.stderr`
+WHERE
+  (
+    DATE(_PARTITIONTIME)
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 1 DAY)
+    AND DATE_ADD(@submission_date, INTERVAL 1 DAY)
+  )
+  AND DATE(`timestamp`) = @submission_date
+  AND jsonPayload.type = 'activityEvent'
+  AND jsonPayload.fields.event = 'account.deleted'
+  AND jsonPayload.fields.uid IS NOT NULL

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v2/schema.yaml
@@ -1,0 +1,10 @@
+fields:
+- name: submission_timestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: user_id
+  type: STRING
+  mode: NULLABLE
+- name: hmac_user_id
+  type: STRING
+  mode: NULLABLE


### PR DESCRIPTION
Along with a view to combine the `fxa_delete_events_v1` and `fxa_delete_events_v2` data, and use that view for Shredder.

This is being done in the context of [DENG-1590](https://mozilla-hub.atlassian.net/browse/DENG-1590) "_Add the new FxA tables to Shredder configuration (if currently not cofigured)_", but should have been done back in September as part of [DENG-1035](https://mozilla-hub.atlassian.net/browse/DENG-1035) "_Apply migration changes to prod datasets_".

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DENG-1590]: https://mozilla-hub.atlassian.net/browse/DENG-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-1035]: https://mozilla-hub.atlassian.net/browse/DENG-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2416)
