### PR TITLE
fix(dryrun): table_metadata used before reference

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -276,23 +276,7 @@ class DryRun:
                     else:
                         raise e
 
-                if (
-                    self.project is not None
-                    and self.table is not None
-                    and self.dataset is not None
-                ):
-                    table = self.client.get_table(
-                        f"{self.project}.{self.dataset}.{self.table}"
-                    )
-                    table_metadata = {
-                        "tableType": table.table_type,
-                        "friendlyName": table.friendly_name,
-                        "schema": {
-                            "fields": [field.to_api_repr() for field in table.schema]
-                        },
-                    }
-
-                return {
+                result = {
                     "valid": True,
                     "referencedTables": [
                         ref.to_api_repr() for ref in job.referenced_tables
@@ -303,8 +287,25 @@ class DryRun:
                         .get("schema", {})
                     ),
                     "datasetLabels": dataset_labels,
-                    "tableMetadata": table_metadata,
                 }
+                if (
+                    self.project is not None
+                    and self.table is not None
+                    and self.dataset is not None
+                ):
+                    table = self.client.get_table(
+                        f"{self.project}.{self.dataset}.{self.table}"
+                    )
+                    result["tableMetadata"] = {
+                        "tableType": table.table_type,
+                        "friendlyName": table.friendly_name,
+                        "schema": {
+                            "fields": [field.to_api_repr() for field in table.schema]
+                        },
+                    }
+
+                return result
+
         except Exception as e:
             print(f"{self.sqlfile!s:59} ERROR\n", e)
             return None


### PR DESCRIPTION
The following is showing up in a few places:
```
INFO - [base]  cannot access local variable 'table_metadata' where it is not associated with a value
```

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4597)
