### PR TITLE
Fall back to running query to get view schema

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -2039,10 +2039,20 @@ def _update_query_schema(
         )
         return
 
+    partitioned_by = None
+    try:
+        metadata = Metadata.of_query_file(query_file_path)
+
+        if metadata.bigquery and metadata.bigquery.time_partitioning:
+            partitioned_by = metadata.bigquery.time_partitioning.field
+    except FileNotFoundError:
+        pass
+
     table_schema = Schema.for_table(
         project_name,
         dataset_name,
         table_name,
+        partitioned_by=partitioned_by,
         use_cloud_function=use_cloud_function,
         respect_skip=respect_dryrun_skip,
         credentials=credentials,

--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -303,11 +303,13 @@ def _view_dependencies(artifact_files, sql_dir):
                     path.mkdir(parents=True, exist_ok=True)
                     # don't create schema for wildcard and metadata tables
                     if "*" not in name and name != "INFORMATION_SCHEMA":
+                        partitioned_by = "submission_timestamp"
                         schema = Schema.for_table(
                             project=project,
                             dataset=dataset,
                             table=name,
                             id_token=id_token,
+                            partitioned_by=partitioned_by,
                         )
                         schema.to_yaml_file(path / SCHEMA_FILE)
 

--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -532,12 +532,21 @@ class DryRun:
         dataset_name = query_file_path.parent.parent.name
         project_name = query_file_path.parent.parent.parent.name
 
+        partitioned_by = None
+        if (
+            self.metadata
+            and self.metadata.bigquery
+            and self.metadata.bigquery.time_partitioning
+        ):
+            partitioned_by = self.metadata.bigquery.time_partitioning.field
+
         table_schema = Schema.for_table(
             project_name,
             dataset_name,
             table_name,
             client=self.client,
             id_token=self.id_token,
+            partitioned_by=partitioned_by,
         )
 
         # This check relies on the new schema being deployed to prod

--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -58,19 +58,24 @@ class Schema:
         return cls(json_schema)
 
     @classmethod
-    def for_table(cls, project, dataset, table, *args, **kwargs):
+    def for_table(cls, project, dataset, table, partitioned_by=None, *args, **kwargs):
         """Get the schema for a BigQuery table."""
+        query = f"SELECT * FROM `{project}.{dataset}.{table}`"
+
+        if partitioned_by:
+            query += f" WHERE DATE(`{partitioned_by}`) = DATE('2020-01-01')"
+
         try:
             return cls(
                 dryrun.DryRun(
                     os.path.join(project, dataset, table, "query.sql"),
-                    "SELECT 1",  # placeholder query
+                    query,
                     project=project,
                     dataset=dataset,
                     table=table,
                     *args,
                     **kwargs,
-                ).get_table_schema()
+                ).get_schema()
             )
         except Exception as e:
             print(f"Cannot get schema for {project}.{dataset}.{table}: {e}")

--- a/sql_generators/glean_usage/glean_app_ping_views.py
+++ b/sql_generators/glean_usage/glean_app_ping_views.py
@@ -110,6 +110,7 @@ class GleanAppPingViews(GleanTable):
                     "moz-fx-data-shared-prod",
                     channel_dataset,
                     view_name,
+                    partitioned_by="submission_timestamp",
                     use_cloud_function=use_cloud_function,
                     id_token=id_token
                 )


### PR DESCRIPTION
This is fixing view deploys

Fixes some issues introduced in https://github.com/mozilla/bigquery-etl/commit/7024b6976e5f8f2f6e365107b3ef97547ee2ab0f

It turns out the dryrun function does not return the `MODE` value for table schemas. Falling back to running queries to get the schemas. This results in the app view schemas not being generated correctly and getting duplicate fields added

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
