### PR TITLE
Bug 1873431 - restrict access to tiktok reporter datasets

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -194,6 +194,9 @@ dry_run:
   - sql/moz-fx-data-shared-prod/mozilla_org_derived/gclid_conversions_v1/query.sql
   - sql/moz-fx-data-shared-prod/mozilla_org_derived/gclid_conversions_v2/query.sql
   - sql/moz-fx-data-shared-prod/mozilla_org/gclid_conversions/view.sql
+  - sql/moz-fx-data-shared-prod/org_mozilla_tiktokreporter/**/*.sql
+  - sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter_tiktok_reportershare/**/*.sql
+  - sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter/**/*.sql
   # Materialized views
   - sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_events_live_v1/init.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/experiment_events_live_v1/init.sql

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: org-mozilla-ios-tiktok-reporter
+# yamllint disable rule:line-length
+description: |-
+  User-facing views related to document namespace org-mozilla-ios-tiktok-reporter; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/org-mozilla-ios-tiktok-reporter
+dataset_base_acl: view_restricted
+user_facing: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:regrets-reporter

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter_derived/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: org-mozilla-ios-tiktok-reporter Derived
+# yamllint disable rule:line-length
+description: |-
+  Derived tables related to document namespace org-mozilla-ios-tiktok-reporter, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
+dataset_base_acl: derived_restricted
+user_facing: false
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:regrets-reporter

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter_tiktok_reportershare/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter_tiktok_reportershare/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: org-mozilla-ios-tiktok-reporter-tiktok-reportershare
+# yamllint disable rule:line-length
+description: |-
+  User-facing views related to document namespace org-mozilla-ios-tiktok-reporter-tiktok-reportershare; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/org-mozilla-ios-tiktok-reporter-tiktok-reportershare
+dataset_base_acl: view_restricted
+user_facing: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:regrets-reporter

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter_tiktok_reportershare_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter_tiktok_reportershare_derived/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: org-mozilla-ios-tiktok-reporter-tiktok-reportershare Derived
+# yamllint disable rule:line-length
+description: |-
+  Derived tables related to document namespace org-mozilla-ios-tiktok-reporter-tiktok-reportershare, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
+dataset_base_acl: derived_restricted
+user_facing: false
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:regrets-reporter

--- a/sql/moz-fx-data-shared-prod/org_mozilla_tiktokreporter/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_tiktokreporter/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: org-mozilla-tiktokreporter
+# yamllint disable rule:line-length
+description: |-
+  User-facing views related to document namespace org-mozilla-tiktokreporter; see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/org-mozilla-tiktokreporter
+dataset_base_acl: view_restricted
+user_facing: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:regrets-reporter

--- a/sql/moz-fx-data-shared-prod/org_mozilla_tiktokreporter_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_tiktokreporter_derived/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: org-mozilla-tiktokreporter Derived
+# yamllint disable rule:line-length
+description: |-
+  Derived tables related to document namespace org-mozilla-tiktokreporter, usually populated via queries defined in https://github.com/mozilla/bigquery-etl and managed by Airflow
+dataset_base_acl: derived_restricted
+user_facing: false
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:regrets-reporter


### PR DESCRIPTION
Discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1873431
Companion PR: https://github.com/mozilla-services/cloudops-infra/pull/5440, likely landing on the 4th
The files were copied from the generated branch and then updated to match workgroup expectations.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2947)
