### PR TITLE
DENG-4631 add profile group ID to metrics_clients_last_seen_v1

### DIFF
--- a/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
@@ -22,9 +22,7 @@
       {% endfor -%}
     {% endif -%}
     {% if app_name == "firefox_desktop" -%}
-      ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS profile_group_id,
-    {% else -%}
-      CAST(NULL AS STRING) AS profile_group_id,
+      ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS profile_group_id
     {% endif -%}
   FROM
     `{{ dataset }}.metrics` AS m

--- a/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
@@ -22,7 +22,9 @@
       {% endfor -%}
     {% endif -%}
     {% if app_name == "firefox_desktop" -%}
-      ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS profile_group_id
+      ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS profile_group_id,
+    {% else -%}
+      CAST(NULL AS STRING) AS profile_group_id,
     {% endif -%}
   FROM
     `{{ dataset }}.metrics` AS m

--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.query.sql
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.query.sql
@@ -35,6 +35,9 @@ SELECT
     {% endif %}
   {% endfor -%}
   {% endif -%}
+  {% if app_name == "firefox_desktop" -%}
+    _current.profile_group_id
+  {% endif -%}
 FROM
   _previous
 FULL JOIN


### PR DESCRIPTION
This PR adds the new column "profile_group_id" to metrics_clients_last_seen_v1 (for Firefox Desktop only)
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4638)
