### PR TITLE
fix(glam): add a more robust way to fetch glean tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM google/cloud-sdk:${GOOGLE_CLOUD_SDK_VERSION}-alpine AS google-cloud-sdk
 
 FROM base
 # add bash for entrypoint
-RUN mkdir -p /usr/share/man/man1 && apt-get update -qqy && apt-get install -qqy bash git
+RUN mkdir -p /usr/share/man/man1 && apt-get update -qqy && apt-get install -qqy bash git jq
 COPY --from=google-cloud-sdk /google-cloud-sdk /google-cloud-sdk
 ENV PATH /google-cloud-sdk/bin:$PATH
 COPY --from=python-deps /usr/local /usr/local

--- a/script/glam/generate_glean_sql
+++ b/script/glam/generate_glean_sql
@@ -63,13 +63,12 @@ function write_clients_daily_aggregates {
     # GLAM only supports tables with glean_ping_* schema.
     # Also excluding use_counters because they are not supported
     # and their generated query is too big to run
-    tables=$(
-        bq ls "$qualified" \
-        | grep TABLE \
-        | grep 'schema_id:glean_ping_[0-9]\+' \
-        | grep -v use_counters \
-        | awk '{print $1}'
-    )
+    tables=$( bq ls --format=json "$qualified" | \
+        jq -r '.[] |
+        select(.labels.schema_id | test("^glean_ping_[0-9]+")) |
+        select(.type == "TABLE") |
+        select(.tableReference.tableId | test("^use_counters.*") | not) |
+        "\(.tableReference.tableId)"')
     # generate all of the schemas in parallel
     for table in $tables; do
         write_scalars "$product" "$dataset" "$table" "$dst_project" "$sql_dir" &

--- a/script/glam/generate_glean_sql
+++ b/script/glam/generate_glean_sql
@@ -63,7 +63,7 @@ function write_clients_daily_aggregates {
     # GLAM only supports tables with glean_ping_* schema.
     # Also excluding use_counters because they are not supported
     # and their generated query is too big to run
-    tables=$( bq ls --format=json "$qualified" | \
+    tables=$(bq ls --format=json "$qualified" | \
         jq -r '.[] |
         select(.labels.schema_id | test("^glean_ping_[0-9]+")) |
         select(.type == "TABLE") |


### PR DESCRIPTION
This fixes the currently broken `glam_fog` and `glam_fenix` ETLs

The current implementation is fragile and now broken. It relies on `schema_id` being the top label printed for the invocation of `bq ls`, which means it would belong in the same line as the `tableId`. After the [include_client_id](https://github.com/mozilla-services/cloudops-infra/pull/5721/files) label was added to the Glean tables, it took the spot of `schema_id` and consequently made the whole command print nothing.

This implementation fetches the metadata for the tables in a `JSON` format and relies only on that to fetch the tables' ids.
I had to add `jq` to the Docker image to make that possible.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4075)
