### PR TITLE
improve is_unique data check message

### DIFF
--- a/tests/checks/is_unique.jinja
+++ b/tests/checks/is_unique.jinja
@@ -18,7 +18,7 @@
   )
   SELECT IF(
    (SELECT COUNT(*) FROM non_unique) > 0,
-   ERROR("Duplicates detected (Expected combined set of values for columns {{ columns }} to be unique.)"),
+   ERROR("Duplicates detected (Expected combined set of values for columns {{ columns }} to be unique{% if where %} where {{ where }}{% endif %}.)"),
    NULL
   );
 {% endmacro %}


### PR DESCRIPTION
A lot of those is_unique tests only have submission_date in the where but I'm currently work on something where I want the combination of columns to be unique for `is_current= True`. There will be multiple entries for `is_current = False` so the current error message does not reflect the truth and it's only expected to be unique for the where clause.

So adding it to the error message.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2898)
