### PR TITLE
Change fxa_carts amount to int in schema

### DIFF
--- a/sql/moz-fx-data-shared-prod/accounts_db_external/fxa_carts_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_db_external/fxa_carts_v1/schema.yaml
@@ -41,7 +41,7 @@ fields:
   type: STRING
   mode: NULLABLE
 - name: amount
-  type: STRING
+  type: INTEGER
   mode: NULLABLE
 - name: version
   type: INTEGER

--- a/sql/moz-fx-data-shared-prod/accounts_db_nonprod_external/fxa_carts_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_db_nonprod_external/fxa_carts_v1/schema.yaml
@@ -41,7 +41,7 @@ fields:
   type: STRING
   mode: NULLABLE
 - name: amount
-  type: STRING
+  type: INTEGER
   mode: NULLABLE
 - name: version
   type: INTEGER


### PR DESCRIPTION
This is failing in table deploy because the deployed tables use INT https://workflow.telemetry.mozilla.org/dags/bqetl_artifact_deployment/grid?root=&dag_run_id=manual__2024-08-01T07%3A16%3A51.391302%2B00%3A00&task_id=publish_new_tables&tab=logs

`amount` should be an integer, per https://mozilla.github.io/ecosystem-platform/reference/database-structure#database-fxa.  I'm guessing the existing table was created using the query.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4436)
