### PR TITLE
DENG-3274 Switch accounts_backend.users_services_daily to events ping

### DIFF
--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_daily_v1/query.sql
@@ -41,7 +41,7 @@ fxa_events AS (
     ) AS service,
     metrics.string.session_flow_id AS flow_id,
     metrics.string.session_entrypoint AS entrypoint,
-    event_name AS event_name,
+    event_name,
     -- `access_token_checked` events are triggered on traffic from RP backend services and don't have client's geo data
     IF(event_name != 'access_token_checked', metadata.geo.country, NULL) AS country,
     metrics.string.utm_term AS utm_term,

--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_daily_v1/query.sql
@@ -29,7 +29,6 @@ WITH events_unnested AS (
     `moz-fx-data-shared-prod.accounts_backend.events` AS e
   CROSS JOIN
     UNNEST(e.events) AS event
-    WITH OFFSET AS event_offset
 ),
 fxa_events AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_daily_v1/query.sql
@@ -19,7 +19,19 @@ CREATE TEMP FUNCTION count_distinct(arr ANY TYPE) AS (
   (SELECT COUNT(DISTINCT x) FROM UNNEST(arr) AS x)
 );
 
-WITH fxa_events AS (
+WITH events_unnested AS (
+  SELECT
+    e.* EXCEPT (events),
+    event.timestamp AS event_timestamp,
+    CONCAT(event.category, "_", event.name) AS event_name,
+    event.extra AS event_extra
+  FROM
+    `moz-fx-data-shared-prod.accounts_backend.events` AS e
+  CROSS JOIN
+    UNNEST(e.events) AS event
+    WITH OFFSET AS event_offset
+),
+fxa_events AS (
   SELECT
     submission_timestamp,
     metrics.string.account_user_id_sha256 AS user_id_sha256,
@@ -30,9 +42,9 @@ WITH fxa_events AS (
     ) AS service,
     metrics.string.session_flow_id AS flow_id,
     metrics.string.session_entrypoint AS entrypoint,
-    metrics.string.event_name AS event_name,
+    event_name AS event_name,
     -- `access_token_checked` events are triggered on traffic from RP backend services and don't have client's geo data
-    IF(metrics.string.event_name != 'access_token_checked', metadata.geo.country, NULL) AS country,
+    IF(event_name != 'access_token_checked', metadata.geo.country, NULL) AS country,
     metrics.string.utm_term AS utm_term,
     metrics.string.utm_medium AS utm_medium,
     metrics.string.utm_source AS utm_source,
@@ -40,12 +52,12 @@ WITH fxa_events AS (
     metrics.string.utm_content AS utm_content,
     metadata.user_agent,
   FROM
-    `accounts_backend.accounts_events`
+    events_unnested
   WHERE
     DATE(submission_timestamp)
     BETWEEN DATE_SUB(@submission_date, INTERVAL 1 DAY)
     AND @submission_date
-    AND metrics.string.event_name IN (
+    AND event_name IN (
       'access_token_checked',
       'access_token_created',
       -- registration and login events used when deriving the first_seen table


### PR DESCRIPTION
This is the first of a series of changes we'll need to do in order to switch to `events` ping in FxA. IN https://github.com/mozilla/bigquery-backfill/tree/main/backfill/2024-04-29-fxa_events/backend I have validated that this yields the same results as the currently used `accounts_events`.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3753)
