### PR TITLE
Fix dataset deprecation metadata

### DIFF
--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -58,16 +58,19 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
             dataset_metadata.default_table_workgroup_access = (
                 dataset_metadata.workgroup_access
             )
-        dataset_metadata.write(dataset_metadata_path)
+        
         if table_metadata.deprecated:
             # set workgroup: [] if table has been tagged as deprecated
             # this overwrites existing workgroups
             table_metadata.workgroup_access = []
+            dataset_metadata.workgroup_access = []
         else:
             if table_metadata.workgroup_access is None:
                 table_metadata.workgroup_access = (
                     dataset_metadata.default_table_workgroup_access
                 )
+
+        dataset_metadata.write(dataset_metadata_path)
         table_metadata.write(table_metadata_file)
         click.echo(f"Updated {table_metadata_file}")
     return None

--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -58,7 +58,7 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
             dataset_metadata.default_table_workgroup_access = (
                 dataset_metadata.workgroup_access
             )
-        
+
         if table_metadata.deprecated:
             # set workgroup: [] if table has been tagged as deprecated
             # this overwrites existing workgroups

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_profiles_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_profiles_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Active Profiles
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/churn_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/churn_v2/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Churn V2
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/churn_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/churn_v3/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Churn V3
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/client_probe_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/client_probe_counts_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Client Probe Counts
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_probe_processes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_probe_processes_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Clients Probe Processes
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_profile_per_install_affected_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_profile_per_install_affected_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  Clients Profile Per Install Affected
+description: |-
+  Client profiles affected by shredder. Populated by shredder.
+owners:
+- ascholtz@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_bucket_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_scalar_bucket_counts_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Clients Scalar Bucket Counts
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/contile_filter_adm_empty_response/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/contile_filter_adm_empty_response/metadata.yaml
@@ -1,0 +1,4 @@
+friendly_name: |-
+  Contile Filter ADM Empty Response
+owners:
+- rburwei@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/contile_tiles_adm_request/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/contile_tiles_adm_request/metadata.yaml
@@ -1,0 +1,4 @@
+friendly_name: |-
+  Contile Tiles ADM Request
+owners:
+- rburwei@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/contile_tiles_adm_response_tiles_count/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/contile_tiles_adm_response_tiles_count/metadata.yaml
@@ -1,0 +1,4 @@
+friendly_name: |-
+  Contile Tiles ADM Response Tiles Count
+owners:
+- rburwei@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/crash_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/crash_aggregates_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Crash Aggregates
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/crash_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/crash_summary_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Crash Summary
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/crash_summary_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/crash_summary_v2/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Crash Summary V2
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/deviations_anomdtct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/deviations_anomdtct_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Deviations Anomdtct
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/deviations_model_cache_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/deviations_model_cache_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Deviations Model Cache
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/deviations_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/deviations_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Deviations
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/eng_workflow_build_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/eng_workflow_build_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Eng Workflow Build Parquet
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/eng_workflow_hgpush_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/eng_workflow_hgpush_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Eng Workflow Hgpush Parquet
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/esr_migration_incorrect_deletion_request_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/esr_migration_incorrect_deletion_request_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Esr Migration Incorrect Deletion Request
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Events
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_base/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_base/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Experiment Enrollment Aggregates Base
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_live/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Experiment Enrollment Aggregates Live
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_error_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_error_aggregates_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Experiment Error Aggregates
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiments_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiments_aggregates_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Experiments Aggregates
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiments_v0/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiments_v0/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Experiments
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fenix_and_firefox_use_counters/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fenix_and_firefox_use_counters/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Fenix And Firefox Use Counters
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/first_shutdown_summary_v4/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/first_shutdown_summary_v4/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: First Shutdown Summary V4
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_extract_firefox_beta_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_extract_firefox_beta_v1/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: |-
+  GLAM Firefox Beta Extracts
+description: |-
+  Holds the data that is surfaced on the GLAM frontend for Firefox Beta.
+  Populated via: https://github.com/mozilla/telemetry-airflow/blob/4050697bd2e283864a9013bd48d439eb66f6d581/utils/glam_subdags/extract.py#L40
+owners:
+- efilho@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_extract_firefox_nightly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_extract_firefox_nightly_v1/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: |-
+  GLAM Firefox Nightly Extracts
+description: |-
+  Holds the data that is surfaced on the GLAM frontend for Firefox Nightly
+  Populated via: https://github.com/mozilla/telemetry-airflow/blob/4050697bd2e283864a9013bd48d439eb66f6d581/utils/glam_subdags/extract.py#L40
+owners:
+- efilho@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_extract_firefox_release_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_extract_firefox_release_v1/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: |-
+  GLAM Firefox Release Extracts
+description: |-
+  Holds the data that is surfaced on the GLAM frontend for Firefox Release
+  Populated via: https://github.com/mozilla/telemetry-airflow/blob/4050697bd2e283864a9013bd48d439eb66f6d581/utils/glam_subdags/extract.py#L40
+owners:
+- efilho@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_sample_counts_extract_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_sample_counts_extract_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Glam Sample Counts Extract
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/hcm_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/hcm_clients_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Hcm Clients
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/kpi_automated_forecast_confidences_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/kpi_automated_forecast_confidences_v1/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: |-
+  KPI Automated Forecast Confidences
+description: |-
+  Populated via https://github.com/mozilla/docker-etl/tree/main/jobs/kpi-forecasting
+owners:
+- bochocki@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/kpi_automated_forecast_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/kpi_automated_forecast_v1/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: |-
+  KPI Automated Forecasts
+description: |-
+  Automated KPI Forecasts for mobile and desktop.
+  Populated via https://github.com/mozilla/docker-etl/tree/main/jobs/kpi-forecasting/kpi_forecasting
+owners:
+- bochocki@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/kpi_forecasts_v0/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/kpi_forecasts_v0/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: |-
+  KPI Forecasts
+description: |-
+  Automated KPI Forecasts for desktop.
+  Populated via https://github.com/mozilla/docker-etl/tree/main/jobs/kpi-forecasting/kpi_forecasting
+owners:
+- bochocki@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/looker_forecasts_cache_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/looker_forecasts_cache_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Looker Forecasts Cache
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_summary_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_summary_v3/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Main Summary V3
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_summary_v4/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_summary_v4/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Main Summary V4
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_hardware/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_hardware/metadata.yaml
@@ -1,0 +1,9 @@
+friendly_name: |-
+  Firefox Public Data Report
+description: |-
+  Powers the public https://data.firefox.com/ dashboard.
+
+  Source code is in the [firefox-public-data-report-etl repository]
+  (https://github.com/mozilla/firefox-public-data-report-etl).
+owners:
+- akomar@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/regrets_reporter_study_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/regrets_reporter_study_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Regrets Reporter Study
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/remote_content_uptake_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/remote_content_uptake_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Remote Content Uptake
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/retention_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/retention_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Retention
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/saved_session_v5/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/saved_session_v5/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Saved Session V5
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/search_mv/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/search_mv/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Search Mv
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/simpleprophet_forecasts_desktop_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/simpleprophet_forecasts_desktop_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Simpleprophet Forecasts Desktop
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/simpleprophet_forecasts_fxa_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/simpleprophet_forecasts_fxa_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Simpleprophet Forecasts Fxa
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/simpleprophet_forecasts_mobile_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/simpleprophet_forecasts_mobile_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Simpleprophet Forecasts Mobile
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/socorro_crash_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/socorro_crash_v2/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: |-
+  Socorro Crash
+description: |-
+  Crash reports imported via socorro.
+  See https://github.com/mozilla/telemetry-airflow/blob/4050697bd2e283864a9013bd48d439eb66f6d581/dags/socorro_import.py#L105
+owners:
+- srose@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/summed_hist_fix/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/summed_hist_fix/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Summed Hist Fix
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sync_log_device_activity_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sync_log_device_activity_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Sync Log Device Activity
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sync_log_device_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sync_log_device_counts_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Sync Log Device Counts
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sync_log_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sync_log_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Sync Log
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_anonymous_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_anonymous_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Telemetry Anonymous Parquet
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_core_parquet_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_core_parquet_v3/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Telemetry Core Parquet V3
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_downgrade_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_downgrade_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Telemetry Downgrade Parquet
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_focus_event_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_focus_event_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Telemetry Focus Event Parquet
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_heartbeat_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_heartbeat_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Telemetry Heartbeat Parquet
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_ip_privacy_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_ip_privacy_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Telemetry Ip Privacy Parquet
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_ip_privacy_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_ip_privacy_v2/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Telemetry Ip Privacy V2
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_mobile_event_parquet_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_mobile_event_parquet_v2/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Telemetry Mobile Event Parquet V2
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_new_profile_parquet_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_new_profile_parquet_v2/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Telemetry New Profile Parquet V2
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_shield_study_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_shield_study_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: Telemetry Shield Study Parquet
+deprecated: true

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -216,8 +216,23 @@ class TestMetadata:
                 "r",
             ) as stream:
                 metadata = yaml.safe_load(stream)
+
+            with open(
+                tmpdirname
+                + "/sql/moz-fx-data-shared-prod/telemetry_derived/dataset_metadata.yaml",
+                "r",
+            ) as stream:
+                dataset_metadata = yaml.safe_load(stream)
+
         assert metadata["workgroup_access"] == []
         assert metadata["deprecated"]
+        assert dataset_metadata["workgroup_access"] == []
+        assert dataset_metadata["default_table_workgroup_access"] == [
+            {
+                "members": ["workgroup:mozilla-confidential"],
+                "role": "roles/bigquery.dataViewer",
+            }
+        ]
 
     def test_metadata_update_do_not_update(self, runner):
         with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/4873
Sets `workgroup_access` for `dataset_metadata.yaml` files to `[]` if it contains deprecated tables.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2470)
