### PR TITLE
Use secrets in bqetl_marketing_suppression_list DAG

### DIFF
--- a/sql/moz-fx-data-shared-prod/marketing_suppression_list_external/campaign_monitor_suppression_list_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/marketing_suppression_list_external/campaign_monitor_suppression_list_v1/metadata.yaml
@@ -9,8 +9,10 @@ labels:
   owner1: leli
 scheduling:
   dag_name: bqetl_marketing_suppression_list
-  arguments:
-  - --api_key={{ var.value.campaign_monitor_api_key }}
-  - --client_id={{ var.value.campaign_monitor_client_id }}
+  secrets:
+  - deploy_target: CAMPAIGN_MONITOR_API_KEY
+    key: bqetl_marketing_suppression_list__campaign_monitor_api_key
+  - deploy_target: CAMPAIGN_MONITOR_CLIENT_ID
+    key: bqetl_marketing_suppression_list__campaign_monitor_client_id
 bigquery: null
 references: {}

--- a/sql/moz-fx-data-shared-prod/marketing_suppression_list_external/campaign_monitor_suppression_list_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/marketing_suppression_list_external/campaign_monitor_suppression_list_v1/query.py
@@ -88,6 +88,7 @@ def download_suppression_list(
 @click.command
 @click.option(
     "--api_key",
+    envvar='CAMPAIGN_MONITOR_API_KEY',
     required=True,
     help="Campaign Monitor API key to use for authentication.",
 )
@@ -111,6 +112,7 @@ def download_suppression_list(
 )
 @click.option(
     "--client_id",
+    envvar='CAMPAIGN_MONITOR_CLIENT_ID',
     required=True,
     help="Client Id for Campaign Monitor.",
 )

--- a/sql/moz-fx-data-shared-prod/marketing_suppression_list_external/send_suppression_list_update_to_campaign_monitor_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/marketing_suppression_list_external/send_suppression_list_update_to_campaign_monitor_v1/metadata.yaml
@@ -6,12 +6,14 @@ owners:
 - cbeck@mozilla.com
 labels:
   incremental: true
-  owner1: leli
+  owner1: cbeck
 scheduling:
   dag_name: bqetl_marketing_suppression_list
-  arguments:
-  - --api_key={{ var.value.campaign_monitor_api_key }}
-  - --client_id={{ var.value.campaign_monitor_client_id }}
+  secrets:
+  - deploy_target: CAMPAIGN_MONITOR_API_KEY
+    key: bqetl_marketing_suppression_list__campaign_monitor_api_key
+  - deploy_target: CAMPAIGN_MONITOR_CLIENT_ID
+    key: bqetl_marketing_suppression_list__campaign_monitor_client_id
   depends_on:
   - task_id: marketing_suppression_list_external__campaign_monitor_suppression_list__v1
     dag_name: bqetl_marketing_suppression_list

--- a/sql/moz-fx-data-shared-prod/marketing_suppression_list_external/send_suppression_list_update_to_campaign_monitor_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/marketing_suppression_list_external/send_suppression_list_update_to_campaign_monitor_v1/query.py
@@ -76,11 +76,13 @@ def store_data_in_bigquery(data, schema, destination_project, destination_table_
 @click.command
 @click.option(
     "--api_key",
+    envvar='CAMPAIGN_MONITOR_API_KEY',
     required=True,
     help="Campaign Monitor API key to use for authentication.",
 )
 @click.option(
     "--client_id",
+    envvar='CAMPAIGN_MONITOR_CLIENT_ID',
     required=True,
     help="Client Id for Campaign Monitor.",
 )


### PR DESCRIPTION
## Description

This rewrites some of the DAG configurations to use secrets instead of variables.

`bqetl_marketing_suppression_list__campaign_monitor_api_key` needs to be added to GSM. This should be set to the same value as `var.value.campaign_monitor_api_key`. I already added the `client_id` to GSM

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**