### PR TITLE
Exclude `baseline_clients_daily` records without a matching `baseline_clients_first_seen` record

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
@@ -144,7 +144,7 @@ joined as (
     (cd.submission_date = cfs.first_seen_date) AS is_new_profile
   FROM
     windowed AS cd
-  LEFT JOIN
+  INNER JOIN
     `{{ first_seen_table }}` AS cfs
     USING (client_id)
   WHERE


### PR DESCRIPTION
Normally all `baseline_clients_daily` records should have matching `baseline_clients_first_seen` records, but recently there are some records for the `org_mozilla_firefox_derived` app which don't due to an unfortunate combination of a backfill and shredder deletions ([bug 1899799](https://bugzilla.mozilla.org/show_bug.cgi?id=1899799), [bug 1899800](https://bugzilla.mozilla.org/show_bug.cgi?id=1899800)).

With this fix in place, re-running the ETLs for the affected tables+dates should resolve those two bugs, and guard against similar situations happening in the future.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4022)
