### PR TITLE
Remove backfill validate ci check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,18 +142,18 @@ jobs:
             echo $PATHS
             PATH="venv/bin:$PATH" script/bqetl dryrun --validate-schemas $PATHS
           # yamllint enable rule:line-length
-  validate-backfills:
-    docker: *docker
-    steps:
-      - checkout
-      - *restore_venv_cache
-      - *build
-      - *attach_generated_sql
-      - *copy_staged_sql
-      - run:
-          name: Verify that backfill.yaml files are valid
-          command: |
-            PATH="venv/bin:$PATH" script/bqetl backfill validate
+#    validate-backfills:
+#      docker: *docker
+#      steps:
+#        - checkout
+#        - *restore_venv_cache
+#        - *build
+#        - *attach_generated_sql
+#        - *copy_staged_sql
+#        - run:
+#            name: Verify that backfill.yaml files are valid
+#            command: |
+#              PATH="venv/bin:$PATH" script/bqetl backfill validate
   validate-metadata:
     docker: *docker
     steps:
@@ -700,9 +700,9 @@ workflows:
           requires:
             - deploy-changes-to-stage
       - integration
-      - validate-backfills:
-          requires:
-            - deploy-changes-to-stage
+#      - validate-backfills:
+#          requires:
+#            - deploy-changes-to-stage
       - validate-dags:
           requires:
             - generate-dags


### PR DESCRIPTION
Removed backfill validate ci check to unblock #4874 for now.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2484)
