### PR TITLE
DENG-2492 - add new column engagement time and update hit time column…

### DIFF
--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v2/query.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v2/query.sql
@@ -197,7 +197,7 @@ final_staging AS (
         THEN 1
       ELSE 0
     END AS bounces, --if the session did not have an engaged event, then the session is considered a bounce, else it is not
-    ( hit_timestamp - visit_start_time) / 1000000 AS hit_time,
+    (hit_timestamp - visit_start_time) / 1000000 AS hit_time,
     SAFE_DIVIDE(engagement_time_msec, 1000) AS engagement_time,
     engmgt.first_interaction,
     CAST(engmgt.last_interaction AS float64) AS last_interaction,

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v2/query.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v2/query.sql
@@ -197,7 +197,7 @@ final_staging AS (
         THEN 1
       ELSE 0
     END AS bounces, --if the session did not have an engaged event, then the session is considered a bounce, else it is not
-    (hit_timestamp - visit_start_time) / 1000000 AS hit_time,
+    (all_events.event_timestamp - all_sessions.visit_start_time) / 1000000 AS hit_time,
     SAFE_DIVIDE(engagement_time_msec, 1000) AS engagement_time,
     engmgt.first_interaction,
     CAST(engmgt.last_interaction AS float64) AS last_interaction,

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v2/query.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v2/query.sql
@@ -197,7 +197,8 @@ final_staging AS (
         THEN 1
       ELSE 0
     END AS bounces, --if the session did not have an engaged event, then the session is considered a bounce, else it is not
-    SAFE_DIVIDE(engagement_time_msec, 1000) AS hit_time,
+    ( hit_timestamp - visit_start_time) / 1000000 AS hit_time,
+    SAFE_DIVIDE(engagement_time_msec, 1000) AS engagement_time,
     engmgt.first_interaction,
     CAST(engmgt.last_interaction AS float64) AS last_interaction,
     all_events.is_entrance AS entrances,
@@ -263,6 +264,7 @@ SELECT
   final.visits,
   final.bounces,
   final.hit_time,
+  final.engagement_time,
   final.first_interaction,
   final.last_interaction,
   final.entrances,

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v2/schema.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_hits_v2/schema.yaml
@@ -110,7 +110,11 @@ fields:
 - mode: NULLABLE
   name: hit_time
   type: FLOAT
-  description: Hit Time - Engagement Time in Seconds
+  description: Hit Time - The number of seconds after the visitStartTime that the hit was registered
+- mode: NULLABLE
+  name: engagement_time
+  type: FLOAT
+  description: Engagement Time - Engagement Time in Seconds
 - mode: NULLABLE
   name: first_interaction
   type: INT64


### PR DESCRIPTION
This MR does 2 things: 

- adds a new column engagement_time (shows the total engagement time for the event)
- updates the logic for hit_time 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2607)
