### PR TITLE
DENG-4847 Revert adding profile_group_id to GLAM clients daily aggregates scalar 3 generated queries

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
@@ -96,10 +96,7 @@ def generate_sql(
                 app_version,
                 app_build_id,
                 channel,
-                {aggregates},
-                mozfun.stats.mode_last(
-                    ARRAY_AGG(profile_group_id ORDER BY submission_timestamp)
-                ) AS profile_group_id,
+                {aggregates}
             FROM sampled_data
             GROUP BY
                 submission_date,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
@@ -12920,10 +12920,7 @@ aggregated AS (
         'true',
         SUM(CASE WHEN payload.processes.parent.scalars.widget_dark_mode = TRUE THEN 1 ELSE 0 END)
       )
-    ] AS scalar_aggregates,
-    mozfun.stats.mode_last(
-      ARRAY_AGG(profile_group_id ORDER BY submission_timestamp)
-    ) AS profile_group_id,
+    ] AS scalar_aggregates
   FROM
     sampled_data
   GROUP BY

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/schema.yaml
@@ -42,6 +42,3 @@ fields:
   mode: REPEATED
   name: scalar_aggregates
   type: RECORD
-- mode: NULLABLE
-  name: profile_group_id
-  type: STRING


### PR DESCRIPTION
## Description

This is meant to revert prior PR https://github.com/mozilla/bigquery-etl/pull/6207 so that I can take a bit more time to make sure it works for all 3 before I push the change again.

## Related Tickets & Documents
* [DENG-4847](https://mozilla-hub.atlassian.net/browse/DENG-4847)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

[DENG-4847]: https://mozilla-hub.atlassian.net/browse/DENG-4847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4867)
