### PR TITLE
Remove gke_command usages

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -5,8 +5,9 @@ from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.task_group import TaskGroup
 import datetime
+from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
+from utils.gcp import bigquery_etl_query, bigquery_dq_check
 
 {% set ns = namespace(uses_fivetran=False) -%}
 {% for task in tasks -%}
@@ -56,13 +57,13 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
 
 {% for task in tasks | sort(attribute='task_name') %}
     {% if task.is_python_script -%}
-        {{ task.task_name }} = gke_command(
+        {{ task.task_name }} = GKEPodOperator(
             task_id='{{ task.task_name }}',
-            command=[
+            arguments=[
                 'python',
                 'sql/{{ task.project }}/{{ task.dataset }}/{{ task.table }}_{{ task.version }}/query.py',
             ] + {{ task.arguments }},
-            docker_image='gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest',
+            image='gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest',
             owner='{{ task.owner }}',
             email={{ task.email | sort }},
     {% elif task.is_dq_check -%}
@@ -121,6 +122,15 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             {%+ endif -%}
             {%+ if task.startup_timeout_seconds -%}
             startup_timeout_seconds={{ task.startup_timeout_seconds }},
+            {%+ endif -%}
+            {%+ if task.gke_project_id != None -%}
+            project_id={{ task.gke_project_id | format_repr }},
+            {%+ endif -%}
+            {%+ if task.gke_location != None -%}
+            location={{ task.gke_location | format_repr }},
+            {%+ endif -%}
+            {%+ if task.gke_cluster_name != None -%}
+            cluster_name={{ task.gke_cluster_name | format_repr }},
             {%+ endif -%}
     {%+ else -%}
         {{ task.task_name }} = bigquery_etl_query(
@@ -189,10 +199,6 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             {%+ if task.priority -%}
             priority_weight={{ task.priority }},
             {%+ endif -%}
-    {% endif -%}
-            {%+ if task.gcp_conn_id != None -%}
-            gcp_conn_id={{ task.gcp_conn_id | format_repr }},
-            {%+ endif -%}
             {%+ if task.gke_project_id != None -%}
             gke_project_id={{ task.gke_project_id | format_repr }},
             {%+ endif -%}
@@ -201,6 +207,10 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             {%+ endif -%}
             {%+ if task.gke_cluster_name != None -%}
             gke_cluster_name={{ task.gke_cluster_name | format_repr }},
+            {%+ endif -%}
+    {% endif -%}
+            {%+ if task.gcp_conn_id != None -%}
+            gcp_conn_id={{ task.gcp_conn_id | format_repr }},
             {%+ endif -%}
             {%+ if task.task_concurrency -%}
             task_concurrency={{ task.task_concurrency }},

--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -6,7 +6,6 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from airflow.sensors.external_task import ExternalTaskSensor
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import gke_command
 
 docs = """
 ### {{ name }}
@@ -134,10 +133,10 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
     {% endif -%}
 {% endfor %}
 
-    public_data_gcs_metadata = gke_command(
+    public_data_gcs_metadata = GKEPodOperator(
         task_id="public_data_gcs_metadata",
-        command=["script/publish_public_data_gcs_metadata"],
-        docker_image=docker_image,
+        arguments=["script/publish_public_data_gcs_metadata"],
+        image=docker_image,
     )
 
     public_data_gcs_metadata.set_upstream(

--- a/tests/data/dags/python_script_test_dag
+++ b/tests/data/dags/python_script_test_dag
@@ -5,8 +5,9 @@ from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.task_group import TaskGroup
 import datetime
+from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
+from utils.gcp import bigquery_etl_query, bigquery_dq_check
 
 docs = """
 ### bqetl_test_dag
@@ -46,14 +47,14 @@ with DAG(
 ) as dag:
     task_group_test_group = TaskGroup("test_group")
 
-    test__python_script_query__v1 = gke_command(
+    test__python_script_query__v1 = GKEPodOperator(
         task_id="test__python_script_query__v1",
-        command=[
+        arguments=[
             "python",
             "sql/moz-fx-data-test-project/test/python_script_query_v1/query.py",
         ]
         + ["--date", "{{ds}}"],
-        docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
+        image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
         owner="test@example.com",
         email=["test@example.com"],
         task_group=task_group_test_group,

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -5,8 +5,9 @@ from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.task_group import TaskGroup
 import datetime
+from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
+from utils.gcp import bigquery_etl_query, bigquery_dq_check
 
 from fivetran_provider.operators.fivetran import FivetranOperator
 from fivetran_provider.sensors.fivetran import FivetranSensor

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -5,8 +5,9 @@ from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.task_group import TaskGroup
 import datetime
+from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
+from utils.gcp import bigquery_etl_query, bigquery_dq_check
 
 docs = """
 ### bqetl_test_dag

--- a/tests/data/dags/test_dag_external_check_dependency
+++ b/tests/data/dags/test_dag_external_check_dependency
@@ -5,8 +5,9 @@ from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.task_group import TaskGroup
 import datetime
+from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
+from utils.gcp import bigquery_etl_query, bigquery_dq_check
 
 docs = """
 ### bqetl_external_test_dag

--- a/tests/data/dags/test_dag_external_dependency
+++ b/tests/data/dags/test_dag_external_dependency
@@ -5,8 +5,9 @@ from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.task_group import TaskGroup
 import datetime
+from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
+from utils.gcp import bigquery_etl_query, bigquery_dq_check
 
 docs = """
 ### bqetl_external_test_dag

--- a/tests/data/dags/test_dag_with_check_dependencies
+++ b/tests/data/dags/test_dag_with_check_dependencies
@@ -5,8 +5,9 @@ from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.task_group import TaskGroup
 import datetime
+from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
+from utils.gcp import bigquery_etl_query, bigquery_dq_check
 
 docs = """
 ### bqetl_test_dag

--- a/tests/data/dags/test_dag_with_check_table_dependencies
+++ b/tests/data/dags/test_dag_with_check_table_dependencies
@@ -5,8 +5,9 @@ from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.task_group import TaskGroup
 import datetime
+from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
+from utils.gcp import bigquery_etl_query, bigquery_dq_check
 
 docs = """
 ### bqetl_test_dag

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -5,8 +5,9 @@ from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.task_group import TaskGroup
 import datetime
+from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import bigquery_etl_query, gke_command, bigquery_dq_check
+from utils.gcp import bigquery_etl_query, bigquery_dq_check
 
 docs = """
 ### bqetl_test_dag

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -6,7 +6,6 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from airflow.sensors.external_task import ExternalTaskSensor
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import gke_command
 
 docs = """
 ### bqetl_public_data_json
@@ -60,10 +59,10 @@ with DAG(
         image=docker_image,
     )
 
-    public_data_gcs_metadata = gke_command(
+    public_data_gcs_metadata = GKEPodOperator(
         task_id="public_data_gcs_metadata",
-        command=["script/publish_public_data_gcs_metadata"],
-        docker_image=docker_image,
+        arguments=["script/publish_public_data_gcs_metadata"],
+        image=docker_image,
     )
 
     public_data_gcs_metadata.set_upstream(


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/4895

We should wait with merging until next week and make those on Airflow Triage aware of these changes

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2506)
