### PR TITLE
Add error message to failed deploys

### DIFF
--- a/bigquery_etl/deploy.py
+++ b/bigquery_etl/deploy.py
@@ -106,21 +106,24 @@ def _create_or_update(
         if skip_existing:
             raise SkippedDeployException(f"{table} already exists.")
         log.info(f"{table} already exists, updating.")
-        client.update_table(
-            table,
-            [
-                "schema",
-                "friendly_name",
-                "description",
-                "time_partitioning",
-                "clustering_fields",
-                "labels",
-            ],
-        )
+        try:
+            client.update_table(
+                table,
+                [
+                    "schema",
+                    "friendly_name",
+                    "description",
+                    "time_partitioning",
+                    "clustering_fields",
+                    "labels",
+                ],
+            )
+        except Exception as e:
+            raise FailedDeployException(f"Unable to update table {table}: {e}") from e
         log.info(f"{table} updated.")
     else:
         try:
             client.create_table(table)
         except Exception as e:
-            raise FailedDeployException(f"Unable to create table {table}") from e
+            raise FailedDeployException(f"Unable to create table {table}: {e}") from e
         log.info(f"{table} created.")


### PR DESCRIPTION
The error from bigquery isn't logged right now which makes it hard to debug, e.g. https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/38985/workflows/ad9dac2f-8cc5-45ea-8b09-be62f635170b/jobs/443475

Example error: `Failed deploy for sql/benwubenwutest/telemetry_derived/ga3_events_v1/query.sql: (Unable to create table benwubenwutest.telemetry_derived.ga3_events_v1: 400 POST https://bigquery.googleapis.com/bigquery/v2/projects/benwubenwutest/datasets/telemetry_derived/tables?prettyPrint=false: Clustering is enabled but no fields were specified.)`

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4789)
