### PR TITLE
fix(backfills): switch from process to thread to avoid pickling bigquery object

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -745,7 +745,7 @@ def backfill(
         if not depends_on_past and parallelism > 0:
             # run backfill for dates in parallel if depends_on_past is false
             failed_backfills = []
-            with futures.ProcessPoolExecutor(max_workers=parallelism) as executor:
+            with futures.ThreadPoolExecutor(max_workers=parallelism) as executor:
                 future_to_date = {
                     executor.submit(backfill_query, backfill_date): backfill_date
                     for backfill_date in date_range


### PR DESCRIPTION
We're getting a pickling error: `Can't pickle local object 'if_exception_type.<locals>.if_exception_type_predicate'` on each concurrent invocation of `cli.query._backfill_query`. [e.g.](https://workflow.telemetry.mozilla.org/dags/bqetl_backfill_initiate/grid?search=bqetl_backfill_initiate&dag_run_id=scheduled__2024-05-23T20%3A00%3A00%2B00%3A00&task_id=initiate_backfill.process_backfill&tab=mapped_tasks&map_index=0). I haven't been able to reproduce this locally. 

Multi-threading tends to require less pickling so here's an attempt to fix it. 

As an aside, most of concurrent functionality is I/O bound (API requests to GCP) so using threads probably makes more sense anyway. 🤞

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3897)
