### PR TITLE
Use updated table object in view publish

### DIFF
--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -78,7 +78,7 @@ class Schema:
             print(f"Cannot get schema for {project}.{dataset}.{table}: {e}")
             return cls({"fields": []})
 
-    def deploy(self, destination_table: str):
+    def deploy(self, destination_table: str) -> bigquery.Table:
         """Deploy the schema to BigQuery named after destination_table."""
         client = bigquery.Client()
         tmp_schema_file = NamedTemporaryFile()
@@ -89,10 +89,10 @@ class Schema:
             # destination table already exists, update schema
             table = client.get_table(destination_table)
             table.schema = bigquery_schema
-            client.update_table(table, ["schema"])
+            return client.update_table(table, ["schema"])
         except NotFound:
             table = bigquery.Table(destination_table, schema=bigquery_schema)
-            client.create_table(table)
+            return client.create_table(table)
 
     def merge(
         self,

--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -414,7 +414,7 @@ class View:
 
                 try:
                     if self.schema_path.is_file():
-                        self.schema.deploy(target_view)
+                        table = self.schema.deploy(target_view)
                 except Exception as e:
                     print(f"Could not update field descriptions for {target_view}: {e}")
 


### PR DESCRIPTION
Following up on https://github.com/mozilla/bigquery-etl/pull/5969.  This currently fails for `telemetry.newtab_clients_daily` with `412 Precondition check failed` because the `client.get_table` call was moved before the schema deploy, which makes the label update call use the ETag of the old table object which fails the `If-Match` check here 
https://github.com/googleapis/python-bigquery/blob/ba61a8ab0da541ba1940211875d7ea2e9e17dfa8/google/cloud/bigquery/client.py#L1424

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4395)
