### PR TITLE
feat(DENG-3462): add baseline_clients_last_seen_extended_activity containing new activity fields to support KPI supporting metrics

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix/baseline_clients_last_seen_extended_activity/view.sql
+++ b/sql/moz-fx-data-shared-prod/fenix/baseline_clients_last_seen_extended_activity/view.sql
@@ -1,0 +1,50 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.fenix.baseline_clients_last_seen_extended_activity`
+AS
+-- This view is being added temporarily until issues preventing
+-- https://github.com/mozilla/bigquery-etl/pull/5434
+-- from merging have been resolved.
+SELECT
+  last_seen.*,
+  CASE
+    WHEN LOWER(isp) = 'browserstack'
+      THEN CONCAT("Fenix", ' ', isp)
+    WHEN LOWER(clients.distribution_id) = 'mozillaonline'
+      THEN CONCAT("Fenix", ' ', clients.distribution_id)
+    ELSE "Fenix"
+  END AS app_name,
+  -- Activity fields to support metrics built on top of activity
+  CASE
+    WHEN BIT_COUNT(days_active_bits)
+      BETWEEN 1
+      AND 6
+      THEN 'infrequent_user'
+    WHEN BIT_COUNT(days_active_bits)
+      BETWEEN 7
+      AND 13
+      THEN 'casual_user'
+    WHEN BIT_COUNT(days_active_bits)
+      BETWEEN 14
+      AND 20
+      THEN 'regular_user'
+    WHEN BIT_COUNT(days_active_bits) >= 21
+      THEN 'core_user'
+    ELSE 'other'
+  END AS activity_segment,
+  IFNULL(mozfun.bits28.days_since_seen(days_active_bits) = 0, FALSE) AS is_dau,
+  IFNULL(mozfun.bits28.days_since_seen(days_active_bits) < 7, FALSE) AS is_wau,
+  IFNULL(mozfun.bits28.days_since_seen(days_active_bits) < 28, FALSE) AS is_mau,
+  -- Metrics based on pings sent
+  IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) = 0, FALSE) AS is_daily_user,
+  IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 7, FALSE) AS is_weekly_user,
+  IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 28, FALSE) AS is_monthly_user,
+  (
+    LOWER(IFNULL(isp, "")) <> "browserstack"
+    AND LOWER(IFNULL(clients.distribution_id, "")) <> "mozillaonline"
+  ) AS is_mobile,  -- Indicates which records should be used for mobile KPI metric calculations.
+  FALSE AS is_desktop,
+FROM
+  `moz-fx-data-shared-prod.fenix.baseline_clients_last_seen` AS last_seen
+LEFT JOIN
+  `moz-fx-data-shared-prod.fenix.firefox_android_clients` AS clients
+  USING (client_id, first_seen_date)

--- a/sql/moz-fx-data-shared-prod/firefox_ios/baseline_clients_last_seen_extended_activity/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/baseline_clients_last_seen_extended_activity/view.sql
@@ -1,0 +1,44 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_ios.baseline_clients_last_seen_extended_activity`
+AS
+-- This view is being added temporarily until issues preventing
+-- https://github.com/mozilla/bigquery-etl/pull/5434
+-- from merging have been resolved.
+SELECT
+  last_seen.*,
+  CASE
+    WHEN LOWER(isp) = 'browserstack'
+      THEN CONCAT("Firefox iOS", ' ', isp)
+    ELSE "Firefox iOS"
+  END AS app_name,
+  -- Activity fields to support metrics built on top of activity
+  CASE
+    WHEN BIT_COUNT(days_active_bits)
+      BETWEEN 1
+      AND 6
+      THEN 'infrequent_user'
+    WHEN BIT_COUNT(days_active_bits)
+      BETWEEN 7
+      AND 13
+      THEN 'casual_user'
+    WHEN BIT_COUNT(days_active_bits)
+      BETWEEN 14
+      AND 20
+      THEN 'regular_user'
+    WHEN BIT_COUNT(days_active_bits) >= 21
+      THEN 'core_user'
+    ELSE 'other'
+  END AS activity_segment,
+  IFNULL(mozfun.bits28.days_since_seen(days_active_bits) = 0, FALSE) AS is_dau,
+  IFNULL(mozfun.bits28.days_since_seen(days_active_bits) < 7, FALSE) AS is_wau,
+  IFNULL(mozfun.bits28.days_since_seen(days_active_bits) < 28, FALSE) AS is_mau,
+  -- Metrics based on pings sent
+  IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) = 0, FALSE) AS is_daily_user,
+  IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 7, FALSE) AS is_weekly_user,
+  IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 28, FALSE) AS is_monthly_user,
+  (
+    LOWER(IFNULL(isp, "")) <> "browserstack"
+  ) AS is_mobile,  -- Indicates which records should be used for mobile KPI metric calculations.
+  FALSE AS is_desktop,
+FROM
+  `moz-fx-data-shared-prod.firefox_ios.baseline_clients_last_seen` AS last_seen


### PR DESCRIPTION
# feat(DENG-3462): add baseline_clients_last_seen_extended_activity containing new activity fields to support KPI supporting metrics

This view is a temporary solution until we can make all required changes to make this PR work:
https://github.com/mozilla/bigquery-etl/pull/5434

Which would add those fields to the `baseline_clients_last_seen` view directly.

The following fields are being added to support our KPI metric calculations:

- `app_name` - application name (based on application, isp and in Fenix case on distribution_id)
- `activity_segment` - categorise a client based on their activity "levels"
- `is_dau` - sent ping and considered active on current date
- `is_wau` - sent ping and considered active in the last 7 days
- `is_mau` - sent ping and considered active in the last 28 days
- `is_daily_user` - client a baseline sent ping on current date
- `is_weekly_user` - client a baseline sent ping in the 7 days
- `is_monthly_user` - client a baseline sent ping in the last 28 days
- `is_mobile` - indicates if the entry counts towards mobile DAU
- `is_desktop` - indicates if the entry counts towards desktop DAU
    is_desktop - indicates if the entry counts towards desktop DAU


---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3649)
