### PR TITLE
Fix link to full `sql.diff` file

### DIFF
--- a/.circleci/post-diff.js
+++ b/.circleci/post-diff.js
@@ -74,7 +74,7 @@ async function minimize_pr_diff_comments() {
 }
 
 function diff() {
-    let root = "/tmp/workspace/generated-sql/";
+    let root = "/tmp/workspace/";
     let diff_content = fs.readFileSync(root + "/" + diff_file, "utf8");
 
     var body = "No content detected.";

--- a/.circleci/post-diff.js
+++ b/.circleci/post-diff.js
@@ -93,11 +93,14 @@ ${diff_content}
 \`\`\`
 
 </details>
+
+${warnings}
+
+[Link to full diff](https://output.circle-artifacts.com/output/job/${process.env.CIRCLE_WORKFLOW_JOB_ID}/artifacts/${process.env.CIRCLE_NODE_INDEX}/${diff_file})
 `
     }
     var content = `#### \`${diff_file}\`
 ${body}
-${warnings}
 `;
     return content;
 }
@@ -107,8 +110,6 @@ function post_diff() {
         process.env.GH_AUTH_TOKEN,
         `### Integration report for "${bot.env.commitMessage}"
 ${diff()}
-
-[Link to full diff](https://output.circle-artifacts.com/output/job/${process.env.CIRCLE_WORKFLOW_JOB_ID}/artifacts/${process.env.CIRCLE_NODE_INDEX}/${diff_file})
 `
     );
 }

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -957,11 +957,13 @@ jobs:
           steps:
             - *skip
   generate-diff:
-    docker: *docker
+    docker:
+      - image: cimg/node:21.2.0
     steps:
       - when:
           condition: *validate-sql-or-routines
           steps:
+            - checkout
             - attach_workspace:
                 at: /tmp/workspace
             - run:
@@ -981,27 +983,9 @@ jobs:
                   diff -bur --no-dereference --new-file \
                     /tmp/workspace/main-generated-sql/sql/ /tmp/workspace/generated-sql/sql/ \
                     >> /tmp/workspace/generated-sql/sql.diff || true
-            - persist_to_workspace:
-                root: /tmp/workspace
-                paths:
-                  - generated-sql
             - store_artifacts:
                 path: /tmp/workspace/generated-sql/sql.diff
                 destination: sql.diff
-      - unless:
-          condition: *validate-sql-or-routines
-          steps:
-            - *skip
-  post-diff:
-    docker:
-      - image: cimg/node:21.2.0
-    steps:
-      - when:
-          condition: *validate-sql-or-routines
-          steps:
-            - checkout
-            - attach_workspace:
-                at: /tmp/workspace
             - run: npm i circle-github-bot@2.1.0 @octokit/graphql@7.0.2
             - run: .circleci/post-diff.js
       - unless:
@@ -1118,12 +1102,6 @@ workflows:
           requires:
             - generate-dags
             - main-generate-sql-and-dags
-          filters:
-            branches:
-              ignore: main
-      - post-diff:
-          requires:
-            - generate-diff
           filters:
             branches:
               ignore: main

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -972,19 +972,19 @@ jobs:
                   diff -qr --no-dereference \
                     /tmp/workspace/main-generated-sql/dags/ /tmp/workspace/generated-sql/dags/ \
                     | grep '^Only in' \
-                    > /tmp/workspace/generated-sql/sql.diff || true
+                    > /tmp/workspace/sql.diff || true
                   diff -bur --no-dereference --new-file \
                     /tmp/workspace/main-generated-sql/dags/ /tmp/workspace/generated-sql/dags/ \
-                    >> /tmp/workspace/generated-sql/sql.diff || true
+                    >> /tmp/workspace/sql.diff || true
                   diff -qr --no-dereference \
                     /tmp/workspace/main-generated-sql/sql/ /tmp/workspace/generated-sql/sql/ \
                     | grep '^Only in' \
-                    >> /tmp/workspace/generated-sql/sql.diff || true
+                    >> /tmp/workspace/sql.diff || true
                   diff -bur --no-dereference --new-file \
                     /tmp/workspace/main-generated-sql/sql/ /tmp/workspace/generated-sql/sql/ \
-                    >> /tmp/workspace/generated-sql/sql.diff || true
+                    >> /tmp/workspace/sql.diff || true
             - store_artifacts:
-                path: /tmp/workspace/generated-sql/sql.diff
+                path: /tmp/workspace/sql.diff
                 destination: sql.diff
             - run: npm i circle-github-bot@2.1.0 @octokit/graphql@7.0.2
             - run: .circleci/post-diff.js


### PR DESCRIPTION
Links to the full `sql.diff` file have been broken since #4593 because they're using the wrong CI job ID.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3838)
