### PR TITLE
fix(managed-backfills): fix unsupported type in backfill complete

### DIFF
--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -487,7 +487,7 @@ def complete(ctx, qualified_table_name, sql_dir, project_id):
 
     project, dataset, table = qualified_table_name_matching(qualified_table_name)
     table_metadata = Metadata.from_file(
-        Path(sql_dir / project / dataset / table / METADATA_FILE)
+        Path(sql_dir) / project / dataset / table / METADATA_FILE
     )
 
     _copy_backfill_staging_to_prod(


### PR DESCRIPTION
Fixes:
```
[2024-04-01, 20:43:09 UTC] {pod_manager.py:466} INFO - [base]   File "/app/bigquery_etl/cli/backfill.py", line 490, in complete
[2024-04-01, 20:43:09 UTC] {pod_manager.py:466} INFO - [base]     Path(sql_dir / project / dataset / table / METADATA_FILE)
[2024-04-01, 20:43:09 UTC] {pod_manager.py:466} INFO - [base]          ~~~~~~~~^~~~~~~~~
[2024-04-01, 20:43:10 UTC] {pod_manager.py:483} INFO - [base] TypeError: unsupported operand type(s) for /: 'str' and 'str'
```

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3284)
