### PR TITLE
Limit Fivetran task concurrency so it only tries to run one sync per connector at a time

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -383,6 +383,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
     {{ fivetran_task.task_id }}_sync_start = FivetranOperator(
         connector_id='{% raw %}{{ var.value.{% endraw %}{{ fivetran_task.task_id }}{% raw %}_connector_id }}{% endraw %}',
         task_id='{{ fivetran_task.task_id }}_task',
+        task_concurrency=1,
     )
 
     {% do fivetran_seen.append(fivetran_task) %}

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -63,6 +63,7 @@ with DAG(
     fivetran_import_1_sync_start = FivetranOperator(
         connector_id="{{ var.value.fivetran_import_1_connector_id }}",
         task_id="fivetran_import_1_task",
+        task_concurrency=1,
     )
 
     test__non_incremental_query__v1.set_upstream(fivetran_import_1_sync_start)
@@ -70,6 +71,7 @@ with DAG(
     fivetran_import_2_sync_start = FivetranOperator(
         connector_id="{{ var.value.fivetran_import_2_connector_id }}",
         task_id="fivetran_import_2_task",
+        task_concurrency=1,
     )
 
     test__non_incremental_query__v1.set_upstream(fivetran_import_2_sync_start)


### PR DESCRIPTION
This only makes sense now that we've switched to Astronomer's Fivetran Airflow provider package (https://github.com/mozilla/telemetry-airflow/pull/1922, https://github.com/mozilla/bigquery-etl/pull/5080), which allows us to have a single task that both starts the Fivetran sync and waits for it to complete.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2818)
