### PR TITLE
Fix table access where dataset ACLs have changed due to deprecation

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
@@ -42,5 +42,6 @@ bigquery:
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
+  - workgroup:mozilla-confidential
   - workgroup:cloudops-managed/poucave
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
@@ -44,5 +44,6 @@ schema:
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
+  - workgroup:mozilla-confidential
   - workgroup:dataops-managed/taar
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_live/metadata.yaml
@@ -2,5 +2,5 @@
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
-      # - workgroup:mozilla-confidential
+      - workgroup:mozilla-confidential
       - workgroup:cloudops-managed/poucave


### PR DESCRIPTION
I'll write a script to reconcile the remaining places where this is an issue later.

This isn't urgent to merge because I've manually applied these changes to production.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2521)
