### PR TITLE
Set find_glean_targets thread count to 6 in shredder

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -603,7 +603,7 @@ def main():
         args.billing_projects,
         args.parallelism,
         connection_pool_max_size=(
-            args.parallelism * args.sampling_parallelism
+            max(args.parallelism * args.sampling_parallelism, 12)
             if len(args.sampling_tables) > 0
             else None
         ),
@@ -651,7 +651,7 @@ def main():
             )
 
     if args.environment == "telemetry":
-        with ThreadPool(args.parallelism) as pool:
+        with ThreadPool(6) as pool:
             glean_targets = find_glean_targets(pool, client)
         targets_with_sources = (
             *DELETE_TARGETS.items(),


### PR DESCRIPTION
## Description

I don't think it makes sense to tie the setup parallelism to the shredder query parallelism.  This reduces startup time when parallelism is low: ~35s at 6 threads vs. 140s at 1 vs. 75s at 2.  

## Related Tickets & Documents
*

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4874)
