### PR TITLE
feat: tweak glean_usage generator to include install_source in derived baseline tables

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
@@ -29,6 +29,11 @@ WITH base AS (
     {% else %}
     CAST(NULL AS STRING) AS distribution_id,
     {% endif %}
+    {% if app_name = "fenix" %}
+    metrics.string.first_session_install_source AS install_source,
+    {% else %}
+    CAST(NULL AS STRING) AS install_source,
+    {% endif %}
     metadata.geo.subdivision1 AS geo_subdivision,
     {% if has_profile_group_id %}
     metrics.uuid.legacy_telemetry_profile_group_id AS profile_group_id,
@@ -102,6 +107,7 @@ windowed AS (
     udf.mode_last(ARRAY_AGG(device_model) OVER w1) AS device_model,
     udf.mode_last(ARRAY_AGG(telemetry_sdk_build) OVER w1) AS telemetry_sdk_build,
     udf.mode_last(ARRAY_AGG(distribution_id) OVER w1) AS distribution_id,
+    udf.mode_last(ARRAY_AGG(install_source) OVER w1) AS install_source,
     udf.mode_last(ARRAY_AGG(geo_subdivision) OVER w1) AS geo_subdivision,
     udf.mode_last(ARRAY_AGG(profile_group_id) OVER w1) AS profile_group_id,
   FROM

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
@@ -29,7 +29,7 @@ WITH base AS (
     {% else %}
     CAST(NULL AS STRING) AS distribution_id,
     {% endif %}
-    {% if app_name = "fenix" %}
+    {% if app_name == "fenix" %}
     metrics.string.first_session_install_source AS install_source,
     {% else %}
     CAST(NULL AS STRING) AS install_source,

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.schema.yaml
@@ -80,3 +80,6 @@ fields:
 - mode: NULLABLE
   name: profile_group_id
   type: STRING
+- mode: NULLABLE
+  name: install_source
+  type: STRING

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
@@ -63,3 +63,6 @@ fields:
 - mode: NULLABLE
   name: profile_group_id
   type: STRING
+- mode: NULLABLE
+  name: install_source
+  type: STRING

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -22,7 +22,7 @@ SELECT
   baseline.sample_id,
   baseline.submission_date,
   baseline.normalized_channel,
-  * EXCEPT(submission_date, normalized_channel, client_id, sample_id{% if app_name = "fenix" %}, install_source{% endif %}),
+  * EXCEPT(submission_date, normalized_channel, client_id, sample_id{% if app_name == "fenix" %}, install_source{% endif %}),
   {% if app_name == "fenix" %}
   COALESCE(baseline.install_source, metrics.install_source) AS install_source,
   {% endif %}

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -23,7 +23,7 @@ SELECT
   baseline.submission_date,
   baseline.normalized_channel,
   * EXCEPT(submission_date, normalized_channel, client_id, sample_id{% if app_name = "fenix" %}, install_source{% endif %}),
-  {% if app_name = "fenix" %}
+  {% if app_name == "fenix" %}
   COALESCE(baseline.install_source, metrics.install_source) AS install_source,
   {% endif %}
 FROM

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -22,10 +22,7 @@ SELECT
   baseline.sample_id,
   baseline.submission_date,
   baseline.normalized_channel,
-  * EXCEPT(submission_date, normalized_channel, client_id, sample_id{% if app_name == "fenix" %}, install_source{% endif %}),
-  {% if app_name == "fenix" %}
-  COALESCE(baseline.install_source, metrics.install_source) AS install_source,
-  {% endif %}
+  * EXCEPT(submission_date, normalized_channel, client_id, sample_id),
 FROM
   baseline
 LEFT JOIN metrics

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -22,7 +22,10 @@ SELECT
   baseline.sample_id,
   baseline.submission_date,
   baseline.normalized_channel,
-  * EXCEPT(submission_date, normalized_channel, client_id, sample_id)
+  * EXCEPT(submission_date, normalized_channel, client_id, sample_id{% if app_name = "fenix" %}, install_source{% endif %}),
+  {% if app_name = "fenix" %}
+  COALESCE(baseline.install_source, metrics.install_source) AS install_source,
+  {% endif %}
 FROM
   baseline
 LEFT JOIN metrics

--- a/tests/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/baseline_clients_daily_v1/moz-fx-data-shared-prod.org_mozilla_fenix_stable.baseline_v1.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/baseline_clients_daily_v1/moz-fx-data-shared-prod.org_mozilla_fenix_stable.baseline_v1.schema.json
@@ -281,6 +281,12 @@
             "type": "STRING",
             "name": "metrics_distribution_id",
             "mode": "NULLABLE"
+          },
+          {
+            "description": "",
+            "type": "STRING",
+            "name": "first_session_install_source",
+            "mode": "NULLABLE"
           }
         ],
         "type": "RECORD",


### PR DESCRIPTION
# feat: tweak glean_usage generator to include install_source in derived baseline tables

As a follow-up this property will be added to the mobile attribution table.

---

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4761)
