### PR TITLE
Update is_weekly_user to use days_seen_bits instead of days_active_bits

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen_v2/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen_v2/view.sql
@@ -35,7 +35,7 @@ WITH days_since AS (
     IFNULL(mozfun.bits28.days_since_seen(cls.days_active_bits) < 7, FALSE) AS is_wau,
     IFNULL(mozfun.bits28.days_since_seen(cls.days_active_bits) < 28, FALSE) AS is_mau,
     IFNULL(mozfun.bits28.days_since_seen(cls.days_seen_bits) = 0, FALSE) AS is_daily_user,
-    IFNULL(mozfun.bits28.days_since_seen(cls.days_active_bits) < 7, FALSE) AS is_weekly_user,
+    IFNULL(mozfun.bits28.days_since_seen(cls.days_seen_bits) < 7, FALSE) AS is_weekly_user,
     IFNULL(mozfun.bits28.days_since_seen(cls.days_seen_bits) < 28, FALSE) AS is_monthly_user,
     IF(
       LOWER(IFNULL(cls.isp_name, '')) <> "browserstack"


### PR DESCRIPTION
This PR fixes the definition of `is_weekly_user` is to use days_seen_bits.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3739)
