### PR TITLE
adding location selected to struct

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
@@ -359,6 +359,7 @@ weather_summary AS (
     ARRAY_AGG(
       STRUCT(
         weather_widget_impressions,
+        weather_widget_location_selected,
         weather_widget_clicks,
         weather_widget_load_errors,
         weather_widget_change_display_to_detailed,

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/test_aggregation/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/test_aggregation/expect.yaml
@@ -61,3 +61,4 @@
       weather_widget_load_errors: 0
       weather_widget_change_display_to_detailed: 0
       weather_widget_change_display_to_simple: 0
+      weather_widget_location_selected: 0


### PR DESCRIPTION
The CI is failing on dry run b/c this field is missing from the struct

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4379)
