### PR TITLE
fix(managed-backfills) Incorrect type for partition string when completing backfill

### DIFF
--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -552,8 +552,7 @@ def _copy_backfill_staging_to_prod(
                     offset,
                     partitioning_type,
                 )
-                is None
-            ):
+            ) is None:
                 raise ValueError(
                     f"Null partition found completing backfill {entry} for {qualified_table_name}."
                 )


### PR DESCRIPTION
Before we were getting `$False` as a partition string, due to a misplaced `is None` Added a test as well.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3295)
