### PR TITLE
DENG-4851 Add profile_group_id to telemetry_derived.clients_daily_histogram_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_v1.sql.py
@@ -368,9 +368,7 @@ def get_histogram_probes_sql_strings(probes_and_buckets, histogram_type):
                 app_version,
                 app_build_id,
                 channel,
-                mozfun.stats.mode_last(
-                    ARRAY_AGG(profile_group_id ORDER BY submission_timestamp)
-                ) AS profile_group_id,
+                profile_group_id,
                 {probes_string}
             FROM sampled_data),
 

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_v1/schema.yaml
@@ -62,3 +62,6 @@ fields:
   mode: REPEATED
   name: histogram_aggregates
   type: RECORD
+- mode: NULLABLE
+  name: profile_group_id
+  type: STRING

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_scalar_aggregates_v1/moz-fx-data-shared-prod.telemetry_stable.main_v5.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_scalar_aggregates_v1/moz-fx-data-shared-prod.telemetry_stable.main_v5.schema.json
@@ -1160,5 +1160,10 @@
         "mode": "NULLABLE",
         "name": "payload",
         "type": "RECORD"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "profile_group_id",
+        "type": "STRING"
     }
 ]


### PR DESCRIPTION
## Description

This PR adds the column "profile_group_id" to the table `moz-fx-data-shared-prod.telemetry_derived.clients_daily_histogram_aggregates_v1`, without changing existing grain of table

## Related Tickets & Documents
* [DENG-4851](https://mozilla-hub.atlassian.net/browse/DENG-4851)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

[DENG-4851]: https://mozilla-hub.atlassian.net/browse/DENG-4851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4854)
