### PR TITLE
fix(dag_gen): depends on external task group

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -75,7 +75,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         task_id='wait_for_{{ dependency.task_id }}',
         external_dag_id='{{ dependency.dag_name }}',
         {% if dependency.task_group -%}
-        external_task_group_id='{{ dependency.task_group }}'
+        external_task_group_id='{{ dependency.task_group }}',
         {% endif -%}
         external_task_id='{{ dependency.task_id }}',
         {% if dependency.get_execution_delta(schedule_interval) -%}

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -75,10 +75,9 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         task_id='wait_for_{{ dependency.task_id }}',
         external_dag_id='{{ dependency.dag_name }}',
         {% if dependency.task_group -%}
-        external_task_id='{{dependency.task_group}}.{{ dependency.task_id }}',
-        {% else -%}
-        external_task_id='{{ dependency.task_id }}',
+        external_task_group_id='{{ dependency.task_group }}'
         {% endif -%}
+        external_task_id='{{ dependency.task_id }}',
         {% if dependency.get_execution_delta(schedule_interval) -%}
         execution_delta={{ dependency.get_execution_delta(schedule_interval) | format_timedelta | format_repr }},
         {% endif -%}

--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -74,7 +74,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         task_id='wait_for_{{ dependency.task_id }}',
         external_dag_id='{{ dependency.dag_name }}',
         {% if dependency.task_group -%}
-        external_task_group_id='{{ dependency.task_group }}'
+        external_task_group_id='{{ dependency.task_group }}',
         {% endif -%}
         external_task_id='{{ dependency.task_id }}',
         {% if dependency.get_execution_delta(schedule_interval) -%}

--- a/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/public_data_json_airflow_dag.j2
@@ -74,10 +74,9 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         task_id='wait_for_{{ dependency.task_id }}',
         external_dag_id='{{ dependency.dag_name }}',
         {% if dependency.task_group -%}
-        external_task_id='{{dependency.task_group}}.{{ dependency.task_id }}',
-        {% else -%}
-        external_task_id='{{ dependency.task_id }}',
+        external_task_group_id='{{ dependency.task_group }}'
         {% endif -%}
+        external_task_id='{{ dependency.task_id }}',
         {% if dependency.get_execution_delta(schedule_interval) -%}
         execution_delta={{ dependency.get_execution_delta(schedule_interval) | format_timedelta | format_repr }},
         {% endif -%}


### PR DESCRIPTION
According to the [documentation](https://airflow.apache.org/docs/apache-airflow/2.8.2/howto/operator/external_task_sensor.html#externaltasksensor-with-task-group-dependency), for tasks belonging to a `task_group` we need to use `external_task_group_id` instead.
I checked the repo and found no dags using this feature so far.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4266)
