### PR TITLE
fix(GLAM): Fix boolean parameter passing to generate_glean_sql

### DIFF
--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -75,7 +75,7 @@ def main():
     parser.add_argument("--dataset", default="glam_etl")
     parser.add_argument("--sql-root", default="sql/")
     parser.add_argument("--daily-view-only", action="store_true", default=False)
-    parser.add_argument("--use-sample-id", default=False)
+    parser.add_argument("--use-sample-id", action="store_true", default=False)
     args = parser.parse_args()
 
     env = Environment(loader=PackageLoader("bigquery_etl", "glam/templates"))

--- a/script/glam/generate_glean_sql
+++ b/script/glam/generate_glean_sql
@@ -92,7 +92,7 @@ sql_dir=${sql_dir%/}
 
 product=${PRODUCT?PRODUCT must be defined}
 stage=${STAGE?$error}
-use_sample_id=${USE_SAMPLE_ID:-False}
+use_sample_id=$( [ "$USE_SAMPLE_ID" = "True" ] && echo "--use-sample-id" || echo "")
 
 # ensure the sql directory exists
 mkdir -p $sql_dir/$dst_project/glam_etl
@@ -109,7 +109,7 @@ elif [[ $stage == "incremental" ]]; then
         --sql-root "$sql_dir" \
         --project "$dst_project" \
         --prefix "${product}" \
-        --use-sample-id "${use_sample_id}"
+        ${use_sample_id}
 elif [[ $stage == "all" ]]; then
     write_clients_daily_aggregates "$product" "$src_project" "$dst_project" "$sql_dir"
     python3 -m bigquery_etl.glam.generate \


### PR DESCRIPTION
This PR addresses the impact of https://github.com/mozilla/telemetry-airflow/pull/2081, which fixes the currently broken GLAM FoG and GLAM Fenix ETLs.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4715)
