### PR TITLE
Fix PyPI package publishing in CI

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1053,7 +1053,7 @@ jobs:
               then
                 echo "Found changes to package version dir, proceeding with deployment."
               else
-                echo "No changes in package version. Skipping metric-config-parser deployment."
+                echo "No changes in package version. Skipping bigquery-etl deployment."
                 circleci-agent step halt
             fi
       - run:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1047,6 +1047,16 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Check for package version change in last commit before proceeding.
+          command: |
+            if git diff main HEAD~1 pyproject.toml | grep 'version'
+              then
+                echo "Found changes to package version dir, proceeding with deployment."
+              else
+                echo "No changes in package version. Skipping metric-config-parser deployment."
+                circleci-agent step halt
+            fi
+      - run:
           name: Install deployment tools
           command: |
             pip install --upgrade setuptools wheel twine
@@ -1211,8 +1221,6 @@ workflows:
     jobs:
       - deploy-to-pypi:
           filters:
-            tags:
-              only: /[0-9]{4}.[0-9]{1,2}.[0-9]+/  # Calver: YYYY.M.MINOR
             branches:
-              # Ignore all branches; this workflow should only run for tags.
-              ignore: /.*/
+              only:
+                - main

--- a/README.md
+++ b/README.md
@@ -47,3 +47,8 @@ cp .vscode/launch.json.default .vscode/launch.json
 ```
 
 And you should now be set up to start working in the repo! The easiest way to do this is for many tasks is to use [`bqetl`](https://mozilla.github.io/bigquery-etl/bqetl/). You may also want to read up on [common workflows](https://mozilla.github.io/bigquery-etl/cookbooks/common_workflows/).
+
+
+## Releasing a new version of `bqetl`
+
+To push a new version of `bqetl` to [PyPI](https://pypi.org/project/mozilla-bigquery-etl/), update the `version` in [`pyproject.toml`](pyproject.toml). The version numbers follow the [CalVer](https://calver.org/) scheme, with the _Micro_ version numbers starting at 1. For example, for the first package version getting published in March 2024, the version would be `2024.3.1`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [
 description = "Tooling for building derived datasets in BigQuery"
 readme = "README.md"
 requires-python = ">=3.11"
-dynamic = ["dependencies", "version"]
+dynamic = ["dependencies"]
+version = "2024.5.1"
 
 [project.urls]
 Homepage = "https://github.com/mozilla/bigquery-etl"


### PR DESCRIPTION
The current setup of publishing PyPI packages via the CI is not working as the tag information is not accessible when using the `path-filtering` orb. This PR changes the process slightly, instead of pushing tag with new version numbers, the version number is now managed via `pyproject.toml`. Whenever the version number changes in that file a new package is published to PyPI (otherwise the step is skipped).

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3915)
