### PR TITLE
Fix dryrun skip on stage deploys

### DIFF
--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -144,6 +144,8 @@ def deploy(
         if dataset == "INFORMATION_SCHEMA" or "INFORMATION_SCHEMA" in name:
             continue
 
+        dataset = f"{dataset}_{project.replace('-', '_')}"
+
         if dataset_suffix:
             dataset = f"{dataset}_{dataset_suffix}"
 
@@ -173,6 +175,8 @@ def deploy(
                         f"{test_dataset}.{test_name}{file_suffix}",
                         f"{test_dataset}.{test_name}.schema{file_suffix}",
                     ):
+                        test_dataset = f"{test_dataset}_{project_id.replace('-', '_')}"
+
                         if dataset_suffix:
                             test_dataset = f"{test_dataset}_{dataset_suffix}"
 
@@ -292,14 +296,18 @@ def _update_references(artifact_files, project_id, dataset_suffix, sql_dir):
         name = artifact_file.parent.name
         name_pattern = name.replace("*", r"\*")  # match literal *
         original_dataset = artifact_file.parent.parent.name
+        original_project = artifact_file.parent.parent.parent.name
+
         deployed_dataset = original_dataset
+        deployed_dataset += f"_{original_project.replace('-', '_')}"
+
         if dataset_suffix and original_dataset not in (
             "INFORMATION_SCHEMA",
             "region-eu",
             "region-us",
         ):
             deployed_dataset += f"_{dataset_suffix}"
-        original_project = artifact_file.parent.parent.parent.name
+
         deployed_project = project_id
 
         # Replace references, preserving fully quoted references.

--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -106,7 +106,10 @@ class DryRun:
                 file
                 for skip in ConfigLoader.get("dry_run", "skip", fallback=[])
                 for file in glob.glob(
-                    file_pattern_re.sub(f"sql/{test_project}/\\2*\\3", skip),
+                    file_pattern_re.sub(
+                        lambda x: f"sql/{test_project}/{x.group(2)}_{x.group(1).replace('-', '_')}*{x.group(3)}",
+                        skip,
+                    ),
                     recursive=True,
                 )
             ]


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/5289

This PR ensures that the project ID is added to the datasets deployed on stage. This way we can support multiple projects that might have the same datasets and skip dry runs for the correct ones

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3244)
