### PR TITLE
Store debug artifacs when CI jobs downstream of SQL generation fail

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -178,14 +178,22 @@ jobs:
                 name: Run SQL tests
                 command: |
                     PATH="venv/bin:$PATH" script/entrypoint -m sql -n 8
-            - run:
-                name: Copy generated SQL and tests to save for debugging
+            - &copy_debug_sql
+              run:
+                name: Copy generated SQL to save for debugging
                 command: |
                   mkdir -p /tmp/debug_artifacts
                   cp -r sql /tmp/debug_artifacts/sql
+                when: on_fail
+            - &copy_debug_tests
+              run:
+                name: Copy generated tests to save for debugging
+                command: |
+                  mkdir -p /tmp/debug_artifacts
                   cp -r tests /tmp/debug_artifacts/tests
                 when: on_fail
-            - store_artifacts:
+            - &store_debug_artifacts
+              store_artifacts:
                 path: /tmp/debug_artifacts
                 destination: /
       - unless:
@@ -232,6 +240,8 @@ jobs:
                   echo $PATHS
                   PATH="venv/bin:$PATH" script/bqetl dryrun --validate-schemas $PATHS
                 # yamllint enable rule:line-length
+            - *copy_debug_sql
+            - *store_debug_artifacts
       - unless:
           condition: *validate-sql-or-routines
           steps:
@@ -254,6 +264,8 @@ jobs:
                 name: Verify that backfill.yaml files are valid
                 command: |
                   PATH="venv/bin:$PATH" script/bqetl backfill validate
+            - *copy_debug_sql
+            - *store_debug_artifacts
       - unless:
           condition: *validate-sql
           steps:
@@ -277,6 +289,8 @@ jobs:
                   # TODO: Add check here to make sure all queries have metadata.yaml
                   PATH="venv/bin:$PATH" script/bqetl query validate \
                     --respect-dryrun-skip
+            - *copy_debug_sql
+            - *store_debug_artifacts
       - unless:
           condition: *validate-sql
           steps:
@@ -372,6 +386,15 @@ jobs:
                   python -m pytest tests/dags/test_dag_validity.py --junitxml=~/telemetry-airflow/test-results/junit.xml
             - store_test_results:
                 path: ~/telemetry-airflow/test-results/junit.xml
+            - &copy_debug_dags
+              run:
+                name: Copy generated DAGs to save for debugging
+                command: |
+                  mkdir -p /tmp/debug_artifacts
+                  cp -r dags /tmp/debug_artifacts/dags
+                when: on_fail
+            - *copy_debug_sql
+            - *store_debug_artifacts
       - unless:
           condition: *validate-sql
           steps:
@@ -399,6 +422,9 @@ jobs:
                 name: Validate doc examples
                 command: |
                   PATH="venv/bin:$PATH" script/bqetl routine validate --docs-only
+            - *copy_debug_sql
+            - *copy_debug_tests
+            - *store_debug_artifacts
       - unless:
           condition: *validate-routines
           steps:
@@ -420,6 +446,8 @@ jobs:
                 name: Validate views
                 command: |
                   PATH="venv/bin:$PATH" script/bqetl view validate
+            - *copy_debug_sql
+            - *store_debug_artifacts
       - unless:
           condition: *validate-sql-or-routines
           steps:
@@ -590,15 +618,8 @@ jobs:
                 root: /tmp/workspace
                 paths:
                   - staged-generated-sql
-            - run:
-                name: Copy generated SQL to save for debugging
-                command: |
-                  mkdir -p /tmp/debug_artifacts
-                  cp -r sql /tmp/debug_artifacts/sql
-                when: on_fail
-            - store_artifacts:
-                path: /tmp/debug_artifacts
-                destination: /
+            - *copy_debug_sql
+            - *store_debug_artifacts
       - unless:
           condition: *validate-sql-or-routines
           steps:


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3616)
