### PR TITLE
Update CircleCI config to use latest Ubuntu 20.04 executor image

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -33,7 +33,7 @@ parameters:
 executors:
   ubuntu-machine-executor:
     machine:
-      image: ubuntu-2004:202111-02
+      image: ubuntu-2004:current
 
 jobs:
   build:


### PR DESCRIPTION
The previously used [Ubuntu 20.04 executor image](https://circleci.com/developer/machine/image/ubuntu-2004) has been [deprecated](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177) and will be removed on 2024-09-30.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4647)
