### PR TITLE
DENG-2896 Telemetry Dev Cycle fix experimenter API

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_external/experiments_stats_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_dev_cycle_external/experiments_stats_v1/query.py
@@ -60,7 +60,7 @@ def store_data_in_bigquery(data, schema, destination_project, destination_table_
 def download_experiments_v1(url):
     """Download experiment data from API v1 and parse it."""
     experiments_v1 = []
-    experiments = get_api_response(f"{url}/api/v1/experiments")
+    experiments = get_api_response(f"{url}/api/v1/experiments/")
     for experiment in experiments:
         if experiment["status"] == "Draft":
             continue
@@ -81,7 +81,7 @@ def download_experiments_v1(url):
 def download_experiments_v6(url):
     """Download experiment data from API v6 and parse it."""
     experiments_v6 = []
-    experiments = get_api_response(f"{url}/api/v6/experiments")
+    experiments = get_api_response(f"{url}/api/v6/experiments/")
     for experiment in experiments:
         experiments_v6.append(
             {


### PR DESCRIPTION
adding a `/` at the end of the URL to appease the API

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2909)
