### PR TITLE
DENG-2492 - update time on site to convert to seconds, add comments

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
@@ -242,7 +242,7 @@ SELECT
     ELSE FALSE
   END AS is_first_session,
   a.ga_session_number AS session_number,
-  (b.max_event_timestamp - b.min_event_timestamp) / 1000000 AS time_on_site,
+  CAST((b.max_event_timestamp - b.min_event_timestamp) / 1000000 as int64) AS time_on_site,
   b.pageviews,
   a.country,
   a.region,

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
@@ -242,7 +242,7 @@ SELECT
     ELSE FALSE
   END AS is_first_session,
   a.ga_session_number AS session_number,
-  (b.max_event_timestamp - b.min_event_timestamp)/1000000 AS time_on_site,
+  (b.max_event_timestamp - b.min_event_timestamp) / 1000000 AS time_on_site,
   b.pageviews,
   a.country,
   a.region,

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
@@ -46,10 +46,10 @@ WITH device_properties_at_session_start_event AS (
   WHERE
     _table_suffix = FORMAT_DATE('%Y%m%d', @submission_date)
     AND e.key = 'ga_session_id'
-    AND e.value.int_value IS NOT NULL
+    AND e.value.int_value IS NOT NULL --only keep rows where GA session ID is not null
     AND a.event_name = 'session_start'
   QUALIFY
-    rnk = 1
+    rnk = 1 --if a ga_session_id / user_pseudo_id / session_date has more than 1 session_start, only keep 1 since a unique session should only have 1 session start
 ),
 --get all the details for that session from the session date and the next day
 event_aggregates AS (
@@ -71,7 +71,7 @@ event_aggregates AS (
     BETWEEN FORMAT_DATE('%Y%m%d', @submission_date)
     AND FORMAT_DATE('%Y%m%d', DATE_ADD(@submission_date, INTERVAL 1 DAY))
     AND e.key = 'ga_session_id'
-    AND e.value.int_value IS NOT NULL
+    AND e.value.int_value IS NOT NULL  --only keep rows where GA session ID is not null
   GROUP BY
     a.user_pseudo_id,
     CAST(e.value.int_value AS string)
@@ -163,7 +163,7 @@ landing_page_by_session_staging AS (
     BETWEEN FORMAT_DATE('%Y%m%d', @submission_date)
     AND FORMAT_DATE('%Y%m%d', DATE_ADD(@submission_date, INTERVAL 1 DAY))
     AND e.key = 'entrances'
-    AND e.value.int_value = 1
+    AND e.value.int_value = 1 --filter to the entrance page view of the session (key = entrances, int_value = 1 to get the landing page of the session)
 ),
 landing_page_by_session AS (
   SELECT
@@ -181,7 +181,7 @@ landing_page_by_session AS (
   FROM
     landing_page_by_session_staging
   QUALIFY
-    lp_rnk = 1
+    lp_rnk = 1 --if there are ever multiple entrances in the same session, pick only 1 (rare but occasionally happens)
 ),
 install_targets_staging AS (
   SELECT
@@ -242,7 +242,7 @@ SELECT
     ELSE FALSE
   END AS is_first_session,
   a.ga_session_number AS session_number,
-  b.max_event_timestamp - b.min_event_timestamp AS time_on_site,
+  (b.max_event_timestamp - b.min_event_timestamp)/1000000 AS time_on_site,
   b.pageviews,
   a.country,
   a.region,

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
@@ -242,7 +242,7 @@ SELECT
     ELSE FALSE
   END AS is_first_session,
   a.ga_session_number AS session_number,
-  CAST((b.max_event_timestamp - b.min_event_timestamp) / 1000000 as int64) AS time_on_site,
+  CAST((b.max_event_timestamp - b.min_event_timestamp) / 1000000 AS int64) AS time_on_site,
   b.pageviews,
   a.country,
   a.region,

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/schema.yaml
@@ -22,7 +22,7 @@ fields:
 - name: time_on_site
   mode: NULLABLE
   type: INTEGER
-  description: "Amount of time the user was on the site for this session."
+  description: "The time in seconds between the first and last event of the session"
 - name: pageviews
   mode: NULLABLE
   type: INTEGER


### PR DESCRIPTION
This change does 2 things: 

- Adds comments to code to explain some of the logic
- Fixes "time on site" calculation to convert to seconds

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
