### PR TITLE
DENG-4847 Fix - add profile_group_id to GLAM CTEs

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
@@ -142,6 +142,7 @@ def _get_generic_keyed_scalar_sql(probes, value_type):
             app_version,
             app_build_id,
             channel,
+            profile_group_id,
             ARRAY<STRUCT<
                 name STRING,
                 process STRING,
@@ -160,6 +161,7 @@ def _get_generic_keyed_scalar_sql(probes, value_type):
               app_version,
               app_build_id,
               channel,
+              profile_group_id,
               metrics.name AS metric,
               metrics.process AS process,
               value.key AS key,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
@@ -98,7 +98,7 @@ def generate_sql(
                 channel,
                 {aggregates},
                 mozfun.stats.mode_last(
-                    ARRAY_AGG(profile_group_id ORDER BY submission_timestamp)
+                    ARRAY_AGG(profile_group_id)
                 ) AS profile_group_id,
             FROM sampled_data
             GROUP BY

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
@@ -222,7 +222,8 @@ def get_keyed_boolean_probes_sql_string(probes):
                     (metric, 'keyed-scalar-boolean', key, process, 'true', true_col),
                     (metric, 'keyed-scalar-boolean', key, process, 'false', false_col)
                 ]
-            ) AS scalar_aggregates
+            ) AS scalar_aggregates,
+            profile_group_id,
         FROM aggregated
         GROUP BY
             sample_id,


### PR DESCRIPTION
## Description

This PR is a fix related to yesterday's PR which added profile_group_id to the clients_daily_scalar_aggregates_v1 Python script which generates the SQL.  The generated SQL worked for clients_daily_scalar_aggregates but failed to work for keyed and boolean aggregates, so this is to fix that issue.

## Related Tickets & Documents
* [DENG-4847](https://mozilla-hub.atlassian.net/browse/DENG-4847)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

[DENG-4847]: https://mozilla-hub.atlassian.net/browse/DENG-4847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4866)
