### PR TITLE
Output DAG tasks for external dependencies first

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -65,6 +65,109 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
     task_group_{{ task_group }} = TaskGroup('{{ task_group }}')
 {% endfor %}
 
+{% set wait_for_seen = [] -%}
+{% set fivetran_seen = [] -%}
+{% for task in tasks | sort(attribute='task_name') %}
+    {% for dependency in (task.upstream_dependencies + task.depends_on) | sort(attribute='task_id') -%}
+    {% if not (dependency.dag_name == name and dependency.get_execution_delta(schedule_interval) in [none, '0h', '0m', '0s']) -%}
+    {% if dependency.task_key not in wait_for_seen -%}
+    wait_for_{{ dependency.task_id | replace('-', '_') }} = ExternalTaskSensor(
+        task_id='wait_for_{{ dependency.task_id }}',
+        external_dag_id='{{ dependency.dag_name }}',
+        {% if dependency.task_group -%}
+        external_task_id='{{dependency.task_group}}.{{ dependency.task_id }}',
+        {% else -%}
+        external_task_id='{{ dependency.task_id }}',
+        {% endif -%}
+        {% if dependency.get_execution_delta(schedule_interval) -%}
+        execution_delta={{ dependency.get_execution_delta(schedule_interval) | format_timedelta | format_repr }},
+        {% endif -%}
+        check_existence=True,
+        mode='reschedule',
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool='DATA_ENG_EXTERNALTASKSENSOR',
+    )
+
+    {% do wait_for_seen.append(dependency.task_key) -%}
+    {% endif -%}
+    {% endif -%}
+    {% endfor -%}
+
+    {% for table_sensor_task in task.depends_on_tables_existing -%}
+    {% set project_id, dataset_name, table_name = table_sensor_task.table_id.split('.') -%}
+    {{ table_sensor_task.task_id }} = BigQueryTableExistenceSensor(
+        task_id={{ table_sensor_task.task_id | format_repr }},
+        project_id={{ project_id | format_repr }},
+        dataset_id={{ dataset_name | format_repr }},
+        table_id={{ table_name | format_repr }},
+        gcp_conn_id='google_cloud_shared_prod',
+        deferrable=True,
+        {% if table_sensor_task.poke_interval != None -%}
+        poke_interval={{ table_sensor_task.poke_interval | format_timedelta | format_repr }},
+        {% else -%}
+        poke_interval=datetime.timedelta(minutes=5),
+        {% endif -%}
+        {% if table_sensor_task.timeout != None -%}
+        timeout={{ table_sensor_task.timeout | format_timedelta | format_repr }},
+        {% else -%}
+        timeout=datetime.timedelta(hours=8),
+        {% endif -%}
+        {% if table_sensor_task.retries != None -%}
+        retries={{ table_sensor_task.retries }},
+        {% endif -%}
+        {% if table_sensor_task.retry_delay != None -%}
+        retry_delay={{ table_sensor_task.retry_delay | format_timedelta | format_repr }},
+        {% endif -%}
+    )
+
+    {% endfor -%}
+
+    {% for table_partition_sensor_task in task.depends_on_table_partitions_existing -%}
+    {% set project_id, dataset_name, table_name = table_partition_sensor_task.table_id.split('.') -%}
+    {{ table_partition_sensor_task.task_id }} = BigQueryTablePartitionExistenceSensor(
+        task_id={{ table_partition_sensor_task.task_id | format_repr }},
+        project_id={{ project_id | format_repr }},
+        dataset_id={{ dataset_name | format_repr }},
+        table_id={{ table_name | format_repr }},
+        partition_id={{ table_partition_sensor_task.partition_id | format_repr }},
+        gcp_conn_id='google_cloud_shared_prod',
+        deferrable=True,
+        {% if table_partition_sensor_task.poke_interval != None -%}
+        poke_interval={{ table_partition_sensor_task.poke_interval | format_timedelta | format_repr }},
+        {% else -%}
+        poke_interval=datetime.timedelta(minutes=5),
+        {% endif -%}
+        {% if table_partition_sensor_task.timeout != None -%}
+        timeout={{ table_partition_sensor_task.timeout | format_timedelta | format_repr }},
+        {% else -%}
+        timeout=datetime.timedelta(hours=8),
+        {% endif -%}
+        {% if table_partition_sensor_task.retries != None -%}
+        retries={{ table_partition_sensor_task.retries }},
+        {% endif -%}
+        {% if table_partition_sensor_task.retry_delay != None -%}
+        retry_delay={{ table_partition_sensor_task.retry_delay | format_timedelta | format_repr }},
+        {% endif -%}
+    )
+
+    {% endfor -%}
+
+    {% if task.depends_on_fivetran != None -%}
+    {% for fivetran_task in task.depends_on_fivetran -%}
+    {% if fivetran_task not in fivetran_seen -%}
+    {{ fivetran_task.task_id }}_sync_start = FivetranOperator(
+        connector_id='{% raw %}{{{% endraw %} var.value.{{ fivetran_task.task_id }}_connector_id {% raw %}}}{% endraw %}',
+        task_id='{{ fivetran_task.task_id }}_task',
+        task_concurrency=1,
+    )
+
+    {% do fivetran_seen.append(fivetran_task) -%}
+    {% endif -%}
+    {% endfor -%}
+    {% endif -%}
+{% endfor -%}
+
 {% for task in tasks | sort(attribute='task_name') %}
     {% if task.is_python_script -%}
         {{ task.task_name }} = GKEPodOperator(
@@ -272,122 +375,40 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             execution_date="{% raw %}{{{% endraw %} (execution_date + {{ downstream_task.get_execution_delta(schedule_interval) | format_timedelta_macro }}).isoformat() {% raw %}}}{% endraw %}",
             {% endif -%}
         )
-        {% do seenDownstreamDags.append(downstream_task.dag_name) %}
+
+        {% do seenDownstreamDags.append(downstream_task.dag_name) -%}
         {% endif -%}
         {% endfor -%}
-
         {{ task.task_name }}_external.set_upstream({{ task.task_name }})
+
     {% endif -%}
 {% endfor -%}
 
-{% set wait_for_seen = [] -%}
-{% set fivetran_seen = [] -%}
 {% for task in tasks | sort(attribute='task_name') %}
     {% for dependency in (task.upstream_dependencies + task.depends_on) | sort(attribute='task_id') -%}
     {% if dependency.dag_name == name and dependency.get_execution_delta(schedule_interval) in [none, '0h', '0m', '0s'] -%}
-    {% if dependency.task_id != task.task_name %}
+    {% if dependency.task_id != task.task_name -%}
     {{ task.task_name }}.set_upstream({{ dependency.task_id }})
+
     {% endif -%}
     {% else -%}
-    {% if dependency.task_key not in wait_for_seen -%}
-    wait_for_{{ dependency.task_id | replace('-', '_') }} = ExternalTaskSensor(
-        task_id='wait_for_{{ dependency.task_id }}',
-        external_dag_id='{{ dependency.dag_name }}',
-        {% if dependency.task_group -%}
-        external_task_id='{{dependency.task_group}}.{{ dependency.task_id }}',
-        {% else -%}
-        external_task_id='{{ dependency.task_id }}',
-        {% endif -%}
-        {% if dependency.get_execution_delta(schedule_interval) -%}
-        execution_delta={{ dependency.get_execution_delta(schedule_interval) | format_timedelta | format_repr }},
-        {% endif -%}
-        check_existence=True,
-        mode='reschedule',
-        allowed_states=ALLOWED_STATES,
-        failed_states=FAILED_STATES,
-        pool='DATA_ENG_EXTERNALTASKSENSOR',
-    )
-    {% do wait_for_seen.append(dependency.task_key) %}
-    {% endif -%}
-
     {{ task.task_name }}.set_upstream(wait_for_{{ dependency.task_id | replace('-', '_') }})
+
     {% endif -%}
     {% endfor -%}
 
     {% for table_sensor_task in task.depends_on_tables_existing -%}
-    {% set project_id, dataset_name, table_name = table_sensor_task.table_id.split('.') -%}
-    {{ table_sensor_task.task_id }} = BigQueryTableExistenceSensor(
-        task_id={{ table_sensor_task.task_id | format_repr }},
-        project_id={{ project_id | format_repr }},
-        dataset_id={{ dataset_name | format_repr }},
-        table_id={{ table_name | format_repr }},
-        gcp_conn_id='google_cloud_shared_prod',
-        deferrable=True,
-        {% if table_sensor_task.poke_interval != None -%}
-        poke_interval={{ table_sensor_task.poke_interval | format_timedelta | format_repr }},
-        {% else -%}
-        poke_interval=datetime.timedelta(minutes=5),
-        {% endif -%}
-        {% if table_sensor_task.timeout != None -%}
-        timeout={{ table_sensor_task.timeout | format_timedelta | format_repr }},
-        {% else -%}
-        timeout=datetime.timedelta(hours=8),
-        {% endif -%}
-        {% if table_sensor_task.retries != None -%}
-        retries={{ table_sensor_task.retries }},
-        {% endif -%}
-        {% if table_sensor_task.retry_delay != None -%}
-        retry_delay={{ table_sensor_task.retry_delay | format_timedelta | format_repr }},
-        {% endif -%}
-    )
-
     {{ task.task_name }}.set_upstream({{ table_sensor_task.task_id }})
 
     {% endfor -%}
 
     {% for table_partition_sensor_task in task.depends_on_table_partitions_existing -%}
-    {% set project_id, dataset_name, table_name = table_partition_sensor_task.table_id.split('.') -%}
-    {{ table_partition_sensor_task.task_id }} = BigQueryTablePartitionExistenceSensor(
-        task_id={{ table_partition_sensor_task.task_id | format_repr }},
-        project_id={{ project_id | format_repr }},
-        dataset_id={{ dataset_name | format_repr }},
-        table_id={{ table_name | format_repr }},
-        partition_id={{ table_partition_sensor_task.partition_id | format_repr }},
-        gcp_conn_id='google_cloud_shared_prod',
-        deferrable=True,
-        {% if table_partition_sensor_task.poke_interval != None -%}
-        poke_interval={{ table_partition_sensor_task.poke_interval | format_timedelta | format_repr }},
-        {% else -%}
-        poke_interval=datetime.timedelta(minutes=5),
-        {% endif -%}
-        {% if table_partition_sensor_task.timeout != None -%}
-        timeout={{ table_partition_sensor_task.timeout | format_timedelta | format_repr }},
-        {% else -%}
-        timeout=datetime.timedelta(hours=8),
-        {% endif -%}
-        {% if table_partition_sensor_task.retries != None -%}
-        retries={{ table_partition_sensor_task.retries }},
-        {% endif -%}
-        {% if table_partition_sensor_task.retry_delay != None -%}
-        retry_delay={{ table_partition_sensor_task.retry_delay | format_timedelta | format_repr }},
-        {% endif -%}
-    )
-
     {{ task.task_name }}.set_upstream({{ table_partition_sensor_task.task_id }})
 
     {% endfor -%}
 
     {% if task.depends_on_fivetran != None -%}
     {% for fivetran_task in task.depends_on_fivetran -%}
-    {% if fivetran_task not in fivetran_seen -%}
-    {{ fivetran_task.task_id }}_sync_start = FivetranOperator(
-        connector_id='{% raw %}{{ var.value.{% endraw %}{{ fivetran_task.task_id }}{% raw %}_connector_id }}{% endraw %}',
-        task_id='{{ fivetran_task.task_id }}_task',
-        task_concurrency=1,
-    )
-
-    {% do fivetran_seen.append(fivetran_task) %}
-    {% endif -%}
     {{ task.task_name }}.set_upstream({{ fivetran_task.task_id }}_sync_start)
 
     {% endfor -%}

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -48,6 +48,18 @@ with DAG(
     tags=tags,
 ) as dag:
 
+    fivetran_import_1_sync_start = FivetranOperator(
+        connector_id="{{ var.value.fivetran_import_1_connector_id }}",
+        task_id="fivetran_import_1_task",
+        task_concurrency=1,
+    )
+
+    fivetran_import_2_sync_start = FivetranOperator(
+        connector_id="{{ var.value.fivetran_import_2_connector_id }}",
+        task_id="fivetran_import_2_task",
+        task_concurrency=1,
+    )
+
     test__non_incremental_query__v1 = bigquery_etl_query(
         task_id="test__non_incremental_query__v1",
         destination_table="non_incremental_query_v1",
@@ -60,18 +72,6 @@ with DAG(
         arguments=["--append_table"],
     )
 
-    fivetran_import_1_sync_start = FivetranOperator(
-        connector_id="{{ var.value.fivetran_import_1_connector_id }}",
-        task_id="fivetran_import_1_task",
-        task_concurrency=1,
-    )
-
     test__non_incremental_query__v1.set_upstream(fivetran_import_1_sync_start)
-
-    fivetran_import_2_sync_start = FivetranOperator(
-        connector_id="{{ var.value.fivetran_import_2_connector_id }}",
-        task_id="fivetran_import_2_task",
-        task_concurrency=1,
-    )
 
     test__non_incremental_query__v1.set_upstream(fivetran_import_2_sync_start)

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -46,6 +46,17 @@ with DAG(
     tags=tags,
 ) as dag:
 
+    wait_for_task1 = ExternalTaskSensor(
+        task_id="wait_for_task1",
+        external_dag_id="external",
+        external_task_id="task1",
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
     test__no_metadata_query__v1 = bigquery_etl_query(
         task_id="test__no_metadata_query__v1",
         destination_table='no_metadata_query_v1${{ macros.ds_format(macros.ds_add(ds, -2), "%Y-%m-%d", "%Y%m%d") }}',
@@ -68,17 +79,6 @@ with DAG(
         date_partition_parameter=None,
         depends_on_past=True,
         parameters=["date:DATE:{{macros.ds_add(ds, -2)}}"],
-    )
-
-    wait_for_task1 = ExternalTaskSensor(
-        task_id="wait_for_task1",
-        external_dag_id="external",
-        external_task_id="task1",
-        check_existence=True,
-        mode="reschedule",
-        allowed_states=ALLOWED_STATES,
-        failed_states=FAILED_STATES,
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     test__no_metadata_query__v1.set_upstream(wait_for_task1)

--- a/tests/data/dags/test_dag_with_bigquery_table_sensors
+++ b/tests/data/dags/test_dag_with_bigquery_table_sensors
@@ -50,18 +50,6 @@ with DAG(
     tags=tags,
 ) as dag:
 
-    test__non_incremental_query__v1 = bigquery_etl_query(
-        task_id="test__non_incremental_query__v1",
-        destination_table="non_incremental_query_v1",
-        dataset_id="test",
-        project_id="moz-fx-data-test-project",
-        owner="test@example.com",
-        email=["test@example.com"],
-        date_partition_parameter="submission_date",
-        depends_on_past=True,
-        arguments=["--append_table"],
-    )
-
     wait_for_foo_bar_baz = BigQueryTableExistenceSensor(
         task_id="wait_for_foo_bar_baz",
         project_id="foo",
@@ -74,8 +62,6 @@ with DAG(
         retries=1,
         retry_delay=datetime.timedelta(seconds=600),
     )
-
-    test__non_incremental_query__v1.set_upstream(wait_for_foo_bar_baz)
 
     wait_for_foo_bar_baz_partition = BigQueryTablePartitionExistenceSensor(
         task_id="wait_for_foo_bar_baz_partition",
@@ -90,5 +76,19 @@ with DAG(
         retries=3,
         retry_delay=datetime.timedelta(seconds=300),
     )
+
+    test__non_incremental_query__v1 = bigquery_etl_query(
+        task_id="test__non_incremental_query__v1",
+        destination_table="non_incremental_query_v1",
+        dataset_id="test",
+        project_id="moz-fx-data-test-project",
+        owner="test@example.com",
+        email=["test@example.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=True,
+        arguments=["--append_table"],
+    )
+
+    test__non_incremental_query__v1.set_upstream(wait_for_foo_bar_baz)
 
     test__non_incremental_query__v1.set_upstream(wait_for_foo_bar_baz_partition)

--- a/tests/data/dags/test_dag_with_check_dependencies
+++ b/tests/data/dags/test_dag_with_check_dependencies
@@ -46,6 +46,17 @@ with DAG(
     tags=tags,
 ) as dag:
 
+    wait_for_checks__fail_test__external_table__v1 = ExternalTaskSensor(
+        task_id="wait_for_checks__fail_test__external_table__v1",
+        external_dag_id="bqetl_external_test_dag",
+        external_task_id="checks__fail_test__external_table__v1",
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
     checks__fail_test__table1__v1 = bigquery_dq_check(
         task_id="checks__fail_test__table1__v1",
         source_table="table1_v1",
@@ -93,17 +104,6 @@ with DAG(
     )
 
     checks__fail_test__table1__v1.set_upstream(test__table1__v1)
-
-    wait_for_checks__fail_test__external_table__v1 = ExternalTaskSensor(
-        task_id="wait_for_checks__fail_test__external_table__v1",
-        external_dag_id="bqetl_external_test_dag",
-        external_task_id="checks__fail_test__external_table__v1",
-        check_existence=True,
-        mode="reschedule",
-        allowed_states=ALLOWED_STATES,
-        failed_states=FAILED_STATES,
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
-    )
 
     test__query__v1.set_upstream(wait_for_checks__fail_test__external_table__v1)
 

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -46,6 +46,17 @@ with DAG(
     tags=tags,
 ) as dag:
 
+    wait_for_test__external_table__v1 = ExternalTaskSensor(
+        task_id="wait_for_test__external_table__v1",
+        external_dag_id="bqetl_external_test_dag",
+        external_task_id="test__external_table__v1",
+        check_existence=True,
+        mode="reschedule",
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
     test__query__v1 = bigquery_etl_query(
         task_id="test__query__v1",
         destination_table="query_v1",
@@ -77,17 +88,6 @@ with DAG(
         email=["test@example.org"],
         date_partition_parameter="submission_date",
         depends_on_past=False,
-    )
-
-    wait_for_test__external_table__v1 = ExternalTaskSensor(
-        task_id="wait_for_test__external_table__v1",
-        external_dag_id="bqetl_external_test_dag",
-        external_task_id="test__external_table__v1",
-        check_existence=True,
-        mode="reschedule",
-        allowed_states=ALLOWED_STATES,
-        failed_states=FAILED_STATES,
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
     )
 
     test__query__v1.set_upstream(wait_for_test__external_table__v1)


### PR DESCRIPTION
So that if any of the ETLs use `depends_on` to manually depend on one of those external dependencies the external task variable will be guaranteed to exist before it's referenced in the `set_upstream()` call.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2844)
