### PR TITLE
chore(GLAM): update list of confidential probes

### DIFF
--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates/view.sql
@@ -28,26 +28,27 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
-        AND metric NOT IN ("characteristics.color_depth",
-            "characteristics.color_gamut",
-            "characteristics.color_scheme",
-            "characteristics.inverted_colors",
-            "characteristics.max_touch_points",
-            "characteristics.missing_fonts",
-            "characteristics.prefers_contrast",
-            "characteristics.prefers_reduced_motion",
-            "characteristics.prefers_reduced_transparency",
-            "characteristics.prefs_media_eme_enabled",
-            "characteristics.prefs_zoom_text_only",
-            "characteristics.processor_count",
-            "characteristics.screen_height",
-            "characteristics.screen_width",
-            "characteristics.submission_schema",
-            "characteristics.target_frame_rate",
-            "characteristics.video_dynamic_range",
-            "pocket.shim",
-            "shopping.product_page_visits"
-          )
+        AND metric NOT IN (
+          "characteristics.color_depth",
+          "characteristics.color_gamut",
+          "characteristics.color_scheme",
+          "characteristics.inverted_colors",
+          "characteristics.max_touch_points",
+          "characteristics.missing_fonts",
+          "characteristics.prefers_contrast",
+          "characteristics.prefers_reduced_motion",
+          "characteristics.prefers_reduced_transparency",
+          "characteristics.prefs_media_eme_enabled",
+          "characteristics.prefs_zoom_text_only",
+          "characteristics.processor_count",
+          "characteristics.screen_height",
+          "characteristics.screen_width",
+          "characteristics.submission_schema",
+          "characteristics.target_frame_rate",
+          "characteristics.video_dynamic_range",
+          "pocket.shim",
+          "shopping.product_page_visits"
+        )
         AND metric_type != "boolean"
     ),
     calculated_percentiles AS (

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates/view.sql
@@ -28,6 +28,26 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric NOT IN ("characteristics.color_depth",
+            "characteristics.color_gamut",
+            "characteristics.color_scheme",
+            "characteristics.inverted_colors",
+            "characteristics.max_touch_points",
+            "characteristics.missing_fonts",
+            "characteristics.prefers_contrast",
+            "characteristics.prefers_reduced_motion",
+            "characteristics.prefers_reduced_transparency",
+            "characteristics.prefs_media_eme_enabled",
+            "characteristics.prefs_zoom_text_only",
+            "characteristics.processor_count",
+            "characteristics.screen_height",
+            "characteristics.screen_width",
+            "characteristics.submission_schema",
+            "characteristics.target_frame_rate",
+            "characteristics.video_dynamic_range",
+            "pocket.shim",
+            "shopping.product_page_visits"
+          )
         AND metric_type != "boolean"
     ),
     calculated_percentiles AS (

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates/view.sql
@@ -28,26 +28,27 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
-        AND metric NOT IN ("characteristics.color_depth",
-            "characteristics.color_gamut",
-            "characteristics.color_scheme",
-            "characteristics.inverted_colors",
-            "characteristics.max_touch_points",
-            "characteristics.missing_fonts",
-            "characteristics.prefers_contrast",
-            "characteristics.prefers_reduced_motion",
-            "characteristics.prefers_reduced_transparency",
-            "characteristics.prefs_media_eme_enabled",
-            "characteristics.prefs_zoom_text_only",
-            "characteristics.processor_count",
-            "characteristics.screen_height",
-            "characteristics.screen_width",
-            "characteristics.submission_schema",
-            "characteristics.target_frame_rate",
-            "characteristics.video_dynamic_range",
-            "pocket.shim",
-            "shopping.product_page_visits"
-          )
+        AND metric NOT IN (
+          "characteristics.color_depth",
+          "characteristics.color_gamut",
+          "characteristics.color_scheme",
+          "characteristics.inverted_colors",
+          "characteristics.max_touch_points",
+          "characteristics.missing_fonts",
+          "characteristics.prefers_contrast",
+          "characteristics.prefers_reduced_motion",
+          "characteristics.prefers_reduced_transparency",
+          "characteristics.prefs_media_eme_enabled",
+          "characteristics.prefs_zoom_text_only",
+          "characteristics.processor_count",
+          "characteristics.screen_height",
+          "characteristics.screen_width",
+          "characteristics.submission_schema",
+          "characteristics.target_frame_rate",
+          "characteristics.video_dynamic_range",
+          "pocket.shim",
+          "shopping.product_page_visits"
+        )
         AND metric_type != "boolean"
     ),
     calculated_percentiles AS (

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates/view.sql
@@ -28,6 +28,26 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric NOT IN ("characteristics.color_depth",
+            "characteristics.color_gamut",
+            "characteristics.color_scheme",
+            "characteristics.inverted_colors",
+            "characteristics.max_touch_points",
+            "characteristics.missing_fonts",
+            "characteristics.prefers_contrast",
+            "characteristics.prefers_reduced_motion",
+            "characteristics.prefers_reduced_transparency",
+            "characteristics.prefs_media_eme_enabled",
+            "characteristics.prefs_zoom_text_only",
+            "characteristics.processor_count",
+            "characteristics.screen_height",
+            "characteristics.screen_width",
+            "characteristics.submission_schema",
+            "characteristics.target_frame_rate",
+            "characteristics.video_dynamic_range",
+            "pocket.shim",
+            "shopping.product_page_visits"
+          )
         AND metric_type != "boolean"
     ),
     calculated_percentiles AS (

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates/view.sql
@@ -28,26 +28,27 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
-        AND metric NOT IN ("characteristics.color_depth",
-            "characteristics.color_gamut",
-            "characteristics.color_scheme",
-            "characteristics.inverted_colors",
-            "characteristics.max_touch_points",
-            "characteristics.missing_fonts",
-            "characteristics.prefers_contrast",
-            "characteristics.prefers_reduced_motion",
-            "characteristics.prefers_reduced_transparency",
-            "characteristics.prefs_media_eme_enabled",
-            "characteristics.prefs_zoom_text_only",
-            "characteristics.processor_count",
-            "characteristics.screen_height",
-            "characteristics.screen_width",
-            "characteristics.submission_schema",
-            "characteristics.target_frame_rate",
-            "characteristics.video_dynamic_range",
-            "pocket.shim",
-            "shopping.product_page_visits"
-          )
+        AND metric NOT IN (
+          "characteristics.color_depth",
+          "characteristics.color_gamut",
+          "characteristics.color_scheme",
+          "characteristics.inverted_colors",
+          "characteristics.max_touch_points",
+          "characteristics.missing_fonts",
+          "characteristics.prefers_contrast",
+          "characteristics.prefers_reduced_motion",
+          "characteristics.prefers_reduced_transparency",
+          "characteristics.prefs_media_eme_enabled",
+          "characteristics.prefs_zoom_text_only",
+          "characteristics.processor_count",
+          "characteristics.screen_height",
+          "characteristics.screen_width",
+          "characteristics.submission_schema",
+          "characteristics.target_frame_rate",
+          "characteristics.video_dynamic_range",
+          "pocket.shim",
+          "shopping.product_page_visits"
+        )
         AND metric_type != "boolean"
     ),
     calculated_percentiles AS (

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates/view.sql
@@ -28,6 +28,26 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric NOT IN ("characteristics.color_depth",
+            "characteristics.color_gamut",
+            "characteristics.color_scheme",
+            "characteristics.inverted_colors",
+            "characteristics.max_touch_points",
+            "characteristics.missing_fonts",
+            "characteristics.prefers_contrast",
+            "characteristics.prefers_reduced_motion",
+            "characteristics.prefers_reduced_transparency",
+            "characteristics.prefs_media_eme_enabled",
+            "characteristics.prefs_zoom_text_only",
+            "characteristics.processor_count",
+            "characteristics.screen_height",
+            "characteristics.screen_width",
+            "characteristics.submission_schema",
+            "characteristics.target_frame_rate",
+            "characteristics.video_dynamic_range",
+            "pocket.shim",
+            "shopping.product_page_visits"
+          )
         AND metric_type != "boolean"
     ),
     calculated_percentiles AS (

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates/view.sql
@@ -28,6 +28,20 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric NOT IN (
+          "browser.search.ad_clicks",
+          "browser.search.in_content",
+          "browser.search.with_ads",
+          "fx_suggest.block_id",
+          "metrics.search_count",
+          "nimbus_health.fetch_experiments_time",
+          "shopping.product_page_visits",
+          "shopping.settings.component_opted_out",
+          "shopping.settings.disabled_ads",
+          "shopping.settings.nimbus_disabled_shopping",
+          "shopping.settings.user_has_onboarded",
+          "top_sites.contile_tile_id"
+        )
         AND metric_type != "boolean"
     ),
     calculated_percentiles AS (

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates/view.sql
@@ -28,6 +28,20 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric NOT IN (
+          "browser.search.ad_clicks",
+          "browser.search.in_content",
+          "browser.search.with_ads",
+          "fx_suggest.block_id",
+          "metrics.search_count",
+          "nimbus_health.fetch_experiments_time",
+          "shopping.product_page_visits",
+          "shopping.settings.component_opted_out",
+          "shopping.settings.disabled_ads",
+          "shopping.settings.nimbus_disabled_shopping",
+          "shopping.settings.user_has_onboarded",
+          "top_sites.contile_tile_id"
+        )
         AND metric_type != "boolean"
     ),
     calculated_percentiles AS (

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates/view.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates/view.sql
@@ -28,6 +28,20 @@ CREATE OR REPLACE VIEW
           AND metric NOT LIKE r"%manager\_message\_size%"
           AND metric NOT LIKE r"%dropped\_frames\_proportion%"
         )
+        AND metric NOT IN (
+          "browser.search.ad_clicks",
+          "browser.search.in_content",
+          "browser.search.with_ads",
+          "fx_suggest.block_id",
+          "metrics.search_count",
+          "nimbus_health.fetch_experiments_time",
+          "shopping.product_page_visits",
+          "shopping.settings.component_opted_out",
+          "shopping.settings.disabled_ads",
+          "shopping.settings.nimbus_disabled_shopping",
+          "shopping.settings.user_has_onboarded",
+          "top_sites.contile_tile_id"
+        )
         AND metric_type != "boolean"
     ),
     calculated_percentiles AS (


### PR DESCRIPTION
This is part of the preparation to make GLAM public. The spreadsheet below was used to classify which probes are `Confidential`, which means they shouldn't be displayed on GLAM.
Source:  https://docs.google.com/spreadsheets/d/1fsmqA0YfFO9gUasfDa6AvQdNgTcC0vIHzzOvLtfJunI/edit?usp=sharing
Note that FoG and Fenix have different lists.

This is the scrappy version of this work. I intend to move these to a centralized source, such as a table or a config file.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4635)
