### PR TITLE
DENG-2645 Fix missing username in bigquery_usage

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.sql
@@ -55,16 +55,21 @@ jobs_by_project AS (
         ARRAY_CONCAT(
           referenced_tables,
           (
-            SELECT
-              ARRAY_AGG(
-                STRUCT(
-                  materialized_view.table_reference.project_id AS project_id,
-                  materialized_view.table_reference.dataset_id AS dataset_id,
-                  materialized_view.table_reference.table_id AS table_id
-                )
-              )
-            FROM
-              UNNEST(materialized_view_statistics.materialized_view) AS materialized_view
+            IFNULL(
+              (
+                SELECT
+                  ARRAY_AGG(
+                    STRUCT(
+                      materialized_view.table_reference.project_id AS project_id,
+                      materialized_view.table_reference.dataset_id AS dataset_id,
+                      materialized_view.table_reference.table_id AS table_id
+                    )
+                  )
+                FROM
+                  UNNEST(materialized_view_statistics.materialized_view) AS materialized_view
+              ),
+              []
+            )
           )
         )
       ) AS referenced_table

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
@@ -36,13 +36,13 @@ def create_query(date, project):
           priority,
           project_id,
           project_number,
-          ARRAY_CONCAT(referenced_tables, (SELECT ARRAY_AGG(
+          ARRAY_CONCAT(referenced_tables, IFNULL((SELECT ARRAY_AGG(
             STRUCT(
               materialized_view.table_reference.project_id AS project_id,
               materialized_view.table_reference.dataset_id AS dataset_id,
               materialized_view.table_reference.table_id AS table_id
             )
-          ) FROM UNNEST(materialized_view_statistics.materialized_view) AS materialized_view)) AS referenced_tables,
+          ) FROM UNNEST(materialized_view_statistics.materialized_view) AS materialized_view), [])) AS referenced_tables,
           reservation_id,
           start_time,
           state,


### PR DESCRIPTION
[DENG-2645](https://mozilla-hub.atlassian.net/browse/DENG-2645):  It was discovered that redash related columns (`username` and `query id`) are null for all redash records in the past few weeks in `bigquery_usage` view.  It looks like #4786 resulted in empty reference table fields and affected the join between jobs_by_org and jobs_by_project.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DENG-2645]: https://mozilla-hub.atlassian.net/browse/DENG-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2653)
