### PR TITLE
Move limited historical Google Search Console data into separate views (DENG-4329)

### DIFF
--- a/sql/moz-fx-data-marketing-prod/google_search_console/search_impressions_by_page/schema.yaml
+++ b/sql/moz-fx-data-marketing-prod/google_search_console/search_impressions_by_page/schema.yaml
@@ -81,9 +81,7 @@ fields:
 - name: has_good_page_experience
   type: BOOLEAN
   mode: NULLABLE
-  description: |-
-    Whether Google Search considers the page to be providing a good page experience.
-    This will be null when the source data wasn't exported directly to BigQuery by Google.
+  description: Whether Google Search considers the page to be providing a good page experience.
 - name: search_type
   type: STRING
   mode: NULLABLE
@@ -98,9 +96,7 @@ fields:
 - name: search_appearance
   type: STRING
   mode: NULLABLE
-  description: |-
-    How the search result appeared (e.g. normal result, translated result, video).
-    This will be null when the source data wasn't exported directly to BigQuery by Google.
+  description: How the search result appeared (e.g. normal result, translated result, video).
 - name: user_country_code
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_page/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_page/metadata.yaml
@@ -1,0 +1,18 @@
+friendly_name: Limited Historical Search Impressions By Page
+description: |-
+  Limited historical Google Search impressions aggregated by page for the following domains:
+    * addons.mozilla.org (between 2021-03-29 and 2023-08-08)
+    * blog.mozilla.org (between 2021-03-29 and 2023-08-08)
+    * developer.mozilla.org (between 2022-12-18 and 2024-04-29)
+    * getpocket.com (between 2021-03-29 and 2023-08-08)
+    * support.mozilla.org (between 2021-03-29 and 2023-08-08)
+    * www.mozilla.org (between 2021-03-29 and 2023-08-08)
+
+  The data has the following limitations:
+    * For each site only data for specific historical dates is included as noted above.
+    * For each site only the top ~50,000 rows of data per day per search type is included (prioritized by number of clicks).
+    * Anonymized search queries aren't included.
+owners:
+- srose@mozilla.com
+labels:
+  owner1: srose

--- a/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_page/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_page/schema.yaml
@@ -1,0 +1,97 @@
+fields:
+- name: date
+  type: DATE
+  mode: NULLABLE
+  description: The day on which the search occurred (Pacific Time).
+- name: site_url
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    For domain properties, this will be `sc-domain:` followed by the domain name.
+    For URL-prefix properties, it will be the full URL of the property definition.
+- name: site_domain_name
+  type: STRING
+  mode: NULLABLE
+  description: Domain name of the site.
+- name: page_url
+  type: STRING
+  mode: NULLABLE
+  description: The final page URL linked by a search result after any skip redirects.
+- name: page_domain_name
+  type: STRING
+  mode: NULLABLE
+  description: Domain name of the page URL.
+- name: page_path
+  type: STRING
+  mode: NULLABLE
+  description: The path part of the page URL.
+- name: localized_site_code
+  type: STRING
+  mode: NULLABLE
+  description: Localized site code such as `en-US` or `de` found in the first segment of the page URL path (if any).
+- name: localized_site
+  type: STRING
+  mode: NULLABLE
+  description: Description of the localized site language and/or country based on `localized_site_code` (if any).
+- name: localized_site_language_code
+  type: STRING
+  mode: NULLABLE
+  description: Localized site language code in ISO-639-alpha-2 format found in the first segment of the page URL path (if any).
+- name: localized_site_language
+  type: STRING
+  mode: NULLABLE
+  description: Localized site language based on `localized_site_language_code` (if any).
+- name: query
+  type: STRING
+  mode: NULLABLE
+  description: The search query.
+- name: query_type
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Type of search query:
+      * Brand: Query contained one or more Mozilla brand keywords.
+      * Non-Brand: Query didn't contain any Mozilla brand keywords.
+      * Unknown: Query couldn't be classified.
+- name: search_type
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Where the link was seen by the user:
+      * Web: In Google Search's default "All" tab.
+      * Image: In Google Search's "Images" tab.
+      * Video: In Google Search's "Videos" tab.
+      * News: In Google Search's "News" tab.
+- name: user_country_code
+  type: STRING
+  mode: NULLABLE
+  description: Country from which the user was searching, in ISO-3166-1-alpha-3 format.
+- name: user_country
+  type: STRING
+  mode: NULLABLE
+  description: Country from which the user was searching.
+- name: user_region
+  type: STRING
+  mode: NULLABLE
+  description: Region from which the user was searching.
+- name: user_subregion
+  type: STRING
+  mode: NULLABLE
+  description: Sub-region from which the user was searching.
+- name: device_type
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The type of device on which the user was searching: Desktop, Mobile, or Tablet.
+- name: impressions
+  type: INTEGER
+  mode: NULLABLE
+  description: The number of times that search results with a link to the page were shown to a user.
+- name: clicks
+  type: INTEGER
+  mode: NULLABLE
+  description: The number of times a user clicked a search result link to the page.
+- name: average_position
+  type: FLOAT
+  mode: NULLABLE
+  description: The average position of the page in the search results, where `1` is the topmost position.

--- a/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_page/view.sql
+++ b/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_page/view.sql
@@ -1,0 +1,66 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.google_search_console.limited_historical_search_impressions_by_page`
+AS
+SELECT
+  search_impressions.date,
+  search_impressions.site_url,
+  search_impressions.site_domain_name,
+  search_impressions.page_url,
+  search_impressions.page_domain_name,
+  search_impressions.page_path,
+  search_impressions.localized_site_code,
+  CONCAT(
+    COALESCE(localized_site_language.name, search_impressions.localized_site_language_code),
+    COALESCE(
+      CONCAT(
+        ' - ',
+        COALESCE(localized_site_country.name, search_impressions.localized_site_country_code)
+      ),
+      ''
+    )
+  ) AS localized_site,
+  search_impressions.localized_site_language_code,
+  COALESCE(
+    localized_site_language.name,
+    search_impressions.localized_site_language_code
+  ) AS localized_site_language,
+  search_impressions.query,
+  mozfun.google_search_console.classify_site_query(
+    search_impressions.site_domain_name,
+    search_impressions.query,
+    search_impressions.search_type
+  ) AS query_type,
+  search_impressions.search_type,
+  search_impressions.user_country_code,
+  COALESCE(user_country.name, search_impressions.user_country_code) AS user_country,
+  user_country.region_name AS user_region,
+  user_country.subregion_name AS user_subregion,
+  search_impressions.device_type,
+  search_impressions.impressions,
+  search_impressions.clicks,
+  search_impressions.average_position
+FROM
+  `moz-fx-data-shared-prod.google_search_console_derived.search_impressions_by_page_v1` AS search_impressions
+LEFT JOIN
+  `moz-fx-data-shared-prod.static.language_codes_v1` AS localized_site_language
+  ON search_impressions.localized_site_language_code = localized_site_language.code_2
+LEFT JOIN
+  `moz-fx-data-shared-prod.static.country_codes_v1` AS localized_site_country
+  ON search_impressions.localized_site_country_code = localized_site_country.code
+LEFT JOIN
+  `moz-fx-data-shared-prod.static.country_codes_v1` AS user_country
+  ON search_impressions.user_country_code = user_country.code_3
+WHERE
+  -- Exclude the last two days of data for each site because the data for those days is incomplete.
+  CASE
+    WHEN site_domain_name IN (
+        'addons.mozilla.org',
+        'blog.mozilla.org',
+        'getpocket.com',
+        'support.mozilla.org',
+        'www.mozilla.org'
+      )
+      THEN `date` <= '2023-08-08'
+    WHEN site_domain_name = 'developer.mozilla.org'
+      THEN `date` <= '2024-04-29'
+  END

--- a/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_site/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_site/metadata.yaml
@@ -1,0 +1,18 @@
+friendly_name: Limited Historical Search Impressions By Site
+description: |-
+  Limited historical Google Search impressions aggregated by site for the following domains:
+    * addons.mozilla.org (between 2021-03-29 and 2023-08-08)
+    * blog.mozilla.org (between 2021-03-29 and 2023-08-08)
+    * developer.mozilla.org (between 2022-12-18 and 2024-04-29)
+    * getpocket.com (between 2021-03-29 and 2023-08-08)
+    * support.mozilla.org (between 2021-03-29 and 2023-08-08)
+    * www.mozilla.org (between 2021-03-29 and 2023-08-08)
+
+  The data has the following limitations:
+    * For each site only data for specific historical dates is included as noted above.
+    * For each site only the top ~50,000 rows of data per day per search type is included (prioritized by number of clicks).
+    * Anonymized search queries aren't included.
+owners:
+- srose@mozilla.com
+labels:
+  owner1: srose

--- a/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_site/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_site/schema.yaml
@@ -1,0 +1,69 @@
+fields:
+- name: date
+  type: DATE
+  mode: NULLABLE
+  description: The day on which the search occurred (Pacific Time).
+- name: site_url
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    For domain properties, this will be `sc-domain:` followed by the domain name.
+    For URL-prefix properties, it will be the full URL of the property definition.
+- name: site_domain_name
+  type: STRING
+  mode: NULLABLE
+  description: Domain name of the site.
+- name: query
+  type: STRING
+  mode: NULLABLE
+  description: The search query.
+- name: query_type
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Type of search query:
+      * Brand: Query contained one or more Mozilla brand keywords.
+      * Non-Brand: Query didn't contain any Mozilla brand keywords.
+      * Unknown: Query couldn't be classified.
+- name: search_type
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Where the link was seen by the user:
+      * Web: In Google Search's default "All" tab.
+      * Image: In Google Search's "Images" tab.
+      * Video: In Google Search's "Videos" tab.
+      * News: In Google Search's "News" tab.
+- name: user_country_code
+  type: STRING
+  mode: NULLABLE
+  description: Country from which the user was searching, in ISO-3166-1-alpha-3 format.
+- name: user_country
+  type: STRING
+  mode: NULLABLE
+  description: Country from which the user was searching.
+- name: user_region
+  type: STRING
+  mode: NULLABLE
+  description: Region from which the user was searching.
+- name: user_subregion
+  type: STRING
+  mode: NULLABLE
+  description: Sub-region from which the user was searching.
+- name: device_type
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The type of device on which the user was searching: Desktop, Mobile, or Tablet.
+- name: impressions
+  type: INTEGER
+  mode: NULLABLE
+  description: The number of times that search results with at least one link to the site were shown to a user.
+- name: clicks
+  type: INTEGER
+  mode: NULLABLE
+  description: The number of times a user clicked at least one search result link to the site.
+- name: average_top_position
+  type: FLOAT
+  mode: NULLABLE
+  description: The average top position of the site in the search results, where `1` is the topmost position.

--- a/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_site/view.sql
+++ b/sql/moz-fx-data-shared-prod/google_search_console/limited_historical_search_impressions_by_site/view.sql
@@ -1,0 +1,41 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.google_search_console.limited_historical_search_impressions_by_site`
+AS
+SELECT
+  search_impressions.`date`,
+  search_impressions.site_url,
+  search_impressions.site_domain_name,
+  search_impressions.query,
+  mozfun.google_search_console.classify_site_query(
+    search_impressions.site_domain_name,
+    search_impressions.query,
+    search_impressions.search_type
+  ) AS query_type,
+  search_impressions.search_type,
+  search_impressions.user_country_code,
+  COALESCE(user_country.name, search_impressions.user_country_code) AS user_country,
+  user_country.region_name AS user_region,
+  user_country.subregion_name AS user_subregion,
+  search_impressions.device_type,
+  search_impressions.impressions,
+  search_impressions.clicks,
+  search_impressions.average_top_position
+FROM
+  `moz-fx-data-shared-prod.google_search_console_derived.search_impressions_by_site_v1` AS search_impressions
+LEFT JOIN
+  `moz-fx-data-shared-prod.static.country_codes_v1` AS user_country
+  ON search_impressions.user_country_code = user_country.code_3
+WHERE
+  -- Exclude the last two days of data for each site because the data for those days is incomplete.
+  CASE
+    WHEN site_domain_name IN (
+        'addons.mozilla.org',
+        'blog.mozilla.org',
+        'getpocket.com',
+        'support.mozilla.org',
+        'www.mozilla.org'
+      )
+      THEN `date` <= '2023-08-08'
+    WHEN site_domain_name = 'developer.mozilla.org'
+      THEN `date` <= '2024-04-29'
+  END

--- a/sql/moz-fx-data-shared-prod/google_search_console/search_impressions_by_page/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_search_console/search_impressions_by_page/metadata.yaml
@@ -1,22 +1,12 @@
 friendly_name: Search Impressions By Page
 description: |-
   Google Search impressions aggregated by page for the following domains:
-    * addons.mozilla.org
-    * blog.mozilla.org
-    * developer.mozilla.org
-    * getpocket.com
-    * support.mozilla.org
-    * www.mozilla.org
-
-  For the developer.mozilla.org domain:
-    * Records from 2024-04-10 onward are from source data exported directly to BigQuery by Google.
-    * Records before 2024-04-10 are from source data synced to BigQuery by Fivetran.
-
-  For the other domains:
-    * Records from 2023-08-01 onward are from source data exported directly to BigQuery by Google.
-    * Records before 2023-08-01 are from source data synced to BigQuery by Fivetran.
-
-  Anonymized search queries, and Discover and Google News search impressions are only included if the source data was exported directly to BigQuery by Google.
+    * addons.mozilla.org (since 2023-07-11)
+    * blog.mozilla.org (since 2023-07-11)
+    * developer.mozilla.org (since 2024-04-10)
+    * getpocket.com (since 2023-07-24)
+    * support.mozilla.org (since 2023-07-11)
+    * www.mozilla.org (since 2023-07-11)
 owners:
 - srose@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/google_search_console/search_impressions_by_page/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/google_search_console/search_impressions_by_page/schema.yaml
@@ -81,9 +81,7 @@ fields:
 - name: has_good_page_experience
   type: BOOLEAN
   mode: NULLABLE
-  description: |-
-    Whether Google Search considers the page to be providing a good page experience.
-    This will be null when the source data wasn't exported directly to BigQuery by Google.
+  description: Whether Google Search considers the page to be providing a good page experience.
 - name: search_type
   type: STRING
   mode: NULLABLE
@@ -98,9 +96,7 @@ fields:
 - name: search_appearance
   type: STRING
   mode: NULLABLE
-  description: |-
-    How the search result appeared (e.g. normal result, translated result, video).
-    This will be null when the source data wasn't exported directly to BigQuery by Google.
+  description: How the search result appeared (e.g. normal result, translated result, video).
 - name: user_country_code
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/google_search_console/search_impressions_by_page/view.sql
+++ b/sql/moz-fx-data-shared-prod/google_search_console/search_impressions_by_page/view.sql
@@ -1,79 +1,6 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.google_search_console.search_impressions_by_page`
 AS
-WITH search_impressions_union AS (
-  SELECT
-    `date`,
-    site_url,
-    site_domain_name,
-    page_url,
-    page_domain_name,
-    page_path,
-    localized_site_code,
-    localized_site_language_code,
-    localized_site_country_code,
-    query,
-    FALSE AS is_anonymized,
-    CAST(NULL AS BOOLEAN) AS has_good_page_experience,
-    search_type,
-    CAST(NULL AS STRING) AS search_appearance,
-    user_country_code,
-    device_type,
-    impressions,
-    clicks,
-    average_position
-  FROM
-    `moz-fx-data-shared-prod.google_search_console_derived.search_impressions_by_page_v1`
-  WHERE
-    CASE
-      WHEN site_domain_name IN (
-          'addons.mozilla.org',
-          'blog.mozilla.org',
-          'getpocket.com',
-          'support.mozilla.org',
-          'www.mozilla.org'
-        )
-        THEN `date` < '2023-08-01'
-      WHEN site_domain_name = 'developer.mozilla.org'
-        THEN `date` < '2024-04-10'
-      ELSE FALSE
-    END
-  UNION ALL
-  SELECT
-    `date`,
-    site_url,
-    site_domain_name,
-    page_url,
-    page_domain_name,
-    page_path,
-    localized_site_code,
-    localized_site_language_code,
-    localized_site_country_code,
-    query,
-    is_anonymized,
-    has_good_page_experience,
-    search_type,
-    search_appearance,
-    user_country_code,
-    device_type,
-    impressions,
-    clicks,
-    average_position
-  FROM
-    `moz-fx-data-shared-prod.google_search_console_derived.search_impressions_by_page_v2`
-  WHERE
-    CASE
-      WHEN site_domain_name IN (
-          'addons.mozilla.org',
-          'blog.mozilla.org',
-          'getpocket.com',
-          'support.mozilla.org',
-          'www.mozilla.org'
-        )
-        THEN `date` >= '2023-08-01'
-      ELSE TRUE
-    END
-)
 SELECT
   search_impressions.date,
   search_impressions.site_url,
@@ -116,7 +43,7 @@ SELECT
   search_impressions.clicks,
   search_impressions.average_position
 FROM
-  search_impressions_union AS search_impressions
+  `moz-fx-data-shared-prod.google_search_console_derived.search_impressions_by_page_v2` AS search_impressions
 LEFT JOIN
   `moz-fx-data-shared-prod.static.language_codes_v1` AS localized_site_language
   ON search_impressions.localized_site_language_code = localized_site_language.code_2

--- a/sql/moz-fx-data-shared-prod/google_search_console/search_impressions_by_site/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_search_console/search_impressions_by_site/metadata.yaml
@@ -1,22 +1,12 @@
 friendly_name: Search Impressions By Site
 description: |-
   Google Search impressions aggregated by site for the following domains:
-    * addons.mozilla.org
-    * blog.mozilla.org
-    * developer.mozilla.org
-    * getpocket.com
-    * support.mozilla.org
-    * www.mozilla.org
-
-  For the developer.mozilla.org domain:
-    * Records from 2024-04-10 onward are from source data exported directly to BigQuery by Google.
-    * Records before 2024-04-10 are from source data synced to BigQuery by Fivetran.
-
-  For the other domains:
-    * Records from 2023-08-01 onward are from source data exported directly to BigQuery by Google.
-    * Records before 2023-08-01 are from source data synced to BigQuery by Fivetran.
-
-  Anonymized search queries are only included if the source data was exported directly to BigQuery by Google.
+    * addons.mozilla.org (since 2023-07-11)
+    * blog.mozilla.org (since 2023-07-11)
+    * developer.mozilla.org (since 2024-04-10)
+    * getpocket.com (since 2023-07-24)
+    * support.mozilla.org (since 2023-07-11)
+    * www.mozilla.org (since 2023-07-11)
 owners:
 - srose@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/google_search_console/search_impressions_by_site/view.sql
+++ b/sql/moz-fx-data-shared-prod/google_search_console/search_impressions_by_site/view.sql
@@ -1,63 +1,6 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.google_search_console.search_impressions_by_site`
 AS
-WITH search_impressions_union AS (
-  SELECT
-    `date`,
-    site_url,
-    site_domain_name,
-    query,
-    FALSE AS is_anonymized,
-    search_type,
-    user_country_code,
-    device_type,
-    impressions,
-    clicks,
-    average_top_position
-  FROM
-    `moz-fx-data-shared-prod.google_search_console_derived.search_impressions_by_site_v1`
-  WHERE
-    CASE
-      WHEN site_domain_name IN (
-          'addons.mozilla.org',
-          'blog.mozilla.org',
-          'getpocket.com',
-          'support.mozilla.org',
-          'www.mozilla.org'
-        )
-        THEN `date` < '2023-08-01'
-      WHEN site_domain_name = 'developer.mozilla.org'
-        THEN `date` < '2024-04-10'
-      ELSE FALSE
-    END
-  UNION ALL
-  SELECT
-    `date`,
-    site_url,
-    site_domain_name,
-    query,
-    is_anonymized,
-    search_type,
-    user_country_code,
-    device_type,
-    impressions,
-    clicks,
-    average_top_position
-  FROM
-    `moz-fx-data-shared-prod.google_search_console_derived.search_impressions_by_site_v2`
-  WHERE
-    CASE
-      WHEN site_domain_name IN (
-          'addons.mozilla.org',
-          'blog.mozilla.org',
-          'getpocket.com',
-          'support.mozilla.org',
-          'www.mozilla.org'
-        )
-        THEN `date` >= '2023-08-01'
-      ELSE TRUE
-    END
-)
 SELECT
   search_impressions.`date`,
   search_impressions.site_url,
@@ -79,7 +22,7 @@ SELECT
   search_impressions.clicks,
   search_impressions.average_top_position
 FROM
-  search_impressions_union AS search_impressions
+  `moz-fx-data-shared-prod.google_search_console_derived.search_impressions_by_site_v2` AS search_impressions
 LEFT JOIN
   `moz-fx-data-shared-prod.static.country_codes_v1` AS user_country
   ON search_impressions.user_country_code = user_country.code_3

--- a/sql/moz-fx-data-shared-prod/google_search_console_derived/search_impressions_by_page_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_search_console_derived/search_impressions_by_page_v1/metadata.yaml
@@ -8,7 +8,9 @@ description: |-
     * support.mozilla.org
     * www.mozilla.org
 
-  Anonymized search queries aren't included.
+  The data has the following limitations:
+    * For each site only the top ~50,000 rows of data per day per search type is included (prioritized by number of clicks).
+    * Anonymized search queries aren't included.
 
   For the developer.mozilla.org domain, we stopped syncing Google Search Console data with Fivetran in May 2024.
   See https://bugzilla.mozilla.org/show_bug.cgi?id=1890816.
@@ -25,6 +27,9 @@ scheduling:
   # See https://bugzilla.mozilla.org/show_bug.cgi?id=1764960#c44 and https://bugzilla.mozilla.org/show_bug.cgi?id=1890816.
   #dag_name: bqetl_google_search_console
   date_partition_parameter: date
+  # Fivetran's rollback sync time frame for Google Search Console connectors is 7 days.
+  # https://fivetran.com/docs/connectors/applications/google-search-console#rollbacksync
+  date_partition_offset: -7
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/google_search_console_derived/search_impressions_by_site_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_search_console_derived/search_impressions_by_site_v1/metadata.yaml
@@ -8,7 +8,9 @@ description: |-
     * support.mozilla.org
     * www.mozilla.org
 
-  Anonymized search queries aren't included.
+  The data has the following limitations:
+    * For each site only the top ~50,000 rows of data per day per search type is included (prioritized by number of clicks).
+    * Anonymized search queries aren't included.
 
   For the developer.mozilla.org domain, we stopped syncing Google Search Console data with Fivetran in May 2024.
   See https://bugzilla.mozilla.org/show_bug.cgi?id=1890816.
@@ -25,6 +27,9 @@ scheduling:
   # See https://bugzilla.mozilla.org/show_bug.cgi?id=1764960#c44 and https://bugzilla.mozilla.org/show_bug.cgi?id=1890816.
   #dag_name: bqetl_google_search_console
   date_partition_parameter: date
+  # Fivetran's rollback sync time frame for Google Search Console connectors is 7 days.
+  # https://fivetran.com/docs/connectors/applications/google-search-console#rollbacksync
+  date_partition_offset: -7
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## [DENG-4329](https://mozilla-hub.atlassian.net/browse/DENG-4329): Google Search Console data synced by Fivetran is not comparable to the data exported by Google

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)


[DENG-4329]: https://mozilla-hub.atlassian.net/browse/DENG-4329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4480)
