### PR TITLE
Fixes #5266 - Add a separate view for live user_reports

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
@@ -1,0 +1,81 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_broken_site_report.user_reports_live`
+AS
+WITH live_reports AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp ASC) AS rn
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_live.broken_site_report_v1`
+  WHERE
+    DATE(submission_timestamp) > "2023-11-01"
+)
+SELECT
+  document_id AS uuid,
+  CAST(submission_timestamp AS DATETIME) AS reported_at,
+  metrics.text2.broken_site_report_description AS comments,
+  metrics.url2.broken_site_report_url AS url,
+  metrics.string.broken_site_report_breakage_category AS breakage_category,
+  "Firefox" AS app_name,
+  client_info.app_display_version AS app_version,
+  normalized_channel AS app_channel,
+  normalized_os AS os,
+  TO_JSON_STRING(
+    STRUCT(
+      STRUCT(
+        STRUCT(
+          metrics.text2.broken_site_report_browser_info_app_default_useragent_string AS default_useragent_string,
+          metrics.boolean.broken_site_report_browser_info_app_fission_enabled AS fission_enabled,
+          metrics.string_list.broken_site_report_browser_info_app_default_locales AS app_default_locales
+        ) AS app,
+        STRUCT(
+          metrics.text2.broken_site_report_browser_info_graphics_devices_json AS devices_json,
+          metrics.text2.broken_site_report_browser_info_graphics_drivers_json AS drivers_json,
+          metrics.text2.broken_site_report_browser_info_graphics_features_json AS features_json,
+          metrics.text2.broken_site_report_browser_info_graphics_monitors_json AS monitors_json,
+          metrics.boolean.broken_site_report_browser_info_graphics_has_touch_screen AS has_touch_screen,
+          metrics.string.broken_site_report_browser_info_graphics_device_pixel_ratio AS device_pixel_ratio
+        ) AS graphics,
+        STRUCT(
+          metrics.boolean.broken_site_report_browser_info_prefs_software_webrender AS software_webrender,
+          metrics.boolean.broken_site_report_browser_info_prefs_global_privacy_control_enabled AS global_privacy_control_enabled,
+          metrics.boolean.broken_site_report_browser_info_prefs_installtrigger_enabled AS installtrigger_enabled,
+          metrics.boolean.broken_site_report_browser_info_prefs_forced_accelerated_layers AS forced_accelerated_layers,
+          metrics.boolean.broken_site_report_browser_info_prefs_opaque_response_blocking AS opaque_response_blocking,
+          metrics.boolean.broken_site_report_browser_info_prefs_resist_fingerprinting_enabled AS resist_fingerprinting_enabled,
+          metrics.quantity.broken_site_report_browser_info_prefs_cookie_behavior AS cookie_behavior
+        ) AS prefs,
+        STRUCT(
+          metrics.boolean.broken_site_report_browser_info_system_is_tablet AS is_tablet,
+          metrics.quantity.broken_site_report_browser_info_system_memory AS memory
+        ) AS system,
+        STRUCT(
+          metrics.string_list.broken_site_report_browser_info_security_antispyware AS antispyware,
+          metrics.string_list.broken_site_report_browser_info_security_antivirus AS antivirus,
+          metrics.string_list.broken_site_report_browser_info_security_firewall AS firewall
+        ) AS security
+      ) AS browser_info,
+      STRUCT(
+        metrics.text2.broken_site_report_tab_info_useragent_string AS useragent_string,
+        metrics.string_list.broken_site_report_tab_info_languages AS languages,
+        STRUCT(
+          metrics.boolean.broken_site_report_tab_info_frameworks_mobify AS mobify,
+          metrics.boolean.broken_site_report_tab_info_frameworks_fastclick AS fastclick,
+          metrics.boolean.broken_site_report_tab_info_frameworks_marfeel AS marfeel
+        ) AS frameworks,
+        STRUCT(
+          metrics.boolean.broken_site_report_tab_info_antitracking_has_mixed_display_content_blocked AS has_mixed_display_content_blocked,
+          metrics.boolean.broken_site_report_tab_info_antitracking_is_private_browsing AS is_private_browsing,
+          metrics.boolean.broken_site_report_tab_info_antitracking_has_mixed_active_content_blocked AS has_mixed_active_content_blocked,
+          metrics.boolean.broken_site_report_tab_info_antitracking_has_tracking_content_blocked AS has_tracking_content_blocked,
+          metrics.string.broken_site_report_tab_info_antitracking_block_list AS block_list
+        ) AS antitracking
+      ) AS tab_info
+    )
+  ) AS details
+FROM
+  live_reports
+WHERE
+  rn = 1
+ORDER BY
+  submission_timestamp ASC


### PR DESCRIPTION
This is a follow up for https://github.com/mozilla/bigquery-etl/issues/5250.

I would like to create a separate live view mainly for ML classification job using bugbug that is defined in [docker-etl](https://github.com/mozilla/docker-etl/blob/main/jobs/broken-site-report-ml/broken_site_report_ml/main.py) repository.

This ETL job runs every 15 minutes and classifies reports gradually throughout the day. That worked well with the live data, but with the switch to historical table that gets updates only once a day, the script will try to classify all reports at once when they appear in the table. Given the size of the job (800-1k reports with non-empty description per day) this will take a long time, and ETL script likely will not get results during a single run. With this approach, by the time a report appears in the historical table, it will be already classified.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
