### PR TITLE
Remove skipping DAG validation in CI

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -334,22 +334,6 @@ jobs:
           steps:
             - checkout
             - run:
-                name: Early return when job not modified
-                command: |
-                  if [ "$CIRCLE_BRANCH" = main ]; then
-                    echo "Run job because branch is $CIRCLE_BRANCH"
-                  elif git log --format=%B --no-merges -n 1 |
-                      grep -qF '[run-tests]'; then
-                    echo "Run job because [run-tests] in commit message"
-                  elif ! git diff --quiet origin/main... \
-                      -- "$(git rev-parse --show-toplevel)"/{.circleci,dags}; then
-                    echo "Run job because .circleci/ and/or dags/ were modified" \
-                      "since branching off main"
-                  else
-                    echo "Skipping job because .circleci/ and dags/ were not modified"
-                    circleci-agent step halt
-                  fi
-            - run:
                 name: Pull telemetry-airflow
                 command: |
                   git clone https://github.com/mozilla/telemetry-airflow.git ~/telemetry-airflow
@@ -367,6 +351,7 @@ jobs:
                   virtualenv .venv
                   source .venv/bin/activate
                   pip install -r requirements.txt
+                  pip install -r requirements-dev.txt
             - run:
                 name: 🧪 Test valid DAGs
                 command: |

--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -209,7 +209,7 @@ class View:
     def _valid_view_naming(self):
         """Validate that the created view naming matches the directory structure."""
         if not (parsed := sqlparse.parse(self.content)):
-            raise ValueError(f"Unable to parse view SQL for {self.name}")
+            raise ValueError(f"Unable to parse view SQL for {self.path}")
 
         tokens = [
             t

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -22,6 +22,7 @@ dry_run:
   function: https://us-central1-moz-fx-data-shared-prod.cloudfunctions.net/bigquery-etl-dryrun
   skip:
   # Access Denied
+  - sql/moz-fx-data-experiments/monitoring/query_cost_v1/query.sql
   - sql/moz-fx-data-shared-prod/app_store_external/**/*.sql
   - sql/moz-fx-data-shared-prod/app_store/**/*.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.sql
@@ -145,6 +146,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dl_token_ga_attribution_lookup_v1/query.sql
   - sql/moz-fx-data-shared-prod/mozilla_org_derived/gclid_conversions_v2/query.sql
   - sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/query.sql
+  - sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v1/view.sql
   # Materialized views
   - sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_events_live_v1/init.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/experiment_events_live_v1/init.sql


### PR DESCRIPTION
It's still being skipped if the path filtering determines that no SQL etc got changed.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3145)
