### PR TITLE
DENG-4847 include profile_group_id in grouped_metrics CTE

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_histogram_aggregates_v1.sql.py
@@ -167,6 +167,7 @@ def _get_keyed_histogram_sql(probes_and_buckets):
             SPLIT(application.version, '.')[OFFSET(0)] AS app_version,
             application.build_id AS app_build_id,
             normalized_channel AS channel,
+            profile_group_id,
             ARRAY<STRUCT<
                 name STRING,
                 metric_type STRING,


### PR DESCRIPTION
## Description

This PR is related to the earlier PR which is trying to add the new column "profile_group_id" to:

-  `moz-fx-data-shared-prod.telemetry_derived.clients_daily_scalar_aggregates_v1`
-  `moz-fx-data-shared-prod.telemetry_derived.clients_daily_keyed_scalar_aggregates_v1`
-  `moz-fx-data-shared-prod.telemetry_derived.clients_daily_keyed_boolean_aggregates_v1`

## Related Tickets & Documents
* [DENG-4847](https://mozilla-hub.atlassian.net/browse/DENG-4847)
* [DENG-4864](https://mozilla-hub.atlassian.net/browse/DENG-4864)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

[DENG-4847]: https://mozilla-hub.atlassian.net/browse/DENG-4847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-4864]: https://mozilla-hub.atlassian.net/browse/DENG-4864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4865)
