### PR TITLE
bug(1905102): disable mobile_support_kpi_metrics engagement not_null check until upstream issue is resolved

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.checks.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.checks.sql
@@ -4,8 +4,14 @@
 #warn
 {{ min_row_count(1, where=_WHERE) }}
 
+{#
+Removed the not_null check for now due to the check failing
+with "first_see_date" due to a known issue where some clients have first_seen_date in Fenix
+set to null: https://bugzilla.mozilla.org/show_bug.cgi?id=1900084
+The check will be readded once the core issue is resolved.
 #warn
 {{ not_null(["first_seen_date", "app_name", "normalized_channel", "is_mobile"], where=_WHERE) }}
+#}
 
 #warn
 {{ value_length(column="country", expected_length="2", where=_WHERE) }}


### PR DESCRIPTION
# bug(1905102): disable mobile_support_kpi_metrics engagement not_null check until upstream issue is resolved

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4223)
