### PR TITLE
feat: add a debug log statement in case TypeError is raised while formating changed view

### DIFF
--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -282,12 +282,18 @@ class View:
             print(f"view {target_view_id} will change: does not exist in BigQuery")
             return True
 
-        expected_view_query = CREATE_VIEW_PATTERN.sub(
-            "", sqlparse.format(self.content, strip_comments=True), count=1
-        ).strip(";" + string.whitespace)
-        actual_view_query = sqlparse.format(
-            table.view_query, strip_comments=True
-        ).strip(";" + string.whitespace)
+        try:
+            expected_view_query = CREATE_VIEW_PATTERN.sub(
+                "", sqlparse.format(self.content, strip_comments=True), count=1
+            ).strip(";" + string.whitespace)
+
+            actual_view_query = sqlparse.format(
+                table.view_query, strip_comments=True
+            ).strip(";" + string.whitespace)
+        except TypeError as err:
+            print(f"ERROR: There has been an issue formating: {target_view_id}")
+            raise err
+
         if expected_view_query != actual_view_query:
             print(f"view {target_view_id} will change: query does not match")
             return True

--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -290,9 +290,9 @@ class View:
             actual_view_query = sqlparse.format(
                 table.view_query, strip_comments=True
             ).strip(";" + string.whitespace)
-        except TypeError as err:
+        except TypeError:
             print(f"ERROR: There has been an issue formating: {target_view_id}")
-            raise err
+            raise
 
         if expected_view_query != actual_view_query:
             print(f"view {target_view_id} will change: query does not match")


### PR DESCRIPTION
# feat: add a debug log statement in case TypeError is raised while formating changed view

This is to help us identifying the source of the following bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1894701

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3593)
