### PR TITLE
GLAM - Calculate percentiles ad hoc

### DIFF
--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_beta_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_beta_aggregates/view.sql
@@ -1,17 +1,93 @@
 CREATE OR REPLACE VIEW
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_beta_aggregates`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_beta_aggregates_v1`
-WHERE
+  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_beta_aggregates` AS (
+    WITH base AS (
+      SELECT
+        * EXCEPT (percentiles, non_norm_percentiles),
+        IF(
+          percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(histogram)
+        ) AS struct_histogram,
+        IF(
+          metric_type IN ("scalar", "keyed-scalar")
+          OR non_norm_percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(non_norm_histogram)
+        ) AS struct_non_norm_histogram,
+        percentiles AS existing_percentiles,
+        non_norm_percentiles AS existing_non_norm_percentiles
+      FROM
+        `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_beta_aggregates_v1`
+      WHERE
   -- filter based on https://github.com/mozilla/python_mozaggregator/blob/6c0119bfd0b535346c37cb3f707d998039d3e24b/mozaggregator/service.py#L51
-  (
-    metric NOT LIKE r"%search\_counts%"
-    AND metric NOT LIKE r"%browser\_search%"
-    AND metric NOT LIKE r"%event\_counts%"
-    AND metric NOT LIKE r"%browser\_engagement\_navigation%"
-    AND metric NOT LIKE r"%manager\_message\_size%"
-    AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        (
+          metric NOT LIKE r"%search\_counts%"
+          AND metric NOT LIKE r"%browser\_search%"
+          AND metric NOT LIKE r"%event\_counts%"
+          AND metric NOT LIKE r"%browser\_engagement\_navigation%"
+          AND metric NOT LIKE r"%manager\_message\_size%"
+          AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        )
+    ),
+    calculated_percentiles AS (
+      SELECT
+        * EXCEPT (struct_histogram, struct_non_norm_histogram),
+        IF(
+          struct_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_histogram, metric_type))
+            ]
+          ),
+          existing_percentiles
+        ) AS percentiles,
+        IF(
+          struct_non_norm_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_non_norm_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_non_norm_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_non_norm_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_non_norm_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_non_norm_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_non_norm_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_non_norm_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_non_norm_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_non_norm_histogram, metric_type))
+            ]
+          ),
+          existing_non_norm_percentiles
+        ) AS non_norm_percentiles
+      FROM
+        base
+    )
+    SELECT
+      version,
+      os,
+      build_id,
+      process,
+      metric,
+      metric_key,
+      client_agg_type,
+      metric_type,
+      total_users,
+      histogram,
+      percentiles,
+      total_sample,
+      non_norm_histogram,
+      IF(
+        metric_type IN ("scalar", "keyed-scalar"),
+        percentiles,
+        non_norm_percentiles
+      ) AS non_norm_percentiles
+    FROM
+      calculated_percentiles
   )

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_nightly_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_nightly_aggregates/view.sql
@@ -1,17 +1,93 @@
 CREATE OR REPLACE VIEW
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_nightly_aggregates`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_nightly_aggregates_v1`
-WHERE
+  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_nightly_aggregates` AS (
+    WITH base AS (
+      SELECT
+        * EXCEPT (percentiles, non_norm_percentiles),
+        IF(
+          percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(histogram)
+        ) AS struct_histogram,
+        IF(
+          metric_type IN ("scalar", "keyed-scalar")
+          OR non_norm_percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(non_norm_histogram)
+        ) AS struct_non_norm_histogram,
+        percentiles AS existing_percentiles,
+        non_norm_percentiles AS existing_non_norm_percentiles
+      FROM
+        `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_nightly_aggregates_v1`
+      WHERE
   -- filter based on https://github.com/mozilla/python_mozaggregator/blob/6c0119bfd0b535346c37cb3f707d998039d3e24b/mozaggregator/service.py#L51
-  (
-    metric NOT LIKE r"%search\_counts%"
-    AND metric NOT LIKE r"%browser\_search%"
-    AND metric NOT LIKE r"%event\_counts%"
-    AND metric NOT LIKE r"%browser\_engagement\_navigation%"
-    AND metric NOT LIKE r"%manager\_message\_size%"
-    AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        (
+          metric NOT LIKE r"%search\_counts%"
+          AND metric NOT LIKE r"%browser\_search%"
+          AND metric NOT LIKE r"%event\_counts%"
+          AND metric NOT LIKE r"%browser\_engagement\_navigation%"
+          AND metric NOT LIKE r"%manager\_message\_size%"
+          AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        )
+    ),
+    calculated_percentiles AS (
+      SELECT
+        * EXCEPT (struct_histogram, struct_non_norm_histogram),
+        IF(
+          struct_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_histogram, metric_type))
+            ]
+          ),
+          existing_percentiles
+        ) AS percentiles,
+        IF(
+          struct_non_norm_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_non_norm_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_non_norm_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_non_norm_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_non_norm_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_non_norm_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_non_norm_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_non_norm_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_non_norm_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_non_norm_histogram, metric_type))
+            ]
+          ),
+          existing_non_norm_percentiles
+        ) AS non_norm_percentiles
+      FROM
+        base
+    )
+    SELECT
+      version,
+      os,
+      build_id,
+      process,
+      metric,
+      metric_key,
+      client_agg_type,
+      metric_type,
+      total_users,
+      histogram,
+      percentiles,
+      total_sample,
+      non_norm_histogram,
+      IF(
+        metric_type IN ("scalar", "keyed-scalar"),
+        percentiles,
+        non_norm_percentiles
+      ) AS non_norm_percentiles
+    FROM
+      calculated_percentiles
   )

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_release_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_release_aggregates/view.sql
@@ -1,17 +1,93 @@
 CREATE OR REPLACE VIEW
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_release_aggregates`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_release_aggregates_v1`
-WHERE
+  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_release_aggregates` AS (
+    WITH base AS (
+      SELECT
+        * EXCEPT (percentiles, non_norm_percentiles),
+        IF(
+          percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(histogram)
+        ) AS struct_histogram,
+        IF(
+          metric_type IN ("scalar", "keyed-scalar")
+          OR non_norm_percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(non_norm_histogram)
+        ) AS struct_non_norm_histogram,
+        percentiles AS existing_percentiles,
+        non_norm_percentiles AS existing_non_norm_percentiles
+      FROM
+        `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_release_aggregates_v1`
+      WHERE
   -- filter based on https://github.com/mozilla/python_mozaggregator/blob/6c0119bfd0b535346c37cb3f707d998039d3e24b/mozaggregator/service.py#L51
-  (
-    metric NOT LIKE r"%search\_counts%"
-    AND metric NOT LIKE r"%browser\_search%"
-    AND metric NOT LIKE r"%event\_counts%"
-    AND metric NOT LIKE r"%browser\_engagement\_navigation%"
-    AND metric NOT LIKE r"%manager\_message\_size%"
-    AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        (
+          metric NOT LIKE r"%search\_counts%"
+          AND metric NOT LIKE r"%browser\_search%"
+          AND metric NOT LIKE r"%event\_counts%"
+          AND metric NOT LIKE r"%browser\_engagement\_navigation%"
+          AND metric NOT LIKE r"%manager\_message\_size%"
+          AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        )
+    ),
+    calculated_percentiles AS (
+      SELECT
+        * EXCEPT (struct_histogram, struct_non_norm_histogram),
+        IF(
+          struct_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_histogram, metric_type))
+            ]
+          ),
+          existing_percentiles
+        ) AS percentiles,
+        IF(
+          struct_non_norm_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_non_norm_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_non_norm_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_non_norm_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_non_norm_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_non_norm_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_non_norm_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_non_norm_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_non_norm_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_non_norm_histogram, metric_type))
+            ]
+          ),
+          existing_non_norm_percentiles
+        ) AS non_norm_percentiles
+      FROM
+        base
+    )
+    SELECT
+      version,
+      os,
+      build_id,
+      process,
+      metric,
+      metric_key,
+      client_agg_type,
+      metric_type,
+      total_users,
+      histogram,
+      percentiles,
+      total_sample,
+      non_norm_histogram,
+      IF(
+        metric_type IN ("scalar", "keyed-scalar"),
+        percentiles,
+        non_norm_percentiles
+      ) AS non_norm_percentiles
+    FROM
+      calculated_percentiles
   )

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates/view.sql
@@ -1,17 +1,97 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_beta_aggregates`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_beta_aggregates_v1`
-WHERE
+AS (
+    WITH base AS (
+      SELECT
+        * EXCEPT (percentiles, non_norm_percentiles),
+        IF(
+          percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(histogram)
+        ) AS struct_histogram,
+        IF(
+          metric_type IN ("counter", "labeled_counter", "quantity")
+          OR non_norm_percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(non_norm_histogram)
+        ) AS struct_non_norm_histogram,
+        percentiles AS existing_percentiles,
+        non_norm_percentiles AS existing_non_norm_percentiles
+      FROM
+        `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_beta_aggregates_v1`
+      WHERE
   -- filter based on https://github.com/mozilla/python_mozaggregator/blob/6c0119bfd0b535346c37cb3f707d998039d3e24b/mozaggregator/service.py#L51
-  (
-    metric NOT LIKE r"%search\_counts%"
-    AND metric NOT LIKE r"%browser\_search%"
-    AND metric NOT LIKE r"%event\_counts%"
-    AND metric NOT LIKE r"%browser\_engagement\_navigation%"
-    AND metric NOT LIKE r"%manager\_message\_size%"
-    AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        (
+          metric NOT LIKE r"%search\_counts%"
+          AND metric NOT LIKE r"%browser\_search%"
+          AND metric NOT LIKE r"%event\_counts%"
+          AND metric NOT LIKE r"%browser\_engagement\_navigation%"
+          AND metric NOT LIKE r"%manager\_message\_size%"
+          AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        )
+    ),
+    calculated_percentiles AS (
+      SELECT
+        * EXCEPT (struct_histogram, struct_non_norm_histogram),
+        IF(
+          struct_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_histogram, metric_type))
+            ]
+          ),
+          existing_percentiles
+        ) AS percentiles,
+        IF(
+          struct_non_norm_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_non_norm_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_non_norm_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_non_norm_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_non_norm_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_non_norm_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_non_norm_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_non_norm_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_non_norm_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_non_norm_histogram, metric_type))
+            ]
+          ),
+          existing_non_norm_percentiles
+        ) AS non_norm_percentiles
+      FROM
+        base
+    )
+    SELECT
+      channel,
+      version,
+      ping_type,
+      os,
+      build_id,
+      build_date,
+      metric,
+      metric_type,
+      metric_key,
+      client_agg_type,
+      total_users,
+      histogram,
+      percentiles,
+      app_id,
+      total_sample,
+      non_norm_histogram,
+      IF(
+        metric_type IN ("counter", "labeled_counter", "quantity"),
+        percentiles,
+        non_norm_percentiles
+      ) AS non_norm_percentiles
+    FROM
+      calculated_percentiles
   )

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates/view.sql
@@ -1,17 +1,96 @@
 CREATE OR REPLACE VIEW
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_nightly_aggregates`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_nightly_aggregates_v1`
-WHERE
+  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_nightly_aggregates` AS (
+    WITH base AS (
+      SELECT
+        * EXCEPT (percentiles, non_norm_percentiles),
+        IF(
+          percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(histogram)
+        ) AS struct_histogram,
+        IF(
+          metric_type IN ("counter", "labeled_counter", "quantity")
+          OR non_norm_percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(non_norm_histogram)
+        ) AS struct_non_norm_histogram,
+        percentiles AS existing_percentiles,
+        non_norm_percentiles AS existing_non_norm_percentiles
+      FROM
+        `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_nightly_aggregates_v1`
+      WHERE
   -- filter based on https://github.com/mozilla/python_mozaggregator/blob/6c0119bfd0b535346c37cb3f707d998039d3e24b/mozaggregator/service.py#L51
-  (
-    metric NOT LIKE r"%search\_counts%"
-    AND metric NOT LIKE r"%browser\_search%"
-    AND metric NOT LIKE r"%event\_counts%"
-    AND metric NOT LIKE r"%browser\_engagement\_navigation%"
-    AND metric NOT LIKE r"%manager\_message\_size%"
-    AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        (
+          metric NOT LIKE r"%search\_counts%"
+          AND metric NOT LIKE r"%browser\_search%"
+          AND metric NOT LIKE r"%event\_counts%"
+          AND metric NOT LIKE r"%browser\_engagement\_navigation%"
+          AND metric NOT LIKE r"%manager\_message\_size%"
+          AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        )
+    ),
+    calculated_percentiles AS (
+      SELECT
+        * EXCEPT (struct_histogram, struct_non_norm_histogram),
+        IF(
+          struct_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_histogram, metric_type))
+            ]
+          ),
+          existing_percentiles
+        ) AS percentiles,
+        IF(
+          struct_non_norm_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_non_norm_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_non_norm_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_non_norm_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_non_norm_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_non_norm_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_non_norm_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_non_norm_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_non_norm_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_non_norm_histogram, metric_type))
+            ]
+          ),
+          existing_non_norm_percentiles
+        ) AS non_norm_percentiles
+      FROM
+        base
+    )
+    SELECT
+      channel,
+      version,
+      ping_type,
+      os,
+      build_id,
+      build_date,
+      metric,
+      metric_type,
+      metric_key,
+      client_agg_type,
+      total_users,
+      histogram,
+      percentiles,
+      app_id,
+      total_sample,
+      non_norm_histogram,
+      IF(
+        metric_type IN ("counter", "labeled_counter", "quantity"),
+        percentiles,
+        non_norm_percentiles
+      ) AS non_norm_percentiles
+    FROM
+      calculated_percentiles
   )

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates/view.sql
@@ -1,17 +1,97 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_release_aggregates`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_release_aggregates_v1`
-WHERE
+AS (
+    WITH base AS (
+      SELECT
+        * EXCEPT (percentiles, non_norm_percentiles),
+        IF(
+          percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(histogram)
+        ) AS struct_histogram,
+        IF(
+          metric_type IN ("counter", "labeled_counter", "quantity")
+          OR non_norm_percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(non_norm_histogram)
+        ) AS struct_non_norm_histogram,
+        percentiles AS existing_percentiles,
+        non_norm_percentiles AS existing_non_norm_percentiles
+      FROM
+        `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_release_aggregates_v1`
+      WHERE
   -- filter based on https://github.com/mozilla/python_mozaggregator/blob/6c0119bfd0b535346c37cb3f707d998039d3e24b/mozaggregator/service.py#L51
-  (
-    metric NOT LIKE r"%search\_counts%"
-    AND metric NOT LIKE r"%browser\_search%"
-    AND metric NOT LIKE r"%event\_counts%"
-    AND metric NOT LIKE r"%browser\_engagement\_navigation%"
-    AND metric NOT LIKE r"%manager\_message\_size%"
-    AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        (
+          metric NOT LIKE r"%search\_counts%"
+          AND metric NOT LIKE r"%browser\_search%"
+          AND metric NOT LIKE r"%event\_counts%"
+          AND metric NOT LIKE r"%browser\_engagement\_navigation%"
+          AND metric NOT LIKE r"%manager\_message\_size%"
+          AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        )
+    ),
+    calculated_percentiles AS (
+      SELECT
+        * EXCEPT (struct_histogram, struct_non_norm_histogram),
+        IF(
+          struct_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_histogram, metric_type))
+            ]
+          ),
+          existing_percentiles
+        ) AS percentiles,
+        IF(
+          struct_non_norm_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(
+            ARRAY<STRUCT<key STRING, value FLOAT64>>[
+              ('0.1', mozfun.glam.percentile(0.1, struct_non_norm_histogram, metric_type)),
+              ('1', mozfun.glam.percentile(1, struct_non_norm_histogram, metric_type)),
+              ('5', mozfun.glam.percentile(5, struct_non_norm_histogram, metric_type)),
+              ('25', mozfun.glam.percentile(25, struct_non_norm_histogram, metric_type)),
+              ('50', mozfun.glam.percentile(50, struct_non_norm_histogram, metric_type)),
+              ('75', mozfun.glam.percentile(75, struct_non_norm_histogram, metric_type)),
+              ('95', mozfun.glam.percentile(95, struct_non_norm_histogram, metric_type)),
+              ('99', mozfun.glam.percentile(99, struct_non_norm_histogram, metric_type)),
+              ('99.9', mozfun.glam.percentile(99.9, struct_non_norm_histogram, metric_type))
+            ]
+          ),
+          existing_non_norm_percentiles
+        ) AS non_norm_percentiles
+      FROM
+        base
+    )
+    SELECT
+      channel,
+      version,
+      ping_type,
+      os,
+      build_id,
+      build_date,
+      metric,
+      metric_type,
+      metric_key,
+      client_agg_type,
+      total_users,
+      histogram,
+      percentiles,
+      app_id,
+      total_sample,
+      non_norm_histogram,
+      IF(
+        metric_type IN ("counter", "labeled_counter", "quantity"),
+        percentiles,
+        non_norm_percentiles
+      ) AS non_norm_percentiles
+    FROM
+      calculated_percentiles
   )

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates/view.sql
@@ -1,17 +1,92 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_beta_aggregates`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_beta_aggregates_v1`
-WHERE
+AS (
+    WITH base AS (
+      SELECT
+        * EXCEPT(percentiles, non_norm_percentiles),
+        IF(
+          percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(histogram)
+        ) AS struct_histogram,
+        IF(
+          metric_type IN ("counter", "labeled_counter", "quantity") OR non_norm_percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(non_norm_histogram)
+        ) AS struct_non_norm_histogram,
+        percentiles AS existing_percentiles,
+        non_norm_percentiles AS existing_non_norm_percentiles
+      FROM
+        `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_beta_aggregates_v1`
+      WHERE
   -- filter based on https://github.com/mozilla/python_mozaggregator/blob/6c0119bfd0b535346c37cb3f707d998039d3e24b/mozaggregator/service.py#L51
-  (
-    metric NOT LIKE r"%search\_counts%"
-    AND metric NOT LIKE r"%browser\_search%"
-    AND metric NOT LIKE r"%event\_counts%"
-    AND metric NOT LIKE r"%browser\_engagement\_navigation%"
-    AND metric NOT LIKE r"%manager\_message\_size%"
-    AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        (
+          metric NOT LIKE r"%search\_counts%"
+          AND metric NOT LIKE r"%browser\_search%"
+          AND metric NOT LIKE r"%event\_counts%"
+          AND metric NOT LIKE r"%browser\_engagement\_navigation%"
+          AND metric NOT LIKE r"%manager\_message\_size%"
+          AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        )
+    ),
+    calculated_percentiles AS (
+      SELECT
+        * EXCEPT (struct_histogram, struct_non_norm_histogram),
+        IF(
+          struct_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(ARRAY<STRUCT<key STRING, value FLOAT64>>[
+            ('0.1', mozfun.glam.percentile(0.1, struct_histogram, metric_type)),
+            ('1', mozfun.glam.percentile(1, struct_histogram, metric_type)),
+            ('5', mozfun.glam.percentile(5, struct_histogram, metric_type)),
+            ('25', mozfun.glam.percentile(25, struct_histogram, metric_type)),
+            ('50', mozfun.glam.percentile(50, struct_histogram, metric_type)),
+            ('75', mozfun.glam.percentile(75, struct_histogram, metric_type)),
+            ('95', mozfun.glam.percentile(95, struct_histogram, metric_type)),
+            ('99', mozfun.glam.percentile(99, struct_histogram, metric_type)),
+            ('99.9', mozfun.glam.percentile(99.9, struct_histogram, metric_type))
+          ]),
+          existing_percentiles
+        ) AS percentiles,
+        IF(
+          struct_non_norm_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(ARRAY<STRUCT<key STRING, value FLOAT64>>[
+            ('0.1', mozfun.glam.percentile(0.1, struct_non_norm_histogram, metric_type)),
+            ('1', mozfun.glam.percentile(1, struct_non_norm_histogram, metric_type)),
+            ('5', mozfun.glam.percentile(5, struct_non_norm_histogram, metric_type)),
+            ('25', mozfun.glam.percentile(25, struct_non_norm_histogram, metric_type)),
+            ('50', mozfun.glam.percentile(50, struct_non_norm_histogram, metric_type)),
+            ('75', mozfun.glam.percentile(75, struct_non_norm_histogram, metric_type)),
+            ('95', mozfun.glam.percentile(95, struct_non_norm_histogram, metric_type)),
+            ('99', mozfun.glam.percentile(99, struct_non_norm_histogram, metric_type)),
+            ('99.9', mozfun.glam.percentile(99.9, struct_non_norm_histogram, metric_type))
+          ]),
+          existing_non_norm_percentiles
+        ) AS non_norm_percentiles
+      FROM
+        base
+    )
+    SELECT
+      app_id,
+      channel,
+      version,
+      ping_type,
+      os,
+      build_id,
+      build_date,
+      metric,
+      metric_type,
+      metric_key,
+      client_agg_type,
+      total_users,
+      histogram,
+      percentiles,
+      total_sample,
+      non_norm_histogram,
+      IF(
+        metric_type IN ("counter", "labeled_counter", "quantity"),
+        percentiles,
+        non_norm_percentiles
+      ) AS non_norm_percentiles
+    FROM
+      calculated_percentiles
   )

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates/view.sql
@@ -1,17 +1,92 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_nightly_aggregates`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_nightly_aggregates_v1`
-WHERE
+AS (
+    WITH base AS (
+      SELECT
+        * EXCEPT(percentiles, non_norm_percentiles),
+        IF(
+          percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(histogram)
+        ) AS struct_histogram,
+        IF(
+          metric_type IN ("counter", "labeled_counter", "quantity") OR non_norm_percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(non_norm_histogram)
+        ) AS struct_non_norm_histogram,
+        percentiles AS existing_percentiles,
+        non_norm_percentiles AS existing_non_norm_percentiles
+      FROM
+        `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_nightly_aggregates_v1`
+      WHERE
   -- filter based on https://github.com/mozilla/python_mozaggregator/blob/6c0119bfd0b535346c37cb3f707d998039d3e24b/mozaggregator/service.py#L51
-  (
-    metric NOT LIKE r"%search\_counts%"
-    AND metric NOT LIKE r"%browser\_search%"
-    AND metric NOT LIKE r"%event\_counts%"
-    AND metric NOT LIKE r"%browser\_engagement\_navigation%"
-    AND metric NOT LIKE r"%manager\_message\_size%"
-    AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        (
+          metric NOT LIKE r"%search\_counts%"
+          AND metric NOT LIKE r"%browser\_search%"
+          AND metric NOT LIKE r"%event\_counts%"
+          AND metric NOT LIKE r"%browser\_engagement\_navigation%"
+          AND metric NOT LIKE r"%manager\_message\_size%"
+          AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        )
+    ),
+    calculated_percentiles AS (
+      SELECT
+        * EXCEPT (struct_histogram, struct_non_norm_histogram),
+        IF(
+          struct_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(ARRAY<STRUCT<key STRING, value FLOAT64>>[
+            ('0.1', mozfun.glam.percentile(0.1, struct_histogram, metric_type)),
+            ('1', mozfun.glam.percentile(1, struct_histogram, metric_type)),
+            ('5', mozfun.glam.percentile(5, struct_histogram, metric_type)),
+            ('25', mozfun.glam.percentile(25, struct_histogram, metric_type)),
+            ('50', mozfun.glam.percentile(50, struct_histogram, metric_type)),
+            ('75', mozfun.glam.percentile(75, struct_histogram, metric_type)),
+            ('95', mozfun.glam.percentile(95, struct_histogram, metric_type)),
+            ('99', mozfun.glam.percentile(99, struct_histogram, metric_type)),
+            ('99.9', mozfun.glam.percentile(99.9, struct_histogram, metric_type))
+          ]),
+          existing_percentiles
+        ) AS percentiles,
+        IF(
+          struct_non_norm_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(ARRAY<STRUCT<key STRING, value FLOAT64>>[
+            ('0.1', mozfun.glam.percentile(0.1, struct_non_norm_histogram, metric_type)),
+            ('1', mozfun.glam.percentile(1, struct_non_norm_histogram, metric_type)),
+            ('5', mozfun.glam.percentile(5, struct_non_norm_histogram, metric_type)),
+            ('25', mozfun.glam.percentile(25, struct_non_norm_histogram, metric_type)),
+            ('50', mozfun.glam.percentile(50, struct_non_norm_histogram, metric_type)),
+            ('75', mozfun.glam.percentile(75, struct_non_norm_histogram, metric_type)),
+            ('95', mozfun.glam.percentile(95, struct_non_norm_histogram, metric_type)),
+            ('99', mozfun.glam.percentile(99, struct_non_norm_histogram, metric_type)),
+            ('99.9', mozfun.glam.percentile(99.9, struct_non_norm_histogram, metric_type))
+          ]),
+          existing_non_norm_percentiles
+        ) AS non_norm_percentiles
+      FROM
+        base
+    )
+    SELECT
+      app_id,
+      channel,
+      version,
+      ping_type,
+      os,
+      build_id,
+      build_date,
+      metric,
+      metric_type,
+      metric_key,
+      client_agg_type,
+      total_users,
+      histogram,
+      percentiles,
+      total_sample,
+      non_norm_histogram,
+      IF(
+        metric_type IN ("counter", "labeled_counter", "quantity"),
+        percentiles,
+        non_norm_percentiles
+      ) AS non_norm_percentiles
+    FROM
+      calculated_percentiles
   )

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates/view.sql
@@ -1,17 +1,92 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_release_aggregates`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_release_aggregates_v1`
-WHERE
+AS (
+    WITH base AS (
+      SELECT
+        * EXCEPT(percentiles, non_norm_percentiles),
+        IF(
+          percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(histogram)
+        ) AS struct_histogram,
+        IF(
+          metric_type IN ("counter", "labeled_counter", "quantity") OR non_norm_percentiles IS NOT NULL,
+          NULL,
+          udfs.glam_histogram_to_struct(non_norm_histogram)
+        ) AS struct_non_norm_histogram,
+        percentiles AS existing_percentiles,
+        non_norm_percentiles AS existing_non_norm_percentiles
+      FROM
+        `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_release_aggregates_v1`
+      WHERE
   -- filter based on https://github.com/mozilla/python_mozaggregator/blob/6c0119bfd0b535346c37cb3f707d998039d3e24b/mozaggregator/service.py#L51
-  (
-    metric NOT LIKE r"%search\_counts%"
-    AND metric NOT LIKE r"%browser\_search%"
-    AND metric NOT LIKE r"%event\_counts%"
-    AND metric NOT LIKE r"%browser\_engagement\_navigation%"
-    AND metric NOT LIKE r"%manager\_message\_size%"
-    AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        (
+          metric NOT LIKE r"%search\_counts%"
+          AND metric NOT LIKE r"%browser\_search%"
+          AND metric NOT LIKE r"%event\_counts%"
+          AND metric NOT LIKE r"%browser\_engagement\_navigation%"
+          AND metric NOT LIKE r"%manager\_message\_size%"
+          AND metric NOT LIKE r"%dropped\_frames\_proportion%"
+        )
+    ),
+    calculated_percentiles AS (
+      SELECT
+        * EXCEPT (struct_histogram, struct_non_norm_histogram),
+        IF(
+          struct_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(ARRAY<STRUCT<key STRING, value FLOAT64>>[
+            ('0.1', mozfun.glam.percentile(0.1, struct_histogram, metric_type)),
+            ('1', mozfun.glam.percentile(1, struct_histogram, metric_type)),
+            ('5', mozfun.glam.percentile(5, struct_histogram, metric_type)),
+            ('25', mozfun.glam.percentile(25, struct_histogram, metric_type)),
+            ('50', mozfun.glam.percentile(50, struct_histogram, metric_type)),
+            ('75', mozfun.glam.percentile(75, struct_histogram, metric_type)),
+            ('95', mozfun.glam.percentile(95, struct_histogram, metric_type)),
+            ('99', mozfun.glam.percentile(99, struct_histogram, metric_type)),
+            ('99.9', mozfun.glam.percentile(99.9, struct_histogram, metric_type))
+          ]),
+          existing_percentiles
+        ) AS percentiles,
+        IF(
+          struct_non_norm_histogram IS NOT NULL,
+          mozfun.glam.histogram_cast_json(ARRAY<STRUCT<key STRING, value FLOAT64>>[
+            ('0.1', mozfun.glam.percentile(0.1, struct_non_norm_histogram, metric_type)),
+            ('1', mozfun.glam.percentile(1, struct_non_norm_histogram, metric_type)),
+            ('5', mozfun.glam.percentile(5, struct_non_norm_histogram, metric_type)),
+            ('25', mozfun.glam.percentile(25, struct_non_norm_histogram, metric_type)),
+            ('50', mozfun.glam.percentile(50, struct_non_norm_histogram, metric_type)),
+            ('75', mozfun.glam.percentile(75, struct_non_norm_histogram, metric_type)),
+            ('95', mozfun.glam.percentile(95, struct_non_norm_histogram, metric_type)),
+            ('99', mozfun.glam.percentile(99, struct_non_norm_histogram, metric_type)),
+            ('99.9', mozfun.glam.percentile(99.9, struct_non_norm_histogram, metric_type))
+          ]),
+          existing_non_norm_percentiles
+        ) AS non_norm_percentiles
+      FROM
+        base
+    )
+    SELECT
+      app_id,
+      channel,
+      version,
+      ping_type,
+      os,
+      build_id,
+      build_date,
+      metric,
+      metric_type,
+      metric_key,
+      client_agg_type,
+      total_users,
+      histogram,
+      percentiles,
+      total_sample,
+      non_norm_histogram,
+      IF(
+        metric_type IN ("counter", "labeled_counter", "quantity"),
+        percentiles,
+        non_norm_percentiles
+      ) AS non_norm_percentiles
+    FROM
+      calculated_percentiles
   )

--- a/sql/mozfun/glam/histogram_cast_struct/metadata.yaml
+++ b/sql/mozfun/glam/histogram_cast_struct/metadata.yaml
@@ -1,0 +1,3 @@
+description: |
+  Cast a String-based JSON histogram to an Array of Structs
+friendly_name: Histogram cast Struct

--- a/sql/mozfun/glam/histogram_cast_struct/udf.sql
+++ b/sql/mozfun/glam/histogram_cast_struct/udf.sql
@@ -1,0 +1,35 @@
+/*
+Casts a JSON String histogram into a ARRAY<STRUCT<key, value>>.
+I found no SQL native way to do this. If you have, please open change or open a ticket.
+*/
+CREATE OR REPLACE FUNCTION glam.histogram_cast_struct(json_str STRING)
+RETURNS ARRAY<STRUCT<KEY STRING, value FLOAT64>>
+LANGUAGE js
+AS
+  """
+  if (!json_str) {
+    return null
+  }
+  const json_dict = JSON.parse(json_str);
+  const entries = Object.entries(json_dict).map(
+      (r)=>Object.fromEntries(
+        [["KEY", parseFloat(r[0])],["value", parseFloat(r[1])]]
+      )
+  );
+  return entries;
+""";
+
+SELECT
+  assert.array_equals(
+    ARRAY<STRUCT<key STRING, value FLOAT64>>[("0", 0.1111), ("1", 0.6667), ("2", 0)],
+    glam.histogram_cast_struct('{"0":0.1111,"1":0.6667,"2":0}')
+  ),
+  assert.array_equals(
+    ARRAY<STRUCT<key STRING, value FLOAT64>>[("0", 0.1111), ("1", 0.6667), ("2", 0), ("10", 100)],
+    glam.histogram_cast_struct('{"0":0.1111,"1":0.6667,"2":0,"10":100}')
+  ),
+  assert.array_empty(glam.histogram_cast_struct('{}')),
+  assert.array_equals(
+    ARRAY<STRUCT<key STRING, value FLOAT64>>[("always", 0.5), ("never", 0.5)],
+    glam.histogram_cast_struct('{"always":0.5,"never":0.5}')
+  )


### PR DESCRIPTION
This PR makes GLAM calculate aggregations' percentiles while querying production data from a view. Existing percentiles will be reused instead of re-calculated. Other PRs to have GLAM stop calculating percentiles in the ETL will follow later, which will reduce GLAM ETL costs.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
