### PR TITLE
Restrict the DO dev ltv table to cat3 access

### DIFF
--- a/sql/data-observability-dev/ltv_derived/dataset_metadata.yaml
+++ b/sql/data-observability-dev/ltv_derived/dataset_metadata.yaml
@@ -1,0 +1,16 @@
+friendly_name: Ltv Derived
+description: |-
+  LTV tables. Limited to Cat2 access unless
+  explicitly specified otherwise.
+dataset_base_acl: derived_restricted
+user_facing: false
+labels: {}
+default_table_workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:revenue/cat2
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:revenue/cat2
+syndication: {}


### PR DESCRIPTION
The tables in ltv_derived dataset does not currently have restrictions. But we would like to add restrictions to prevent the DO tool from accessing them (a use case to test)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3760)
