### PR TITLE
DENG-2407 Fix: Use flow_id string metric for accounts event flow monitoring

### DIFF
--- a/sql_generators/glean_usage/templates/event_flow_monitoring_aggregates_v1.script.sql
+++ b/sql_generators/glean_usage/templates/event_flow_monitoring_aggregates_v1.script.sql
@@ -21,7 +21,7 @@ CREATE TEMP TABLE
         {% if not loop.first -%}
           UNION ALL
         {% endif %}
-        {% if app['bq_dataset_family'] not in ["telemetry"] %}
+        {% if app['bq_dataset_family'] not in ["telemetry", "accounts_frontend", "accounts_backend"] %}
           SELECT DISTINCT
             @submission_date AS submission_date,
             ext.value AS flow_id,
@@ -39,12 +39,41 @@ CREATE TEMP TABLE
             UNNEST(event_extra) AS ext
           WHERE
             DATE(submission_timestamp) = @submission_date
-            {% if app['bq_dataset_family'] in ["accounts_frontend", "accounts_backend"] %}
-            AND metrics.string.session_flow_id IS NOT NULL
-            AND metrics.string.session_flow_id != ""
-            {% else %}
             AND ext.key = "flow_id"
-            {% endif %}
+        {% elif app['bq_dataset_family'] in ["accounts_frontend", "accounts_backend"] %}
+          (WITH events_unnested_with_metrics AS (
+            -- events_unnested views do not have metrics, accounts send flow_id in a string metric
+            -- so we need to unnest with metrics here
+            SELECT
+            e.* EXCEPT (events),
+            event.timestamp AS event_timestamp,
+            event.category AS event_category,
+            event.name AS event_name,
+            event.extra AS event_extra
+          FROM
+            `moz-fx-data-shared-prod.{{ app['app_name'] }}.events` e
+          CROSS JOIN
+            UNNEST(e.events) AS event
+          )
+          SELECT DISTINCT
+            @submission_date AS submission_date,
+            ext.value AS flow_id,
+            event_category AS category,
+            event_name AS name,
+            TIMESTAMP_ADD(
+              submission_timestamp,
+          -- limit event.timestamp, otherwise this will cause an overflow
+              INTERVAL LEAST(event_timestamp, 20000000000000) MILLISECOND
+            ) AS timestamp,
+            "{{ app['canonical_app_name'] }}" AS normalized_app_name,
+            client_info.app_channel AS channel
+          FROM
+            events_unnested_with_metrics,
+            UNNEST(event_extra) AS ext
+          WHERE
+            DATE(submission_timestamp) = @submission_date
+            AND metrics.string.session_flow_id IS NOT NULL
+            AND metrics.string.session_flow_id != "")
         {% endif %}
       {% endfor %}
     ),


### PR DESCRIPTION
Follow up to https://github.com/mozilla/bigquery-etl/pull/5812 that brings this query closer to the state before https://github.com/mozilla/bigquery-etl/pull/5801.

Because `events_unnested` views do not expose `metrics` field, we need to unnest explicitly here.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4116)
