### PR TITLE
[DENG-3335] Set project in experiments shredder config

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -647,7 +647,7 @@ def find_experiment_analysis_targets(
     ]
 
     return {
-        client_id_target(table=qualified_table_id(table)): DESKTOP_SRC
+        client_id_target(table=qualified_table_id(table), project=project): DESKTOP_SRC
         for table in tables
     }
 

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -39,10 +39,11 @@ parser.add_argument(
     default="telemetry",
     const="telemetry",
     nargs="?",
-    choices=["telemetry", "pioneer"],
-    help="environment to run in (dictates the choice of source and target tables):"
-    "telemetry - standard environment"
-    "pioneer - restricted pioneer environment",
+    choices=["telemetry", "pioneer", "experiments"],
+    help="environment to run in (dictates the choice of source and target tables): "
+    "telemetry - standard environment, "
+    "pioneer - restricted pioneer environment, "
+    "experiments - experiment analysis tables",
 )
 parser.add_argument(
     "--pioneer-study-projects",
@@ -483,12 +484,15 @@ def main():
     if args.environment == "telemetry":
         with ThreadPool(args.parallelism) as pool:
             glean_targets = find_glean_targets(pool, client)
-            experiment_analysis_targets = find_experiment_analysis_targets(pool, client)
         targets_with_sources = chain(
             DELETE_TARGETS.items(),
             glean_targets.items(),
-            experiment_analysis_targets.items(),
         )
+    elif args.environment == "experiments":
+        with ThreadPool(args.parallelism) as pool:
+            targets_with_sources = find_experiment_analysis_targets(
+                pool, client
+            ).items()
     elif args.environment == "pioneer":
         with ThreadPool(args.parallelism) as pool:
             targets_with_sources = find_pioneer_targets(


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-3335

Sets project for experiment tables in shredder so it doesn't look for the tables in shared-prod.  Also splits experiments into it's own "environment" so it can be run as a separate airflow task.

I verified that it no longer prints `Skipping moz-fx-data-shared-prod.mozanalysis.... due to NotFound exception` and the queries look correct but I can't complete a dry run because I don't have write access to the tables.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3745)
