### PR TITLE
Don't overwrite existing `gcp.json` files unless that's actually necessary

### DIFF
--- a/script/entrypoint
+++ b/script/entrypoint
@@ -8,12 +8,12 @@ if [ -n "$GCLOUD_SERVICE_KEY" ]; then
     # Google's client libraries will check for GOOGLE_APPLICATION_CREDENTIALS
     # and use a file in that location for credentials if present;
     # See https://cloud.google.com/docs/authentication/production
-    if [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
-        # Create a unique credentials file since this script can be called in parallel by multiple tests.
-        export GOOGLE_APPLICATION_CREDENTIALS=$(mktemp /tmp/gcp.json.XXXXXXXXXX)
+    export GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS:-/tmp/gcp.json}"
+    # Only write the credentials file if it doesn't exist yet or doesn't match the current credentials.
+    if [ ! -e "$GOOGLE_APPLICATION_CREDENTIALS" -o "$(cat "$GOOGLE_APPLICATION_CREDENTIALS")" != "$GCLOUD_SERVICE_KEY" ]; then
+        echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+        echo "DEBUG: Wrote $(echo "$GCLOUD_SERVICE_KEY" | wc -c) bytes to '$GOOGLE_APPLICATION_CREDENTIALS'."
     fi
-    echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-    echo "DEBUG: Wrote $(echo "$GCLOUD_SERVICE_KEY" | wc -c) bytes to '$GOOGLE_APPLICATION_CREDENTIALS'."
 fi
 
 if [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ] && which gcloud > /dev/null; then

--- a/script/entrypoint
+++ b/script/entrypoint
@@ -10,7 +10,7 @@ if [ -n "$GCLOUD_SERVICE_KEY" ]; then
     # See https://cloud.google.com/docs/authentication/production
     export GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS:-/tmp/gcp.json}"
     # Only write the credentials file if it doesn't exist yet or doesn't match the current credentials.
-    if [ ! -e "$GOOGLE_APPLICATION_CREDENTIALS" -o "$(cat "$GOOGLE_APPLICATION_CREDENTIALS")" != "$GCLOUD_SERVICE_KEY" ]; then
+    if [ ! -e "$GOOGLE_APPLICATION_CREDENTIALS" -o "$(cat "$GOOGLE_APPLICATION_CREDENTIALS" | md5sum)" != "$(echo "$GCLOUD_SERVICE_KEY" | md5sum)" ]; then
         echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
         echo "DEBUG: Wrote $(echo "$GCLOUD_SERVICE_KEY" | wc -c) bytes to '$GOOGLE_APPLICATION_CREDENTIALS'."
     fi

--- a/script/entrypoint
+++ b/script/entrypoint
@@ -10,7 +10,7 @@ if [ -n "$GCLOUD_SERVICE_KEY" ]; then
     # See https://cloud.google.com/docs/authentication/production
     export GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS:-/tmp/gcp.json}"
     # Only write the credentials file if it doesn't exist yet or doesn't match the current credentials.
-    if [ ! -e "$GOOGLE_APPLICATION_CREDENTIALS" -o "$(cat "$GOOGLE_APPLICATION_CREDENTIALS" | md5sum)" != "$(echo "$GCLOUD_SERVICE_KEY" | md5sum)" ]; then
+    if [ ! -e "$GOOGLE_APPLICATION_CREDENTIALS" ] || [ "$(cat "$GOOGLE_APPLICATION_CREDENTIALS" | md5sum)" != "$(echo "$GCLOUD_SERVICE_KEY" | md5sum)" ]; then
         echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
         echo "DEBUG: Wrote $(echo "$GCLOUD_SERVICE_KEY" | wc -c) bytes to '$GOOGLE_APPLICATION_CREDENTIALS'."
     fi


### PR DESCRIPTION
#4924 didn't eliminate the "_File /tmp/gcp.json is not a valid json file_" errors we keep getting sporadically in CI jobs, and I think the reason is that the individual parallelized tests that call the entrypoint script weren't getting their own unique `gcp.json` files and instead were using (and overwriting) the same "unique" `gcp.json` file created by the initial entrypoint script run that kicked off the overall test run, since the `GOOGLE_APPLICATION_CREDENTIALS` environment variable was set by that initial entrypoint script.

This PR takes a different tack and goes back to using one `gcp.json` file, but avoids overwriting that `gcp.json` file unless it doesn't contain the expected credentials.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2691)
