### PR TITLE
[DENG-2956][DENG-2894] Add Spain and Canada to public user activity report

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_user_activity_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_user_activity_v1/metadata.yaml
@@ -1,6 +1,9 @@
 friendly_name: |-
-  Telemetry Derived - Public Data Report User Activity
+  Firefox Public Data Report User Activity
 description: |-
-  [DESCRIPTION_MISSING]
+  Data used to populate https://data.firefox.com/dashboard/user-activity.
+
+  Code to parse and format this data is in the
+  [firefox-public-data-report-etl repository](https://github.com/mozilla/firefox-public-data-report-etl/tree/main/public_data_report/user_activity).
 owners:
-- data-platform-infra-wg@mozilla.com
+- bewu@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_user_activity_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_user_activity_v1/query.sql
@@ -29,6 +29,7 @@ sample AS (
     COALESCE(cn.name, country_group) IN (
       'Worldwide',
       'Brazil',
+      'Canada',
       'China',
       'France',
       'Germany',
@@ -37,6 +38,7 @@ sample AS (
       'Italy',
       'Poland',
       'Russia',
+      'Spain',
       'United States'
     )
     -- we need the whole week for daily_usage metric
@@ -63,7 +65,7 @@ sample_addons AS (
       IF(
         ARRAY_LENGTH(active_addons) > 0,
         active_addons,
-            -- include a null addon if there were none (either null or an empty list)
+        -- include a null addon if there were none (either null or an empty list)
         [active_addons[SAFE_OFFSET(0)]]
       )
     ) AS addons


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-2894
https://mozilla-hub.atlassian.net/browse/DENG-2956

Adding countries and also taking ownership of the table since it's unclaimed.  Code in https://github.com/mozilla/firefox-public-data-report-etl/ will automatically pick up countries but data should also be backfilled, probably only for these countries so existing data doesn't change.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3063)
