### PR TITLE
DO NOT MERGE: feat(): Update fxa_users_ views to use v2 of the corresponding tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_daily/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_daily/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_daily_v1`
+  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_daily_v2`

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_first_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_first_seen/view.sql
@@ -2,6 +2,8 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_accounts.fxa_users_first_seen`
 AS
 SELECT
-  *
+  *,
+  -- TODO: remove the `services_used` field once we confirm no downstream usage.
+  [CAST(NULL AS STRING)] AS services_used,
 FROM
-  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_first_seen_v1`
+  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_first_seen_v2`

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_last_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_last_seen/view.sql
@@ -7,7 +7,8 @@ SELECT
     days_seen_in_tier1_country_bits
   ) AS days_since_seen_in_tier1_country,
   mozfun.bits28.days_since_seen(days_registered_bits) AS days_since_registered,
-  mozfun.bits28.days_since_seen(days_seen_no_monitor_bits) AS days_since_seen_no_monitor,
+  -- TODO: remove the `days_since_seen_no_monitor` field once we confirm no downstream usage.
+  CAST(NULL AS INTEGER) AS days_since_seen_no_monitor,
   *
 FROM
-  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_last_seen_v1`
+  `moz-fx-data-shared-prod.firefox_accounts_derived.fxa_users_last_seen_v2`

--- a/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_last_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts/fxa_users_last_seen/view.sql
@@ -7,6 +7,10 @@ SELECT
     days_seen_in_tier1_country_bits
   ) AS days_since_seen_in_tier1_country,
   mozfun.bits28.days_since_seen(days_registered_bits) AS days_since_registered,
+  mozfun.bits28.active_in_range(days_seen_bits, -6, 7) AS active_this_week,
+  mozfun.bits28.active_in_range(days_seen_bits, -13, 7) AS active_last_week,
+  DATE_DIFF(submission_date, first_run_date, DAY) BETWEEN 0 AND 6 AS new_this_week,
+  DATE_DIFF(${submission_date}, first_run_date, DAY) BETWEEN 7 AND 13 AS new_last_week,
   -- TODO: remove the `days_since_seen_no_monitor` field once we confirm no downstream usage.
   CAST(NULL AS INTEGER) AS days_since_seen_no_monitor,
   *


### PR DESCRIPTION
# feat(): Update fxa_users_ views to use v2 of the corresponding tables

depends on: https://github.com/mozilla/bigquery-etl/pull/4893

Prior to merging this PR we need to update the scheduling configuration for the corresponding v2 table:
https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v2/metadata.yaml#L14-L22

Also, we need to make sure nothing will break in Looker. Currently, it appears both `fxa_users_first_seen` and `fxa_users_last_seen` are used inside Looker:
https://github.com/mozilla/lookml-generator/blob/main/custom-namespaces.yaml#L516-L525C1

=> https://github.com/mozilla/looker-hub/blob/main/firefox_accounts/views/fxa_first_seen_table.view.lkml#L7-L11
This is where the first seen table is referenced, but it looks like the field we want to remove is actually hidden in this Looker table view.

---

Last seen appear to be utilized here:
https://github.com/mozilla/looker-hub/blob/main/firefox_accounts/views/growth_accounting.view.lkml

And the v2 version of this table is missing fields which are used:
- days_since_seen_no_monitor (want to deprecate / remove)
- language
- app_version
- country
- os_name
- os_version

We should consider if these fields should instead be retrieved from the daily table instead.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2496)
