### PR TITLE
Fix DAG failures caused due to bad int value

### DIFF
--- a/sql_generators/urlbar_events/templates/desktop_query.sql
+++ b/sql_generators/urlbar_events/templates/desktop_query.sql
@@ -72,7 +72,10 @@ WITH events_unnested AS (
     SAFE_CAST(mozfun.map.get_key(extra, "n_chars") AS int) AS num_chars_typed,
     SAFE_CAST(mozfun.map.get_key(extra, "n_results") AS int) AS num_total_results,
   --If 0, then no result was selected.
-    NULLIF(SAFE_CAST(mozfun.map.get_key(extra, "selected_position") AS int), 0) AS selected_position,
+    NULLIF(
+      SAFE_CAST(mozfun.map.get_key(extra, "selected_position") AS int),
+      0
+    ) AS selected_position,
     mozfun.map.get_key(extra, "selected_result") AS selected_result,
     enumerated_array(
       SPLIT(mozfun.map.get_key(extra, "results"), ','),

--- a/sql_generators/urlbar_events/templates/desktop_query.sql
+++ b/sql_generators/urlbar_events/templates/desktop_query.sql
@@ -69,8 +69,8 @@ WITH events_unnested AS (
     COALESCE(metrics.boolean.urlbar_pref_suggest_nonsponsored, FALSE) AS pref_fx_suggestions,
     mozfun.map.get_key(extra, "engagement_type") AS engagement_type,
     mozfun.map.get_key(extra, "interaction") AS interaction,
-    CAST(mozfun.map.get_key(extra, "n_chars") AS int) AS num_chars_typed,
-    CAST(mozfun.map.get_key(extra, "n_results") AS int) AS num_total_results,
+    SAFE_CAST(mozfun.map.get_key(extra, "n_chars") AS int) AS num_chars_typed,
+    SAFE_CAST(mozfun.map.get_key(extra, "n_results") AS int) AS num_total_results,
   --If 0, then no result was selected.
     NULLIF(CAST(mozfun.map.get_key(extra, "selected_position") AS int), 0) AS selected_position,
     mozfun.map.get_key(extra, "selected_result") AS selected_result,

--- a/sql_generators/urlbar_events/templates/desktop_query.sql
+++ b/sql_generators/urlbar_events/templates/desktop_query.sql
@@ -72,7 +72,7 @@ WITH events_unnested AS (
     SAFE_CAST(mozfun.map.get_key(extra, "n_chars") AS int) AS num_chars_typed,
     SAFE_CAST(mozfun.map.get_key(extra, "n_results") AS int) AS num_total_results,
   --If 0, then no result was selected.
-    NULLIF(CAST(mozfun.map.get_key(extra, "selected_position") AS int), 0) AS selected_position,
+    NULLIF(SAFE_CAST(mozfun.map.get_key(extra, "selected_position") AS int), 0) AS selected_position,
     mozfun.map.get_key(extra, "selected_result") AS selected_result,
     enumerated_array(
       SPLIT(mozfun.map.get_key(extra, "results"), ','),


### PR DESCRIPTION
The bqetl_urlbar is failing 
https://workflow.telemetry.mozilla.org/dags/bqetl_urlbar/grid?dag_run_id=scheduled__2024-06-05T03%3A00%3A00%2B00%3A00&task_id=firefox_desktop_urlbar_events__v2&tab=logs


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4029)
