### PR TITLE
bug(): added submission_date and made it the partition key to address rows belonging to different partitions error

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v1/metadata.yaml
@@ -12,7 +12,7 @@ scheduling:
 bigquery:
   time_partitioning:
     type: day
-    field: ping_date
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
 deprecated: false

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v1/query.sql
@@ -128,6 +128,7 @@ metric_ping_clients_feature_usage AS (
 )
 -- Aggregated feature usage
 SELECT
+  @submission_date AS submission_date,
   ping_date,
   channel,
   country,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v1/schema.yaml
@@ -1,4 +1,8 @@
 fields:
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+  description: Airflow's internal execution_date.
 - name: ping_date
   type: DATE
   mode: NULLABLE


### PR DESCRIPTION
# bug(): added submission_date and made it the partition key to address rows belonging to different partitions error

follows-up: https://github.com/mozilla/bigquery-etl/pull/4950

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2618)
