### PR TITLE
remove leli from braze dag docs

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1530,12 +1530,11 @@ bqetl_braze:
     ## Triage notes:
     Don't rerun this DAG!
     Ping Chelsey Beck.
-    If both are out, follow the [workbook](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/730234942/bqetl+braze+DAG+workbook) in confluence.
+    If Chelsey is out, follow the [workbook](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/730234942/bqetl+braze+DAG+workbook) in confluence.
   default_args:
     owner: cbeck@mozilla.com
     email:
       - cbeck@mozilla.com
-      - leli@mozilla.com
     start_date: '2024-04-15'
     retries: 3
     retry_delay: 5m

--- a/dags.yaml
+++ b/dags.yaml
@@ -1529,7 +1529,7 @@ bqetl_braze:
     ETL for Braze workflows.
     ## Triage notes:
     Don't rerun this DAG!
-    Ping Chelsey Beck or Leli Schiestl.
+    Ping Chelsey Beck.
     If both are out, follow the [workbook](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/730234942/bqetl+braze+DAG+workbook) in confluence.
   default_args:
     owner: cbeck@mozilla.com


### PR DESCRIPTION
remove Leli from the docs for the Braze DAG

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4788)
