### PR TITLE
feat(): added scheduling settings to all fxa_users_*_v2 queries

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v1/metadata.yaml
@@ -11,6 +11,8 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
+# TODO: Once fxa_users_daily_v2 backfill is completed and data confirmed to be heatlhy
+# this query should be descheduled, description and the corresponding view updated.
 scheduling:
   dag_name: bqetl_fxa_events
 bigquery:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
@@ -8,23 +8,20 @@ description: |
   along with some attributes related to that user.
   See the schema for a list of attributes and their descriptions.
 
-  Partitioned by submission_date,
-  clustered by country, os_name, and user_id
-
   This lower level model uses the following category of events:
   event_category IN ('auth', 'auth_bounce', 'content', 'oauth')
 
   Partitioned by submission_date,
-  clustered by country, os_name, and user_id
+  clustered by registered, seen_in_tier1_country, country, os_name
 owners:
   - kik@mozilla.com
 labels:
   application: fxa
   incremental: true
   schedule: daily
-# TODO: once we agree on the model scheduling needs to be uncommented.
-# scheduling:
-#   dag_name: bqetl_fxa_events
+scheduling:
+  dag_name: bqetl_fxa_events
+  start_date: "2024-01-26"
 bigquery:
   time_partitioning:
     type: day
@@ -32,6 +29,7 @@ bigquery:
     require_partition_filter: true
   clustering:
     fields:
+      - registered
+      - seen_in_tier1_country
       - country
       - os_name
-      - user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_daily_v2/metadata.yaml
@@ -21,7 +21,7 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_fxa_events
-  start_date: "2024-01-26"
+  start_date: "2024-02-11"
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/metadata.yaml
@@ -8,6 +8,8 @@ labels:
   application: firefox_accounts
   incremental: true
   schedule: daily
+# TODO: Once fxa_users_first_seen_v2 backfill is completed and data confirmed to be heatlhy
+# this query should be descheduled, description and the corresponding view updated.
 scheduling:
   dag_name: bqetl_fxa_events
   start_date: '2021-07-09'

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v2/metadata.yaml
@@ -4,22 +4,20 @@ description: |-
   for each user along with some attributes.
 
   Partitioned by submission_date,
-  clustered by country, os_name
+  clustered by seen_in_tier1_country, country, os_name
 owners:
 - kik@mozilla.com
 labels:
   application: firefox_accounts
   incremental: true
   schedule: daily
-# TODO: once we agree on the model scheduling needs to be uncommented.
-# scheduling:
-#   dag_name: bqetl_fxa_events
-#   start_date: '2021-07-09'
-#   priority: 80
-#   depends_on_past: true
-#   date_partition_parameter: null
-#   parameters:
-#   - submission_date:DATE:{{ds}}
+scheduling:
+  dag_name: bqetl_fxa_events
+  start_date: "2024-01-26"
+  depends_on_past: true
+  date_partition_parameter: null
+  parameters:
+  - submission_date:DATE:{{ds}}
 bigquery:
   time_partitioning:
     type: day
@@ -27,5 +25,6 @@ bigquery:
     require_partition_filter: false
   clustering:
     fields:
+    - seen_in_tier1_country
     - country
     - os_name

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v2/metadata.yaml
@@ -13,7 +13,7 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_fxa_events
-  start_date: "2024-01-26"
+  start_date: "2024-02-11"
   depends_on_past: true
   date_partition_parameter: null
   parameters:

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v1/metadata.yaml
@@ -15,6 +15,8 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
+# TODO: Once fxa_users_last_seen_v2 backfill is completed and data confirmed to be heatlhy
+# this query should be descheduled, description and the corresponding view updated.
 scheduling:
   dag_name: bqetl_fxa_events
   depends_on_past: true

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/metadata.yaml
@@ -15,16 +15,13 @@ labels:
   application: fxa
   incremental: true
   schedule: daily
-# scheduling:
-#   dag_name: bqetl_fxa_events
-#   depends_on_past: true
-#   start_date: '2019-04-23'
+scheduling:
+  dag_name: bqetl_fxa_events
+  depends_on_past: true
+  start_date: "2024-01-26"
 bigquery:
   time_partitioning:
     type: day
     field: submission_date
     require_partition_filter: true
     expiration_days: null
-  clustering:
-    fields:
-      - user_id

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_last_seen_v2/metadata.yaml
@@ -18,7 +18,7 @@ labels:
 scheduling:
   dag_name: bqetl_fxa_events
   depends_on_past: true
-  start_date: "2024-01-26"
+  start_date: "2024-02-11"
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
# feat(): added scheduling settings to all fxa_users_*_v2 queries

Rationale for these changes:

- Simplify the data lineage of these tables (higher grain built on top of lower grain tables)
- Only include relevant dimensions in the tables
- Include all important dimensions in the first_seen table to simplify the usage
 
---

Changes made:

- Added a TODO note to all v1 queries as a reminder to remove the scheduling settings once the corresponding v2 table is backfilled and verified to be healthy.
- Added scheduling settings to fxa_users_*_v2 tables
- Small clustering setting adjustments for `fxa_users_first_seen_v2` and `fxa_users_daily_v2`, `fxa_users_last_seen_v2`.

Follow-up actions required:

- Redeploy `fxa_users_first_seen_v2`, `fxa_users_daily_v2` and `fxa_users_last_seen_v2` tables (to apply new clustering settings)
- Backfiill the three tables in the following order:

1. `fxa_users_daily_v2` 
2. `fxa_users_first_seen_v2`
3. `fxa_users_last_seen_v2`

- Validate the tables to make sure they appear healthy.
- Update the `fxa_users_*` views to use the new version of the corresponding table
- Tag v1 versions of the table as deprecated

---

Follow-up: https://github.com/mozilla/bigquery-etl/pull/4891

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2499)
