### PR TITLE
Add missing column views to dry run skip

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -143,6 +143,8 @@ dry_run:
   - sql/moz-fx-data-shared-prod/mozilla_org_derived/gclid_conversions_v2/query.sql
   - sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/query.sql
   - sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/query.sql
+  - sql/moz-fx-data-shared-prod/monitoring/structured_missing_columns/view.sql
+  - sql/moz-fx-data-shared-prod/monitoring/telemetry_missing_columns/view.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v1/view.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/table_partition_expirations_v1/query.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/query.sql


### PR DESCRIPTION
## Description

Dry runs have been failing from https://github.com/mozilla/bigquery-etl/pull/6215 (although it didn't start failing right away) because the dry run service account doesn't have the permissions to read from the information schema view ([doc](https://cloud.google.com/bigquery/docs/information-schema-column-field-paths)). [Example failure](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/39602/workflows/f5991ead-ad2c-4492-a983-396e43ea2d5c/jobs/451705)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4971)
