### PR TITLE
fix: correct firefox_ios and fenix retention views and queries

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios/retention_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios/retention_clients/view.sql
@@ -6,6 +6,7 @@ WITH clients_last_seen AS (
     submission_date,
     client_id,
     sample_id,
+    app_name,
     normalized_channel,
     mozfun.bits28.retention(days_seen_bits, submission_date) AS retention_seen,
     mozfun.bits28.retention(days_active_bits & days_seen_bits, submission_date) AS retention_active,
@@ -23,7 +24,7 @@ attribution AS (
     adjust_campaign,
     adjust_creative,
     adjust_network,
-    is_suspicious_device_profile,
+    is_suspicious_device_client,
   FROM
     `moz-fx-data-shared-prod.firefox_ios_derived.firefox_ios_clients_v1`
 )
@@ -39,7 +40,7 @@ SELECT
   clients_daily.app_display_version AS app_version,
   clients_daily.locale,
   clients_daily.isp,
-  attribution.is_suspicious_device_profile,
+  attribution.is_suspicious_device_client,
   -- ping sent retention
   clients_last_seen.retention_seen.day_27.active_on_metric_date AS ping_sent_metric_date,
   (
@@ -89,6 +90,7 @@ INNER JOIN
   AND clients_daily.normalized_channel = clients_last_seen.normalized_channel
 LEFT JOIN
   attribution
-  USING (client_id, normalized_channel)
+  ON clients_daily.client_id = attribution.client_id
+  AND clients_daily.normalized_channel = attribution.normalized_channel
 WHERE
   clients_last_seen.retention_seen.day_27.active_on_metric_date

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/metadata.yaml
@@ -12,7 +12,7 @@ description: |
   - adjust_campaign
   - adjust_creative
   - adjust_network
-  - is_suspicious_device_profile
+  - is_suspicious_device_client
 
   For all profiles that sent us a ping on the metric date.
   Profiles's attributes are the attribute values observed on the metric date.

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/query.sql
@@ -10,7 +10,7 @@ SELECT
   adjust_campaign,
   adjust_creative,
   adjust_network,
-  is_suspicious_device_profile,
+  is_suspicious_device_client,
   COUNTIF(ping_sent_metric_date) AS ping_sent_metric_date,
   COUNTIF(ping_sent_week_4) AS ping_sent_week_4,
   COUNTIF(active_metric_date) AS active_metric_date,
@@ -35,4 +35,4 @@ GROUP BY
   adjust_campaign,
   adjust_creative,
   adjust_network,
-  is_suspicious_device_profile
+  is_suspicious_device_client

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/schema.yaml
@@ -55,7 +55,7 @@ fields:
   mode: NULLABLE
   description: Adjust Network the profile is attributed to.
 
-- name: is_suspicious_device_profile
+- name: is_suspicious_device_client
   type: STRING
   mode: NULLABLE
   description: Flag to identify suspicious device users, see bug-1846554 for more info.


### PR DESCRIPTION
fix: correct firefox_ios and fenix retention views and queries

There is a mistake in the retention queries causing the SQL validation to fail. These changes make the SQL valid.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3672)
