### PR TITLE
DENG-2492 Update Product Download Types for www_site_landing_page_metrics_v2

### DIFF
--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_landing_page_metrics_v2/query.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_landing_page_metrics_v2/query.sql
@@ -22,9 +22,31 @@ SELECT
   SUM(
     IF(NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(browser), entrances, 0)
   ) AS non_fx_sessions,
-  COUNTIF(event_name = 'product_download') AS downloads,
   COUNTIF(
-    event_name = 'product_download'
+    (date <= '2024-02-16' AND event_name = 'product_download')
+    OR (
+      date > '2024-02-16'
+      AND event_name IN (
+        'firefox_download',
+        'focus_download',
+        'klar_download',
+        'firefox_mobile_download'
+      )
+    )
+  ) AS downloads,
+  COUNTIF(
+    (
+      (date <= '2024-02-16' AND event_name = 'product_download')
+      OR (
+        date > '2024-02-16'
+        AND event_name IN (
+          'firefox_download',
+          'focus_download',
+          'klar_download',
+          'firefox_mobile_download'
+        )
+      )
+    )
     AND NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(browser)
   ) AS non_fx_downloads,
   COUNTIF(event_name = 'page_view') AS pageviews,


### PR DESCRIPTION
The product_download event was used for a long period only, but recently was split into 4 separate types. To not double count, before a certain date, should use the "product_download" event only, after that date, use the 4 types only.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2756)
