### PR TITLE
fixing the readme

### DIFF
--- a/sql/mozfun/google_ads/extract_segments_from_campaign_name/README.md
+++ b/sql/mozfun/google_ads/extract_segments_from_campaign_name/README.md
@@ -7,6 +7,6 @@ viewing the documentation at https://mozilla.github.io/bigquery-etl
 You can embed an SQL file into your README using the following
 syntax:
 
-@sql(../examples/fenix_app_info.sql)
+@sql(../../norm/examples/fenix_app_info.sql)
 -->
 


### PR DESCRIPTION
Fix #5393 
The boilerplate README does have problems with the path so the docs are failing in the CI
This is not a good fix .. there should be a README, but it will hopefull get the CI back to green.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3512)
