### PR TITLE
DENG-2950 - Rename drafting -> initiate, modify json output of scheduled command

### DIFF
--- a/bigquery_etl/backfill/parse.py
+++ b/bigquery_etl/backfill/parse.py
@@ -49,7 +49,7 @@ yaml.add_representer(Literal, literal_presenter)
 class BackfillStatus(enum.Enum):
     """Represents backfill status types."""
 
-    DRAFTING = "Drafting"
+    INITIATE = "Initiate"
     VALIDATED = "Validated"
     COMPLETE = "Complete"
 

--- a/bigquery_etl/backfill/utils.py
+++ b/bigquery_etl/backfill/utils.py
@@ -181,7 +181,7 @@ def qualified_table_name_matching(qualified_table_name) -> Tuple[str, str, str]:
     return project_id, dataset_id, table_id
 
 
-def get_backfill_entries_to_process_dict(
+def get_backfill_entries_to_process(
     sql_dir, project, qualified_table_name=None
 ) -> Dict[str, Backfill]:
     """Return backfill entries that require processing."""

--- a/bigquery_etl/backfill/utils.py
+++ b/bigquery_etl/backfill/utils.py
@@ -181,10 +181,10 @@ def qualified_table_name_matching(qualified_table_name) -> Tuple[str, str, str]:
     return project_id, dataset_id, table_id
 
 
-def get_backfill_entries_to_process(
+def get_backfill_entries_to_initiate(
     sql_dir, project, qualified_table_name=None
 ) -> Dict[str, Backfill]:
-    """Return backfill entries that require processing."""
+    """Return backfill entries to initiate."""
     try:
         bigquery.Client(project="")
     except DefaultCredentialsError:
@@ -198,12 +198,12 @@ def get_backfill_entries_to_process(
     if qualified_table_name:
         backfills_dict = {
             qualified_table_name: get_entries_from_qualified_table_name(
-                sql_dir, qualified_table_name, BackfillStatus.DRAFTING.value
+                sql_dir, qualified_table_name, BackfillStatus.INITIATE.value
             )
         }
     else:
         backfills_dict = get_qualified_table_name_to_entries_map_by_project(
-            sql_dir, project, BackfillStatus.DRAFTING.value
+            sql_dir, project, BackfillStatus.INITIATE.value
         )
 
     backfills_to_process_dict = {}
@@ -221,7 +221,7 @@ def get_backfill_entries_to_process(
             sys.exit(1)
         elif (len(entries)) > 1:
             click.echo(
-                f"There should not be more than one entry in backfill.yaml file with status: {BackfillStatus.DRAFTING} "
+                f"There should not be more than one entry in backfill.yaml file with status: {BackfillStatus.INITIATE} "
             )
             sys.exit(1)
 

--- a/bigquery_etl/backfill/validate.py
+++ b/bigquery_etl/backfill/validate.py
@@ -68,10 +68,10 @@ def validate_entries(backfills: list) -> None:
         validate_reason(backfill_entry_1)
         validate_excluded_dates(backfill_entry_1)
 
-        # validate against other entries with drafting status
-        if backfill_entry_1.status == BackfillStatus.DRAFTING:
+        # validate against other entries with initiate status
+        if backfill_entry_1.status == BackfillStatus.INITIATE:
             for backfill_entry_2 in backfills[i + 1 :]:
-                if backfill_entry_2.status == BackfillStatus.DRAFTING:
+                if backfill_entry_2.status == BackfillStatus.INITIATE:
                     validate_duplicate_entry_dates(backfill_entry_1, backfill_entry_2)
                     validate_overlap_dates(backfill_entry_1, backfill_entry_2)
 

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/backfill.yaml
@@ -4,4 +4,4 @@
   reason: This is mostly a test backfill, this table will replace newtab_interactions_v1 eventually
   watchers:
   - anicholson@mozilla.com
-  status: Drafting
+  status: Initiate

--- a/tests/backfill/backfill.yaml
+++ b/tests/backfill/backfill.yaml
@@ -6,4 +6,4 @@
   reason: Please provide a reason for the backfill and links to any related bugzilla or jira tickets
   watchers:
   - nobody@mozilla.com
-  status: Drafting
+  status: Initiate

--- a/tests/backfill/test_dir_multiple/backfill.yaml
+++ b/tests/backfill/test_dir_multiple/backfill.yaml
@@ -6,7 +6,7 @@
   reason: Please provide a reason for the backfill and links to any related bugzilla or jira tickets
   watchers:
   - nobody@mozilla.com
-  status: Drafting
+  status: Initiate
 
 2021-05-03:
   start_date: 2021-01-03
@@ -16,4 +16,4 @@
   reason: Please provide a reason for the backfill and links to any related bugzilla or jira tickets
   watchers:
   - nobody@mozilla.com
-  status: Drafting
+  status: Initiate

--- a/tests/backfill/test_dir_valid/backfill.yaml
+++ b/tests/backfill/test_dir_valid/backfill.yaml
@@ -6,4 +6,4 @@
   reason: no_reason
   watchers:
   - test@example.org
-  status: Drafting
+  status: Initiate

--- a/tests/backfill/test_parse_backfill.py
+++ b/tests/backfill/test_parse_backfill.py
@@ -11,7 +11,7 @@ from bigquery_etl.backfill.parse import (
     BackfillStatus,
 )
 
-DEFAULT_STATUS = BackfillStatus.DRAFTING
+DEFAULT_STATUS = BackfillStatus.INITIATE
 
 TEST_DIR = Path(__file__).parent.parent
 
@@ -333,7 +333,7 @@ class TestParseBackfill(object):
             "    or jira tickets\n"
             "  watchers:\n"
             "  - nobody@mozilla.com\n"
-            "  status: Drafting\n"
+            "  status: Initiate\n"
         )
 
         results = TEST_BACKFILL_1.to_yaml()
@@ -349,7 +349,7 @@ class TestParseBackfill(object):
             excluded_dates = [2021-02-03]
             reason = Please provide a reason for the backfill and links to any related bugzilla or jira tickets
             watcher(s) = [nobody@mozilla.com]
-            status = Drafting
+            status = Initiate
             """
 
         assert actual_backfill_str == expected_backfill_str
@@ -364,7 +364,7 @@ class TestParseBackfill(object):
             "    or jira tickets\n"
             "  watchers:\n"
             "  - nobody@mozilla.com\n"
-            "  status: Drafting\n"
+            "  status: Initiate\n"
         )
 
         TEST_BACKFILL_1.excluded_dates = []

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -27,7 +27,7 @@ from bigquery_etl.backfill.utils import (
 )
 from bigquery_etl.cli.backfill import create, info, scheduled, validate
 
-DEFAULT_STATUS = BackfillStatus.DRAFTING
+DEFAULT_STATUS = BackfillStatus.INITIATE
 VALID_REASON = "test_reason"
 VALID_WATCHER = "test@example.org"
 VALID_BACKFILL = Backfill(
@@ -48,7 +48,7 @@ BACKFILL_YAML_TEMPLATE = (
     "  reason: test_reason\n"
     "  watchers:\n"
     "  - test@example.org\n"
-    "  status: Drafting\n"
+    "  status: Initiate\n"
 )
 
 VALID_WORKGROUP_ACCESS = [
@@ -830,7 +830,7 @@ class TestBackfill:
                     + "  reason: test_reason\n"
                     "  watchers:\n"
                     "  - test@example.org\n"
-                    "  status: Drafting\n"
+                    "  status: Initiate\n"
                 )
             )
 
@@ -877,7 +877,7 @@ class TestBackfill:
                 + "  reason: test_reason\n"
                 "  watchers:\n"
                 "  - test@example.org\n"
-                "  status: Drafting\n"
+                "  status: Initiate\n"
             )
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
@@ -921,7 +921,7 @@ class TestBackfill:
                 "  reason: test_reason\n"
                 "  watchers:\n"
                 "  - test@example.org\n"
-                "  status: Drafting\n"
+                "  status: Initiate\n"
             )
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
@@ -965,7 +965,7 @@ class TestBackfill:
                 "  reason: test_reason\n"
                 "  watchers:\n"
                 "  - test@example.org\n"
-                "  status: Drafting\n"
+                "  status: Initiate\n"
             )
 
             assert BACKFILL_FILE in os.listdir(SQL_DIR)
@@ -1098,7 +1098,7 @@ class TestBackfill:
 
             assert result.exit_code == 0
             assert qualified_table_name_1 in result.output
-            assert BackfillStatus.DRAFTING.value in result.output
+            assert BackfillStatus.INITIATE.value in result.output
             assert BackfillStatus.VALIDATED.value in result.output
             assert "total of 2 backfill(s)" in result.output
             assert qualified_table_name_2 not in result.output
@@ -1126,12 +1126,12 @@ class TestBackfill:
 
             result = runner.invoke(
                 info,
-                [qualified_table_name, "--status=drafting"],
+                [qualified_table_name, "--status=initiate"],
             )
 
             assert result.exit_code == 0
             assert qualified_table_name in result.output
-            assert BackfillStatus.DRAFTING.value in result.output
+            assert BackfillStatus.INITIATE.value in result.output
             assert "total of 1 backfill(s)" in result.output
             assert BackfillStatus.VALIDATED.value not in result.output
             assert BackfillStatus.COMPLETE.value not in result.output
@@ -1213,7 +1213,7 @@ class TestBackfill:
             assert result.exit_code == 0
             assert qualified_table_name_1 in result.output
             assert qualified_table_name_2 in result.output
-            assert BackfillStatus.DRAFTING.value in result.output
+            assert BackfillStatus.INITIATE.value in result.output
             assert BackfillStatus.VALIDATED.value in result.output
             assert "total of 3 backfill(s)" in result.output
             assert BackfillStatus.COMPLETE.value not in result.output
@@ -1268,7 +1268,7 @@ class TestBackfill:
             assert qualified_table_name_2 in result.output
             assert BackfillStatus.VALIDATED.value in result.output
             assert "total of 2 backfill(s)" in result.output
-            assert BackfillStatus.DRAFTING.value not in result.output
+            assert BackfillStatus.INITIATE.value not in result.output
             assert BackfillStatus.COMPLETE.value not in result.output
 
     def test_backfill_info_with_invalid_path(self, runner):

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -1824,8 +1824,5 @@ class TestBackfill:
             )
 
             assert result.exit_code == 0
-            assert (
-                "There are a total of 1 backfill(s) that require processing."
-                in result.output
-            )
+            assert "1 backfill(s) require processing." in result.output
             assert Path("tmp.json").exists()


### PR DESCRIPTION
1. Renames Drafting -> Initiate to match Complete
2. Modifies the output of `bqetl backfill scheduled` so the contact and backfill details can be used directly for `SlackOperator`s.
3. Minor renames/refactor to shorten code.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2957)
