### PR TITLE
Create unique `gcp.json` temp files to avoid file contention from parallel tests

### DIFF
--- a/script/entrypoint
+++ b/script/entrypoint
@@ -8,7 +8,10 @@ if [ -n "$GCLOUD_SERVICE_KEY" ]; then
     # Google's client libraries will check for GOOGLE_APPLICATION_CREDENTIALS
     # and use a file in that location for credentials if present;
     # See https://cloud.google.com/docs/authentication/production
-    export GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS:-/tmp/gcp.json}"
+    if [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+        # Create a unique credentials file since this script can be called in parallel by multiple tests.
+        export GOOGLE_APPLICATION_CREDENTIALS=$(mktemp /tmp/gcp.json.XXXXXXXXXX)
+    fi
     echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
 fi
 


### PR DESCRIPTION
pytest runs tests in parallel, some of which call the entrypoint script which is overwriting `/tmp/gcp.json`, and if one test's BigQuery client is trying to read `/tmp/gcp.json` while another invocation of the entrypoint script is in the middle of overwriting it, then the file could be read while it's in an empty or incomplete state.

This PR works around that by creating a unique `gcp.json` temp file for every invocation of the entrypoint script.

I'm hopeful this will eliminate the annoying "_File /tmp/gcp.json is not a valid json file_" error we keep getting sporadically in CI jobs. 🤞 

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2553)
