### PR TITLE
Revert "Fix initialize logic for materialized views"

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1430,7 +1430,7 @@ def initialize(
     else:
         file_regex = re.compile(
             r"^.*/([a-zA-Z0-9-]+)/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+(_v[0-9]+)?)/"
-            r"(?:query\.sql|init\.sql|materialized_view\.sql)$"
+            r"(?:query\.sql|init\.sql)$"
         )
         query_files = paths_matching_name_pattern(
             name, sql_dir, project_id, file_regex=file_regex
@@ -1472,7 +1472,7 @@ def initialize(
             except NotFound:
                 # continue with creating the table
                 pass
-        elif len(materialized_views) == 0:
+        else:
             return
 
         try:


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#5640

This results in materialized views getting re-deployed whenever artifacts are being deployed. Since there is a delay when applying permissions to materialized views, they're unaccessible via Looker etc. Reverting until we find a better way to deploy materialized views. For now deployment needs to happen manually

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4133)
