### PR TITLE
Stop using data-eng-circleci-tests context in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -823,15 +823,13 @@ workflows:
   build:
     jobs: &build_jobs
       - manual-trigger-required-for-fork
-      - build:
-          context: data-eng-circleci-tests
+      - build
       - verify-format-sql
       - deploy-changes-to-stage:
           requires:
             - generate-sql
       - verify-requirements
       - test-sql:
-          context: data-eng-circleci-tests
           requires:
             - deploy-changes-to-stage
       - dry-run-sql:


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DSRE-65?focusedCommentId=820935

This is part of the prep for using OIDC auth. We're expecting to use the SA whose key is currently in the `data-eng-circleci-tests` context for tests eventually but without needing the hard-coded credentials. For now, this switches CI to use the creds for the SA in the CircleCI environment variables of this repo (used when context is left unspecified e.g. `deploy-changes-to-stage`). https://github.com/mozilla-services/cloudops-infra/pull/5371 appears to have been the only change needed to get tests working, but I expect more significant code changes to be required to wire this back up into the SRE-managed tests project.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2485)
