### PR TITLE
Revert "Add days_active_bits to baseline_clients_last_seen"

### DIFF
--- a/sql_generators/glean_usage/baseline_clients_last_seen.py
+++ b/sql_generators/glean_usage/baseline_clients_last_seen.py
@@ -4,7 +4,7 @@ from sql_generators.glean_usage.common import GleanTable
 
 TARGET_TABLE_ID = "baseline_clients_last_seen_v1"
 PREFIX = "last_seen"
-USAGE_TYPES = ("seen", "active", "created_profile", "seen_session_start", "seen_session_end")
+USAGE_TYPES = ("seen", "created_profile", "seen_session_start", "seen_session_end")
 
 
 class BaselineClientsLastSeenTable(GleanTable):

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
@@ -26,7 +26,6 @@
   "sample_id",
   "first_seen_date",
   "days_seen_bits",
-  "days_active_bits",
   "days_created_profile_bits",
   "days_seen_session_start_bits",
   "days_seen_session_end_bits"

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.query.sql
@@ -14,7 +14,6 @@ OPTIONS
 AS
 SELECT
   CAST(NULL AS INT64) AS days_seen_bits,
-  CAST(NULL AS INT64) AS days_active_bits,
   CAST(NULL AS INT64) AS days_created_profile_bits,
   -- We make sure to delay * until the end so that as new columns are added
   -- to the daily table we can add those columns in the same order to the end
@@ -33,11 +32,8 @@ WITH _current AS (
   SELECT
     -- In this raw table, we capture the history of activity over the past
     -- 28 days for each usage criterion as a single 64-bit integer. The
-    -- rightmost bit in 'days_since_seen' represents whether the user sent a
-    -- baseline ping in the submission_date and similarly, the rightmost bit in
-    -- days_active_bits represents whether the user counts as active on that date.
+    -- rightmost bit represents whether the user was active in the current day.
     CAST(TRUE AS INT64) AS days_seen_bits,
-    CAST(TRUE AS INT64) & CAST(durations > 0  AS INT64) AS days_active_bits,
     udf.days_since_created_profile_as_28_bits(
       DATE_DIFF(submission_date, first_run_date, DAY)
     ) AS days_created_profile_bits,


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#5225, which should be merged only after updating the schemas in production.
These schemas are currently updated via init files.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3174)
