### PR TITLE
Fix set_bigquery_clustering

### DIFF
--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -424,15 +424,18 @@ class Metadata:
 
     def set_bigquery_clustering(self, clustering_fields):
         """Update the BigQuery partitioning metadata."""
+        time_partitioning = None
+        range_partitioning = None
+        
         if self.bigquery:
             time_partitioning = self.bigquery.time_partitioning
             range_partitioning = self.bigquery.range_partitioning
 
-            self.bigquery = BigQueryMetadata(
-                time_partitioning=time_partitioning,
-                range_partitioning=range_partitioning,
-                clustering=ClusteringMetadata(fields=clustering_fields),
-            )
+        self.bigquery = BigQueryMetadata(
+            time_partitioning=time_partitioning,
+            range_partitioning=range_partitioning,
+            clustering=ClusteringMetadata(fields=clustering_fields),
+        )
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
Follow-up to https://github.com/mozilla/bigquery-etl/pull/5690/files#r1621329870

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
