### PR TITLE
Revert "Store artifacts when `test-sql` CI job fails for troubleshooting"

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -178,12 +178,6 @@ jobs:
                 name: Run SQL tests
                 command: |
                     PATH="venv/bin:$PATH" script/entrypoint -m sql -n 8
-            - store_artifacts:
-                path: sql
-                when: on_fail
-            - store_artifacts:
-                path: tests
-                when: on_fail
       - unless:
           condition: *validate-sql-or-routines
           steps:


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#5451

It turns out the `when:` conditional parameter is only valid for `run` steps, so after #5451 it's actually always storing the artifacts, and I'd rather not increase the CI runtimes across the board (even by the ~1 minute this currently appears to take) just to help troubleshoot occasional test failures.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3569)
