### PR TITLE
Adjust date_partition_offset for downstream dependencies of clients_l…

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_attribution_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_attribution_v1/metadata.yaml
@@ -29,6 +29,7 @@ bigquery:
     field: submission_date
     require_partition_filter: true
     expiration_days: null
+    date_partition_offset: -1
   clustering:
     fields:
     - country

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_device_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_device_v1/metadata.yaml
@@ -21,6 +21,7 @@ bigquery:
     field: submission_date
     require_partition_filter: true
     expiration_days: null
+    date_partition_offset: -1
   clustering:
     fields:
     - country

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/metadata.yaml
@@ -22,6 +22,7 @@ bigquery:
     field: submission_date
     require_partition_filter: true
     expiration_days: null
+    date_partition_offset: -1
   clustering:
     fields:
     - country

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
@@ -14,6 +14,7 @@ labels:
 scheduling:
   dag_name: bqetl_analytics_aggregations
   date_partition_parameter: activity_date
+  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/metadata.yaml
@@ -11,6 +11,7 @@ labels:
   owner1: anicholson
 scheduling:
   dag_name: bqetl_newtab
+  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/metadata.yaml
@@ -12,6 +12,7 @@ labels:
   dag: bqetl_newtab
 scheduling:
   dag_name: bqetl_newtab
+  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/metadata.yaml
@@ -16,6 +16,7 @@ labels:
 scheduling:
   dag_name: bqetl_unified
   date_partition_parameter: cohort_date
+  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
@@ -15,6 +15,7 @@ bigquery:
     field: submission_date
     require_partition_filter: true
     expiration_days: null
+    date_partition_offset: -1
   clustering:
     fields:
     - normalized_channel

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/metadata.yaml
@@ -21,6 +21,7 @@ scheduling:
   - task_id: wait_for_unified_metrics
     dag_name: kpi_forecasting
     execution_delta: 1h
+  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
…ast_seen_joined

Follow-up to https://github.com/mozilla/bigquery-etl/pull/5344
Some of the `date_partition_offsets` didn't get propagated to downstream tables. Manually setting them here

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3376)
