### PR TITLE
fix(deploy): skip (instead of fail) deploys with explicitly null destination_table

### DIFF
--- a/bigquery_etl/deploy.py
+++ b/bigquery_etl/deploy.py
@@ -45,8 +45,8 @@ def deploy_table(
             and "destination_table" in metadata.scheduling
             and metadata.scheduling["destination_table"] is None
         ):
-            raise FailedDeployException(
-                f"Destination table configured for {query_file} in metadata but is empty."
+            raise SkippedDeployException(
+                f"Skipping deploy for {query_file}, null destination_table configured."
             )
     except FileNotFoundError:
         log.warning(f"No metadata found for {query_file}.")


### PR DESCRIPTION
Previous logic was a skip rather than a fail. This isn't mis-configuration, these are used for empty check queries, e.g. `site_metrics_empty_check_v1`. Medium-long term these could probably be migrated to a data check.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3951)
