### PR TITLE
Adding table for merino export to gcs

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1790,3 +1790,24 @@ bqetl_firefox_desktop_ad_click_history:
   tags:
     - repo/bigquery-etl
     - impact/tier_2
+
+bqetl_merino_newtab_aggregates_to_gcs:
+  default_args:
+    depends_on_past: false
+    email:
+      - cbeck@mozilla.com
+      - gkatre@mozilla.com
+    email_on_failure: true
+    email_on_retry: false
+    end_date: null
+    owner: cbeck@mozilla.com
+    retries: 2
+    retry_delay: 5m
+    start_date: '2024-08-12'
+  description: |
+    Aggregates Newtab engagement data that lands in a GCS bucket for Merino recommendations.
+  repo: bigquery-etl
+  schedule_interval: "*/20 * * * *"
+  tags:
+    - repo/bigquery-etl
+    - impact/tier_1

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/merino_newtab_aggregates_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/merino_newtab_aggregates_v1/checks.sql
@@ -1,0 +1,16 @@
+-- macro checks
+
+#fail
+{{ not_null(["scheduled_corpus_item_id"]) }}
+
+#fail
+{{ is_unique(["scheduled_corpus_item_id"]) }}
+
+#fail
+{{ not_null(["impression_count"]) }}
+
+#fail
+{{ not_null(["click_count"]) }}
+
+#fail
+{{ min_row_count(1) }}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/merino_newtab_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/merino_newtab_aggregates_v1/query.sql
@@ -1,0 +1,47 @@
+WITH deduplicated_pings AS (
+  SELECT
+    submission_timestamp,
+    document_id,
+    events,
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
+  WHERE
+    submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+  QUALIFY
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        DATE(submission_timestamp),
+        document_id
+      ORDER BY
+        submission_timestamp DESC
+    ) = 1
+),
+flattened_newtab_events AS (
+  SELECT
+    document_id,
+    submission_timestamp,
+    unnested_events.name AS event_name,
+    mozfun.map.get_key(
+      unnested_events.extra,
+      'scheduled_corpus_item_id'
+    ) AS scheduled_corpus_item_id,
+    mozfun.map.get_key(unnested_events.extra, 'position') AS position,
+    COUNT(1) OVER (PARTITION BY document_id, unnested_events.name) AS user_event_count
+  FROM
+    deduplicated_pings,
+    UNNEST(events) AS unnested_events
+    --filter to Pocket events
+  WHERE
+    unnested_events.category = 'pocket'
+    AND unnested_events.name IN ('impression', 'click', 'save', 'dismiss')
+    --keep only data with a non-null scheduled corpus item ID
+    AND (mozfun.map.get_key(unnested_events.extra, 'scheduled_corpus_item_id') IS NOT NULL)
+)
+SELECT
+  scheduled_corpus_item_id,
+  SUM(CASE WHEN event_name = 'impression' THEN 1 ELSE 0 END) AS impression_count,
+  SUM(CASE WHEN event_name = 'click' THEN 1 ELSE 0 END) AS click_count
+FROM
+  flattened_newtab_events
+GROUP BY
+  1;

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/merino_newtab_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/merino_newtab_aggregates_v1/schema.yaml
@@ -1,0 +1,10 @@
+fields:
+- mode: NULLABLE
+  name: scheduled_corpus_item_id
+  type: STRING
+- mode: NULLABLE
+  name: impression_count
+  type: INTEGER
+- mode: NULLABLE
+  name: click_count
+  type: INTEGER


### PR DESCRIPTION
Creating the table for Merino extracts to GCS
- Aggregates Newtab engagement data
  - runs every 20 minutes aggregating data for the previous 24 hours (1 day)
- Once the table is built, will add a script to export the data in the table to a GCS bucket for Merino consumption

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
