### PR TITLE
Add job error fields to shredder job monitoring

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_per_table_stats/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_per_table_stats/view.sql
@@ -14,6 +14,7 @@ SELECT
   SUM(tib_processed) AS tib_processed,
   SUM(slot_hours) AS slot_hours,
   COUNT(*) AS num_jobs,
+  COUNT(error_reason) AS num_job_errors,
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.shredder_per_job_stats_v1`
 GROUP BY

--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_run_stats/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_run_stats/view.sql
@@ -20,6 +20,7 @@ SELECT
   SUM(tib_processed) AS tib_processed,
   SUM(slot_hours) AS slot_hours,
   COUNT(*) AS num_jobs,
+  COUNT(error_reason) AS num_job_errors,
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.shredder_per_job_stats_v1`
 GROUP BY

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/query.sql
@@ -23,6 +23,8 @@ SELECT
   shredder_rows_deleted.partition_id,
   REGEXP_REPLACE(task_id, r"__sample_([0-9]+)$", "") AS parent_task_id,
   SAFE_CAST(REGEXP_EXTRACT(task_id, r"__sample_([0-9]+)$") AS INT) AS shredded_sample_id,
+  shredder_jobs.error_result.reason AS error_reason,
+  shredder_jobs.error_result.message AS error_message,
 FROM
   `moz-fx-data-shredder.shredder_state.shredder_state` AS shredder_state
 INNER JOIN

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/schema.yaml
@@ -47,3 +47,9 @@ fields:
 - name: shredded_sample_id
   type: INTEGER
   mode: NULLABLE
+- name: error_reason
+  type: STRING
+  mode: NULLABLE
+- name: error_message
+  type: STRING
+  mode: NULLABLE


### PR DESCRIPTION
## Description

This will make it easier to find failed jobs and filter them out in some aggregations 

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4890)
