### PR TITLE
feat: convert KPI source query checks from fail to warn

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/checks.sql
@@ -1,10 +1,10 @@
-#fail
+#warn
 {{ is_unique(columns=["client_id"]) }}
 
-#fail
+#warn
 {{ not_null(columns=["client_id", "sample_id"], where="submission_date = @submission_date") }}
 
-#fail
+#warn
 {{ min_row_count(1, "submission_date = @submission_date") }}
 
 #warn

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/checks.sql
@@ -4,7 +4,7 @@
 #warn
 {{ not_null(columns=["client_id", "sample_id"], where="submission_date = @submission_date") }}
 
-#warn
+#fail
 {{ min_row_count(1, "submission_date = @submission_date") }}
 
 #warn

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
@@ -1,12 +1,12 @@
-#fail
+#warn
 {{ is_unique(["submission_date", "country"], "country IS NOT NULL") }}
 -- min_row_count helps us detect if we're seeing delays in the data arriving
 -- could also be an indicator of an upstream issue.
 
-#fail
+#warn
 {{ min_row_count(1, "submission_date = @submission_date") }}
 
-#fail
+#warn
 WITH fx_ios_count AS (
   SELECT
     COUNT(*)
@@ -70,7 +70,7 @@ SELECT
 FROM
   base;
 
-#fail
+#warn
 SELECT
   IF(
     DATE_DIFF(submission_date, first_seen_date, DAY) <> 7,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
@@ -3,7 +3,7 @@
 -- min_row_count helps us detect if we're seeing delays in the data arriving
 -- could also be an indicator of an upstream issue.
 
-#warn
+#fail
 {{ min_row_count(1, "submission_date = @submission_date") }}
 
 #warn

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
@@ -1,10 +1,10 @@
-#fail
+#warn
 {{ is_unique(["client_id"]) }}
 
-#fail
+#warn
 {{ min_row_count(1, "`submission_date` = @submission_date") }}
 
-#fail
+#warn
 WITH upstream_clients_count AS (
   SELECT
     COUNT(*)
@@ -28,7 +28,7 @@ SELECT
     NULL
   );
 
-#fail
+#warn
 SELECT
   IF(
     DATE_DIFF(submission_date, first_seen_date, DAY) <> 6,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
@@ -1,7 +1,7 @@
 #warn
 {{ is_unique(["client_id"]) }}
 
-#warn
+#fail
 {{ min_row_count(1, "`submission_date` = @submission_date") }}
 
 #warn

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/checks.sql
@@ -4,7 +4,7 @@
 #warn
 {{ not_null(columns=["client_id"], where="first_seen_date = @submission_date") }}
 
-#warn
+#fail
 {{ min_row_count(1, where="first_seen_date = @submission_date") }}
 
 #warn

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/checks.sql
@@ -1,10 +1,10 @@
-#fail
+#warn
 {{ is_unique(columns=["client_id"]) }}
 
-#fail
+#warn
 {{ not_null(columns=["client_id"], where="first_seen_date = @submission_date") }}
 
-#fail
+#warn
 {{ min_row_count(1, where="first_seen_date = @submission_date") }}
 
 #warn

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v2/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v2/checks.sql
@@ -1,10 +1,10 @@
-#fail
+#warn
 {{ is_unique(["client_id"]) }}
 
-#fail
+#warn
 {{ min_row_count(1, "`date` = @submission_date") }}
 
-#fail
+#warn
 SELECT
   IF(
     COUNTIF(is_new_profile) <> COUNT(*),
@@ -16,7 +16,7 @@ FROM
 WHERE
   `date` = @submission_date;
 
-#fail
+#warn
 SELECT
   IF(
     DATE_DIFF(`date`, first_seen_date, DAY) <> 6,

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v2/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v2/checks.sql
@@ -1,7 +1,7 @@
 #warn
 {{ is_unique(["client_id"]) }}
 
-#warn
+#fail
 {{ min_row_count(1, "`date` = @submission_date") }}
 
 #warn

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
@@ -1,4 +1,4 @@
-#warn
+#fail
 {{ min_row_count(1000, where="submission_date = @submission_date") }}
 
 #warn

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/checks.sql
@@ -1,19 +1,19 @@
-#fail
+#warn
 {{ min_row_count(1000, where="submission_date = @submission_date") }}
 
-#fail
+#warn
 {{ not_null(columns=["submission_date", "client_id", "first_seen_date"], where="submission_date = @submission_date") }}
 
-#fail
+#warn
 {{ row_count_within_past_partitions_avg(number_of_days=7, threshold_percentage=5) }}
 
-#fail
+#warn
 {{ value_length(column="client_id", expected_length=36, where="submission_date = @submission_date") }}
 {#
 -- Commented out due to upstream duplication issue inside Fenix data
 -- which will cause this check to fail, see: bug(1803609).
 -- Once the duplication issue has been resolved, this check can be uncommented.
--- #fail
+-- #warn
 -- {{ is_unique(columns=["client_id"], where="submission_date = @submission_date") }}
 #}
 


### PR DESCRIPTION
# feat: convert KPI source query checks from fail to warn

This is to prevent blocking KPI metric generation but still maintain visibility into potential data issues.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3285)
