### PR TITLE
Fix desktop_tiles_forecast_inputs submission_month parameter and move query to dryrun skip list

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -161,6 +161,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/query.sql
   - sql/moz-fx-data-shared-prod/fenix_derived/android_onboarding_v1/query.sql
   # Query parameter not found
+  - sql/moz-fx-data-shared-prod/ads_derived/desktop_tiles_forecast_inputs_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/experiments_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_scalar_aggregates_v1/query.sql

--- a/sql/moz-fx-data-shared-prod/ads_derived/desktop_tiles_forecast_inputs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/desktop_tiles_forecast_inputs_v1/metadata.yaml
@@ -14,10 +14,10 @@ labels:
 scheduling:
   dag_name: bqetl_ads
   destination_table: >-
-    desktop_tiles_forecast_inputs_v1${{ds.strftime("%Y%m01")}}
+    desktop_tiles_forecast_inputs_v1${{execution_date.strftime("%Y%m01")}}
   parameters:
     - >-
-      submission_month:DATE:{{ds.strftime('%Y-%m-01')}}
+      submission_month:DATE:{{execution_date.strftime('%Y-%m-01')}}
   query_file_path:
     # explicit query file path is necessary because the destination table
     # includes a partition identifier that is not in the path


### PR DESCRIPTION
## Description

This PR fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1918461 (I think). I had changed `execution_date` to `ds` not realizing that `ds` is a string representation of the Pendulum object `execution_date`, and this caused `strftime` to error. To change this back, I also need to add this query to the dry-run skip list because the dryrun code only supports parameters that use `ds`

## Related Tickets & Documents
* [Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1918461)