### PR TITLE
Public image must be pushed after the private one

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -539,6 +539,21 @@ jobs:
             git add << parameters.repo-to-sync >>
             git commit --allow-empty -m "Automatic commit from ${CIRCLE_PROJECT_REPONAME} commit ${CIRCLE_SHA1:0:9} build ${CIRCLE_BUILD_NUM} [skip ci]"
             git push origin main
+  deploy-to-private-gcr:
+    executor: ubuntu-machine-executor
+    steps:
+      - checkout
+      - *attach_generated_sql
+      - run:
+          name: Move generated-sql into place
+          command: |
+            rm -rf sql/
+            cp -r /tmp/workspace/private-generated-sql/sql sql
+      - gcp-gcr/gcr-auth
+      - gcp-gcr/build-image: &private-image
+          image: bigquery-etl
+          tag: ${CIRCLE_TAG:-latest}
+      - gcp-gcr/push-image: *private-image
   deploy:
     executor: ubuntu-machine-executor
     steps:
@@ -637,21 +652,6 @@ jobs:
               && git push \
               || echo "Skipping push since it looks like there were no changes"
           # yamllint enable rule:line-length
-  deploy-to-private-gcr:
-    executor: ubuntu-machine-executor
-    steps:
-      - checkout
-      - *attach_generated_sql
-      - run:
-          name: Move generated-sql into place
-          command: |
-            rm -rf sql/
-            cp -r /tmp/workspace/private-generated-sql/sql sql
-      - gcp-gcr/gcr-auth
-      - gcp-gcr/build-image: &private-image
-          image: bigquery-etl
-          tag: ${CIRCLE_TAG:-latest}
-      - gcp-gcr/push-image: *private-image
   main-generate-sql-and-dags:
     docker: *docker
     resource_class: large


### PR DESCRIPTION

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
