### PR TITLE
bug(1880851): Remove failing week 4 retention check

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios/funnel_retention_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/funnel_retention_clients/view.sql
@@ -13,6 +13,9 @@ SELECT
     retention_week_4.first_reported_isp,
     retention_week_2.first_reported_isp
   ) AS first_reported_isp,
+  -- We prioritize the retention_week_4 values over week 2 because we expect them to be more complete
+  -- due to delays potential delays in attribution data arriving. However, this could potentially mean
+  -- that after two weeks a small number of clients might experience a change in their adjust attributes.
   COALESCE(retention_week_4.adjust_ad_group, retention_week_2.adjust_ad_group) AS adjust_ad_group,
   COALESCE(retention_week_4.adjust_campaign, retention_week_2.adjust_campaign) AS adjust_campaign,
   COALESCE(retention_week_4.adjust_creative, retention_week_2.adjust_creative) AS adjust_creative,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/checks.sql
@@ -5,40 +5,6 @@
 {{ min_row_count(1, "submission_date = @submission_date") }}
 
 #fail
--- Here we're checking that the retention_week_2 generated inside funnel_retention_week_2_v1
--- matches that reported by this table (generated 2 weeks later).
-WITH retention_week_2 AS (
-  SELECT
-    COUNTIF(retained_week_2)
-  FROM
-    `moz-fx-data-shared-prod.firefox_ios_derived.funnel_retention_clients_week_2_v1`
-  WHERE
-    first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
-),
-retention_week_2_week_4_generated AS (
-  SELECT
-    COUNTIF(retained_week_2)
-  FROM
-    `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
-  WHERE
-    first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
-)
-SELECT
-  IF(
-    (SELECT * FROM retention_week_2) <> (SELECT * FROM retention_week_2_week_4_generated),
-    ERROR(
-      CONCAT(
-        "Retention reported for week 2 by week_2 (",
-        (SELECT * FROM retention_week_2),
-        ") and week_4 (",
-        (SELECT * FROM retention_week_2_week_4_generated),
-        ") tables does not match."
-      )
-    ),
-    NULL
-  );
-
-#fail
 SELECT
   IF(
     DATE_DIFF(submission_date, first_seen_date, DAY) <> 27,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/metadata.yaml
@@ -10,10 +10,6 @@ labels:
 scheduling:
   dag_name: bqetl_firefox_ios
   depends_on_past: false
-  # Explicitly specifying referenced table here to make sure we only run this query and its checks
-  # after the referenced table is materialized. This is because the checks depend on it.
-  referenced_tables:
-  - ['moz-fx-data-shared-prod', 'firefox_ios_derived', 'funnel_retention_clients_week_2_v1']
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/query.sql
@@ -52,9 +52,7 @@ SELECT
     ) AS first_seen_date
   ),
   days_seen_in_first_28_days > 1 AS repeat_first_month_user,
-  -- retention UDF works on 0 index basis, that's why for example week_1 is aliased as week 2 to make it a bit more user friendly.
-  -- retained_week_2 added for testing.
-  retention.day_27.active_in_week_1 AS retained_week_2,
+  -- retention UDF works on 0 index basis, that's why week_3 is aliased as week 4 to make it a bit more user friendly.
   retention.day_27.active_in_week_3 AS retained_week_4,
 FROM
   retention_calculation

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/schema.yaml
@@ -73,12 +73,6 @@ fields:
     Indicates if the client qualified as a repeat first month user (observed more than once within their first 28 days).
 
 - mode: NULLABLE
-  name: retained_week_2
-  type: BOOLEAN
-  description: |
-    True if the client was seen in the second week (days 8 - 14) since they were first seen.
-
-- mode: NULLABLE
   name: retained_week_4
   type: BOOLEAN
   description: |


### PR DESCRIPTION
# bug(1880851): Remove failing week 4 retention check

The reason for this is that the check was recalculating week 2 retention and comparing it against previously generated data. The main problem with this approach is that these two are meant to generate the same numbers, however, because they are executed at different times the base data has potential to change (due to Shredder) resulting in different numbers being generated. And therefore, rendering the check to fail.

This is why the check is being removed as we know it will result in failures and cause noise.

One follow-up step is required:

- Drop column `retention_week_2` from `firefox_ios_derived.funnel_retention_clients_week_4` table.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2795)
