### PR TITLE
[DENG-3417] Get event pings from probe info for monitoring events

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -356,10 +356,10 @@ generate:
       - topsites-impression # access denied
       - serp-categorization # access denied
       - background-update # table doesn't exist
-      events_tables:
-        accounts_frontend:
+      events_tables: # overwrite event tables
+        accounts_frontend: # event pings land in accounts_events_v1 tables
         - accounts_events_v1
         accounts_backend:
         - accounts_events_v1
-        pine:
+        pine: # Probe info returns pings that don't have tables, only use events_v1
         - events_v1

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -353,9 +353,13 @@ generate:
       - org_mozilla_tiktokreporter
     events_monitoring:
       skip_pings:
-      - topsites-impression
+      - topsites-impression # access denied
+      - serp-categorization # access denied
+      - background-update # table doesn't exist
       events_tables:
         accounts_frontend:
         - accounts_events_v1
         accounts_backend:
         - accounts_events_v1
+        pine:
+        - events_v1

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -352,8 +352,10 @@ generate:
       - org_mozilla_ios_tiktok_reporter_tiktok_reportershare
       - org_mozilla_tiktokreporter
     events_monitoring:
-      default_event_table: events_v1
-      event_table:
-        mozillavpn: main_v1
-        accounts_frontend: accounts_events_v1
-        accounts_backend: accounts_events_v1
+      skip_pings:
+      - topsites-impression
+      events_tables:
+        accounts_frontend:
+        - accounts_events_v1
+        accounts_backend:
+        - accounts_events_v1

--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -274,7 +274,10 @@ class GleanTable:
         # Schema files are optional
         try:
             schema = render(
-                schema_filename, format=False, template_folder=PATH / "templates", **render_kwargs
+                schema_filename,
+                format=False,
+                template_folder=PATH / "templates",
+                **render_kwargs,
             )
         except TemplateNotFound:
             schema = None
@@ -303,7 +306,7 @@ class GleanTable:
                     )
                 else:
                     artifacts.append(Artifact(table, "checks.sql", checks_sql))
-            
+
             if schema:
                 artifacts.append(Artifact(table, "schema.yaml", schema))
 

--- a/sql_generators/glean_usage/event_monitoring_live.py
+++ b/sql_generators/glean_usage/event_monitoring_live.py
@@ -42,8 +42,6 @@ class EventMonitoringLive(GleanTable):
     def _get_tables_with_events(self, v1_name: str) -> Set[str]:
         pings = set()
         resp = requests.get(METRICS_INFO_URL.format(app_name=v1_name))
-        if resp.status_code == 404:
-            return pings
         resp.raise_for_status()
         metrics_json = resp.json()
 

--- a/sql_generators/glean_usage/event_monitoring_live.py
+++ b/sql_generators/glean_usage/event_monitoring_live.py
@@ -4,6 +4,9 @@ import os
 from collections import namedtuple
 from datetime import datetime
 from pathlib import Path
+from typing import Set
+
+import requests
 
 from bigquery_etl.config import ConfigLoader
 from bigquery_etl.schema.stable_table_schema import get_stable_table_schemas
@@ -20,6 +23,7 @@ TARGET_TABLE_ID = "event_monitoring_live_v1"
 TARGET_DATASET_CROSS_APP = "monitoring"
 PREFIX = "event_monitoring"
 PATH = Path(os.path.dirname(__file__))
+METRICS_INFO_URL = "https://probeinfo.telemetry.mozilla.org/glean/{app_name}/metrics"
 
 
 class EventMonitoringLive(GleanTable):
@@ -34,6 +38,21 @@ class EventMonitoringLive(GleanTable):
         self.target_table_id = TARGET_TABLE_ID
         self.custom_render_kwargs = {}
         self.base_table_name = "events_v1"
+
+    def _get_tables_with_events(self, v1_name: str) -> Set[str]:
+        pings = set()
+        resp = requests.get(METRICS_INFO_URL.format(app_name=v1_name))
+        if resp.status_code == 404:
+            return pings
+        resp.raise_for_status()
+        metrics_json = resp.json()
+
+        for _, metric in metrics_json.items():
+            if metric.get("type", None) == "event":
+                latest_history = metric.get("history", [])[-1]
+                pings.update(latest_history.get("send_in_pings", []))
+
+        return pings
 
     def generate_per_app_id(
         self,
@@ -52,16 +71,38 @@ class EventMonitoringLive(GleanTable):
         table = tables[f"{self.prefix}"]
         dataset = tables[self.prefix].split(".")[-2].replace("_derived", "")
 
-        default_events_table = ConfigLoader.get(
-            "generate",
-            "glean_usage",
-            "events_monitoring",
-            "default_event_table",
-            fallback="events_v1",
-        )
         events_table_overwrites = ConfigLoader.get(
-            "generate", "glean_usage", "events_monitoring", "event_table", fallback={}
+            "generate", "glean_usage", "events_monitoring", "events_tables", fallback={}
         )
+
+        app_name = [
+            app_dataset["app_name"]
+            for _, app in get_app_info().items()
+            for app_dataset in app
+            if dataset == app_dataset["bq_dataset_family"]
+        ][0]
+
+        if app_name in events_table_overwrites:
+            events_tables = events_table_overwrites[app_name]
+        else:
+            v1_name = [
+                app_dataset["v1_name"]
+                for _, app in get_app_info().items()
+                for app_dataset in app
+                if dataset == app_dataset["bq_dataset_family"]
+            ][0]
+            events_tables = self._get_tables_with_events(v1_name)
+            events_tables = [
+                f"{ping.replace('-', '_')}_v1"
+                for ping in events_tables
+                if ping
+                not in ConfigLoader.get(
+                    "generate", "glean_usage", "events_monitoring", "skip_pings"
+                )
+            ]
+
+        if len(events_tables) == 0:
+            return
 
         render_kwargs = dict(
             header="-- Generated via bigquery_etl.glean_usage\n",
@@ -76,11 +117,7 @@ class EventMonitoringLive(GleanTable):
                 for app_dataset in app
                 if dataset == app_dataset["bq_dataset_family"]
             ][0],
-            events_table=(
-                default_events_table
-                if dataset not in events_table_overwrites
-                else events_table_overwrites[dataset]
-            ),
+            events_tables=events_tables,
         )
 
         render_kwargs.update(self.custom_render_kwargs)

--- a/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
@@ -32,8 +32,8 @@ IF
       event_extra.key AS event_extra_key,
       normalized_country_code AS country,
       '{{ app_name }}' AS normalized_app_name,
-      client_info.app_channel AS channel,
-      client_info.app_display_version AS version,
+      channel,
+      version,
       -- Access experiment information.
       -- Additional iteration is necessary to aggregate total event count across experiments
       -- which is denoted with "*".
@@ -64,7 +64,8 @@ IF
         submission_timestamp,
         events,
         normalized_country_code,
-        client_info,
+        client_info.app_channel AS channel,
+        client_info.app_display_version AS version,
         ping_info
       FROM
       `{{ project_id }}.{{ dataset }}_live.{{ events_table }}`
@@ -104,12 +105,12 @@ IF
         ) MINUTE
       ) AS window_end,
       NULL AS event_category,
-      metrics.string.event_name,
+      event_name,
       NULL AS event_extra_key,
       normalized_country_code AS country,
       '{{ app_name }}' AS normalized_app_name,
-      client_info.app_channel AS channel,
-      client_info.app_display_version AS VERSION,
+      channel,
+      version,
       -- Access experiment information.
       -- Additional iteration is necessary to aggregate total event count across experiments
       -- which is denoted with "*".
@@ -134,8 +135,21 @@ IF
         ping_info.experiments[SAFE_OFFSET(experiment_index)].value.branch 
       END AS experiment_branch,
       COUNT(*) AS total_events
-    FROM
+    FROM (
+      {% for events_table in events_tables -%}
+      SELECT
+        submission_timestamp,
+        events,
+        metrics.string.event_name,
+        normalized_country_code,
+        client_info.app_channel AS channel,
+        client_info.app_display_version AS version,
+        ping_info
+      FROM
       `{{ project_id }}.{{ dataset }}_live.{{ events_table }}`
+      {{ "UNION ALL" if not loop.last }}
+      {% endfor -%}
+    )
     CROSS JOIN
       -- Iterator for accessing experiments.
       -- Add one more for aggregating events across all experiments

--- a/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
@@ -58,8 +58,19 @@ IF
         ping_info.experiments[SAFE_OFFSET(experiment_index)].value.branch 
       END AS experiment_branch,
       COUNT(*) AS total_events
-    FROM
+    FROM (
+      {% for events_table in events_tables -%}
+      SELECT
+        submission_timestamp,
+        events,
+        normalized_country_code,
+        client_info,
+        ping_info
+      FROM
       `{{ project_id }}.{{ dataset }}_live.{{ events_table }}`
+      {{ "UNION ALL" if not loop.last }}
+      {% endfor -%}
+    )
     CROSS JOIN
       UNNEST(events) AS event,
       -- Iterator for accessing experiments.

--- a/sql_generators/search/__init__.py
+++ b/sql_generators/search/__init__.py
@@ -15,7 +15,6 @@ from bigquery_etl.cli.utils import use_cloud_function_option
 from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.util.common import write_sql
 
-
 # fmt: off
 FIREFOX_ANDROID_TUPLES = [
     ("org_mozilla_fenix",           "Firefox Preview",  "beta"),  # noqa E241 E501

--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -129,9 +129,9 @@ def write_view_if_not_exists(target_project: str, sql_dir: Path, schema: SchemaF
     from bigquery_etl.format_sql.formatter import reformat
     from bigquery_etl.schema import Schema
     from sql_generators.stable_views import (
+        FF_INSTLL_VIEW_QUERY_TEMPLATE,
         VIEW_METADATA_TEMPLATE,
         VIEW_QUERY_TEMPLATE,
-        FF_INSTLL_VIEW_QUERY_TEMPLATE,
     )
 
     VIEW_CREATE_REGEX = re.compile(


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-3417

This PR makes some changes to the `event_monitoring` datasets. Instead of fetching events just from the `event_v1` tables, the generation logic fetches the pings that are sending events from https://probeinfo.telemetry.mozilla.org/glean/ for each app.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3748)
