### PR TITLE
Ignore missing SQL generators

### DIFF
--- a/bigquery_etl/cli/generate.py
+++ b/bigquery_etl/cli/generate.py
@@ -22,7 +22,7 @@ def generate_group():
         if "__pycache__" in path.parts:
             # Ignore pycache subdirectories
             continue
-        if path.is_dir():
+        if path.is_dir() and (path / "__init__.py").exists():
             # get Python modules for generators
             spec = importlib.util.spec_from_file_location(
                 path.name, (path / "__init__.py").absolute()


### PR DESCRIPTION
When SQL generators are deleted and people pull down those changes into their local working directories, empty directories for the SQL generators can be left behind which would cause an error when `bqetl` tries to load all the SQL generators.  This fixes that.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
