### PR TITLE
feat: update firefox_android_clients_v1 to pull distribution_id only from the baseline ping

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
@@ -19,6 +19,7 @@ WITH baseline_clients AS (
     app_display_version AS app_version,
     locale,
     is_new_profile,
+    distribution_id,
   FROM
     `moz-fx-data-shared-prod.fenix.baseline_clients_daily`
   WHERE
@@ -43,7 +44,8 @@ first_seen AS (
     device_model,
     os_version,
     app_version,
-    locale
+    locale,
+    distribution_id,
   FROM
     baseline_clients
   WHERE
@@ -154,11 +156,6 @@ first_session_ping AS (
       ORDER BY
         submission_timestamp ASC
     )[SAFE_OFFSET(0)] AS play_store_attribution_install_referrer_response,
-    ARRAY_AGG(
-      metrics.string.first_session_distribution_id IGNORE NULLS
-      ORDER BY
-        submission_timestamp ASC
-    )[SAFE_OFFSET(0)] AS distribution_id,
     ARRAY_AGG(metrics.string.meta_attribution_app IGNORE NULLS ORDER BY submission_timestamp ASC)[
       SAFE_OFFSET(0)
     ] AS meta_attribution_app,
@@ -231,11 +228,6 @@ metrics_ping AS (
       ORDER BY
         submission_timestamp DESC
     )[SAFE_OFFSET(0)] AS last_reported_adjust_campaign,
-    ARRAY_AGG(
-      metrics.string.metrics_distribution_id IGNORE NULLS
-      ORDER BY
-        submission_timestamp ASC
-    )[SAFE_OFFSET(0)] AS distribution_id,
   FROM
     fenix.metrics AS fenix_metrics
   WHERE
@@ -299,7 +291,7 @@ _current AS (
     first_session.play_store_attribution_source,
     first_session.play_store_attribution_term,
     first_session.play_store_attribution_install_referrer_response,
-    COALESCE(first_session.distribution_id, metrics.distribution_id) AS distribution_id,
+    baseline.distribution_id,
     first_session.meta_attribution_app AS meta_attribution_app,
     metrics.last_reported_adjust_campaign AS last_reported_adjust_campaign,
     metrics.last_reported_adjust_ad_group AS last_reported_adjust_ad_group,

--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/query.sql
@@ -45,7 +45,6 @@ first_seen AS (
     os_version,
     app_version,
     locale,
-    distribution_id,
   FROM
     baseline_clients
   WHERE
@@ -259,6 +258,9 @@ baseline_ping AS (
     ARRAY_AGG(locale IGNORE NULLS ORDER BY submission_date DESC)[
       SAFE_OFFSET(0)
     ] AS last_reported_locale,
+    ARRAY_AGG(distribution_id IGNORE NULLS ORDER BY submission_date DESC)[
+      SAFE_OFFSET(0)
+    ] AS distribution_id,
   FROM
     baseline_clients
   GROUP BY

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/moz-fx-data-shared-prod.fenix.baseline_clients_daily.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/moz-fx-data-shared-prod.fenix.baseline_clients_daily.schema.json
@@ -55,5 +55,9 @@
   {
     "type": "BOOLEAN",
     "name": "is_new_profile"
+  },
+  {
+    "type": "STRING",
+    "name": "distribution_id"
   }
 ]


### PR DESCRIPTION
# feat: update firefox_android_clients_v1 to pull distribution_id only from the baseline ping

The distribution_id currently appears to be wrong inside firefox_android_clients_v1, this is a quick "solution" to try and mitigate this issue by pulling distribution_id from the baseline ping instead. The reason for this is that we decided that the baseline ping on mobile will serve as the primary source of truth in relation to KPI reporting.

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3935)
