### PR TITLE
Add signed_types to active_addons udf

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf_js/main_summary_active_addons/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/main_summary_active_addons/udf.sql
@@ -35,7 +35,8 @@ CREATE OR REPLACE FUNCTION udf_js.main_summary_active_addons(
         user_disabled INT64,
         version STRING,
         quarantine_ignored_by_app BOOL,
-        quarantine_ignored_by_user BOOL
+        quarantine_ignored_by_user BOOL,
+        signed_types STRING
       >
     >
   >,


### PR DESCRIPTION
This fixes clients_daily etl https://workflow.telemetry.mozilla.org/dags/bqetl_main_summary/grid?root=&dag_run_id=scheduled__2024-03-21T02%3A00%3A00%2B00%3A00&task_id=telemetry_derived__clients_daily__v6&tab=logs

I tested this by creating the udf in a separate project and dry running the query with that one

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3203)
