### PR TITLE
Unskip ads_backend in glean_usage generator

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -287,7 +287,6 @@ generate:
     - org_mozilla_ios_tiktok_reporter_tiktok_reportershare
     - org_mozilla_tiktokreporter
     - relay_backend  # see https://mozilla-hub.atlassian.net/browse/DENG-3720
-    - ads_backend
     - monitor_backend  # see https://bugzilla.mozilla.org/show_bug.cgi?id=1905444
     events_stream:
       skip_apps:


### PR DESCRIPTION
This will generate events_stream and event_monitoring_live tables for ads_backend.
We originally skipped this app because there was a delay in its ping table deployment.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4775)
