### PR TITLE
Speed up stage deploys

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1629,7 +1629,7 @@ def schema():
     ./bqetl query schema update telemetry_derived.clients_daily_v6 --update-downstream
     """,
 )
-@click.argument("name")
+@click.argument("name", nargs=-1)
 @sql_dir_option
 @click.option(
     "--project-id",
@@ -1993,7 +1993,7 @@ def _update_query_schema(
     ./bqetl query schema deploy telemetry_derived.clients_daily_v6
     """,
 )
-@click.argument("name")
+@click.argument("name", nargs=-1)
 @sql_dir_option
 @click.option(
     "--project-id",

--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -5,7 +5,6 @@ import shutil
 import tempfile
 from datetime import datetime
 from glob import glob
-from multiprocessing.pool import ThreadPool
 from pathlib import Path
 
 import rich_click as click
@@ -371,26 +370,22 @@ def _deploy_artifacts(ctx, artifact_files, project_id, dataset_suffix, sql_dir):
             project_id=project_id, dataset=dataset, suffix=dataset_suffix
         )
 
-    def _deploy_schema(query_file):
-        ctx.invoke(
-            update_query_schema,
-            name=str(query_file),
-            sql_dir=sql_dir,
-            project_id=project_id,
-            respect_dryrun_skip=True,
-        )
-        ctx.invoke(
-            deploy_query_schema,
-            name=str(query_file),
-            sql_dir=sql_dir,
-            project_id=project_id,
-            force=True,
-            respect_dryrun_skip=False,
-            skip_external_data=True,
-        )
-
-    with ThreadPool(8) as p:
-        p.map(_deploy_schema, query_files)
+    ctx.invoke(
+        update_query_schema,
+        name=query_files,
+        sql_dir=sql_dir,
+        project_id=project_id,
+        respect_dryrun_skip=True,
+    )
+    ctx.invoke(
+        deploy_query_schema,
+        name=query_files,
+        sql_dir=sql_dir,
+        project_id=project_id,
+        force=True,
+        respect_dryrun_skip=False,
+        skip_external_data=True,
+    )
 
     # deploy views
     view_files = [

--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -109,7 +109,12 @@ def paths_matching_name_pattern(
     if pattern is None:
         pattern = "*.*"
 
-    if os.path.isdir(pattern):
+    if isinstance(pattern, list):
+        for p in pattern:
+            matching_files += paths_matching_name_pattern(
+                str(p), sql_path, project_id, files, file_regex
+            )
+    elif os.path.isdir(pattern):
         for root, _, _ in os.walk(pattern, followlinks=True):
             for file in files:
                 matching_files.extend(


### PR DESCRIPTION
I did some profiling and one of the memory and time bottlenecks is

```
dependency_graph = get_dependency_graph([sql_dir], without_views=True)
```

when updating query schemas. Currently, we call the schema `update` function for each query that has changed in stage deploys. This change allows a list of files as CLI parameter so that the dependency graph can be reused when doing stage deploys

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3194)
