### PR TITLE
Revert "DENG-3503 updating to use v2 table"

### DIFF
--- a/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/query.sql
@@ -46,7 +46,7 @@ subscriptions_mapped AS (
   FROM
     subscriptions
   JOIN
-    `moz-fx-data-shared-prod.braze_derived.subscriptions_map_v2` AS map
+    `moz-fx-data-shared-prod.braze_derived.subscriptions_map_v1` AS map
     ON subscriptions.subscription_name = map.braze_subscription_name
 )
 SELECT

--- a/tests/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/test_braze_subscriptions/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/test_braze_subscriptions/expect.yaml
@@ -1,0 +1,65 @@
+# test_braze_subscriptions - expect braze subscriptions
+---
+# user 1
+- external_id: user_1
+  subscriptions:
+    - subscription_name: newsletter_1
+      firefox_subscription_id: firefox_newsletter_1
+      mozilla_subscription_id: mozilla_newsletter_1
+      mozilla_dev_subscription_id: mozilla_dev_newsletter_1
+      subscription_state: subscribed
+      update_timestamp: 2020-01-01T10:00:00+00:00
+    - subscription_name: newsletter_2
+      firefox_subscription_id: firefox_newsletter_2
+      mozilla_subscription_id: mozilla_newsletter_2
+      mozilla_dev_subscription_id: mozilla_dev_newsletter_2
+      subscription_state: subscribed
+      update_timestamp: 2020-01-02T10:00:00+00:00
+    - subscription_name: newsletter_3
+      firefox_subscription_id: firefox_newsletter_3
+      mozilla_subscription_id: mozilla_newsletter_3
+      mozilla_dev_subscription_id: mozilla_dev_newsletter_3
+      subscription_state: unsubscribed
+      update_timestamp: 2020-01-03T10:00:00+00:00
+    - subscription_name: newsletter_4
+      firefox_subscription_id: firefox_newsletter_4
+      mozilla_subscription_id: mozilla_newsletter_4
+      mozilla_dev_subscription_id: mozilla_dev_newsletter_4
+      subscription_state: unsubscribed
+      update_timestamp: 2020-01-04T10:00:00+00:00
+    - subscription_name: waitlist_1-waitlist
+      firefox_subscription_id: firefox_waitlist_1
+      mozilla_subscription_id: mozilla_waitlist_1
+      mozilla_dev_subscription_id: mozilla_dev_waitlist_1
+      subscription_state: subscribed
+      update_timestamp: 2020-01-01T11:00:00+00:00
+# user 2
+- external_id: user_2
+  subscriptions:
+    - subscription_name: newsletter_1
+      firefox_subscription_id: firefox_newsletter_1
+      mozilla_subscription_id: mozilla_newsletter_1
+      mozilla_dev_subscription_id: mozilla_dev_newsletter_1
+      subscription_state: subscribed
+      update_timestamp: 2020-02-01T10:00:00+00:00
+    - subscription_name: waitlist_1-waitlist
+      firefox_subscription_id: firefox_waitlist_1
+      mozilla_subscription_id: mozilla_waitlist_1
+      mozilla_dev_subscription_id: mozilla_dev_waitlist_1
+      subscription_state: subscribed
+      update_timestamp: 2020-02-01T11:00:00+00:00
+# user 3
+- external_id: user_3
+  subscriptions:
+    - subscription_name: newsletter_1
+      firefox_subscription_id: firefox_newsletter_1
+      mozilla_subscription_id: mozilla_newsletter_1
+      mozilla_dev_subscription_id: mozilla_dev_newsletter_1
+      subscription_state: subscribed
+      update_timestamp: 2020-03-01T10:00:00+00:00
+    - subscription_name: waitlist_2-waitlist
+      firefox_subscription_id: firefox_waitlist_2
+      mozilla_subscription_id: mozilla_waitlist_2
+      mozilla_dev_subscription_id: mozilla_dev_waitlist_2
+      subscription_state: subscribed
+      update_timestamp: 2020-03-02T11:00:00+00:00

--- a/tests/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/test_braze_subscriptions/moz-fx-data-shared-prod.braze_derived.subscriptions_map_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/test_braze_subscriptions/moz-fx-data-shared-prod.braze_derived.subscriptions_map_v1.yaml
@@ -1,0 +1,34 @@
+# test_braze_subscriptions - braze subscription map
+---
+- braze_subscription_name: newsletter_1
+  firefox_subscription_id: firefox_newsletter_1
+  mozilla_subscription_id: mozilla_newsletter_1
+  mozilla_dev_subscription_id: mozilla_dev_newsletter_1
+- braze_subscription_name: newsletter_2
+  firefox_subscription_id: firefox_newsletter_2
+  mozilla_subscription_id: mozilla_newsletter_2
+  mozilla_dev_subscription_id: mozilla_dev_newsletter_2
+- braze_subscription_name: newsletter_3
+  firefox_subscription_id: firefox_newsletter_3
+  mozilla_subscription_id: mozilla_newsletter_3
+  mozilla_dev_subscription_id: mozilla_dev_newsletter_3
+- braze_subscription_name: newsletter_4
+  firefox_subscription_id: firefox_newsletter_4
+  mozilla_subscription_id: mozilla_newsletter_4
+  mozilla_dev_subscription_id: mozilla_dev_newsletter_4
+- braze_subscription_name: waitlist_1-waitlist
+  firefox_subscription_id: firefox_waitlist_1
+  mozilla_subscription_id: mozilla_waitlist_1
+  mozilla_dev_subscription_id: mozilla_dev_waitlist_1
+- braze_subscription_name: waitlist_2-waitlist
+  firefox_subscription_id: firefox_waitlist_2
+  mozilla_subscription_id: mozilla_waitlist_2
+  mozilla_dev_subscription_id: mozilla_dev_waitlist_2
+- braze_subscription_name: waitlist_3-waitlist
+  firefox_subscription_id: firefox_waitlist_3
+  mozilla_subscription_id: mozilla_waitlist_3
+  mozilla_dev_subscription_id: mozilla_dev_waitlist_3
+- braze_subscription_name: waitlist_4-waitlist
+  firefox_subscription_id: firefox_waitlist_4
+  mozilla_subscription_id: mozilla_waitlist_4
+  mozilla_dev_subscription_id: mozilla_dev_waitlist_4

--- a/tests/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/test_braze_subscriptions/moz-fx-data-shared-prod.braze_derived.user_profiles_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/test_braze_subscriptions/moz-fx-data-shared-prod.braze_derived.user_profiles_v1.yaml
@@ -1,0 +1,48 @@
+# test_braze_subscriptions - braze user profiles w/ newsletter and waitlist data
+---
+# user 1
+- external_id: user_1
+  newsletters:
+    - newsletter_name: newsletter_1
+      subscribed: true
+      update_timestamp: 2020-01-01T10:00:00+00:00
+    - newsletter_name: newsletter_2
+      subscribed: true
+      update_timestamp: 2020-01-02T10:00:00+00:00
+    - newsletter_name: newsletter_3
+      subscribed: false
+      update_timestamp: 2020-01-03T10:00:00+00:00
+    - newsletter_name: newsletter_4
+      subscribed: false
+      update_timestamp: 2020-01-04T10:00:00+00:00
+  waitlists:
+    - waitlist_name: waitlist_1
+      subscribed: true
+      update_timestamp: 2020-01-01 11:00:00+00:00
+# user 2
+- external_id: user_2
+  newsletters:
+    - newsletter_name: newsletter_1
+      subscribed: true
+      update_timestamp: 2020-02-01 10:00:00+00:00
+  waitlists:
+    - waitlist_name: waitlist_1
+      subscribed: true
+      update_timestamp: 2020-02-01 11:00:00+00:00
+# user 3
+- external_id: user_3
+  newsletters:
+    - newsletter_name: newsletter_1
+      subscribed: true
+      update_timestamp: 2020-03-01 10:00:00+00:00
+    - newsletter_name: not_a_newsletter
+      subscribed: true
+      update_timestamp: 2020-03-10 10:00:00+00:00
+  waitlists:
+    - waitlist_name: waitlist_2
+      subscribed: true
+      update_timestamp: 2020-03-02 11:00:00+00:00
+    - waitlist_name: not_a_waitlist
+      subscribed: true
+      update_timestamp: 2020-03-11 11:00:00+00:00
+# user 4 not in braze_users


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#6097

I need to revert this to prevent task failures while I work on the work around that will duplicate the table in a way that Airflow has access (there are permission issues). See [this PR](https://github.com/mozilla/private-bigquery-etl/pull/199) for more context

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-3503)
