### PR TITLE
bug(): adding firefox_ios_derived.retention_clients to shredder config

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -156,8 +156,16 @@ user_id_target = partial(DeleteTarget, field=USER_ID)
 context_id_target = partial(DeleteTarget, field=CONTEXT_ID)
 
 DELETE_TARGETS: DeleteIndex = {
+    # Fenix
     client_id_target(table="fenix_derived.firefox_android_clients_v1"): FENIX_SRC,
     client_id_target(table="fenix_derived.new_profile_activation_v1"): FENIX_SRC,
+    client_id_target(
+        table="fenix_derived.funnel_retention_clients_week_2_v1"
+    ): FENIX_SRC,
+    client_id_target(
+        table="fenix_derived.funnel_retention_clients_week_4_v1"
+    ): FENIX_SRC,
+    # Firefox iOS
     client_id_target(
         table="firefox_ios_derived.firefox_ios_clients_v1"
     ): FIREFOX_IOS_SRC,
@@ -165,11 +173,12 @@ DELETE_TARGETS: DeleteIndex = {
         table="firefox_ios_derived.clients_activation_v1"
     ): FIREFOX_IOS_SRC,
     client_id_target(
-        table="fenix_derived.funnel_retention_clients_week_2_v1"
-    ): FENIX_SRC,
+        table="firefox_ios_derived.funnel_retention_clients_week_2_v1"
+    ): FIREFOX_IOS_SRC,
     client_id_target(
-        table="fenix_derived.funnel_retention_clients_week_4_v1"
-    ): FENIX_SRC,
+        table="firefox_ios_derived.funnel_retention_clients_week_4_v1"
+    ): FIREFOX_IOS_SRC,
+    # Other
     client_id_target(table="search_derived.acer_cohort_v1"): DESKTOP_SRC,
     client_id_target(
         table="search_derived.mobile_search_clients_daily_v1"


### PR DESCRIPTION
# bug(): adding firefox_ios_derived.retention_clients to shredder config

This is causing some count discrepancies.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2679)
