### PR TITLE
Bug 1868244 Publish views if dry run schema differs from deployed

### DIFF
--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import attr
 import sqlparse
-from google.api_core.exceptions import BadRequest, NotFound, Forbidden
+from google.api_core.exceptions import BadRequest, Forbidden, NotFound
 from google.cloud import bigquery
 
 from bigquery_etl.config import ConfigLoader

--- a/tests/view/test_view.py
+++ b/tests/view/test_view.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
 from google.api_core.exceptions import NotFound
 from google.cloud.bigquery import SchemaField
 
-from bigquery_etl.view import View, CREATE_VIEW_PATTERN
+from bigquery_etl.view import CREATE_VIEW_PATTERN, View
 
 TEST_DIR = Path(__file__).parent.parent
 

--- a/tests/view/test_view.py
+++ b/tests/view/test_view.py
@@ -1,10 +1,12 @@
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import pytest
 from click.testing import CliRunner
+from google.api_core.exceptions import NotFound
+from google.cloud.bigquery import SchemaField
 
-from bigquery_etl.view import View
+from bigquery_etl.view import View, CREATE_VIEW_PATTERN
 
 TEST_DIR = Path(__file__).parent.parent
 
@@ -14,8 +16,9 @@ class TestView:
     def runner(self):
         return CliRunner()
 
-    def test_from_file(self):
-        view_file = (
+    @pytest.fixture
+    def simple_view(self):
+        return View.from_file(
             TEST_DIR
             / "data"
             / "test_sql"
@@ -25,12 +28,26 @@ class TestView:
             / "view.sql"
         )
 
-        view = View.from_file(view_file)
-        assert view.dataset == "test"
-        assert view.project == "moz-fx-data-test-project"
-        assert view.name == "simple_view"
-        assert view.view_identifier == "moz-fx-data-test-project.test.simple_view"
-        assert view.is_user_facing
+    @pytest.fixture
+    def metadata_view(self):
+        return View.from_file(
+            TEST_DIR
+            / "data"
+            / "test_sql"
+            / "moz-fx-data-test-project"
+            / "test"
+            / "view_with_metadata"
+            / "view.sql"
+        )
+
+    def test_from_file(self, simple_view):
+        assert simple_view.dataset == "test"
+        assert simple_view.project == "moz-fx-data-test-project"
+        assert simple_view.name == "simple_view"
+        assert (
+            simple_view.view_identifier == "moz-fx-data-test-project.test.simple_view"
+        )
+        assert simple_view.is_user_facing
 
     def test_view_create(self, runner):
         with runner.isolated_filesystem():
@@ -91,21 +108,13 @@ class TestView:
 
     @patch("google.cloud.bigquery.Client")
     @patch("google.cloud.bigquery.Table")
-    def test_publish_valid_view(self, mock_bigquery_table, mock_bigquery_client):
+    def test_publish_valid_view(
+        self, mock_bigquery_table, mock_bigquery_client, metadata_view
+    ):
         mock_bigquery_client().get_table.return_value = mock_bigquery_table()
 
-        view = View.from_file(
-            TEST_DIR
-            / "data"
-            / "test_sql"
-            / "moz-fx-data-test-project"
-            / "test"
-            / "view_with_metadata"
-            / "view.sql"
-        )
-
-        assert view.is_valid()
-        assert view.publish()
+        assert metadata_view.is_valid()
+        assert metadata_view.publish()
         assert mock_bigquery_client().update_table.call_count == 1
         assert (
             mock_bigquery_client().update_table.call_args[0][0].friendly_name
@@ -136,3 +145,65 @@ class TestView:
         )
         assert mock_bigquery_table().friendly_name == "Test metadata file"
         assert mock_bigquery_table().description == "Test description"
+
+    @patch("google.cloud.bigquery.Client")
+    def test_view_has_changes_no_changes(self, mock_client, simple_view):
+        deployed_view = Mock()
+        deployed_view.view_query = CREATE_VIEW_PATTERN.sub("", simple_view.content)
+        deployed_view.schema = [SchemaField("a", "INT")]
+        mock_client.return_value.get_table.return_value = deployed_view
+        mock_client.return_value.query.return_value.schema = [SchemaField("a", "INT")]
+
+        assert not simple_view.has_changes()
+
+    def test_view_has_changes_non_matching_project(self, simple_view):
+        assert not simple_view.has_changes(target_project="other-project")
+
+    @patch("google.cloud.bigquery.Client")
+    def test_view_has_changes_new_view(self, mock_client, simple_view, capsys):
+        mock_client.return_value.get_table.side_effect = NotFound("")
+
+        assert simple_view.has_changes()
+        assert "does not exist" in capsys.readouterr().out
+
+    @patch("google.cloud.bigquery.Client")
+    def test_view_has_changes_changed_defn(self, mock_client, simple_view, capsys):
+        deployed_view = Mock()
+        deployed_view.view_query = """
+        CREATE OR REPLACE VIEW
+          `moz-fx-data-test-project.test.simple_view`
+        AS
+        SELECT
+          99
+        """
+        mock_client.return_value.get_table.return_value = deployed_view
+
+        assert simple_view.has_changes()
+        assert "query" in capsys.readouterr().out
+
+    @patch("google.cloud.bigquery.Client")
+    def test_view_has_changes_changed_metadata(
+        self, mock_client, metadata_view, capsys
+    ):
+        deployed_view = Mock()
+        deployed_view.view_query = CREATE_VIEW_PATTERN.sub("", metadata_view.content)
+        deployed_view.description = metadata_view.metadata.description
+        deployed_view.friendly_name = metadata_view.metadata.friendly_name + "123"
+        mock_client.return_value.get_table.return_value = deployed_view
+
+        assert metadata_view.has_changes()
+        assert "friendly_name" in capsys.readouterr().out
+
+    @patch("google.cloud.bigquery.Client")
+    def test_view_has_changes_changed_schema(self, mock_client, simple_view, capsys):
+        deployed_view = Mock()
+        deployed_view.view_query = CREATE_VIEW_PATTERN.sub("", simple_view.content)
+        deployed_view.schema = [SchemaField("a", "INT")]
+        mock_client.return_value.get_table.return_value = deployed_view
+        mock_client.return_value.query.return_value.schema = [
+            SchemaField("a", "INT"),
+            SchemaField("b", "INT"),
+        ]
+
+        assert simple_view.has_changes()
+        assert "schema" in capsys.readouterr().out


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1868244

This adds a dry run step to the function that checks if a view has changes to be published.  The dry run result includes the schema of the resulting view that can be compared to the active schema.

Did a quick performance test locally with this:
```python
for view in _collect_views(None, "sql", "moz-fx-data-shared-prod", False, False):
    view.has_changes()
```
The dry run adds on average ~0.4s to every view that reaches that code path.  The total time to check all the views after running `./script/bqetl generate stable_views` was 526 seconds without dry run and 688 seconds with dry run.  This seems acceptable to me but I don't have all the context around how this is run other than in the airflow task.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2785)
