### PR TITLE
bug():  remove unwanted space in bqetl checks labels

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/checks.sql
@@ -1,10 +1,10 @@
-# fail
+#fail
 {{ is_unique(["country", "state"]) }}
 
-# fail
+#fail
 {{ min_row_count(1000) }}
 
-# fail
+#fail
 -- Each country should have a single state function
 SELECT
   mozfun.assert.equals(1, COUNT(DISTINCT state_function))
@@ -13,7 +13,7 @@ FROM
 GROUP BY
   country;
 
-# fail
+#fail
 -- There should be more than 2 countries present
 SELECT
   `mozfun.assert.true`(COUNT(DISTINCT country) > 2)

--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v2/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v2/checks.sql
@@ -1,10 +1,10 @@
-# fail
+#fail
 {{ is_unique(["country", "state"]) }}
 
-# fail
+#fail
 {{ min_row_count(1000) }}
 
-# fail
+#fail
 -- Each country should have a single state function
 SELECT
   mozfun.assert.equals(1, COUNT(DISTINCT state_function))
@@ -13,7 +13,7 @@ FROM
 GROUP BY
   country;
 
-# fail
+#fail
 -- There should be more than 2 countries present
 SELECT
   `mozfun.assert.true`(COUNT(DISTINCT country) > 2)

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
@@ -19,7 +19,7 @@
 #warn
 {{ min_row_count(1, where="submission_date = @submission_date") }}
 
-# warn
+#warn
 {{ not_null([
   "submission_date",
   "client_id",


### PR DESCRIPTION
# bug():  remove unwanted space in bqetl checks labels

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2524)
