### PR TITLE
Filter out clients with too many pings * addons in clients_daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
@@ -163,8 +163,8 @@ WITH base AS (
     AND document_id IS NOT NULL
 ),
 overactive AS (
-  -- Find client_ids with over 150,000 pings in a day, which could errors in the
-  -- next step due to aggregation overflows.
+  -- Find client_ids with over 150 000 pings in a day or over 3 000 000 across all pings,
+  -- which could cause errors in the next step due to aggregation overflows.
   SELECT
     client_id
   FROM
@@ -173,6 +173,7 @@ overactive AS (
     client_id
   HAVING
     COUNT(*) > 150000
+    OR SUM(ARRAY_LENGTH(environment.addons.active_addons)) > 3000000
 ),
 clients_summary AS (
   SELECT


### PR DESCRIPTION
This is to prevent out of memory errors which started in [the ETL](https://workflow.telemetry.mozilla.org/dags/bqetl_main_summary/grid?root=&dag_run_id=scheduled__2024-03-21T02%3A00%3A00%2B00%3A00&task_id=telemetry_derived__clients_daily__v6&tab=logs).  In the past 3 weeks this should only filter out one client (starting on 2024-03-20): https://sql.telemetry.mozilla.org/queries/98557/source

The ETL succeeded with 3070808 but 4142944 was too much.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3210)
