### PR TITLE
fix: update entry date to be the same as the end_date

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
@@ -1,4 +1,4 @@
-2024-05-30:
+2024-05-31:
   start_date: 2021-01-01
   end_date: 2024-05-31
   reason: The table is created, this is to populate it with data.

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/backfill.yaml
@@ -1,4 +1,4 @@
-2024-05-30:
+2024-05-31:
   start_date: 2021-01-01
   end_date: 2024-05-31
   reason: The table is created, this is to populate it with data.


### PR DESCRIPTION
fix: update entry date to be the same as the end_date

This should address the following CI error:

```
    backfill = cls(
               ^^^^
  File "<attrs generated init bigquery_etl.backfill.parse.Backfill>", line 13, in __init__
  File "/root/project/bigquery_etl/backfill/parse.py", line 112, in validate_end_date
    raise ValueError(f"Invalid end date: {value}.")
ValueError: Invalid end date: 2024-05-31.
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3950)
