### PR TITLE
Add distinct to count of newtab visits

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_clients_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_clients_daily_v1/query.sql
@@ -38,7 +38,7 @@ visits_data AS (
     client_id,
     submission_date,
     ANY_VALUE(legacy_telemetry_client_id) AS legacy_telemetry_client_id,
-    COUNT(newtab_visit_id) AS newtab_visit_count,
+    COUNT(DISTINCT newtab_visit_id) AS newtab_visit_count,
     ANY_VALUE(normalized_os) AS normalized_os,
     ANY_VALUE(normalized_os_version) AS normalized_os_version,
     ANY_VALUE(country_code) AS country_code,


### PR DESCRIPTION
I've found that there are instances in `newtab_visits` where `newtab_visit_id` occurs multiple times. This adds a DISTINCT to the count of `newtab_visit_id` in `newtab_clients_daily`

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3332)
