### PR TITLE
[DENG-3918] Ignore glean stable tables with no client id for shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -578,6 +578,8 @@ def find_glean_targets(
             and not table.table_id.startswith(source_doctype)
             # migration tables not yet supported
             and not table.table_id.startswith("migration")
+            # skip tables with explicitly excluded client ids
+            and table.labels.get("include_client_id", "true").lower() != "false"
         },
         **{
             # glean derived tables that contain client_id


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-3918

Depends on https://github.com/mozilla-services/cloudops-infra/pull/5721 and https://github.com/mozilla/mozilla-schema-generator/pull/268

Skip stable tables for pings that have `include_client_id: false`.  Default to true.  This will skip 181 tables.  Tables are in the query in this comment https://mozilla-hub.atlassian.net/browse/DENG-3918?focusedCommentId=894752

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4070)
