### PR TITLE
Give Census access to country codes table

### DIFF
--- a/sql/moz-fx-data-shared-prod/static/country_codes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/country_codes_v1/metadata.yaml
@@ -4,3 +4,7 @@ description: |
 
   Includes XK/XKK for Kosovo, which is not in the ISO 3166 standard, but is recognized
   by some governing bodies and is present in MaxMind's GeoIP2 database.
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataops-managed/external-census


### PR DESCRIPTION
## Description

This PR is to grant the table moz-fx-data-shared-prod.static.country_codes_v1 permission to be read by our Census data feed tool.


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-4976)
