### PR TITLE
Don't fetch boolean probes since GLAM doesn't support them yet

### DIFF
--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_beta_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_beta_aggregates/view.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric_type NOT IN ("boolean", "keyed-scalar-boolean")
     ),
     calculated_percentiles AS (
       SELECT

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_nightly_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_nightly_aggregates/view.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric_type NOT IN ("boolean", "keyed-scalar-boolean")
     ),
     calculated_percentiles AS (
       SELECT

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_release_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_release_aggregates/view.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric_type NOT IN ("boolean", "keyed-scalar-boolean")
     ),
     calculated_percentiles AS (
       SELECT

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates/view.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric_type != "boolean"
     ),
     calculated_percentiles AS (
       SELECT

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates/view.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric_type != "boolean"
     ),
     calculated_percentiles AS (
       SELECT

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates/view.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric_type != "boolean"
     ),
     calculated_percentiles AS (
       SELECT

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates/view.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric_type != "boolean"
     ),
     calculated_percentiles AS (
       SELECT

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates/view.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric_type != "boolean"
     ),
     calculated_percentiles AS (
       SELECT

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates/view.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric_type != "boolean"
     ),
     calculated_percentiles AS (
       SELECT


### PR DESCRIPTION
This PR filters out `boolean` probes and Metrics from the GLAM views used to serve the app. GLAM does not officially support `boolean` probes yet.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4406)
