### PR TITLE
Use % formatting in logging instead of braces

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -935,7 +935,7 @@ def _run_query(
             logging.error(e)
             sys.exit(1)
         except FileNotFoundError:
-            logging.warning("No metadata.yaml found for {}", query_file)
+            logging.warning("No metadata.yaml found for %s", query_file)
 
         if not use_public_table and destination_table is not None:
             # destination table was parsed by argparse, however if it wasn't modified to

--- a/bigquery_etl/public_data/publish_json.py
+++ b/bigquery_etl/public_data/publish_json.py
@@ -79,7 +79,7 @@ class JsonPublisher:
             self.table = query_file_re.group(2)
             self.version = query_file_re.group(3)
         else:
-            logging.error("Invalid file naming format: {}", self.query_file)
+            logging.error("Invalid file naming format: %s", self.query_file)
             sys.exit(1)
 
     def _clear_stage_directory(self):

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -31,12 +31,12 @@ class TestEntrypoint:
                 b"+---+-----+\n| a |  b  |\n+---+-----+\n| 1 | abc |\n+---+-----+\n"
                 in result
             )
-            assert b"No metadata.yaml found for {}" in result
+            assert b"No metadata.yaml found for " in result
         except subprocess.CalledProcessError as e:
             # running bq in CircleCI will fail since it's not installed
             # but the error output can be checked for whether bq was called
             assert b"No such file or directory: 'bq'" in e.output
-            assert b"No metadata.yaml found for {}" in e.output
+            assert b"No metadata.yaml found for " in e.output
             assert (
                 b'subprocess.check_call(["bq"] + query_arguments, stdin=query_stream)'
                 in e.output
@@ -72,12 +72,12 @@ class TestEntrypoint:
                 b"+---+---+---+\n| a | b | c |\n+---+---+---+\n| a | b | c |\n+---+---+---+"
                 in result
             )
-            assert b"No metadata.yaml found for {}" in result
+            assert b"No metadata.yaml found for " in result
         except subprocess.CalledProcessError as e:
             # running bq in CircleCI will fail since it's not installed
             # but the error output can be checked for whether bq was called
             assert b"No such file or directory: 'bq'" in e.output
-            assert b"No metadata.yaml found for {}" in e.output
+            assert b"No metadata.yaml found for " in e.output
             assert (
                 b'subprocess.check_call(["bq"] + query_arguments, stdin=query_stream)'
                 in e.output
@@ -113,7 +113,7 @@ class TestEntrypoint:
                 stderr=subprocess.STDOUT,
             )
             assert b"Current status: DONE" in result
-            assert b"No metadata.yaml found for {}" in result
+            assert b"No metadata.yaml found for " in result
 
             result = bigquery_client.query(
                 f"SELECT a FROM {project_id}.{temporary_dataset}.query_v1"
@@ -123,7 +123,7 @@ class TestEntrypoint:
                 assert row.a == "foo"
         except subprocess.CalledProcessError as e:
             assert b"No such file or directory: 'bq'" in e.output
-            assert b"No metadata.yaml found for {}" in e.output
+            assert b"No metadata.yaml found for " in e.output
             assert (
                 b'subprocess.check_call(["bq"] + query_arguments, stdin=query_stream)'
                 in e.output


### PR DESCRIPTION
These logs will result in `TypeError: not all arguments converted during string formatting`.  This can be seen by renaming a metadata file and running the query through bqetl, e.g. `bqetl query run firefox_ios_derived.firefox_ios_clients_v1 --dry_run --nouse_legacy_sql --project_id=moz-fx-data-shared-prod`
It doesn't actually crash because the logger will catch it.  It does crash for unit tests though but I didn't look too deep into why.

The logger defaults to the `%` style formatting and not the `{}` https://docs.python.org/3/howto/logging-cookbook.html#use-of-alternative-formatting-styles
This can be changed by configuring a formatter and handler but it didn't seem worth it to me.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
