### PR TITLE
feat(bug-1887708): disable uniqueness check for retention_week_* tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_2_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_2_v1/checks.sql
@@ -1,5 +1,6 @@
 {#
--- Disabled for now due to known duplication issue in Fenix data, see: bug-1887708
+-- Disabled for now due to known duplication issue in Fenix data, see:
+-- https://bugzilla.mozilla.org/show_bug.cgi?id=1887708
 -- #warn
 -- {{ is_unique(["client_id"]) }}
 #}

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_2_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_2_v1/checks.sql
@@ -1,5 +1,8 @@
-#warn
-{{ is_unique(["client_id"]) }}
+{#
+-- Disabled for now due to known duplication issue in Fenix data, see: bug-1887708
+-- #warn
+-- {{ is_unique(["client_id"]) }}
+#}
 
 #warn
 {{ min_row_count(1, "submission_date = @submission_date") }}

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/checks.sql
@@ -1,5 +1,6 @@
 {#
--- Disabled for now due to known duplication issue in Fenix data, see: bug-1887708
+-- Disabled for now due to known duplication issue in Fenix data, see: 
+-- [bug-1887708](https://bugzilla.mozilla.org/show_bug.cgi?id=1887708)
 -- #warn
 -- {{ is_unique(["client_id"]) }}
 #}

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_clients_week_4_v1/checks.sql
@@ -1,5 +1,8 @@
-#warn
-{{ is_unique(["client_id"]) }}
+{#
+-- Disabled for now due to known duplication issue in Fenix data, see: bug-1887708
+-- #warn
+-- {{ is_unique(["client_id"]) }}
+#}
 
 #warn
 {{ min_row_count(1, "submission_date = @submission_date") }}


### PR DESCRIPTION
# feat(bug-1887708): disable uniqueness check for retention_week_* tables

This is an ongoing issue, and these tables should get replaced by tables developed in:

- https://github.com/mozilla/bigquery-etl/pull/5304

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3483)
