### PR TITLE
Deprecate average_ping_sizes_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/average_ping_sizes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/average_ping_sizes_v1/metadata.yaml
@@ -1,18 +1,20 @@
 friendly_name: Average Ping Sizes
-description: Average ping size, partitioned by day.
+description: |-
+  Average ping size, partitioned by day.
+owners:
+- ascholtz@mozilla.com
 labels:
   incremental: true
-owners:
-  - ascholtz@mozilla.com
-scheduling:
-  dag_name: bqetl_monitoring
-  arguments: ["--date", "{{ ds }}"]
-  referenced_tables:
-    - ['moz-fx-data-shared-prod', 'monitoring_derived', 'stable_table_sizes_v1']
-    - ['moz-fx-data-shared-prod', '*_stable', "*"]
+  dag: bqetl_monitoring
+  owner1: ascholtz
 bigquery:
   time_partitioning:
     type: day
     field: submission_date
     require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering: null
+references: {}
 deprecated: true
+deletion_date: 2024-05-09

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/average_ping_sizes_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/average_ping_sizes_v1/query.py
@@ -46,7 +46,7 @@ def get_average_ping_size_json(client, date, table):
                 SAFE_DIVIDE(byte_size, total) AS average_ping_size,
                 byte_size as total_byte_size,
                 total as row_count
-            FROM total_pings, `moz-fx-data-shared-prod.monitoring.stable_table_sizes`
+            FROM total_pings, `moz-fx-data-shared-prod.monitoring.stable_and_derived_table_sizes`
             WHERE submission_date = '{date}' AND dataset_id = '{dataset_id}' AND table_id = '{table_id}'
         """
 
@@ -114,6 +114,10 @@ def main():
         )
 
         average_ping_sizes = [s for s in average_ping_sizes if s is not None]
+        total_row_count = sum([ping_size["row_count"] for ping_size in average_ping_sizes])
+
+        if total_row_count == 0:
+            raise RuntimeError("No tables with rows found; job may be incorrectly configured.")
 
         save_average_ping_sizes(
             client,


### PR DESCRIPTION
`monitoring_derived.stable_table_sizes_v1` stopped updating on 2022-08-07 and is now deprecated and replaced by `stable_and_derived_table_sizes`.

@scholtzan `average_ping_size` hasn't had data for nearly two years.  Do you think we should backfill it or could we take this as an opportunity to deprecate it?

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3365)
