### PR TITLE
Bug 1880837: Remove metadata.yaml from GLAM folders that aren't tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_content_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_content_v1/metadata.yaml
@@ -1,6 +1,0 @@
-friendly_name: |-
-  Telemetry Derived - Clients Daily Histogram Aggregates Content
-description: |-
-  [DESCRIPTION_MISSING]
-owners:
-- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_gpu_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_gpu_v1/metadata.yaml
@@ -1,6 +1,0 @@
-friendly_name: |-
-  Telemetry Derived - Clients Daily Histogram Aggregates Gpu
-description: |-
-  [DESCRIPTION_MISSING]
-owners:
-- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_parent_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_parent_v1/metadata.yaml
@@ -1,6 +1,0 @@
-friendly_name: |-
-  Telemetry Derived - Clients Daily Histogram Aggregates Parent
-description: |-
-  [DESCRIPTION_MISSING]
-owners:
-- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_boolean_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_boolean_aggregates_v1/metadata.yaml
@@ -1,6 +1,0 @@
-friendly_name: |-
-  Telemetry Derived - Clients Daily Keyed Boolean Aggregates
-description: |-
-  [DESCRIPTION_MISSING]
-owners:
-- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_histogram_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_histogram_aggregates_v1/metadata.yaml
@@ -1,6 +1,0 @@
-friendly_name: |-
-  Telemetry Derived - Clients Daily Keyed Histogram Aggregates
-description: |-
-  [DESCRIPTION_MISSING]
-owners:
-- data-platform-infra-wg@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_scalar_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_scalar_aggregates_v1/metadata.yaml
@@ -1,6 +1,0 @@
-friendly_name: |-
-  Telemetry Derived - Clients Daily Keyed Scalar Aggregates
-description: |-
-  [DESCRIPTION_MISSING]
-owners:
-- data-platform-infra-wg@mozilla.com


### PR DESCRIPTION
Attempts to fix `publish_metadata` job by removing `metadata.yaml` files from GLAM folders that are not tables. 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2797)
