### PR TITLE
feat: make changes to generate retention and engagement for focus and klar products also

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
@@ -8,11 +8,7 @@ SELECT
   country,
   locale,
   is_mobile,
-  adjust_ad_group,
-  adjust_campaign,
-  adjust_creative,
-  adjust_network,
-  {% for field in product_specific_attribution_fields %}
+  {% for field in attribution_fields %}
     {{ field.name }},
   {% endfor %}
   COUNTIF(is_dau) AS dau,
@@ -31,11 +27,7 @@ GROUP BY
   country,
   locale,
   is_mobile,
-  adjust_ad_group,
-  adjust_campaign,
-  adjust_creative,
-  adjust_network,
-  {% for field in product_specific_attribution_fields %}
+  {% for field in attribution_fields %}
     {{ field.name }}
     {% if not loop.last %},
     {% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
@@ -17,7 +17,13 @@ SELECT
 FROM
   `{{ project_id }}.{{ dataset }}.engagement_clients`
 WHERE
-  submission_date = @submission_date
+  {% raw %}
+  {% if is_init() %}
+    submission_date < CURRENT_DATE
+  {% else %}
+    submission_date = @submission_date
+  {% endif %}
+  {% endraw %}
 GROUP BY
   submission_date,
   first_seen_date,

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
@@ -13,7 +13,7 @@ SELECT
   {% endfor %}
   COUNTIF(is_dau) AS dau,
   COUNTIF(is_wau) AS wau,
-  COUNTIF(is_mau) AS mau
+  COUNTIF(is_mau) AS mau,
 FROM
   `{{ project_id }}.{{ dataset }}.engagement_clients`
 WHERE
@@ -32,8 +32,10 @@ GROUP BY
   app_version,
   country,
   locale,
-  is_mobile,
+  is_mobile
   {% for field in attribution_fields %}
+    {% if loop.first %},
+    {% endif %}
     {{ field.name }}
     {% if not loop.last %},
     {% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.schema.yaml
@@ -38,27 +38,7 @@ fields:
   type: BOOLEAN
   mode: NULLABLE
   description: Indicates if this specific entry is used towards calculating mobile DAU.
-
-- name: adjust_ad_group
-  type: STRING
-  mode: NULLABLE
-  description: Adjust Ad Group the profile is attributed to.
-
-- name: adjust_campaign
-  type: STRING
-  mode: NULLABLE
-  description: Adjust Campaign the profile is attributed to.
-
-- name: adjust_creative
-  type: STRING
-  mode: NULLABLE
-  description: Adjust Creative the profile is attributed to.
-
-- name: adjust_network
-  type: STRING
-  mode: NULLABLE
-  description: Adjust Network the profile is attributed to.
-{% for field in product_specific_attribution_fields %}
+{% for field in attribution_fields %}
 - name: {{ field.name }}
   type: {{ field.type }}
   mode: NULLABLE

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement_clients.view.sql
@@ -20,29 +20,24 @@ WITH active_users AS (
     is_mobile,
   FROM
     `{{ project_id }}.{{ dataset }}.active_users`
-),
-attribution AS (
+)
+{% if attribution_fields %}
+, attribution AS (
   SELECT
     client_id,
     sample_id,
     channel AS normalized_channel,
-    NULLIF(adjust_ad_group, "") AS adjust_ad_group,
-    NULLIF(adjust_creative, "") AS adjust_creative,
-    NULLIF(adjust_network, "") AS adjust_network,
-    {% if app_name == "fenix" %}
+    {% for field in attribution_fields %}
+      {% if app_name == "fenix" and field.name == "adjust_campaign" %}
       CASE
         WHEN adjust_network IN ('Google Organic Search', 'Organic')
           THEN 'Organic'
         ELSE NULLIF(adjust_campaign, "")
-      END
-    {% else %}
-      NULLIF(adjust_campaign, "")
-    {% endif %} AS adjust_campaign,
-    {% for field in product_specific_attribution_fields %}
-      {% if field.type == "STRING" %}
+      END AS adjust_campaign,
+      {% elif field.type == "STRING" %}
         NULLIF({{ field.name }}, "") AS {{ field.name }},
       {% else %}
-        {{ field.name }}
+        {{ field.name }},
       {% endif %}
     {% endfor %}
   FROM
@@ -52,6 +47,7 @@ attribution AS (
       `{{ project_id }}.{{ dataset }}_derived.firefox_ios_clients_v1`
     {% endif %}
 )
+{% endif %}
 SELECT
   submission_date,
   client_id,
@@ -67,11 +63,7 @@ SELECT
   is_wau,
   is_mau,
   is_mobile,
-  attribution.adjust_ad_group,
-  attribution.adjust_campaign,
-  attribution.adjust_creative,
-  attribution.adjust_network,
-  {% for field in product_specific_attribution_fields %}
+  {% for field in attribution_fields %}
     attribution.{{ field.name }},
   {% endfor %}
   CASE
@@ -87,6 +79,8 @@ SELECT
   END AS lifecycle_stage,
 FROM
   active_users
+{% if attribution_fields %}
 LEFT JOIN
   attribution
   USING (client_id, sample_id, normalized_channel)
+{% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
@@ -38,8 +38,10 @@ GROUP BY
   country,
   app_version,
   locale,
-  is_mobile,
+  is_mobile
   {% for field in attribution_fields %}
+    {% if loop.first %},
+    {% endif %}
     {{ field.name }}
     {% if not loop.last %},
     {% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
@@ -21,8 +21,15 @@ SELECT
 FROM
   `{{ project_id }}.{{ dataset }}.retention_clients`
 WHERE
-  metric_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
-  AND submission_date = @submission_date
+  {% raw %}
+  {% if is_init() %}
+    metric_date < DATE_SUB(CURRENT_DATE, INTERVAL 27 DAY)
+    AND submission_date < CURRENT_DATE
+  {% else %}
+    metric_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
+    AND submission_date = @submission_date
+  {% endif %}
+  {% endraw %}
 GROUP BY
   metric_date,
   first_seen_date,

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
@@ -8,11 +8,7 @@ SELECT
   app_version,
   locale,
   is_mobile,
-  adjust_ad_group,
-  adjust_campaign,
-  adjust_creative,
-  adjust_network,
-  {% for field in product_specific_attribution_fields %}
+  {% for field in attribution_fields %}
     {{ field.name }},
   {% endfor %}
   COUNTIF(ping_sent_metric_date) AS ping_sent_metric_date,
@@ -36,11 +32,7 @@ GROUP BY
   app_version,
   locale,
   is_mobile,
-  adjust_ad_group,
-  adjust_campaign,
-  adjust_creative,
-  adjust_network,
-  {% for field in product_specific_attribution_fields %}
+  {% for field in attribution_fields %}
     {{ field.name }}
     {% if not loop.last %},
     {% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.schema.yaml
@@ -1,5 +1,4 @@
 fields:
-
 - mode: NULLABLE
   name: metric_date
   type: DATE
@@ -39,27 +38,7 @@ fields:
   type: BOOLEAN
   mode: NULLABLE
   description: Indicates if this specific entry is used towards calculating mobile DAU.
-
-- name: adjust_ad_group
-  type: STRING
-  mode: NULLABLE
-  description: Adjust Ad Group the profile is attributed to.
-
-- name: adjust_campaign
-  type: STRING
-  mode: NULLABLE
-  description: Adjust Campaign the profile is attributed to.
-
-- name: adjust_creative
-  type: STRING
-  mode: NULLABLE
-  description: Adjust Creative the profile is attributed to.
-
-- name: adjust_network
-  type: STRING
-  mode: NULLABLE
-  description: Adjust Network the profile is attributed to.
-{% for field in product_specific_attribution_fields %}
+{% for field in attribution_fields %}
 - name: {{ field.name }}
   type: {{ field.type }}
   mode: NULLABLE

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention_clients.view.sql
@@ -16,29 +16,24 @@ WITH active_users AS (
     is_mobile,
   FROM
     `{{ project_id }}.{{ dataset }}.active_users`
-),
-attribution AS (
+)
+{% if attribution_fields %}
+, attribution AS (
   SELECT
     client_id,
     sample_id,
     channel AS normalized_channel,
-    NULLIF(adjust_ad_group, "") AS adjust_ad_group,
-    NULLIF(adjust_creative, "") AS adjust_creative,
-    NULLIF(adjust_network, "") AS adjust_network,
-    {% if app_name == "fenix" %}
+    {% for field in attribution_fields %}
+      {% if app_name == "fenix" and field.name == "adjust_campaign" %}
       CASE
         WHEN adjust_network IN ('Google Organic Search', 'Organic')
           THEN 'Organic'
         ELSE NULLIF(adjust_campaign, "")
-      END
-    {% else %}
-      NULLIF(adjust_campaign, "")
-    {% endif %} AS adjust_campaign,
-    {% for field in product_specific_attribution_fields %}
-      {% if field.type == "STRING" %}
+      END AS adjust_campaign,
+      {% elif field.type == "STRING" %}
         NULLIF({{ field.name }}, "") AS {{ field.name }},
       {% else %}
-        {{ field.name }}
+        {{ field.name }},
       {% endif %}
     {% endfor %}
   FROM
@@ -48,6 +43,7 @@ attribution AS (
       `{{ project_id }}.{{ dataset }}_derived.firefox_ios_clients_v1`
     {% endif %}
 )
+{% endif %}
 SELECT
   active_users.submission_date AS submission_date,
   clients_daily.submission_date AS metric_date,
@@ -61,7 +57,7 @@ SELECT
   clients_daily.locale,
   clients_daily.isp,
   active_users.is_mobile,
-  {% for field in product_specific_attribution_fields %}
+  {% for field in attribution_fields %}
     attribution.{{ field.name }},
   {% endfor %}
   -- ping sent retention
@@ -87,10 +83,6 @@ SELECT
     -- Looking back at 27 days to support the official definition of repeat_profile (someone active between days 2 and 28):
     AND BIT_COUNT(mozfun.bits28.range(active_users.days_active_bits, -26, 27)) > 0
   ) AS repeat_profile,
-  attribution.adjust_ad_group,
-  attribution.adjust_campaign,
-  attribution.adjust_creative,
-  attribution.adjust_network,
   active_users.days_seen_bits,
   active_users.days_active_bits,
   CASE
@@ -111,9 +103,11 @@ INNER JOIN
   ON clients_daily.submission_date = active_users.retention_seen.day_27.metric_date
   AND clients_daily.client_id = active_users.client_id
   AND clients_daily.normalized_channel = active_users.normalized_channel
+{% if attribution_fields %}
 LEFT JOIN
   attribution
   ON clients_daily.client_id = attribution.client_id
   AND clients_daily.normalized_channel = attribution.normalized_channel
+{% endif %}
 WHERE
   active_users.retention_seen.day_27.active_on_metric_date

--- a/sql_generators/mobile_kpi_support_metrics/templates/union.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/union.view.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE VIEW
     {% endif %}
     SELECT
       *
-      {% for field in product.additional_attribution_fields if field.exists %}
+      {% for field in product.all_possible_attribution_fields if field.exists %}
         {% if loop.first %}
           EXCEPT(
         {% endif %}
@@ -19,13 +19,14 @@ CREATE OR REPLACE VIEW
 {% endif %}
 {% else %},
 {% endfor %}
-{% for field in product.additional_attribution_fields %}
+{% for field in product.all_possible_attribution_fields %}
   {% if field.exists %}
     {{ field.name }},
   {% else %}
-    CAST(NULL AS {{field.type}}) AS {{ field.name }},
+    CAST(NULL AS {{ field.type }}) AS {{ field.name }},
   {% endif %}
 {% endfor %}
+"{{ product.name }}" AS product_name,
 FROM
   `{{ project_id }}.{{ product.name }}.{{ name }}`
 {% endfor %}


### PR DESCRIPTION
# feat: make changes to generate retention and engagement for focus and klar products also

The current version only generates `retention` and `engagement` artifacts for `firefox_ios` and `fenix`. This change aims to introduce these artifacts to the following mobile products:

- `klar_ios`
- `focus_ios`
- `klar_android`
- `focus_android`


---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3965)
