### PR TITLE
feat: add more granual attribution fields to the mobile_kpi_metric generator

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/__init__.py
+++ b/sql_generators/mobile_kpi_support_metrics/__init__.py
@@ -19,18 +19,18 @@ GENERATOR_ROOT = Path(path.dirname(__file__))
 HEADER = f"-- Query generated via `{GENERATOR_ROOT.name}` SQL generator."
 VERSION = "v1"
 TEMPLATES = (
-    "active_users.view.sql",
-    "retention_clients.view.sql",
-    "retention.query.sql",
-    "retention.view.sql",
-    "engagement_clients.view.sql",
-    "engagement.query.sql",
-    "engagement.view.sql",
-    "attribution_clients.view.sql",
-    "attribution_clients.query.sql",
-    "new_profile_clients.view.sql",
-    "new_profiles.view.sql",
-    "new_profiles.query.sql",
+    ("CLIENT", "active_users.view.sql"),
+    ("CLIENT", "retention_clients.view.sql"),
+    ("AGGREGATE", "retention.query.sql"),
+    ("AGGREGATE", "retention.view.sql"),
+    ("CLIENT", "engagement_clients.view.sql"),
+    ("AGGREGATE", "engagement.query.sql"),
+    ("AGGREGATE", "engagement.view.sql"),
+    ("CLIENT", "attribution_clients.view.sql"),
+    ("CLIENT", "attribution_clients.query.sql"),
+    ("CLIENT", "new_profile_clients.view.sql"),
+    ("AGGREGATE", "new_profiles.view.sql"),
+    ("AGGREGATE", "new_profiles.query.sql"),
 )
 
 
@@ -93,6 +93,7 @@ class AttributionFields:
                 "name": "adjust_attribution_timestamp",
                 "type": "TIMESTAMP",
                 "description": "Timestamp corresponding to the ping that contained the adjust attribution.",
+                "client_only": True,
             },
         ],
     )
@@ -119,23 +120,26 @@ class AttributionFields:
                 "name": "play_store_attribution_timestamp",
                 "type": "TIMESTAMP",
                 "description": "Timestamp corresponding to the ping that contained the play_store attribution.",
+                "client_only": True,
             },
-            # TODO: decide if this should be added here?
-            # {
-            #     "name": "play_store_attribution_content",
-            #     "type": "STRING",
-            #     "description": "",
-            # },
-            # {
-            #     "name": "play_store_attribution_term",
-            #     "type": "STRING",
-            #     "description": "",
-            # },
-            # {
-            #     "name": "play_store_attribution_install_referrer_response",
-            #     "type": "STRING",
-            #     "description": "Play store source the profile is attributed to.",
-            # },
+            {
+                "name": "play_store_attribution_content",
+                "type": "STRING",
+                "description": "",
+                "client_only": True,
+            },
+            {
+                "name": "play_store_attribution_term",
+                "type": "STRING",
+                "description": "",
+                "client_only": True,
+            },
+            {
+                "name": "play_store_attribution_install_referrer_response",
+                "type": "STRING",
+                "description": "Play store source the profile is attributed to.",
+                "client_only": True,
+            },
         ],
     )
     meta = AttributionFieldGroup(
@@ -151,6 +155,7 @@ class AttributionFields:
                 "name": "meta_attribution_timestamp",
                 "type": "TIMESTAMP",
                 "description": "Timestamp corresponding to the ping that contained the meta attribution.",
+                "client_only": True,
             },
         ],
     )
@@ -311,7 +316,7 @@ def generate(target_project, output_dir, use_cloud_function):
         )
     )
 
-    for template in TEMPLATES:
+    for template_grain, template in TEMPLATES:
         for product in MobileProducts:
 
             target_name, target_filename, target_extension = template.split(".")
@@ -398,6 +403,7 @@ def generate(target_project, output_dir, use_cloud_function):
             name=target_name,
             target_name=union_target_name,
             target_filename=target_filename,
+            template_grain=template_grain,
             format=False,
             products=[
                 {
@@ -409,6 +415,9 @@ def generate(target_project, output_dir, use_cloud_function):
                                 in product.value.get_product_attribution_fields().keys(),
                                 "name": field_name,
                                 "type": field_properties["type"],
+                                "client_only": field_properties.get(
+                                    "client_only", False
+                                ),
                             }
                             for field_name, field_properties in all_possible_attribution_fields.items()
                         ]

--- a/sql_generators/mobile_kpi_support_metrics/__init__.py
+++ b/sql_generators/mobile_kpi_support_metrics/__init__.py
@@ -392,6 +392,10 @@ def generate(target_project, output_dir, use_cloud_function):
         if target_filename != "view":
             continue
 
+        # For now skipping attribution_clients union. Will add in the future.
+        if target_name == "attribution_clients":
+            continue
+
         target_dataset = "telemetry"
 
         union_target_name = f"mobile_{target_name}"

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
@@ -8,7 +8,7 @@ SELECT
   country,
   locale,
   is_mobile,
-  {% for field in product_attribution_fields.values() if not field.name.endswith("_timestamp") %}
+  {% for field in product_attribution_fields.values() if not field.client_only %}
   {{ field.name }},
   {% endfor %}
   COUNTIF(is_dau) AS dau,
@@ -33,7 +33,7 @@ GROUP BY
   country,
   locale,
   is_mobile
-  {% for field in product_attribution_fields.values() if not field.name.endswith("_timestamp") %}
+  {% for field in product_attribution_fields.values() if not field.client_only %}
     {% if loop.first %},{% endif %}
     {{ field.name }}
     {% if not loop.last %},{% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.schema.yaml
@@ -38,7 +38,7 @@ fields:
   type: BOOLEAN
   mode: NULLABLE
   description: Indicates if this specific entry is used towards calculating mobile DAU.
-{% for field in product_attribution_fields.values() if not field.name.endswith("_timestamp") %}
+{% for field in product_attribution_fields.values() if not field.client_only %}
 - name: {{ field.name }}
   type: {{ field.type }}
   mode: NULLABLE

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.query.sql
@@ -10,7 +10,7 @@ SELECT
   os_version,
   device_manufacturer,
   is_mobile,
-  {% for field in product_attribution_fields.values() if not field.name.endswith("_timestamp") %}
+  {% for field in product_attribution_fields.values() if not field.client_only %}
   {{ field.name }},
   {% endfor %}
   COUNT(*) AS new_profiles,
@@ -35,7 +35,7 @@ GROUP BY
   os_version,
   device_manufacturer,
   is_mobile
-  {% for field in product_attribution_fields.values() if not field.name.endswith("_timestamp") %}
+  {% for field in product_attribution_fields.values() if not field.client_only %}
     {% if loop.first %},{% endif %}
     {{ field.name }}
     {% if not loop.last %},{% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.schema.yaml
@@ -48,7 +48,7 @@ fields:
   type: BOOLEAN
   mode: NULLABLE
   description: Indicates if this specific entry is used towards calculating mobile DAU.
-{% for field in product_attribution_fields.values() if not field.name.endswith("_timestamp") %}
+{% for field in product_attribution_fields.values() if not field.client_only %}
 - name: {{ field.name }}
   type: {{ field.type }}
   mode: NULLABLE

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
@@ -8,7 +8,7 @@ SELECT
   app_version,
   locale,
   is_mobile,
-  {% for field in product_attribution_fields.values() if not field.name.endswith("_timestamp") %}
+  {% for field in product_attribution_fields.values() if not field.client_only %}
   {{ field.name }},
   {% endfor %}
   COUNTIF(ping_sent_metric_date) AS ping_sent_metric_date,
@@ -39,7 +39,7 @@ GROUP BY
   app_version,
   locale,
   is_mobile
-  {% for field in product_attribution_fields.values() if not field.name.endswith("_timestamp") %}
+  {% for field in product_attribution_fields.values() if not field.client_only %}
     {% if loop.first %},{% endif %}
     {{ field.name }}
     {% if not loop.last %},{% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.schema.yaml
@@ -38,7 +38,7 @@ fields:
   type: BOOLEAN
   mode: NULLABLE
   description: Indicates if this specific entry is used towards calculating mobile DAU.
-{% for field in product_attribution_fields.values() if not field.name.endswith("_timestamp") %}
+{% for field in product_attribution_fields.values() if not field.client_only %}
 - name: {{ field.name }}
   type: {{ field.type }}
   mode: NULLABLE

--- a/sql_generators/mobile_kpi_support_metrics/templates/union.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/union.view.sql
@@ -8,18 +8,18 @@ UNION ALL
 {% endif %}
 SELECT
   *
-  {% for field in product.all_possible_attribution_fields if field.exists and template_grain == "AGGREGATE" and not field.client_only%}
+  {% for field in product.all_possible_attribution_fields if field.exists and template_grain == "AGGREGATE" and not field.client_only %}
     {% if loop.first %}EXCEPT({% endif %}
       {{ field.name }}{% if not loop.last %},{% endif %}
     {% if loop.last %}){% endif %}
   {% endfor %}
-  {% for field in product.all_possible_attribution_fields if field.exists and template_grain == "CLIENT"%}
+  {% for field in product.all_possible_attribution_fields if field.exists and template_grain == "CLIENT" and not field.name.endswith("_timestamp") %}
     {% if loop.first %}EXCEPT({% endif %}
       {{ field.name }}{% if not loop.last %},{% endif %}
     {% if loop.last %}){% endif %}
   {% endfor %}
   ,
-{% for field in product.all_possible_attribution_fields %}
+{% for field in product.all_possible_attribution_fields if not field.name.endswith("_timestamp")%}
   {% if template_grain == "AGGREGATE" and not field.client_only %}
     {% if field.exists %}
     {{ field.name }},

--- a/sql_generators/mobile_kpi_support_metrics/templates/union.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/union.view.sql
@@ -8,25 +8,17 @@ UNION ALL
 {% endif %}
 SELECT
   *
-  {% for field in product.all_possible_attribution_fields if field.exists %}
+  {% for field in product.all_possible_attribution_fields if field.exists and template_grain == "AGGREGATE" and not field.client_only%}
     {% if loop.first %}EXCEPT({% endif %}
-    {% if not loop.last %}
-      {% if template_grain == "AGGREGATE" and not field.client_only %}
-        {% if field.exists %}
-        {{ field.name }},
-        {% else %}
-        {{ field.name }}
-        {% endif %}
-      {% elif template_grain == "CLIENT" %}
-        {% if field.exists %}
-        {{ field.name }},
-        {% else %}
-        {{ field.name }}
-        {% endif %}
-      {% endif %}
-    {% endif %}
-    {% if loop.last %}),{% endif %}
-  {% else %},{% endfor %}
+      {{ field.name }}{% if not loop.last %},{% endif %}
+    {% if loop.last %}){% endif %}
+  {% endfor %}
+  {% for field in product.all_possible_attribution_fields if field.exists and template_grain == "CLIENT"%}
+    {% if loop.first %}EXCEPT({% endif %}
+      {{ field.name }}{% if not loop.last %},{% endif %}
+    {% if loop.last %}){% endif %}
+  {% endfor %}
+  ,
 {% for field in product.all_possible_attribution_fields %}
   {% if template_grain == "AGGREGATE" and not field.client_only %}
     {% if field.exists %}


### PR DESCRIPTION
## feat: add more granual attribution fields to the mobile_kpi_metric generator

This is to ensure that the following fields are also available on the client level tables/views:

- `play_store_attribution_content`
- `play_store_attribution_term`
- `play_store_attribution_install_referrer_response`

These fields however get excluded from aggregate views and tables as the values there can be too unique which would defeat the purpose of the aggregations.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4941)
