### PR TITLE
Bug 1915728 - Reduce overactive clients filter value in events_daily queries

### DIFF
--- a/sql_generators/events_daily/templates/events_daily_v1/query.sql
+++ b/sql_generators/events_daily/templates/events_daily_v1/query.sql
@@ -50,7 +50,7 @@ WITH sample AS (
     )
     AND client_id IS NOT NULL
     -- filter out overactive clients: they distort the data and can cause the job to fail: https://bugzilla.mozilla.org/show_bug.cgi?id=1730190
-    AND client_event_count < 3000000
+    AND client_event_count < 300000
 ),
 joined AS (
   SELECT


### PR DESCRIPTION
This fixes `bqetl_fenix_event_rollup.fenix_derived__events_daily__v1` that is currently failing.

I have tested this reduced threshold on `2024-08-29`, getting `20451307/20451581=~99.99%` record count vs. production. This seems like a reasonable tradeoff for a quick fix given that `events_daily` is no longer our preferred way to analyze funnels.