### PR TITLE
adding connection user role for braze access

### DIFF
--- a/sql/moz-fx-data-shared-prod/braze_external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_external/dataset_metadata.yaml
@@ -13,3 +13,6 @@ workgroup_access:
   - role: roles/bigquery.dataEditor
     members:
       - workgroup:braze/writers
+  - role: roles/bigquery.connectionUser
+    members:
+      - workgroup:braze/ingestion-mozilla-dev


### PR DESCRIPTION
In order for [Braze's Cloud Data Ingestion](https://www.braze.com/docs/user_guide/data_and_analytics/cloud_ingestion/integrations/#step-1-set-up-tables-or-views) (CDI) tool to sync w/ BigQuery, the service account needs connection user permissions.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3459)
