### PR TITLE
GLAM fix replace_dataset to account for fully qualified datasets in query

### DIFF
--- a/script/glam/run_glam_sql
+++ b/script/glam/run_glam_sql
@@ -39,7 +39,8 @@ SUBMISSION_DATE=${SUBMISSION_DATE:-$(yesterday)}
 # changing the dataset location for testing.
 function replace_dataset {
     local sql_path=$1
-    sed "s/$PROD_DATASET/$FULLY_QUALIFIED_DATASET/g" < "$sql_path"
+    local fully_qualified_dataset_bq=$(echo "$FULLY_QUALIFIED_DATASET" | sed 's/:/./g')
+    sed "s/\($DST_PROJECT.\)\?$PROD_DATASET/$fully_qualified_dataset_bq/g" < "$sql_path"
 }
 
 


### PR DESCRIPTION
`glam fog` dag is currently failing because this function is replacing a dataset string that's already in a fully qualified form. This also fixes a bug by replacing colons with dots, which is the right format for fully qualified datasets in SQL code.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3660)
