### PR TITLE
Preempt IndexError when unable to parse view content

### DIFF
--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -208,10 +208,12 @@ class View:
 
     def _valid_view_naming(self):
         """Validate that the created view naming matches the directory structure."""
-        parsed = sqlparse.parse(self.content)[0]
+        if not (parsed := sqlparse.parse(self.content)):
+            raise ValueError(f"Unable to parse view SQL for {self.name}")
+
         tokens = [
             t
-            for t in parsed.tokens
+            for t in parsed[0].tokens
             if not (t.is_whitespace or isinstance(t, sqlparse.sql.Comment))
         ]
         is_view_statement = (


### PR DESCRIPTION
More specific error message when unable to parse the view (`sqlparse.parse` returns an empty tuple), this lets us know which view failed to parse. 

Instead of a generic `IndexError`: e.g. https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/30667/workflows/e2d4f47e-6028-42e5-ac84-5b3c32c58d14/jobs/330932

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2884)
