### PR TITLE
DENG-4847 - Add profile_group_id to  clients_daily_scalar_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1.sql.py
@@ -92,6 +92,7 @@ def generate_sql(
                 submission_date,
                 sample_id,
                 client_id,
+                profile_group_id,
                 os,
                 app_version,
                 app_build_id,
@@ -102,6 +103,7 @@ def generate_sql(
                 submission_date,
                 sample_id,
                 client_id,
+                profile_group_id,
                 os,
                 app_version,
                 app_build_id,
@@ -134,6 +136,7 @@ def _get_generic_keyed_scalar_sql(probes, value_type):
           (SELECT
             sample_id,
             client_id,
+            profile_group_id,
             submission_date,
             os,
             app_version,
@@ -152,6 +155,7 @@ def _get_generic_keyed_scalar_sql(probes, value_type):
             (SELECT
               sample_id,
               client_id,
+              profile_group_id,
               submission_date,
               os,
               app_version,
@@ -200,6 +204,7 @@ def get_keyed_boolean_probes_sql_string(probes):
         SELECT
               sample_id,
               client_id,
+              profile_group_id,
               submission_date,
               os,
               app_version,
@@ -222,6 +227,7 @@ def get_keyed_boolean_probes_sql_string(probes):
         GROUP BY
             sample_id,
             client_id,
+            profile_group_id,
             submission_date,
             os,
             app_version,
@@ -253,6 +259,7 @@ def get_keyed_scalar_probes_sql_string(probes):
         SELECT
             sample_id,
             client_id,
+            profile_group_id,
             submission_date,
             os,
             app_version,
@@ -278,6 +285,7 @@ def get_keyed_scalar_probes_sql_string(probes):
         GROUP BY
             sample_id,
             client_id,
+            profile_group_id,
             submission_date,
             os,
             app_version,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/schema.yaml
@@ -9,6 +9,9 @@ fields:
   name: client_id
   type: STRING
 - mode: NULLABLE
+  name: profile_group_id
+  type: STRING
+- mode: NULLABLE
   name: os
   type: STRING
 - mode: NULLABLE


### PR DESCRIPTION
## Description

This PR adds the new column "profile group ID" to the 3 different queries that get generated from moz-fx-data-shared-prod.telemetry_derived.clients_daily_scalar_aggregates_v1.sql.py for the 3 agg types:
- scalars
- keyed_scalars
- keyed_booleans

## Related Tickets & Documents
* [DENG-4847](https://mozilla-hub.atlassian.net/browse/DENG-4847)
* [DENG-4864](https://mozilla-hub.atlassian.net/browse/DENG-4864)
* [DENG-4868](https://mozilla-hub.atlassian.net/browse/DENG-4868)

## Testing Done
[keyed_booleans_new.txt](https://github.com/user-attachments/files/17075872/keyed_booleans_new.txt) >>  mozdata.analysis.kwindau_test_20240920_keyed_bools
[keyed_scalars_new.txt](https://github.com/user-attachments/files/17075873/keyed_scalars_new.txt) >> mozdata.analysis.kwindau_test_20240920_keyed_scalars
[scalars_new.txt](https://github.com/user-attachments/files/17075874/scalars_new.txt) >> mozdata.analysis.kwindau_test_20240920_scalars


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

[DENG-4847]: https://mozilla-hub.atlassian.net/browse/DENG-4847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-4864]: https://mozilla-hub.atlassian.net/browse/DENG-4864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-4868]: https://mozilla-hub.atlassian.net/browse/DENG-4868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ