### PR TITLE
Extend the completed backfill

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/backfill.yaml
@@ -1,3 +1,17 @@
+2024-04-05:
+  start_date: 2023-03-01
+  end_date: 2024-03-17
+  reason:
+    The previous backfill needs to be extended to cover the full history of visits
+    to fill in the two new fields. The PR that added these fields merged on
+    '2024-03-18' (https://github.com/mozilla/bigquery-etl/pull/5224#event-12159631760),
+    and `newtab_visits` has the new fields populated on that date
+  watchers:
+    - mbowerman@mozilla.com
+    - anicholson@mozilla.com
+    - wichan@mozilla.com
+  status: Initiate
+
 2024-04-02:
   start_date: 2022-11-01
   end_date: 2023-02-28


### PR DESCRIPTION
The previous backfill needs to be extended to cover the full history of visits
    to fill in the two new fields. The PR that added these fields merged on
    '2024-03-18' (https://github.com/mozilla/bigquery-etl/pull/5224#event-12159631760),
    and `newtab_visits` has the new fields populated on that date

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3330)
