### PR TITLE
Add workgroup_access to GLAM prod tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_desktop_beta_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_desktop_beta_aggregates_v1/metadata.yaml
@@ -13,3 +13,7 @@ scheduling:
   - task_id: extracts
     dag_name: glam
     execution_delta: 6h
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/glam

--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_desktop_nightly_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_desktop_nightly_aggregates_v1/metadata.yaml
@@ -13,3 +13,7 @@ scheduling:
   - task_id: extracts
     dag_name: glam
     execution_delta: 6h
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/glam

--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_desktop_release_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_desktop_release_aggregates_v1/metadata.yaml
@@ -13,3 +13,7 @@ scheduling:
   - task_id: extracts
     dag_name: glam
     execution_delta: 6h
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/glam

--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_beta_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_beta_aggregates_v1/metadata.yaml
@@ -13,3 +13,7 @@ scheduling:
   - task_id: export_org_mozilla_fenix_glam_beta
     dag_name: glam_fenix
     execution_delta: 6h
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/glam

--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_nightly_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_nightly_aggregates_v1/metadata.yaml
@@ -13,3 +13,7 @@ scheduling:
   - task_id: export_org_mozilla_fenix_glam_nightly
     dag_name: glam_fenix
     execution_delta: 6h
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/glam

--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_release_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_fenix_release_aggregates_v1/metadata.yaml
@@ -13,3 +13,7 @@ scheduling:
   - task_id: export_org_mozilla_fenix_glam_release
     dag_name: glam_fenix
     execution_delta: 6h
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/glam

--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_fog_beta_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_fog_beta_aggregates_v1/metadata.yaml
@@ -13,3 +13,7 @@ scheduling:
   - task_id: export_firefox_desktop_glam_beta
     dag_name: glam_fog
     execution_delta: 6h
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/glam

--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_fog_nightly_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_fog_nightly_aggregates_v1/metadata.yaml
@@ -13,3 +13,7 @@ scheduling:
   - task_id: export_firefox_desktop_glam_nightly
     dag_name: glam_fog
     execution_delta: 6h
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/glam

--- a/sql/moz-fx-data-shared-prod/glam_etl/glam_fog_release_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/glam_fog_release_aggregates_v1/metadata.yaml
@@ -13,3 +13,7 @@ scheduling:
   - task_id: export_firefox_desktop_glam_release
     dag_name: glam_fog
     execution_delta: 6h
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/glam


### PR DESCRIPTION
As a preparation for GLAM serving data from BQ. Ensures proper access to production tables.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2594)
