### PR TITLE
feat(): add distribution id to attribution clients template

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/__init__.py
+++ b/sql_generators/mobile_kpi_support_metrics/__init__.py
@@ -165,6 +165,21 @@ class AttributionFields:
             },
         ],
     )
+    distribution_id = AttributionFieldGroup(
+        name="distribution_id",
+        source_pings=[
+            AttributionPings.first_session,
+            AttributionPings.baseline,
+            AttributionPings.metrics,
+        ],
+        fields=[
+            {
+                "name": "distribution_id",
+                "type": "STRING",
+                "description": "TODO",
+            },
+        ],
+    )
     empty = AttributionFieldGroup(
         name="empty",
         source_pings=[],
@@ -225,6 +240,7 @@ class MobileProducts(Enum):
             AttributionFields.meta,
             AttributionFields.install_source,
             AttributionFields.adjust,
+            AttributionFields.distribution_id,
         ],
     )
     focus_android = Product(

--- a/sql_generators/mobile_kpi_support_metrics/__init__.py
+++ b/sql_generators/mobile_kpi_support_metrics/__init__.py
@@ -176,7 +176,7 @@ class AttributionFields:
             {
                 "name": "distribution_id",
                 "type": "STRING",
-                "description": "TODO",
+                "description": "A string containing the distribution identifier.",
             },
         ],
     )

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.schema.yaml
@@ -37,9 +37,3 @@ fields:
 {% endfor -%}
 {% endif -%}
 {% endfor -%}
-{% if app_name == "fenix" %}
-- mode: NULLABLE
-  name: distribution_id
-  type: STRING
-  description:
-{% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.schema.yaml
@@ -37,3 +37,9 @@ fields:
 {% endfor -%}
 {% endif -%}
 {% endfor -%}
+{% if app_name == "fenix" %}
+- mode: NULLABLE
+  name: distribution_id
+  type: STRING
+  description:
+{% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.view.sql
@@ -26,5 +26,8 @@ SELECT
   {% if 'is_suspicious_device_client' in product_attribution_group_names %}
   is_suspicious_device_client,
   {% endif %}
+  {% if app_name == "fenix" %}
+  distribution_id,
+  {% endif %}
 FROM
   `{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}`

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.view.sql
@@ -26,7 +26,7 @@ SELECT
   {% if 'is_suspicious_device_client' in product_attribution_group_names %}
   is_suspicious_device_client,
   {% endif %}
-  {% if app_name == "fenix" %}
+  {% if 'distribution_id' in product_attribution_group_names %}
   distribution_id,
   {% endif %}
 FROM


### PR DESCRIPTION
## feat(): add distribution id to attribution clients template

We need to add this field to the attribution field to be able to identify which partnership a specific client came from.


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4935)
