### PR TITLE
feat(DENG-2432/): irefox ios clients v1 removing activation field view update

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/firefox_ios_clients/view.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_ios.firefox_ios_clients`
 AS
 SELECT
-  clients.* EXCEPT(is_activated) REPLACE (
+  clients.* REPLACE (
     CASE
       WHEN adjust_network IS NULL
         THEN 'Unknown'


### PR DESCRIPTION
# feat(DENG-2432/): irefox ios clients v1 removing activation field view update

Follow up to: https://github.com/mozilla/bigquery-etl/pull/4853

This also updates the view which was missed in the original PR.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2434)
