### PR TITLE
Have CI run SQL generation if files in `sql/` were renamed

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -527,10 +527,10 @@ jobs:
                     GENERATED_SQL_CHANGED=true
                   fi
 
-                  # Check if this PR removes a file. SQL generation needs to be re-run because
+                  # Check if this PR removes or renames a file. SQL generation needs to be re-run because
                   # simply merging the changes with the generated-sql branch would result in files being part of generated DAGs
-                  # and other artifacts that were actually removed
-                  if [[ $(git diff --no-index --name-only --diff-filter=D ~/remote-bigquery-etl-main/sql sql) ]]; then
+                  # and other artifacts that were actually removed or renamed
+                  if [[ $(git diff --no-index --name-only --diff-filter=DR ~/remote-bigquery-etl-main/sql sql) ]]; then
                     echo "SQL file was removed; re-generate SQL"
                     GENERATED_SQL_CHANGED=true
                   fi
@@ -914,10 +914,10 @@ jobs:
                     GENERATED_SQL_CHANGED=true
                   fi
 
-                  # If a SQL was removed from main re-run SQL generation
+                  # If a SQL was removed from main or renamed re-run SQL generation
                   # simply merging the changes with the generated-sql branch would result in files being part of generated DAGs
-                  # and other artifacts that were removed
-                  if [[ $(git diff --name-only --diff-filter=D $LATEST_TAG_GENERATED_SQL...HEAD -- sql) ]]; then
+                  # and other artifacts that were removed or renamed
+                  if [[ $(git diff --name-only --diff-filter=DR $LATEST_TAG_GENERATED_SQL...HEAD -- sql) ]]; then
                     echo "SQL file was removed; re-generate SQL"
                     GENERATED_SQL_CHANGED=true
                   fi


### PR DESCRIPTION
Files being renamed can have similar effects as files being deleted, so we want CI to run SQL generation when files are renamed for the same reasons we do that when files are deleted.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4129)
