### PR TITLE
DENG-4630 Add profile_group_id to review_checker_microsurvey_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_microsurvey_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_microsurvey_v1/query.sql
@@ -1,83 +1,59 @@
-#microsurvey response rates
-WITH microsurvey_responses AS (
-  SELECT
-    DATE(submission_timestamp) AS submission_date,
-    COUNT(DISTINCT CASE WHEN event = 'IMPRESSION' THEN client_id END) AS n_impression,
-    COUNT(DISTINCT CASE WHEN event = 'SELECT_CHECKBOX' THEN client_id END) AS n_response,
-    REGEXP_EXTRACT(
-      message_id,
-      'SHOPPING_MICROSURVEY_(\\d)_SHOPPING_MICROSURVEY_SCREEN_.*'
-    ) AS question_index
-  FROM
-    `moz-fx-data-shared-prod.firefox_desktop.onboarding`
-  WHERE
-    DATE(submission_timestamp) = @submission_date
-    AND message_id LIKE '%SHOPPING%'
-  GROUP BY
-    question_index,
-    submission_date
-),
-filter_ms_microsurvey AS (
-  SELECT
-    metrics.uuid.messaging_system_client_id AS client_id,
-    msg.sample_id,
-    msg.normalized_channel AS normalized_channel,
-    msg.normalized_country_code AS country_code,
-    mozfun.norm.truncate_version(client_info.app_display_version, "major") AS os_version,
-    DATE(submission_timestamp) AS submission_date,
-    metrics.text.messaging_system_message_id AS message_id,
-    metrics.string.messaging_system_event AS event,
-    metrics.string.messaging_system_event_page AS event_page,
-    metrics.string.messaging_system_event_reason AS event_reason,
-    metrics.string.messaging_system_event_source AS event_source,
-    IF(DATE_DIFF(DATE(submission_timestamp), first_seen_date, DAY) <= 27, 1, 0) AS new_user,
-    IF(DATE_DIFF(DATE(submission_timestamp), first_seen_date, DAY) > 27, 1, 0) AS existing_user,
-    CASE
-      WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
-        THEN 'how satisfied'
-      WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_1_SHOPPING_MICROSURVEY_SCREEN_2'
-        THEN 'is useful'
-      ELSE NULL
-    END AS coded_question,
-    CASE
-      WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
-        AND metrics.string.messaging_system_event_source = 'radio-1'
-        THEN 'very satisfied'
-      WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
-        AND metrics.string.messaging_system_event_source = 'radio-2'
-        THEN 'satisfied'
-      WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
-        AND metrics.string.messaging_system_event_source = 'radio-3'
-        THEN 'neutral'
-      WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
-        AND metrics.string.messaging_system_event_source = 'radio-4'
-        THEN 'unsatisfied'
-      WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
-        AND metrics.string.messaging_system_event_source = 'radio-5'
-        THEN 'very unsatisfied'
-      WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_1_SHOPPING_MICROSURVEY_SCREEN_2'
-        AND metrics.string.messaging_system_event_source = 'radio-1'
-        THEN 'yes'
-      WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_1_SHOPPING_MICROSURVEY_SCREEN_2'
-        AND metrics.string.messaging_system_event_source = 'radio-2'
-        THEN 'no'
-      WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_1_SHOPPING_MICROSURVEY_SCREEN_2'
-        AND metrics.string.messaging_system_event_source = 'radio-3'
-        THEN 'unsure'
-      ELSE NULL
-    END AS coded_answers,
-    ping_info.experiments
-  FROM
-    `moz-fx-data-shared-prod.firefox_desktop.messaging_system` msg
-  LEFT JOIN
-    `moz-fx-data-shared-prod.telemetry_derived.clients_first_seen_v2` cfs
-    ON cfs.client_id = msg.metrics.uuid.messaging_system_client_id
-  WHERE
-    DATE(submission_timestamp) = @submission_date
-    AND metrics.string.messaging_system_ping_type IS NULL
-    AND metrics.text.messaging_system_message_id LIKE '%SHOPPING%'
-)
 SELECT
-  *
+  metrics.uuid.messaging_system_client_id AS client_id,
+  msg.sample_id,
+  msg.normalized_channel AS normalized_channel,
+  msg.normalized_country_code AS country_code,
+  mozfun.norm.truncate_version(client_info.app_display_version, "major") AS os_version,
+  DATE(submission_timestamp) AS submission_date,
+  metrics.text.messaging_system_message_id AS message_id,
+  metrics.string.messaging_system_event AS event,
+  metrics.string.messaging_system_event_page AS event_page,
+  metrics.string.messaging_system_event_reason AS event_reason,
+  metrics.string.messaging_system_event_source AS event_source,
+  IF(DATE_DIFF(DATE(submission_timestamp), first_seen_date, DAY) <= 27, 1, 0) AS new_user,
+  IF(DATE_DIFF(DATE(submission_timestamp), first_seen_date, DAY) > 27, 1, 0) AS existing_user,
+  CASE
+    WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
+      THEN 'how satisfied'
+    WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_1_SHOPPING_MICROSURVEY_SCREEN_2'
+      THEN 'is useful'
+    ELSE NULL
+  END AS coded_question,
+  CASE
+    WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
+      AND metrics.string.messaging_system_event_source = 'radio-1'
+      THEN 'very satisfied'
+    WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
+      AND metrics.string.messaging_system_event_source = 'radio-2'
+      THEN 'satisfied'
+    WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
+      AND metrics.string.messaging_system_event_source = 'radio-3'
+      THEN 'neutral'
+    WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
+      AND metrics.string.messaging_system_event_source = 'radio-4'
+      THEN 'unsatisfied'
+    WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_0_SHOPPING_MICROSURVEY_SCREEN_1'
+      AND metrics.string.messaging_system_event_source = 'radio-5'
+      THEN 'very unsatisfied'
+    WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_1_SHOPPING_MICROSURVEY_SCREEN_2'
+      AND metrics.string.messaging_system_event_source = 'radio-1'
+      THEN 'yes'
+    WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_1_SHOPPING_MICROSURVEY_SCREEN_2'
+      AND metrics.string.messaging_system_event_source = 'radio-2'
+      THEN 'no'
+    WHEN metrics.text.messaging_system_message_id = 'SHOPPING_MICROSURVEY_1_SHOPPING_MICROSURVEY_SCREEN_2'
+      AND metrics.string.messaging_system_event_source = 'radio-3'
+      THEN 'unsure'
+    ELSE NULL
+  END AS coded_answers,
+  ping_info.experiments,
+  cfs.profile_group_id
 FROM
-  filter_ms_microsurvey
+  `moz-fx-data-shared-prod.firefox_desktop.messaging_system` msg
+LEFT JOIN
+  `moz-fx-data-shared-prod.telemetry_derived.clients_first_seen_v2` cfs
+  ON cfs.client_id = msg.metrics.uuid.messaging_system_client_id
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND metrics.string.messaging_system_ping_type IS NULL
+  AND metrics.text.messaging_system_message_id LIKE '%SHOPPING%'

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_microsurvey_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_microsurvey_v1/schema.yaml
@@ -1,0 +1,73 @@
+fields:
+- name: client_id
+  type: STRING
+  mode: NULLABLE
+- name: sample_id
+  type: INTEGER
+  mode: NULLABLE
+- name: normalized_channel
+  type: STRING
+  mode: NULLABLE
+- name: country_code
+  type: STRING
+  mode: NULLABLE
+- name: os_version
+  type: NUMERIC
+  mode: NULLABLE
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+- name: message_id
+  type: STRING
+  mode: NULLABLE
+- name: event
+  type: STRING
+  mode: NULLABLE
+- name: event_page
+  type: STRING
+  mode: NULLABLE
+- name: event_reason
+  type: STRING
+  mode: NULLABLE
+- name: event_source
+  type: STRING
+  mode: NULLABLE
+- name: new_user
+  type: INTEGER
+  mode: NULLABLE
+- name: existing_user
+  type: INTEGER
+  mode: NULLABLE
+- name: coded_question
+  type: STRING
+  mode: NULLABLE
+- name: coded_answers
+  type: STRING
+  mode: NULLABLE
+- name: experiments
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: key
+    type: STRING
+    mode: NULLABLE
+  - name: value
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: branch
+      type: STRING
+      mode: NULLABLE
+    - name: extra
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: enrollment_id
+        type: STRING
+        mode: NULLABLE
+      - name: type
+        type: STRING
+        mode: NULLABLE
+- name: profile_group_id
+  type: STRING
+  mode: NULLABLE


### PR DESCRIPTION
This PR does 3 things:
* Adds profile group ID to the table
* Adds a schema since one doesn't exist
* Rewrites the query slightly since, in the existing code, the first CTE is unnecessary/not doing anything


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4708)
