### PR TITLE
[DENG-3889] Replace events_stream temp udfs with inline usages

### DIFF
--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -1,70 +1,4 @@
 {{ header }}
--- convert array of key value pairs to a json object, cast numbers and booleans if possible
-CREATE TEMP FUNCTION from_map_event_extra(input ARRAY<STRUCT<key STRING, value STRING>>)
-RETURNS json AS (
-  IF(
-    ARRAY_LENGTH(input) = 0,
-    NULL,
-    JSON_OBJECT(
-      ARRAY(SELECT key FROM UNNEST(input)),
-      ARRAY(
-        SELECT
-          CASE
-            WHEN SAFE_CAST(value AS NUMERIC) IS NOT NULL
-              THEN TO_JSON(SAFE_CAST(value AS NUMERIC))
-            WHEN SAFE_CAST(value AS BOOL) IS NOT NULL
-              THEN TO_JSON(SAFE_CAST(value AS BOOL))
-            ELSE TO_JSON(value)
-          END
-        FROM
-          UNNEST(input)
-      )
-    )
-  )
-);
-
--- convert array of key value pairs to a json object
--- values are nested structs and will be converted to json objects
-CREATE TEMP FUNCTION from_map_experiment(
-  input ARRAY<
-    STRUCT<key STRING, value STRUCT<branch STRING, extra STRUCT<type STRING, enrollment_id STRING>>>
-  >
-)
-RETURNS json AS (
-  IF(
-    ARRAY_LENGTH(input) = 0,
-    NULL,
-    JSON_OBJECT(ARRAY(SELECT key FROM UNNEST(input)), ARRAY(SELECT value FROM UNNEST(input)))
-  )
-);
-
-CREATE TEMP FUNCTION metrics_to_json(metrics JSON)
-RETURNS JSON AS (
-  JSON_STRIP_NULLS(
-    JSON_REMOVE(
-      -- labeled_* are the only ones that SHOULD show up as context for events pings,
-      -- thus we special-case them
-      --
-      -- The JSON_SET/JSON_EXTRACT shenanigans are needed
-      -- because those subfields might not exist, so accessing the columns would fail.
-      -- but accessing non-existent fields in a JSON object simply gives us NULL.
-      JSON_SET(
-        metrics,
-        '$.labeled_counter',
-        mozfun.json.from_nested_map(metrics.labeled_counter),
-        '$.labeled_string',
-        mozfun.json.from_nested_map(metrics.labeled_string),
-        '$.labeled_boolean',
-        mozfun.json.from_nested_map(metrics.labeled_boolean),
-        '$.url',
-        metrics.url2
-      ),
-      '$.url2'
-    ),
-    remove_empty => TRUE
-  )
-);
-
 WITH base AS (
   SELECT
     * REPLACE (
@@ -92,11 +26,20 @@ WITH base AS (
         ping_info.parsed_end_time,
         ping_info.ping_type
       ) AS ping_info,
-      metrics_to_json(TO_JSON(metrics)) AS metrics
+      TO_JSON(metrics) AS metrics
     ),
     client_info.client_id AS client_id,
     ping_info.reason AS reason,
-    from_map_experiment(ping_info.experiments) AS experiments,
+    -- convert array of key value pairs to a json object
+    -- values are nested structs and will be converted to json objects
+    IF(
+      ARRAY_LENGTH(ping_info.experiments) = 0,
+      NULL,
+      JSON_OBJECT(
+        ARRAY(SELECT key FROM UNNEST(ping_info.experiments)),
+        ARRAY(SELECT value FROM UNNEST(ping_info.experiments))
+      )
+    ) AS experiments,
   FROM
     `{{ events_view }}`
   WHERE
@@ -107,10 +50,40 @@ WITH base AS (
       DATE(submission_timestamp) = @submission_date
     {% endif %}
     {% endraw %}
+),
+json_metrics AS (
+  SELECT
+    * REPLACE (
+      JSON_STRIP_NULLS(
+        JSON_REMOVE(
+          -- labeled_* are the only ones that SHOULD show up as context for events pings,
+          -- thus we special-case them
+          --
+          -- The JSON_SET/JSON_EXTRACT shenanigans are needed
+          -- because those subfields might not exist, so accessing the columns would fail.
+          -- but accessing non-existent fields in a JSON object simply gives us NULL.
+          JSON_SET(
+            metrics,
+            '$.labeled_counter',
+            mozfun.json.from_nested_map(metrics.labeled_counter),
+            '$.labeled_string',
+            mozfun.json.from_nested_map(metrics.labeled_string),
+            '$.labeled_boolean',
+            mozfun.json.from_nested_map(metrics.labeled_boolean),
+            '$.url',
+            metrics.url2
+          ),
+          '$.url2'
+        ),
+        remove_empty => TRUE
+      ) AS metrics
+    )
+  FROM
+    base
 )
 --
 SELECT
-  base.* EXCEPT (events),
+  json_metrics.* EXCEPT (events),
   COALESCE(
     SAFE.TIMESTAMP_MILLIS(SAFE_CAST(mozfun.map.get_key(event.extra, 'glean_timestamp') AS INT64)),
     SAFE.TIMESTAMP_ADD(ping_info.parsed_start_time, INTERVAL event.timestamp MILLISECOND)
@@ -118,8 +91,27 @@ SELECT
   event.category AS event_category,
   event.name AS event_name,
   ARRAY_TO_STRING([event.category, event.name], '.') AS event, -- handles NULL values better
-  from_map_event_extra(event.extra) AS event_extra,
+  -- convert array of key value pairs to a json object, cast numbers and booleans if possible
+  IF(
+    ARRAY_LENGTH(event.extra) = 0,
+    NULL,
+    JSON_OBJECT(
+      ARRAY(SELECT key FROM UNNEST(event.extra)),
+      ARRAY(
+        SELECT
+          CASE
+            WHEN SAFE_CAST(value AS NUMERIC) IS NOT NULL
+              THEN TO_JSON(SAFE_CAST(value AS NUMERIC))
+            WHEN SAFE_CAST(value AS BOOL) IS NOT NULL
+              THEN TO_JSON(SAFE_CAST(value AS BOOL))
+            ELSE TO_JSON(value)
+          END
+        FROM
+          UNNEST(event.extra)
+      )
+    )
+  ) AS event_extra,
 FROM
-  base
+  json_metrics
 CROSS JOIN
   UNNEST(events) AS event


### PR DESCRIPTION
Following up on https://github.com/mozilla/bigquery-etl/pull/5659, I found the billing project option doesn't work when there are temp udfs (DENG-3905).  I'm working on a fix for that but I want to do this in the meantime to get the query working again.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3910)
