### PR TITLE
DENG-2492 - Update logic for ga_sessions_v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/script.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/script.sql
@@ -133,7 +133,7 @@ MERGE INTO
         ) AS ga_session_id,
         CAST(e.value.int_value AS string) AS stub_session_id
       FROM
-        `moz-fx-data-marketing-prod.analytics_313696158.events_2*`
+        `moz-fx-data-marketing-prod.analytics_313696158.events_2*` a
       JOIN
         UNNEST(event_params) AS e
       JOIN


### PR DESCRIPTION
Updates to try to make query process less data - old merge would update everything each day, now this is just getting all events from the last 3 days leading up to the submission date, figuring out the unique client ID / session IDs these belong to, then re-calculating the entire session's data for that session, across the whole events_ source table from Google.  

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2759)
