### PR TITLE
Fix publish metadata task failing when table not found

### DIFF
--- a/bigquery_etl/metadata/publish_metadata.py
+++ b/bigquery_etl/metadata/publish_metadata.py
@@ -3,6 +3,7 @@
 from argparse import ArgumentParser
 
 import yaml
+from google.api_core.exceptions import NotFound
 
 from ..config import ConfigLoader
 from ..util import standard_args
@@ -51,4 +52,6 @@ def publish_metadata(client, project, dataset, table, metadata):
         print("Published metadata for: {}.{}.{}".format(project, dataset, table))
 
     except yaml.YAMLError as e:
+        print(e)
+    except NotFound as e:
         print(e)


### PR DESCRIPTION
It looks like publish metadata airflow task is failing with `google.api_core.exceptions.NotFound` when table does not exist:  
https://workflow.telemetry.mozilla.org/dags/bqetl_artifact_deployment/grid?dag_run_id=scheduled__2024-02-14T00%3A00%3A00%2B00%3A00&task_id=publish_metadata&tab=logs

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2787)
