### PR TITLE
DENG-2095 Update accounts_backend.users_services_daily_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_daily_v1/schema.yaml
@@ -2,16 +2,13 @@ fields:
 - name: submission_date
   type: DATE
   mode: NULLABLE
-- name: user_id
+- name: user_id_sha256
   type: STRING
   mode: NULLABLE
 - name: service
   type: STRING
   mode: NULLABLE
 - name: country
-  type: STRING
-  mode: NULLABLE
-- name: language
   type: STRING
   mode: NULLABLE
 - name: seen_in_tier1_country


### PR DESCRIPTION
This:
* renames `user_id` to `user_id_sha256` to make it clear about the content of the field in downstream tables
* removes `language` column that is always null

This will require the table to be recreated.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
