### PR TITLE
Exclude `firefox_crashreporter` Glean app from baseline ping checks (bug 1920582)

### DIFF
--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -28,6 +28,7 @@ NO_BASELINE_PING_APPS = (
     "accounts_backend",
     "accounts_cirrus",
     "burnham",
+    "firefox_crashreporter",
     "firefox_reality_pc",
     "lockwise_android",
     "mach",


### PR DESCRIPTION
## Description
The Firefox crash reporter app only sends crash pings, so it won't have any baseline pings.

## Related Tickets & Documents
* [Bug 1920582](https://bugzilla.mozilla.org/show_bug.cgi?id=1920582): Airflow task `bqetl_glean_usage.checks__warn_firefox_crashreporter_derived__baseline_clients_last_seen__v1` failed for exec_date 2024-09-20

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4925)
