### PR TITLE
DENG-2095 Add accounts_backend.users_services_last_seen_v1

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -51,6 +51,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/accounts_backend_external/nonprod_accounts_v1/query.sql
   - sql/moz-fx-data-shared-prod/accounts_backend_external/nonprod_emails_v1/query.sql
   - sql/moz-fx-data-shared-prod/accounts_backend/nonprod_accounts/view.sql
+  - sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_last_seen_v1/query.sql
   - sql/moz-fx-data-shared-prod/accounts_backend_external/accounts_v1/query.sql
   - sql/moz-fx-data-shared-prod/accounts_backend_external/emails_v1/query.sql
   - sql/moz-fx-data-shared-prod/accounts_backend/accounts/view.sql

--- a/sql/moz-fx-data-shared-prod/accounts_backend/users_services_last_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/accounts_backend/users_services_last_seen/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.accounts_backend.users_services_last_seen`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.accounts_backend_derived.users_services_last_seen_v1`

--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_last_seen_v1/metadata.yaml
@@ -1,6 +1,6 @@
-friendly_name: Users Services Daily
+friendly_name: Accounts Backend Users Services Last Seen
 description: |-
-  Activity aggregates per Mozilla Account per service per day
+  Usage aggregations per Mozilla Accounts user per service per day over a 28-day window
 owners:
 - ksiegler@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_last_seen_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_last_seen_v1/query.sql
@@ -1,0 +1,62 @@
+CREATE TEMP FUNCTION contains_qualified_fxa_activity_event(events ANY TYPE) AS (
+  EXISTS(
+    SELECT
+      event_type
+    FROM
+      UNNEST(events) AS event_type
+    WHERE
+      event_type IN ('login_complete', 'reg_complete')
+      OR (event_type LIKE r'access\_token%')
+  )
+);
+
+WITH _current AS (
+  SELECT
+    * EXCEPT (submission_date, registered, seen_in_tier1_country, service_events),
+    -- In this raw table, we capture the history of activity over the past
+    -- 28 days for each usage criterion as a single 64-bit integer. The
+    -- rightmost bit represents whether the user was active in the current day.
+    CAST(TRUE AS INT64) AS days_seen_bits,
+    -- Record days on which the user was in a "Tier 1" country;
+    -- this allows a variant of country-segmented MAU where we can still count
+    -- a user that appeared in one of the target countries in the previous
+    -- 28 days even if the most recent "country" value is not in this set.
+    CAST(seen_in_tier1_country AS INT64) AS days_seen_in_tier1_country_bits,
+    CAST(registered AS INT64) AS days_registered_bits,
+  FROM
+    accounts_backend_derived.users_services_daily_v1
+  WHERE
+    submission_date = @submission_date
+    AND contains_qualified_fxa_activity_event(service_events)
+),
+_previous AS (
+  SELECT
+    * EXCEPT (submission_date)
+  FROM
+    accounts_backend_derived.users_services_last_seen_v1
+  WHERE
+    submission_date = DATE_SUB(@submission_date, INTERVAL 1 DAY)
+    -- Filter out rows from yesterday that have now fallen outside the 28-day window.
+    AND udf.shift_28_bits_one_day(days_seen_bits) > 0
+)
+SELECT
+  @submission_date AS submission_date,
+  IF(_current.user_id IS NOT NULL, _current, _previous).* REPLACE (
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_seen_bits,
+      _current.days_seen_bits
+    ) AS days_seen_bits,
+    udf.combine_adjacent_days_28_bits(
+      _previous.days_seen_in_tier1_country_bits,
+      _current.days_seen_in_tier1_country_bits
+    ) AS days_seen_in_tier1_country_bits,
+    udf.coalesce_adjacent_days_28_bits(
+      _previous.days_registered_bits,
+      _current.days_registered_bits
+    ) AS days_registered_bits
+  )
+FROM
+  _current
+FULL JOIN
+  _previous
+  USING (user_id, service)

--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_last_seen_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_last_seen_v1/query.sql
@@ -41,7 +41,7 @@ _previous AS (
 )
 SELECT
   @submission_date AS submission_date,
-  IF(_current.user_id IS NOT NULL, _current, _previous).* REPLACE (
+  IF(_current.user_id_sha256 IS NOT NULL, _current, _previous).* REPLACE (
     udf.combine_adjacent_days_28_bits(
       _previous.days_seen_bits,
       _current.days_seen_bits
@@ -59,4 +59,4 @@ FROM
   _current
 FULL JOIN
   _previous
-  USING (user_id, service)
+  USING (user_id_sha256, service)

--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_last_seen_v1/schema.yaml
@@ -3,16 +3,13 @@ fields:
   name: submission_date
   type: DATE
 - mode: NULLABLE
-  name: user_id
+  name: user_id_sha256
   type: STRING
 - mode: NULLABLE
   name: service
   type: STRING
 - mode: NULLABLE
   name: country
-  type: STRING
-- mode: NULLABLE
-  name: language
   type: STRING
 - mode: NULLABLE
   name: days_seen_bits

--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_last_seen_v1/schema.yaml
@@ -1,0 +1,31 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+- mode: NULLABLE
+  name: user_id
+  type: STRING
+- mode: NULLABLE
+  name: service
+  type: STRING
+- mode: NULLABLE
+  name: country
+  type: STRING
+- mode: NULLABLE
+  name: language
+  type: STRING
+- mode: NULLABLE
+  name: days_seen_bits
+  type: INTEGER
+  description: |
+    No. of days since the user had activity event.
+- mode: NULLABLE
+  name: days_seen_in_tier1_country_bits
+  type: INTEGER
+  description: |
+    No. of days since seen_in_tier1_country was last True.
+- mode: NULLABLE
+  name: days_registered_bits
+  type: INTEGER
+  description: |
+    No. of days since registration event.


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-2095

Before we merge this, I think we should rename `user_id` to `user_id_hashed` in `accounts_backend_derived.users_services_daily_v1` and here.

@ksiegler1 I noticed that `language` is always null in `accounts_backend_derived.users_services_daily_v1` (and also here).

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2882)
