### PR TITLE
Restore init logic for `baseline_clients_last_seen_v1`

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.query.sql
@@ -1,5 +1,28 @@
 {{ header }}
 
+{% raw %}
+{% if is_init() %}
+{% endraw %}
+
+SELECT
+  CAST(NULL AS INT64) AS days_seen_bits,
+  CAST(NULL AS INT64) AS days_active_bits,
+  CAST(NULL AS INT64) AS days_created_profile_bits,
+  -- We make sure to delay * until the end so that as new columns are added
+  -- to the daily table we can add those columns in the same order to the end
+  -- of this schema, which may be necessary for the daily join query between
+  -- the two tables to validate.
+  *
+FROM
+  `{{ daily_table }}`
+WHERE
+  -- Output empty table and read no input rows
+  FALSE
+
+{% raw %}
+{% else %}
+{% endraw %}
+
 WITH _current AS (
   SELECT
     -- In this raw table, we capture the history of activity over the past
@@ -49,3 +72,7 @@ FROM
 FULL JOIN
   _previous
   USING (client_id)
+
+{% raw %}
+{% endif %}
+{% endraw %}


### PR DESCRIPTION
So it can be deployed to stage by CI.  The original init logic was removed in #5342.

This issue is currently blocking #5434 from passing CI checks.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3582)
