### PR TITLE
fix(glam) standardize project_id in templates 

### DIFF
--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_beta__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_beta__view_clients_daily_histogram_aggregates_v1.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.firefox_desktop_glam_beta__view_clients_daily_histogram_aggregates_v1
+  `{{ project }}.glam_etl.firefox_desktop_glam_beta__view_clients_daily_histogram_aggregates_v1`
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_histogram_aggregates_v1
+    `{{ project }}.glam_etl.firefox_desktop__view_clients_daily_histogram_aggregates_v1`
   WHERE
     channel = 'beta'
     AND SAFE.PARSE_DATETIME('%Y%m%d%H%M%S', app_build_id) IS NOT NULL

--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_beta__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_beta__view_clients_daily_scalar_aggregates_v1.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.firefox_desktop_glam_beta__view_clients_daily_scalar_aggregates_v1
+  `{{ project }}.glam_etl.firefox_desktop_glam_beta__view_clients_daily_scalar_aggregates_v1`
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_scalar_aggregates_v1
+    `{{ project }}.glam_etl.firefox_desktop__view_clients_daily_scalar_aggregates_v1`
   WHERE
     channel = 'beta'
     AND SAFE.PARSE_DATETIME('%Y%m%d%H%M%S', app_build_id) IS NOT NULL

--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.firefox_desktop_glam_nightly__view_clients_daily_histogram_aggregates_v1
+  `{{ project }}.glam_etl.firefox_desktop_glam_nightly__view_clients_daily_histogram_aggregates_v1`
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_histogram_aggregates_v1
+    `{{ project }}.glam_etl.firefox_desktop__view_clients_daily_histogram_aggregates_v1`
   WHERE
     channel = 'nightly'
     AND SAFE.PARSE_DATETIME('%Y%m%d%H%M%S', app_build_id) IS NOT NULL

--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.firefox_desktop_glam_nightly__view_clients_daily_scalar_aggregates_v1
+  `{{ project }}.glam_etl.firefox_desktop_glam_nightly__view_clients_daily_scalar_aggregates_v1`
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_scalar_aggregates_v1
+    `{{ project }}.glam_etl.firefox_desktop__view_clients_daily_scalar_aggregates_v1`
   WHERE
     channel = 'nightly'
     AND SAFE.PARSE_DATETIME('%Y%m%d%H%M%S', app_build_id) IS NOT NULL

--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_release__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_release__view_clients_daily_histogram_aggregates_v1.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.firefox_desktop_glam_release__view_clients_daily_histogram_aggregates_v1
+  `{{ project }}.glam_etl.firefox_desktop_glam_release__view_clients_daily_histogram_aggregates_v1`
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_histogram_aggregates_v1
+    `{{ project }}.glam_etl.firefox_desktop__view_clients_daily_histogram_aggregates_v1`
   WHERE
     channel = 'release'
     AND SAFE.PARSE_DATETIME('%Y%m%d%H%M%S', app_build_id) IS NOT NULL

--- a/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_release__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/firefox_desktop_glam_release__view_clients_daily_scalar_aggregates_v1.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.firefox_desktop_glam_release__view_clients_daily_scalar_aggregates_v1
+  {{ project }}.glam_etl.firefox_desktop_glam_release__view_clients_daily_scalar_aggregates_v1
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.firefox_desktop__view_clients_daily_scalar_aggregates_v1
+    `{{ project }}.glam_etl.firefox_desktop__view_clients_daily_scalar_aggregates_v1`
   WHERE
     channel = 'release'
     AND SAFE.PARSE_DATETIME('%Y%m%d%H%M%S', app_build_id) IS NOT NULL

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_histogram_aggregates_v1.sql
@@ -1,18 +1,18 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.org_mozilla_fenix_glam_beta__view_clients_daily_histogram_aggregates_v1
+  `{{ project }}.glam_etl.org_mozilla_fenix_glam_beta__view_clients_daily_histogram_aggregates_v1`
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_fenix__view_clients_daily_histogram_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_fenix__view_clients_daily_histogram_aggregates_v1`
   WHERE
     mozfun.norm.fenix_app_info('org_mozilla_fenix', app_build_id).channel = 'beta'
   UNION ALL
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_firefox_beta__view_clients_daily_histogram_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_firefox_beta__view_clients_daily_histogram_aggregates_v1`
 )
 SELECT
   * EXCEPT (app_build_id, channel),

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_beta__view_clients_daily_scalar_aggregates_v1.sql
@@ -1,18 +1,18 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.org_mozilla_fenix_glam_beta__view_clients_daily_scalar_aggregates_v1
+  `{{ project }}.glam_etl.org_mozilla_fenix_glam_beta__view_clients_daily_scalar_aggregates_v1`
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_fenix__view_clients_daily_scalar_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_fenix__view_clients_daily_scalar_aggregates_v1`
   WHERE
     mozfun.norm.fenix_app_info('org_mozilla_fenix', app_build_id).channel = 'beta'
   UNION ALL
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_firefox_beta__view_clients_daily_scalar_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_firefox_beta__view_clients_daily_scalar_aggregates_v1`
 )
 SELECT
   * EXCEPT (app_build_id, channel),

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1.sql
@@ -1,23 +1,23 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1
+  `{{ project }}.glam_etl.org_mozilla_fenix_glam_nightly__view_clients_daily_histogram_aggregates_v1`
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_fenix__view_clients_daily_histogram_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_fenix__view_clients_daily_histogram_aggregates_v1`
   WHERE
     mozfun.norm.fenix_app_info('org_mozilla_fenix', app_build_id).channel = 'nightly'
   UNION ALL
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_fenix_nightly__view_clients_daily_histogram_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_fenix_nightly__view_clients_daily_histogram_aggregates_v1`
   UNION ALL
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_histogram_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_histogram_aggregates_v1`
 ),
 with_app_build_id AS (
   SELECT

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1.sql
@@ -1,23 +1,23 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1
+  `{{ project }}.glam_etl.org_mozilla_fenix_glam_nightly__view_clients_daily_scalar_aggregates_v1`
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_fenix__view_clients_daily_scalar_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_fenix__view_clients_daily_scalar_aggregates_v1`
   WHERE
     mozfun.norm.fenix_app_info('org_mozilla_fenix', app_build_id).channel = 'nightly'
   UNION ALL
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_fenix_nightly__view_clients_daily_scalar_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_fenix_nightly__view_clients_daily_scalar_aggregates_v1`
   UNION ALL
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_scalar_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_fennec_aurora__view_clients_daily_scalar_aggregates_v1`
 ),
 with_app_build_id AS (
   SELECT

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_release__view_clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_release__view_clients_daily_histogram_aggregates_v1.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.org_mozilla_fenix_glam_release__view_clients_daily_histogram_aggregates_v1
+  `{{ project }}.glam_etl.org_mozilla_fenix_glam_release__view_clients_daily_histogram_aggregates_v1`
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_firefox__view_clients_daily_histogram_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_firefox__view_clients_daily_histogram_aggregates_v1`
 )
 SELECT
   * EXCEPT (app_build_id, channel),

--- a/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_release__view_clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/logical_app_id/org_mozilla_fenix_glam_release__view_clients_daily_scalar_aggregates_v1.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE VIEW
-  `{{ project }}`.glam_etl.org_mozilla_fenix_glam_release__view_clients_daily_scalar_aggregates_v1
+  `{{ project }}.glam_etl.org_mozilla_fenix_glam_release__view_clients_daily_scalar_aggregates_v1`
 AS
 WITH extracted AS (
   SELECT
     *
   FROM
-    `{{ project }}`.glam_etl.org_mozilla_firefox__view_clients_daily_scalar_aggregates_v1
+    `{{ project }}.glam_etl.org_mozilla_firefox__view_clients_daily_scalar_aggregates_v1`
 )
 SELECT
   * EXCEPT (app_build_id, channel),

--- a/bigquery_etl/glam/templates/view_user_counts_v1.sql
+++ b/bigquery_etl/glam/templates/view_user_counts_v1.sql
@@ -9,14 +9,14 @@ WITH all_clients AS (
   SELECT
     client_id,
     {{ attributes }}
-  FROM `{{ project }}`.{{ dataset }}.{{ prefix }}__clients_scalar_aggregates_v1
-  
+  FROM `{{ project }}.{{ dataset }}.{{ prefix }}__clients_scalar_aggregates_v1`
+
   UNION ALL
-  
+
   SELECT
     client_id,
     {{ attributes }}
-  FROM `{{ project }}`.{{ dataset }}.{{ prefix }}__clients_histogram_aggregates_v1
+  FROM `{{ project }}.{{ dataset }}.{{ prefix }}__clients_histogram_aggregates_v1`
 ),
 {{
     enumerate_table_combinations(


### PR DESCRIPTION
Removes backticks after `project_id` (which prevents the string replacement done in https://github.com/mozilla/bigquery-etl/pull/5517 from working fully) and adds them at the end of the fully qualified table name instead.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3681)
