### PR TITLE
chore(deploys): Catch and raise for missing dataset/project in table deploys

### DIFF
--- a/bigquery_etl/deploy.py
+++ b/bigquery_etl/deploy.py
@@ -119,5 +119,10 @@ def _create_or_update(
         )
         log.info(f"{table} updated.")
     else:
-        client.create_table(table)
+        try:
+            client.create_table(table)
+        except NotFound as e:  # Raised when project/dataset doesn't exist.
+            raise FailedDeployException(
+                f"Unable to create {table} in missing dataset/project"
+            ) from e
         log.info(f"{table} created.")

--- a/bigquery_etl/deploy.py
+++ b/bigquery_etl/deploy.py
@@ -121,8 +121,6 @@ def _create_or_update(
     else:
         try:
             client.create_table(table)
-        except NotFound as e:  # Raised when project/dataset doesn't exist.
-            raise FailedDeployException(
-                f"Unable to create {table} in missing dataset/project"
-            ) from e
+        except Exception as e:
+            raise FailedDeployException(f"Unable to create table {table}") from e
         log.info(f"{table} created.")

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -59,7 +59,7 @@ class TestDeploy:
         )
 
         with pytest.raises(
-            deploy.FailedDeployException, match="missing dataset/project"
+            deploy.FailedDeployException, match="Unable to create table"
         ):
             deploy.deploy_table(query_file=query_path / "query.sql")
 


### PR DESCRIPTION
This was a recent deploy failure case, see `bqetl_artifact_deployment` [earlier this week](https://workflow.telemetry.mozilla.org/dags/bqetl_artifact_deployment/grid?dag_run_id=scheduled__2024-08-11T00%3A00%3A00%2B00%3A00&task_id=publish_new_tables&tab=logs). 

Raises the except `FailedDeployException` to ensure deploys that fail for this reason get added to the failed deploys list for easier debugging in the future.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4532)
