### PR TITLE
Use temporary session tables for shredder sampling

### DIFF
--- a/tests/shredder/test_delete.py
+++ b/tests/shredder/test_delete.py
@@ -13,8 +13,8 @@ wait_for_job_partial = partial(
         "proj.dataset_table_v1$20240101": "proj:US.job_id1",
     },
     task_id="proj.dataset_table_v1$20240101",
-    dry_run=True,
-    create_job=lambda client: Mock(job_id="proj:US.job_id2"),
+    dry_run=False,
+    create_job=lambda client: (Mock(job_id="proj:US.job_id2"), None),
     start_date=None,
     end_date=None,
     state_table=None,
@@ -80,10 +80,16 @@ def test_wait_for_job_succeed():
 def test_wait_for_job_new_job():
     """wait_for_job should return a new job if there's no previous attempt."""
     mock_client = Mock()
+    mock_callback = Mock()
+    wait_for_job_partial.keywords["create_job"] = lambda client: (
+        Mock(job_id="proj:US.job_id2"),
+        mock_callback,
+    )
 
     job = wait_for_job_partial(client=mock_client, states={})
 
     assert job.job_id == "proj:US.job_id2"
+    mock_callback.assert_called_with(client=mock_client)
 
 
 # args for delete_from_table, delete_from_partition_with_sampling, and delete_from_partition


### PR DESCRIPTION
## Description

Adds option to write intermediate query results to temp tables a bigquery sessions and ll the sessions are ended after the partition copy is complete.  The goal of this is to reduce the physical storage cost because writing to permanent tables incurs cost for the time travel fail-safe period (and we have some limitations on our storage setup https://github.com/mozilla-services/cloudops-infra/pull/5939#issuecomment-2369616376).  Temporary tables shouldn't have this cost but I need to confirm

## Related Tickets & Documents
* DENG-4641

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4942)
