### PR TITLE
Revert "change 'creation_date' to 'table_creation_date' to be more clear"

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/query.py
@@ -49,7 +49,7 @@ def create_last_modified_tmp_table(date, project, tmp_table_name):
                 project_id,
                 dataset_id,
                 table_id,
-                DATE(TIMESTAMP_MILLIS(creation_time)) AS table_creation_date,
+                DATE(TIMESTAMP_MILLIS(creation_time)) AS creation_date,
                 DATE(TIMESTAMP_MILLIS(last_modified_time)) AS last_modified_date
                 FROM `{project}.{dataset.dataset_id}.__TABLES__`
                 WHERE DATE(TIMESTAMP_MILLIS(creation_time)) <= DATE('{date}')
@@ -88,12 +88,13 @@ def create_query(date, source_project, tmp_table_name):
             GROUP BY table_catalog, table_schema, table_name
         ),
         max_job_creation_date AS (
-            SELECT max(submission_date) as last_used_date,
+            SELECT max(creation_date) as last_used_date,
                 reference_project_id AS project_id,
                 reference_dataset_id AS dataset_id,
                 reference_table_id AS table_id
             FROM `moz-fx-data-shared-prod.monitoring_derived.bigquery_usage_v2`
-            WHERE submission_date >= "2023-01-01"
+            WHERE creation_date >= "2023-01-01"
+            AND submission_date >= "2023-01-01"
             GROUP BY project_id, dataset_id, table_id
         ),
         table_info AS (
@@ -101,7 +102,7 @@ def create_query(date, source_project, tmp_table_name):
             FROM
                 (SELECT
                     DATE('{date}') AS submission_date,
-                    DATE(creation_time) AS table_creation_date,
+                    DATE(creation_time) AS creation_date,
                     table_catalog AS project_id,
                     table_schema AS dataset_id,
                     table_name AS table_id,
@@ -112,10 +113,10 @@ def create_query(date, source_project, tmp_table_name):
                     USING (table_catalog, table_schema, table_name)
                     WHERE DATE(creation_time) <= DATE('{date}'))
             LEFT JOIN {tmp_table_name}
-            USING (project_id, dataset_id, table_id, table_creation_date)
+            USING (project_id, dataset_id, table_id, creation_date)
         )
         SELECT submission_date,
-            table_creation_date,
+            creation_date,
             project_id,
             dataset_id,
             table_id,

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/schema.yaml
@@ -6,7 +6,7 @@ fields:
   description: The date when data was captured
 
 - mode: NULLABLE
-  name: table_creation_date
+  name: creation_date
   type: DATE
   description: The table's creation date
 

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.sql
@@ -74,6 +74,7 @@ jobs_by_project AS (
 )
 SELECT DISTINCT
   jo.source_project,
+  jo.creation_date,
   jo.job_id,
   jo.job_type,
   jo.reservation_id,

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/schema.yaml
@@ -6,6 +6,11 @@ fields:
   description: Project used for executing job
 
 - mode: NULLABLE
+  name: creation_date
+  type: DATE
+  description: Job creation date
+
+- mode: NULLABLE
   name: job_id
   type: STRING
   description: ID of job


### PR DESCRIPTION
The table field can't just be renamed since it's essentially deleting an existing row (and adding a new one).
I'd instead recommend renaming the fields in the public views (https://github.com/mozilla/bigquery-etl/blob/dd8d736c99bd9b4efd6b666e4fe424b86029bd20/sql/moz-fx-data-shared-prod/monitoring/bigquery_tables_inventory/view.sql). Although that would break all the dashboards that are currently using this table.

Or alternatively, we could add `table_creation_date` without removing `creation_date`, and optionally hide the `creation_date` field in the view.

Reverts mozilla/bigquery-etl#4797

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2493)
