### PR TITLE
AD-178 Update event_aggregates tables to pull query_type from the Ads team's table

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
@@ -1,9 +1,9 @@
 WITH blocks AS (
   SELECT
     b.id,
-    b.query_type,
+    b.queryType AS query_type,
   FROM
-    `moz-fx-data-bq-fivetran.admarketplace_suggest.blocks` b
+    `moz-fx-ads-prod.adm.blocks` b
   WHERE
     b.date <= @submission_date
   QUALIFY

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/query.sql
@@ -1,9 +1,9 @@
 WITH blocks AS (
   SELECT
     b.id,
-    b.query_type,
+    b.queryType AS query_type,
   FROM
-    `moz-fx-data-bq-fivetran.admarketplace_suggest.blocks` b
+    `moz-fx-ads-prod.adm.blocks` b
   WHERE
     b.date <= @submission_date
   QUALIFY

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/moz-fx-ads-prod.adm.blocks.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/moz-fx-ads-prod.adm.blocks.yaml
@@ -5,4 +5,4 @@
   _modified: "2024-01-01 01:00:00"
   date: "2023-12-31"
   id: 123
-  query_type: branded
+  queryType: branded

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/moz-fx-ads-prod.adm.blocks.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/moz-fx-ads-prod.adm.blocks.yaml
@@ -5,4 +5,4 @@
   _modified: "2024-01-01 01:00:00"
   date: "2023-12-31"
   id: 123
-  query_type: branded
+  queryType: branded


### PR DESCRIPTION
We previously set up a workaround via Box + Fivetran to pull this data into BQ; this switches over to pulling from a table the Ads team maintains and updates automatically each time we get a new file from AMP and load it into Remote Settings

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2641)
