### PR TITLE
Fix `bqetl stage` to create parent dataset for stored procedures

### DIFF
--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -17,6 +17,7 @@ from ..cli.utils import paths_matching_name_pattern, sql_dir_option
 from ..cli.view import publish as publish_view
 from ..dryrun import DryRun
 from ..routine.parse_routine import (
+    ROUTINE_FILES,
     UDF_FILE,
     RawRoutine,
     accumulate_dependencies,
@@ -341,11 +342,11 @@ def _update_references(artifact_files, project_id, dataset_suffix, sql_dir):
 
 
 def _deploy_artifacts(ctx, artifact_files, project_id, dataset_suffix, sql_dir):
-    """Deploy UDFs, tables and views."""
-    # deploy UDFs
-    udf_files = [file for file in artifact_files if file.name == UDF_FILE]
-    for udf_file in udf_files:
-        dataset = udf_file.parent.parent.name
+    """Deploy routines, tables and views."""
+    # deploy routines
+    routine_files = [file for file in artifact_files if file.name in ROUTINE_FILES]
+    for routine_file in routine_files:
+        dataset = routine_file.parent.parent.name
         create_dataset_if_not_exists(
             project_id=project_id, dataset=dataset, suffix=dataset_suffix
         )

--- a/bigquery_etl/routine/parse_routine.py
+++ b/bigquery_etl/routine/parse_routine.py
@@ -21,7 +21,7 @@ from bigquery_etl.util.common import render
 UDF_CHAR = "[a-zA-Z0-9_]"
 UDF_FILE = "udf.sql"
 PROCEDURE_FILE = "stored_procedure.sql"
-ROUTINE_FILE = (UDF_FILE, PROCEDURE_FILE)
+ROUTINE_FILES = (UDF_FILE, PROCEDURE_FILE)
 TEMP_UDF_RE = re.compile(f"(?:udf|assert)_{UDF_CHAR}+")
 PERSISTENT_UDF_PREFIX_RE_STR = (
     r"CREATE\s+(?:OR\s+REPLACE\s+)?(?:FUNCTION|PROCEDURE)(?:\s+IF\s+NOT\s+EXISTS)?"
@@ -47,7 +47,7 @@ def get_routines_from_dir(project_dir):
         }
         for root, dirs, files in os.walk(project_dir)
         for filename in files
-        if filename in ROUTINE_FILE
+        if filename in ROUTINE_FILES
     ]
 
 
@@ -237,7 +237,7 @@ def read_routine_dir(*project_dirs):
             for root, dirs, files in os.walk(project_dir)
             if os.path.basename(root) != ConfigLoader.get("routine", "example_dir")
             for filename in files
-            if filename in ROUTINE_FILE
+            if filename in ROUTINE_FILES
             for raw_routine in (RawRoutine.from_file(os.path.join(root, filename)),)
         }
 


### PR DESCRIPTION
The `deploy-changes-to-stage` CI for #4860 is currently failing because `bqetl stage` isn't first creating the dataset it's trying to deploy the new stored procedure into.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2453)
