### PR TITLE
feat(): convert all funnel_retention mobile checks to warn instead of fail

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_2_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_2_v1/checks.sql
@@ -4,10 +4,10 @@
 -- {{ is_unique(["client_id"]) }}
 #}
 
-#fail
+#warn
 {{ min_row_count(1, "submission_date = @submission_date") }}
 
-#fail
+#warn
 SELECT
   IF(
     DATE_DIFF(submission_date, first_seen_date, DAY) <> 13,

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_clients_week_4_v1/checks.sql
@@ -4,10 +4,10 @@
 -- {{ is_unique(["client_id"]) }}
 #}
 
-#fail
+#warn
 {{ min_row_count(1, "submission_date = @submission_date") }}
 
-#fail
+#warn
 SELECT
   IF(
     DATE_DIFF(submission_date, first_seen_date, DAY) <> 27,

--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_week_4_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_week_4_v1/checks.sql
@@ -1,4 +1,4 @@
-#fail
+#warn
 {{ is_unique([
   "first_seen_date", "first_reported_country", "first_reported_isp",
   "adjust_ad_group", "adjust_campaign", "adjust_creative", "adjust_network", "install_source"
@@ -7,10 +7,10 @@
 #warn
 {{ not_null(["first_seen_date", "adjust_network"], "submission_date = @submission_date") }}
 
-#fail
+#warn
 {{ min_row_count(1, "submission_date = @submission_date") }}
 
-#fail
+#warn
 WITH new_profile_count AS (
   SELECT
     SUM(new_profiles)
@@ -42,7 +42,7 @@ SELECT
     NULL
   );
 
-#fail
+#warn
 WITH repeat_user_count AS (
   SELECT
     SUM(repeat_user)
@@ -74,7 +74,7 @@ SELECT
     NULL
   );
 
-#fail
+#warn
 WITH retained_week_4_count AS (
   SELECT
     SUM(retained_week_4)
@@ -106,7 +106,7 @@ SELECT
     NULL
   );
 
-#fail
+#warn
 SELECT
   IF(
     DATE_DIFF(submission_date, first_seen_date, DAY) <> 27,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_2_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_2_v1/checks.sql
@@ -1,10 +1,10 @@
-#fail
+#warn
 {{ is_unique(["client_id"]) }}
 
-#fail
+#warn
 {{ min_row_count(1, "submission_date = @submission_date") }}
 
-#fail
+#warn
 SELECT
   IF(
     DATE_DIFF(submission_date, first_seen_date, DAY) <> 13,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/checks.sql
@@ -1,10 +1,10 @@
-#fail
+#warn
 {{ is_unique(["client_id"]) }}
 
-#fail
+#warn
 {{ min_row_count(1, "submission_date = @submission_date") }}
 
-#fail
+#warn
 SELECT
   IF(
     DATE_DIFF(submission_date, first_seen_date, DAY) <> 27,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/checks.sql
@@ -1,16 +1,16 @@
-#fail
+#warn
 {{ is_unique([
   "first_seen_date", "first_reported_country", "first_reported_isp",
   "adjust_ad_group", "adjust_campaign", "adjust_creative", "adjust_network"
 ]) }}
 
-#fail
+#warn
 {{ not_null(["first_seen_date", "adjust_network"], "submission_date = @submission_date") }}
 
-#fail
+#warn
 {{ min_row_count(1, "submission_date = @submission_date") }}
 
-#fail
+#warn
 WITH new_profile_count AS (
   SELECT
     SUM(new_profiles)
@@ -42,7 +42,7 @@ SELECT
     NULL
   );
 
-#fail
+#warn
 WITH repeat_user_count AS (
   SELECT
     SUM(repeat_user)
@@ -74,7 +74,7 @@ SELECT
     NULL
   );
 
-#fail
+#warn
 WITH retained_week_4_count AS (
   SELECT
     SUM(retained_week_4)
@@ -106,7 +106,7 @@ SELECT
     NULL
   );
 
-#fail
+#warn
 SELECT
   IF(
     DATE_DIFF(submission_date, first_seen_date, DAY) <> 27,


### PR DESCRIPTION
# feat(): convert all funnel_retention mobile checks to warn instead of fail

This is to unblock downsteam jobs from failing to run as the result of the fail checks failing (minor duplication issue that seems to come up).

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3282)
