### PR TITLE
Fixes #5126 - Add additional fields to org_mozilla_broken_site_report.user_reports view

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
@@ -41,6 +41,10 @@ SELECT
   metrics.text2.broken_site_report_description AS comments,
   metrics.url2.broken_site_report_url AS url,
   metrics.string.broken_site_report_breakage_category AS breakage_category,
+  "Firefox" AS app_name,
+  client_info.app_display_version as app_version,
+  normalized_channel as app_channel,
+  normalized_os as os,
   TO_JSON_STRING(
     STRUCT(
       STRUCT(

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
@@ -42,9 +42,9 @@ SELECT
   metrics.url2.broken_site_report_url AS url,
   metrics.string.broken_site_report_breakage_category AS breakage_category,
   "Firefox" AS app_name,
-  client_info.app_display_version as app_version,
-  normalized_channel as app_channel,
-  normalized_os as os,
+  client_info.app_display_version AS app_version,
+  normalized_channel AS app_channel,
+  normalized_os AS os,
   TO_JSON_STRING(
     STRUCT(
       STRUCT(


### PR DESCRIPTION
I'd like to add these fields to the existing view:

Product name or app name (Fenix, Focus, etc.)
Firefox version
Firefox channel
Operating system

Example fields when running the query:

<img width="396" alt="Screen Shot 2024-02-27 at 8 56 07 PM" src="https://github.com/mozilla/bigquery-etl/assets/1303908/d70419b9-f721-4d1d-9e27-177c9fcbd746">

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2900)
