### PR TITLE
Add view for unnested serp category data

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/serp_categorization_unnested/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/serp_categorization_unnested/view.sql
@@ -51,9 +51,15 @@ WITH flat AS (
 )
 SELECT
   *,
---   `moz-fx-data-shared-prod`.udf.serp_category_name(
---     sponsored_category_id
---   ) AS sponsored_category_name,
---   `moz-fx-data-shared-prod`.udf.serp_category_name(organic_category_id) AS organic_category_name
+  nsp.category_name AS sponsored_category_name,
+  norg.category_name AS organic_category_name
 FROM
-  flat
+  flat AS f
+LEFT JOIN
+  `moz-fx-data-shared-prod.static.serp_category_name` AS nsp
+  ON f.mappings_version = nsp.mappings_version
+  AND f.sponsored_category_id = nsp.category_id
+LEFT JOIN
+  `moz-fx-data-shared-prod.static.serp_category_name` AS norg
+  ON f.mappings_version = norg.mappings_version
+  AND f.organic_category_id = norg.category_id

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/serp_categorization_unnested/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/serp_categorization_unnested/view.sql
@@ -6,7 +6,6 @@ WITH flat AS (
     DATE(submission_timestamp) AS submission_date,
     document_id,
     CONCAT(document_id, '-', event_offset) AS event_id,
-    event.timestamp AS event_timestamp,
     SAFE.TIMESTAMP_MILLIS(
       SAFE_CAST(mozfun.map.get_key(event.extra, 'glean_timestamp') AS INT64)
     ) AS glean_timestamp,

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/serp_categorization_unnested/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/serp_categorization_unnested/view.sql
@@ -1,0 +1,59 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.serp_categorization_unnested`
+AS
+WITH flat AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    document_id,
+    CONCAT(document_id, '-', event_offset) AS event_id,
+    event.timestamp AS event_timestamp,
+    SAFE.TIMESTAMP_MILLIS(
+      SAFE_CAST(mozfun.map.get_key(event.extra, 'glean_timestamp') AS INT64)
+    ) AS glean_timestamp,
+    mozfun.map.get_key(event.extra, 'channel') AS channel,
+    SAFE_CAST(mozfun.map.get_key(event.extra, 'app_version') AS INT) AS browser_major_version,
+    mozfun.map.get_key(event.extra, 'region') AS country,
+    mozfun.map.get_key(event.extra, 'provider') AS provider,
+    mozfun.map.get_key(event.extra, 'partner_code') AS partner_code,
+    SAFE_CAST(mozfun.map.get_key(event.extra, 'tagged') AS BOOLEAN) AS tagged,
+    SAFE_CAST(mozfun.map.get_key(event.extra, 'is_shopping_page') AS BOOLEAN) AS is_shopping_page,
+    SAFE_CAST(
+      mozfun.map.get_key(event.extra, 'sponsored_category') AS INT
+    ) AS sponsored_category_id,
+    SAFE_CAST(
+      mozfun.map.get_key(event.extra, 'sponsored_num_domains') AS INT
+    ) AS sponsored_num_domains,
+    SAFE_CAST(
+      mozfun.map.get_key(event.extra, 'sponsored_num_unknown') AS INT
+    ) AS sponsored_num_unknown,
+    SAFE_CAST(
+      mozfun.map.get_key(event.extra, 'sponsored_num_inconclusive') AS INT
+    ) AS sponsored_num_inconclusive,
+    SAFE_CAST(mozfun.map.get_key(event.extra, 'organic_category') AS INT) AS organic_category_id,
+    SAFE_CAST(mozfun.map.get_key(event.extra, 'organic_num_domains') AS INT) AS organic_num_domains,
+    SAFE_CAST(mozfun.map.get_key(event.extra, 'organic_num_unknown') AS INT) AS organic_num_unknown,
+    SAFE_CAST(
+      mozfun.map.get_key(event.extra, 'organic_num_inconclusive') AS INT
+    ) AS organic_num_inconclusive,
+    SAFE_CAST(mozfun.map.get_key(event.extra, 'num_ads_loaded') AS INT) AS num_ads_loaded,
+    SAFE_CAST(mozfun.map.get_key(event.extra, 'num_ads_visible') AS INT) AS num_ads_visible,
+    SAFE_CAST(mozfun.map.get_key(event.extra, 'num_ads_hidden') AS INT) AS num_ads_hidden,
+    SAFE_CAST(mozfun.map.get_key(event.extra, 'num_ads_clicked') AS INT) AS num_ads_clicked,
+    mozfun.map.get_key(event.extra, 'mappings_version') AS mappings_version
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_stable.serp_categorization_v1` AS s
+  CROSS JOIN
+    UNNEST(events) AS event
+    WITH OFFSET AS event_offset
+  WHERE
+    event.category = 'serp'
+    AND event.name = 'categorization'
+)
+SELECT
+  *,
+--   `moz-fx-data-shared-prod`.udf.serp_category_name(
+--     sponsored_category_id
+--   ) AS sponsored_category_name,
+--   `moz-fx-data-shared-prod`.udf.serp_category_name(organic_category_id) AS organic_category_name
+FROM
+  flat


### PR DESCRIPTION
Flattens serp_categorization data into 1 row per event and expands the extras fields into columns. Also maps the category IDs to names.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3909)
