### PR TITLE
Revert clients_last_seen_joined date offset

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_attribution_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_attribution_v1/metadata.yaml
@@ -29,7 +29,6 @@ bigquery:
     field: submission_date
     require_partition_filter: true
     expiration_days: null
-    date_partition_offset: -1
   clustering:
     fields:
     - country

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_device_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_device_v1/metadata.yaml
@@ -21,7 +21,6 @@ bigquery:
     field: submission_date
     require_partition_filter: true
     expiration_days: null
-    date_partition_offset: -1
   clustering:
     fields:
     - country

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/metadata.yaml
@@ -22,7 +22,6 @@ bigquery:
     field: submission_date
     require_partition_filter: true
     expiration_days: null
-    date_partition_offset: -1
   clustering:
     fields:
     - country

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
@@ -14,7 +14,6 @@ labels:
 scheduling:
   dag_name: bqetl_analytics_aggregations
   date_partition_parameter: activity_date
-  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/metadata.yaml
@@ -11,7 +11,6 @@ labels:
   owner1: anicholson
 scheduling:
   dag_name: bqetl_newtab
-  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/metadata.yaml
@@ -12,7 +12,6 @@ labels:
   dag: bqetl_newtab
 scheduling:
   dag_name: bqetl_newtab
-  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v1/metadata.yaml
@@ -16,7 +16,6 @@ labels:
 scheduling:
   dag_name: bqetl_unified
   date_partition_parameter: cohort_date
-  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
@@ -15,7 +15,6 @@ bigquery:
     field: submission_date
     require_partition_filter: true
     expiration_days: null
-    date_partition_offset: -1
   clustering:
     fields:
     - normalized_channel

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/metadata.yaml
@@ -21,7 +21,6 @@ scheduling:
   - task_id: wait_for_unified_metrics
     dag_name: kpi_forecasting
     execution_delta: 1h
-  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
@@ -15,7 +15,6 @@ scheduling:
   dag_name: bqetl_glean_usage
   task_group: {{ app_name }}
   depends_on_past: true
-  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -14,7 +14,7 @@ metrics AS (
   WHERE
     -- The join between baseline and metrics pings is based on submission_date with a 1 day delay,
     -- since metrics pings usually arrive within 1 day after their logical activity period.
-    submission_date BETWEEN @submission_date AND DATE_ADD(@submission_date, INTERVAL 1 DAY)
+    submission_date = DATE_ADD(@submission_date, INTERVAL 1 DAY)
 )
 SELECT 
   baseline.client_id,


### PR DESCRIPTION
Reverts https://github.com/mozilla/bigquery-etl/pull/5344 and https://github.com/mozilla/bigquery-etl/pull/5357 due to causing duplicate client ids in downstream tables.  Tables will be backfilled and a proper solution will be figured out later

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3484)
