### PR TITLE
fix: baseline_clients_daily to only grab distribution_id for fenix app

### DIFF
--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -36,6 +36,8 @@ NO_BASELINE_PING_APPS = (
     "mozregression",
 )
 
+APPS_WITH_DISTRIBUTION_ID = ("fenix",)
+
 
 def write_dataset_metadata(output_dir, full_table_id, derived_dataset_metadata=False):
     """
@@ -238,6 +240,7 @@ class GleanTable:
             project_id=project_id,
             derived_dataset=derived_dataset,
             app_name=app_name,
+            has_distribution_id=app_name in APPS_WITH_DISTRIBUTION_ID,
         )
 
         render_kwargs.update(self.custom_render_kwargs)

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
@@ -24,7 +24,11 @@ WITH base AS (
     normalized_channel,
     normalized_os,
     normalized_os_version,
+    {% if has_distribution_id %}
+    metrics.string.metrics_distribution_id AS distribution_id,
+    {% else %}
     CAST(NULL AS STRING) AS distribution_id,
+    {% endif %}
     metadata.geo.subdivision1 AS geo_subdivision,
   FROM
     `{{ baseline_table }}`

--- a/tests/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/baseline_clients_first_seen_v1/test_aggregation/org_mozilla_ios_firefox_stable.baseline_v1.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/baseline_clients_first_seen_v1/test_aggregation/org_mozilla_ios_firefox_stable.baseline_v1.schema.json
@@ -275,12 +275,6 @@
             "type": "STRING",
             "name": "glean_baseline_locale",
             "mode": "NULLABLE"
-          },
-          {
-            "description": "",
-            "type": "STRING",
-            "name": "metrics_distribution_id",
-            "mode": "NULLABLE"
           }
         ],
         "type": "RECORD",

--- a/tests/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/baseline_clients_first_seen_v1/test_init/org_mozilla_ios_firefox_stable.baseline_v1.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/baseline_clients_first_seen_v1/test_init/org_mozilla_ios_firefox_stable.baseline_v1.schema.json
@@ -275,12 +275,6 @@
             "type": "STRING",
             "name": "glean_baseline_locale",
             "mode": "NULLABLE"
-          },
-          {
-            "description": "",
-            "type": "STRING",
-            "name": "metrics_distribution_id",
-            "mode": "NULLABLE"
           }
         ],
         "type": "RECORD",


### PR DESCRIPTION
fix: baseline_clients_daily to only grab distribution_id for fenix app

This is to address an incorrect assumption that every `baseline` ping would have the same structure. It turns out the field containing distribution_id only exists for Fenix.

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3829)
