### PR TITLE
Reduce overactive clients threshold in `events_daily_v1` ETLs (bug 1921117)

### DIFF
--- a/sql_generators/events_daily/templates/events_daily_v1/query.sql
+++ b/sql_generators/events_daily/templates/events_daily_v1/query.sql
@@ -50,7 +50,7 @@ WITH sample AS (
     )
     AND client_id IS NOT NULL
     -- filter out overactive clients: they distort the data and can cause the job to fail: https://bugzilla.mozilla.org/show_bug.cgi?id=1730190
-    AND client_event_count < 300000
+    AND client_event_count < 200000
 ),
 joined AS (
   SELECT


### PR DESCRIPTION
## Description

An overactive Fenix client on 2024-09-24 had 289,653 events, which is causing the `fenix_derived.events_daily_v1` ETL to fail with the error "*Cannot query rows larger than 100MB limit*".

## Related Tickets & Documents
* [Bug 1921117](https://bugzilla.mozilla.org/show_bug.cgi?id=1921117): Airflow task `bqetl_fenix_event_rollup.fenix_derived__events_daily__v1` failed for exec_date 2024-09-24

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4965)
