### PR TITLE
DENG-4962 Add legacy telemetry client ID to events_stream

### DIFF
--- a/sql_generators/glean_usage/events_stream.py
+++ b/sql_generators/glean_usage/events_stream.py
@@ -49,12 +49,21 @@ class EventsStreamTable(GleanTable):
             "generate", "glean_usage", "events_stream", "metrics_as_struct", fallback=[]
         )
 
+        # Separate apps with legacy telemetry client ID vs those that don't have it
+        if app_id == "firefox_desktop":
+            has_legacy_telemetry_client_id = True
+        else:
+            has_legacy_telemetry_client_id = False
+
+        # Separate apps with profile group ID vs those that don't have it
         if app_id == "firefox_desktop":
             has_profile_group_id = True
         else:
             has_profile_group_id = False
+
         self.custom_render_kwargs = {
             "has_profile_group_id": has_profile_group_id,
+            "has_legacy_telemetry_client_id": has_legacy_telemetry_client_id,
             "metrics_as_struct": metrics_as_struct,
         }
 

--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -105,6 +105,7 @@ WITH base AS (
     {% else %}
       CAST(NULL AS STRING) AS profile_group_id,
     {% endif %}
+      metrics.uuid.legacy_telemetry_client_id AS legacy_telemetry_client_id,
   FROM
     `{{ events_view }}`
   WHERE

--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -105,7 +105,11 @@ WITH base AS (
     {% else %}
       CAST(NULL AS STRING) AS profile_group_id,
     {% endif %}
+    {% if has_legacy_telemetry_client_id %}
       metrics.uuid.legacy_telemetry_client_id AS legacy_telemetry_client_id,
+    {% else %}
+      CAST(NULL AS STRING) AS legacy_telemetry_client_id,
+    {% endif %}
   FROM
     `{{ events_view }}`
   WHERE


### PR DESCRIPTION
## Description

This PR adds the new column "legacy_telemetry_client_id" to the glean_usage generator for the various "events_stream_v1" tables.

## Related Tickets & Documents
* [DENG-4962](https://mozilla-hub.atlassian.net/browse/DENG-4962)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

[DENG-4962]: https://mozilla-hub.atlassian.net/browse/DENG-4962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4963)
