### PR TITLE
DENG-4847 Add profile_group_id to "clients_daily_scalar_aggregates_v1"

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
@@ -96,7 +96,10 @@ def generate_sql(
                 app_version,
                 app_build_id,
                 channel,
-                {aggregates}
+                {aggregates},
+                mozfun.stats.mode_last(
+                    ARRAY_AGG(profile_group_id ORDER BY submission_timestamp)
+                ) AS profile_group_id
             FROM sampled_data
             GROUP BY
                 submission_date,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
@@ -220,7 +220,8 @@ def get_keyed_boolean_probes_sql_string(probes):
                     (metric, 'keyed-scalar-boolean', key, process, 'true', true_col),
                     (metric, 'keyed-scalar-boolean', key, process, 'false', false_col)
                 ]
-            ) AS scalar_aggregates
+            ) AS scalar_aggregates,
+            max(profile_group_id) AS profile_group_id
         FROM aggregated
         GROUP BY
             sample_id,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
@@ -12920,7 +12920,10 @@ aggregated AS (
         'true',
         SUM(CASE WHEN payload.processes.parent.scalars.widget_dark_mode = TRUE THEN 1 ELSE 0 END)
       )
-    ] AS scalar_aggregates
+    ] AS scalar_aggregates,
+    mozfun.stats.mode_last(
+      ARRAY_AGG(profile_group_id ORDER BY submission_timestamp)
+    ) AS profile_group_id,
   FROM
     sampled_data
   GROUP BY

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
@@ -12920,10 +12920,7 @@ aggregated AS (
         'true',
         SUM(CASE WHEN payload.processes.parent.scalars.widget_dark_mode = TRUE THEN 1 ELSE 0 END)
       )
-    ] AS scalar_aggregates,
-    mozfun.stats.mode_last(
-      ARRAY_AGG(profile_group_id ORDER BY submission_timestamp)
-    ) AS profile_group_id,
+    ] AS scalar_aggregates
   FROM
     sampled_data
   GROUP BY

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/schema.yaml
@@ -42,3 +42,6 @@ fields:
   mode: REPEATED
   name: scalar_aggregates
   type: RECORD
+- mode: NULLABLE
+  name: profile_group_id
+  type: STRING


### PR DESCRIPTION
## Description

This PR adds the new column "profile group ID" to the 3 different queries that get generated from `moz-fx-data-shared-prod.telemetry_derived.clients_daily_scalar_aggregates_v1.sql.py` for the 3 agg types
- scalars
- keyed_scalars
- keyed_booleans

Note - Decided to not change the grain of this table, since that could potentially cause issues downstream in any queries built assuming a certain existing grain.  So to add profile group ID, I added it as an aggregate calculated as the max(profile group ID) out of all group IDs on that client/that date/(the rest of the stuff already in the group by).   In theory, in a perfect world, each client ID should belong to at most 1 profile group ID (which is true 99% of the time) but sometimes we do see the same uniquely generated client ID having 2 or more profile group IDs), but this is a rare case.

New Generated SQL:
* [scalars_new.txt](https://github.com/user-attachments/files/17050657/scalars_new.txt) -> tested to `mozdata.analysis.kwindau_scalars_test_20240918`
* [keyed_scalars_new.txt](https://github.com/user-attachments/files/17050658/keyed_scalars_new.txt)  -> tested to `mozdata.analysis.kwindau_keyed_scalars_20240918`
* [keyed_booleans_new.txt](https://github.com/user-attachments/files/17050659/keyed_booleans_new.txt)  -> tested to `mozdata.analysis.kwindau_20240918_keyed_booleans`

## Related Tickets & Documents
* [DENG-4847](https://mozilla-hub.atlassian.net/browse/DENG-4847)
* [DENG-4864](https://mozilla-hub.atlassian.net/browse/DENG-4864)
* [DENG-4868](https://mozilla-hub.atlassian.net/browse/DENG-4868)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

[DENG-4847]: https://mozilla-hub.atlassian.net/browse/DENG-4847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4876)


[DENG-4864]: https://mozilla-hub.atlassian.net/browse/DENG-4864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-4868]: https://mozilla-hub.atlassian.net/browse/DENG-4868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ