### PR TITLE
Enable deprecation on datasets with deprecated tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/dataset_metadata.yaml
@@ -4,7 +4,8 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-workgroup_access:
+workgroup_access: []
+default_table_workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/dataset_metadata.yaml
@@ -5,7 +5,8 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-workgroup_access:
+workgroup_access: []
+default_table_workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential


### PR DESCRIPTION
Table-level deprecation only works when access granted at the dataset level is removed. For the two cases where we have `deprecated: true` currently set, this isn't the case, and so the deprecation metadata isn't taking effect. The purpose of having `workgroup_access`, `default_table_workgroup_access` and associated metadata generation logic is to support deprecation use cases, but they need to be used in tandem.

There was some discussion in slack that this might be a tooling issue. I could see it being fine for `main` branch metadata to be incorrect when deprecation metadata is present as long as the generated branch `dataset_metadata.yaml` files  have the correct settings. However, it might be preferable to have tooling ensure datasets have empty `workgroup_access`  when adding deprecation metadata or perhaps a CI check that verifies that when table-level deprecation metadata is present, dataset metadata is correctly configured.

It's worth explicitly mentioning this PR will lock down dataset-level access to `telemetry_derived`, and with the way our deprecation metadata works, any table in that dataset that isn't managed by bqetl (or minimally for which `metadata.yaml` file with `workgroup_access` doesn't end up on the generated branch) will no longer be accessible to `workgroup:mozilla-confidential`. This appears to be a nontrivial set of tables (I count 182 tables in `telemetry_derived` and about `121` `metadata.yaml` files), and so I'm marking this PR as draft to indicate it shouldn't be merged as-is. Some of these tables e.g. `telemetry_derived.eng_workflow_build_parquet_v1` probably should be deprecated but not all of them.

If we want to test things out with solving `telemetry_derived`, we can merge the `monitoring_derived` change separately since that dataset is hopefully almost entirely managed via bqetl.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2465)
