### PR TITLE
[Bug 1892284] Run events_stream_v1 queries in moz-fx-data-backfill-2

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -870,12 +870,6 @@ def _run_query(
     billing_project is the project to run the query in for the purposes of billing and
     slot reservation selection.  This is project_id if billing_project is not set
     """
-    # if billing_project is set, default dataset is set with the @@dataset_id variable instead
-    if dataset_id is not None and billing_project is None:
-        # dataset ID was parsed by argparse but needs to be passed as parameter
-        # when running the query
-        query_arguments.append(f"--dataset_id={dataset_id}")
-
     if billing_project is not None:
         query_arguments.append(f"--project_id={billing_project}")
     elif project_id is not None:
@@ -962,6 +956,11 @@ def _run_query(
                 default_dataset=dataset_id or default_dataset,
             )
             query_arguments.append(f"--session_id={session_id}")
+        # if billing_project is set, default dataset is set with the @@dataset_id variable instead
+        elif dataset_id is not None:
+            # dataset ID was parsed by argparse but needs to be passed as parameter
+            # when running the query
+            query_arguments.append(f"--dataset_id={dataset_id}")
 
         # write rendered query to a temporary file;
         # query string cannot be passed directly to bq as SQL comments will be interpreted as CLI arguments

--- a/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
@@ -14,6 +14,8 @@ labels:
 scheduling:
   dag_name: bqetl_glean_usage
   task_group: {{ app_name }}
+  # Use backfill-2 project for on-demand query billing
+  arguments: ["--billing-project", "moz-fx-data-backfill-2"]
 bigquery:
   time_partitioning:
     type: day

--- a/tests/test_run_query.py
+++ b/tests/test_run_query.py
@@ -37,8 +37,8 @@ class TestRunQuery:
                 [
                     "bq",
                     "query",
-                    "--dataset_id=test",
                     "--destination_table=query_v1",
+                    "--dataset_id=test",
                 ],
             )
             assert "stdin" in mock_call.call_args.kwargs
@@ -76,8 +76,8 @@ class TestRunQuery:
                 [
                     "bq",
                     "query",
-                    "--dataset_id=test",
                     "--destination_table=mozdata:test.query_v1",
+                    "--dataset_id=test",
                 ],
             )
             assert "stdin" in mock_call.call_args.kwargs
@@ -112,8 +112,8 @@ class TestRunQuery:
                 [
                     "bq",
                     "query",
-                    "--dataset_id=test",
                     "--destination_table=mozilla-public-data:test.query_v1",
+                    "--dataset_id=test",
                 ],
             )
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1892284

This makes all the events_stream_v1 queries run in `moz-fx-data-backfill-2` instead of shared prod because the desktop query uses a lot of compute time and relatively low bytes scanned.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3704)
