### PR TITLE
Remove submission_date from events_stream tables

### DIFF
--- a/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
@@ -17,7 +17,7 @@ scheduling:
 bigquery:
   time_partitioning:
     type: day
-    field: submission_date
+    field: submission_timestamp
     require_partition_filter: true
   clustering:
     fields:

--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -26,7 +26,6 @@ WITH base AS (
         ping_info.ping_type
       ) AS ping_info
     ),
-    DATE(submission_timestamp) AS submission_date,
     client_info.client_id AS client_id,
     ping_info.reason AS reason,
     `mozfun.json.from_map`(ping_info.experiments) AS experiments,


### PR DESCRIPTION
Wil pointed out that the `events_stream` tables have both `submission_date` and `submission_timestamp` fields. Currently, the tables are partitioned on `submission_date` and are requiring a partition date filter. This is causing some issues when using the explores in Looker, but is also potentially quite inconvenient for users that want to filter down to a specific timestamp range and now need to filter on both `submission_date` and `submission_timestamp`. Looker is representing timestamps and dates as dimension groups. In this case with both `submission_date` and `submission_timestamp` being present there is a naming "collision" with `submission_timestamp` taking precedence resulting in the date filter not being applied to `submission_date`.

I think it would be more convenient to remove `submission_date` from the tables and partition on `submission_timestamp` instead. We'd need to redeploy the existing tables with the new partitioning.
I added `submission_date` to the user-facing views for backwards compatibility.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2849)
