### PR TITLE
[DENG-577] Create monitoring table for stable table expiration

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -143,6 +143,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/query.sql
   - sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/query.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v1/view.sql
+  - sql/moz-fx-data-shared-prod/monitoring_derived/table_partition_expirations_v1/query.sql
   # No matching signature for function IF
   - sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_last_seen/query.sql
   # Duplicate UDF

--- a/sql_generators/table_partition_expirations/__init__.py
+++ b/sql_generators/table_partition_expirations/__init__.py
@@ -1,0 +1,62 @@
+import shutil
+from pathlib import Path
+
+import click
+from jinja2 import FileSystemLoader, Environment
+
+from bigquery_etl.cli.utils import use_cloud_function_option
+from bigquery_etl.format_sql.formatter import reformat
+from bigquery_etl.schema.stable_table_schema import get_stable_table_schemas
+from bigquery_etl.util.common import write_sql, get_table_dir
+
+
+@click.command("generate")
+@click.option(
+    "--target-project",
+    "--target_project",
+    help="Which project the queries should be written to.",
+    default="moz-fx-data-shared-prod",
+)
+@click.option(
+    "--output-dir",
+    "--output_dir",
+    help="The location to write to. Defaults to sql/.",
+    default=Path("sql"),
+    type=click.Path(file_okay=False),
+)
+@use_cloud_function_option
+def generate(target_project, output_dir, use_cloud_function):
+    stable_datasets = {
+        schema.bq_dataset_family + "_stable" for schema in get_stable_table_schemas()
+    }
+
+    template_dir = Path(__file__).parent / "templates"
+    env = Environment(loader=FileSystemLoader(template_dir))
+
+    output_table = f"{target_project}.monitoring_derived.table_partition_expirations_v1"
+
+    template = env.get_template("table_partition_expirations.sql")
+    query = template.render(datasets=stable_datasets, destination_table=output_table)
+
+    table_dir = get_table_dir(Path(output_dir) / target_project, output_table)
+
+    write_sql(
+        Path(output_dir) / target_project,
+        output_table,
+        "query.sql",
+        reformat(query),
+    )
+
+    shutil.copyfile(
+        template_dir / "schema.yaml",
+        table_dir / "schema.yaml",
+    )
+
+    shutil.copyfile(
+        template_dir / "metadata.yaml",
+        table_dir / "metadata.yaml",
+    )
+
+
+if __name__ == "__main__":
+    generate()

--- a/sql_generators/table_partition_expirations/templates/metadata.yaml
+++ b/sql_generators/table_partition_expirations/templates/metadata.yaml
@@ -1,0 +1,17 @@
+friendly_name: Table Partition Expirations
+description: |-
+  Earliest partitions and partition expiration info per stable table per day.
+owners:
+- bewu@mozilla.cam
+labels:
+  incremental: true
+  owner1: benwu
+scheduling:
+  dag_name: bqetl_monitoring
+  depends_on_past: true
+bigquery:
+  time_partitioning:
+    type: day
+    field: run_date
+    require_partition_filter: false
+    expiration_days: null

--- a/sql_generators/table_partition_expirations/templates/schema.yaml
+++ b/sql_generators/table_partition_expirations/templates/schema.yaml
@@ -1,0 +1,46 @@
+fields:
+- name: run_date
+  type: DATE
+  mode: NULLABLE
+- name: project_id
+  type: STRING
+  mode: NULLABLE
+- name: dataset_id
+  type: STRING
+  mode: NULLABLE
+- name: table_id
+  type: STRING
+  mode: NULLABLE
+- name: first_partition_historical
+  type: DATE
+  mode: NULLABLE
+  description: First recorded partition
+- name: first_partition_current
+  type: DATE
+  mode: NULLABLE
+  description: First partition as of the current run date
+- name: first_non_empty_partition_historical
+  type: DATE
+  description: >
+    First recorded partition with at least one row,
+    or the first recorded partition if the table existed before the partitions
+    started being recorded.
+  mode: NULLABLE
+- name: first_non_empty_partition_current
+  type: DATE
+  description: First partition with at least one row as of the current run date
+  mode: NULLABLE
+- name: first_partition_row_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of rows in the current first partition
+- name: partition_expiration_days
+  type: INTEGER
+  mode: NULLABLE
+  description: Maximum age of a partition before it is deleted
+- name: next_deletion_date
+  type: DATE
+  mode: NULLABLE
+  description: >
+    Next date on which a partition will be dropped.
+    Only partitions after first_non_empty_partition_historical are considered.

--- a/sql_generators/table_partition_expirations/templates/table_partition_expirations.sql
+++ b/sql_generators/table_partition_expirations/templates/table_partition_expirations.sql
@@ -1,0 +1,123 @@
+WITH
+  {% for dataset_id in datasets %}
+    first_partition_{{ dataset_id }} AS (
+      SELECT
+        table_catalog,
+        table_schema,
+        table_name,
+        PARSE_DATE("%Y%m%d", partition_id) AS first_partition_current,
+        total_rows AS first_partition_row_count,
+      FROM
+        `moz-fx-data-shared-prod.{{ dataset_id }}.INFORMATION_SCHEMA.PARTITIONS`
+      WHERE
+        partition_id != '__NULL__'
+      QUALIFY
+        ROW_NUMBER() OVER (PARTITION BY table_name ORDER BY partition_id) = 1
+    ),
+    first_non_empty_partition_{{ dataset_id }} AS (
+      SELECT
+        table_name,
+        PARSE_DATE("%Y%m%d", MIN(partition_id)) AS first_non_empty_partition_current,
+      FROM
+        `moz-fx-data-shared-prod.{{ dataset_id }}.INFORMATION_SCHEMA.PARTITIONS`
+      WHERE
+        partition_id != '__NULL__'
+        AND total_rows > 0
+      GROUP BY
+        table_name
+    ),
+  {% endfor %}
+current_partitions AS (
+  {% for dataset_id in datasets %}
+    SELECT
+      {% raw %}
+        {% if is_init() %}
+          CURRENT_DATE() - 1
+        {% else %}
+          DATE(@submission_date)
+        {% endif %}
+      {% endraw %}
+      AS run_date,
+      table_catalog AS project_id,
+      table_schema AS dataset_id,
+      table_name AS table_id,
+      first_partition_current,
+      first_non_empty_partition_current,
+      first_partition_row_count,
+    FROM
+      first_partition_{{ dataset_id }}
+    LEFT JOIN
+      first_non_empty_partition_{{ dataset_id }}
+    USING
+      (table_name)
+    {% if not loop.last %}
+      UNION ALL
+    {% endif %}
+  {% endfor %}
+),
+partition_stats AS (
+  SELECT
+    current_partitions.run_date,
+    current_partitions.project_id,
+    current_partitions.dataset_id,
+    current_partitions.table_id,
+    COALESCE(
+      previous.first_partition_historical,
+      current_partitions.first_partition_current
+    ) AS first_partition_historical,
+    current_partitions.first_partition_current,
+    {% raw %}
+      {% if is_init() %}
+        -- can't know whether the table had data in the past
+        -- if data is already being dropped, so assume it did
+        IF(
+          DATE_DIFF(
+            current_partitions.run_date,
+            current_partitions.first_partition_current,
+            DAY
+          ) >= CAST(option_value AS FLOAT64) - 2,
+          current_partitions.first_partition_current,
+          current_partitions.first_non_empty_partition_current
+        )
+      {% else %}
+        COALESCE(
+          previous.first_non_empty_partition_historical,
+          current_partitions.first_non_empty_partition_current
+        )
+      {% endif %}
+    {% endraw %}
+    AS first_non_empty_partition_historical,
+    current_partitions.first_non_empty_partition_current,
+    current_partitions.first_partition_row_count,
+    CAST(CAST(option_value AS FLOAT64) AS INT) AS partition_expiration_days,
+  FROM
+    current_partitions
+  LEFT JOIN
+    `moz-fx-data-shared-prod.monitoring_derived.table_partition_expirations_v1` AS previous
+    ON current_partitions.project_id = previous.project_id
+    AND current_partitions.dataset_id = previous.dataset_id
+    AND current_partitions.table_id = previous.table_id
+    AND current_partitions.run_date = previous.run_date + 1
+  LEFT JOIN
+    `moz-fx-data-shared-prod.region-us.INFORMATION_SCHEMA.TABLE_OPTIONS`
+    ON table_catalog = current_partitions.project_id
+    AND table_schema = current_partitions.dataset_id
+    AND table_name = current_partitions.table_id
+  WHERE
+    option_name = 'partition_expiration_days'
+)
+
+SELECT
+  *,
+  -- If there was data in the past, then first partition is the next deletion.
+  -- Otherwise, next deletion is the first non-empty partition.
+  DATE_ADD(
+    IF(
+      COALESCE(first_non_empty_partition_historical, '9999-12-31') <= first_partition_current,
+      first_partition_current,
+      first_non_empty_partition_current
+    ),
+    INTERVAL partition_expiration_days DAY
+  ) AS next_deletion_date,
+FROM
+  partition_stats


### PR DESCRIPTION
Table to track stable table partition expiry as part of [the data expiry alerts proposal](https://docs.google.com/document/d/15_JR2niBY2jZqbt9wzJVrXH_EGL3D2SrS7G7gUVBei8/edit#heading=h.frvje7pnwo3v).

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4454)
