### PR TITLE
GROWTH-90 Fix Grain of New Table - can have multiple rows per client per search engine

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/metadata.yaml
@@ -14,6 +14,5 @@ scheduling:
 bigquery:
   clustering:
     fields:
-    - sample_id
     - client_id
 references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/query.sql
@@ -2,21 +2,15 @@ WITH new_data AS (
   SELECT
     client_id,
     sample_id,
-    ad_click AS ad_clicks
+    sum(ad_click) AS ad_clicks
   FROM
     `moz-fx-data-shared-prod.search_derived.search_clients_daily_v8`
   WHERE
     submission_date = @submission_date
     AND ad_click > 0
-),
-existing_data AS (
-  SELECT
-    client_id,
-    sample_id,
-    ad_click_history
-  FROM
-    `moz-fx-data-shared-prod.firefox_desktop_derived.adclick_history_v1`
+    GROUP BY 1,2
 )
+    
 SELECT
   client_id,
   sample_id,
@@ -24,5 +18,5 @@ SELECT
 FROM
   new_data
 FULL OUTER JOIN
-  existing_data
+  `moz-fx-data-shared-prod.firefox_desktop_derived.adclick_history_v1`
   USING (sample_id, client_id)

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/query.sql
@@ -2,17 +2,16 @@ WITH new_data AS (
   SELECT
     client_id,
     sample_id,
-    sum(ad_click) AS ad_clicks
+    SUM(ad_click) AS ad_clicks
   FROM
     `moz-fx-data-shared-prod.search_derived.search_clients_daily_v8`
   WHERE
     submission_date = @submission_date
     AND ad_click > 0
-    GROUP BY 
+  GROUP BY
     client_id,
     sample_id
 )
-    
 SELECT
   client_id,
   sample_id,

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/query.sql
@@ -1,7 +1,6 @@
 WITH new_data AS (
   SELECT
     client_id,
-    sample_id,
     SUM(ad_click) AS ad_clicks
   FROM
     `moz-fx-data-shared-prod.search_derived.search_clients_daily_v8`
@@ -9,15 +8,13 @@ WITH new_data AS (
     submission_date = @submission_date
     AND ad_click > 0
   GROUP BY
-    client_id,
-    sample_id
+    client_id
 )
 SELECT
   client_id,
-  sample_id,
   mozfun.map.set_key(ad_click_history, @submission_date, ad_clicks) AS ad_click_history
 FROM
   new_data
 FULL OUTER JOIN
   `moz-fx-data-shared-prod.firefox_desktop_derived.adclick_history_v1`
-  USING (sample_id, client_id)
+  USING (client_id)

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/query.sql
@@ -8,7 +8,9 @@ WITH new_data AS (
   WHERE
     submission_date = @submission_date
     AND ad_click > 0
-    GROUP BY 1,2
+    GROUP BY 
+    client_id,
+    sample_id
 )
     
 SELECT

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/adclick_history_v1/schema.yaml
@@ -3,10 +3,6 @@ fields:
   mode: NULLABLE
   name: client_id
   type: STRING
-- description: Sample ID to limit query results during an analysis.
-  mode: NULLABLE
-  name: sample_id
-  type: INTEGER
 - description: History of ad_clicks for a user, by submission_date
   fields:
   - description: The date associated with the ad_click value


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4347)
