### PR TITLE
feat(sql/moz-fx-data-shared-prod): grant access to cloudops-managed/ads workgroup

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads/dataset_metadata.yaml
@@ -8,3 +8,4 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:ads
+      - workgroup:cloudops-managed/ads


### PR DESCRIPTION
grant access to `moz-fx-data-shared-prod.ads.consolidated_ad_metrics_daily_pt` to the ads workgroup generated in https://github.com/mozilla-services/cloudops-infra/pull/5931.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4894)
