### PR TITLE
Bug 1879826 - events stream: Default enable for all apps with an exclusion list

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -2111,7 +2111,7 @@ def deploy(
             _attach_metadata(query_file_path, table)
 
             if not table.created:
-                client.create_table(table)
+                client.create_table(table, exists_ok=True)
                 click.echo(f"Destination table {full_table_id} created.")
             elif not skip_existing:
                 client.update_table(

--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -398,13 +398,15 @@ def _deploy_artifacts(ctx, artifact_files, project_id, dataset_suffix, sql_dir):
     ctx.invoke(publish_routine, name=None, project_id=project_id, dry_run=False)
 
     # deploy table schemas
-    query_files = [
-        file
-        for file in artifact_files
-        if file.name in [QUERY_FILE, QUERY_SCRIPT]
-        # don't attempt to deploy wildcard or metadata tables
-        and "*" not in file.parent.name and file.parent.name != "INFORMATION_SCHEMA"
-    ]
+    query_files = list(
+        {
+            file
+            for file in artifact_files
+            if file.name in [QUERY_FILE, QUERY_SCRIPT]
+            # don't attempt to deploy wildcard or metadata tables
+            and "*" not in file.parent.name and file.parent.name != "INFORMATION_SCHEMA"
+        }
+    )
 
     if len(query_files) > 0:
         # checking and creating datasets needs to happen sequentially

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -372,15 +372,10 @@ generate:
     - org_mozilla_ios_tiktok_reporter_tiktok_reportershare
     - org_mozilla_tiktokreporter
     events_stream:
-      datasets:
-      - fenix
-      app_ids:
-      - bedrock
-      - debug_ping_view
-      - glean_dictionary
-      - org_mozilla_fenix
-      - org_mozilla_firefox_beta
-      - org_mozilla_firefox
+      skip_apps:
+      - org_mozilla_ios_tiktok_reporter
+      - org_mozilla_ios_tiktok_reporter_tiktok_reportershare
+      - org_mozilla_tiktokreporter
     events_monitoring:
       default_event_table: events_v1
       event_table:

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -364,6 +364,8 @@ generate:
     skip_apps:
     - mlhackweek_search
     - moso_mastodon_android
+    - moso_mastodon_web
+    - moso_mastodon_backend
     - regrets_reporter
     - regrets_reporter_ucs
     - tiktokreporter_android

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -375,6 +375,13 @@ generate:
     - org_mozilla_tiktokreporter
     events_stream:
       skip_apps:
+      - bergamot
+      - firefox_echo_show
+      - firefox_fire_tv
+      - firefox_reality
+      - firefox_reality_pc
+      - lockwise_android
+      - lockwise_ios
       - org_mozilla_ios_tiktok_reporter
       - org_mozilla_ios_tiktok_reporter_tiktok_reportershare
       - org_mozilla_tiktokreporter

--- a/sql_generators/glean_usage/event_monitoring_live.py
+++ b/sql_generators/glean_usage/event_monitoring_live.py
@@ -107,7 +107,7 @@ class EventMonitoringLive(GleanTable):
 
         if output_dir:
             if not self.no_init:
-                artifacts.append(Artifact(table, "init.sql", init_sql))
+                artifacts.append(Artifact(table, "materialized_view.sql", init_sql))
 
             for artifact in artifacts:
                 destination = (

--- a/sql_generators/glean_usage/events_stream.py
+++ b/sql_generators/glean_usage/events_stream.py
@@ -39,8 +39,8 @@ class EventsStreamTable(GleanTable):
         app_id = ".".join(app_id.split(".")[1:])
 
         # Skip any not-allowed app.
-        if app_id not in ConfigLoader.get(
-            "generate", "glean_usage", "events_stream", "app_ids", fallback=[]
+        if app_id in ConfigLoader.get(
+            "generate", "glean_usage", "events_stream", "skip_apps", fallback=[]
         ):
             return
 
@@ -59,6 +59,8 @@ class EventsStreamTable(GleanTable):
         """Generate the events_stream table query per app_name."""
         target_dataset = app_info[0]["app_name"]
         if target_dataset in ConfigLoader.get(
-            "generate", "glean_usage", "events_stream", "datasets", fallback=[]
+            "generate", "glean_usage", "events_stream", "skip_datasets", fallback=[]
         ):
-            super().generate_per_app(project_id, app_info, output_dir)
+            return
+
+        super().generate_per_app(project_id, app_info, output_dir)

--- a/sql_generators/glean_usage/templates/cross_channel_events_stream.query.sql
+++ b/sql_generators/glean_usage/templates/cross_channel_events_stream.query.sql
@@ -16,5 +16,5 @@ SELECT
     "{{ channel }}" AS normalized_channel
     {% endif -%}
   ),
-FROM `{{ project_id }}.{{ dataset }}_derived.events_stream` AS e
+FROM `{{ project_id }}.{{ dataset }}.events_stream` AS e
 {% endfor %}

--- a/sql_generators/glean_usage/templates/cross_channel_events_stream.query.sql
+++ b/sql_generators/glean_usage/templates/cross_channel_events_stream.query.sql
@@ -9,12 +9,10 @@ UNION ALL
 SELECT
   "{{ dataset }}" AS normalized_app_id,
   e.*
-  REPLACE(
-    {% if app_name == "fenix" -%}
-    mozfun.norm.fenix_app_info("{{ dataset }}", client_info.app_build).channel AS normalized_channel
-    {% elif datasets|length > 1 -%}
-    "{{ channel }}" AS normalized_channel
-    {% endif -%}
-  ),
+  {% if app_name == "fenix" -%}
+  REPLACE(mozfun.norm.fenix_app_info("{{ dataset }}", client_info.app_build).channel AS normalized_channel),
+  {% elif datasets|length > 1 -%}
+  REPLACE("{{ channel }}" AS normalized_channel),
+  {% endif -%}
 FROM `{{ project_id }}.{{ dataset }}.events_stream` AS e
 {% endfor %}


### PR DESCRIPTION
Inverting the check, excluding tiktok just because it was excluded for the other part too and to showcase it.

What apps do we need to exclude here to begin with?

@scholtzan :
With respect to `datasets` / `skip_datasets`: I assumed we would get a merged view for `fenix` over the app IDs, but I guess that never actually happened. Will this happen with the inversion now? Is there some manual step we need to make it happen?

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3154)
