### PR TITLE
Fix setting partitioning metadata

### DIFF
--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -428,11 +428,11 @@ class Metadata:
             time_partitioning = self.bigquery.time_partitioning
             range_partitioning = self.bigquery.range_partitioning
 
-        self.bigquery = BigQueryMetadata(
-            time_partitioning=time_partitioning,
-            range_partitioning=range_partitioning,
-            clustering=ClusteringMetadata(fields=clustering_fields),
-        )
+            self.bigquery = BigQueryMetadata(
+                time_partitioning=time_partitioning,
+                range_partitioning=range_partitioning,
+                clustering=ClusteringMetadata(fields=clustering_fields),
+            )
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
This should fix the errors we are seeing in Airflow:

```
[2024-05-30, 18:00:03 UTC] {pod_manager.py:466} INFO - [base]     changed = _update_query_schema(
[2024-05-30, 18:00:03 UTC] {pod_manager.py:466} INFO - [base]               ^^^^^^^^^^^^^^^^^^^^^
[2024-05-30, 18:00:03 UTC] {pod_manager.py:466} INFO - [base]   File "/app/bigquery_etl/cli/query.py", line 2008, in _update_query_schema
[2024-05-30, 18:00:03 UTC] {pod_manager.py:466} INFO - [base]     metadata.set_bigquery_clustering(table.clustering_fields)
[2024-05-30, 18:00:03 UTC] {pod_manager.py:466} INFO - [base]   File "/app/bigquery_etl/metadata/parse_metadata.py", line 432, in set_bigquery_clustering
[2024-05-30, 18:00:03 UTC] {pod_manager.py:466} INFO - [base]     time_partitioning=time_partitioning,
[2024-05-30, 18:00:03 UTC] {pod_manager.py:466} INFO - [base]                       ^^^^^^^^^^^^^^^^^
2024-05-30T18:00:03.709365151Z 
[2024-05-30, 18:00:03 UTC] {pod_manager.py:466} INFO - [base] UnboundLocalError: cannot access local variable 'time_partitioning' where it is not associated with a value
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3940)
