### PR TITLE
[Bug 1903788] Update checks for reference_browser_derived.baseline_clients_last_seen_v1

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -325,6 +325,7 @@ generate:
     skip_existing: # Skip automatically updating the following artifacts
     - sql/moz-fx-data-shared-prod/fenix/client_deduplication/**
     - sql/moz-fx-data-shared-prod/org_mozilla_tv_firefox_derived/baseline_clients_last_seen_v1/checks.sql
+    - sql/moz-fx-data-shared-prod/org_mozilla_reference_browser_derived/baseline_clients_last_seen_v1/checks.sql
     skip_apps:
     - mlhackweek_search
     - moso_mastodon_android

--- a/sql/moz-fx-data-shared-prod/org_mozilla_reference_browser_derived/baseline_clients_last_seen_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_reference_browser_derived/baseline_clients_last_seen_v1/checks.sql
@@ -1,0 +1,32 @@
+-- Overrides bigquery_etl.glean_usage due to this app having very limited data, sometimes none
+
+#warn
+{{ is_unique(["client_id"], where="submission_date = @submission_date") }}
+
+#warn
+{{ not_null([
+  "submission_date",
+  "client_id",
+  "sample_id",
+  "first_seen_date",
+  "days_seen_bits",
+  "days_active_bits",
+  "days_created_profile_bits",
+  "days_seen_session_start_bits",
+  "days_seen_session_end_bits"
+  ], where="submission_date = @submission_date") }}
+
+#warn
+SELECT
+  IF(
+    COUNTIF(normalized_channel NOT IN ("nightly", "aurora", "release", "Other", "beta", "esr")) > 0,
+    ERROR("Unexpected values for field normalized_channel detected."),
+    NULL
+  )
+FROM
+  `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+WHERE
+  submission_date = @submission_date;
+
+#warn
+{{ value_length(column="client_id", expected_length=36, where="submission_date = @submission_date") }}


### PR DESCRIPTION
This app is sending very little data, some days none at all. I updated some of the tests (like min row count), so they don't go off constantly

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4158)
