### PR TITLE
Fix union error in `telemetry.active_users_aggregates_mobile` view (bug 1901121)

### DIFF
--- a/sql_generators/active_users_aggregates_v3/templates/mobile_query.sql
+++ b/sql_generators/active_users_aggregates_v3/templates/mobile_query.sql
@@ -64,7 +64,7 @@ metrics AS (
     ] AS normalized_channel,
     {% if app_name == "klar_android"%}
       CAST(NULL AS INTEGER) AS uri_count,
-      CAST(NULL AS INTEGER) AS is_default_browser,
+      CAST(NULL AS BOOL) AS is_default_browser,
     {% else %}
       ARRAY_AGG(uri_count IGNORE NULLS ORDER BY submission_date ASC)[SAFE_OFFSET(0)] AS uri_count,
       ARRAY_AGG(is_default_browser IGNORE NULLS ORDER BY submission_date ASC)[

--- a/sql_generators/active_users_aggregates_v3/templates/mobile_view.sql
+++ b/sql_generators/active_users_aggregates_v3/templates/mobile_view.sql
@@ -1,33 +1,51 @@
 --- User-facing view for all mobile apps. Generated via sql_generators.active_users.
 CREATE OR REPLACE VIEW
-  `{{ project_id }}.{{ dataset_id }}.active_users_aggregates_mobile`
-AS
-SELECT
-  *
-FROM
-  `{{ project_id }}.{{ fenix_dataset }}.active_users_aggregates`
-UNION ALL
-SELECT
-  *
-FROM
-  `{{ project_id }}.{{ firefox_ios_dataset }}.active_users_aggregates`
-UNION ALL
-SELECT
-  *
-FROM
-  `{{ project_id }}.{{ focus_ios_dataset }}.active_users_aggregates`
-UNION ALL
-SELECT
-  *
-FROM
-  `{{ project_id }}.{{ klar_ios_dataset }}.active_users_aggregates`
-UNION ALL
-SELECT
-  *
-FROM
-  `{{ project_id }}.{{ focus_android_dataset }}.active_users_aggregates`
-UNION ALL
-SELECT
-  *
-FROM
-  `{{ project_id }}.{{ klar_android_dataset }}.active_users_aggregates`
+  `{{ project_id }}.{{ dataset_id }}.active_users_aggregates_mobile` AS
+  {% for app_dataset_id in [
+      fenix_dataset,
+      firefox_ios_dataset,
+      focus_ios_dataset,
+      klar_ios_dataset,
+      focus_android_dataset,
+      klar_android_dataset
+  ] %}
+    {% if not loop.first %}
+      UNION ALL
+    {% endif %}
+    SELECT
+      segment,
+      attribution_medium,
+      attribution_source,
+      attributed,
+      city,
+      country,
+      distribution_id,
+      first_seen_year,
+      is_default_browser,
+      locale,
+      channel,
+      os,
+      os_version,
+      os_version_major,
+      os_version_minor,
+      submission_date,
+      adjust_network,
+      install_source,
+      daily_users,
+      weekly_users,
+      monthly_users,
+      dau,
+      wau,
+      mau,
+      uri_count,
+      active_hours,
+      app_name,
+      app_version,
+      app_version_major,
+      app_version_minor,
+      app_version_patch_revision,
+      app_version_is_major_release,
+      os_grouped,
+    FROM
+      `{{ project_id }}.{{ app_dataset_id }}.active_users_aggregates`
+  {% endfor %}


### PR DESCRIPTION
The `klar_android.active_users_aggregates` view and its underlying `klar_android_derived.active_users_aggregates_v3` table have a different schema than the rest of the apps, because it was added more recently (#5624) after some columns were removed from the `active_users_aggregates_v3` ETL (#5396).

This should fix [bug 1901121](https://bugzilla.mozilla.org/show_bug.cgi?id=1901121) "_Airflow task `bqetl_artifact_deployment.publish_views` failed for exec_date 2024-06-06_".

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4040)
