### PR TITLE
Fixes #5250 - Change broken_site_report view to only use historical table

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
@@ -1,47 +1,13 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.org_mozilla_broken_site_report.user_reports`
 AS
-WITH historical_reports AS (
-  -- get old reports; already deduplicated
-  SELECT
-    *
-  FROM
-    `moz-fx-data-shared-prod.firefox_desktop_stable.broken_site_report_v1`
-  WHERE
-    DATE(submission_timestamp) > "2023-11-01"
-),
-live_reports AS (
-  SELECT
-    *,
-    ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) AS rn
-  FROM
-    `moz-fx-data-shared-prod.firefox_desktop_live.broken_site_report_v1`
-  WHERE
-    -- only get reports from the live tables that haven't gotten materialized in the stable tables
-    DATE(submission_timestamp) > (SELECT DATE(MAX(submission_timestamp)) FROM historical_reports)
-    AND DATE(submission_timestamp) > "2023-11-01"
-),
-all_reports AS (
-  -- merge historical and new reports; deduplicate reports from the live tables
-  SELECT
-    * EXCEPT (rn)
-  FROM
-    live_reports
-  WHERE
-    rn = 1
-  UNION ALL
-  SELECT
-    *
-  FROM
-    historical_reports
-)
 SELECT
   document_id AS uuid,
   CAST(submission_timestamp AS DATETIME) AS reported_at,
   metrics.text2.broken_site_report_description AS comments,
   metrics.url2.broken_site_report_url AS url,
   metrics.string.broken_site_report_breakage_category AS breakage_category,
-  "Firefox" AS app_name,
+  normalized_app_name AS app_name,
   client_info.app_display_version AS app_version,
   normalized_channel AS app_channel,
   normalized_os AS os,
@@ -99,6 +65,8 @@ SELECT
     )
   ) AS details
 FROM
-  all_reports
+    `moz-fx-data-shared-prod.firefox_desktop.broken_site_report`
+WHERE
+    DATE(submission_timestamp) > "2023-11-01"
 ORDER BY
   submission_timestamp ASC


### PR DESCRIPTION
We've decided to switch to only historical tables to simplify the query as there is no immediate need to get "live" reports.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3172)
