### PR TITLE
Fix mobile suggest in event_aggregates_suggest

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
@@ -101,25 +101,23 @@ combined AS (
   SELECT
     metrics.uuid.fx_suggest_context_id AS context_id,
     DATE(submission_timestamp) AS submission_date,
-    'suggest' AS source,
-    IF(
-      metrics.string.fx_suggest_ping_type = "fxsuggest-click",
-      "click",
-      "impression"
-    ) AS event_type,
     'phone' AS form_factor,
     normalized_country_code AS country,
-    metadata.geo.subdivision1 AS subdivision1,
     metrics.string.fx_suggest_advertiser AS advertiser,
+    SPLIT(metadata.user_agent.os, ' ')[SAFE_OFFSET(0)] AS normalized_os,
     client_info.app_channel AS release_channel,
     metrics.quantity.fx_suggest_position AS position,
     -- Only remote settings is in use on mobile
     'remote settings' AS provider,
     -- Only standard suggestions are in use on mobile
     'firefox-suggest' AS match_type,
-    SPLIT(metadata.user_agent.os, ' ')[SAFE_OFFSET(0)] AS normalized_os,
     -- This is the opt-in for Merino, not in use on mobile
     CAST(NULL AS BOOLEAN) AS suggest_data_sharing_enabled,
+    IF(
+      metrics.string.fx_suggest_ping_type = "fxsuggest-click",
+      "click",
+      "impression"
+    ) AS event_type,
     blocks.query_type,
   FROM
     `moz-fx-data-shared-prod.fenix.fx_suggest` fs
@@ -133,25 +131,23 @@ combined AS (
   SELECT
     metrics.uuid.fx_suggest_context_id AS context_id,
     DATE(submission_timestamp) AS submission_date,
-    'suggest' AS source,
-    IF(
-      metrics.string.fx_suggest_ping_type = "fxsuggest-click",
-      "click",
-      "impression"
-    ) AS event_type,
     'phone' AS form_factor,
     normalized_country_code AS country,
-    metadata.geo.subdivision1 AS subdivision1,
     metrics.string.fx_suggest_advertiser AS advertiser,
+    SPLIT(metadata.user_agent.os, ' ')[SAFE_OFFSET(0)] AS normalized_os,
     client_info.app_channel AS release_channel,
     metrics.quantity.fx_suggest_position AS position,
     -- Only remote settings is in use on mobile
     'remote settings' AS provider,
     -- Only standard suggestions are in use on mobile
     'firefox-suggest' AS match_type,
-    SPLIT(metadata.user_agent.os, ' ')[SAFE_OFFSET(0)] AS normalized_os,
     -- This is the opt-in for Merino, not in use on mobile
     CAST(NULL AS BOOLEAN) AS suggest_data_sharing_enabled,
+    IF(
+      metrics.string.fx_suggest_ping_type = "fxsuggest-click",
+      "click",
+      "impression"
+    ) AS event_type,
     blocks.query_type,
   FROM
     `moz-fx-data-shared-prod.firefox_ios.fx_suggest` fs


### PR DESCRIPTION
I copied this part of the query from `event_aggregates_v1` without realizing that `event_aggregates_suggest_v1` has slightly different columns, so this PR fixes that.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3734)
