### PR TITLE
Fix hardware report schema

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_hardware_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_hardware_v1/schema.yaml
@@ -1,128 +1,117 @@
 fields:
-  - name: date_from
-    type: DATE
+- name: date_from
+  type: DATE
+  mode: NULLABLE
+- name: date_to
+  type: DATE
+  mode: NULLABLE
+- name: browser_arch
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: value
+    type: FLOAT
     mode: NULLABLE
-  - name: date_to
-    type: DATE
+  - name: key
+    type: STRING
     mode: NULLABLE
-  - name: client_count
-    type: INTEGER
+- name: cpu_cores
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: value
+    type: FLOAT
     mode: NULLABLE
-  - name: os
-    type: RECORD
-    mode: REPEATED
-    fields:
-      - name: os
-        type: STRING
-        mode: NULLABLE
-      - name: client_count
-        type: INTEGER
-        mode: NULLABLE
-  - name: browser_arch
-    type: RECORD
-    mode: REPEATED
-    fields:
-      - name: browser_arch
-        type: STRING
-        mode: NULLABLE
-      - name: client_count
-        type: INTEGER
-        mode: NULLABLE
-  - name: cpu_cores
-    type: RECORD
-    mode: REPEATED
-    fields:
-      - name: cpu_cores
-        type: INTEGER
-        mode: NULLABLE
-      - name: client_count
-        type: INTEGER
-        mode: NULLABLE
-  - name: cpu_vendor
-    type: RECORD
-    mode: REPEATED
-    fields:
-      - name: cpu_vendor
-        type: STRING
-        mode: NULLABLE
-      - name: client_count
-        type: INTEGER
-        mode: NULLABLE
-  - name: cpu_speed
-    type: RECORD
-    mode: REPEATED
-    fields:
-      - name: cpu_speed
-        type: STRING
-        mode: NULLABLE
-      - name: client_count
-        type: INTEGER
-        mode: NULLABLE
-  - name: resolution
-    type: RECORD
-    mode: REPEATED
-    fields:
-      - name: resolution
-        type: STRING
-        mode: NULLABLE
-      - name: client_count
-        type: INTEGER
-        mode: NULLABLE
-  - name: memory_gb
-    type: RECORD
-    mode: REPEATED
-    fields:
-      - name: memory_gb
-        type: INTEGER
-        mode: NULLABLE
-      - name: client_count
-        type: INTEGER
-  - name: has_flash
-    type: RECORD
-    mode: REPEATED
-    fields:
-      - name: has_flash
-        type: BOOLEAN
-        mode: NULLABLE
-      - name: client_count
-        type: INTEGER
-        mode: NULLABLE
-  - name: os_arch
-    type: RECORD
-    mode: REPEATED
-    fields:
-      - name: browser_arch
-        type: STRING
-        mode: NULLABLE
-      - name: os
-        type: STRING
-        mode: NULLABLE
-      - name: is_wow64
-        type: BOOLEAN
-        mode: NULLABLE
-      - name: client_count
-        type: INTEGER
-        mode: NULLABLE
-  - name: gfx0_vendor_name
-    type: RECORD
-    mode: REPEATED
-    fields:
-      - name: gfx0_vendor_id
-        type: STRING
-        mode: NULLABLE
-      - name: client_count
-        type: INTEGER
-        mode: NULLABLE
-  - name: gfx0_model
-    type: RECORD
-    mode: REPEATED
-    fields:
-      - name: gfx0_vendor_id
-        type: STRING
-        mode: NULLABLE
-      - name: gfx0_device_id
-        type: STRING
-        mode: NULLABLE
-      - name: client_count
-        type: INTEGER
-        mode: NULLABLE
+  - name: key
+    type: STRING
+    mode: NULLABLE
+- name: cpu_speed
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: value
+    type: FLOAT
+    mode: NULLABLE
+  - name: key
+    type: STRING
+    mode: NULLABLE
+- name: cpu_vendor
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: value
+    type: FLOAT
+    mode: NULLABLE
+  - name: key
+    type: STRING
+    mode: NULLABLE
+- name: gfx0_model
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: value
+    type: FLOAT
+    mode: NULLABLE
+  - name: key
+    type: STRING
+    mode: NULLABLE
+- name: gfx0_vendor_name
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: value
+    type: FLOAT
+    mode: NULLABLE
+  - name: key
+    type: STRING
+    mode: NULLABLE
+- name: has_flash
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: value
+    type: FLOAT
+    mode: NULLABLE
+  - name: key
+    type: BOOLEAN
+    mode: NULLABLE
+- name: memory_gb
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: value
+    type: FLOAT
+    mode: NULLABLE
+  - name: key
+    type: STRING
+    mode: NULLABLE
+- name: os
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: value
+    type: FLOAT
+    mode: NULLABLE
+  - name: key
+    type: STRING
+    mode: NULLABLE
+- name: os_arch
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: value
+    type: FLOAT
+    mode: NULLABLE
+  - name: key
+    type: STRING
+    mode: NULLABLE
+- name: resolution
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: value
+    type: FLOAT
+    mode: NULLABLE
+  - name: key
+    type: STRING
+    mode: NULLABLE


### PR DESCRIPTION
Follow up to https://github.com/mozilla/bigquery-etl/pull/5332 where I copied the wrong schema.  This schema is from the test table I was using.  Table needs to be deleted before redeploying since it's not compatible

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3420)
