### PR TITLE
Format braze_derived queries

### DIFF
--- a/sql/moz-fx-data-shared-prod/braze_derived/newsletters_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/newsletters_v1/query.sql
@@ -8,7 +8,10 @@ SELECT
       create_timestamp,
       update_timestamp
     )
-    ORDER BY update_timestamp, create_timestamp, name
+    ORDER BY
+      update_timestamp,
+      create_timestamp,
+      name
   ) AS newsletters
 FROM
   `moz-fx-data-shared-prod.ctms_braze.ctms_newsletters`

--- a/sql/moz-fx-data-shared-prod/braze_derived/products_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/products_v1/query.sql
@@ -11,7 +11,12 @@ SELECT
       plan_interval_count,
       event_timestamp AS update_timestamp
     )
-    ORDER BY event_timestamp, plan_started_at, plan_ended_at, plan_id, product_id
+    ORDER BY
+      event_timestamp,
+      plan_started_at,
+      plan_ended_at,
+      plan_id,
+      product_id
   ) AS products
 FROM
   `moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_v1`

--- a/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/query.sql
@@ -18,7 +18,6 @@ WITH unified AS (
   CROSS JOIN
     UNNEST(waitlists) AS waitlist
 )
-
 SELECT
   unified.external_id AS external_id,
   unified.subscription_name AS subscription_name,

--- a/sql/moz-fx-data-shared-prod/braze_derived/waitlists_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/waitlists_v1/query.sql
@@ -11,7 +11,10 @@ SELECT
       unsub_reason,
       update_timestamp
     )
-    ORDER BY update_timestamp, create_timestamp, name
+    ORDER BY
+      update_timestamp,
+      create_timestamp,
+      name
   ) AS waitlists
 FROM
   `moz-fx-data-shared-prod.ctms_braze.ctms_waitlists`


### PR DESCRIPTION
Follow-up to https://github.com/mozilla/bigquery-etl/pull/5394.  This is causing failed checks on other prs even though CI should only check changed files.

Ran `bqetl format sql/moz-fx-data-shared-prod/braze_derived/`

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3477)
