### PR TITLE
Add a derived query to compute Firefox-CI task run costs

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci/task_run_costs/view.sql
+++ b/sql/moz-fx-data-shared-prod/fxci/task_run_costs/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.fxci.task_run_costs`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.fxci_derived.task_run_costs_v1`

--- a/sql/moz-fx-data-shared-prod/fxci_derived/task_run_costs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/task_run_costs_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Firefox-CI Task Run Costs
+description: |-
+  Derived Firefox-CI task run cost data.
+owners:
+- ahalberstadt@mozilla.com
+labels:
+  incremental: true
+  owner1: ahalberstadt
+  dag: bqetl_internal_tooling
+scheduling:
+  dag_name: bqetl_internal_tooling
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - task_id
+    - run_id
+references: {}

--- a/sql/moz-fx-data-shared-prod/fxci_derived/task_run_costs_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/task_run_costs_v1/query.sql
@@ -1,0 +1,56 @@
+WITH run AS (
+  SELECT
+    task_runs.task_id AS task_id,
+    task_runs.run_id AS run_id,
+    task_runs.worker_group AS worker_group,
+    task_runs.worker_id AS worker_id,
+    TIMESTAMP_DIFF(task_runs.resolved, task_runs.started, SECOND) AS duration
+  FROM
+    `moz-fx-data-shared-prod.fxci.task_runs_v1` AS task_runs
+  WHERE
+    task_runs.submission_date = @submission_date
+),
+worker AS (
+  SELECT
+    worker_cost.zone AS zone,
+    worker_cost.instance_id AS instance_id,
+    SUM(worker_cost.total_cost) AS total_cost,
+    SUM(worker_metrics.uptime) AS uptime,
+  FROM
+    `moz-fx-data-shared-prod.fxci.worker_metrics_v1` AS worker_metrics
+  INNER JOIN
+    `moz-fx-data-shared-prod.fxci_derived.worker_costs_v1` AS worker_cost
+    ON worker_metrics.project = worker_cost.project
+    AND worker_metrics.zone = worker_cost.zone
+    AND worker_metrics.instance_id = worker_cost.instance_id
+  WHERE
+    worker_metrics.submission_date
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 30 DAY)
+    AND @submission_date
+    AND worker_cost.usage_start_date
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 30 DAY)
+    AND @submission_date
+  GROUP BY
+    zone,
+    instance_id
+)
+SELECT
+  run.task_id AS task_id,
+  run.run_id AS run_id,
+  @submission_date AS submission_date,
+  (run.duration / worker.uptime) * worker.total_cost AS run_cost,
+FROM
+  run
+INNER JOIN
+  worker
+  ON run.worker_group = worker.zone
+  AND run.worker_id = worker.instance_id
+WHERE
+  worker.uptime > run.duration
+GROUP BY
+  task_id,
+  run_id,
+  submission_date,
+  run.duration,
+  worker.uptime,
+  worker.total_cost


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4452)
