### PR TITLE
Have Jinja in generated SQL

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -520,10 +520,6 @@ jobs:
                     cp -a sql/. /tmp/workspace/generated-sql/sql
                   fi
 
-                  PATH="venv/bin:$PATH" script/bqetl query render \
-                    --sql-dir /tmp/workspace/generated-sql/sql/ \
-                    --output-dir /tmp/workspace/generated-sql/sql/ \
-                    /tmp/workspace/generated-sql/sql/
                   PATH="venv/bin:$PATH" script/bqetl dependency record \
                     --skip-existing \
                     "/tmp/workspace/generated-sql/sql/"
@@ -744,10 +740,6 @@ jobs:
                   PATH="venv/bin:$PATH" script/bqetl generate all \
                     --output-dir /tmp/workspace/private-generated-sql/sql/ \
                     --target-project moz-fx-data-shared-prod
-                  PATH="venv/bin:$PATH" script/bqetl query render \
-                    --sql-dir /tmp/workspace/private-generated-sql/sql/ \
-                    --output-dir /tmp/workspace/private-generated-sql/sql/ \
-                    /tmp/workspace/private-generated-sql/sql/
                   PATH="venv/bin:$PATH" script/bqetl dependency record \
                     --skip-existing \
                     "/tmp/workspace/private-generated-sql/sql/"
@@ -902,10 +894,6 @@ jobs:
                     cp -a sql/. /tmp/workspace/main-generated-sql/sql
                   fi
 
-                  ./script/bqetl query render \
-                    --sql-dir /tmp/workspace/main-generated-sql/sql/ \
-                    --output-dir /tmp/workspace/main-generated-sql/sql/ \
-                    /tmp/workspace/main-generated-sql/sql/
                   ./script/bqetl dependency record \
                     --skip-existing \
                     "/tmp/workspace/main-generated-sql/sql/"

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1383,6 +1383,7 @@ def initialize(
                         sql_dir=sql_dir,
                         project_id=project,
                         update_downstream=False,
+                        is_init=True,
                     )
 
                     ctx.invoke(
@@ -1612,6 +1613,13 @@ def schema():
 @use_cloud_function_option
 @respect_dryrun_skip_option(default=True)
 @parallelism_option()
+@click.option(
+    "--is-init",
+    "--is_init",
+    help="Indicates whether the `is_init()` condition should be set to true of false.",
+    is_flag=True,
+    default=False,
+)
 def update(
     name,
     sql_dir,
@@ -1621,6 +1629,7 @@ def update(
     use_cloud_function,
     respect_dryrun_skip,
     parallelism,
+    is_init,
 ):
     """CLI command for generating the query schema."""
     if not is_authenticated():
@@ -1671,6 +1680,7 @@ def update(
             use_cloud_function,
             respect_dryrun_skip,
             update_downstream,
+            is_init=is_init,
         )
     )
 
@@ -1692,6 +1702,7 @@ def _update_query_schema_with_downstream(
     update_downstream=False,
     query_file=None,
     follow_up_queue=None,
+    is_init=False,
 ):
     try:
         changed = _update_query_schema(
@@ -1702,6 +1713,7 @@ def _update_query_schema_with_downstream(
             tmp_tables,
             use_cloud_function,
             respect_dryrun_skip,
+            is_init,
         )
 
         if update_downstream:
@@ -1751,6 +1763,7 @@ def _update_query_schema(
     tmp_tables={},
     use_cloud_function=True,
     respect_dryrun_skip=True,
+    is_init=False,
 ):
     """
     Update the schema of a specific query file.
@@ -1827,6 +1840,7 @@ def _update_query_schema(
         template_folder=str(query_file_path.parent),
         templates_dir="",
         format=False,
+        **{"is_init": lambda: is_init},
     )
 
     for orig_table, tmp_table in tmp_tables.items():

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -2019,6 +2019,7 @@ def deploy(
     query_files = paths_matching_name_pattern(
         name, sql_dir, project_id, ["query.*", "script.sql"]
     )
+
     if not query_files:
         # run SQL generators if no matching query has been found
         ctx.invoke(

--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -195,7 +195,7 @@ def deploy(
                         f"{test_dataset}.{test_name}{file_suffix}",
                         f"{test_dataset}.{test_name}.schema{file_suffix}",
                     ):
-                        test_dataset = f"{test_dataset}_{project_id.replace('-', '_')}"
+                        test_dataset = f"{test_dataset}_{project.replace('-', '_')}"
 
                         if dataset_suffix:
                             test_dataset = f"{test_dataset}_{dataset_suffix}"


### PR DESCRIPTION
In order to support the `is_init()` jinja statements when running the the artifact deployments, the queries should not be rendered before getting pushed to the `generated-sql` branch.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3170)
