### PR TITLE
AD-178 Add query_type to event_aggregates_suggest and event_aggregates

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/init.sql
@@ -17,4 +17,5 @@ SELECT
   CAST(NULL AS STRING) AS match_type,
   CAST(NULL AS BOOL) AS suggest_data_sharing_enabled,
   CAST(NULL AS INT64) AS impression_count,
-  CAST(NULL AS INT64) AS click_count
+  CAST(NULL AS INT64) AS click_count,
+  CAST(NULL AS STRING) AS query_type

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
@@ -1,4 +1,14 @@
-WITH combined AS (
+WITH blocks AS (
+  SELECT
+    b.id,
+    b.query_type,
+  FROM
+    `moz-fx-data-bq-fivetran.admarketplace_suggest.blocks` b
+  WHERE
+    b.date <= @submission_date
+  QUALIFY
+    1 = ROW_NUMBER() OVER (PARTITION BY b.id ORDER BY b.date DESC)
+), combined AS (
   SELECT
     metrics.uuid.quick_suggest_context_id AS context_id,
     DATE(submission_timestamp) AS submission_date,
@@ -23,8 +33,12 @@ WITH combined AS (
       "click",
       "impression"
     ) AS event_type,
+    blocks.query_type,
   FROM
-    `moz-fx-data-shared-prod.firefox_desktop.quick_suggest`
+    `moz-fx-data-shared-prod.firefox_desktop.quick_suggest` qs
+  LEFT JOIN
+    blocks
+    ON SAFE_CAST(qs.metrics.string.quick_suggest_block_id AS INT) = blocks.id
   WHERE
     metrics.string.quick_suggest_ping_type IN ("quicksuggest-click", "quicksuggest-impression")
   UNION ALL
@@ -47,6 +61,7 @@ WITH combined AS (
       FALSE
     ) AS suggest_data_sharing_enabled,
     'impression' AS event_type,
+    CAST(NULL AS STRING) AS query_type,
   FROM
     `moz-fx-data-shared-prod.contextual_services.quicksuggest_impression`
   WHERE
@@ -73,6 +88,7 @@ WITH combined AS (
       FALSE
     ) AS suggest_data_sharing_enabled,
     'click' AS event_type,
+    CAST(NULL AS STRING) AS query_type,
   FROM
     `moz-fx-data-shared-prod.contextual_services.quicksuggest_click`
   WHERE
@@ -96,9 +112,10 @@ with_event_count AS (
     context_id
 )
 SELECT
-  * EXCEPT (context_id, user_event_count, event_type),
+  * EXCEPT (context_id, user_event_count, event_type, query_type),
   COUNTIF(event_type = "impression") AS impression_count,
   COUNTIF(event_type = "click") AS click_count,
+  query_type,
 FROM
   with_event_count
 WHERE
@@ -120,4 +137,5 @@ GROUP BY
   position,
   provider,
   match_type,
-  suggest_data_sharing_enabled
+  suggest_data_sharing_enabled,
+  query_type

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
@@ -8,7 +8,8 @@ WITH blocks AS (
     b.date <= @submission_date
   QUALIFY
     1 = ROW_NUMBER() OVER (PARTITION BY b.id ORDER BY b.date DESC)
-), combined AS (
+),
+combined AS (
   SELECT
     metrics.uuid.quick_suggest_context_id AS context_id,
     DATE(submission_timestamp) AS submission_date,

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/init.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/init.sql
@@ -23,3 +23,4 @@ SELECT
   CAST(NULL AS STRING) AS match_type,
   CAST(NULL AS STRING) AS normalized_os,
   CAST(NULL AS BOOL) AS suggest_data_sharing_enabled,
+  CAST(NULL AS STRING) AS query_type,

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/expect.yaml
@@ -15,6 +15,7 @@
   position: 1
   event_count: 1
   user_count: 1
+  query_type: branded
 - <<: *suggest_base
   event_type: click
 - &topsites_base

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/firefox_desktop.quick_suggest.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/firefox_desktop.quick_suggest.yaml
@@ -15,6 +15,7 @@
       quick_suggest_position: 1
     string: &click_strings
       quick_suggest_advertiser: ad1
+      quick_suggest_block_id: "123"
       quick_suggest_match_type: firefox-suggest
       quick_suggest_ping_type: quicksuggest-click
       quick_suggest_request_id: HASH123

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/moz-fx-data-bq-fivetran.admarketplace_suggest.blocks.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/moz-fx-data-bq-fivetran.admarketplace_suggest.blocks.yaml
@@ -1,0 +1,8 @@
+---
+- _file: source_file.json
+  _line: 1
+  _fivetran_synced: "2024-01-01 02:00:00"
+  _modified: "2024-01-01 01:00:00"
+  date: "2023-12-31"
+  id: 123
+  query_type: branded

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/expect.yaml
@@ -15,6 +15,7 @@
   position: 1
   event_count: 52
   user_count: 2
+  query_type: branded
 - <<: *suggest_base
   event_type: click
   event_count: 1

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/firefox_desktop.quick_suggest.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/firefox_desktop.quick_suggest.yaml
@@ -15,6 +15,7 @@
       quick_suggest_position: 1
     string: &click_strings
       quick_suggest_advertiser: ad1
+      quick_suggest_block_id: "123"
       quick_suggest_match_type: firefox-suggest
       quick_suggest_ping_type: quicksuggest-click
       quick_suggest_request_id: HASH123

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/moz-fx-data-bq-fivetran.admarketplace_suggest.blocks.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/moz-fx-data-bq-fivetran.admarketplace_suggest.blocks.yaml
@@ -1,0 +1,8 @@
+---
+- _file: source_file.json
+  _line: 1
+  _fivetran_synced: "2024-01-01 02:00:00"
+  _modified: "2024-01-01 01:00:00"
+  date: "2023-12-31"
+  id: 123
+  query_type: branded


### PR DESCRIPTION
Fixed version of #4901 -- pulls `query_type` from AMP suggestions data and adds that to suggest event aggregates

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2557)
