### PR TITLE
fix: DENG-3161 add date_partition_parameter: null to suppression list

### DIFF
--- a/sql/moz-fx-data-marketing-prod/acoustic/suppression_list_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/acoustic/suppression_list_v1/metadata.yaml
@@ -8,3 +8,6 @@ owners:
   - leli@mozilla.com
 scheduling:
   dag_name: bqetl_acoustic_suppression_list
+  date_partition_parameter: null
+bigquery: null
+references: {}


### PR DESCRIPTION
The DAG failed with 
```
Cannot read partition information from a table that is not partitioned: moz-fx-data-marketing-prod:acoustic.suppression_list_v1$20240320
```
so I'm adding a specific line that there is no partition on this table as it appears the default is partitioned tables

fix for #5246

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3184)
