### PR TITLE
Allow specifying a collection for monitored tables

### DIFF
--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -157,13 +157,13 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
                                     metric.metric_type.predefined_metric
                                 )
 
-                        if (
-                            metadata.monitoring.collection
-                            and collection.collection is None
-                        ):
-                            collection.collection = SimpleCollection(
-                                name=metadata.monitoring.collection
-                            )
+                    if (
+                        metadata.monitoring.collection
+                        and collection.collection is None
+                    ):
+                        collection.collection = SimpleCollection(
+                            name=metadata.monitoring.collection
+                        )
 
                 if len(default_metrics) > 0:
                     deployments = [

--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -157,10 +157,7 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
                                     metric.metric_type.predefined_metric
                                 )
 
-                    if (
-                        metadata.monitoring.collection
-                        and collection.collection is None
-                    ):
+                    if metadata.monitoring.collection and collection.collection is None:
                         collection.collection = SimpleCollection(
                             name=metadata.monitoring.collection
                         )

--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -12,6 +12,7 @@ from bigeye_sdk.controller.metric_suite_controller import MetricSuiteController
 from bigeye_sdk.exceptions.exceptions import FileLoadException
 from bigeye_sdk.model.big_config import BigConfig, TableDeployment, TableDeploymentSuite
 from bigeye_sdk.model.protobuf_message_facade import (
+    SimpleCollection,
     SimpleMetricDefinition,
     SimpleMetricSchedule,
     SimpleNamedSchedule,
@@ -156,6 +157,14 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
                                     metric.metric_type.predefined_metric
                                 )
 
+                        if (
+                            metadata.monitoring.collection
+                            and collection.collection is None
+                        ):
+                            collection.collection = SimpleCollection(
+                                name=metadata.monitoring.collection
+                            )
+
                 if len(default_metrics) > 0:
                     deployments = [
                         TableDeployment(
@@ -175,8 +184,17 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
                             ],
                         )
                     ]
+
+                    collection = None
+                    if metadata.monitoring.collection:
+                        collection = SimpleCollection(
+                            name=metadata.monitoring.collection
+                        )
+
                     bigconfig.table_deployments += [
-                        TableDeploymentSuite(deployments=deployments)
+                        TableDeploymentSuite(
+                            deployments=deployments, collection=collection
+                        )
                     ]
 
                 bigconfig.save(

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -157,6 +157,7 @@ class MonitoringMetadata:
     """Metadata for specifying observability and monitoring configuration."""
 
     enabled: bool = attr.ib(True)
+    collection: Optional[str] = attr.ib(None)
 
 
 @attr.s(auto_attribs=True)

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/releases_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/releases_v1/bigconfig.yml
@@ -1,6 +1,8 @@
 type: BIGCONFIG_FILE
 table_deployments:
-- deployments:
+- collection:
+    name: Test
+  deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.org_mozilla_fenix_derived.releases_v1
     table_metrics:
     - metric_type:

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/releases_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/releases_v1/metadata.yaml
@@ -13,3 +13,4 @@ scheduling:
   dag_name: bqetl_releases
 monitoring:
   enabled: true
+  collection: Test


### PR DESCRIPTION
## Description

This extends the `monitoring` metadata to allow for specifying a collection that the metric should be added to.


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4943)
