### PR TITLE
DENG-4482 update clients_last_seen_v2 query to include profile_group_id

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/query.sql
@@ -576,6 +576,7 @@ SELECT
   max_subsession_counter,
   min_subsession_counter,
   startup_profile_selection_first_ping_only,
-  days_active_bits
+  days_active_bits,
+  profile_group_id
 FROM
   staging a


### PR DESCRIPTION
The column was added to schema in previous [PR-6025](https://github.com/mozilla/bigquery-etl/pull/6025/files#diff-6a95ab1028bac9fe9f6ff09d27107bc49d34f91e4190125f6bb57bd2df7436cb) , but earlier I missed adding it to the query itself, so this is to add it to the query. 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4506)
