### PR TITLE
[DENG-4601] Add monitoring metadata support

### DIFF
--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -153,6 +153,13 @@ class ExternalDataMetadata:
 
 
 @attr.s(auto_attribs=True)
+class MonitoringMetadata:
+    """Metadata for specifying observability and monitoring configuration."""
+
+    enabled: bool = attr.ib(True)
+
+
+@attr.s(auto_attribs=True)
 class Metadata:
     """
     Representation of a table or view Metadata configuration.
@@ -173,6 +180,7 @@ class Metadata:
     external_data: Optional[ExternalDataMetadata] = attr.ib(None)
     deprecated: bool = attr.ib(False)
     deletion_date: Optional[date] = attr.ib(None)
+    monitoring: Optional[MonitoringMetadata] = attr.ib(None)
 
     @owners.validator
     def validate_owners(self, attribute, value):
@@ -249,6 +257,7 @@ class Metadata:
         external_data = None
         deprecated = False
         deletion_date = None
+        monitoring = None
 
         with open(metadata_file, "r") as yaml_stream:
             try:
@@ -319,6 +328,12 @@ class Metadata:
                 if "deletion_date" in metadata:
                     deletion_date = metadata["deletion_date"]
 
+                if "monitoring" in metadata:
+                    converter = cattrs.BaseConverter()
+                    monitoring = converter.structure(
+                        metadata["monitoring"], MonitoringMetadata
+                    )
+
                 return cls(
                     friendly_name,
                     description,
@@ -332,6 +347,7 @@ class Metadata:
                     external_data,
                     deprecated,
                     deletion_date,
+                    monitoring,
                 )
             except yaml.YAMLError as e:
                 raise e
@@ -375,6 +391,9 @@ class Metadata:
 
         if not metadata_dict["deletion_date"]:
             del metadata_dict["deletion_date"]
+
+        if not metadata_dict["monitoring"]:
+            del metadata_dict["monitoring"]
 
         file.write_text(
             yaml.dump(

--- a/bigquery_etl/metadata/publish_metadata.py
+++ b/bigquery_etl/metadata/publish_metadata.py
@@ -51,6 +51,8 @@ def publish_metadata(client, project, dataset, table, metadata):
         if metadata.deletion_date:
             table.labels["deletion_date"] = metadata.deletion_date.strftime("%Y-%m-%d")
             # TODO: in the future we can consider updating the table expiration date based on deletion_date
+        if metadata.monitoring and metadata.monitoring.enabled:
+            table.labels["monitoring"] = "true"
 
         client.update_table(table, ["friendly_name", "description", "labels"])
         print("Published metadata for: {}.{}.{}".format(project, dataset, table))

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -282,6 +282,7 @@ class TestMetadata:
             "deletion_date": "2024-03-02",
             "deprecated": "true",
             "owner1": "test",
+            "monitoring": "true",
         }
         assert (
             mock_bigquery_client()
@@ -297,6 +298,7 @@ class TestMetadata:
             "deletion_date": "2024-03-02",
             "deprecated": "true",
             "owner1": "test",
+            "monitoring": "true",
         }
 
     @patch("google.cloud.bigquery.Client")

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
@@ -4,4 +4,6 @@ description: |-
 owners:
   - test@mozilla.com
 deprecated: true
+monitoring:
+  enabled: true
 deletion_date: 2024-03-02


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-4601

This PR adds support for `monitoring` metadata. Initially, this will just indicate whether a table should/is monitored in Bigeye.


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4710)
