### PR TITLE
chore: refactor schema deploys, add and use deploy utils

### DIFF
--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -399,11 +399,7 @@ def initiate(
     )
 
     project, dataset, table = qualified_table_name_matching(qualified_table_name)
-    query_path = Path(sql_dir) / project / dataset / table
-    # deploy backfill staging table
-    # TODO: We've been silently ignoring missing schema files in calls to
-    # TODO: ctx.invoke(deploy). We should either call schema update to write
-    # TODO: the schema or write the schema directly.
+    query_path = Path(sql_dir) / project / dataset / table / "query.sql"
 
     try:
         deploy_table(

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -2197,9 +2197,7 @@ def deploy(
         click.echo("The following tables could not be deployed:")
         for failed_deploy in failed_deploys:
             click.echo(failed_deploy)
-        sys.exit(
-            1
-        )  # TODO: It would be nice to raise an ExceptionGroup here with the FailedDeployExceptions
+        sys.exit(1)
 
 
 def _deploy_external_data(

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1,5 +1,6 @@
 """bigquery-etl CLI query command."""
 
+import concurrent.futures
 import copy
 import datetime
 import json
@@ -45,6 +46,7 @@ from ..cli.utils import (
 )
 from ..config import ConfigLoader
 from ..dependency import get_dependency_graph
+from ..deploy import FailedDeployException, SkippedDeployException, deploy_table
 from ..dryrun import DryRun
 from ..format_sql.format import skip_format
 from ..format_sql.formatter import reformat
@@ -59,6 +61,7 @@ from ..metadata.parse_metadata import (
     PartitionMetadata,
     PartitionType,
 )
+from ..metadata.publish_metadata import attach_metadata
 from ..query_scheduling.dag_collection import DagCollection
 from ..query_scheduling.generate_airflow_dags import get_dags
 from ..schema import SCHEMA_FILE, Schema
@@ -2132,7 +2135,6 @@ def deploy(
             "and check that the project is set correctly."
         )
         sys.exit(1)
-    client = bigquery.Client()
 
     query_files = paths_matching_name_pattern(
         name, sql_dir, project_id, ["query.*", "script.sql"]
@@ -2151,91 +2153,34 @@ def deploy(
         if not query_files:
             raise click.ClickException(f"No queries matching `{name}` were found.")
 
-    def _deploy(query_file):
-        if respect_dryrun_skip and str(query_file) in DryRun.skipped_files():
-            click.echo(f"{query_file} dry runs are skipped. Cannot validate schemas.")
-            return
+    _deploy = partial(
+        deploy_table,
+        destination_table=destination_table,
+        force=force,
+        use_cloud_function=use_cloud_function,
+        skip_existing=skip_existing,
+        respect_dryrun_skip=respect_dryrun_skip,
+        sql_dir=sql_dir,
+    )
 
-        query_file_path = Path(query_file)
-        existing_schema_path = query_file_path.parent / SCHEMA_FILE
-
-        if not existing_schema_path.is_file():
-            click.echo(f"No schema file found for {query_file}")
-            return
-
-        try:
-            metadata = Metadata.of_query_file(query_file_path)
-            if (
-                metadata.scheduling
-                and "destination_table" in metadata.scheduling
-                and metadata.scheduling["destination_table"] is None
-            ):
-                click.echo(f"No destination table defined for {query_file}")
-                return
-        except FileNotFoundError:
-            pass
-
-        try:
-            table_name = query_file_path.parent.name
-            dataset_name = query_file_path.parent.parent.name
-            project_name = query_file_path.parent.parent.parent.name
-
-            if destination_table:
-                full_table_id = destination_table
-            else:
-                full_table_id = f"{project_name}.{dataset_name}.{table_name}"
-
-            existing_schema = Schema.from_schema_file(existing_schema_path)
-
-            if not force and str(query_file_path).endswith("query.sql"):
-                query_schema = Schema.from_query_file(
-                    query_file_path,
-                    use_cloud_function=use_cloud_function,
-                    respect_skip=respect_dryrun_skip,
-                    sql_dir=sql_dir,
-                )
-                if not existing_schema.equal(query_schema):
-                    click.echo(
-                        f"Query {query_file_path} does not match "
-                        f"schema in {existing_schema_path}. "
-                        f"To update the local schema file, "
-                        f"run `./bqetl query schema update "
-                        f"{dataset_name}.{table_name}`",
-                        err=True,
-                    )
-                    sys.exit(1)
-
-            bigquery_schema = existing_schema.to_bigquery_schema()
+    failed_deploys, skipped_deploys = [], []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=parallelism) as executor:
+        future_to_query = {
+            executor.submit(_deploy, query_file): query_file
+            for query_file in query_files
+        }
+        for future in futures.as_completed(future_to_query):
+            query_file = future_to_query[future]
             try:
-                table = client.get_table(full_table_id)
-            except NotFound:
-                table = bigquery.Table(full_table_id)
-
-            table.schema = bigquery_schema
-            _attach_metadata(query_file_path, table)
-
-            if not table.created:
-                client.create_table(table, exists_ok=True)
-                click.echo(f"Destination table {full_table_id} created.")
-            elif not skip_existing:
-                client.update_table(
-                    table,
-                    [
-                        "schema",
-                        "friendly_name",
-                        "description",
-                        "time_partitioning",
-                        "clustering_fields",
-                        "labels",
-                    ],
-                )
-                click.echo(f"Schema (and metadata) updated for {full_table_id}.")
-        except Exception:
-            print_exc()
-            return query_file
-
-    with ThreadPool(parallelism) as pool:
-        failed_deploys = [r for r in pool.map(_deploy, query_files) if r]
+                future.result()
+            except SkippedDeployException as e:
+                print(f"Skipped deploy for {query_file}: ({e})")
+                skipped_deploys.append(query_file)
+            except FailedDeployException as e:
+                print(f"Failed deploy for {query_file}: ({e})")
+                failed_deploys.append(query_file)
+            else:
+                print(f"{query_file} successfully deployed!")
 
     if not skip_external_data:
         failed_external_deploys = _deploy_external_data(
@@ -2243,55 +2188,18 @@ def deploy(
         )
         failed_deploys += failed_external_deploys
 
-    if len(failed_deploys) > 0:
+    if skipped_deploys:
+        click.echo("The following deploys were skipped:")
+        for skipped_deploy in skipped_deploys:
+            click.echo(skipped_deploy)
+
+    if failed_deploys:
         click.echo("The following tables could not be deployed:")
         for failed_deploy in failed_deploys:
             click.echo(failed_deploy)
-        sys.exit(1)
-
-    click.echo("All tables have been deployed.")
-
-
-def _attach_metadata(query_file_path: Path, table: bigquery.Table) -> None:
-    """Add metadata from query file's metadata.yaml to table object."""
-    try:
-        metadata = Metadata.of_query_file(query_file_path)
-    except FileNotFoundError:
-        return
-
-    table.description = metadata.description
-    table.friendly_name = metadata.friendly_name
-
-    if metadata.bigquery and metadata.bigquery.time_partitioning:
-        table.time_partitioning = bigquery.TimePartitioning(
-            metadata.bigquery.time_partitioning.type.bigquery_type,
-            field=metadata.bigquery.time_partitioning.field,
-            require_partition_filter=(
-                metadata.bigquery.time_partitioning.require_partition_filter
-            ),
-            expiration_ms=metadata.bigquery.time_partitioning.expiration_ms,
-        )
-    elif metadata.bigquery and metadata.bigquery.range_partitioning:
-        table.range_partitioning = bigquery.RangePartitioning(
-            field=metadata.bigquery.range_partitioning.field,
-            range_=bigquery.PartitionRange(
-                start=metadata.bigquery.range_partitioning.range.start,
-                end=metadata.bigquery.range_partitioning.range.end,
-                interval=metadata.bigquery.range_partitioning.range.interval,
-            ),
-        )
-
-    if metadata.bigquery and metadata.bigquery.clustering:
-        table.clustering_fields = metadata.bigquery.clustering.fields
-
-    # BigQuery only allows for string type labels with specific requirements to be published:
-    # https://cloud.google.com/bigquery/docs/labels-intro#requirements
-    if metadata.labels:
-        table.labels = {
-            key: value
-            for key, value in metadata.labels.items()
-            if isinstance(value, str)
-        }
+        sys.exit(
+            1
+        )  # TODO: It would be nice to raise an ExceptionGroup here with the FailedDeployExceptions
 
 
 def _deploy_external_data(
@@ -2335,7 +2243,7 @@ def _deploy_external_data(
 
             bigquery_schema = existing_schema.to_bigquery_schema()
             table.schema = bigquery_schema
-            _attach_metadata(metadata_file_path, table)
+            attach_metadata(metadata_file_path, table)
 
             if not table.created:
                 if metadata.external_data.format in (

--- a/bigquery_etl/deploy.py
+++ b/bigquery_etl/deploy.py
@@ -1,0 +1,121 @@
+"""Utilities for deploying BigQuery tables from bigquery-etl queries."""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from google.cloud import bigquery
+from google.cloud.exceptions import NotFound
+
+from .config import ConfigLoader
+from .dryrun import DryRun
+from .metadata.parse_metadata import Metadata
+from .metadata.publish_metadata import attach_metadata
+from .schema import SCHEMA_FILE, Schema
+
+log = logging.getLogger(__name__)
+
+
+class SkippedDeployException(Exception):
+    """Raised when a deployment is skipped."""
+
+
+class FailedDeployException(Exception):
+    """Raised for failed deployments."""
+
+
+def deploy_table(
+    query_file: Path,
+    destination_table: Optional[str] = None,
+    force: bool = False,
+    use_cloud_function: bool = False,
+    skip_existing: bool = False,
+    update_metadata: bool = True,
+    respect_dryrun_skip: bool = True,
+    sql_dir=ConfigLoader.get("default", "sql_dir"),
+) -> None:
+    """Deploy a query to a destination."""
+    if respect_dryrun_skip and str(query_file) in DryRun.skipped_files():
+        raise SkippedDeployException(f"Dry run skipped for {query_file}.")
+
+    try:
+        metadata = Metadata.of_query_file(query_file)
+        if (
+            metadata.scheduling
+            and "destination_table" in metadata.scheduling
+            and metadata.scheduling["destination_table"] is None
+        ):
+            raise FailedDeployException(
+                f"Destination table configured for {query_file} in metadata but is empty."
+            )
+    except FileNotFoundError:
+        log.warning(f"No metadata found for {query_file}.")
+
+    table_name = query_file.parent.name
+    dataset_name = query_file.parent.parent.name
+    project_name = query_file.parent.parent.parent.name
+
+    if destination_table is None:
+        destination_table = f"{project_name}.{dataset_name}.{table_name}"
+
+    existing_schema_path = query_file.parent / SCHEMA_FILE
+    try:
+        existing_schema = Schema.from_schema_file(existing_schema_path)
+    except Exception as e:  # TODO: Raise/catch more specific exception
+        raise SkippedDeployException(f"Schema missing for {query_file}.") from e
+
+    if not force and str(query_file).endswith("query.sql"):
+        query_schema = Schema.from_query_file(
+            query_file,
+            use_cloud_function=use_cloud_function,
+            respect_skip=respect_dryrun_skip,
+            sql_dir=sql_dir,
+        )
+        if not existing_schema.equal(query_schema):
+            raise FailedDeployException(
+                f"Query {query_file} does not match "
+                f"schema in {existing_schema_path}. "
+                f"To update the local schema file, "
+                f"run `./bqetl query schema update "
+                f"{dataset_name}.{table_name}`",
+            )
+
+    client = bigquery.Client()
+    try:
+        table = client.get_table(destination_table)
+    except NotFound:
+        table = bigquery.Table(destination_table)
+
+    bigquery_schema = existing_schema.to_bigquery_schema()
+    table.schema = bigquery_schema
+    if update_metadata:
+        attach_metadata(query_file, table)
+
+    _create_or_update(client, table, destination_table, skip_existing)
+
+
+def _create_or_update(
+    client: bigquery.Client,
+    table: bigquery.Table,
+    destination_table: str,
+    skip_existing: bool = False,
+) -> None:
+    if table.created:
+        if skip_existing:
+            raise SkippedDeployException(f"{destination_table} already exists.")
+        log.info(f"{destination_table} already exists, updating.")
+        client.update_table(
+            table,
+            [
+                "schema",
+                "friendly_name",
+                "description",
+                "time_partitioning",
+                "clustering_fields",
+                "labels",
+            ],
+        )
+        log.info(f"{destination_table} updated.")
+    else:
+        client.create_table(table)
+        log.info(f"{destination_table} created.")

--- a/bigquery_etl/deploy.py
+++ b/bigquery_etl/deploy.py
@@ -85,9 +85,8 @@ def deploy_table(
         table = client.get_table(destination_table)
     except NotFound:
         table = bigquery.Table(destination_table)
+    table.schema = existing_schema.to_bigquery_schema()
 
-    bigquery_schema = existing_schema.to_bigquery_schema()
-    table.schema = bigquery_schema
     if update_metadata:
         attach_metadata(query_file, table)
 

--- a/bigquery_etl/deploy.py
+++ b/bigquery_etl/deploy.py
@@ -90,19 +90,18 @@ def deploy_table(
     if update_metadata:
         attach_metadata(query_file, table)
 
-    _create_or_update(client, table, destination_table, skip_existing)
+    _create_or_update(client, table, skip_existing)
 
 
 def _create_or_update(
     client: bigquery.Client,
     table: bigquery.Table,
-    destination_table: str,
     skip_existing: bool = False,
 ) -> None:
     if table.created:
         if skip_existing:
-            raise SkippedDeployException(f"{destination_table} already exists.")
-        log.info(f"{destination_table} already exists, updating.")
+            raise SkippedDeployException(f"{table} already exists.")
+        log.info(f"{table} already exists, updating.")
         client.update_table(
             table,
             [
@@ -114,7 +113,7 @@ def _create_or_update(
                 "labels",
             ],
         )
-        log.info(f"{destination_table} updated.")
+        log.info(f"{table} updated.")
     else:
         client.create_table(table)
-        log.info(f"{destination_table} created.")
+        log.info(f"{table} created.")

--- a/bigquery_etl/metadata/publish_metadata.py
+++ b/bigquery_etl/metadata/publish_metadata.py
@@ -1,9 +1,13 @@
 """Update metadata of BigQuery tables and views."""
 
 from argparse import ArgumentParser
+from pathlib import Path
+
+from google.cloud import bigquery
 
 from ..config import ConfigLoader
 from ..util import standard_args
+from .parse_metadata import Metadata
 
 METADATA_FILE = "metadata.yaml"
 DEFAULT_PATTERN = (
@@ -53,3 +57,45 @@ def publish_metadata(client, project, dataset, table, metadata):
 
     except Exception as e:
         print(e)
+
+
+def attach_metadata(query_file_path: Path, table: bigquery.Table) -> None:
+    """Add metadata from query file's metadata.yaml to table object."""
+    try:
+        metadata = Metadata.of_query_file(query_file_path)
+    except FileNotFoundError:
+        return
+
+    table.description = metadata.description
+    table.friendly_name = metadata.friendly_name
+
+    if metadata.bigquery and metadata.bigquery.time_partitioning:
+        table.time_partitioning = bigquery.TimePartitioning(
+            metadata.bigquery.time_partitioning.type.bigquery_type,
+            field=metadata.bigquery.time_partitioning.field,
+            require_partition_filter=(
+                metadata.bigquery.time_partitioning.require_partition_filter
+            ),
+            expiration_ms=metadata.bigquery.time_partitioning.expiration_ms,
+        )
+    elif metadata.bigquery and metadata.bigquery.range_partitioning:
+        table.range_partitioning = bigquery.RangePartitioning(
+            field=metadata.bigquery.range_partitioning.field,
+            range_=bigquery.PartitionRange(
+                start=metadata.bigquery.range_partitioning.range.start,
+                end=metadata.bigquery.range_partitioning.range.end,
+                interval=metadata.bigquery.range_partitioning.range.interval,
+            ),
+        )
+
+    if metadata.bigquery and metadata.bigquery.clustering:
+        table.clustering_fields = metadata.bigquery.clustering.fields
+
+    # BigQuery only allows for string type labels with specific requirements to be published:
+    # https://cloud.google.com/bigquery/docs/labels-intro#requirements
+    if metadata.labels:
+        table.labels = {
+            key: value
+            for key, value in metadata.labels.items()
+            if isinstance(value, str)
+        }

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -34,6 +34,7 @@ from bigquery_etl.cli.backfill import (
     scheduled,
     validate,
 )
+from bigquery_etl.deploy import FailedDeployException
 
 DEFAULT_STATUS = BackfillStatus.INITIATE
 VALID_REASON = "test_reason"
@@ -2215,7 +2216,197 @@ class TestBackfill:
 
     @patch("google.cloud.bigquery.Client")
     @patch("subprocess.check_call")
-    def test_initiate_partitioned_backfill(self, check_call, mock_client, runner):
+    @patch("bigquery_etl.cli.backfill.deploy_table")
+    def test_initiate_partitioned_backfill(
+        self, mock_deploy_table, check_call, mock_client, runner
+    ):
+        mock_client().get_table.side_effect = [
+            NotFound(  # Check that staging data does not exist
+                "moz-fx-data-shared-prod.backfills_staging_derived.test_query_v1_backup_2021_05_03"
+                "not found"
+            ),
+            None,  # Check that production data exists during dry run
+            None,  # Check that production data exists
+        ]
+
+        with runner.isolated_filesystem():
+            SQL_DIR = "sql/moz-fx-data-shared-prod/test/test_query_v1"
+            os.makedirs(SQL_DIR)
+
+            with open(
+                "sql/moz-fx-data-shared-prod/test/test_query_v1/query.sql", "w"
+            ) as f:
+                f.write("SELECT 1")
+
+            with open(
+                "sql/moz-fx-data-shared-prod/test/test_query_v1/schema.yaml", "w"
+            ) as f:
+                f.write(yaml.dump({"fields": [{"name": "f0_", "type": "INTEGER"}]}))
+
+            with open(
+                "sql/moz-fx-data-shared-prod/test/test_query_v1/metadata.yaml",
+                "w",
+            ) as f:
+                f.write(yaml.dump(PARTITIONED_TABLE_METADATA))
+
+            with open(
+                "sql/moz-fx-data-shared-prod/test/dataset_metadata.yaml", "w"
+            ) as f:
+                f.write(yaml.dump(DATASET_METADATA_CONF_EMPTY_WORKGROUP))
+
+            backfill_file = Path(SQL_DIR) / BACKFILL_FILE
+            backfill_file.write_text(
+                """
+2021-05-03:
+  start_date: 2021-01-03
+  end_date: 2021-01-08
+  reason: test_reason
+  watchers:
+  - test@example.org
+  status: Initiate"""
+            )
+
+            result = runner.invoke(
+                initiate,
+                ["moz-fx-data-shared-prod.test.test_query_v1", "--parallelism=0"],
+            )
+
+            assert result.exit_code == 0
+
+            mock_deploy_table.assert_called_with(
+                query_file=Path(
+                    "sql/moz-fx-data-shared-prod/test/test_query_v1/query.sql"
+                ),
+                destination_table="moz-fx-data-shared-prod.backfills_staging_derived.test_query_v1_2021_05_03",
+            )
+
+            expected_submission_date_params = [
+                f"--parameter=submission_date:DATE:2021-01-0{day}"
+                for day in range(3, 9)
+            ]
+
+            expected_destination_table_params = [
+                f"--destination_table=moz-fx-data-shared-prod:backfills_staging_derived.test_query_v1_2021_05_03$2021010{day}"
+                for day in range(3, 9)
+            ]
+
+            # this is inspecting calls to the underlying subprocess.check_call(["bq]"...)
+            assert check_call.call_count == 12  # 6 for dry run, 6 for backfill
+            for call in check_call.call_args_list:
+                submission_date_params = [
+                    arg for arg in call.args[0] if "--parameter=submission_date" in arg
+                ]
+                assert len(submission_date_params) == 1
+                assert submission_date_params[0] in expected_submission_date_params
+                assert f"--project_id={DEFAULT_BILLING_PROJECT}" in call.args[0]
+                destination_table_params = [
+                    arg for arg in call.args[0] if "--destination_table" in arg
+                ]
+                assert destination_table_params[0] in expected_destination_table_params
+
+    @patch("google.cloud.bigquery.Client")
+    @patch("subprocess.check_call")
+    @patch("bigquery_etl.cli.backfill.deploy_table")
+    def test_initiate_partitioned_backfill_with_valid_billing_project_from_entry(
+        self, mock_deploy_table, check_call, mock_client, runner
+    ):
+
+        mock_client().get_table.side_effect = [
+            NotFound(  # Check that staging data does not exist
+                "moz-fx-data-shared-prod.backfills_staging_derived.test_query_v1_backup_2021_05_03"
+                "not found"
+            ),
+            None,  # Check that production data exists during dry run
+            None,  # Check that production data exists
+        ]
+
+        with runner.isolated_filesystem():
+            SQL_DIR = "sql/moz-fx-data-shared-prod/test/test_query_v1"
+            os.makedirs(SQL_DIR)
+
+            with open(
+                "sql/moz-fx-data-shared-prod/test/test_query_v1/query.sql", "w"
+            ) as f:
+                f.write("SELECT 1")
+
+            with open(
+                "sql/moz-fx-data-shared-prod/test/test_query_v1/schema.yaml", "w"
+            ) as f:
+                f.write(yaml.dump({"fields": [{"name": "f0_", "type": "INTEGER"}]}))
+
+            with open(
+                "sql/moz-fx-data-shared-prod/test/test_query_v1/metadata.yaml",
+                "w",
+            ) as f:
+                f.write(yaml.dump(PARTITIONED_TABLE_METADATA))
+
+            with open(
+                "sql/moz-fx-data-shared-prod/test/dataset_metadata.yaml", "w"
+            ) as f:
+                f.write(yaml.dump(DATASET_METADATA_CONF_EMPTY_WORKGROUP))
+
+            backfill_file = Path(SQL_DIR) / BACKFILL_FILE
+            backfill_file.write_text(
+                f"""
+2021-05-03:
+  start_date: 2021-01-03
+  end_date: 2021-01-08
+  reason: test_reason
+  watchers:
+  - test@example.org
+  status: Initiate
+  billing_project: {VALID_BILLING_PROJECT}
+  """
+            )
+
+            result = runner.invoke(
+                initiate,
+                [
+                    "moz-fx-data-shared-prod.test.test_query_v1",
+                    "--parallelism=0",
+                ],
+            )
+
+            mock_deploy_table.assert_called_with(
+                query_file=Path(
+                    "sql/moz-fx-data-shared-prod/test/test_query_v1/query.sql"
+                ),
+                destination_table="moz-fx-data-shared-prod.backfills_staging_derived.test_query_v1_2021_05_03",
+            )
+            assert result.exit_code == 0
+
+            expected_submission_date_params = [
+                f"--parameter=submission_date:DATE:2021-01-0{day}"
+                for day in range(3, 9)
+            ]
+
+            expected_destination_table_params = [
+                f"--destination_table=moz-fx-data-shared-prod:backfills_staging_derived.test_query_v1_2021_05_03$2021010{day}"
+                for day in range(3, 9)
+            ]
+
+            # this is inspecting calls to the underlying subprocess.check_call(["bq]"...)
+            assert check_call.call_count == 12  # 6 for dry run, 6 for backfill
+            for call in check_call.call_args_list:
+                submission_date_params = [
+                    arg for arg in call.args[0] if "--parameter=submission_date" in arg
+                ]
+                assert len(submission_date_params) == 1
+                assert submission_date_params[0] in expected_submission_date_params
+                assert f"--project_id={VALID_BILLING_PROJECT}" in call.args[0]
+                destination_table_params = [
+                    arg for arg in call.args[0] if "--destination_table" in arg
+                ]
+                assert destination_table_params[0] in expected_destination_table_params
+
+    @patch("google.cloud.bigquery.Client")
+    @patch("bigquery_etl.cli.backfill.deploy_table")
+    def test_initiate_backfill_with_failed_deploy(
+        self, mock_deploy_table, mock_client, runner
+    ):
+
+        mock_deploy_table.side_effect = FailedDeployException("Unable to deploy table")
+
         mock_client().get_table.side_effect = [
             NotFound(  # Check that staging data does not exist
                 "moz-fx-data-shared-prod.backfills_staging_derived.test_query_v1_backup_2021_05_03"
@@ -2254,85 +2445,7 @@ class TestBackfill:
   reason: test_reason
   watchers:
   - test@example.org
-  status: Initiate"""
-            )
-
-            result = runner.invoke(
-                initiate,
-                ["moz-fx-data-shared-prod.test.test_query_v1", "--parallelism=0"],
-            )
-
-            assert result.exit_code == 0
-
-            expected_submission_date_params = [
-                f"--parameter=submission_date:DATE:2021-01-0{day}"
-                for day in range(3, 9)
-            ]
-
-            expected_destination_table_params = [
-                f"--destination_table=moz-fx-data-shared-prod:backfills_staging_derived.test_query_v1_2021_05_03$2021010{day}"
-                for day in range(3, 9)
-            ]
-
-            # this is inspecting calls to the underlying subprocess.check_call(["bq]"...)
-            assert check_call.call_count == 12  # 6 for dry run, 6 for backfill
-            for call in check_call.call_args_list:
-                submission_date_params = [
-                    arg for arg in call.args[0] if "--parameter=submission_date" in arg
-                ]
-                assert len(submission_date_params) == 1
-                assert submission_date_params[0] in expected_submission_date_params
-                assert f"--project_id={DEFAULT_BILLING_PROJECT}" in call.args[0]
-                destination_table_params = [
-                    arg for arg in call.args[0] if "--destination_table" in arg
-                ]
-                assert destination_table_params[0] in expected_destination_table_params
-
-    @patch("google.cloud.bigquery.Client")
-    @patch("subprocess.check_call")
-    def test_initiate_partitioned_backfill_with_valid_billing_project_from_entry(
-        self, check_call, mock_client, runner
-    ):
-        mock_client().get_table.side_effect = [
-            NotFound(  # Check that staging data does not exist
-                "moz-fx-data-shared-prod.backfills_staging_derived.test_query_v1_backup_2021_05_03"
-                "not found"
-            ),
-            None,  # Check that production data exists during dry run
-            None,  # Check that production data exists
-        ]
-
-        with runner.isolated_filesystem():
-            SQL_DIR = "sql/moz-fx-data-shared-prod/test/test_query_v1"
-            os.makedirs(SQL_DIR)
-
-            with open(
-                "sql/moz-fx-data-shared-prod/test/test_query_v1/query.sql", "w"
-            ) as f:
-                f.write("SELECT 1")
-
-            with open(
-                "sql/moz-fx-data-shared-prod/test/test_query_v1/metadata.yaml",
-                "w",
-            ) as f:
-                f.write(yaml.dump(PARTITIONED_TABLE_METADATA))
-
-            with open(
-                "sql/moz-fx-data-shared-prod/test/dataset_metadata.yaml", "w"
-            ) as f:
-                f.write(yaml.dump(DATASET_METADATA_CONF_EMPTY_WORKGROUP))
-
-            backfill_file = Path(SQL_DIR) / BACKFILL_FILE
-            backfill_file.write_text(
-                f"""
-2021-05-03:
-  start_date: 2021-01-03
-  end_date: 2021-01-08
-  reason: test_reason
-  watchers:
-  - test@example.org
   status: Initiate
-  billing_project: {VALID_BILLING_PROJECT}
   """
             )
 
@@ -2344,31 +2457,14 @@ class TestBackfill:
                 ],
             )
 
-            assert result.exit_code == 0
-
-            expected_submission_date_params = [
-                f"--parameter=submission_date:DATE:2021-01-0{day}"
-                for day in range(3, 9)
-            ]
-
-            expected_destination_table_params = [
-                f"--destination_table=moz-fx-data-shared-prod:backfills_staging_derived.test_query_v1_2021_05_03$2021010{day}"
-                for day in range(3, 9)
-            ]
-
-            # this is inspecting calls to the underlying subprocess.check_call(["bq]"...)
-            assert check_call.call_count == 12  # 6 for dry run, 6 for backfill
-            for call in check_call.call_args_list:
-                submission_date_params = [
-                    arg for arg in call.args[0] if "--parameter=submission_date" in arg
-                ]
-                assert len(submission_date_params) == 1
-                assert submission_date_params[0] in expected_submission_date_params
-                assert f"--project_id={VALID_BILLING_PROJECT}" in call.args[0]
-                destination_table_params = [
-                    arg for arg in call.args[0] if "--destination_table" in arg
-                ]
-                assert destination_table_params[0] in expected_destination_table_params
+            mock_deploy_table.assert_called_with(
+                query_file=Path(
+                    "sql/moz-fx-data-shared-prod/test/test_query_v1/query.sql"
+                ),
+                destination_table="moz-fx-data-shared-prod.backfills_staging_derived.test_query_v1_2021_05_03",
+            )
+            assert result.exit_code == 1
+            assert "Backfill initiate failed to deploy" in str(result.exception)
 
     @patch("google.cloud.bigquery.Client")
     def test_initiate_partitioned_backfill_with_invalid_billing_project_from_entry_should_fail(

--- a/tests/cli/test_cli_query.py
+++ b/tests/cli/test_cli_query.py
@@ -8,13 +8,13 @@ import yaml
 from click.testing import CliRunner
 
 from bigquery_etl.cli.query import (
-    _attach_metadata,
     backfill,
     create,
     info,
     paths_matching_name_pattern,
     schedule,
 )
+from bigquery_etl.metadata.publish_metadata import attach_metadata
 
 
 class TestQuery:
@@ -487,7 +487,7 @@ class TestQuery:
                 f.write(yaml.dump(metadata_conf))
 
             table = types.SimpleNamespace()
-            _attach_metadata(
+            attach_metadata(
                 "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1/query.sql",
                 table,
             )

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,105 @@
+from unittest.mock import patch
+
+import pytest
+import yaml
+from google.cloud.exceptions import NotFound
+
+from bigquery_etl import deploy
+
+
+class TestDeploy:
+
+    @pytest.fixture(scope="session")
+    def query_path(self, tmp_path_factory):
+        path = (
+            tmp_path_factory.mktemp("sql")
+            / "moz-fx-data-shared-prod"
+            / "test"
+            / "test_query_v1"
+        )
+        path.mkdir(parents=True)
+        (path / "query.sql").write_text("SELECT 1")
+        (path / "schema.yaml").write_text(
+            yaml.dump({"fields": [{"name": "f0_", "type": "INTEGER"}]})
+        )
+        return path
+
+    @patch("google.cloud.bigquery.Client")
+    @patch("bigquery_etl.dryrun.DryRun")
+    def test_deploy_new_table(self, mock_dryrun, mock_client, query_path):
+
+        mock_dryrun().get_schema.return_value = {
+            "fields": [{"name": "f0_", "type": "INTEGER"}]
+        }
+
+        client = mock_client.return_value
+        client.get_table.side_effect = NotFound("table not found")
+
+        deploy.deploy_table(
+            query_file=query_path / "query.sql",
+        )
+
+        client.create_table.assert_called_once()
+        assert client.update_table.call_count == 0
+
+    def test_deploy_table_without_schema_raises_skip(self, tmp_path):
+        query_path = (
+            tmp_path / "sql" / "moz-fx-data-shared-prod" / "test" / "test_query_v1"
+        )
+        query_path.mkdir(parents=True)
+        (query_path / "query.sql").write_text("SELECT 1")
+
+        with pytest.raises(deploy.SkippedDeployException, match="Schema missing"):
+            deploy.deploy_table(query_file=tmp_path / "query.sql")
+
+    @patch("google.cloud.bigquery.Client")
+    @patch("bigquery_etl.dryrun.DryRun")
+    def test_deploy_table_already_exists(self, mock_dryrun, mock_client, query_path):
+        mock_dryrun().get_schema.return_value = {
+            "fields": [{"name": "f0_", "type": "INTEGER"}]
+        }
+
+        client = mock_client.return_value
+        deploy.deploy_table(
+            query_file=query_path / "query.sql",
+        )
+
+        client.update_table.assert_called_once()
+        assert client.create_table.call_count == 0
+
+    @patch("google.cloud.bigquery.Client")
+    @patch("bigquery_etl.dryrun.DryRun")
+    def test_deploy_table_already_exists_skip_existing(
+        self, mock_dryrun, mock_client, query_path
+    ):
+        mock_dryrun().get_schema.return_value = {
+            "fields": [{"name": "f0_", "type": "INTEGER"}]
+        }
+
+        with pytest.raises(deploy.SkippedDeployException, match="already exists"):
+            deploy.deploy_table(query_file=query_path / "query.sql", skip_existing=True)
+
+    @patch("bigquery_etl.dryrun.DryRun")
+    def test_deploy_fails_when_schemas_dont_match(self, mock_dryrun, query_path):
+        mock_dryrun().get_schema.return_value = {
+            "fields": [{"name": "doesnt_exist", "type": "STRING"}]
+        }
+        with pytest.raises(deploy.FailedDeployException, match="does not match schema"):
+            deploy.deploy_table(
+                query_file=query_path / "query.sql",
+            )
+
+    @patch("google.cloud.bigquery.Client")
+    @patch("bigquery_etl.dryrun.DryRun")
+    def test_force_deploy_with_not_matching_schemas(
+        self, mock_dryrun, mock_client, query_path
+    ):
+        mock_dryrun().get_schema.return_value = {
+            "fields": [{"name": "doesnt_exist", "type": "STRING"}]
+        }
+        client = mock_client.return_value
+        client.get_table.side_effect = NotFound("table not found")
+
+        deploy.deploy_table(query_file=query_path / "query.sql", force=True)
+
+        client.create_table.assert_called_once()


### PR DESCRIPTION
Mainly introduces a `deploy` module for table deployment logic. Additionally does the following:

- Adds specific exceptions for skipped and failed deploys. 
-  Updates multiprocessing code to `concurrent.futures` to collect individual exceptions as exception handling instead of using return values. 
- Moves metadata attaching logic to metadata module. 
- Update backfill initiate tests to mock deployment. These tests currently pass because skipped deploys currently "fail" silently in the click deploy command. Running a backfill without a schema in production will skip the deploy and fail when running the backfill queries. An example of this is the conversation linked in https://github.com/mozilla/bigquery-etl/pull/5646. (Missing schemas should be fixed by https://github.com/mozilla/bigquery-etl/pull/5643). 