### PR TITLE
chore(data-privacy-mapping): DSRE-1690 - ignore tables contaiing RECORD type

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitor_frontend_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitor_frontend_derived/dataset_metadata.yaml
@@ -9,4 +9,3 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
-  - workgroup:dataops-managed/external-fides

--- a/sql/moz-fx-data-shared-prod/monitor_frontend_derived/event_monitoring_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitor_frontend_derived/event_monitoring_live_v1/metadata.yaml
@@ -1,20 +1,5 @@
-friendly_name: Event Monitoring Live
-description: |-
-  Materialized view of experimentation related events
-  coming from monitor_frontend.
-owners:
-- ascholtz@mozilla.com
-- akomar@mozilla.com
-labels:
-  materialized_view: true
-  owner1: ascholtz
-  owner2: akomar
-bigquery: null
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
   - workgroup:dataops-managed/external-fides
-references:
-  materialized_view.sql:
-  - moz-fx-data-shared-prod.monitor_frontend_live.events_v1

--- a/sql/moz-fx-data-shared-prod/monitor_frontend_derived/event_monitoring_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitor_frontend_derived/event_monitoring_live_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Event Monitoring Live
+description: |-
+  Materialized view of experimentation related events
+  coming from monitor_frontend.
+owners:
+- ascholtz@mozilla.com
+- akomar@mozilla.com
+labels:
+  materialized_view: true
+  owner1: ascholtz
+  owner2: akomar
+bigquery: null
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+  - workgroup:dataops-managed/external-fides
+references:
+  materialized_view.sql:
+  - moz-fx-data-shared-prod.monitor_frontend_live.events_v1

--- a/sql/moz-fx-data-shared-prod/monitor_frontend_derived/monitor_dashboard_user_journey_funnels_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitor_frontend_derived/monitor_dashboard_user_journey_funnels_v1/metadata.yaml
@@ -1,27 +1,5 @@
-friendly_name: Monitor Dashboard User Journey Funnels
-description: |-
-  Please provide a description for the query
-owners:
-- ksiegler@mozilla.org
-labels:
-  incremental: true
-  dag: bqetl_generated_funnels
-  owner1: ksiegler
-scheduling:
-  dag_name: bqetl_generated_funnels
-bigquery:
-  time_partitioning:
-    type: day
-    field: submission_date
-    require_partition_filter: false
-    expiration_days: null
-  range_partitioning: null
-  clustering: null
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
   - workgroup:dataops-managed/external-fides
-references:
-  query.sql:
-  - mozdata.monitor_frontend.events_unnested

--- a/sql/moz-fx-data-shared-prod/monitor_frontend_derived/monitor_dashboard_user_journey_funnels_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitor_frontend_derived/monitor_dashboard_user_journey_funnels_v1/metadata.yaml
@@ -1,0 +1,27 @@
+friendly_name: Monitor Dashboard User Journey Funnels
+description: |-
+  Please provide a description for the query
+owners:
+- ksiegler@mozilla.org
+labels:
+  incremental: true
+  dag: bqetl_generated_funnels
+  owner1: ksiegler
+scheduling:
+  dag_name: bqetl_generated_funnels
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering: null
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+  - workgroup:dataops-managed/external-fides
+references:
+  query.sql:
+  - mozdata.monitor_frontend.events_unnested


### PR DESCRIPTION
Followup to https://github.com/mozilla-services/cloudops-infra/pull/5790, specify metadata for tables that don't have `RECORD` columns.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4312)
