### PR TITLE
DENG-2919 Change logic for measuring product downloads

### DIFF
--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_metrics_summary_v2/query.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_metrics_summary_v2/query.sql
@@ -1,4 +1,77 @@
-WITH site_data AS (
+WITH firefox_desktop_downloads AS (
+  --use this logic on or before 2024-02-16
+  SELECT
+    PARSE_DATE('%Y%m%d', event_date) AS date,
+    device.category AS device_category,
+    device.operating_system AS operating_system,
+    device.web_info.browser AS browser,
+    device.language AS language,
+    geo.country AS country,
+    collected_traffic_source.manual_source AS source,
+    collected_traffic_source.manual_medium AS medium,
+    collected_traffic_source.manual_campaign_name AS campaign,
+    collected_traffic_source.manual_content AS ad_content,
+    COUNTIF(
+      NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(device.web_info.browser)
+    ) AS non_fx_downloads,
+    COUNT(1) AS downloads
+  FROM
+    `moz-fx-data-marketing-prod.analytics_313696158.events_*`
+  JOIN
+    UNNEST(event_params) e
+  WHERE
+    _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d', @submission_date)
+    AND _TABLE_SUFFIX <= '20240216'
+    AND event_name = 'product_download'
+    AND e.key = 'product'
+    AND e.value.string_value = 'firefox'
+  GROUP BY
+    event_date,
+    device.category,
+    device.operating_system,
+    device.web_info.browser,
+    device.language,
+    geo.country,
+    collected_traffic_source.manual_source,
+    collected_traffic_source.manual_medium,
+    collected_traffic_source.manual_campaign_name,
+    collected_traffic_source.manual_content
+  UNION ALL
+    --use this logic on & after 2024-02-17
+  SELECT
+    PARSE_DATE('%Y%m%d', event_date) AS date,
+    device.category AS device_category,
+    device.operating_system AS operating_system,
+    device.web_info.browser AS browser,
+    device.language AS language,
+    geo.country AS country,
+    collected_traffic_source.manual_source AS source,
+    collected_traffic_source.manual_medium AS medium,
+    collected_traffic_source.manual_campaign_name AS campaign,
+    collected_traffic_source.manual_content AS ad_content,
+    COUNTIF(
+      NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(device.web_info.browser)
+    ) AS non_fx_downloads,
+    COUNT(1) AS downloads
+  FROM
+    `moz-fx-data-marketing-prod.analytics_313696158.events_*`
+  WHERE
+    _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d', @submission_date)
+    AND event_name = 'firefox_download'
+    AND _TABLE_SUFFIX >= '20240217'
+  GROUP BY
+    event_date,
+    device.category,
+    device.operating_system,
+    device.web_info.browser,
+    device.language,
+    geo.country,
+    collected_traffic_source.manual_source,
+    collected_traffic_source.manual_medium,
+    collected_traffic_source.manual_campaign_name,
+    collected_traffic_source.manual_content
+),
+sessions_data AS (
   SELECT
     PARSE_DATE('%Y%m%d', event_date) AS date,
     device.category AS device_category,
@@ -14,34 +87,7 @@ WITH site_data AS (
     COUNTIF(
       event_name = 'session_start'
       AND NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(device.web_info.browser)
-    ) AS non_fx_sessions,
-    COUNTIF(
-      (event_date <= '20240216' AND event_name = 'product_download')
-      OR (
-        event_date > '20240216'
-        AND event_name IN (
-          'firefox_download',
-          'focus_download',
-          'klar_download',
-          'firefox_mobile_download'
-        )
-      )
-    ) AS downloads,
-    COUNTIF(
-      (
-        (event_date <= '20240216' AND event_name = 'product_download')
-        OR (
-          event_date > '20240216'
-          AND event_name IN (
-            'firefox_download',
-            'focus_download',
-            'klar_download',
-            'firefox_mobile_download'
-          )
-        )
-      )
-      AND NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(device.web_info.browser)
-    ) AS non_fx_downloads
+    ) AS non_fx_sessions
   FROM
     `moz-fx-data-marketing-prod.analytics_313696158.events_*`
   WHERE
@@ -57,6 +103,37 @@ WITH site_data AS (
     collected_traffic_source.manual_medium,
     collected_traffic_source.manual_campaign_name,
     collected_traffic_source.manual_content
+),
+sessions_and_downloads_combined AS (
+  SELECT
+    COALESCE(sess.date, dl.date) AS date,
+    COALESCE(sess.device_category, dl.device_category) AS device_category,
+    COALESCE(sess.operating_system, dl.operating_system) AS operating_system,
+    COALESCE(sess.browser, dl.browser) AS browser,
+    COALESCE(sess.language, dl.language) AS language,
+    COALESCE(sess.country, dl.country) AS country,
+    COALESCE(sess.source, dl.source) AS source,
+    COALESCE(sess.medium, dl.medium) AS medium,
+    COALESCE(sess.campaign, dl.campaign) AS campaign,
+    COALESCE(sess.ad_content, dl.ad_content) AS ad_content,
+    COALESCE(sess.sessions, 0) AS sessions,
+    COALESCE(sess.non_fx_sessions, 0) AS non_fx_sessions,
+    COALESCE(dl.downloads, 0) AS downloads,
+    COALESCE(dl.non_fx_downloads, 0) AS non_fx_downloads
+  FROM
+    sessions_data sess
+  FULL OUTER JOIN
+    firefox_desktop_downloads dl
+    ON sess.date = dl.date
+    AND COALESCE(sess.device_category, '') = COALESCE(dl.device_category, '')
+    AND COALESCE(sess.operating_system, '') = COALESCE(dl.operating_system, '')
+    AND COALESCE(sess.browser, '') = COALESCE(dl.browser, '')
+    AND COALESCE(sess.language, '') = COALESCE(dl.language, '')
+    AND COALESCE(sess.country, '') = COALESCE(dl.country, '')
+    AND COALESCE(sess.source, 'NA') = COALESCE(dl.source, 'NA')
+    AND COALESCE(sess.medium, 'NA') = COALESCE(dl.medium, 'NA')
+    AND COALESCE(sess.campaign, 'NA') = COALESCE(dl.campaign, 'NA')
+    AND COALESCE(sess.ad_content, 'NA') = COALESCE(dl.ad_content, 'NA')
 )
 SELECT
   s.date,
@@ -75,7 +152,7 @@ SELECT
   s.downloads,
   s.non_fx_downloads
 FROM
-  site_data AS s
+  sessions_and_downloads_combined AS s
 LEFT JOIN
   `moz-fx-data-shared-prod.static.third_party_standardized_country_names` AS std_cntry_nms
   ON s.country = std_cntry_nms.raw_country

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_metrics_summary_v2/query.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_metrics_summary_v2/query.sql
@@ -1,11 +1,11 @@
 WITH firefox_desktop_downloads AS (
   --use this logic on or before 2024-02-16
   SELECT
-    PARSE_DATE('%Y%m%d', event_date) AS date,
+    PARSE_DATE('%Y%m%d', event_date) AS `date`,
     device.category AS device_category,
     device.operating_system AS operating_system,
     device.web_info.browser AS browser,
-    device.language AS language,
+    device.language AS `language`,
     geo.country AS country,
     collected_traffic_source.manual_source AS source,
     collected_traffic_source.manual_medium AS medium,
@@ -39,11 +39,11 @@ WITH firefox_desktop_downloads AS (
   UNION ALL
     --use this logic on & after 2024-02-17
   SELECT
-    PARSE_DATE('%Y%m%d', event_date) AS date,
+    PARSE_DATE('%Y%m%d', event_date) AS `date`,
     device.category AS device_category,
     device.operating_system AS operating_system,
     device.web_info.browser AS browser,
-    device.language AS language,
+    device.language AS `language`,
     geo.country AS country,
     collected_traffic_source.manual_source AS source,
     collected_traffic_source.manual_medium AS medium,
@@ -73,11 +73,11 @@ WITH firefox_desktop_downloads AS (
 ),
 sessions_data AS (
   SELECT
-    PARSE_DATE('%Y%m%d', event_date) AS date,
+    PARSE_DATE('%Y%m%d', event_date) AS `date`,
     device.category AS device_category,
     device.operating_system AS operating_system,
     device.web_info.browser AS browser,
-    device.language AS language,
+    device.language AS `language`,
     geo.country AS country,
     collected_traffic_source.manual_source AS source,
     collected_traffic_source.manual_medium AS medium,


### PR DESCRIPTION
Had to refactor code to update logic to track only Firefox Desktop downloads and not all downloads (Before, the code was including Klar, Mobile, etc downloads under the product download umbrella, but to match the logic used in the old table more closely, we only want to track Desktop downloads).

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2922)
