### PR TITLE
bug(1876789): Delete active_users_aggregates_v1/checks.sql as no longer needed due to the dataset deprecation

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/checks.sql
@@ -1,3 +1,0 @@
-#fail
-{{ row_count_within_past_partitions_avg(number_of_days=7, threshold_percentage=5) }}
-


### PR DESCRIPTION
# bug(1876789): Delete active_users_aggregates_v1/checks.sql as no longer needed due to the dataset deprecation

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2526)
