### PR TITLE
Exclude `accounts_cirrus` Glean app from baseline ping checks as it has no baseline pings (bug 1888718)

### DIFF
--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -26,6 +26,7 @@ NO_BASELINE_PING_APPS = (
     "mozilla_vpn",
     "mozillavpn_backend_cirrus",
     "accounts_backend",
+    "accounts_cirrus",
     "burnham",
     "firefox_reality_pc",
     "lockwise_android",


### PR DESCRIPTION
Cirrus apps generally don't have baseline pings.

This should resolve [bug 1888718](https://bugzilla.mozilla.org/show_bug.cgi?id=1888718) "Airflow task bqetl_glean_usage.checks__warn_accounts_cirrus_derived__baseline_clients_last_seen__v1 failing since exec_date 2024-03-23".

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3993)
