### PR TITLE
Bug 1880270 Allow glam-prod project queries to execute

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -14,6 +14,7 @@ default:
   additional_projects: # additional valid projects managed outside of bigquery-etl
   - moz-fx-data-pioneer-nonprod
   - moz-fx-data-pioneer-prod
+  - moz-fx-data-glam-prod-fca7
   public_project: mozilla-public-data
 
 
@@ -436,9 +437,3 @@ generate:
       - org_mozilla_fenix
       - org_mozilla_fenix_beta
       - org_mozilla_firefox
-    events_monitoring:
-      default_event_table: events_v1
-      event_table:
-        mozillavpn: main_v1
-        accounts_frontend: accounts_events_v1
-        accounts_backend: accounts_events_v1

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -437,3 +437,9 @@ generate:
       - org_mozilla_fenix
       - org_mozilla_fenix_beta
       - org_mozilla_firefox
+    events_monitoring:
+      default_event_table: events_v1
+      event_table:
+        mozillavpn: main_v1
+        accounts_frontend: accounts_events_v1
+        accounts_backend: accounts_events_v1


### PR DESCRIPTION
Fixes [1880270](https://bugzilla.mozilla.org/show_bug.cgi?id=1880270)

bqetl_glam_refresh_aggregates failing with error
```Invalid value for '--project-id' / '--project_id': Invalid project  moz-fx-data-glam-prod-fca7 ```

This will allow the query to be executed on the project.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2771)
