### PR TITLE
Skip apps with no events in monitoring.event_monitoring_live

### DIFF
--- a/sql_generators/glean_usage/templates/event_monitoring_live.view.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_live.view.sql
@@ -1,8 +1,31 @@
-CREATE OR REPLACE VIEW `{{ project_id }}.{{ target_view }}` AS
-{% for app in apps %}
-{% set outer_loop = loop -%}
-{% for dataset in app -%}
-{% if dataset['bq_dataset_family'] in prod_datasets %}
+CREATE OR REPLACE VIEW
+  `{{ project_id }}.{{ target_view }}` AS
+  {% for app in apps %}
+    {% set outer_loop = loop -%}
+    {% for dataset in app -%}
+      {% if dataset['bq_dataset_family'] in prod_datasets
+        and dataset['bq_dataset_family'] in event_tables_per_dataset %}
+        SELECT
+          window_start,
+          window_end,
+          event_category,
+          event_name,
+          event_extra_key,
+          country,
+          normalized_app_name,
+          channel,
+          version,
+          experiment,
+          experiment_branch,
+          total_events
+        FROM
+          `{{ project_id }}.{{ dataset['bq_dataset_family'] }}_derived.event_monitoring_live_v1`
+        WHERE
+          submission_date > DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+        UNION ALL
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
 SELECT
   window_start,
   window_end,
@@ -16,28 +39,7 @@ SELECT
   experiment,
   experiment_branch,
   total_events
-FROM 
-  `{{ project_id }}.{{ dataset['bq_dataset_family'] }}_derived.event_monitoring_live_v1`
-WHERE 
-  submission_date > DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
-UNION ALL
-{% endif %}
-{% endfor %}
-{% endfor %}
-SELECT 
-  window_start,
-  window_end,
-  event_category,
-  event_name,
-  event_extra_key,
-  country,
-  normalized_app_name,
-  channel,
-  version,
-  experiment,
-  experiment_branch,
-  total_events
-FROM 
+FROM
   `{{ project_id }}.{{ target_table }}`
 WHERE
   submission_date <= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)


### PR DESCRIPTION
Should fix view deploys by not including `gleanjs_docs` in the `event_monitoring_live` view but `gleanjs_docs` shouldn't actually be skipped and the issue described in https://github.com/mozilla/bigquery-etl/issues/5797 still exists.

This change is to match the app filtering that's used in generating the `event_monitoring_live_v1` materialized view.  Currently, `monitoring.event_monitoring_live` unions views that weren't generated.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4096)
