### PR TITLE
Ignore stable table schemas without `bq_dataset_family` and `bq_table` metadata

### DIFF
--- a/bigquery_etl/schema/stable_table_schema.py
+++ b/bigquery_etl/schema/stable_table_schema.py
@@ -79,10 +79,14 @@ def get_stable_table_schemas() -> List[SchemaFile]:
                 schema = json.load(tar.extractfile(tarinfo.name))  # type: ignore
                 bq_schema = {}
 
-                # Schemas without pipeline metadata (like glean/glean)
+                # Schemas without `bq_dataset_family` and `bq_table` metadata (like glean/glean)
                 # do not have corresponding BQ tables, so we skip them here.
                 pipeline_meta = schema.get("mozPipelineMetadata", None)
-                if pipeline_meta is None:
+                if (
+                    pipeline_meta is None
+                    or "bq_dataset_family" not in pipeline_meta
+                    or "bq_table" not in pipeline_meta
+                ):
                     continue
 
                 try:


### PR DESCRIPTION
The `glean/glean` schema now has `mozPipelineMetadata` as of mozilla-services/mozilla-pipeline-schemas#793, so we need to be more specific to continue excluding it.

Depends on mozilla-services/mozilla-pipeline-schemas#805.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2761)
