### PR TITLE
feat(DENG-2432): removed activations field from firefox_ios_clients_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/init.sql
@@ -26,14 +26,6 @@ WITH first_seen AS (
     submission_date < CURRENT_DATE
     AND client_id IS NOT NULL
 ),
--- Find the most recent activation record per client_id.
-activations AS (
-  SELECT
-    client_id,
-    is_activated,
-  FROM
-    firefox_ios_derived.new_profile_activation_v2
-),
 -- Find earliest data per client from the first_session ping.
 first_session_ping_base AS (
   SELECT
@@ -168,10 +160,6 @@ SELECT
   app_version,
   adjust_info.*,
   metadata,
-  activations.is_activated,
   is_suspicious_device_client,
 FROM
   _current
-LEFT JOIN
-  activations
-  USING (client_id)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -18,14 +18,6 @@ WITH first_seen AS (
     submission_date = @submission_date
     AND client_id IS NOT NULL
 ),
--- Find the most recent activation record per client_id.
-activations AS (
-  SELECT
-    client_id,
-    is_activated,
-  FROM
-    firefox_ios_derived.new_profile_activation_v2
-),
 -- Find earliest data per client from the first_session ping.
 first_session_ping_base AS (
   SELECT
@@ -175,7 +167,6 @@ SELECT
   COALESCE(_previous.device_model, _current.device_model) AS device_model,
   COALESCE(_previous.os_version, _current.os_version) AS os_version,
   COALESCE(_previous.app_version, _current.app_version) AS app_version,
-  activations.is_activated,
   -- below is to avoid mix and matching different adjust attributes
   -- from different records. This way we always treat them as a single "unit"
   IF(
@@ -214,6 +205,3 @@ FROM
 FULL OUTER JOIN
   _previous
   USING (client_id, sample_id)
-LEFT JOIN
-  activations
-  USING (client_id)

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/schema.yaml
@@ -61,12 +61,6 @@ fields:
     App display version for this client installation.
 
 - mode: NULLABLE
-  name: is_activated
-  type: BOOLEAN
-  description: |
-    !!! INVALID !!! Please use firefox_ios.clients_activation instead.
-
-- mode: NULLABLE
   name: submission_timestamp
   type: TIMESTAMP
   description: |


### PR DESCRIPTION
# feat(DENG-2432): removed activations field from firefox_ios_clients_v1

## Context:

We found that there were some inconsistencies with how we were previously generating the value for `is_activated` inside `firefox_ios_clients_v1` (see: DENG-2083). Instead of using `new_profile_activations_v2` we decided to make a new table to calculate activation information. This is for two main reasons: 

1) Cleaner data lineage
2) new_profile_activations has an awkward self dependency which makes the model more fragile and more difficult to recalculate if necessary.

## Change

This PR removes is_activated field related logic from the query file for firefox_ios_clients_v1

This information instead comes from `firefox_ios_derived.clients_activation_v1` and is also accessible via the `firefox_ios.firefox_ios_clients` view.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2433)
