### PR TITLE
Revert "Backfill desktop search aggregates from 2022-01-01"

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/backfill.yaml
@@ -1,6 +1,6 @@
-2024-07-09:
-  start_date: 2022-01-01
-  end_date: 2024-06-25
+2024-06-27:
+  start_date: 2024-04-01
+  end_date: 2024-05-31
   reason: https://mozilla-hub.atlassian.net/browse/RS-1247
   watchers:
   - akommasani@mozilla.com


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#5897

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4301)
