### PR TITLE
Add project and dataset to destination table if billing project is set

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -925,6 +925,15 @@ def _run_query(
                     destination_table
                 )
                 destination_table = "{}:{}.{}".format(project, dataset, table)
+            elif billing_project is not None:
+                # add project and dataset to destination table if it isn't qualified
+                if project_id is None or dataset_id is None:
+                    raise ValueError(
+                        "Cannot determine destination table without project_id and dataset_id"
+                    )
+                destination_table = "{}:{}.{}".format(
+                    project_id, dataset_id, destination_table
+                )
 
             query_arguments.append("--destination_table={}".format(destination_table))
 

--- a/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
@@ -14,6 +14,8 @@ labels:
 scheduling:
   dag_name: bqetl_glean_usage
   task_group: {{ app_name }}
+  # Use backfill-2 project for on-demand query billing
+  arguments: ["--billing-project", "moz-fx-data-backfill-2"]
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
The generated airflow dags use just the table name in `destination_table` which I forgot to test because backfill and init use the full table id

Tested this with `bqetl query run ... --billing-project moz-fx-data-backfill-2 --project_id moz-fx-data-shared-prod --destination_table benwu_dest_test --dataset_id analysis`

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3711)
