### PR TITLE
fix(fxci): Normalize 'resource.name' in fxci_derived.worker_costs_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci_derived/worker_costs_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/worker_costs_v1/query.sql
@@ -1,6 +1,10 @@
 SELECT
   project.id AS project,
-  REGEXP_EXTRACT(resource.name, "/instances/(.+)$") AS name,
+  IF(
+    resource.name LIKE "%/instances/%",
+    REGEXP_EXTRACT(resource.name, "/instances/(.+)$"),
+    resource.name
+  ) AS name,
   REGEXP_EXTRACT(resource.global_name, "/zones/([^/]+)") AS zone,
   REGEXP_EXTRACT(resource.global_name, "/instances/([^/]+)") AS instance_id,
   DATE(usage_start_time) AS usage_start_date,


### PR DESCRIPTION
It seems that the `resource.name` field from the billing export can sometimes take the form:

    projects/<id>/instances/<name>

And other times it's simply:

    <name>

Update the worker costs query to account for this.

Issue: #5759

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [x] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [x] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4111)
