### PR TITLE
feat(DENG-3212): Create views for data observability test datasets

### DIFF
--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -192,8 +192,13 @@ def deploy(
                     if test_file_path.name in (
                         f"{test_project}.{test_dataset}.{test_name}{file_suffix}",
                         f"{test_project}.{test_dataset}.{test_name}.schema{file_suffix}",
-                        f"{test_dataset}.{test_name}{file_suffix}",
-                        f"{test_dataset}.{test_name}.schema{file_suffix}",
+                    ) or (
+                        test_file_path.name
+                        in (
+                            f"{test_dataset}.{test_name}{file_suffix}",
+                            f"{test_dataset}.{test_name}.schema{file_suffix}",
+                        )
+                        and test_project == project
                     ):
                         test_dataset = f"{test_dataset}_{project.replace('-', '_')}"
 

--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -317,6 +317,7 @@ def _view_dependencies(artifact_files, sql_dir):
 
 def _update_references(artifact_files, project_id, dataset_suffix, sql_dir):
     replace_references = []
+    replace_partial_references = []
     for artifact_file in artifact_files:
         name = artifact_file.parent.name
         name_pattern = name.replace("*", r"\*")  # match literal *
@@ -336,30 +337,36 @@ def _update_references(artifact_files, project_id, dataset_suffix, sql_dir):
         deployed_project = project_id
 
         # Replace references, preserving fully quoted references.
-        replace_references += [
+        replace_partial_references += [
             # partially qualified references (like "telemetry.main")
             (
                 re.compile(rf"(?<![\._])`{original_dataset}\.{name_pattern}`"),
                 f"`{deployed_project}.{deployed_dataset}.{name}`",
+                original_project,
             ),
             (
                 re.compile(
                     rf"(?<![\._])`?{original_dataset}`?\.`?{name_pattern}(?![a-zA-Z0-9_])`?"
                 ),
                 f"`{deployed_project}`.`{deployed_dataset}`.`{name}`",
+                original_project,
             ),
+        ]
+        replace_references += [
             # fully qualified references (like "moz-fx-data-shared-prod.telemetry.main")
             (
                 re.compile(
                     rf"`{original_project}\.{original_dataset}\.{name_pattern}`"
                 ),
                 f"`{deployed_project}.{deployed_dataset}.{name}`",
+                original_project,
             ),
             (
                 re.compile(
                     rf"(?<![a-zA-Z0-9_])`?{original_project}`?\.`?{original_dataset}`?\.`?{name_pattern}(?![a-zA-Z0-9_])`?"
                 ),
                 f"`{deployed_project}`.`{deployed_dataset}`.`{name}`",
+                original_project,
             ),
         ]
 
@@ -370,6 +377,11 @@ def _update_references(artifact_files, project_id, dataset_suffix, sql_dir):
 
             for ref in replace_references:
                 sql = re.sub(ref[0], ref[1], sql)
+
+            for ref in replace_partial_references:
+                file_project = path.parent.parent.parent.name
+                if file_project == ref[2]:
+                    sql = re.sub(ref[0], ref[1], sql)
 
             path.write_text(sql)
 

--- a/sql/data-observability-dev/fenix/clients_last_seen_joined/view.sql
+++ b/sql/data-observability-dev/fenix/clients_last_seen_joined/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `data-observability-dev.fenix.clients_last_seen_joined`
+AS
+SELECT
+  *
+FROM
+  `data-observability-dev.fenix_derived.clients_last_seen_joined_v1`

--- a/sql/data-observability-dev/fenix/dataset_metadata.yaml
+++ b/sql/data-observability-dev/fenix/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Fenix
+description: |-
+  Data related to Fenix (Firefox for Android)
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/data-observability-dev/fenix/event_types/view.sql
+++ b/sql/data-observability-dev/fenix/event_types/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `data-observability-dev.fenix.event_types`
+AS
+SELECT
+  *
+FROM
+  `data-observability-dev.fenix_derived.event_types_v1`

--- a/sql/data-observability-dev/fenix/events_daily/view.sql
+++ b/sql/data-observability-dev/fenix/events_daily/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `data-observability-dev.fenix.events_daily`
+AS
+SELECT
+  *
+FROM
+  `data-observability-dev.fenix_derived.events_daily_v1`

--- a/sql/data-observability-dev/fenix/firefox_android_clients/view.sql
+++ b/sql/data-observability-dev/fenix/firefox_android_clients/view.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE VIEW
+  `data-observability-dev.fenix.firefox_android_clients`
+AS
+SELECT
+  COALESCE(
+    first_seen_date,
+    metadata.min_first_session_ping_submission_date,
+    metadata.min_metrics_ping_submission_date
+  ) AS first_seen_date,
+  * EXCEPT (first_seen_date, adjust_network, install_source),
+  CASE
+    WHEN adjust_network IS NULL
+      OR adjust_network = ''
+      THEN 'Unknown'
+    WHEN adjust_network NOT IN (
+        'Organic',
+        'Google Organic Search',
+        'Untrusted Devices',
+        'Product Marketing (Owned media)',
+        'Google Ads ACI'
+      )
+      THEN 'Other'
+    ELSE adjust_network
+  END AS adjust_network,
+  CASE
+    WHEN install_source IS NULL
+      OR install_source = ''
+      THEN 'Unknown'
+    WHEN install_source NOT IN ('com.android.vending')
+      THEN 'Other'
+    ELSE install_source
+  END AS install_source,
+FROM
+  `data-observability-dev.fenix_derived.firefox_android_clients_v1`
+WHERE
+  metadata.reported_baseline_ping

--- a/sql/data-observability-dev/fenix/metrics_clients_last_seen/view.sql
+++ b/sql/data-observability-dev/fenix/metrics_clients_last_seen/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `data-observability-dev.fenix.metrics_clients_last_seen`
+AS
+SELECT
+  *
+FROM
+  `data-observability-dev.fenix_derived.metrics_clients_last_seen_v1`

--- a/sql/data-observability-dev/org_mozilla_firefox/dataset_metadata.yaml
+++ b/sql/data-observability-dev/org_mozilla_firefox/dataset_metadata.yaml
@@ -1,0 +1,16 @@
+friendly_name: org-mozilla-firefox
+description: |-
+  User-facing views related to document namespace org-mozilla-firefox;
+  see https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas/org-mozilla-firefox
+dataset_base_acl: view
+user_facing: true
+labels: {}
+default_table_workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+syndication: {}

--- a/sql/data-observability-dev/org_mozilla_firefox/event_monitoring_live/view.sql
+++ b/sql/data-observability-dev/org_mozilla_firefox/event_monitoring_live/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `data-observability-dev.org_mozilla_firefox.event_monitoring_live`
+AS
+SELECT
+  *
+FROM
+  `data-observability-dev.org_mozilla_firefox_derived.event_monitoring_live_v1`

--- a/sql/data-observability-dev/telemetry/dataset_metadata.yaml
+++ b/sql/data-observability-dev/telemetry/dataset_metadata.yaml
@@ -1,0 +1,12 @@
+friendly_name: Telemetry
+description: |-
+  Views on data from legacy Firefox telemetry, plus many other
+  general-purpose datasets
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/taar
+  - workgroup:mozilla-confidential


### PR DESCRIPTION
feat(DENG-3212): Create views for data observability test datasets

Original PR: https://github.com/mozilla/bigquery-etl/pull/5314
Reverted due to test-sql errors: https://github.com/mozilla/bigquery-etl/pull/5326

Re-opening this PR as these changes are still needed. Will separate out the view changes and the changes to bqetl logic to fix the test errors.



---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3322)
