### PR TITLE
Add defaults in template

### DIFF
--- a/bigquery_etl/backfill/query_with_shredder_mitigation_template.sql
+++ b/bigquery_etl/backfill/query_with_shredder_mitigation_template.sql
@@ -12,11 +12,11 @@ WITH {{ new_version_cte | default('new_version') }} AS (
   {{ shredded | default('SELECT 1')  }}
 )
 SELECT
-  {{ final_select | default('*') }}
+  {{ final_select | default('1') }}
 FROM
   {{ new_version_cte | default('new_version') }}
 UNION ALL
 SELECT
-  {{ final_select | default('*') }}
+  {{ final_select | default('1') }}
 FROM
   {{ shredded_cte | default('shredded') }};

--- a/bigquery_etl/backfill/query_with_shredder_mitigation_template.sql
+++ b/bigquery_etl/backfill/query_with_shredder_mitigation_template.sql
@@ -1,23 +1,22 @@
 -- Query generated using a template for shredder mitigation.
-WITH {{ new_version_cte }} AS (
-  {{ new_version }}
+WITH {{ new_version_cte | default('new_version') }} AS (
+  {{ new_version | default('SELECT 1')  }}
 ),
-{{ new_agg_cte }} AS (
-  {{ new_agg }}
+{{ new_agg_cte | default('new_agg') }} AS (
+  {{ new_agg | default('SELECT 1')  }}
 ),
-{{ previous_agg_cte }} AS (
-  {{ previous_agg }}
+{{ previous_agg_cte | default('previous_agg') }} AS (
+  {{ previous_agg | default('SELECT 1')  }}
 ),
-{{  shredded_cte }} AS (
-  {{ shredded }}
+{{  shredded_cte | default('shredded') }} AS (
+  {{ shredded | default('SELECT 1')  }}
 )
 SELECT
-    {{ final_select }}
+  {{ final_select | default('*') }}
 FROM
-    {{ new_version_cte }}
+  {{ new_version_cte | default('new_version') }}
 UNION ALL
 SELECT
-  {{ final_select}}
+  {{ final_select | default('*') }}
 FROM
-    {{ shredded_cte }}
-;
+  {{ shredded_cte | default('shredded') }};


### PR DESCRIPTION
Fixes a to fix sqlglot parsing error in the CI.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4747)
