### PR TITLE
Removing modified at timestamp from all schemas

### DIFF
--- a/sql/moz-fx-data-shared-prod/braze_derived/newsletters_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/newsletters_v1/query.sql
@@ -8,8 +8,7 @@ SELECT
       create_timestamp,
       update_timestamp
     )
-  ) AS newsletters,
-  CURRENT_TIMESTAMP() AS last_modified_timestamp,
+  ) AS newsletters
 FROM
   `moz-fx-data-shared-prod.ctms_braze.ctms_newsletters`
 GROUP BY

--- a/sql/moz-fx-data-shared-prod/braze_derived/newsletters_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/newsletters_v1/schema.yaml
@@ -21,6 +21,3 @@ fields:
   mode: REPEATED
   name: newsletters
   type: RECORD
-- mode: NULLABLE
-  name: last_modified_timestamp
-  type: TIMESTAMP

--- a/sql/moz-fx-data-shared-prod/braze_derived/products_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/products_v1/query.sql
@@ -11,8 +11,7 @@ SELECT
       plan_interval_count,
       event_timestamp AS update_timestamp
     )
-  ) AS products,
-  CURRENT_TIMESTAMP() AS last_modified_timestamp,
+  ) AS products
 FROM
   `moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_v1`
 GROUP BY

--- a/sql/moz-fx-data-shared-prod/braze_derived/products_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/products_v1/schema.yaml
@@ -30,6 +30,3 @@ fields:
   mode: REPEATED
   name: products
   type: RECORD
-- mode: NULLABLE
-  name: last_modified_timestamp
-  type: TIMESTAMP

--- a/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/query.sql
@@ -3,8 +3,7 @@ SELECT
   unified.subscription_name AS subscription_name,
   map.firefox_subscription_id AS firefox_subscription_id,
   map.mozilla_subscription_id AS mozilla_subscription_id,
-  unified.subscription_state AS subscription_state,
-  CURRENT_TIMESTAMP() AS last_modified_timestamp,
+  unified.subscription_state AS subscription_state
 FROM
   (
   -- Combine newsletters and waitlists into a single set of records

--- a/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/schema.yaml
@@ -14,6 +14,3 @@ fields:
 - mode: NULLABLE
   name: subscription_state
   type: STRING
-- mode: NULLABLE
-  name: last_modified_timestamp
-  type: TIMESTAMP

--- a/sql/moz-fx-data-shared-prod/braze_derived/suppressions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/suppressions_v1/query.sql
@@ -22,7 +22,6 @@ WITH suppressions AS (
     has_opted_out_of_email = 1
 )
 SELECT
-  *,
-  CURRENT_TIMESTAMP() AS last_modified_timestamp
+  *
 FROM
   suppressions

--- a/sql/moz-fx-data-shared-prod/braze_derived/suppressions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/suppressions_v1/schema.yaml
@@ -5,6 +5,3 @@ fields:
 - mode: NULLABLE
   name: email_id
   type: STRING
-- mode: NULLABLE
-  name: last_modified_timestamp
-  type: TIMESTAMP

--- a/sql/moz-fx-data-shared-prod/braze_derived/user_profiles_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/user_profiles_v1/query.sql
@@ -13,8 +13,7 @@ SELECT
   u.first_service,
   n.newsletters,
   w.waitlists,
-  p.products,
-  CURRENT_TIMESTAMP() AS last_modified_timestamp,
+  p.products
 FROM
   `moz-fx-data-shared-prod.braze_derived.users_v1` u
 LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/braze_derived/user_profiles_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/user_profiles_v1/schema.yaml
@@ -110,6 +110,3 @@ fields:
   mode: REPEATED
   name: products
   type: RECORD
-- mode: NULLABLE
-  name: last_modified_timestamp
-  type: TIMESTAMP

--- a/sql/moz-fx-data-shared-prod/braze_derived/users_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/users_v1/query.sql
@@ -82,7 +82,6 @@ SELECT
   fxa_lang,
   first_service,
   create_timestamp,
-  update_timestamp,
-  CURRENT_TIMESTAMP() AS last_modified_timestamp,
+  update_timestamp
 FROM
   exclusions;

--- a/sql/moz-fx-data-shared-prod/braze_derived/users_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/users_v1/query.sql
@@ -13,7 +13,7 @@ WITH ctms_emails AS (
     END AS email_subscribe,
     e.basket_token,
     e.email_lang,
-    COALESCE(TO_HEX(SHA256(f.fxa_id)), TO_HEX(SHA256(fxa.fxa_id))) AS fxa_id_sha256,
+    TO_HEX(SHA256(f.fxa_id)) AS fxa_id_sha256,
     f.primary_email AS fxa_primary_email,
     f.lang AS fxa_lang,
     f.first_service,
@@ -24,9 +24,6 @@ WITH ctms_emails AS (
   LEFT JOIN
     `moz-fx-data-shared-prod.ctms_braze.ctms_fxa` f
     ON e.email_id = f.email_id
-  LEFT JOIN
-    `moz-fx-data-shared-prod.ctms.ctms_fxa` fxa
-    ON e.email_id = fxa.email_id
 ),
 exclusions AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/braze_derived/users_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/users_v1/schema.yaml
@@ -35,6 +35,3 @@ fields:
 - mode: NULLABLE
   name: first_service
   type: STRING
-- mode: NULLABLE
-  name: last_modified_timestamp
-  type: TIMESTAMP

--- a/sql/moz-fx-data-shared-prod/braze_derived/waitlists_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/waitlists_v1/query.sql
@@ -11,8 +11,7 @@ SELECT
       unsub_reason,
       update_timestamp
     )
-  ) AS waitlists,
-  CURRENT_TIMESTAMP() AS last_modified_timestamp,
+  ) AS waitlists
 FROM
   `moz-fx-data-shared-prod.ctms_braze.ctms_waitlists`
 GROUP BY

--- a/sql/moz-fx-data-shared-prod/braze_derived/waitlists_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/waitlists_v1/schema.yaml
@@ -30,6 +30,3 @@ fields:
   mode: REPEATED
   name: waitlists
   type: RECORD
-- mode: NULLABLE
-  name: last_modified_timestamp
-  type: TIMESTAMP


### PR DESCRIPTION
We're removing the modified timestamp because it's interfering with writing tests. We don't need it since these tables are refreshed daily and not partitioned. If/when that changes, we will add this metadata back in. We're also removing a ctms_fxa table from one of the joins in the users table that we no longer need. 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3456)
