### PR TITLE
Revert "chore(data-privacy-mapping): DSRE-1690 - ignore tables contaiing RECORD type"

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitor_frontend_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitor_frontend_derived/dataset_metadata.yaml
@@ -9,3 +9,4 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
+  - workgroup:dataops-managed/external-fides

--- a/sql/moz-fx-data-shared-prod/monitor_frontend_derived/event_monitoring_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitor_frontend_derived/event_monitoring_live_v1/metadata.yaml
@@ -1,5 +1,0 @@
-workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
-  - workgroup:dataops-managed/external-fides

--- a/sql/moz-fx-data-shared-prod/monitor_frontend_derived/monitor_dashboard_user_journey_funnels_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitor_frontend_derived/monitor_dashboard_user_journey_funnels_v1/metadata.yaml
@@ -1,5 +1,0 @@
-workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
-  - workgroup:dataops-managed/external-fides


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#5916

`RECORD` types are now supported in fides

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4592)
