### PR TITLE
feat(DENG-656): Add client_id deduplication to fenix_derived.clients_last_seen_joined query

### DIFF
--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
@@ -7,7 +7,7 @@ description: |-
   such that a given client will not appear in the result if
   it is only represented in the metrics-based table.
 
-  NOTE FENIX ONLY:
+  NOTE:
   In rare cases the union can result in the same client_id entry from different channels.
   In such cases, the resulting data will only include the entry for the client_id
   with the oldest first_seen_date value.

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
@@ -6,6 +6,11 @@ description: |-
   Join on baseline and metrics views, but uses a LEFT JOIN
   such that a given client will not appear in the result if
   it is only represented in the metrics-based table.
+
+  NOTE FENIX ONLY:
+  In rare cases the union can result in the same client_id entry from different channels.
+  In such cases, the resulting data will only include the entry for the client_id
+  with the oldest first_seen_date value.
 owners:
   - ascholtz@mozilla.com
 labels:

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -1,29 +1,29 @@
 WITH baseline AS (
-  SELECT 
+  SELECT
     *
-  FROM 
-    `{{ project_id }}.{{ app_name }}.baseline_clients_last_seen` 
-  WHERE 
+  FROM
+    `{{ project_id }}.{{ app_name }}.baseline_clients_last_seen`
+  WHERE
     submission_date = @submission_date
 ),
 metrics AS (
-  SELECT 
-    * 
-  FROM 
+  SELECT
+    *
+  FROM
     `{{ project_id }}.{{ app_name }}.metrics_clients_last_seen`
   WHERE
     -- The join between baseline and metrics pings is based on submission_date with a 1 day delay,
     -- since metrics pings usually arrive within 1 day after their logical activity period.
     submission_date = DATE_ADD(@submission_date, INTERVAL 1 DAY)
 )
-SELECT 
+SELECT
   baseline.client_id,
   baseline.sample_id,
-  baseline.submission_date, 
+  baseline.submission_date,
   baseline.normalized_channel,
-  * EXCEPT(submission_date, normalized_channel, client_id, sample_id) 
+  * EXCEPT(submission_date, normalized_channel, client_id, sample_id)
 FROM
-  baseline 
+  baseline
 LEFT JOIN metrics
 ON baseline.client_id = metrics.client_id AND
   baseline.sample_id = metrics.sample_id AND
@@ -31,3 +31,16 @@ ON baseline.client_id = metrics.client_id AND
     baseline.normalized_channel = metrics.normalized_channel OR
     (baseline.normalized_channel IS NULL AND metrics.normalized_channel IS NULL)
   )
+{% if app_name == "fenix" -%}
+-- In some rare cases we end up with same client_id in multiple channels in Fenix
+-- In those cases, this union can result in client_id duplicates.
+-- This logic ensures that the resulting table only includes the client from the channel
+-- we've seen first.
+QUALIFY
+  ROW_NUMBER() OVER (
+    PARTITION BY
+      client_id
+    ORDER BY
+      first_seen_date ASC
+) = 1
+{% endif -%}

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -31,8 +31,7 @@ ON baseline.client_id = metrics.client_id AND
     baseline.normalized_channel = metrics.normalized_channel OR
     (baseline.normalized_channel IS NULL AND metrics.normalized_channel IS NULL)
   )
-{% if app_name == "fenix" -%}
--- In some rare cases we end up with same client_id in multiple channels in Fenix
+-- In some rare cases we end up with the same client_id in multiple channels
 -- In those cases, this union can result in client_id duplicates.
 -- This logic ensures that the resulting table only includes the client from the channel
 -- we've seen first.
@@ -43,4 +42,3 @@ QUALIFY
     ORDER BY
       first_seen_date ASC
 ) = 1
-{% endif -%}


### PR DESCRIPTION
# feat(DENG-656): Add client_id deduplication to fenix_derived.clients_last_seen_joined query

In some rare cases we end up with same client_id in multiple channels in Fenix. In those cases, this union can result in client_id duplicates. This logic ensures that the resulting table only includes the client from the channel we've seen first.

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3399)
