### PR TITLE
DENG-4691 Add views for Ray Serve compute costs for fakespot tenant

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -187,6 +187,7 @@ dry_run:
   # Source table does not have a verifiable schema
   - sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_cost_per_flow_run_v1/view.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_cost_per_flow_v1/view.sql
+  - sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
     # Query templates
   - sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/fenix_metrics.template.sql
   - sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/mobile_search_clients_daily.template.sql

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
@@ -12,6 +12,7 @@ WITH cost_data AS (
       FROM
         UNNEST(labels)
       WHERE
+        -- the label to identify the kuberay created ray serve workloads
         KEY = "k8s-label/app.kubernetes.io/created-by"
     ) AS k8s_label_akio_createdBy,
   FROM

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
@@ -1,0 +1,65 @@
+with cost_data as (
+SELECT
+  cost + (IFNULL((SELECT SUM(c.amount)
+                  FROM UNNEST(credits) c), 0))
+    AS total_cost,
+  #labels,
+  DATE_TRUNC(usage_start_time, DAY) AS invoice_day,
+(
+ SELECT
+  value
+ FROM
+  UNNEST(labels)
+ WHERE
+  KEY = "k8s-namespace"
+) AS k8s_namespace,
+
+(
+  SELECT
+   value
+  FROM
+   UNNEST(labels)
+  WHERE
+   KEY = "k8s-label/app.kubernetes.io/created-by"
+ ) AS k8s_label_akio_createdBy,
+
+FROM
+moz-fx-data-shared-prod.billing_syndicate.gcp_billing_export_resource_v1_01E7D5_97288E_E2EBA0
+
+WHERE
+project.id = "moz-fx-dataservices-high-nonpr" #moz-fx-dataservices-high-nonpr
+AND DATE(usage_start_time) >= '2024-01-01'
+AND service.description = "Compute Engine"
+),
+ daily_cost_data_per_kuberay_workload as (
+  select SUM(total_cost) as daily_cost_per_kuberay_workload, invoice_day, k8s_namespace, k8s_label_akio_createdBy,
+  from cost_data
+  where k8s_namespace = "fakespot-ml-stage" AND k8s_label_akio_createdBy = "kuberay-operator"
+  group by
+  invoice_day, k8s_namespace, k8s_label_akio_createdBy
+  order by invoice_day
+)
+
+SELECT SUM(daily_cost_per_kuberay_workload)
+From daily_cost_data_per_kuberay_workload
+
+
+#select COUNT(total), COUNT(k8s_namespace), COUNT(total), COUNT(k8s_namespace), COUNT(goog_k8s_namespace), COUNT(k8s_namespace_labels_meta_name) from data
+/*select labels from data where k8s_namespace IN (#'kube:unallocated'
+     #'goog-k8s-unsupported-sku',
+     #'goog-k8s-unknown',
+     'kube-system'
+     #'kube:system-overhead'
+     )*/
+#select COUNT(total), COUNT(k8s_namespace), COUNT(goog_k8s_namespace), COUNT(k8s_namespace_labels_meta_name) from data where k8s_namespace = "fakespot-ml-stage"
+#select labels from data
+#select total from data
+/*
+(
+ SELECT
+  value
+ FROM
+  UNNEST(labels)
+ WHERE
+  KEY = "k8s-namespace-labels/kubernetes.io/metadata.name"
+) AS k8s_namespace_labels_meta_name,*/

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
@@ -17,7 +17,7 @@ WITH cost_data AS (
   FROM
     `moz-fx-data-shared-prod.billing_syndicate.gcp_billing_export_resource_v1_01E7D5_97288E_E2EBA0`
   WHERE
-    project.id = "moz-fx-dataservices-high-nonpr" #moz-fx-dataservices-high-nonpr
+    project.id = "moz-fx-dataservices-high-nonpr"
     AND DATE(usage_start_time) >= '2024-01-01'
     AND service.description = "Compute Engine"
 ),

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
@@ -1,49 +1,46 @@
-with cost_data as (
-SELECT
-  cost + (IFNULL((SELECT SUM(c.amount)
-                  FROM UNNEST(credits) c), 0))
-    AS total_cost,
-  #labels,
-  DATE_TRUNC(usage_start_time, DAY) AS invoice_day,
-(
- SELECT
-  value
- FROM
-  UNNEST(labels)
- WHERE
-  KEY = "k8s-namespace"
-) AS k8s_namespace,
-
-(
+WITH cost_data AS (
   SELECT
-   value
+    cost + (IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) AS total_cost,
+  #labels,
+    DATE_TRUNC(usage_start_time, DAY) AS invoice_day,
+    (SELECT value FROM UNNEST(labels) WHERE KEY = "k8s-namespace") AS k8s_namespace,
+    (
+      SELECT
+        value
+      FROM
+        UNNEST(labels)
+      WHERE
+        KEY = "k8s-label/app.kubernetes.io/created-by"
+    ) AS k8s_label_akio_createdBy,
   FROM
-   UNNEST(labels)
+    moz - fx - data - shared - prod.billing_syndicate.gcp_billing_export_resource_v1_01E7D5_97288E_E2EBA0
   WHERE
-   KEY = "k8s-label/app.kubernetes.io/created-by"
- ) AS k8s_label_akio_createdBy,
-
-FROM
-moz-fx-data-shared-prod.billing_syndicate.gcp_billing_export_resource_v1_01E7D5_97288E_E2EBA0
-
-WHERE
-project.id = "moz-fx-dataservices-high-nonpr" #moz-fx-dataservices-high-nonpr
-AND DATE(usage_start_time) >= '2024-01-01'
-AND service.description = "Compute Engine"
+    project.id = "moz-fx-dataservices-high-nonpr" #moz-fx-dataservices-high-nonpr
+    AND DATE(usage_start_time) >= '2024-01-01'
+    AND service.description = "Compute Engine"
 ),
- daily_cost_data_per_kuberay_workload as (
-  select SUM(total_cost) as daily_cost_per_kuberay_workload, invoice_day, k8s_namespace, k8s_label_akio_createdBy,
-  from cost_data
-  where k8s_namespace = "fakespot-ml-stage" AND k8s_label_akio_createdBy = "kuberay-operator"
-  group by
-  invoice_day, k8s_namespace, k8s_label_akio_createdBy
-  order by invoice_day
+daily_cost_data_per_kuberay_workload AS (
+  SELECT
+    SUM(total_cost) AS daily_cost_per_kuberay_workload,
+    invoice_day,
+    k8s_namespace,
+    k8s_label_akio_createdBy,
+  FROM
+    cost_data
+  WHERE
+    k8s_namespace = "fakespot-ml-stage"
+    AND k8s_label_akio_createdBy = "kuberay-operator"
+  GROUP BY
+    invoice_day,
+    k8s_namespace,
+    k8s_label_akio_createdBy
+  ORDER BY
+    invoice_day
 )
-
-SELECT SUM(daily_cost_per_kuberay_workload)
-From daily_cost_data_per_kuberay_workload
-
-
+SELECT
+  SUM(daily_cost_per_kuberay_workload)
+FROM
+  daily_cost_data_per_kuberay_workload
 #select COUNT(total), COUNT(k8s_namespace), COUNT(total), COUNT(k8s_namespace), COUNT(goog_k8s_namespace), COUNT(k8s_namespace_labels_meta_name) from data
 /*select labels from data where k8s_namespace IN (#'kube:unallocated'
      #'goog-k8s-unsupported-sku',

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.monitoring_derived.rayserve_cost_fakespot_tenant_v1`
+AS
 WITH cost_data AS (
   SELECT
     cost + (IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) AS total_cost,
-  #labels,
     DATE_TRUNC(usage_start_time, DAY) AS invoice_day,
     (SELECT value FROM UNNEST(labels) WHERE KEY = "k8s-namespace") AS k8s_namespace,
     (
@@ -13,7 +15,7 @@ WITH cost_data AS (
         KEY = "k8s-label/app.kubernetes.io/created-by"
     ) AS k8s_label_akio_createdBy,
   FROM
-    moz - fx - data - shared - prod.billing_syndicate.gcp_billing_export_resource_v1_01E7D5_97288E_E2EBA0
+    `moz-fx-data-shared-prod.billing_syndicate.gcp_billing_export_resource_v1_01E7D5_97288E_E2EBA0`
   WHERE
     project.id = "moz-fx-dataservices-high-nonpr" #moz-fx-dataservices-high-nonpr
     AND DATE(usage_start_time) >= '2024-01-01'
@@ -37,26 +39,4 @@ daily_cost_data_per_kuberay_workload AS (
   ORDER BY
     invoice_day
 )
-SELECT
-  SUM(daily_cost_per_kuberay_workload)
-FROM
-  daily_cost_data_per_kuberay_workload
-#select COUNT(total), COUNT(k8s_namespace), COUNT(total), COUNT(k8s_namespace), COUNT(goog_k8s_namespace), COUNT(k8s_namespace_labels_meta_name) from data
-/*select labels from data where k8s_namespace IN (#'kube:unallocated'
-     #'goog-k8s-unsupported-sku',
-     #'goog-k8s-unknown',
-     'kube-system'
-     #'kube:system-overhead'
-     )*/
-#select COUNT(total), COUNT(k8s_namespace), COUNT(goog_k8s_namespace), COUNT(k8s_namespace_labels_meta_name) from data where k8s_namespace = "fakespot-ml-stage"
-#select labels from data
-#select total from data
-/*
-(
- SELECT
-  value
- FROM
-  UNNEST(labels)
- WHERE
-  KEY = "k8s-namespace-labels/kubernetes.io/metadata.name"
-) AS k8s_namespace_labels_meta_name,*/
+SELECT * FROM daily_cost_data_per_kuberay_workload

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
@@ -39,4 +39,7 @@ daily_cost_data_per_kuberay_workload AS (
   ORDER BY
     invoice_day
 )
-SELECT * FROM daily_cost_data_per_kuberay_workload
+SELECT
+  *
+FROM
+  daily_cost_data_per_kuberay_workload


### PR DESCRIPTION
This PR adds a view to surface the total compute cost of all Ray Serve workloads of `fakespot` tenant that are deployed via [kuberay operator](https://docs.ray.io/en/latest/serve/production-guide/kubernetes.html) on `dataservices-high-nonprod` shared GKE cluster.

I have added the view in `monitoring_derived` following the pattern in https://github.com/mozilla/bigquery-etl/pull/5956

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4691)
