### PR TITLE
Replace the `mozilla_vpn_derived.vat_rates_v1` ETL with a CSV file (bug 1878898)

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn/vat_rates/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn/vat_rates/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-shared-prod`.mozilla_vpn_derived.vat_rates_v1
+  `moz-fx-data-shared-prod`.mozilla_vpn_derived.vat_rates_v2

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v1/metadata.yaml
@@ -6,10 +6,11 @@ owners:
   - srose@mozilla.com
 labels:
   schedule: daily
-scheduling:
-  dag_name: bqetl_subplat
-  retry_delay: 5m
-  gke_cluster_name: workloads-prod-v1
-  gke_location: us-west1
-  gcp_conn_id: google_cloud_airflow_gke
-  gke_project_id: moz-fx-data-airflow-gke-prod
+# Descheduled because the source Google Sheet has apparently been deleted (bug 1878898).
+#scheduling:
+#  dag_name: bqetl_subplat
+#  retry_delay: 5m
+#  gke_cluster_name: workloads-prod-v1
+#  gke_location: us-west1
+#  gcp_conn_id: google_cloud_airflow_gke
+#  gke_project_id: moz-fx-data-airflow-gke-prod

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/data.csv
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/data.csv
@@ -1,16 +1,21 @@
 country_code,country,vat,effective_date
 AT,Austria,0.2,2021-01-01
 BE,Belgium,0.21,2021-01-01
+BG,Bulgaria,0.2,2022-05-10
 CA,Canada,0.1,2021-01-01
 CH,Switzerland,0.077,2021-01-01
 CY,Cyprus,0.19,2022-05-10
+CZ,Czech Republic,0.21,2022-05-10
 DE,Germany,0.19,2021-01-01
+DK,Denmark,0.25,2022-05-10
 EE,Estonia,0.2,2022-05-10
 ES,Spain,0.21,2021-01-01
 FI,Finland,0.24,2022-01-01
 FR,France,0.2,2021-01-01
 GB,United Kingdom,0.2,2021-01-01
 GR,Greece,0.24,2022-05-10
+HR,Croatia,0.25,2022-05-10
+HU,Hungary,0.27,2022-05-10
 IE,Ireland,0.23,2021-01-01
 IT,Italy,0.22,2021-01-01
 LT,Lithuania,0.21,2022-05-10
@@ -20,7 +25,9 @@ MT,Malta,0.18,2022-05-10
 MY,Malaysia,0.05,2021-01-01
 NL,Netherlands,0.21,2021-01-01
 NZ,New Zealand,0.15,2021-01-01
+PL,Poland,0.23,2022-05-10
 PT,Portugal,0.23,2022-05-10
+RO,Romania,0.19,2022-05-10
 SE,Sweden,0.25,2022-01-01
 SG,Singapore,0.07,2021-01-01
 SI,Slovenia,0.22,2022-05-10

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/data.csv
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/data.csv
@@ -1,0 +1,27 @@
+country_code,country,vat,effective_date
+AT,Austria,0.2,2021-01-01
+CA,Canada,0.1,2021-01-01
+CH,Switzerland,0.077,2021-01-01
+CY,Cyprus,0.19,2022-05-10
+DE,Germany,0.19,2021-01-01
+EE,Estonia,0.2,2022-05-10
+ES,Spain,0.21,2021-01-01
+FI,Finland,0.24,2022-01-01
+FR,France,0.2,2021-01-01
+GB,United Kingdom,0.2,2021-01-01
+GR,Greece,0.24,2022-05-10
+IE,Ireland,0.23,2021-01-01
+IT,Italy,0.22,2021-01-01
+LT,Lithuania,0.21,2022-05-10
+LU,Luxembourg,0.17,2022-05-10
+LV,Latvia,0.21,2022-05-10
+MT,Malta,0.18,2022-05-10
+MY,Malaysia,0.05,2021-01-01
+NL,Netherlands,0.21,2021-01-01
+NZ,New Zealand,0.15,2021-01-01
+PT,Portugal,0.23,2022-05-10
+SE,Sweden,0.25,2022-01-01
+SG,Singapore,0.07,2021-01-01
+SI,Slovenia,0.22,2022-05-10
+SK,Slovakia,0.2,2022-05-10
+US,United States,0,2021-01-01

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/data.csv
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/data.csv
@@ -1,5 +1,6 @@
 country_code,country,vat,effective_date
 AT,Austria,0.2,2021-01-01
+BE,Belgium,0.21,2021-01-01
 CA,Canada,0.1,2021-01-01
 CH,Switzerland,0.077,2021-01-01
 CY,Cyprus,0.19,2022-05-10

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/description.txt
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/description.txt
@@ -1,0 +1,1 @@
+VAT rates for countries where Mozilla VPN is available.

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/schema.json
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/schema.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "country_code",
+    "description": "ISO 3166 alpha-2 country code.",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "country",
+    "description": "Country name.",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "vat",
+    "description": "VAT rate.",
+    "type": "NUMERIC",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "effective_date",
+    "description": "Date when the VAT rate should take effect.",
+    "type": "DATE",
+    "mode": "REQUIRED"
+  }
+]


### PR DESCRIPTION
Because the source Google Sheet for the `mozilla_vpn_derived.vat_rates_v1` ETL has apparently been deleted ([bug 1878898](https://bugzilla.mozilla.org/show_bug.cgi?id=1878898)).

This also adds some VAT rates that were missing from the source Google Sheet.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2654)
