### PR TITLE
Include VPN iOS network extension app in VPN events ETLs

### DIFF
--- a/sql_generators/events_daily/templates/event_types_history_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/event_types_history_v1/templating.yaml
@@ -40,6 +40,7 @@ mozilla_vpn_derived:
     - mozillavpn
     - org_mozilla_firefox_vpn
     - org_mozilla_ios_firefoxvpn
+    - org_mozilla_ios_firefoxvpn_network_extension
   start_date: 2021-10-01
   skipped_properties:
     - time_ms

--- a/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
@@ -137,6 +137,7 @@ mozilla_vpn_derived:
     - mozillavpn
     - org_mozilla_firefox_vpn
     - org_mozilla_ios_firefoxvpn
+    - org_mozilla_ios_firefoxvpn_network_extension
   start_date: 2021-10-01
   dag_name: bqetl_event_rollup
   user_properties:


### PR DESCRIPTION
While the VPN iOS network extension app isn't currently sending `main` pings with events like the other VPN apps are, it's good to include it for consistency, as the network extension app's `main` pings are automatically included in the generated `mozilla_vpn.main` view, and thus are also included in the `mozilla_vpn.events_unnested` view.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3925)
