### PR TITLE
Bug 1919236 - Fix Shredder monitoring query

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_rows_deleted_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_rows_deleted_v1/query.py
@@ -30,7 +30,7 @@ WITH shredder AS (
   WHERE
     DATE(job_created) BETWEEN @end_date - 1 AND @end_date
     -- ignore intermediate sample id queries; only use final copy job
-    AND NOT REGEXP_CONTAINS(task_id, "__sample_[0-9]{1,2}$")
+    AND NOT REGEXP_CONTAINS(task_id, "__sample_[0-9]{{1,2}}$")
 ),
 successful_jobs AS (
   -- https://cloud.google.com/bigquery/docs/information-schema-jobs


### PR DESCRIPTION
Curly braces need to be escaped.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1919236 and https://github.com/mozilla/bigquery-etl/pull/6197/files#diff-57d8ebcb18d45fb7886e62272db614409d5d34e58e9a77d421a94130f3ca1dcd

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4859)
