### PR TITLE
Require authentication for dry run function and run gcloud auth when …

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -159,6 +159,7 @@ jobs:
       - when:
           condition: *validate-sql-or-routines
           steps:
+            - *skip_forked_pr
             - checkout
             - *restore_venv_cache
             - *build
@@ -176,12 +177,7 @@ jobs:
             - run:
                 name: Run SQL tests
                 command: |
-                  if [ -n "$CIRCLE_PR_NUMBER" ]; then
-                    echo "Cannot pass creds to forked PRs," \
-                      "so skipping routine and SQL tests"
-                  else
                     PATH="venv/bin:$PATH" script/entrypoint -m sql -n 8
-                  fi
       - unless:
           condition: *validate-sql-or-routines
           steps:
@@ -392,6 +388,7 @@ jobs:
               - << pipeline.parameters.validate-routines >>
               - << pipeline.parameters.deploy >>
           steps:
+            - *skip_forked_pr
             - checkout
             - *restore_venv_cache
             - *build
@@ -400,12 +397,7 @@ jobs:
             - run:
                 name: Run routine tests
                 command: |
-                  if [ -n "$CIRCLE_PR_NUMBER" ]; then
-                    echo "Cannot pass creds to forked PRs," \
-                      "so skipping routine tests"
-                  else
-                    PATH="venv/bin:$PATH" script/entrypoint -m routine -n 8
-                  fi
+                  PATH="venv/bin:$PATH" script/entrypoint -m routine -n 8
             - run:
                 name: Validate doc examples
                 command: |
@@ -722,6 +714,7 @@ jobs:
             - checkout
             - *restore_venv_cache
             - *build
+            - *authenticate
             - add_ssh_keys:
                 # deploy key to private-bigquery-etl
                 fingerprints:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -120,6 +120,15 @@ jobs:
               - << pipeline.parameters.deploy >>
           steps:
             - checkout
+            - &skip_forked_pr
+              run:
+                name: Early return if this build is from a forked PR
+                command: |
+                  if [ -n "$CIRCLE_PR_NUMBER" ]; then
+                    echo "Cannot pass creds to forked PRs," \
+                      "so marking this step successful"
+                    circleci-agent step halt
+                  fi
             - *restore_venv_cache
             - *build
             - run:
@@ -129,6 +138,9 @@ jobs:
                 # since those tests take the longest to run and running those tests
                 # in parallel speeds up CI
                 command: |
+                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
+                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+
                   PATH="venv/bin:$PATH" script/entrypoint --black --flake8 \
                     --isort --mypy-ignore-missing-imports --pydocstyle \
                     -m "not (routine or sql or integration)" \
@@ -177,6 +189,7 @@ jobs:
           condition: *validate-sql-or-routines
           steps:
             - checkout
+            - *skip_forked_pr
             - *restore_venv_cache
             - *build
             - *attach_generated_sql
@@ -203,6 +216,9 @@ jobs:
                   else
                     PATHS="sql/bigquery-etl-integration-test"
                   fi
+                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
+                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+
                   echo $PATHS
                   PATH="venv/bin:$PATH" script/bqetl dryrun --validate-schemas $PATHS
                 # yamllint enable rule:line-length
@@ -239,6 +255,7 @@ jobs:
           condition: *validate-sql
           steps:
             - checkout
+            - *skip_forked_pr
             - *restore_venv_cache
             - *build
             - *attach_generated_sql
@@ -246,6 +263,9 @@ jobs:
             - run:
                 name: Verify that metadata files are valid
                 command: |
+                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
+                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+
                   # TODO: Add check here to make sure all queries have metadata.yaml
                   PATH="venv/bin:$PATH" script/bqetl query validate \
                     --respect-dryrun-skip
@@ -260,15 +280,7 @@ jobs:
           condition: *validate-bqetl
           steps:
             - checkout
-            - &skip_forked_pr
-              run:
-                name: Early return if this build is from a forked PR
-                command: |
-                  if [ -n "$CIRCLE_PR_NUMBER" ]; then
-                    echo "Cannot pass creds to forked PRs," \
-                      "so marking this step successful"
-                    circleci-agent step halt
-                  fi
+            - *skip_forked_pr
             - *restore_venv_cache
             - *build
             - run:
@@ -289,6 +301,7 @@ jobs:
           condition: *validate-sql
           steps:
             - checkout
+            - *skip_forked_pr
             - *restore_venv_cache
             - *build
             - *attach_generated_sql
@@ -301,6 +314,9 @@ jobs:
             - run:
                 name: Generate DAGs
                 command: |
+                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
+                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+
                   mkdir -p /tmp/workspace/generated-sql/dags
                   PATH="venv/bin:$PATH" script/bqetl dag generate --output-dir=/tmp/workspace/generated-sql/dags
             # this task is overwriting the content produced by generate-sql;
@@ -407,13 +423,17 @@ jobs:
           condition: *validate-sql-or-routines
           steps:
             - checkout
+            - *skip_forked_pr
             - *restore_venv_cache
             - *build
             - *attach_generated_sql
             - *copy_staged_sql
             - run:
                 name: Validate views
-                command: PATH="venv/bin:$PATH" script/bqetl view validate
+                command: |
+                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
+                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+                  PATH="venv/bin:$PATH" script/bqetl view validate
       - unless:
           condition: *validate-sql-or-routines
           steps:
@@ -453,11 +473,15 @@ jobs:
           condition: *validate-sql-or-routines
           steps:
             - checkout
+            - *skip_forked_pr
             - *restore_venv_cache
             - *build
             - run:
                 name: Generate SQL content
                 command: |
+                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
+                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+
                   # Check if the generated-sql branch can simply be re-used and SQL generation can be skipped.
                   git clone -b generated-sql git@github.com:mozilla/bigquery-etl ~/remote-generated-sql
                   cd ~/remote-generated-sql
@@ -824,6 +848,7 @@ jobs:
           condition: *validate-sql-or-routines
           steps:
             - checkout
+            - *skip_forked_pr
             - run:
                 name: Switch to main branch
                 command: |
@@ -838,6 +863,8 @@ jobs:
                 name: Generate SQL content
                 command: |
                   export PATH="venv/bin:$PATH"
+                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
+                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
 
                   # Check if the generated-sql branch can simply be re-used and SQL generation can be skipped.
                   # There is a delay between pushing changes to main and pushing a new generated-sql branch,

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -119,7 +119,6 @@ jobs:
               - << pipeline.parameters.validate-bqetl >>
               - << pipeline.parameters.deploy >>
           steps:
-            - checkout
             - &skip_forked_pr
               run:
                 name: Early return if this build is from a forked PR
@@ -129,8 +128,16 @@ jobs:
                       "so marking this step successful"
                     circleci-agent step halt
                   fi
+            - checkout
             - *restore_venv_cache
             - *build
+            - &authenticate
+              run:
+                name: Authenticate to GCP
+                command: |
+                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
+                  echo 'export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"' >> "$BASH_ENV"
+                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
             - run:
                 name: PyTest with linters
                 # integration tests are run in a separate `integration` step;
@@ -138,9 +145,6 @@ jobs:
                 # since those tests take the longest to run and running those tests
                 # in parallel speeds up CI
                 command: |
-                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
-                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-
                   PATH="venv/bin:$PATH" script/entrypoint --black --flake8 \
                     --isort --mypy-ignore-missing-imports --pydocstyle \
                     -m "not (routine or sql or integration)" \
@@ -188,12 +192,13 @@ jobs:
       - when:
           condition: *validate-sql-or-routines
           steps:
-            - checkout
             - *skip_forked_pr
+            - checkout
             - *restore_venv_cache
             - *build
             - *attach_generated_sql
             - *copy_staged_sql
+            - *authenticate
             - run:
                 name: Dry run queries
                 # yamllint disable rule:line-length
@@ -216,9 +221,6 @@ jobs:
                   else
                     PATHS="sql/bigquery-etl-integration-test"
                   fi
-                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
-                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-
                   echo $PATHS
                   PATH="venv/bin:$PATH" script/bqetl dryrun --validate-schemas $PATHS
                 # yamllint enable rule:line-length
@@ -254,18 +256,16 @@ jobs:
       - when:
           condition: *validate-sql
           steps:
-            - checkout
             - *skip_forked_pr
+            - checkout
             - *restore_venv_cache
             - *build
             - *attach_generated_sql
             - *copy_staged_sql
+            - *authenticate
             - run:
                 name: Verify that metadata files are valid
                 command: |
-                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
-                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-
                   # TODO: Add check here to make sure all queries have metadata.yaml
                   PATH="venv/bin:$PATH" script/bqetl query validate \
                     --respect-dryrun-skip
@@ -279,8 +279,8 @@ jobs:
       - when:
           condition: *validate-bqetl
           steps:
-            - checkout
             - *skip_forked_pr
+            - checkout
             - *restore_venv_cache
             - *build
             - run:
@@ -300,8 +300,8 @@ jobs:
       - when:
           condition: *validate-sql
           steps:
-            - checkout
             - *skip_forked_pr
+            - checkout
             - *restore_venv_cache
             - *build
             - *attach_generated_sql
@@ -311,12 +311,10 @@ jobs:
                 command: |
                   rm -rf sql/
                   cp -r /tmp/workspace/generated-sql/sql sql
+            - *authenticate
             - run:
                 name: Generate DAGs
                 command: |
-                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
-                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-
                   mkdir -p /tmp/workspace/generated-sql/dags
                   PATH="venv/bin:$PATH" script/bqetl dag generate --output-dir=/tmp/workspace/generated-sql/dags
             # this task is overwriting the content produced by generate-sql;
@@ -422,17 +420,16 @@ jobs:
       - when:
           condition: *validate-sql-or-routines
           steps:
-            - checkout
             - *skip_forked_pr
+            - checkout
             - *restore_venv_cache
             - *build
             - *attach_generated_sql
             - *copy_staged_sql
+            - *authenticate
             - run:
                 name: Validate views
                 command: |
-                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
-                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
                   PATH="venv/bin:$PATH" script/bqetl view validate
       - unless:
           condition: *validate-sql-or-routines
@@ -444,8 +441,8 @@ jobs:
       - when:
           condition: *validate-sql-or-routines
           steps:
-            - checkout
             - *skip_forked_pr
+            - checkout
             - *restore_venv_cache
             - *build
             - *attach_generated_sql
@@ -472,16 +469,14 @@ jobs:
       - when:
           condition: *validate-sql-or-routines
           steps:
-            - checkout
             - *skip_forked_pr
+            - checkout
             - *restore_venv_cache
             - *build
+            - *authenticate
             - run:
                 name: Generate SQL content
                 command: |
-                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
-                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-
                   # Check if the generated-sql branch can simply be re-used and SQL generation can be skipped.
                   git clone -b generated-sql git@github.com:mozilla/bigquery-etl ~/remote-generated-sql
                   cd ~/remote-generated-sql
@@ -570,8 +565,8 @@ jobs:
       - when:
           condition: *validate-sql-or-routines
           steps:
-            - checkout
             - *skip_forked_pr
+            - checkout
             - *restore_venv_cache
             - *build
             - *attach_generated_sql
@@ -586,13 +581,11 @@ jobs:
                   git clone --single-branch --branch generated-sql \
                     git@github.com:mozilla/bigquery-etl \
                     generated-sql
+            - *authenticate
             - run:
                 name: Deploy changes to stage
                 command: |
                   if [ "<< pipeline.parameters.skip-stage-deploys >>" = "false" ]; then
-                    export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
-                    echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-
                     PATHS="$(git diff --no-index --name-only --diff-filter=d generated-sql/sql sql)" || true
                     echo $PATHS
                     PATH="venv/bin:$PATH" script/bqetl stage deploy \
@@ -725,8 +718,8 @@ jobs:
       - when:
           condition: *deploy
           steps:
-            - checkout
             - *skip_forked_pr
+            - checkout
             - *restore_venv_cache
             - *build
             - add_ssh_keys:
@@ -847,8 +840,8 @@ jobs:
       - when:
           condition: *validate-sql-or-routines
           steps:
-            - checkout
             - *skip_forked_pr
+            - checkout
             - run:
                 name: Switch to main branch
                 command: |
@@ -859,12 +852,11 @@ jobs:
                 at: /tmp/workspace
             - *restore_venv_cache
             - *build
+            - *authenticate
             - run:
                 name: Generate SQL content
                 command: |
                   export PATH="venv/bin:$PATH"
-                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
-                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
 
                   # Check if the generated-sql branch can simply be re-used and SQL generation can be skipped.
                   # There is a delay between pushing changes to main and pushing a new generated-sql branch,
@@ -1000,15 +992,13 @@ jobs:
       - when:
           condition: *validate-sql-or-routines
           steps:
-            - checkout
             - *skip_forked_pr
+            - checkout
             - *build
+            - *authenticate
             - run:
                 name: "Delete stage datasets"
                 command: |
-                  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
-                  echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-
                   PATH="venv/bin:$PATH" script/bqetl stage clean --dataset-suffix=$CIRCLE_SHA1 --delete-expired
       - unless:
           condition: *validate-sql-or-routines

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more information, see [https://mozilla.github.io/bigquery-etl/](https://mozi
 
 ### GCP CLI tools
 
-- **For Mozilla Employees or Contributors (not in Data Engineering)** - Set up GCP command line tools, [as described on docs.telemetry.mozilla.org](https://docs.telemetry.mozilla.org/cookbooks/bigquery/access.html#using-the-bq-command-line-tool). Note that some functionality (e.g. writing UDFs or backfilling queries) may not be allowed.
+- **For Mozilla Employees (not in Data Engineering)** - Set up GCP command line tools, [as described on docs.telemetry.mozilla.org](https://docs.telemetry.mozilla.org/cookbooks/bigquery/access.html#using-the-bq-command-line-tool). Note that some functionality (e.g. writing UDFs or backfilling queries) may not be allowed. Run `gcloud auth login --update-adc` to authenticate against GCP.
 - **For Data Engineering** - In addition to setting up the command line tools, you will want to log in to `shared-prod` if making changes to production systems. Run `gcloud auth login --update-adc --project=moz-fx-data-shared-prod` (if you have not run it previously).
 
 ### Installing bqetl

--- a/bigquery_etl/backfill/utils.py
+++ b/bigquery_etl/backfill/utils.py
@@ -189,7 +189,7 @@ def get_backfill_entries_to_initiate(
         bigquery.Client(project="")
     except DefaultCredentialsError:
         click.echo(
-            "Authentication to GCP required. Run `gcloud auth login` "
+            "Authentication to GCP required. Run `gcloud auth login  --update-adc` "
             "and check that the project is set correctly."
         )
         sys.exit(1)

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -424,7 +424,7 @@ def complete(ctx, qualified_table_name, sql_dir, project_id):
     """Complete backfill entry in backfill.yaml file(s)."""
     if not is_authenticated():
         click.echo(
-            "Authentication to GCP required. Run `gcloud auth login` "
+            "Authentication to GCP required. Run `gcloud auth login  --update-adc` "
             "and check that the project is set correctly."
         )
         sys.exit(1)

--- a/bigquery_etl/cli/check.py
+++ b/bigquery_etl/cli/check.py
@@ -199,7 +199,7 @@ def run(ctx, dataset, project_id, sql_dir, marker, dry_run):
     """Run a check."""
     if not is_authenticated():
         click.echo(
-            "Authentication to GCP required. Run `gcloud auth login` "
+            "Authentication to GCP required. Run `gcloud auth login  --update-adc` "
             "and check that the project is set correctly."
         )
         sys.exit(1)

--- a/bigquery_etl/cli/dryrun.py
+++ b/bigquery_etl/cli/dryrun.py
@@ -12,6 +12,7 @@ from typing import List, Set
 import rich_click as click
 from google.cloud import bigquery
 
+from ..cli.utils import is_authenticated
 from ..config import ConfigLoader
 from ..dryrun import DryRun
 
@@ -94,6 +95,10 @@ def dryrun(
     if not sql_files:
         print("Skipping dry run because no queries matched")
         sys.exit(0)
+
+    if not use_cloud_function and not is_authenticated():
+        click.echo("Not authenticated to GCP. Run `gcloud auth login` to login.")
+        sys.exit(1)
 
     sql_file_valid = partial(
         _sql_file_valid, use_cloud_function, project, respect_skip, validate_schemas

--- a/bigquery_etl/cli/dryrun.py
+++ b/bigquery_etl/cli/dryrun.py
@@ -12,7 +12,6 @@ from typing import List, Set
 import rich_click as click
 from google.cloud import bigquery
 
-from ..cli.utils import is_authenticated
 from ..config import ConfigLoader
 from ..dryrun import DryRun
 
@@ -95,10 +94,6 @@ def dryrun(
     if not sql_files:
         print("Skipping dry run because no queries matched")
         sys.exit(0)
-
-    if not use_cloud_function and not is_authenticated():
-        click.echo("Not authenticated to GCP. Run `gcloud auth login` to login.")
-        sys.exit(1)
 
     sql_file_valid = partial(
         _sql_file_valid, use_cloud_function, project, respect_skip, validate_schemas

--- a/bigquery_etl/cli/dryrun.py
+++ b/bigquery_etl/cli/dryrun.py
@@ -97,7 +97,9 @@ def dryrun(
         sys.exit(0)
 
     if not use_cloud_function and not is_authenticated():
-        click.echo("Not authenticated to GCP. Run `gcloud auth login` to login.")
+        click.echo(
+            "Not authenticated to GCP. Run `gcloud auth login  --update-adc` to login."
+        )
         sys.exit(1)
 
     sql_file_valid = partial(

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -731,7 +731,7 @@ def backfill(
     """Run a backfill."""
     if not is_authenticated():
         click.echo(
-            "Authentication to GCP required. Run `gcloud auth login` "
+            "Authentication to GCP required. Run `gcloud auth login  --update-adc` "
             "and check that the project is set correctly."
         )
         sys.exit(1)
@@ -906,7 +906,7 @@ def run(
     """Run a query."""
     if not is_authenticated():
         click.echo(
-            "Authentication to GCP required. Run `gcloud auth login` "
+            "Authentication to GCP required. Run `gcloud auth login  --update-adc` "
             "and check that the project is set correctly."
         )
         sys.exit(1)
@@ -1667,7 +1667,7 @@ def update(
     """CLI command for generating the query schema."""
     if not is_authenticated():
         click.echo(
-            "Authentication to GCP required. Run `gcloud auth login` "
+            "Authentication to GCP required. Run `gcloud auth login  --update-adc` "
             "and check that the project is set correctly."
         )
         sys.exit(1)
@@ -1752,7 +1752,7 @@ def _update_query_schema_with_downstream(
                 if not is_authenticated():
                     click.echo(
                         "Cannot update downstream dependencies."
-                        "Authentication to GCP required. Run `gcloud auth login` "
+                        "Authentication to GCP required. Run `gcloud auth login  --update-adc` "
                         "and check that the project is set correctly."
                     )
                     sys.exit(1)
@@ -2052,7 +2052,7 @@ def deploy(
     """CLI command for deploying destination table schemas."""
     if not is_authenticated():
         click.echo(
-            "Authentication to GCP required. Run `gcloud auth login` "
+            "Authentication to GCP required. Run `gcloud auth login  --update-adc` "
             "and check that the project is set correctly."
         )
         sys.exit(1)

--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -3,6 +3,7 @@
 import fnmatch
 import os
 import re
+import subprocess
 from fnmatch import fnmatchcase
 from glob import glob
 from pathlib import Path
@@ -44,7 +45,11 @@ def is_authenticated():
     try:
         bigquery.Client(project="")
     except DefaultCredentialsError:
-        return False
+        try:
+            subprocess.run(["gcloud", "auth", "application-default", "login"])
+        except Exception as e:
+            print(f"Could not log in to GCP: {e}")
+            return False
     return True
 
 

--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -3,7 +3,6 @@
 import fnmatch
 import os
 import re
-import subprocess
 from fnmatch import fnmatchcase
 from glob import glob
 from pathlib import Path
@@ -45,11 +44,7 @@ def is_authenticated():
     try:
         bigquery.Client(project="")
     except DefaultCredentialsError:
-        try:
-            subprocess.run(["gcloud", "auth", "application-default", "login"])
-        except Exception as e:
-            print(f"Could not log in to GCP: {e}")
-            return False
+        return False
     return True
 
 

--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -77,7 +77,7 @@ class DryRun:
 
         if not is_authenticated():
             print(
-                "Authentication to GCP required. Run `gcloud auth login` "
+                "Authentication to GCP required. Run `gcloud auth login  --update-adc` "
                 "and check that the project is set correctly."
             )
             sys.exit(1)

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -197,6 +197,8 @@ dry_run:
   - sql/moz-fx-data-shared-prod/org_mozilla_tiktokreporter/**/*.sql
   - sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter_tiktok_reportershare/**/*.sql
   - sql/moz-fx-data-shared-prod/org_mozilla_ios_tiktok_reporter/**/*.sql
+  - sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/query.sql
+  - sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v2/query.sql
   # Materialized views
   - sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_events_live_v1/init.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/experiment_events_live_v1/init.sql


### PR DESCRIPTION
…not logged in

I opened https://mozilla-hub.atlassian.net/browse/DSRE-1558 to actually require authentication for the dryrun function and give dryrun permissions against restricted datasets. The PR should be merged before we apply these changes.

Fixes https://github.com/mozilla/bigquery-etl/issues/5168

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2968)
