### PR TITLE
Filter out overactive clients in all events_daily queries

### DIFF
--- a/sql_generators/events_daily/templates/events_daily_v1/query.sql
+++ b/sql_generators/events_daily/templates/events_daily_v1/query.sql
@@ -21,7 +21,8 @@ WITH sample AS (
               ARRAY_AGG(STRUCT(key, value.branch AS value))
             FROM
               UNNEST(ping_info.experiments)
-          ) AS experiments
+          ) AS experiments,
+          COUNT(*) OVER (PARTITION BY DATE(submission_timestamp), client_info.client_id) AS client_event_count
         FROM
           {{ glean_app_id }}.{{ events_table_name }} e
         CROSS JOIN
@@ -32,22 +33,14 @@ WITH sample AS (
       {% endfor %}
     {% else %}
     SELECT
-      {% if dataset == "telemetry" %}
       *,
       COUNT(*) OVER (PARTITION BY submission_date, client_id) AS client_event_count
-      {% else %}
-      *
-      {% endif %}
     FROM
       {{ source_table }}
     {% endif %}
 ), events AS (
   SELECT
-    {% if dataset == "telemetry" %}
     * EXCEPT (client_event_count)
-    {% else %}
-    *
-    {% endif %}
   FROM
     sample
   WHERE
@@ -56,10 +49,8 @@ WITH sample AS (
       OR (@submission_date IS NULL AND submission_date >= '{{ start_date }}')
     )
     AND client_id IS NOT NULL
-    {% if dataset == "telemetry" %}
     -- filter out overactive clients: they distort the data and can cause the job to fail: https://bugzilla.mozilla.org/show_bug.cgi?id=1730190
     AND client_event_count < 3000000
-    {% endif %}
 ),
 joined AS (
   SELECT


### PR DESCRIPTION
In https://github.com/mozilla/bigquery-etl/pull/2333 we started filtering out overactive clients from desktop events_daily query. Back then I opted for not adding this filter to Glean queries as their event counts were significantly lower than desktop.

We are now having `bqetl_event_rollup.mozilla_vpn_derived__events_daily__v1` failing with `Cannot query rows larger than 100MB limit.` error. We'll fix it by extending the `client_event_count` filter to all queries.

3M threshold seems safe and a good first value to try - I have tested this query with this threshold on `2024-08-18` and got the same number of rows in the output table as currently in production (10598).

I tested `2024-08-19` by running:
```
bqetl generate events_daily --use_cloud_function=False --output_dir=sql_test_events_daily
cat sql_test_events_daily/moz-fx-data-shared-prod/mozilla_vpn_derived/events_daily_v1/query.sql | bq query --project_id=moz-fx-data-shared-prod --parameter=submission_date:DATE:2024-08-19 --use_legacy_sql=false --max_rows=0 --dataset_id=mozdata:tmp --destination_table=akomar_vpn_events_daily_test --replace
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
