### PR TITLE
Fix skipping of apps in glean_usage

### DIFF
--- a/sql_generators/glean_usage/event_error_monitoring.py
+++ b/sql_generators/glean_usage/event_error_monitoring.py
@@ -56,6 +56,13 @@ class EventErrorMonitoring(GleanTable):
             "generate", "glean_usage", "events_monitoring", "event_table", fallback={}
         )
 
+        # Skip any not-allowed app.
+        skip_apps = ConfigLoader.get(
+            "generate", "glean_usage", "events_monitoring", "skip_apps", fallback=[]
+        )
+
+        apps = [app for app in apps if app[0]["app_name"] not in skip_apps]
+
         render_kwargs = dict(
             project_id=project_id,
             target_table=f"{TARGET_DATASET_CROSS_APP}_derived.{AGGREGATE_TABLE_NAME}",

--- a/sql_generators/glean_usage/event_monitoring_live.py
+++ b/sql_generators/glean_usage/event_monitoring_live.py
@@ -198,8 +198,16 @@ class EventMonitoringLive(GleanTable):
 
         event_tables_per_dataset = OrderedDict()
 
+        # Skip any not-allowed app.
+        skip_apps = ConfigLoader.get(
+            "generate", "glean_usage", "events_monitoring", "skip_apps", fallback=[]
+        )
+
         for app in apps:
             for app_dataset in app:
+                if app_dataset["app_name"] in skip_apps:
+                    continue
+
                 dataset = app_dataset["bq_dataset_family"]
                 app_name = [
                     app_dataset["app_name"]


### PR DESCRIPTION
This fixes the new logic for skipping Glean apps in the glean_usage generation for event monitoring. This should also unblock view deploys

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4801)
