### PR TITLE
[Bug 1904423] Support ohttp for generated app views

### DIFF
--- a/sql_generators/glean_usage/glean_app_ping_views.py
+++ b/sql_generators/glean_usage/glean_app_ping_views.py
@@ -158,6 +158,12 @@ class GleanAppPingViews(GleanTable):
                             table=view_name,
                             channel=channel_app.get("app_channel"),
                             app_name=release_app["app_name"],
+                            includes_client_info=any(
+                                [
+                                    "client_info" == f["name"]
+                                    for f in unioned_schema.schema["fields"]
+                                ]
+                            ),
                         )
                     )
 

--- a/sql_generators/glean_usage/templates/app_ping_view.view.sql
+++ b/sql_generators/glean_usage/templates/app_ping_view.view.sql
@@ -10,8 +10,12 @@ SELECT
   "{{ query.dataset }}" AS normalized_app_id,
   {% if query.channel and query.app_name != "fenix" -%}
   "{{ query.channel }}" AS normalized_channel,
-  {% elif query.app_name == "fenix" %}
+  {% elif query.app_name == "fenix" and query.includes_client_info %}
   mozfun.norm.fenix_app_info("{{ query.dataset }}", client_info.app_build).channel AS normalized_channel,
+  {% elif query.app_name == "fenix" and not query.includes_client_info %}
+    -- set app build to 21850000 since all affected pings are coming from versions older than that
+    -- abb build only used to differentiate between preview (pre 21850000) and nightly (everything after)
+    mozfun.norm.fenix_app_info("{{ query.dataset }}", '21850000').channel AS normalized_channel,
   {% else %}
   normalized_channel,
   {% endif %}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1904423

Some new pings that don't have `client_info` fields got added for Fenix. The generation template references `client_info` to get the channel. This PR should avoid referencing the field for affected pings

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4139)
