### PR TITLE
Restrict derived view schema generation to views with upstream schema files and directly copy reference schemas for simple views.

### DIFF
--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -379,3 +379,22 @@ class View:
             return False
 
         return True
+
+    @property
+    def is_default_view(self) -> bool:
+        """Determine whether view just SELECTS * FROM its (one) upstream reference."""
+        if len(self.table_references) != 1:
+            return False
+
+        default_view_content = reformat(
+            f"""
+           CREATE OR REPLACE VIEW `{self.project}.{self.dataset}.{self.name}` AS
+           SELECT * FROM `{self.table_references[0]}`
+           """
+        )
+
+        formatted_content = sqlparse.format(self.content, strip_comments=True).strip(
+            ";" + string.whitespace
+        )
+
+        return formatted_content == default_view_content

--- a/sql_generators/derived_view_schemas/__init__.py
+++ b/sql_generators/derived_view_schemas/__init__.py
@@ -9,22 +9,14 @@ from pathos.multiprocessing import ProcessingPool
 
 from bigquery_etl.cli.utils import use_cloud_function_option
 
-NON_USER_FACING_DATASET_SUBSTRINGS = (
-    "_derived",
-    "_external",
-    "_bi",
-    "_restricted",
-    "udf",
-)
-
 
 def _generate_view_schema(sql_dir: Path, view_directory: Path) -> None:
     import logging
 
-    from view import View
-
+    from bigquery_etl.format_sql.formatter import reformat
     from bigquery_etl.metadata.parse_metadata import Metadata
     from bigquery_etl.schema import Schema
+    from bigquery_etl.view import View
 
     logging.basicConfig(format="%(levelname)s (%(filename)s:%(lineno)d) - %(message)s")
 
@@ -32,24 +24,43 @@ def _generate_view_schema(sql_dir: Path, view_directory: Path) -> None:
     METADATA_FILE = "metadata.yaml"
     SCHEMA_FILE = "schema.yaml"
 
-    # If the view references only one table, we can:
-    # 1. Get the reference table partition key if it exists.
-    #   (to dry run views to partitioned tables).
-    # 2. Get the reference table schema and use it to enrich the
-    #   view schema we get from dry-running.
+    if (view_schema_path := view_directory / SCHEMA_FILE).exists():
+        return None
 
     view = View.from_file(view_directory / VIEW_FILE)
-    if len(view.table_references) != 1:
+
+    if "-- Generated via" in view.content:
         return None
 
-    ref_project, ref_dataset, ref_table = view.table_references[0].split(".")
-    ref_dir = sql_dir / ref_project / ref_dataset / ref_table
+    ref_dir, ref_schema = None, None
+    if len(view.table_references) == 1:
+        ref_project, ref_dataset, ref_table = view.table_references[0].split(".")
+        ref_dir = sql_dir / ref_project / ref_dataset / ref_table
 
-    non_user_facing = any(s in ref_dataset for s in NON_USER_FACING_DATASET_SUBSTRINGS)
-    if not ref_dir.exists() or non_user_facing or ref_dataset.name.endswith("_stable"):
-        return None
+        if ref_dataset.endswith("_stable"):
+            return None
 
-    def _get_reference_partition_key(ref_path: Path) -> Optional[str]:
+        if (ref_schema_path := ref_dir / SCHEMA_FILE).exists():
+            ref_schema = Schema.from_schema_file(ref_schema_path)
+
+        # If it's a "simple view", copy the upstream schema verbatim:
+        if (
+            reformat(
+                f"""
+                   CREATE OR REPLACE VIEW `{view.project}.{view.dataset}.{view.name}` AS
+                   SELECT * FROM `{ref_project}.{ref_dataset}.{ref_table}`
+                   """
+            ).strip()
+            in view.content.strip()
+            and ref_schema is not None
+        ):
+            ref_schema.to_yaml_file(view_schema_path)
+            return None
+
+    def _get_reference_partition_key(ref_path: Optional[Path]) -> Optional[str]:
+        if ref_path is None:
+            return None
+
         try:
             reference_metadata = Metadata.from_file(ref_path / METADATA_FILE)
         except Exception as metadata_exception:
@@ -74,21 +85,27 @@ def _generate_view_schema(sql_dir: Path, view_directory: Path) -> None:
         view.project, view.dataset, view.name, partitioned_by=reference_partition_key
     )
 
-    if len(view_schema.get("fields")) == 0:
+    if len(view_schema.schema.get("fields")) == 0:
         logging.warning(
             f"Got empty schema for {view.path} potentially "
             f"due to dry-run error. Won't write yaml."
         )
         return None
 
-    # Optionally enrich the view schema if we have a valid table reference
-    try:
-        reference_schema = Schema.from_schema_file(ref_dir / SCHEMA_FILE)
-        view_schema.merge(reference_schema, add_missing_fields=False)
-    except Exception as e:
-        logging.info(f"Unable to open reference schema; unable to enrich schema: {e}")
-
-    view_schema.to_yaml_file(view_directory / SCHEMA_FILE)
+    if ref_schema is not None:
+        # Optionally enrich the view schema if we have a valid table reference
+        try:
+            view_schema.merge(
+                ref_schema,
+                attributes=["description"],
+                ignore_missing_fields=True,
+                add_missing_fields=False,
+            )
+        except Exception as e:
+            # This is a broad exception raised upstream
+            # TODO: Update this and upstream to raise more specific exception
+            logging.warning(f"Failed to merge schemas {ref_dir} and {view.path}: {e}")
+    view_schema.to_yaml_file(view_schema_path)
 
 
 @click.command("generate")
@@ -122,6 +139,8 @@ def generate(target_project, output_dir, parallelism, use_cloud_function):
     We dry-run to get the schema data and where possible we enrich the
     view schemas with underlying table descriptions.
     """
+    print("Generating schemas for derived views")
+
     project_path = Path(f"{output_dir}/{target_project}")
     view_files = project_path.glob("*/*/view.sql")
 

--- a/sql_generators/derived_view_schemas/__init__.py
+++ b/sql_generators/derived_view_schemas/__init__.py
@@ -2,6 +2,7 @@
 
 from functools import partial
 from pathlib import Path
+from typing import Optional
 
 import click
 from pathos.multiprocessing import ProcessingPool
@@ -17,13 +18,13 @@ NON_USER_FACING_DATASET_SUBSTRINGS = (
 )
 
 
-def _generate_view_schema(sql_dir, view_directory):
+def _generate_view_schema(sql_dir: Path, view_directory: Path) -> None:
     import logging
 
-    from bigquery_etl.dependency import extract_table_references
+    from view import View
+
     from bigquery_etl.metadata.parse_metadata import Metadata
     from bigquery_etl.schema import Schema
-    from bigquery_etl.util.common import render
 
     logging.basicConfig(format="%(levelname)s (%(filename)s:%(lineno)d) - %(message)s")
 
@@ -36,102 +37,58 @@ def _generate_view_schema(sql_dir, view_directory):
     #   (to dry run views to partitioned tables).
     # 2. Get the reference table schema and use it to enrich the
     #   view schema we get from dry-running.
-    def _get_reference_dir_path(view_dir):
-        view_file = view_dir / VIEW_FILE
-        if not view_file.exists():
-            return
 
-        view_references = extract_table_references(render(view_file.name, view_dir))
-        if len(view_references) != 1:
-            return
+    view = View.from_file(view_directory / VIEW_FILE)
+    if len(view.table_references) != 1:
+        return None
 
-        target_project = view_dir.parent.parent.name
-        target_dataset = view_dir.parent.name
+    ref_project, ref_dataset, ref_table = view.table_references[0].split(".")
+    ref_dir = sql_dir / ref_project / ref_dataset / ref_table
 
-        target_reference = view_references[0]
-        parts = target_reference.split(".")
-        if len(parts) == 3:
-            reference_project_id, reference_dataset_id, reference_table_id = parts
-        # Fully qualify the reference:
-        elif len(parts) == 2:
-            reference_project_id = target_project
-            reference_dataset_id, reference_table_id = parts
-        elif len(parts) == 1:
-            reference_project_id = target_project
-            reference_dataset_id = target_dataset
-            reference_table_id = parts[0]
-        else:
-            return
+    non_user_facing = any(s in ref_dataset for s in NON_USER_FACING_DATASET_SUBSTRINGS)
+    if not ref_dir.exists() or non_user_facing or ref_dataset.name.endswith("_stable"):
+        return None
 
-        return (
-            sql_dir / reference_project_id / reference_dataset_id / reference_table_id
-        )
-
-    def _get_reference_partition_key(ref_path):
-        if ref_path is None:
-            logging.debug("No table reference, skipping partition key.")
-            return
-
+    def _get_reference_partition_key(ref_path: Path) -> Optional[str]:
         try:
             reference_metadata = Metadata.from_file(ref_path / METADATA_FILE)
         except Exception as metadata_exception:
             logging.warning(f"Unable to get reference metadata: {metadata_exception}")
-            return
+            return None
 
         bigquery_metadata = reference_metadata.bigquery
-        if bigquery_metadata is None:
-            logging.warning(
-                f"No bigquery metadata at {ref_path}, unable to get partition key."
-            )
-            return
-
-        partition_metadata = bigquery_metadata.time_partitioning
-        if partition_metadata is None:
+        if bigquery_metadata is None or bigquery_metadata.time_partitioning is None:
             logging.warning(
                 f"No partition metadata at {ref_path}, unable to get partition key."
             )
-            return
+            return None
 
-        return partition_metadata.field
-
-    reference_path = _get_reference_dir_path(view_directory)
-
-    # If this is a view to a stable table, don't try to write the schema:
-    if reference_path is not None:
-        reference_dataset = reference_path.parent.name
-        if reference_dataset.endswith("_stable"):
-            return
+        return bigquery_metadata.time_partitioning.field
 
     # Optionally get the upstream partition key
-    reference_partition_key = _get_reference_partition_key(reference_path)
+    reference_partition_key = _get_reference_partition_key(ref_dir)
     if reference_partition_key is None:
         logging.debug("No reference partition key, dry running without one.")
 
-    project_id = view_directory.parent.parent.name
-    dataset_id = view_directory.parent.name
-    view_id = view_directory.name
-
-    schema = Schema.for_table(
-        project_id, dataset_id, view_id, partitioned_by=reference_partition_key
+    view_schema = Schema.for_table(
+        view.project, view.dataset, view.name, partitioned_by=reference_partition_key
     )
-    if len(schema.schema.get("fields")) == 0:
+
+    if len(view_schema.get("fields")) == 0:
         logging.warning(
-            f"Got empty schema for {project_id}.{dataset_id}.{view_id} potentially "
+            f"Got empty schema for {view.path} potentially "
             f"due to dry-run error. Won't write yaml."
         )
-        return
+        return None
 
     # Optionally enrich the view schema if we have a valid table reference
-    if reference_path:
-        try:
-            reference_schema = Schema.from_schema_file(reference_path / SCHEMA_FILE)
-            schema.merge(reference_schema, add_missing_fields=False)
-        except Exception as e:
-            logging.info(
-                f"Unable to open reference schema; unable to enrich schema: {e}"
-            )
+    try:
+        reference_schema = Schema.from_schema_file(ref_dir / SCHEMA_FILE)
+        view_schema.merge(reference_schema, add_missing_fields=False)
+    except Exception as e:
+        logging.info(f"Unable to open reference schema; unable to enrich schema: {e}")
 
-    schema.to_yaml_file(view_directory / SCHEMA_FILE)
+    view_schema.to_yaml_file(view_directory / SCHEMA_FILE)
 
 
 @click.command("generate")
@@ -166,25 +123,13 @@ def generate(target_project, output_dir, parallelism, use_cloud_function):
     view schemas with underlying table descriptions.
     """
     project_path = Path(f"{output_dir}/{target_project}")
+    view_files = project_path.glob("*/*/view.sql")
 
-    dataset_paths = [
-        dataset_path
-        for dataset_path in project_path.iterdir()
-        if dataset_path.is_dir()
-        and all(
-            substring not in str(dataset_path)
-            for substring in NON_USER_FACING_DATASET_SUBSTRINGS
+    with ProcessingPool(parallelism) as pool:
+        pool.map(
+            partial(
+                _generate_view_schema,
+                Path(output_dir),
+            ),
+            [path.parent for path in view_files],
         )
-    ]
-
-    for dataset_path in dataset_paths:
-        view_directories = [path for path in dataset_path.iterdir() if path.is_dir()]
-
-        with ProcessingPool(parallelism) as pool:
-            pool.map(
-                partial(
-                    _generate_view_schema,
-                    Path(output_dir),
-                ),
-                view_directories,
-            )

--- a/tests/data/test_sql/moz-fx-data-test-project/test/default/view.sql
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/default/view.sql
@@ -1,0 +1,8 @@
+-- Test comment
+CREATE OR REPLACE VIEW
+  `moz-fx-data-test-project.test.default`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-test-project.test_derived.default_v1`

--- a/tests/view/test_view.py
+++ b/tests/view/test_view.py
@@ -136,3 +136,16 @@ class TestView:
         )
         assert mock_bigquery_table().friendly_name == "Test metadata file"
         assert mock_bigquery_table().description == "Test description"
+
+    def test_simple_views(self):
+        view = View.from_file(
+            TEST_DIR
+            / "data"
+            / "test_sql"
+            / "moz-fx-data-test-project"
+            / "test"
+            / "default"
+            / "view.sql"
+        )
+
+        assert view.is_default_view


### PR DESCRIPTION
View schema files are only used for adding descriptions, this PR adds that assumption to the generator. 

Previously it was attempting to generate schema files for all views, including where they wouldn't/didn't have descriptions and so wouldn't be useful. This added a lot of extra dryruns to CI. 

Also copies the reference schema directly for "simple"/default views.  

A few schema files will be removed from this PR (see diff comment), but these aren't currently used for anything.
