### PR TITLE
fix(bqetl): issue running ./bqetl with Fedora Silverblue

### DIFF
--- a/bqetl
+++ b/bqetl
@@ -3,7 +3,7 @@
 set -e
 
 # Absolute path this script is in
-SCRIPT_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+SCRIPT_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd )"
 CMD=$1
 
 if [ "$PWD" != "$SCRIPT_PATH" ]; then


### PR DESCRIPTION
Silverblue symlinks `/home` -> `/var/home`, so using `pwd -P` returns
something different than $PWD. E.g:

    $ pwd -P; pwd; echo $PWD
    /var/home/ahal/dev/bigquery-etl
    /home/ahal/dev/bigquery-etl
    /home/ahal/dev/bigquery-etl

Removing the `-P` flag respects the symlink.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
