### PR TITLE
Bug 1897824 - Make clients_yearly schema static; add new fields

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/baseline_clients_yearly_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/baseline_clients_yearly_v1/query.sql
@@ -33,7 +33,33 @@
       {% for usage_type, criterion in usage_types %}
         udf.bool_to_365_bits({{ criterion }}) AS `days_{{ usage_type }}_bytes`,
       {% endfor %}
-      * EXCEPT (submission_date),
+      -- List cols explicitly here: the schema is static (schema.yaml),
+      -- and new columns added upstream will need to be manually added
+      normalized_app_id client_id,
+      sample_id,
+      first_run_date,
+      durations,
+      days_seen_session_start_bits,
+      days_seen_session_end_bits,
+      normalized_channel,
+      normalized_os,
+      normalized_os_version,
+      android_sdk_version,
+      locale,
+      city,
+      country,
+      app_build,
+      app_channel,
+      app_display_version,
+      architecture,
+      device_manufacturer,
+      device_model,
+      telemetry_sdk_build,
+      first_seen_date,
+      is_new_profile,
+      isp,
+      distribution_id,
+      geo_subdivision,
     FROM
       `moz-fx-data-shared-prod`.firefox_ios.baseline_clients_daily
     WHERE

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/baseline_clients_yearly_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/baseline_clients_yearly_v1/schema.yaml
@@ -80,3 +80,9 @@ fields:
 - name: isp
   type: STRING
   mode: NULLABLE
+- name: distribution_id
+  type: STRING
+  mode: NULLABLE
+- name: geo_subdivision
+  type: STRING
+  mode: NULLABLE


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3839)
