### PR TITLE
replace events_metrics_v2 metadata.yaml file with the proper one. Pre…

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_events_metrics_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_events_metrics_v2/metadata.yaml
@@ -1,11 +1,12 @@
-friendly_name: WWW Site Page Metrics V2
+friendly_name: WWW Site Events Metrics V2
 description: |-
-  Aggregated metrics per page on www.mozilla.org from Google Analytics 4
+  Aggregated metrics on non-page view events on www.mozilla.org
+  Sourced from Google Analytics 4 (GA4) data
 owners:
-- kwindau@mozilla.com
+- mhirose@mozilla.com
 labels:
   incremental: true
-  owner1: kwindau@mozilla.com
+  owner1: mhirose@mozilla.com
 scheduling:
   dag_name: bqetl_google_analytics_derived_ga4
 bigquery:
@@ -16,8 +17,8 @@ bigquery:
     expiration_days: null
   clustering:
     fields:
-    - page_name
-    - locale
     - country
-    - medium
+    - device_category
+    - event_category
+    - browser
 references: {}


### PR DESCRIPTION
…vious one was the page_metrics metadata.yaml file. The clustering in page_metrics is different from events_metrics. This was causing issues when copying data from marketing-prod to shared-prod

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4636)
