### PR TITLE
bug(1891523): comment out uniqueness check for firefox_ios clients_activation due to upstream issue

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/checks.sql
@@ -1,5 +1,10 @@
+{#
+-- Commented out for now as due an upstream issue we're ending up with
+-- a small number of duplicates across channels causing this check to fail.
+-- The upstream issue is described in this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1887708
 #warn
 {{ is_unique(["client_id"]) }}
+#}
 
 #fail
 {{ min_row_count(1, "`submission_date` = @submission_date") }}


### PR DESCRIPTION
# bug(1891523): comment out uniqueness check for firefox_ios clients_activation due to upstream issue

This is where we end up with the same client_id showing in different channels in rare cases. Unioning the channels then results in duplication that we're observing.

As a temporary measure, commenting out this check to reduce task failure noise.

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3573)
