### PR TITLE
removing upstream dependencies for now

### DIFF
--- a/sql/moz-fx-data-shared-prod/braze_derived/products_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/products_v1/metadata.yaml
@@ -13,5 +13,7 @@ bigquery:
 scheduling:
   dag_name: bqetl_braze
   date_partition_parameter: null
-  referenced_tables:
-  - ['moz-fx-data-shared-prod', 'subscription_platform_derived', 'logical_subscriptions_history_v1']
+  # this dag runs more frequently than the upstream tables and relies
+  # mostly on data replicated into bq from ctms cloud sql
+  # once product latency is at an hour, we can remove the below
+  referenced_tables: []

--- a/sql/moz-fx-data-shared-prod/braze_derived/users_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/users_v1/metadata.yaml
@@ -14,5 +14,4 @@ bigquery:
 scheduling:
   dag_name: bqetl_braze
   date_partition_parameter: null
-  referenced_tables:
-  - ['moz-fx-data-shared-prod', 'marketing_suppression_list_derived', 'main_suppression_list_v1']
+  referenced_tables: []

--- a/sql/moz-fx-data-shared-prod/braze_derived/users_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/users_v1/metadata.yaml
@@ -14,4 +14,7 @@ bigquery:
 scheduling:
   dag_name: bqetl_braze
   date_partition_parameter: null
+  # this dag runs more frequently than the upstream tables and relies
+  # mostly on data replicated into bq from ctms cloud sql
+  # once suppression latency is at an hour, we can remove the below
   referenced_tables: []


### PR DESCRIPTION
The braze dag schedule now runs 3 times a day and upstream dependencies do not. We can get by with the upstream tables having a daily cadence as the rest of the data comes from an upstream source off of bqetl

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3938)
