### PR TITLE
[RS-959] Add OS breakouts to desktop & mobile tables, durations to mobile tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/query.sql
@@ -12,6 +12,8 @@ SELECT
   default_search_engine,
   os,
   os_version,
+  os_version_major,
+  os_version_minor,
   COUNT(*) AS client_count,
   SUM(search_count) AS search_count,
   SUM(organic) AS organic,
@@ -41,3 +43,5 @@ GROUP BY
   default_search_engine,
   os,
   os_version
+  os_version_major,
+  os_version_minor

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql
@@ -864,6 +864,14 @@ unfiltered_search_clients AS (
     channel,
     udf.mode_last(ARRAY_AGG(os)) AS os,
     udf.mode_last(ARRAY_AGG(os_version)) AS os_version,
+    COALESCE(
+      SAFE_CAST(NULLIF(SPLIT(udf.mode_last(ARRAY_AGG(os_version)), ".")[SAFE_OFFSET(0)], "") AS INTEGER),
+      0
+    ) AS os_version_major,
+    COALESCE(
+      SAFE_CAST(NULLIF(SPLIT(udf.mode_last(ARRAY_AGG(os_version)), ".")[SAFE_OFFSET(1)], "") AS INTEGER),
+      0
+    ) AS os_version_minor,
     udf.mode_last(ARRAY_AGG(default_search_engine)) AS default_search_engine,
     udf.mode_last(
       ARRAY_AGG(default_search_engine_submission_url)


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2539)
