### PR TITLE
Add unit test to verify shredder delete target and source counts

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -242,7 +242,8 @@ DELETE_TARGETS: DeleteIndex = {
     client_id_target(table="telemetry_stable.update_v4"): DESKTOP_SRC,
     client_id_target(table="telemetry_stable.voice_v4"): DESKTOP_SRC,
     DeleteTarget(
-        table="telemetry_derived.mobile_engagement_clients_v1", field=CLIENT_ID
+        table="telemetry_derived.mobile_engagement_clients_v1",
+        field=(CLIENT_ID, CLIENT_ID),
     ): (
         DeleteSource(table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID),

--- a/tests/shredder/test_config.py
+++ b/tests/shredder/test_config.py
@@ -6,6 +6,7 @@ from google.cloud import bigquery
 from google.cloud.bigquery import DatasetReference
 
 from bigquery_etl.shredder.config import (
+    DELETE_TARGETS,
     DeleteSource,
     DeleteTarget,
     _list_tables,
@@ -309,3 +310,14 @@ def test_list_tables_wrapper_empty():
     tables = _list_tables(DatasetReference("project", "dataset"), EmptyFakeClient())
 
     assert tables == []
+
+
+def test_delete_target_fields_match_sources():
+    """The number of fields in the delete targets should match the number of sources."""
+    for target, sources in DELETE_TARGETS.items():
+        field_count = 1 if isinstance(target.field, str) else len(target.field)
+        source_count = 1 if isinstance(sources, DeleteSource) else len(sources)
+        assert field_count == source_count, (
+            f"Invalid delete target for {target.table}: number of fields in target "
+            f"(found {field_count}) must match number of sources (found {source_count})"
+        )


### PR DESCRIPTION
The number of fields must match the number of sources because they get zipped, otherwise some sources will be ignored.

https://github.com/mozilla/bigquery-etl/blob/1d1addb86cd097f7c3cf03d84ec1c30537591a47/bigquery_etl/shredder/delete.py#L217

I think unit test for this is better than a runtime error because crashing shredder can be expensive

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3764)
