### PR TITLE
feat(): Update description, partitioning and clustering setting for fenix_derived.firefox_android_clients_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/metadata.yaml
@@ -1,12 +1,9 @@
 friendly_name: Firefox Android Clients
 description: |-
-  First observations for Firefox Android clients of channel Release,
-  retrieved from the earliest pings: baseline, first_session and metrics.
-  The attributes stored in this table include the first attribution,
-  device, OS and ISP details.
+  Contains a list of Firefox Android clients along with their first attributes
+  retrieved from baseline, first_session and metrics pings.
 
-  This table should be accessed through the user-facing view
-  `fenix.firefox_android_clients`.
+  This includes information such as their initial geo, OS, ISP, and attribution info.
 
   For analysis purposes, use first_seen_date to query clients that
   effectively appeared on that date. The submission_date indicates
@@ -24,6 +21,8 @@ owners:
 - lvargas@mozilla.com
 labels:
   application: firefox_android
+  # This query results in the table being rebuilt on each run
+  # by combining mix of all old and new records, in some cases combining them together.
   incremental: true
   schedule: daily
   owner1: lvargas
@@ -31,19 +30,10 @@ scheduling:
   dag_name: bqetl_analytics_tables
   task_name: firefox_android_clients
   depends_on_past: true
-  date_partition_parameter: null
-  parameters:
-  - submission_date:DATE:{{ds}}
 bigquery:
-  time_partitioning:
-    type: day
-    field: first_seen_date
-    require_partition_filter: false
-    expiration_days: null
   clustering:
     fields:
-    - channel
+    - first_seen_date
     - sample_id
+    - channel
     - first_reported_country
-    - device_model
-references: {}


### PR DESCRIPTION
# feat(): Update description, partitioning and clustering setting for fenix_derived.firefox_android_clients_v1

This change would allow us to run "backfills" without running into this error if attempting to re-run the query for roughly more than a week worth runs:
```
BigQuery error in query operation: Error processing job 'moz-fx-data-shared-
[2024-02-06, 10:07:30 UTC] {pod_manager.py:437} INFO - [base] prod:bqjob_r5e253910c092afa7_0000018d7de3106f_1': Quota exceeded: Your table
[2024-02-06, 10:07:30 UTC] {pod_manager.py:437} INFO - [base] exceeded quota for Number of partition modifications to a column partitioned
```

This would require redeploying this table with new partitioning and clustering settings.


Alternative approach would be to reinitialize the table via the `query initialize` command: https://mozilla.github.io/bigquery-etl/bqetl/#initialize if a backfill for more than a week worth of data is necessary.

This just means having to work with all historical data.

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
