### PR TITLE
feat(DENG-4847): Add profile_group_id to telemetry_derived.clients_daily_scalar_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
@@ -96,7 +96,10 @@ def generate_sql(
                 app_version,
                 app_build_id,
                 channel,
-                {aggregates}
+                {aggregates},
+                mozfun.stats.mode_last(
+                    ARRAY_AGG(profile_group_id ORDER BY submission_timestamp)
+                ) AS profile_group_id,
             FROM sampled_data
             GROUP BY
                 submission_date,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
@@ -12920,7 +12920,10 @@ aggregated AS (
         'true',
         SUM(CASE WHEN payload.processes.parent.scalars.widget_dark_mode = TRUE THEN 1 ELSE 0 END)
       )
-    ] AS scalar_aggregates
+    ] AS scalar_aggregates,
+    mozfun.stats.mode_last(
+      ARRAY_AGG(profile_group_id ORDER BY submission_timestamp)
+    ) AS profile_group_id,
   FROM
     sampled_data
   GROUP BY

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/schema.yaml
@@ -42,3 +42,6 @@ fields:
   mode: REPEATED
   name: scalar_aggregates
   type: RECORD
+- mode: NULLABLE
+  name: profile_group_id
+  type: STRING

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/moz-fx-data-shared-prod.telemetry_stable.main_v5.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/moz-fx-data-shared-prod.telemetry_stable.main_v5.schema.json
@@ -1631,5 +1631,10 @@
         "mode": "NULLABLE",
         "name": "payload",
         "type": "RECORD"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "profile_group_id",
+        "type": "STRING"
     }
 ]


### PR DESCRIPTION
## Description

Add profile_group_id to telemetry_derived.clients_daily_scalar_aggregates_v1 without changing existing grain of table

## Related Tickets & Documents
* [DENG-4847](https://mozilla-hub.atlassian.net/browse/DENG-4847)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

[DENG-4847]: https://mozilla-hub.atlassian.net/browse/DENG-4847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4850)
