### PR TITLE
Remove sqlglot workarounds which are no longer necessary

### DIFF
--- a/bigquery_etl/dependency.py
+++ b/bigquery_etl/dependency.py
@@ -39,10 +39,10 @@ def extract_table_references(sql: str) -> List[str]:
     if re.search(r"^\s*DECLARE\b", sql, flags=re.MULTILINE):
         return []
     # sqlglot parses UDFs with keyword names incorrectly:
-    # https://github.com/tobymao/sqlglot/issues/1535
+    # https://github.com/tobymao/sqlglot/issues/3332
     sql = re.sub(
-        r"\.(range|true|false|null)\(",
-        r".\1_(",
+        r"\.(true|false|null)\(",
+        r".`\1`(",
         sql,
         flags=re.IGNORECASE,
     )

--- a/bigquery_etl/dependency.py
+++ b/bigquery_etl/dependency.py
@@ -53,13 +53,6 @@ def extract_table_references(sql: str) -> List[str]:
         sql,
         flags=re.MULTILINE | re.IGNORECASE,
     )
-    # sqlglot doesn't fully support byte strings
-    sql = re.sub(
-        r"""b(["'])""",
-        r"\1",
-        sql,
-        flags=re.IGNORECASE,
-    )
     query = sqlglot.parse(sql, read="bigquery")
     creates = set()
     tables = set()

--- a/bigquery_etl/dependency.py
+++ b/bigquery_etl/dependency.py
@@ -46,13 +46,6 @@ def extract_table_references(sql: str) -> List[str]:
         sql,
         flags=re.IGNORECASE,
     )
-    # sqlglot doesn't suppport OPTIONS on UDFs
-    sql = re.sub(
-        r"""OPTIONS\s*\(("([^"]|\\")*"|'([^']|\\')*'|[^)])*\)""",
-        "",
-        sql,
-        flags=re.MULTILINE | re.IGNORECASE,
-    )
     query = sqlglot.parse(sql, read="bigquery")
     creates = set()
     tables = set()


### PR DESCRIPTION
What instigated this is the workaround for sqlglot not supporting byte strings causes parsing failures if the SQL contains a raw string that ends with `\b`, because it removes the `b` so the raw string ends with a backlash, which isn't valid.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3448)
