### PR TITLE
DENG-2950 - Update backfill commands to allow retrieving backfills scheduled for completion 

### DIFF
--- a/bigquery_etl/backfill/parse.py
+++ b/bigquery_etl/backfill/parse.py
@@ -50,7 +50,6 @@ class BackfillStatus(enum.Enum):
     """Represents backfill status types."""
 
     INITIATE = "Initiate"
-    VALIDATED = "Validated"
     COMPLETE = "Complete"
 
 
@@ -157,7 +156,7 @@ class Backfill:
                 backfills = yaml.load(yaml_stream, Loader=UniqueKeyLoader) or {}
 
                 for entry_date, entry in backfills.items():
-                    if status is not None and entry["status"].lower() != status.lower():
+                    if status is not None and entry["status"] != status:
                         continue
 
                     excluded_dates = []

--- a/bigquery_etl/backfill/utils.py
+++ b/bigquery_etl/backfill/utils.py
@@ -2,12 +2,11 @@
 
 import re
 import sys
-from glob import glob
+from datetime import date
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import click
-from google.auth.exceptions import DefaultCredentialsError
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 
@@ -37,14 +36,11 @@ def get_entries_from_qualified_table_name(
     """Return backfill entries from qualified table name."""
     backfills = []
 
-    project_id, dataset_id, table_id = qualified_table_name_matching(
-        qualified_table_name
-    )
-
-    table_path = Path(sql_dir) / project_id / dataset_id / table_id
+    project, dataset, table = qualified_table_name_matching(qualified_table_name)
+    table_path = Path(sql_dir) / project / dataset / table
 
     if not table_path.exists():
-        click.echo(f"{project_id}.{dataset_id}.{table_id}" + " does not exist")
+        click.echo(f"{project}.{dataset}.{table}" + " does not exist")
         sys.exit(1)
 
     backfill_file = get_backfill_file_from_qualified_table_name(
@@ -58,16 +54,12 @@ def get_entries_from_qualified_table_name(
 
 
 def get_qualified_table_name_to_entries_map_by_project(
-    sql_dir, project_id, status=None
+    sql_dir, project_id: str, status: Optional[str] = None
 ) -> Dict[str, List[Backfill]]:
     """Return backfill entries from project."""
     backfills_dict: dict = {}
 
-    search_path = Path(sql_dir) / project_id
-    backfill_files = map(
-        Path, glob(f"{search_path}/**/{BACKFILL_FILE}", recursive=True)
-    )
-
+    backfill_files = Path(sql_dir).glob(f"{project_id}/*/*/{BACKFILL_FILE}")
     for backfill_file in backfill_files:
         project, dataset, table = extract_from_query_path(backfill_file)
         qualified_table_name = f"{project}.{dataset}.{table}"
@@ -95,11 +87,18 @@ def get_backfill_file_from_qualified_table_name(sql_dir, qualified_table_name) -
 # TODO: It would be better to take in a backfill object.
 def get_backfill_staging_qualified_table_name(qualified_table_name, entry_date) -> str:
     """Return full table name where processed backfills are stored."""
-    project, dataset, table = qualified_table_name_matching(qualified_table_name)
-
+    _, _, table = qualified_table_name_matching(qualified_table_name)
     backfill_table_id = f"{table}_{entry_date}".replace("-", "_")
 
     return f"{BACKFILL_DESTINATION_PROJECT}.{BACKFILL_DESTINATION_DATASET}.{backfill_table_id}"
+
+
+def get_backfill_backup_table_name(qualified_table_name: str, entry_date: date) -> str:
+    """Return full table name where backup of production table is stored."""
+    _, _, table = qualified_table_name_matching(qualified_table_name)
+    cloned_table_id = f"{table}_backup_{entry_date}".replace("-", "_")
+
+    return f"{BACKFILL_DESTINATION_PROJECT}.{BACKFILL_DESTINATION_DATASET}.{cloned_table_id}"
 
 
 def validate_metadata_workgroups(sql_dir, qualified_table_name) -> bool:
@@ -181,29 +180,24 @@ def qualified_table_name_matching(qualified_table_name) -> Tuple[str, str, str]:
     return project_id, dataset_id, table_id
 
 
-def get_backfill_entries_to_initiate(
-    sql_dir, project, qualified_table_name=None
+def get_scheduled_backfills(
+    sql_dir,
+    project: str,
+    qualified_table_name: Optional[str] = None,
+    status: Optional[str] = None,
 ) -> Dict[str, Backfill]:
     """Return backfill entries to initiate."""
-    try:
-        bigquery.Client(project="")
-    except DefaultCredentialsError:
-        click.echo(
-            "Authentication to GCP required. Run `gcloud auth login  --update-adc` "
-            "and check that the project is set correctly."
-        )
-        sys.exit(1)
     client = bigquery.Client(project=project)
 
     if qualified_table_name:
         backfills_dict = {
             qualified_table_name: get_entries_from_qualified_table_name(
-                sql_dir, qualified_table_name, BackfillStatus.INITIATE.value
+                sql_dir, qualified_table_name, status
             )
         }
     else:
         backfills_dict = get_qualified_table_name_to_entries_map_by_project(
-            sql_dir, project, BackfillStatus.INITIATE.value
+            sql_dir, project, status
         )
 
     backfills_to_process_dict = {}
@@ -211,37 +205,77 @@ def get_backfill_entries_to_initiate(
     for qualified_table_name, entries in backfills_dict.items():
         # do not return backfill if not mozilla-confidential
         if not validate_metadata_workgroups(sql_dir, qualified_table_name):
-            click.echo(
-                f"Only mozilla-confidential workgroups are supported.  {qualified_table_name} contain workgroup access that is not supported"
-            )
-            sys.exit(1)
+            continue
 
         if not entries:
-            click.echo(f"No backfill to process for table: {qualified_table_name} ")
-            sys.exit(1)
-        elif (len(entries)) > 1:
-            click.echo(
-                f"There should not be more than one entry in backfill.yaml file with status: {BackfillStatus.INITIATE} "
+            continue
+
+        if BackfillStatus.INITIATE.value == status and (len(entries)) > 1:
+            raise ValueError(
+                f"More than one backfill entry for {qualified_table_name} found with status: {status}."
             )
-            sys.exit(1)
 
         entry_to_process = entries[0]
 
-        backfill_staging_qualified_table_name = (
-            get_backfill_staging_qualified_table_name(
-                qualified_table_name, entry_to_process.entry_date
-            )
-        )
-
-        try:
-            client.get_table(backfill_staging_qualified_table_name)
-            click.echo(
-                f"""
-                Backfill staging table already exists for {qualified_table_name}: {backfill_staging_qualified_table_name}.
-                Backfills will not be processed for this table.
-                """
-            )
-        except NotFound:
+        if (
+            BackfillStatus.INITIATE.value == status
+            and _should_initiate(client, entry_to_process, qualified_table_name)
+        ) or (
+            BackfillStatus.COMPLETE.value == status
+            and _should_complete(client, entry_to_process, qualified_table_name)
+        ):
             backfills_to_process_dict[qualified_table_name] = entry_to_process
 
     return backfills_to_process_dict
+
+
+def _should_initiate(
+    client: bigquery.Client, backfill: Backfill, qualified_table_name: str
+) -> bool:
+    """Determine whether a backfill should be initiated.
+
+    Return true if the backfill is in Initiate status and the staging data does not yet exist.
+    """
+    if backfill.status != BackfillStatus.INITIATE:
+        return False
+
+    staging_table = get_backfill_staging_qualified_table_name(
+        qualified_table_name, backfill.entry_date
+    )
+    if _table_exists(client, staging_table):
+        return False
+
+    return True
+
+
+def _should_complete(
+    client: bigquery.Client, backfill: Backfill, qualified_table_name: str
+) -> bool:
+    """Determine whether a backfill should be completed.
+
+    Return true if the backfill is in Complete status, the staging data exists, and the backup does not yet exist.
+    """
+    if backfill.status != BackfillStatus.COMPLETE:
+        return False
+
+    staging_table = get_backfill_staging_qualified_table_name(
+        qualified_table_name, backfill.entry_date
+    )
+    if not _table_exists(client, staging_table):
+        return False
+
+    backup_table_name = get_backfill_backup_table_name(
+        qualified_table_name, backfill.entry_date
+    )
+    if _table_exists(client, backup_table_name):
+        return False
+
+    return True
+
+
+def _table_exists(client: bigquery.Client, qualified_table_name: str) -> bool:
+    try:
+        client.get_table(qualified_table_name)
+        return True
+    except NotFound:
+        return False

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -19,13 +19,12 @@ from ..backfill.parse import (
     BackfillStatus,
 )
 from ..backfill.utils import (
-    BACKFILL_DESTINATION_DATASET,
-    BACKFILL_DESTINATION_PROJECT,
-    get_backfill_entries_to_initiate,
+    get_backfill_backup_table_name,
     get_backfill_file_from_qualified_table_name,
     get_backfill_staging_qualified_table_name,
     get_entries_from_qualified_table_name,
     get_qualified_table_name_to_entries_map_by_project,
+    get_scheduled_backfills,
     qualified_table_name_matching,
     validate_metadata_workgroups,
 )
@@ -238,7 +237,7 @@ def validate(
 )
 @click.option(
     "--status",
-    type=click.Choice([s.value.lower() for s in BackfillStatus]),
+    type=click.Choice([s.value for s in BackfillStatus]),
     help="Filter backfills with this status.",
 )
 @click.pass_context
@@ -302,15 +301,9 @@ def info(ctx, qualified_table_name, sql_dir, project_id, status):
 @click.pass_context
 def scheduled(ctx, qualified_table_name, sql_dir, project_id, status, json_path=None):
     """Return list of backfill(s) that require processing."""
-    match status:
-        case BackfillStatus.INITIATE.value:
-            backfills = get_backfill_entries_to_initiate(
-                sql_dir, project_id, qualified_table_name
-            )
-        case BackfillStatus.COMPLETE.value:
-            raise NotImplementedError("Placeholder - TODO")
-        case _:
-            raise ValueError(f"Invalid status status {status}.")
+    backfills = get_scheduled_backfills(
+        sql_dir, project_id, qualified_table_name, status=status
+    )
 
     for qualified_table_name, entry in backfills.items():
         click.echo(f"Backfill scheduled for {qualified_table_name}:\n{entry}")
@@ -354,7 +347,7 @@ def process(ctx, qualified_table_name, sql_dir, project_id):
     """Process backfill entry with drafting status in backfill.yaml file(s)."""
     click.echo("Backfill processing initiated....")
 
-    backfills_to_process_dict = get_backfill_entries_to_initiate(
+    backfills_to_process_dict = get_scheduled_backfills(
         sql_dir, project_id, qualified_table_name
     )
 
@@ -405,7 +398,7 @@ def _process_backfill(ctx, qualified_table_name, entry_to_process, dry_run=None)
 
 
 @backfill.command(
-    help="""Complete entry in backfill.yaml with Validated status.
+    help="""Complete entry in backfill.yaml with Complete status.
 
     Examples:
 
@@ -433,7 +426,7 @@ def complete(ctx, qualified_table_name, sql_dir, project_id):
     client = bigquery.Client(project=project_id)
 
     entries = get_entries_from_qualified_table_name(
-        sql_dir, qualified_table_name, BackfillStatus.VALIDATED.value
+        sql_dir, qualified_table_name, BackfillStatus.COMPLETE.value
     )
 
     if not entries:
@@ -466,11 +459,10 @@ def complete(ctx, qualified_table_name, sql_dir, project_id):
         )
         sys.exit(1)
 
-    project, dataset, table = qualified_table_name_matching(qualified_table_name)
-
     # clone production table
-    cloned_table_id = f"{table}_backup_{entry_to_complete.entry_date}".replace("-", "_")
-    cloned_table_full_name = f"{BACKFILL_DESTINATION_PROJECT}.{BACKFILL_DESTINATION_DATASET}.{cloned_table_id}"
+    cloned_table_full_name = get_backfill_backup_table_name(
+        qualified_table_name, entry_to_complete.entry_date
+    )
     _copy_table(qualified_table_name, cloned_table_full_name, client, clone=True)
 
     # copy backfill data to production data


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2967)
