### PR TITLE
removing uniqueness check on scheduled corpus item id

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v1/checks.sql
@@ -4,9 +4,6 @@
 {{ not_null(["scheduled_corpus_item_id"]) }}
 
 #fail
-{{ is_unique(["scheduled_corpus_item_id"]) }}
-
-#fail
 {{ not_null(["impression_count"]) }}
 
 #fail


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR removes the check on uniqueness for scheduled corpus item id. We are now grouping on this field by country and so no longer expect unique values
-->

## Related Tickets & Documents
* MC-1457

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4905)
