### PR TITLE
DENG-3096 - remove tests since they do not work with the python flags…

### DIFF
--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_errors_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_errors_v1/checks.sql
@@ -1,2 +1,0 @@
-#warn
-{{ is_unique(["dte", "location", "user_type", "device_type", "operating_system"]) }}

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/checks.sql
@@ -1,2 +1,0 @@
-#warn
-{{ is_unique(["dte", "device_type", "user_type", "location", "browser", "operating_system"]) }}

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_errors_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_errors_v1/checks.sql
@@ -1,2 +1,0 @@
-#warn
-{{ is_unique(["dte", "location"]) }}

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/checks.sql
@@ -1,2 +1,0 @@
-#warn
-{{ is_unique(["dte", "location", "user_type"]) }}

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_errors_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_errors_v1/checks.sql
@@ -1,2 +1,0 @@
-#warn
-{{ is_unique(["dte", "location", "device_type"]) }}

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/checks.sql
@@ -1,2 +1,0 @@
-#warn
-{{ is_unique(["dte", "os", "location", "device_type"]) }}


### PR DESCRIPTION
Reverting https://github.com/mozilla/bigquery-etl/pull/6008 - Basically I added new tests last Friday, but because the  python operator includes flags, the same flags are being passed into the checks and the checks are therefore failing, not knowing what to do with those flags.

This PR is to revert / remove the tests until I can figure out a better way to add the tests back in.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4458)
