### PR TITLE
[DENG-3889] Rewrite events_stream_v1 for better performance

### DIFF
--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -1,8 +1,73 @@
 {{ header }}
+-- convert array of key value pairs to a json object, cast numbers and booleans if possible
+CREATE TEMP FUNCTION from_map_event_extra(input ARRAY<STRUCT<key STRING, value STRING>>)
+RETURNS json AS (
+  IF(
+    ARRAY_LENGTH(input) = 0,
+    NULL,
+    JSON_OBJECT(
+      ARRAY(SELECT key FROM UNNEST(input)),
+      ARRAY(
+        SELECT
+          CASE
+            WHEN SAFE_CAST(value AS NUMERIC) IS NOT NULL
+              THEN TO_JSON(SAFE_CAST(value AS NUMERIC))
+            WHEN SAFE_CAST(value AS BOOL) IS NOT NULL
+              THEN TO_JSON(SAFE_CAST(value AS BOOL))
+            ELSE TO_JSON(value)
+          END
+        FROM
+          UNNEST(input)
+      )
+    )
+  )
+);
+
+-- convert array of key value pairs to a json object
+-- values are nested structs and will be converted to json objects
+CREATE TEMP FUNCTION from_map_experiment(
+  input ARRAY<
+    STRUCT<key STRING, value STRUCT<branch STRING, extra STRUCT<type STRING, enrollment_id STRING>>>
+  >
+)
+RETURNS json AS (
+  IF(
+    ARRAY_LENGTH(input) = 0,
+    NULL,
+    JSON_OBJECT(ARRAY(SELECT key FROM UNNEST(input)), ARRAY(SELECT value FROM UNNEST(input)))
+  )
+);
+
+CREATE TEMP FUNCTION metrics_to_json(metrics JSON)
+RETURNS JSON AS (
+  JSON_STRIP_NULLS(
+    JSON_REMOVE(
+      -- labeled_* are the only ones that SHOULD show up as context for events pings,
+      -- thus we special-case them
+      --
+      -- The JSON_SET/JSON_EXTRACT shenanigans are needed
+      -- because those subfields might not exist, so accessing the columns would fail.
+      -- but accessing non-existent fields in a JSON object simply gives us NULL.
+      JSON_SET(
+        metrics,
+        '$.labeled_counter',
+        mozfun.json.from_nested_map(metrics.labeled_counter),
+        '$.labeled_string',
+        mozfun.json.from_nested_map(metrics.labeled_string),
+        '$.labeled_boolean',
+        mozfun.json.from_nested_map(metrics.labeled_boolean),
+        '$.url',
+        metrics.url2
+      ),
+      '$.url2'
+    ),
+    remove_empty => TRUE
+  )
+);
 
 WITH base AS (
   SELECT
-    * EXCEPT (metrics, events, name, category, extra, timestamp) REPLACE (
+    * REPLACE (
       STRUCT(
         client_info.app_build AS app_build,
         client_info.app_channel AS app_channel,
@@ -26,27 +91,14 @@ WITH base AS (
         ping_info.end_time,
         ping_info.parsed_end_time,
         ping_info.ping_type
-      ) AS ping_info
+      ) AS ping_info,
+      metrics_to_json(TO_JSON(metrics)) AS metrics
     ),
     client_info.client_id AS client_id,
     ping_info.reason AS reason,
-    `mozfun.json.from_map`(ping_info.experiments) AS experiments,
-    COALESCE(
-      SAFE.TIMESTAMP_MILLIS(SAFE_CAST(mozfun.map.get_key(event.extra, 'glean_timestamp') AS INT64)),
-      SAFE.TIMESTAMP_ADD(
-        ping_info.parsed_start_time,
-        INTERVAL event.timestamp MILLISECOND
-      )
-    ) AS event_timestamp,
-    event.category as event_category,
-    event.name as event_name,
-    ARRAY_TO_STRING([event.category, event.name], '.') AS event, -- handles NULL values better
-    `mozfun.json.from_map`(event.extra) AS event_extra,
-    TO_JSON(metrics) AS metrics
+    from_map_experiment(ping_info.experiments) AS experiments,
   FROM
-    `{{ events_view }}` AS e
-  CROSS JOIN
-    UNNEST(events) AS event
+    `{{ events_view }}`
   WHERE
     {% raw %}
     {% if is_init() %}
@@ -58,34 +110,16 @@ WITH base AS (
 )
 --
 SELECT
-  * REPLACE (
-    -- expose as easy to access JSON column,
-    -- strip nulls,
-    -- translate nested array records into a JSON object,
-    -- rename url2 -> url
-    JSON_STRIP_NULLS(
-      JSON_REMOVE(
-        -- labeled_* are the only ones that SHOULD show up as context for events pings,
-        -- thus we special-case them
-        --
-        -- The JSON_SET/JSON_EXTRACT shenanigans are needed
-        -- because those subfields might not exist, so accessing the columns would fail.
-        -- but accessing non-existent fields in a JSON object simply gives us NULL.
-        JSON_SET(
-          metrics,
-          '$.labeled_counter',
-          mozfun.json.from_nested_map(metrics.labeled_counter),
-          '$.labeled_string',
-          mozfun.json.from_nested_map(metrics.labeled_string),
-          '$.labeled_boolean',
-          mozfun.json.from_nested_map(metrics.labeled_boolean),
-          '$.url',
-          metrics.url2
-        ),
-        '$.url2'
-      ),
-      remove_empty => TRUE
-    ) AS metrics
-  )
+  base.* EXCEPT (events),
+  COALESCE(
+    SAFE.TIMESTAMP_MILLIS(SAFE_CAST(mozfun.map.get_key(event.extra, 'glean_timestamp') AS INT64)),
+    SAFE.TIMESTAMP_ADD(ping_info.parsed_start_time, INTERVAL event.timestamp MILLISECOND)
+  ) AS event_timestamp,
+  event.category AS event_category,
+  event.name AS event_name,
+  ARRAY_TO_STRING([event.category, event.name], '.') AS event, -- handles NULL values better
+  from_map_event_extra(event.extra) AS event_extra,
 FROM
   base
+CROSS JOIN
+  UNNEST(events) AS event


### PR DESCRIPTION
DENG-3889

Changes:
- replace two (out of five) of the javascript udfs usages with a sql udf
- rearrange ctes so most of the udfs are called per event ping rather than on the unnested events

### performance

1% sample (sample_id = 1) on firefox desktop for 2024-05-22:
changes | slot hours | job id (backfill-2)
-- | -- | --
base | 24.5 | bquxjob_7a85e33a_18fab4919e3
rearranged | 5.7 | bquxjob_4ababcd5_18fab3b62ea
sql udfs | 4.3 | bquxjob_129253ac_18fab52d5c9
rearranged + sql udfs | 3.4 | bquxjob_4145760d_18fab765f03

100% of firefox desktop for 2024-05-22 (both overwriting a clustered partition):

changes | slot hours | job id (backfill-2)
-- | -- | --
base (airflow run) | 3910 😵‍💫 | bqjob_r6deaccf950e8d7f5_0000018fa35c4fce_1
rearranged + sql udfs | 699 | bquxjob_5293faeb_18fab5ab707

I'm mostly confident the output is equivalent because this doesn't throw any errors:
```sql
SELECT
  mozfun.assert.json_equals(from_map_event_extra(event.extra), mozfun.json.from_map(event.extra)),
  mozfun.assert.json_equals(from_map_experiment(ping_info.experiments), mozfun.json.from_map(ping_info.experiments)),
FROM
  `moz-fx-data-shared-prod.firefox_desktop_stable.events_v1`
CROSS JOIN 
  UNNEST(events) AS event
WHERE 
  DATE(submission_timestamp) IN ('2024-05-22')
  AND sample_id = 1
```
Also ran this for fenix and ios

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3900)
