### PR TITLE
Change Fivetran Airflow operators to run synchronously so the task concurrency limit is respected

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -159,6 +159,8 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
     {{ fivetran_task.task_id }}_sync_start = FivetranOperator(
         connector_id='{% raw %}{{{% endraw %} var.value.{{ fivetran_task.task_id }}_connector_id {% raw %}}}{% endraw %}',
         task_id='{{ fivetran_task.task_id }}_task',
+        {# Have the operator run synchronously so the task concurrency limit is respected. -#}
+        deferrable=False,
         task_concurrency=1,
     )
 

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -51,12 +51,14 @@ with DAG(
     fivetran_import_1_sync_start = FivetranOperator(
         connector_id="{{ var.value.fivetran_import_1_connector_id }}",
         task_id="fivetran_import_1_task",
+        deferrable=False,
         task_concurrency=1,
     )
 
     fivetran_import_2_sync_start = FivetranOperator(
         connector_id="{{ var.value.fivetran_import_2_connector_id }}",
         task_id="fivetran_import_2_task",
+        deferrable=False,
         task_concurrency=1,
     )
 


### PR DESCRIPTION
#5083 tried to limit Fivetran task concurrency so it would only run one sync per connector at a time, but that didn't actually work because task concurrency limits apparently don't apply when tasks get deferred (maybe an Airflow bug?).  This will address that.

While having the operator be deferred while waiting for the Fivetran sync to complete would be ideal from an Airflow resource usage perspective, I believe having the sync behavior work as intended is more important, and having the Fivetran operator take up a worker slot while it's waiting shouldn't be a dealbreaker since that was the behavior until very recently when we switched to Astronomer's Fivetran Airflow provider package with its deferrable operator implementation (https://github.com/mozilla/telemetry-airflow/pull/1922, https://github.com/mozilla/bigquery-etl/pull/5080).

Related PR: https://github.com/mozilla/telemetry-airflow/pull/1932

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2925)
