### PR TITLE
DENG-4588 Add profile_group_id to newtab_visits_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
@@ -27,7 +27,7 @@ visit_metadata AS (
     submission_date,
     ANY_VALUE(client_info.client_id) AS client_id,
     ANY_VALUE(metrics.uuid.legacy_telemetry_client_id) AS legacy_telemetry_client_id,
-    ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS profile_group_id,
+    CAST(ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS STRING) AS profile_group_id,
     ANY_VALUE(normalized_os) AS normalized_os,
     ANY_VALUE(normalized_os_version) AS normalized_os_version,
     ANY_VALUE(normalized_country_code) AS country_code,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
@@ -27,7 +27,7 @@ visit_metadata AS (
     submission_date,
     ANY_VALUE(client_info.client_id) AS client_id,
     ANY_VALUE(metrics.uuid.legacy_telemetry_client_id) AS legacy_telemetry_client_id,
-    CAST(ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS STRING) AS profile_group_id,
+    ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS profile_group_id,
     ANY_VALUE(normalized_os) AS normalized_os,
     ANY_VALUE(normalized_os_version) AS normalized_os_version,
     ANY_VALUE(normalized_country_code) AS country_code,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
@@ -27,6 +27,7 @@ visit_metadata AS (
     submission_date,
     ANY_VALUE(client_info.client_id) AS client_id,
     ANY_VALUE(metrics.uuid.legacy_telemetry_client_id) AS legacy_telemetry_client_id,
+    ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS profile_group_id,
     ANY_VALUE(normalized_os) AS normalized_os,
     ANY_VALUE(normalized_os_version) AS normalized_os_version,
     ANY_VALUE(normalized_country_code) AS country_code,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/schema.yaml
@@ -332,3 +332,6 @@ fields:
   - name: topic_selection_topics_updated
     type: INTEGER
     mode: NULLABLE
+- mode: NULLABLE
+  name: profile_group_id
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/schema.yaml
@@ -235,7 +235,7 @@ fields:
     type: INTEGER
   - mode: NULLABLE
     name: pocket_received_rank
-    type: INTEGER
+    type: STRING
   - name: pocket_scheduled_corpus_item_id
     type: STRING
     mode: NULLABLE


### PR DESCRIPTION
Purpose: 
* Fix existing CI error of incompatible schema/query caused by [PR-6004](https://github.com/mozilla/bigquery-etl/pull/6004/files)
* Add profile_group_id to the table and query

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4590)
