### PR TITLE
Fix main_summary_active_addons to handle additional addon fields

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf_js/main_summary_active_addons/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/main_summary_active_addons/udf.sql
@@ -33,7 +33,9 @@ CREATE OR REPLACE FUNCTION udf_js.main_summary_active_addons(
         type STRING,
         update_day INT64,
         user_disabled INT64,
-        version STRING
+        version STRING,
+        quarantine_ignored_by_app BOOL,
+        quarantine_ignored_by_user BOOL
       >
     >
   >,
@@ -113,21 +115,21 @@ WITH result AS (
   SELECT AS VALUE
     ARRAY_CONCAT(
       udf_js.main_summary_active_addons(
-        ARRAY<STRUCT<STRING,STRUCT<BOOL,BOOL,STRING,INT64,BOOL,INT64,BOOL,BOOL,BOOL,STRING,INT64,INT64,STRING,INT64,INT64,STRING>>>[
+        ARRAY<STRUCT<STRING,STRUCT<BOOL,BOOL,STRING,INT64,BOOL,INT64,BOOL,BOOL,BOOL,STRING,INT64,INT64,STRING,INT64,INT64,STRING,BOOL,BOOL>>>[
           -- truthy columns and additional_properties
-          ('a', (TRUE, TRUE, 'description', NULL, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, NULL, NULL)),
+          ('a', (TRUE, TRUE, 'description', NULL, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, NULL, NULL, NULL, NULL)),
           -- falsey columns and truthy additional_properties
-          ('b', (FALSE, FALSE, '', NULL, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, NULL, NULL)),
+          ('b', (FALSE, FALSE, '', NULL, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, NULL, NULL, NULL, NULL)),
           -- falsey columns and additional_properties
-          ('c', (FALSE, FALSE, '', NULL, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, NULL, NULL)),
+          ('c', (FALSE, FALSE, '', NULL, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, NULL, NULL, NULL, NULL)),
           -- truthy columns and falsey additional_properties
-          ('d', (TRUE, TRUE, 'description', NULL, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, NULL, NULL)),
+          ('d', (TRUE, TRUE, 'description', NULL, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, NULL, NULL, NULL, NULL)),
           -- truthy columns and missing additional_properties
-          ('e', (TRUE, TRUE, 'description', 1, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, 1, "version")),
+          ('e', (TRUE, TRUE, 'description', 1, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, 1, "version", NULL, NULL)),
           -- falsey columns and missing additional_properties
-          ('f', (FALSE, FALSE, '', 0, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, 0, "")),
+          ('f', (FALSE, FALSE, '', 0, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, 0, "", NULL, NULL)),
           -- null columns and missing additional_properties
-          ('g', (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)),
+          ('g', (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)),
           -- null value and ignore additional_properties
           ('h', NULL),
           -- null value and truthy additional_properties
@@ -149,11 +151,11 @@ WITH result AS (
       ),
       -- null additional properties
       udf_js.main_summary_active_addons(
-        ARRAY<STRUCT<STRING,STRUCT<BOOL,BOOL,STRING,INT64,BOOL,INT64,BOOL,BOOL,BOOL,STRING,INT64,INT64,STRING,INT64,INT64,STRING>>>[
+        ARRAY<STRUCT<STRING,STRUCT<BOOL,BOOL,STRING,INT64,BOOL,INT64,BOOL,BOOL,BOOL,STRING,INT64,INT64,STRING,INT64,INT64,STRING,BOOL,BOOL>>>[
           -- truthy columns and null additional_properties
-          ('l', (TRUE, TRUE, 'description', 1, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, 1, "version")),
+          ('l', (TRUE, TRUE, 'description', 1, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, 1, "version", FALSE, FALSE)),
           -- falsey columns and null additional_properties
-          ('m', (FALSE, FALSE, '', 0, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, 0, "")),
+          ('m', (FALSE, FALSE, '', 0, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, 0, "", TRUE, TRUE)),
           -- null columns and additional_properties
           ('n', NULL)
         ],


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2617)
