### PR TITLE
fix(): incorrect type for event_timestamp raw_recipient_raw_v1

### DIFF
--- a/sql/moz-fx-data-marketing-prod/acoustic/raw_recipient_raw_v1/schema.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/raw_recipient_raw_v1/schema.yaml
@@ -35,7 +35,7 @@ fields:
 
 - mode: NULLABLE
   name: event_timestamp
-  type: DATETIME
+  type: STRING
   description: The date and time of the event in the API user’s time zone.
 
 - mode: NULLABLE


### PR DESCRIPTION
# fix(): incorrect type for event_timestamp raw_recipient_raw_v1

Currently this is causing the following error in publish_tables task:
```
[2024-03-19, 08:20:14 UTC] {pod_manager.py:466} INFO - [base] Traceback (most recent call last):
[2024-03-19, 08:20:14 UTC] {pod_manager.py:466} INFO - [base]   File "/app/bigquery_etl/cli/query.py", line 1739, in _update_query_schema_with_downstream
[2024-03-19, 08:20:14 UTC] {pod_manager.py:466} INFO - [base]     changed = _update_query_schema(
[2024-03-19, 08:20:14 UTC] {pod_manager.py:466} INFO - [base]               ^^^^^^^^^^^^^^^^^^^^^
[2024-03-19, 08:20:14 UTC] {pod_manager.py:466} INFO - [base]   File "/app/bigquery_etl/cli/query.py", line 1974, in _update_query_schema
[2024-03-19, 08:20:14 UTC] {pod_manager.py:466} INFO - [base]     existing_schema.merge(table_schema)
[2024-03-19, 08:20:14 UTC] {pod_manager.py:466} INFO - [base]   File "/app/bigquery_etl/schema/__init__.py", line 108, in merge
[2024-03-19, 08:20:14 UTC] {pod_manager.py:466} INFO - [base]     self._traverse(
[2024-03-19, 08:20:14 UTC] {pod_manager.py:466} INFO - [base]   File "/app/bigquery_etl/schema/__init__.py", line 245, in _traverse
[2024-03-19, 08:20:14 UTC] {pod_manager.py:466} INFO - [base]     raise Exception(
[2024-03-19, 08:20:14 UTC] {pod_manager.py:466} INFO - [base] Exception: Cannot merge schemas. type attributes for root.event_timestamp are incompatible
```

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3139)
