### PR TITLE
bug(DENG-2598): No logic changes required, added a note to the views to for clarification

### DIFF
--- a/sql/moz-fx-data-shared-prod/apple_ads/ad_group_report/view.sql
+++ b/sql/moz-fx-data-shared-prod/apple_ads/ad_group_report/view.sql
@@ -1,6 +1,11 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.apple_ads.ad_group_report`
 AS
+-- As per the Fivetran connector docs (https://fivetran.com/docs/applications/apple-search-ads#utcconversion):
+-- "We don't convert source timestamps to Universal Time Coordinated (UTC)
+-- but use the Apple Search Ads account's time zone to store the data in your destination."
+--
+-- ! We should be careful about this and make sure our account is set to UTC and not changed.
 SELECT
   *
 FROM

--- a/sql/moz-fx-data-shared-prod/apple_ads/campaign_report/view.sql
+++ b/sql/moz-fx-data-shared-prod/apple_ads/campaign_report/view.sql
@@ -1,6 +1,11 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.apple_ads.campaign_report`
 AS
+-- As per the Fivetran connector docs (https://fivetran.com/docs/applications/apple-search-ads#utcconversion):
+-- "We don't convert source timestamps to Universal Time Coordinated (UTC)
+-- but use the Apple Search Ads account's time zone to store the data in your destination."
+--
+-- ! We should be careful about this and make sure our account is set to UTC and not changed.
 SELECT
   *
 FROM

--- a/sql/moz-fx-data-shared-prod/apple_ads/keyword_report/view.sql
+++ b/sql/moz-fx-data-shared-prod/apple_ads/keyword_report/view.sql
@@ -1,6 +1,11 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.apple_ads.keyword_report`
 AS
+-- As per the Fivetran connector docs (https://fivetran.com/docs/applications/apple-search-ads#utcconversion):
+-- "We don't convert source timestamps to Universal Time Coordinated (UTC)
+-- but use the Apple Search Ads account's time zone to store the data in your destination."
+--
+-- ! We should be careful about this and make sure our account is set to UTC and not changed.
 SELECT
   *
 FROM

--- a/sql/moz-fx-data-shared-prod/apple_ads/organization_report/view.sql
+++ b/sql/moz-fx-data-shared-prod/apple_ads/organization_report/view.sql
@@ -1,6 +1,11 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.apple_ads.organization_report`
 AS
+-- As per the Fivetran connector docs (https://fivetran.com/docs/applications/apple-search-ads#utcconversion):
+-- "We don't convert source timestamps to Universal Time Coordinated (UTC)
+-- but use the Apple Search Ads account's time zone to store the data in your destination."
+--
+-- ! We should be careful about this and make sure our account is set to UTC and not changed.
 SELECT
   *
 FROM

--- a/sql/moz-fx-data-shared-prod/apple_ads/search_term_report/view.sql
+++ b/sql/moz-fx-data-shared-prod/apple_ads/search_term_report/view.sql
@@ -1,6 +1,11 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.apple_ads.search_term_report`
 AS
+-- As per the Fivetran connector docs (https://fivetran.com/docs/applications/apple-search-ads#utcconversion):
+-- "We don't convert source timestamps to Universal Time Coordinated (UTC)
+-- but use the Apple Search Ads account's time zone to store the data in your destination."
+--
+-- ! We should be careful about this and make sure our account is set to UTC and not changed.
 SELECT
   *
 FROM


### PR DESCRIPTION
# bug(DENG-2598): No logic changes required, added a note to the views to for clarification

No changes to logic required as the timzone used corresponds to your Apple Ads accounts default timezone settings. Added a note to avoid confusion in the future.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2601)
