### PR TITLE
Bug 1879039 - events stream: Convert nested maps in metrics

### DIFF
--- a/sql/mozfun/json/from_nested_map/README.md
+++ b/sql/mozfun/json/from_nested_map/README.md
@@ -1,0 +1,3 @@
+Convert a JSON object like `{ "metric": [ {"key": "extra", "value": 2 } ] }` to a `JSON` object like `{ "metric": { "key": 2 } }`.
+
+This only works on JSON types.

--- a/sql/mozfun/json/from_nested_map/metadata.yaml
+++ b/sql/mozfun/json/from_nested_map/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: To JSON from nested map
+description: Converts a nested JSON object with repeated key/value pairs into a nested JSON object.

--- a/sql/mozfun/json/from_nested_map/udf.sql
+++ b/sql/mozfun/json/from_nested_map/udf.sql
@@ -1,0 +1,34 @@
+-- Definition for json.from_nested_map
+CREATE OR REPLACE function json.from_nested_map(input JSON)
+RETURNS json
+LANGUAGE js
+AS
+  """
+  if (input && Object.keys(input).length) {
+    for (const k in input) {
+      if (input[k] && input[k].length) {
+        input[k] = input[k].reduce((acc, {key, value}) => {
+          acc[key] = value;
+          return acc;
+        }, {});
+      }
+    }
+  }
+  return input;
+""";
+
+-- Tests
+SELECT
+  assert.null(json.from_nested_map(NULL)),
+  assert.json_equal(JSON '{ "metric": [] }', json.from_nested_map(JSON '{ "metric": [] }')),
+  assert.json_equal(JSON '{ "metric": {} }', json.from_nested_map(JSON '{ "metric": {} }')),
+  assert.json_equal(
+    JSON '{ "metric": { "extra": 2 } }',
+    json.from_nested_map(JSON '{ "metric": [ {"key": "extra", "value": 2 } ] }')
+  ),
+  assert.json_equal(JSON '{ "metric": {}}', json.from_nested_map(JSON '{ "metric": [1, 2, 3]}')),
+  assert.json_equal(JSON '{ "metric": "value"}', json.from_nested_map(JSON '{ "metric": "value"}')),
+  assert.json_equal(
+    JSON '{ "metric": {}}',
+    json.from_nested_map(JSON '{ "metric": [{"key": "value"}]}')
+  ),

--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -37,10 +37,7 @@ WITH base AS (
     event.name as event_name,
     ARRAY_TO_STRING([event.category, event.name], '.') AS event, -- handles NULL values better
     `mozfun.json.from_map`(event.extra) AS event_extra,
-    JSON_STRIP_NULLS(
-      TO_JSON(metrics),  -- expose as easy to access JSON column
-      remove_empty => true -- no reason to keep empty objects around
-    ) AS metrics
+    TO_JSON(metrics) AS metrics
   FROM
     `{{ events_view }}` AS e
   CROSS JOIN
@@ -56,6 +53,34 @@ WITH base AS (
 )
 --
 SELECT
-  *
+  * REPLACE (
+    -- expose as easy to access JSON column,
+    -- strip nulls,
+    -- translate nested array records into a JSON object,
+    -- rename url2 -> url
+    JSON_STRIP_NULLS(
+      JSON_REMOVE(
+        -- labeled_* are the only ones that SHOULD show up as context for events pings,
+        -- thus we special-case them
+        --
+        -- The JSON_SET/JSON_EXTRACT shenanigans are needed
+        -- because those subfields might not exist, so accessing the columns would fail.
+        -- but accessing non-existent fields in a JSON object simply gives us NULL.
+        JSON_SET(
+          metrics,
+          '$.labeled_counter',
+          mozfun.json.from_nested_map(metrics.labeled_counter),
+          '$.labeled_string',
+          mozfun.json.from_nested_map(metrics.labeled_string),
+          '$.labeled_boolean',
+          mozfun.json.from_nested_map(metrics.labeled_boolean),
+          '$.url',
+          metrics.url2
+        ),
+        '$.url2'
+      ),
+      remove_empty => TRUE
+    ) AS metrics
+  )
 FROM
   base


### PR DESCRIPTION
I'm not entirely sure that this works. Can we add a new UDF and use it in the same PR?

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2659)
