### PR TITLE
feat(DENG-1590): added existing fxa tables to shredder config

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -303,18 +303,6 @@ DELETE_TARGETS: DeleteIndex = {
     fxa_user_id_target(
         table="firefox_accounts_derived.fxa_gcp_stdout_events_v1"
     ): FXA_SRC,
-    fxa_user_id_target(
-        table="firefox_accounts_derived.docker_fxa_customs_sanitized_v1"
-    ): FXA_SRC,
-    fxa_user_id_target(
-        table="firefox_accounts_derived.docker_fxa_customs_sanitized_v2"
-    ): FXA_SRC,
-    fxa_user_id_target(
-        table="firefox_accounts_derived.docker_fxa_admin_server_sanitized_v1"
-    ): FXA_SRC,
-    fxa_user_id_target(
-        table="firefox_accounts_derived.docker_fxa_admin_server_sanitized_v2"
-    ): FXA_SRC,
     user_id_target(
         table="firefox_accounts_derived.fxa_log_device_command_events_v1"
     ): FXA_HMAC_SRC,

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -285,7 +285,6 @@ DELETE_TARGETS: DeleteIndex = {
     DeleteTarget(table="telemetry_stable.sync_v5", field=SYNC_IDS): SYNC_SOURCES,
     # fxa
     client_id_target(table="firefox_accounts_derived.events_daily_v1"): FXA_SRC,
-    client_id_target(table="firefox_accounts_derived.users_first_seen_v1"): FXA_SRC,
     client_id_target(table="firefox_accounts_derived.funnel_events_source_v1"): FXA_SRC,
     user_id_target(
         table="firefox_accounts_derived.fxa_amplitude_export_v1"
@@ -324,7 +323,6 @@ DELETE_TARGETS: DeleteIndex = {
     ): FXA_HMAC_SRC,
     fxa_user_id_target(table="firefox_accounts_derived.fxa_oauth_events_v1"): FXA_SRC,
     fxa_user_id_target(table="firefox_accounts_derived.fxa_stdout_events_v1"): FXA_SRC,
-    fxa_user_id_target(table="firefox_accounts_derived.fxa_server_events_v1"): FXA_SRC,
     user_id_target(table="firefox_accounts_derived.fxa_users_daily_v1"): FXA_SRC,
     user_id_target(table="firefox_accounts_derived.fxa_users_daily_v2"): FXA_SRC,
     user_id_target(table="firefox_accounts_derived.fxa_users_first_seen_v1"): FXA_SRC,

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -285,6 +285,7 @@ DELETE_TARGETS: DeleteIndex = {
     DeleteTarget(table="telemetry_stable.sync_v5", field=SYNC_IDS): SYNC_SOURCES,
     # fxa
     client_id_target(table="firefox_accounts_derived.events_daily_v1"): FXA_SRC,
+    client_id_target(table="firefox_accounts_derived.users_first_seen_v1"): FXA_SRC,
     client_id_target(table="firefox_accounts_derived.funnel_events_source_v1"): FXA_SRC,
     user_id_target(
         table="firefox_accounts_derived.fxa_amplitude_export_v1"
@@ -303,6 +304,18 @@ DELETE_TARGETS: DeleteIndex = {
     fxa_user_id_target(
         table="firefox_accounts_derived.fxa_gcp_stdout_events_v1"
     ): FXA_SRC,
+    fxa_user_id_target(
+        table="firefox_accounts_derived.docker_fxa_customs_sanitized_v1"
+    ): FXA_SRC,
+    fxa_user_id_target(
+        table="firefox_accounts_derived.docker_fxa_customs_sanitized_v2"
+    ): FXA_SRC,
+    fxa_user_id_target(
+        table="firefox_accounts_derived.docker_fxa_admin_server_sanitized_v1"
+    ): FXA_SRC,
+    fxa_user_id_target(
+        table="firefox_accounts_derived.docker_fxa_admin_server_sanitized_v2"
+    ): FXA_SRC,
     user_id_target(
         table="firefox_accounts_derived.fxa_log_device_command_events_v1"
     ): FXA_HMAC_SRC,
@@ -311,11 +324,13 @@ DELETE_TARGETS: DeleteIndex = {
     ): FXA_HMAC_SRC,
     fxa_user_id_target(table="firefox_accounts_derived.fxa_oauth_events_v1"): FXA_SRC,
     fxa_user_id_target(table="firefox_accounts_derived.fxa_stdout_events_v1"): FXA_SRC,
+    fxa_user_id_target(table="firefox_accounts_derived.fxa_server_events_v1"): FXA_SRC,
     user_id_target(table="firefox_accounts_derived.fxa_users_daily_v1"): FXA_SRC,
     user_id_target(table="firefox_accounts_derived.fxa_users_daily_v2"): FXA_SRC,
     user_id_target(table="firefox_accounts_derived.fxa_users_first_seen_v1"): FXA_SRC,
     user_id_target(table="firefox_accounts_derived.fxa_users_first_seen_v2"): FXA_SRC,
     user_id_target(table="firefox_accounts_derived.fxa_users_last_seen_v1"): FXA_SRC,
+    user_id_target(table="firefox_accounts_derived.fxa_users_last_seen_v2"): FXA_SRC,
     user_id_target(
         table="firefox_accounts_derived.fxa_users_services_daily_v1"
     ): FXA_SRC,
@@ -330,6 +345,9 @@ DELETE_TARGETS: DeleteIndex = {
     ): FXA_SRC,
     user_id_target(
         table="firefox_accounts_derived.fxa_users_services_last_seen_v1"
+    ): FXA_SRC,
+    user_id_target(
+        table="firefox_accounts_derived.fxa_users_services_last_seen_v2"
     ): FXA_SRC,
     user_id_target(
         table="firefox_accounts_derived.fxa_users_services_devices_daily_v1"


### PR DESCRIPTION
# feat(DENG-1590): added existing fxa tables to shredder config

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
