### PR TITLE
Pass a fixed list of fields to main_summary_active_addons in clients_daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
@@ -368,7 +368,32 @@ clients_summary AS (
         UNNEST([REPLACE(key, 'in-content.', 'in-content:')]) AS _key,
         UNNEST([LENGTH(REGEXP_EXTRACT(_key, '.+?[.].'))]) AS pos
     ) AS search_counts,
-    udf_js.main_summary_active_addons(environment.addons.active_addons, NULL) AS active_addons,
+    -- A fixed list of fields is selected to maintain compatibility with the udf as fields are added
+    udf_js.main_summary_active_addons(
+      ARRAY(
+        SELECT AS STRUCT
+          addons.key,
+          STRUCT(
+            addons.value.blocklisted,
+            addons.value.description,
+            addons.value.foreign_install,
+            addons.value.has_binary_components,
+            addons.value.install_day,
+            addons.value.is_system,
+            addons.value.is_web_extension,
+            addons.value.multiprocess_compatible,
+            addons.value.name,
+            addons.value.scope,
+            addons.value.signed_state,
+            addons.value.type,
+            addons.value.update_day,
+            addons.value.user_disabled,
+            addons.value.version
+          ) AS value
+        FROM
+          UNNEST(environment.addons.active_addons) AS addons
+      )
+    ) AS active_addons,
     ARRAY_LENGTH(environment.addons.active_addons) AS active_addons_count,
     environment.settings.blocklist_enabled,
     environment.settings.addon_compatibility_check_enabled,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/query.sql
@@ -374,6 +374,7 @@ clients_summary AS (
         SELECT AS STRUCT
           addons.key,
           STRUCT(
+            addons.value.app_disabled,
             addons.value.blocklisted,
             addons.value.description,
             addons.value.foreign_install,
@@ -392,7 +393,8 @@ clients_summary AS (
           ) AS value
         FROM
           UNNEST(environment.addons.active_addons) AS addons
-      )
+      ),
+      NULL
     ) AS active_addons,
     ARRAY_LENGTH(environment.addons.active_addons) AS active_addons_count,
     environment.settings.blocklist_enabled,

--- a/sql/moz-fx-data-shared-prod/udf_js/main_summary_active_addons/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/main_summary_active_addons/udf.sql
@@ -33,10 +33,7 @@ CREATE OR REPLACE FUNCTION udf_js.main_summary_active_addons(
         type STRING,
         update_day INT64,
         user_disabled INT64,
-        version STRING,
-        quarantine_ignored_by_app BOOL,
-        quarantine_ignored_by_user BOOL,
-        signed_types STRING
+        version STRING
       >
     >
   >,
@@ -116,21 +113,21 @@ WITH result AS (
   SELECT AS VALUE
     ARRAY_CONCAT(
       udf_js.main_summary_active_addons(
-        ARRAY<STRUCT<STRING,STRUCT<BOOL,BOOL,STRING,INT64,BOOL,INT64,BOOL,BOOL,BOOL,STRING,INT64,INT64,STRING,INT64,INT64,STRING,BOOL,BOOL,STRING>>>[
+        ARRAY<STRUCT<STRING,STRUCT<BOOL,BOOL,STRING,INT64,BOOL,INT64,BOOL,BOOL,BOOL,STRING,INT64,INT64,STRING,INT64,INT64,STRING>>>[
           -- truthy columns and additional_properties
-          ('a', (TRUE, TRUE, 'description', NULL, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, NULL, NULL, NULL, NULL, 'signed_types')),
+          ('a', (TRUE, TRUE, 'description', NULL, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, NULL, NULL)),
           -- falsey columns and truthy additional_properties
-          ('b', (FALSE, FALSE, '', NULL, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, NULL, NULL, NULL, NULL, '')),
+          ('b', (FALSE, FALSE, '', NULL, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, NULL, NULL)),
           -- falsey columns and additional_properties
-          ('c', (FALSE, FALSE, '', NULL, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, NULL, NULL, NULL, NULL, '')),
+          ('c', (FALSE, FALSE, '', NULL, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, NULL, NULL)),
           -- truthy columns and falsey additional_properties
-          ('d', (TRUE, TRUE, 'description', NULL, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, NULL, NULL, NULL, NULL, 'signed_types')),
+          ('d', (TRUE, TRUE, 'description', NULL, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, NULL, NULL)),
           -- truthy columns and missing additional_properties
-          ('e', (TRUE, TRUE, 'description', 1, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, 1, "version", NULL, NULL, 'signed_types')),
+          ('e', (TRUE, TRUE, 'description', 1, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, 1, "version")),
           -- falsey columns and missing additional_properties
-          ('f', (FALSE, FALSE, '', 0, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, 0, "", NULL, NULL, '')),
+          ('f', (FALSE, FALSE, '', 0, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, 0, "")),
           -- null columns and missing additional_properties
-          ('g', (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)),
+          ('g', (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)),
           -- null value and ignore additional_properties
           ('h', NULL),
           -- null value and truthy additional_properties
@@ -152,11 +149,11 @@ WITH result AS (
       ),
       -- null additional properties
       udf_js.main_summary_active_addons(
-        ARRAY<STRUCT<STRING,STRUCT<BOOL,BOOL,STRING,INT64,BOOL,INT64,BOOL,BOOL,BOOL,STRING,INT64,INT64,STRING,INT64,INT64,STRING,BOOL,BOOL,STRING>>>[
+        ARRAY<STRUCT<STRING,STRUCT<BOOL,BOOL,STRING,INT64,BOOL,INT64,BOOL,BOOL,BOOL,STRING,INT64,INT64,STRING,INT64,INT64,STRING>>>[
           -- truthy columns and null additional_properties
-          ('l', (TRUE, TRUE, 'description', 1, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, 1, "version", FALSE, FALSE, 'signed_types')),
+          ('l', (TRUE, TRUE, 'description', 1, TRUE, 2, TRUE, TRUE, TRUE, 'name', 1, 4, 'type', 3, 1, "version")),
           -- falsey columns and null additional_properties
-          ('m', (FALSE, FALSE, '', 0, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, 0, "", TRUE, TRUE, '')),
+          ('m', (FALSE, FALSE, '', 0, FALSE, 0, FALSE, FALSE, FALSE, '', 0, 0, '', 0, 0, "")),
           -- null columns and additional_properties
           ('n', NULL)
         ],


### PR DESCRIPTION
A struct with only the fields used by the udf is passed in to prevent the clients_daily_v6 query from breaking each time active_addons is modified on the client side.  The only usage of `main_summary_active_addons` I could find is in clients_daily

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3224)
