### PR TITLE
Remove percentiles columns from client_probe_counts schema

### DIFF
--- a/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_beta_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_beta_v1/schema.yaml
@@ -29,15 +29,9 @@ fields:
 - name: histogram
   type: STRING
   mode: NULLABLE
-- name: percentiles
-  type: STRING
-  mode: NULLABLE
 - name: total_sample
   type: BIGNUMERIC
   mode: NULLABLE
 - name: non_norm_histogram
-  type: STRING
-  mode: NULLABLE
-- name: non_norm_percentiles
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_nightly_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_derived/client_probe_counts_firefox_desktop_nightly_v1/schema.yaml
@@ -29,15 +29,9 @@ fields:
 - name: histogram
   type: STRING
   mode: NULLABLE
-- name: percentiles
-  type: STRING
-  mode: NULLABLE
 - name: total_sample
   type: BIGNUMERIC
   mode: NULLABLE
 - name: non_norm_histogram
-  type: STRING
-  mode: NULLABLE
-- name: non_norm_percentiles
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/glam_client_probe_counts_extract_v1/schema.yaml
@@ -1,48 +1,37 @@
 fields:
-- mode: NULLABLE
-  name: channel
+- name: app_version
   type: INTEGER
-
-- mode: NULLABLE
-  name: app_version
+  mode: NULLABLE
+- name: os
+  type: STRING
+  mode: NULLABLE
+- name: app_build_id
+  type: STRING
+  mode: NULLABLE
+- name: process
+  type: STRING
+  mode: NULLABLE
+- name: metric
+  type: STRING
+  mode: NULLABLE
+- name: key
+  type: STRING
+  mode: NULLABLE
+- name: client_agg_type
+  type: STRING
+  mode: NULLABLE
+- name: metric_type
+  type: STRING
+  mode: NULLABLE
+- name: total_users
   type: INTEGER
-
-- mode: NULLABLE
-  name: agg_type
-  type: INTEGER
-
-- mode: NULLABLE
-  name: os
+  mode: NULLABLE
+- name: histogram
   type: STRING
-
-- mode: NULLABLE
-  name: app_build_id
+  mode: NULLABLE
+- name: total_sample
+  type: BIGNUMERIC
+  mode: NULLABLE
+- name: non_norm_histogram
   type: STRING
-
-- mode: NULLABLE
-  name: process
-  type: INTEGER
-
-- mode: NULLABLE
-  name: metric
-  type: STRING
-
-- mode: NULLABLE
-  name: key
-  type: STRING
-
-- mode: NULLABLE
-  name: client_agg_type
-  type: STRING
-
-- mode: NULLABLE
-  name: metric_type
-  type: STRING
-
-- mode: NULLABLE
-  name: total_users
-  type: INTEGER
-
-- mode: NULLABLE
-  name: aggregates
-  type: STRING
+  mode: NULLABLE


### PR DESCRIPTION
percentiles columns were removed in https://github.com/mozilla/bigquery-etl/pull/5966 so this is failing dry run which wasn't caught in the original pr because these queries weren't changed.  Also updated the upstream `glam_client_probe_counts_extract_v1` schema for consistency but I don't think this uses bqetl tooling.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4410)
