### PR TITLE
fix(managed-backfills): fix date formats from CLI and from backfill initiate

### DIFF
--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -419,9 +419,9 @@ def _initiate_backfill(
             query_backfill,
             name=f"{dataset}.{table}",
             project_id=project,
-            start_date=entry.start_date,
-            end_date=entry.end_date,
-            exclude=entry.excluded_dates,
+            start_date=datetime.fromisoformat(entry.start_date.isoformat()),
+            end_date=datetime.fromisoformat(entry.end_date.isoformat()),
+            exclude=[e.strftime("%Y-%m-%d") for e in entry.excluded_dates],
             destination_table=backfill_staging_qualified_table_name,
             dry_run=dry_run,
         )

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -739,8 +739,8 @@ def backfill(
             partitioning_type = metadata.bigquery.time_partitioning.type
 
         date_range = BackfillDateRange(
-            start_date,
-            end_date,
+            start_date.date(),
+            end_date.date(),
             excludes=[date.fromisoformat(x) for x in exclude],
             range_type=partitioning_type or PartitionType.DAY,
         )

--- a/tests/cli/test_cli_query.py
+++ b/tests/cli/test_cli_query.py
@@ -557,8 +557,8 @@ class TestQuery:
                     "--project_id=moz-fx-data-shared-prod",
                     "--start_date=2021-01-05",
                     "--end_date=2021-01-09",
+                    "--exclude=2021-01-06",
                     "--parallelism=0",
-                    "--no-partition",
                 ],
             )
 
@@ -566,10 +566,10 @@ class TestQuery:
 
             expected_submission_date_params = [
                 f"--parameter=submission_date:DATE:2021-01-0{day}"
-                for day in range(3, 8)
+                for day in (3, 5, 6, 7)
             ]
 
-            assert check_call.call_count == 5
+            assert check_call.call_count == 4
             for call in check_call.call_args_list:
                 submission_date_params = [
                     arg for arg in call.args[0] if "--parameter=submission_date" in arg


### PR DESCRIPTION
There were some mismatched types between how we invoke CLI backfills causing excludes to be ignored 

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3231)
