### PR TITLE
Separate CI workflow for pushing packages to pypi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,3 +66,9 @@ workflows:
             .circleci/.* validate-sql true
             .circleci/.* validate-bqetl true
             .circleci/.* validate-routines true
+  setup-tag:
+    when:
+      matches: {pattern: '^[0-9]{4}.[0-9]{1,2}.[0-9]+$', value: << pipeline.git.tag >>}
+    jobs:
+      - continuation/continue:
+          configuration_path: .circleci/workflows.yml

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1054,6 +1054,7 @@ jobs:
       - run:
           name: Create the distribution files
           command: |
+            python -m pip install build
             python -m build --sdist --wheel
       - run:
           name: Upload to PyPI
@@ -1071,16 +1072,6 @@ workflows:
       - build
       - verify-requirements
       - verify-format-yaml
-      - deploy-to-pypi:
-          name: Deploy bqetl to PyPI
-          requires:
-            - build
-          filters:
-            tags:
-              only: /[0-9]{4}.[0-9]{1,2}.[0-9]+/  # Calver: YYYY.M.MINOR
-            branches:
-              # Ignore all branches; this workflow should only run for tags.
-              ignore: /.*/
       - verify-format-sql
       - deploy-changes-to-stage:
           requires:
@@ -1223,3 +1214,12 @@ workflows:
             branches:
               only:
                 - main
+  tagged-deploy:
+    jobs:
+      - deploy-to-pypi:
+          filters:
+            tags:
+              only: /[0-9]{4}.[0-9]{1,2}.[0-9]+/  # Calver: YYYY.M.MINOR
+            branches:
+              # Ignore all branches; this workflow should only run for tags.
+              ignore: /.*/


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3087)
