### PR TITLE
DENG-4546 - add profile_group_id to events_v1 view and add schema.yaml 

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/events_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/events_v1/view.sql
@@ -44,6 +44,9 @@ WITH parquet_events AS (
     ),
     CAST(NULL AS STRING) AS build_id,
     `mozfun.norm.browser_version_info`(app_version) AS browser_version_info,
+    CAST(
+      NULL AS STRING
+    ) AS profile_group_id --this table is deprecated and no longer updating, so is not receiving the new field profile group id
   FROM
     `moz-fx-data-shared-prod.telemetry_derived.events_v1`
   WHERE
@@ -77,6 +80,7 @@ main_events AS (
     session_id,
     build_id,
     `mozfun.norm.browser_version_info`(app_version) AS browser_version_info,
+    profile_group_id
   FROM
     `moz-fx-data-shared-prod`.telemetry_derived.main_events_v1
   WHERE
@@ -110,6 +114,7 @@ event_events AS (
     session_id,
     build_id,
     `mozfun.norm.browser_version_info`(app_version) AS browser_version_info,
+    profile_group_id
   FROM
     `moz-fx-data-shared-prod`.telemetry_derived.event_events_v1
   WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_v1/schema.yaml
@@ -1,0 +1,155 @@
+fields:
+- mode: REQUIRED
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: REQUIRED
+  name: doc_type
+  type: STRING
+  description: Document Type
+- mode: NULLABLE
+  name: document_id
+  type: STRING
+  description: Document ID
+- mode: NULLABLE
+  name: client_id
+  type: STRING
+  description: Client ID
+- mode: NULLABLE
+  name: normalized_channel
+  type: STRING
+  description: Normalized Channel
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: Country
+- mode: NULLABLE
+  name: locale
+  type: STRING
+  description: Locale
+- mode: NULLABLE
+  name: app_name
+  type: STRING
+  description: App Name
+- mode: NULLABLE
+  name: app_version
+  type: STRING
+  description: App Version
+- mode: NULLABLE
+  name: os
+  type: STRING
+  description: Operating System
+- mode: NULLABLE
+  name: os_version
+  type: STRING
+  description: Operating System Version
+- mode: NULLABLE
+  name: e10s_enabled
+  type: BOOLEAN
+  description: E10S Enabled
+- mode: NULLABLE
+  name: e10s_cohort
+  type: STRING
+  description: E10S Cohort
+- mode: NULLABLE
+  name: subsession_start_date
+  type: STRING
+  description: Subsession Start Date
+- mode: NULLABLE
+  name: subsession_length
+  type: INT64
+  description: Subsession Length
+- mode: NULLABLE
+  name: sync_configured
+  type: BOOLEAN
+  description: Sync Configured
+- mode: NULLABLE
+  name: sync_count_desktop
+  type: INT64
+  description: Sync Count Desktop
+- mode: NULLABLE
+  name: sync_count_mobile
+  type: INT64
+  description: Sync Count Mobile
+- mode: NULLABLE
+  name: timestamp
+  type: INTEGER
+  description: Timestamp
+- mode: NULLABLE
+  name: sample_id
+  type: INTEGER
+  description: Sample ID
+- mode: NULLABLE
+  name: active_experiment_id
+  type: STRING
+  description: Active Experiment ID
+- mode: NULLABLE
+  name: active_experiment_branch
+  type: STRING
+  description: Active Experiment Branch
+- mode: NULLABLE
+  name: event_timestamp
+  type: INTEGER
+  description: Event Timestamp
+- mode: NULLABLE
+  name: event_category
+  type: STRING
+  description: Event Category
+- mode: NULLABLE
+  name: event_method
+  type: STRING
+  description: Event Method
+- mode: NULLABLE
+  name: event_object
+  type: STRING
+  description: Event Object
+- mode: NULLABLE
+  name: event_string_value
+  type: STRING
+  description: Event String Value
+- mode: NULLABLE
+  name: event_map_values
+  type: RECORD
+  description: Event Map Values
+  fields:
+  - mode: REPEATED
+    name: key_value
+    type: RECORD
+    fields:
+    - mode: REQUIRED
+      name: key
+      type: STRING
+    - mode: NULLABLE
+      name: value
+      type: STRING
+- mode: NULLABLE
+  name: experiments
+  type: RECORD
+  description: Experiments
+  fields:
+  - mode: REPEATED
+    name: key_value
+    type: RECORD
+    fields:
+    - mode: REQUIRED
+      name: key
+      type: STRING
+    - mode: NULLABLE
+      name: value
+      type: STRING
+- mode: NULLABLE
+  name: event_process
+  type: STRING
+  description: Event Process
+- mode: NULLABLE
+  name: subsession_id
+  type: STRING
+  description: Subsession ID
+- mode: NULLABLE
+  name: session_start_time
+  type: INTEGER
+  description: Session Start Time
+- mode: NULLABLE
+  name: session_id
+  type: STRING
+  description: Session ID


### PR DESCRIPTION
**Purpose:** 
* Adding profile_group_id to events_v1 view
* Adding schema.yaml for existing deprecated table in production since it's needed for CI checks to pass

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4553)
