### PR TITLE
AD-178 quick_suggest query type field

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/init.sql
@@ -17,4 +17,5 @@ SELECT
   CAST(NULL AS STRING) AS match_type,
   CAST(NULL AS BOOL) AS suggest_data_sharing_enabled,
   CAST(NULL AS INT64) AS impression_count,
-  CAST(NULL AS INT64) AS click_count
+  CAST(NULL AS INT64) AS click_count,
+  CAST(NULL AS STRING) AS query_type

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
@@ -23,12 +23,12 @@ WITH combined AS (
       "click",
       "impression"
     ) AS event_type,
-    suggestions.query_type
+    blocks.query_type
   FROM
     `moz-fx-data-shared-prod.firefox_desktop.quick_suggest` qs
   LEFT JOIN
-    `moz-fx-ads-prod.???.???` suggestions  -- TODO
-    ON CAST(qs.metrics.string.quick_suggest_block_id AS INT) = suggestions.block_id
+    `moz-fx-data-bq-fivetran.admarketplace_suggest.blocks` blocks
+    ON SAFE_CAST(qs.metrics.string.quick_suggest_block_id AS INT) = blocks.block_id
   WHERE
     metrics.string.quick_suggest_ping_type IN ("quicksuggest-click", "quicksuggest-impression")
   UNION ALL

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
@@ -28,8 +28,7 @@ WITH combined AS (
     `moz-fx-data-shared-prod.firefox_desktop.quick_suggest` qs
   LEFT JOIN
     `moz-fx-ads-prod.???.???` suggestions  -- TODO
-  ON
-    CAST(qs.metrics.string.quick_suggest_block_id AS INT) = suggestions.block_id
+    ON CAST(qs.metrics.string.quick_suggest_block_id AS INT) = suggestions.block_id
   WHERE
     metrics.string.quick_suggest_ping_type IN ("quicksuggest-click", "quicksuggest-impression")
   UNION ALL

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
@@ -23,8 +23,13 @@ WITH combined AS (
       "click",
       "impression"
     ) AS event_type,
+    suggestions.query_type
   FROM
-    `moz-fx-data-shared-prod.firefox_desktop.quick_suggest`
+    `moz-fx-data-shared-prod.firefox_desktop.quick_suggest` qs
+  LEFT JOIN
+    `moz-fx-ads-prod.???.???` suggestions  -- TODO
+  ON
+    CAST(qs.metrics.string.quick_suggest_block_id AS INT) = suggestions.block_id
   WHERE
     metrics.string.quick_suggest_ping_type IN ("quicksuggest-click", "quicksuggest-impression")
   UNION ALL
@@ -47,6 +52,7 @@ WITH combined AS (
       FALSE
     ) AS suggest_data_sharing_enabled,
     'impression' AS event_type,
+    CAST(NULL AS STRING) AS query_type
   FROM
     `moz-fx-data-shared-prod.contextual_services.quicksuggest_impression`
   WHERE
@@ -73,6 +79,7 @@ WITH combined AS (
       FALSE
     ) AS suggest_data_sharing_enabled,
     'click' AS event_type,
+    CAST(NULL AS STRING) AS query_type
   FROM
     `moz-fx-data-shared-prod.contextual_services.quicksuggest_click`
   WHERE
@@ -120,4 +127,5 @@ GROUP BY
   position,
   provider,
   match_type,
-  suggest_data_sharing_enabled
+  suggest_data_sharing_enabled,
+  query_type


### PR DESCRIPTION
Adds a `query_type` field ("branded" vs "non-branded") to suggest event aggregates, joining to the AMP suggestions data that we are now loading into BQ.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2507)
