### PR TITLE
DENG-2492 - update logic of new ga_sessions_v2 table

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
@@ -66,7 +66,8 @@ device_properties_at_session_start_event_or_first_event AS (
           WHEN a.event_name = 'session_start'
             THEN 0
           ELSE 1
-        END,
+        END
+        ASC,
         a.event_timestamp ASC
     ) AS rnk
   FROM

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/query.sql
@@ -1,5 +1,29 @@
-WITH device_properties_at_session_start_event AS (
-  --get all sessions starting on the submission date
+WITH sessions_with_no_event_yesterday AS (
+  --looking at events on submission date or day before, get the GA Client ID / GA Session ID with no events on day before but events on date itself
+  SELECT
+    a.user_pseudo_id AS ga_client_id,
+    CAST(e.value.int_value AS string) AS ga_session_id,
+    MIN(PARSE_DATE('%Y%m%d', event_date)) AS min_session_date,
+  FROM
+    `moz-fx-data-marketing-prod.analytics_313696158.events_*` a
+  JOIN
+    UNNEST(event_params) e
+  WHERE
+    _table_suffix
+    BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(@submission_date, INTERVAL 1 DAY))
+    AND FORMAT_DATE('%Y%m%d', @submission_date)
+    AND e.key = 'ga_session_id'
+    AND e.value.int_value IS NOT NULL --only keep rows where GA session ID is not null
+  GROUP BY
+    1,
+    2
+  HAVING
+    min_session_date = @submission_date
+),
+device_properties_at_session_start_event_or_first_event AS (
+  --get the device properties for each client ID / session ID with events on the submission date
+  --use the properties on the session start event if available
+  --else, use the properties on the first event based on timestamp
   SELECT
     a.user_pseudo_id AS ga_client_id,
     CAST(e.value.int_value AS string) AS ga_session_id,
@@ -32,11 +56,17 @@ WITH device_properties_at_session_start_event AS (
     device.web_info.browser AS browser,
     device.web_info.browser_version AS browser_version,
     PARSE_DATE('%Y%m%d', event_date) AS session_date,
+    --if there is a session start event, use properties at the time that event fires; if not, use the first event's properties
     ROW_NUMBER() OVER (
       PARTITION BY
         a.user_pseudo_id,
         e.value.int_value
       ORDER BY
+        CASE
+          WHEN a.event_name = 'session_start'
+            THEN 0
+          ELSE 1
+        END,
         a.event_timestamp ASC
     ) AS rnk
   FROM
@@ -47,9 +77,19 @@ WITH device_properties_at_session_start_event AS (
     _table_suffix = FORMAT_DATE('%Y%m%d', @submission_date)
     AND e.key = 'ga_session_id'
     AND e.value.int_value IS NOT NULL --only keep rows where GA session ID is not null
-    AND a.event_name = 'session_start'
   QUALIFY
     rnk = 1 --if a ga_session_id / user_pseudo_id / session_date has more than 1 session_start, only keep 1 since a unique session should only have 1 session start
+),
+session_device_properties AS (
+  --only look at sessions that had no events the day before
+  SELECT
+    a.*
+  FROM
+    device_properties_at_session_start_event_or_first_event a
+  JOIN
+    sessions_with_no_event_yesterday b
+    ON a.ga_client_id = b.ga_client_id
+    AND a.ga_session_id = b.ga_session_id
 ),
 --get all the details for that session from the session date and the next day
 event_aggregates AS (
@@ -269,7 +309,7 @@ SELECT
   d.all_reported_stub_session_ids,
   e.page_location AS landing_screen
 FROM
-  device_properties_at_session_start_event a
+  session_device_properties a
 LEFT JOIN
   event_aggregates b
   ON a.ga_client_id = b.ga_client_id


### PR DESCRIPTION
This logic change helps make sure that if a session does not have a session start event, that it still shows up in the table

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2670)
