### PR TITLE
feat: add additional firefox android queries to simulate a data lineage/flow

### DIFF
--- a/sql/data-observability-dev/fenix/firefox_android_aggregates/view.sql
+++ b/sql/data-observability-dev/fenix/firefox_android_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `data-observability-dev.fenix.firefox_android_aggregates`
+AS
+SELECT
+  *
+FROM
+  `data-observability-dev.fenix_derived.firefox_android_aggregates_v1`

--- a/sql/data-observability-dev/fenix/firefox_android_anonymised/view.sql
+++ b/sql/data-observability-dev/fenix/firefox_android_anonymised/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `data-observability-dev.fenix.firefox_android_anonymised`
+AS
+SELECT
+  *
+FROM
+  `data-observability-dev.fenix_derived.firefox_android_anonymised_v1`

--- a/sql/data-observability-dev/fenix_derived/firefox_android_aggregates_v1/metadata.yaml
+++ b/sql/data-observability-dev/fenix_derived/firefox_android_aggregates_v1/metadata.yaml
@@ -1,0 +1,26 @@
+friendly_name: Firefox Android Aggregates
+description: |-
+  [Missing]
+owners:
+- kik@mozilla.com
+labels:
+  application: firefox_android
+  incremental: false
+  schedule: daily
+scheduling:
+  dag_name: bqetl_data_observability_test_data_copy
+  depends_on_past: true
+  date_partition_parameter: null
+  parameters:
+  - submission_date:DATE:{{ds}}
+bigquery:
+  time_partitioning:
+    type: day
+    field: first_seen_date
+    require_partition_filter: false
+    expiration_days: null
+  clustering:
+    fields:
+    - channel
+    - first_reported_country
+references: {}

--- a/sql/data-observability-dev/fenix_derived/firefox_android_aggregates_v1/query.sql
+++ b/sql/data-observability-dev/fenix_derived/firefox_android_aggregates_v1/query.sql
@@ -1,0 +1,17 @@
+SELECT
+  first_seen_date,
+  channel,
+  first_reported_country,
+  install_source,
+  distribution_id,
+  COUNT(*) AS client_count,
+FROM
+  `data-observability-dev.fenix_derived.firefox_android_clients`
+WHERE
+  submission_date = @submission_date
+GROUP BY
+  first_seen_date,
+  channel,
+  first_reported_country,
+  install_source,
+  distribution_id

--- a/sql/data-observability-dev/fenix_derived/firefox_android_aggregates_v1/schema.yaml
+++ b/sql/data-observability-dev/fenix_derived/firefox_android_aggregates_v1/schema.yaml
@@ -1,0 +1,25 @@
+fields:
+- description: Date when the app first reported a baseline ping for the client.
+  mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+- description: First reported country for the client installation
+  mode: NULLABLE
+  name: first_reported_country
+  type: STRING
+- description: Channel where the browser is released.
+  mode: NULLABLE
+  name: channel
+  type: STRING
+- description:
+  mode: NULLABLE
+  name: install_source
+  type: STRING
+- description:
+  mode: NULLABLE
+  name: distribution_id
+  type: STRING
+- description:
+  mode: NULLABLE
+  name: client_count
+  type: INTEGER

--- a/sql/data-observability-dev/fenix_derived/firefox_android_anonymised_v1/metadata.yaml
+++ b/sql/data-observability-dev/fenix_derived/firefox_android_anonymised_v1/metadata.yaml
@@ -1,0 +1,26 @@
+friendly_name: Firefox Android Anonymised
+description: |-
+  [Missing]
+owners:
+- kik@mozilla.com
+labels:
+  application: firefox_android
+  incremental: false
+  schedule: daily
+scheduling:
+  dag_name: bqetl_data_observability_test_data_copy
+  depends_on_past: true
+  date_partition_parameter: null
+  parameters:
+  - submission_date:DATE:{{ds}}
+bigquery:
+  time_partitioning:
+    type: day
+    field: first_seen_date
+    require_partition_filter: false
+    expiration_days: null
+  clustering:
+    fields:
+    - channel
+    - first_reported_country
+references: {}

--- a/sql/data-observability-dev/fenix_derived/firefox_android_anonymised_v1/query.sql
+++ b/sql/data-observability-dev/fenix_derived/firefox_android_anonymised_v1/query.sql
@@ -1,0 +1,9 @@
+SELECT
+  SHA256(client_id) AS client_id_hashed,
+  first_seen_date,
+  channel,
+  ASCII(SHA256(client_id)) AS funky_column,
+FROM
+  `data-observability-dev.fenix_derived.firefox_android_clients`
+WHERE
+  submission_date = @submission_date

--- a/sql/data-observability-dev/fenix_derived/firefox_android_anonymised_v1/schema.yaml
+++ b/sql/data-observability-dev/fenix_derived/firefox_android_anonymised_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- description: Date when the app first reported a baseline ping for the client.
+  mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+- description: First reported country for the client installation
+  mode: NULLABLE
+  name: first_reported_country
+  type: STRING
+- description: Channel where the browser is released.
+  mode: NULLABLE
+  name: channel
+  type: STRING
+- description:
+  mode: NULLABLE
+  name: funky_column
+  type: STRING

--- a/sql/data-observability-dev/telemetry/firefox_aggregates/view.sql
+++ b/sql/data-observability-dev/telemetry/firefox_aggregates/view.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE VIEW
+  `data-observability-dev.telemetry.firefox_aggregates`
+AS
+SELECT
+  first_seen_date,
+  channel,
+  first_reported_country,
+  SUM(client_count) AS client_count,
+FROM
+  `data-observability-dev.telemetry_derived.firefox_aggregates_v1`
+GROUP BY
+  first_seen_date,
+  channel,
+  first_reported_country

--- a/sql/data-observability-dev/telemetry_derived/firefox_aggregates_v1/metadata.yaml
+++ b/sql/data-observability-dev/telemetry_derived/firefox_aggregates_v1/metadata.yaml
@@ -1,0 +1,26 @@
+friendly_name: Firefox Aggregates
+description: |-
+  [Missing]
+owners:
+- kik@mozilla.com
+labels:
+  application: firefox
+  incremental: false
+  schedule: daily
+scheduling:
+  dag_name: bqetl_data_observability_test_data_copy
+  depends_on_past: true
+  date_partition_parameter: null
+  parameters:
+  - submission_date:DATE:{{ds}}
+bigquery:
+  time_partitioning:
+    type: day
+    field: first_seen_date
+    require_partition_filter: false
+    expiration_days: null
+  clustering:
+    fields:
+    - channel
+    - first_reported_country
+references: {}

--- a/sql/data-observability-dev/telemetry_derived/firefox_aggregates_v1/query.sql
+++ b/sql/data-observability-dev/telemetry_derived/firefox_aggregates_v1/query.sql
@@ -1,0 +1,13 @@
+SELECT
+  first_seen_date,
+  channel,
+  first_reported_country,
+  SUM(client_count) AS client_count,
+FROM
+  `data-observability-dev.fenix.firefox_android_aggregates`
+WHERE
+  submission_date = @submission_date
+GROUP BY
+  first_seen_date,
+  channel,
+  first_reported_country

--- a/sql/data-observability-dev/telemetry_derived/firefox_aggregates_v1/schema.yaml
+++ b/sql/data-observability-dev/telemetry_derived/firefox_aggregates_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- description: Date when the app first reported a baseline ping for the client.
+  mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+- description: First reported country for the client installation
+  mode: NULLABLE
+  name: first_reported_country
+  type: STRING
+- description: Channel where the browser is released.
+  mode: NULLABLE
+  name: channel
+  type: STRING
+- description:
+  mode: NULLABLE
+  name: client_count
+  type: INTEGER


### PR DESCRIPTION
# feat: add additional firefox android queries to simulate a data lineage/flow

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3737)
