### PR TITLE
Fix udf_js.gunzip to allow very long inputs

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf_js/gunzip/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf_js/gunzip/udf.sql
@@ -22,7 +22,10 @@ AS
 
     function binary2String(byteArray) {
         // converts a UTF-16 byte array to a string
-        return String.fromCharCode.apply(String, byteArray);
+        return byteArray.reduce(
+          (accumulator, char_code) => accumulator + String.fromCharCode(char_code),
+          "",
+        )
     }
 
     // BYTES are base64 encoded by BQ, so this needs to be decoded
@@ -70,6 +73,7 @@ unzipped AS (
 )
   --
 SELECT
-  mozfun.assert.equals(expected, result)
+  mozfun.assert.equals(expected, result),
+  mozfun.assert.equals(udf_js.gunzip(CAST(REPEAT("a", 500000) AS BYTES)), REPEAT("a", 500000)),
 FROM
   unzipped


### PR DESCRIPTION
This function currently fails for long payloads.  This can be reproduced with:
```sql
SELECT `moz-fx-data-shared-prod.udf_js.gunzip`(CAST(REPEAT("a", 500000) AS BYTES))
```
which gives `RangeError: Maximum call stack size exceeded at UDF$1(BYTES) line 13, columns 35-36`

or more a more realistic example:
```sql
SELECT
  `moz-fx-data-shared-prod.udf_js.gunzip`(payload)
FROM
  `moz-fx-data-shared-prod.payload_bytes_error.telemetry`
WHERE
  TIMESTAMP_TRUNC(submission_timestamp, DAY) = TIMESTAMP("2024-07-08")
  AND document_type = 'crash'
  AND LENGTH(payload) > 40000
```

Performance seems to about the same in my limited testing