### PR TITLE
feat(DENG-3462): add activity fields to support KPI metrics to baseline_last_seen views

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen.view.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen.view.sql
@@ -1,5 +1,4 @@
 {{ header }}
-
 CREATE OR REPLACE VIEW
   `{{ project_id }}.{{ last_seen_view }}`
 AS
@@ -7,6 +6,28 @@ SELECT
   {% for ut in usage_types %}
     `moz-fx-data-shared-prod`.udf.pos_of_trailing_set_bit(days_{{ ut }}_bits) AS days_since_{{ ut }},
   {% endfor %}
-  *
+  *,
+  -- Activity fields to support metrics built on top of activity
+  CASE
+    WHEN BIT_COUNT(days_active_bits)
+        BETWEEN 1 AND 6
+            THEN 'infrequent_user'
+    WHEN BIT_COUNT(days_active_bits)
+        BETWEEN 7 AND 13
+            THEN 'casual_user'
+    WHEN BIT_COUNT(days_active_bits)
+        BETWEEN 14 AND 20
+            THEN 'regular_user'
+    WHEN BIT_COUNT(days_active_bits) >= 21
+        THEN 'core_user'
+    ELSE 'other'
+  END AS activity_segment,
+  IFNULL(mozfun.bits28.days_since_seen(days_active_bits) = 0, FALSE) AS is_dau,
+  IFNULL(mozfun.bits28.days_since_seen(days_active_bits) < 7, FALSE) AS is_wau,
+  IFNULL(mozfun.bits28.days_since_seen(days_active_bits) < 28, FALSE) AS is_mau,
+  -- Metrics based on pings sent
+  IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) = 0, FALSE) AS is_daily_user,
+  IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 7, FALSE) AS is_weekly_user,
+  IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 28, FALSE) AS is_monthly_user,
 FROM
   `{{ project_id }}.{{ last_seen_table }}`

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -1,6 +1,17 @@
 WITH baseline AS (
   SELECT
-    *
+    * EXCEPT(
+      -- These were added as part of https://mozilla-hub.atlassian.net/browse/DENG-3462
+      -- to enable KPI metric calculations. This exclusion is to avoid potential compatibility
+      -- issues downstream from this query.
+      activity_segment,
+      is_dau,
+      is_wau,
+      is_mau,
+      is_daily_user,
+      is_weekly_user,
+      is_monthly_user,
+    )
   FROM
     `{{ project_id }}.{{ app_name }}.baseline_clients_last_seen`
   WHERE

--- a/sql_generators/glean_usage/templates/cross_channel.view.sql
+++ b/sql_generators/glean_usage/templates/cross_channel.view.sql
@@ -7,11 +7,11 @@ AS
 UNION ALL
 {% endif -%}
 {% if app_name == "fenix" -%}
-SELECT 
+SELECT
     "{{ dataset }}" AS normalized_app_id,
     * REPLACE(mozfun.norm.fenix_app_info("{{ dataset }}", app_build).channel AS normalized_channel),
 {% else -%}
-SELECT 
+SELECT
     "{{ dataset }}" AS normalized_app_id,
     * REPLACE("{{ channel }}" AS normalized_channel)
 {% endif -%}


### PR DESCRIPTION
# feat(DENG-3462): add activity fields to support KPI metrics to `baseline_last_seen` views

This approach aims to add fields to enable us to calculate KPI metrics based on activity. The original proposal was to have a "main" view which would union all the tables and add these field (see: [Create telemetry.active_users view](https://github.com/mozilla/bigquery-etl/pull/5247) ).

This PR takes a slightly different approach and instead introduces those additional fields in the upstream view (baseline_clients_last_seen).

The following fields are being added to support our KPI metric calculations:

- `activity_segment` - categorise a client based on their activity "levels"
- `is_dau` - sent ping and considered active on current date
- `is_wau` - sent ping and considered active in the last 7 days
- `is_mau` - sent ping and considered active in the last 28 days
- `is_daily_user` - client a baseline sent ping on current date
- `is_weekly_user` - client a baseline sent ping in the 7 days
- `is_monthly_user` - client a baseline sent ping in the last 28 days

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3531)
