### PR TITLE
[Bug 1889418] Delay clients_last_seen_joined runs by a day

### DIFF
--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
@@ -15,6 +15,7 @@ scheduling:
   dag_name: bqetl_glean_usage
   task_group: {{ app_name }}
   depends_on_past: true
+  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -14,7 +14,7 @@ metrics AS (
   WHERE
     -- The join between baseline and metrics pings is based on submission_date with a 1 day delay,
     -- since metrics pings usually arrive within 1 day after their logical activity period.
-    submission_date = DATE_ADD(@submission_date, INTERVAL 1 DAY)
+    submission_date BETWEEN @submission_date AND DATE_ADD(@submission_date, INTERVAL 1 DAY)
 )
 SELECT 
   baseline.client_id,


### PR DESCRIPTION
Metric values seem to be missing in `clients_last_seen_joined` tables. The reason is that the query is looking for metric values a day into the future. Since that data doesn't exist at that point all the values are null.

This PR delays running `clients_last_seen_joined` tasks by a day so that data exists when run.

This will also delay the following tables by a day:
`unified_metrics`
`active_users_aggregates`
`active_users_deletion_request`

and their downstream dependencies

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3349)
