### PR TITLE
DENG-2924 - update product download logic

### DIFF
--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v2/query.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v2/query.sql
@@ -104,10 +104,10 @@ SELECT
   browser,
   download_events,
   download_events AS downloads,
-  CASE
-    WHEN NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(browser)
-      THEN download_events
-    ELSE 0
-  END AS non_fx_downloads
+  IF(
+    NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(browser),
+    download_events,
+    0
+  ) AS non_fx_downloads
 FROM
   staging

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v2/query.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v2/query.sql
@@ -1,50 +1,114 @@
-SELECT
-  PARSE_DATE('%Y%m%d', event_date) AS date,
-  a.user_pseudo_id || '-' || CAST(e.value.int_value AS string) AS visit_identifier,
-  device.category AS device_category,
-  device.operating_system AS operating_system,
-  device.language AS `language`,
-  geo.country AS country,
-  collected_traffic_source.manual_source AS source,
-  collected_traffic_source.manual_medium AS medium,
-  collected_traffic_source.manual_campaign_name AS campaign,
-  collected_traffic_source.manual_content AS ad_content,
-  device.web_info.browser AS browser,
+WITH staging AS (
+  SELECT
+    `date`,
+    visit_identifier,
+    device_category,
+    operating_system,
+    `language`,
+    country,
+    source,
+    medium,
+    campaign,
+    ad_content,
+    browser,
   --note: the 2 columns are the same because in GA4, there is no logic saying you can only count 1 download per session, unlike GA3
-  COUNT(1) AS download_events,
-  COUNT(1) AS downloads,
-  COUNTIF(
-    NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(device.web_info.browser)
-  ) AS non_fx_downloads,
-FROM
-  `moz-fx-data-marketing-prod.analytics_313696158.events_*` AS a
-JOIN
-  UNNEST(event_params) AS e
-WHERE
-  _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d', @submission_date)
-  AND e.key = 'ga_session_id'
-  AND e.value.int_value IS NOT NULL
-  AND (
-    (a.event_name = 'product_download' AND a.event_date <= '20240216')
-    OR (
-      a.event_name IN (
-        'firefox_download',
-        'focus_download',
-        'klar_download',
-        'firefox_mobile_download'
+    COUNTIF(
+    --prior to and including 2/16/24
+      (
+        `date` <= '2024-02-16'
+        AND event_name = 'product_download'
+        AND platform_type IN (
+          'win',
+          'win64',
+          'macos',
+          'linux64',
+          'win64-msi',
+          'linux',
+          'win-msi',
+          'win64-aarch64'
+        )
+        AND product_type = 'firefox'
       )
-      AND a.event_date > '20240216'
+      OR
+    --on and after 2/17/24
+      (`date` >= '2024-02-17' AND event_name = 'firefox_download')
+    ) AS download_events
+  FROM
+    (
+      (
+        SELECT
+          PARSE_DATE('%Y%m%d', event_date) AS `date`,
+          user_pseudo_id || '-' || CAST(e.value.int_value AS string) AS visit_identifier,
+          device.category AS device_category,
+          device.operating_system AS operating_system,
+          device.language AS `language`,
+          geo.country AS country,
+          collected_traffic_source.manual_source AS source,
+          collected_traffic_source.manual_medium AS medium,
+          collected_traffic_source.manual_campaign_name AS campaign,
+          collected_traffic_source.manual_content AS ad_content,
+          device.web_info.browser AS browser,
+          event_name,
+          (
+            SELECT
+              `value`
+            FROM
+              UNNEST(event_params)
+            WHERE
+              key = 'product'
+            LIMIT
+              1
+          ).string_value AS product_type,
+          (
+            SELECT
+              `value`
+            FROM
+              UNNEST(event_params)
+            WHERE
+              key = 'platform'
+            LIMIT
+              1
+          ).string_value AS platform_type
+        FROM
+          `moz-fx-data-marketing-prod.analytics_313696158.events_*`
+        JOIN
+          UNNEST(event_params) AS e
+        WHERE
+          _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d', @submission_date)
+          AND e.key = 'ga_session_id'
+          AND e.value.int_value IS NOT NULL
+      ) staging
+      GROUP BY
+        `date`,
+        visit_identifier,
+        device_category,
+        operating_system,
+        `language`,
+        country,
+        source,
+        medium,
+        campaign,
+        ad_content,
+        browser
     )
-  )
-GROUP BY
-  date,
-  visit_identifier,
-  device_category,
-  operating_system,
-  `language`,
-  country,
-  source,
-  medium,
-  campaign,
-  ad_content,
-  browser
+  SELECT
+    `date`,
+    visit_identifier,
+    device_category,
+    operating_system,
+    `language`,
+    country,
+    source,
+    medium,
+    campaign,
+    ad_content,
+    browser,
+    download_events,
+    download_events AS downloads,
+    CASE
+      WHEN NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(browser)
+        THEN download_events
+      ELSE 0
+    END AS non_fx_downloads
+  FROM
+    staging

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v2/query.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v2/query.sql
@@ -76,7 +76,7 @@ WITH staging AS (
         _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d', @submission_date)
         AND e.key = 'ga_session_id'
         AND e.value.int_value IS NOT NULL
-    ) staging
+    ) stg
   GROUP BY
     `date`,
     visit_identifier,

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v2/query.sql
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v2/query.sql
@@ -35,63 +35,49 @@ WITH staging AS (
     ) AS download_events
   FROM
     (
-      (
-        SELECT
-          PARSE_DATE('%Y%m%d', event_date) AS `date`,
-          user_pseudo_id || '-' || CAST(e.value.int_value AS string) AS visit_identifier,
-          device.category AS device_category,
-          device.operating_system AS operating_system,
-          device.language AS `language`,
-          geo.country AS country,
-          collected_traffic_source.manual_source AS source,
-          collected_traffic_source.manual_medium AS medium,
-          collected_traffic_source.manual_campaign_name AS campaign,
-          collected_traffic_source.manual_content AS ad_content,
-          device.web_info.browser AS browser,
-          event_name,
-          (
-            SELECT
-              `value`
-            FROM
-              UNNEST(event_params)
-            WHERE
-              key = 'product'
-            LIMIT
-              1
-          ).string_value AS product_type,
-          (
-            SELECT
-              `value`
-            FROM
-              UNNEST(event_params)
-            WHERE
-              key = 'platform'
-            LIMIT
-              1
-          ).string_value AS platform_type
-        FROM
-          `moz-fx-data-marketing-prod.analytics_313696158.events_*`
-        JOIN
-          UNNEST(event_params) AS e
-        WHERE
-          _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d', @submission_date)
-          AND e.key = 'ga_session_id'
-          AND e.value.int_value IS NOT NULL
-      ) staging
-      GROUP BY
-        `date`,
-        visit_identifier,
-        device_category,
-        operating_system,
-        `language`,
-        country,
-        source,
-        medium,
-        campaign,
-        ad_content,
-        browser
-    )
-  SELECT
+      SELECT
+        PARSE_DATE('%Y%m%d', event_date) AS `date`,
+        user_pseudo_id || '-' || CAST(e.value.int_value AS string) AS visit_identifier,
+        device.category AS device_category,
+        device.operating_system AS operating_system,
+        device.language AS `language`,
+        geo.country AS country,
+        collected_traffic_source.manual_source AS source,
+        collected_traffic_source.manual_medium AS medium,
+        collected_traffic_source.manual_campaign_name AS campaign,
+        collected_traffic_source.manual_content AS ad_content,
+        device.web_info.browser AS browser,
+        event_name,
+        (
+          SELECT
+            `value`
+          FROM
+            UNNEST(event_params)
+          WHERE
+            key = 'product'
+          LIMIT
+            1
+        ).string_value AS product_type,
+        (
+          SELECT
+            `value`
+          FROM
+            UNNEST(event_params)
+          WHERE
+            key = 'platform'
+          LIMIT
+            1
+        ).string_value AS platform_type
+      FROM
+        `moz-fx-data-marketing-prod.analytics_313696158.events_*`
+      JOIN
+        UNNEST(event_params) AS e
+      WHERE
+        _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d', @submission_date)
+        AND e.key = 'ga_session_id'
+        AND e.value.int_value IS NOT NULL
+    ) staging
+  GROUP BY
     `date`,
     visit_identifier,
     device_category,
@@ -102,13 +88,26 @@ WITH staging AS (
     medium,
     campaign,
     ad_content,
-    browser,
-    download_events,
-    download_events AS downloads,
-    CASE
-      WHEN NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(browser)
-        THEN download_events
-      ELSE 0
-    END AS non_fx_downloads
-  FROM
-    staging
+    browser
+)
+SELECT
+  `date`,
+  visit_identifier,
+  device_category,
+  operating_system,
+  `language`,
+  country,
+  source,
+  medium,
+  campaign,
+  ad_content,
+  browser,
+  download_events,
+  download_events AS downloads,
+  CASE
+    WHEN NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(browser)
+      THEN download_events
+    ELSE 0
+  END AS non_fx_downloads
+FROM
+  staging

--- a/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v2/schema.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/www_site_downloads_v2/schema.yaml
@@ -46,7 +46,7 @@ fields:
 - mode: NULLABLE
   name: download_events
   type: INT64
-  description: Download Events
+  description: Download Events - Number of Firefox Desktop Downloads
 - mode: NULLABLE
   name: downloads
   type: INT64
@@ -54,4 +54,4 @@ fields:
 - mode: NULLABLE
   name: non_fx_downloads
   type: INT64
-  description: Non Firefox Downloads
+  description: Non Firefox Downloads - Number of Firefox Desktop Downloads from a Non-Firefox Browser


### PR DESCRIPTION
Updating logic for measuring product downloads; used to be all product downloads, now updated to Firefox Desktop downloads only (with differing logic used before and after 2/16/24 due to instrumentation changes)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2937)
