### PR TITLE
Remove billing project from events_stream (reverts #5543)

### DIFF
--- a/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
@@ -14,8 +14,6 @@ labels:
 scheduling:
   dag_name: bqetl_glean_usage
   task_group: {{ app_name }}
-  # Use backfill-2 project for on-demand query billing
-  arguments: ["--billing-project", "moz-fx-data-backfill-2"]
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
Partially reverts https://github.com/mozilla/bigquery-etl/pull/5543.  I found a bug with the destination table setting so reverting before the next run and I can fix it tomorrow

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3707)
