### PR TITLE
Avoid table stage deploy when there are no queries

### DIFF
--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -363,29 +363,30 @@ def _deploy_artifacts(ctx, artifact_files, project_id, dataset_suffix, sql_dir):
         and "*" not in file.parent.name and file.parent.name != "INFORMATION_SCHEMA"
     ]
 
-    # checking and creating datasets needs to happen sequentially
-    for query_file in query_files:
-        dataset = query_file.parent.parent.name
-        create_dataset_if_not_exists(
-            project_id=project_id, dataset=dataset, suffix=dataset_suffix
-        )
+    if len(query_files) > 0:
+        # checking and creating datasets needs to happen sequentially
+        for query_file in query_files:
+            dataset = query_file.parent.parent.name
+            create_dataset_if_not_exists(
+                project_id=project_id, dataset=dataset, suffix=dataset_suffix
+            )
 
-    ctx.invoke(
-        update_query_schema,
-        name=query_files,
-        sql_dir=sql_dir,
-        project_id=project_id,
-        respect_dryrun_skip=True,
-    )
-    ctx.invoke(
-        deploy_query_schema,
-        name=query_files,
-        sql_dir=sql_dir,
-        project_id=project_id,
-        force=True,
-        respect_dryrun_skip=False,
-        skip_external_data=True,
-    )
+        ctx.invoke(
+            update_query_schema,
+            name=query_files,
+            sql_dir=sql_dir,
+            project_id=project_id,
+            respect_dryrun_skip=True,
+        )
+        ctx.invoke(
+            deploy_query_schema,
+            name=query_files,
+            sql_dir=sql_dir,
+            project_id=project_id,
+            force=True,
+            respect_dryrun_skip=False,
+            skip_external_data=True,
+        )
 
     # deploy views
     view_files = [

--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -109,7 +109,8 @@ def paths_matching_name_pattern(
     if pattern is None:
         pattern = "*.*"
 
-    if isinstance(pattern, list):
+    # click nargs are passed in as a tuple
+    if isinstance(pattern, tuple) or isinstance(pattern, list):
         for p in pattern:
             matching_files += paths_matching_name_pattern(
                 str(p), sql_path, project_id, files, file_regex


### PR DESCRIPTION
Follow up to https://github.com/mozilla/bigquery-etl/pull/5262

This fixes table deploys by allowing tuples in `paths_matching_name_pattern` since click nargs are passed in as tuples instead of lists.  [airflow log](https://workflow.telemetry.mozilla.org/dags/bqetl_artifact_deployment/grid?root=&dag_run_id=manual__2024-03-22T00%3A47%3A18.169752%2B00%3A00&task_id=publish_new_tables&tab=logs)

Also fixes stage deploys when there are no queries ([CI log](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/31671/workflows/efa8d915-53d0-4d79-9f30-ac9a85ec739c/jobs/344716)) by not attempting to deploy.  This was the previous behaviour.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3201)
