### PR TITLE
Add table for Android Client LTV

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix/client_ltv/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/client_ltv/view.sql
@@ -1,0 +1,96 @@
+-- Params Note: Set these same values in fenix.ltv_states
+{% set max_weeks = 32 %}
+{% set death_time = 168 %}
+{% set lookback = 28 %}
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.fenix.client_ltv`
+AS
+WITH extracted_fields AS (
+  SELECT
+    *,
+    BIT_COUNT(
+      `mozfun`.bytes.extract_bits(days_seen_bytes, -1 * {{ lookback }}, {{ lookback }})
+    ) AS activity_pattern,
+    BIT_COUNT(`mozfun`.bytes.extract_bits(days_seen_bytes, -1, 1)) AS active_on_this_date,
+  FROM
+    `frank-sandbox.fenix_derived.client_ltv_v1`
+), with_states AS (
+  SELECT
+    client_id,
+    sample_id,
+    as_of_date,
+    first_reported_country AS country,
+    [
+      STRUCT(
+        mozfun.ltv.android_states_v1(
+          adjust_network,
+          days_since_first_seen,
+          as_of_date,
+          first_seen_date,
+          activity_pattern,
+          active_on_this_date,
+          {{ max_weeks }},
+          first_reported_country
+        ) AS state,
+        'android_states_v1' AS state_function
+      ),
+      STRUCT(
+        mozfun.ltv.android_states_with_paid_v1(
+          adjust_network,
+          days_since_first_seen,
+          as_of_date,
+          first_seen_date,
+          activity_pattern,
+          active_on_this_date,
+          {{ max_weeks }},
+          first_reported_country
+        ) AS state,
+        'android_states_with_paid_v1' AS state_function
+      ),
+      STRUCT(
+        mozfun.ltv.android_states_with_paid_v2(
+          adjust_network,
+          days_since_first_seen,
+          days_since_seen,
+          {{ death_time }},
+          as_of_date,
+          first_seen_date,
+          activity_pattern,
+          active_on_this_date,
+          {{ max_weeks }},
+          first_reported_country
+        ) AS state,
+        'android_states_with_paid_v2' AS state_function
+      )
+    ] AS markov_states,
+    * EXCEPT (client_id, sample_id, as_of_date)
+  FROM
+    extracted_fields
+), state_ad_clicks_prediction AS (
+  -- When this table is moved to bqetl, these will be enabled as checks
+  SELECT
+    -- Each country in this table should only have states for one state function
+    mozfun.assert.equals(1, COUNT(DISTINCT state_function) OVER (PARTITION BY country)) AS is_valid_countries,
+    -- Each country should have each state present only once
+    mozfun.assert.equals(1, COUNT(*) OVER (PARTITION BY country, state)) AS is_valid_states,
+    *,
+  FROM
+    mozdata.analysis.android_states_predicted_ad_clicks_v1
+)
+
+SELECT
+  client_id,
+  sample_id,
+  country,
+  COALESCE(total_historic_ad_clicks, 0) AS total_historic_ad_clicks,
+  COALESCE(predicted_ad_clicks, 0) AS total_future_ad_clicks,
+  COALESCE(total_historic_ad_clicks, 0) + COALESCE(predicted_ad_clicks, 0) AS total_predicted_ad_clicks,
+FROM
+  with_states
+CROSS JOIN
+  UNNEST(markov_states)
+JOIN
+  state_ad_clicks_prediction
+  USING (country, state_function, state)
+WHERE
+  is_valid_countries AND is_valid_states

--- a/sql/moz-fx-data-shared-prod/fenix/client_ltv/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/client_ltv/view.sql
@@ -13,7 +13,7 @@ WITH extracted_fields AS (
     ) AS activity_pattern,
     BIT_COUNT(`mozfun`.bytes.extract_bits(days_seen_bytes, -1, 1)) AS active_on_this_date,
   FROM
-    `frank-sandbox.fenix_derived.client_ltv_v1`
+    `moz-fx-data-shared-prod.fenix_derived.client_ltv_v1`
 ),
 with_states AS (
   SELECT
@@ -83,5 +83,5 @@ FROM
 CROSS JOIN
   UNNEST(markov_states)
 JOIN
-  mozdata.analysis.android_states_predicted_ad_clicks_v1
+  `moz-fx-data-shared-prod`.fenix_derived.android_states_predicted_ad_clicks_v1
   USING (country, state_function, state)

--- a/sql/moz-fx-data-shared-prod/fenix/client_ltv/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/client_ltv/view.sql
@@ -14,7 +14,8 @@ WITH extracted_fields AS (
     BIT_COUNT(`mozfun`.bytes.extract_bits(days_seen_bytes, -1, 1)) AS active_on_this_date,
   FROM
     `frank-sandbox.fenix_derived.client_ltv_v1`
-), with_states AS (
+),
+with_states AS (
   SELECT
     client_id,
     sample_id,
@@ -67,14 +68,16 @@ WITH extracted_fields AS (
   FROM
     extracted_fields
 )
-
 SELECT
   client_id,
   sample_id,
   country,
   COALESCE(total_historic_ad_clicks, 0) AS total_historic_ad_clicks,
   COALESCE(predicted_ad_clicks, 0) AS total_future_ad_clicks,
-  COALESCE(total_historic_ad_clicks, 0) + COALESCE(predicted_ad_clicks, 0) AS total_predicted_ad_clicks,
+  COALESCE(total_historic_ad_clicks, 0) + COALESCE(
+    predicted_ad_clicks,
+    0
+  ) AS total_predicted_ad_clicks,
 FROM
   with_states
 CROSS JOIN

--- a/sql/moz-fx-data-shared-prod/fenix/client_ltv/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/client_ltv/view.sql
@@ -83,5 +83,5 @@ FROM
 CROSS JOIN
   UNNEST(markov_states)
 JOIN
-  `moz-fx-data-shared-prod`.fenix_derived.android_states_predicted_ad_clicks_v1
+  `moz-fx-data-shared-prod`.fenix_derived.ltv_state_values_v1
   USING (country, state_function, state)

--- a/sql/moz-fx-data-shared-prod/fenix/client_ltv/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/client_ltv/view.sql
@@ -66,16 +66,6 @@ WITH extracted_fields AS (
     * EXCEPT (client_id, sample_id, as_of_date)
   FROM
     extracted_fields
-), state_ad_clicks_prediction AS (
-  -- When this table is moved to bqetl, these will be enabled as checks
-  SELECT
-    -- Each country in this table should only have states for one state function
-    mozfun.assert.equals(1, COUNT(DISTINCT state_function) OVER (PARTITION BY country)) AS is_valid_countries,
-    -- Each country should have each state present only once
-    mozfun.assert.equals(1, COUNT(*) OVER (PARTITION BY country, state)) AS is_valid_states,
-    *,
-  FROM
-    mozdata.analysis.android_states_predicted_ad_clicks_v1
 )
 
 SELECT
@@ -90,7 +80,5 @@ FROM
 CROSS JOIN
   UNNEST(markov_states)
 JOIN
-  state_ad_clicks_prediction
+  mozdata.analysis.android_states_predicted_ad_clicks_v1
   USING (country, state_function, state)
-WHERE
-  is_valid_countries AND is_valid_states

--- a/sql/moz-fx-data-shared-prod/fenix/ltv_state_values/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/ltv_state_values/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.fenix.ltv_state_values`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.fenix_derived.ltv_state_values_v1`

--- a/sql/moz-fx-data-shared-prod/fenix/ltv_states/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/ltv_states/view.sql
@@ -1,3 +1,4 @@
+-- Params Note: Set these same values in fenix.client_ltv
 {% set max_weeks = 32 %}
 {% set death_time = 168 %}
 {% set lookback = 28 %}

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/checks.sql
@@ -1,0 +1,6 @@
+#fail
+{{ is_unique("client_id") }}
+
+#fail
+{{ min_row_count(10000, "as_of_date = @submission_date") }}
+

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/metadata.yaml
@@ -15,7 +15,7 @@ scheduling:
   parameters:
   - "submission_date:DATE:{{ds}}"
 bigquery:
-  time_partition: null
+  time_partitioning: null
   clustering:
     fields:
     - sample_id

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/metadata.yaml
@@ -1,0 +1,28 @@
+friendly_name: Client LTV States
+description: |-
+  LTV states by client, rather than by client-day.
+  Uses the most recently seen values for a client.
+  LTV here is number of ad-clicks.
+owners:
+- frank@mozilla.com
+labels:
+  incremental: true
+  owner1: frank@mozilla.com
+scheduling:
+  depends_on_past: true
+  dag_name: bqetl_org_mozilla_firefox_derived
+  date_partition_parameter: null
+  parameters:
+  - "submission_date:DATE:{{ds}}"
+bigquery:
+  time_partition: null
+  clustering:
+    fields:
+    - sample_id
+    - first_reported_country
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+references: {}
+deprecated: false

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/query.sql
@@ -5,7 +5,7 @@ WITH new_data AS (
     MAX(submission_date) AS as_of_date,
     MAX_BY(ltv_states_v1, submission_date).* EXCEPT (client_id, sample_id, submission_date),
   FROM
-    moz - fx - data - shared - prod.fenix_derived.ltv_states_v1
+    `moz-fx-data-shared-prod`.fenix_derived.ltv_states_v1
   WHERE
     {% if is_init() %}
       submission_date >= "2020-01-01"

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/query.sql
@@ -1,0 +1,42 @@
+WITH new_data AS (
+  SELECT
+    client_id,
+    sample_id,
+    MAX(submission_date) AS as_of_date,
+    MAX_BY(ltv_states_v1, submission_date).* EXCEPT (client_id, sample_id, submission_date),
+  FROM
+    moz-fx-data-shared-prod.fenix_derived.ltv_states_v1
+  WHERE
+    {% if is_init() %}
+      submission_date >= "2020-01-01"
+    {% else %}
+      submission_date = @submission_date
+    {% endif %}
+  GROUP BY
+    client_id,
+    sample_id
+),
+historic_data AS (
+  SELECT
+    *
+  FROM
+    fenix_derived.client_ltv_v1
+)
+SELECT
+  (
+    CASE
+      WHEN new_data.as_of_date IS NULL
+        THEN historic_data
+      WHEN historic_data.as_of_date IS NULL
+        THEN new_data
+      WHEN new_data.as_of_date > historic_data.as_of_date
+        THEN new_data
+      ELSE historic_data
+    END
+  ).*
+FROM
+  historic_data
+FULL OUTER JOIN
+  new_data
+USING
+  (sample_id, client_id)

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/query.sql
@@ -5,7 +5,7 @@ WITH new_data AS (
     MAX(submission_date) AS as_of_date,
     MAX_BY(ltv_states_v1, submission_date).* EXCEPT (client_id, sample_id, submission_date),
   FROM
-    moz-fx-data-shared-prod.fenix_derived.ltv_states_v1
+    moz - fx - data - shared - prod.fenix_derived.ltv_states_v1
   WHERE
     {% if is_init() %}
       submission_date >= "2020-01-01"
@@ -38,5 +38,4 @@ FROM
   historic_data
 FULL OUTER JOIN
   new_data
-USING
-  (sample_id, client_id)
+  USING (sample_id, client_id)

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/schema.yaml
@@ -1,0 +1,62 @@
+fields:
+  - name: client_id
+    mode: NULLABLE
+    type: STRING
+    description: "Client ID; uniquely identifies a client. Joinable with fenix.firefox_android_clients."
+  - name: sample_id
+    mode: NULLABLE
+    type: INTEGER
+    description: "A number, 0-99, that samples by client_id."
+  - name: as_of_date
+    mode: NULLABLE
+    type: DATE
+    description: >
+      The date from which the markov states are pulled from.
+      After a year of inactivity, the markov states will stop updated;
+      similarly, the as_of_date will not update.
+  - name: first_seen_date
+    mode: NULLABLE
+    type: DATE
+    description: "First submission date that this client was seen on."
+  - name: days_since_first_seen
+    mode: NULLABLE
+    type: INTEGER
+    description: "Number of days since this client was first seen."
+  - name: days_since_seen
+    mode: NULLABLE
+    type: INTEGER
+    description: "Number of days since this client was last seen. For example, if they were seen yesterday, days_since_seen would be 1."
+  - name: consecutive_days_seen
+    mode: NULLABLE
+    type: INTEGER
+    description: >
+      Number of consecutive days this client has been seen.
+      For example, if they were missing two days ago but present yesterday & today, consecutive_days_seen would be 2.
+  - name: days_seen_bytes
+    mode: NULLABLE
+    type: BYTES
+    description: "Days seen over the past year, represented as bytes."
+  - name: ad_clicks_on_date
+    mode: NULLABLE
+    type: INTEGER
+    description: "Number of ad clicks by this client on this submission date."
+  - name: total_historic_ad_clicks
+    mode: NULLABLE
+    type: INTEGER
+    description: "Total historic ad clicks by this client up to this date (inclusive of this date)."
+  - name: first_reported_country
+    mode: NULLABLE
+    type: STRING
+    description: "First country reported by this client."
+  - name: first_reported_isp
+    mode: NULLABLE
+    type: STRING
+    description: "First ISP reported by this client."
+  - name: adjust_network
+    mode: NULLABLE
+    type: STRING
+    description: "First Adjust Network reported by this client."
+  - name: install_source
+    mode: NULLABLE
+    type: STRING
+    description: "First install source reported by this client."

--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/checks.sql
@@ -12,6 +12,7 @@ FROM
   fenix_derived.ltv_state_values_v1
 GROUP BY
   country;
+
 # fail
 -- There should be more than 2 countries present
 SELECT

--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/checks.sql
@@ -12,7 +12,6 @@ FROM
   fenix_derived.ltv_state_values_v1
 GROUP BY
   country
-
 # fail
 -- There should be more than 2 countries present
 SELECT

--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/checks.sql
@@ -1,0 +1,21 @@
+# fail
+{{ is_unique(["country", "state"]) }}
+
+# fail
+{{ min_row_count(1000) }}
+
+# fail
+-- Each country should have a single state function
+SELECT
+  mozfun.assert.equals(1, COUNT(DISTINCT state_function))
+FROM
+  fenix_derived.ltv_state_values_v1
+GROUP BY
+  country
+
+# fail
+-- There should be more than 2 countries present
+SELECT
+  mozfun.assert.true(COUNT(DISTINCT country) > 2)
+FROM
+  fenix_derived.ltv_state_values_v1

--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/checks.sql
@@ -11,10 +11,10 @@ SELECT
 FROM
   fenix_derived.ltv_state_values_v1
 GROUP BY
-  country
+  country;
 # fail
 -- There should be more than 2 countries present
 SELECT
-  mozfun.assert.true(COUNT(DISTINCT country) > 2)
+  `mozfun.assert.true`(COUNT(DISTINCT country) > 2)
 FROM
-  fenix_derived.ltv_state_values_v1
+  fenix_derived.ltv_state_values_v1;

--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/metadata.yaml
@@ -8,7 +8,7 @@ labels:
   incremental: false
   owner1: frank@mozilla.com
 scheduling:
-  dag_name: bqetl_org_mozilla_firefox
+  dag_name: bqetl_org_mozilla_firefox_derived
   depends_on_past: false
   date_partition_parameter: null
 bigquery:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/metadata.yaml
@@ -1,0 +1,19 @@
+friendly_name: Ltv State Values
+description: |-
+  Android state values, in terms of Ad Clicks.
+  Each country has their own ad click LTV for each state.
+owners:
+- frank@mozilla.com
+labels:
+  incremental: false
+  owner1: frank@mozilla.com
+scheduling:
+  dag_name: bqetl_org_mozilla_firefox
+  depends_on_past: false
+  date_partition_parameter: null
+bigquery:
+  time_partitioning: null
+  clustering:
+    fields: [country]
+references: {}
+deprecated: false

--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  state,
+  ltv AS predicted_ad_clicks,
+  t AS time_horizon,
+  country,
+  CASE
+    WHEN country IN ('IN', 'US', 'CA', 'DE', 'BE', 'FR', 'GB', 'CH',  'NL', 'ES', 'AT', 'MX', 'PL', 'IT') THEN 'android_states_with_paid_v1'
+    WHEN country IN ('BR', 'KE', 'AU', 'JP') THEN 'android_states_v1'
+    ELSE NULL
+  END AS state_function
+FROM
+  mozdata.analysis.android_state_ltvs_v1

--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/query.sql
@@ -4,8 +4,25 @@ SELECT
   t AS time_horizon,
   country,
   CASE
-    WHEN country IN ('IN', 'US', 'CA', 'DE', 'BE', 'FR', 'GB', 'CH',  'NL', 'ES', 'AT', 'MX', 'PL', 'IT') THEN 'android_states_with_paid_v1'
-    WHEN country IN ('BR', 'KE', 'AU', 'JP') THEN 'android_states_v1'
+    WHEN country IN (
+        'IN',
+        'US',
+        'CA',
+        'DE',
+        'BE',
+        'FR',
+        'GB',
+        'CH',
+        'NL',
+        'ES',
+        'AT',
+        'MX',
+        'PL',
+        'IT'
+      )
+      THEN 'android_states_with_paid_v1'
+    WHEN country IN ('BR', 'KE', 'AU', 'JP')
+      THEN 'android_states_v1'
     ELSE NULL
   END AS state_function
 FROM

--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/schema.yaml
@@ -1,0 +1,21 @@
+fields:
+- name: state
+  type: STRING
+  mode: NULLABLE
+  description: "The markov state, as determined by the state function."
+- name: predicted_ad_clicks
+  type: FLOAT64
+  mode: NULLABLE
+  description: "Number of predicted ad clicks for the specified time horizon."
+- name: time_horizon
+  type: INTEGER
+  mode: NULLABLE
+  description: "Number of days into the future that ad clicks are being predicted for."
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: "The country that this prediction is specified for."
+- name: state_function
+  type: STRING
+  mode: NULLABLE
+  description: "The state function used to determine the LTV for this state."


### PR DESCRIPTION
The previous LTV table has a state value per-day. This table takes the most recent state value for each client, so the grain is simply `client_id`. The view joins with the state predictions, so we get the historic ad clicks and predicted future ad clicks for each client.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
