### PR TITLE
Remove glam intermediate tables from shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -181,30 +181,12 @@ DELETE_TARGETS: DeleteIndex = {
         table="telemetry_derived.desktop_engagement_clients_v1"
     ): DESKTOP_SRC,
     client_id_target(table="search_derived.search_clients_last_seen_v1"): DESKTOP_SRC,
-    client_id_target(
-        table="telemetry_derived.clients_daily_histogram_aggregates_v1"
-    ): DESKTOP_SRC,
-    client_id_target(
-        table="telemetry_derived.clients_daily_scalar_aggregates_v1"
-    ): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.clients_daily_v6"): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.clients_daily_joined_v1"): DESKTOP_SRC,
-    client_id_target(
-        table="telemetry_derived.clients_daily_histogram_aggregates_v1"
-    ): DESKTOP_SRC,
-    client_id_target(
-        table="telemetry_derived.clients_daily_scalar_aggregates_v1"
-    ): DESKTOP_SRC,
-    client_id_target(
-        table="telemetry_derived.clients_histogram_aggregates_v1"
-    ): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.clients_last_seen_v1"): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.clients_last_seen_v2"): DESKTOP_SRC,
     client_id_target(
         table="telemetry_derived.clients_last_seen_joined_v1"
-    ): DESKTOP_SRC,
-    client_id_target(
-        table="telemetry_derived.clients_scalar_aggregates_v1"
     ): DESKTOP_SRC,
     client_id_target(
         table="telemetry_derived.clients_profile_per_install_affected_v1"


### PR DESCRIPTION
These tables have seven days of retention so shredder doesn't actually do anything when it tries to delete.  I'm looking to clean up the config and be more explicit about what doesn't need shredding.

@edugfilho Does removing these tables from shredder make sense to you?

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4407)
