### PR TITLE
Add distribution_id to feature_usage_events_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/metadata.yaml
@@ -1,6 +1,8 @@
 friendly_name: Feature Usage Events (Android - Fenix)
 description: |-
-  Metrics from events pings for mobile feature usage dashboards (Fenix)
+  Metrics from events pings for mobile feature usage dashboards (Fenix).
+  `distribution_id` was added as a dimension to this table beginning on
+  2024-10-08.
 owners:
 - rzhao@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/query.sql
@@ -339,7 +339,7 @@ event_ping_clients_feature_usage AS (
     COUNTIF(
       event_category = 'top_sites'
       AND event_name = 'contile_impression'
-    ) AS top_sites_contile_impression
+    ) AS top_sites_contile_impression,
   FROM
     `moz-fx-data-shared-prod.fenix.events_unnested`
   WHERE

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/query.sql
@@ -362,6 +362,7 @@ SELECT
   country,
   adjust_network,
   is_default_browser,
+  distribution_id,
 /*Logins*/
 --autofill_prompt_shown
   SUM(autofill_password_detected_logins) AS autofill_password_detected_logins,
@@ -948,7 +949,6 @@ SELECT
         THEN client_id
     END
   ) AS home_page_customize_home_clicked_users,
-  distribution_id,
 /*Sponsored Tiles*/
 --top_sites_contile_click
   SUM(top_sites_contile_click) AS top_sites_contile_click,

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/query.sql
@@ -331,7 +331,15 @@ event_ping_clients_feature_usage AS (
     COUNTIF(
       event_category = 'home_screen'
       AND event_name = 'customize_home_clicked'
-    ) AS home_page_customize_home_clicked
+    ) AS home_page_customize_home_clicked,
+    COUNTIF(
+      event_category = 'top_sites'
+      AND event_name = 'contile_click'
+    ) AS top_sites_contile_click,
+    COUNTIF(
+      event_category = 'top_sites'
+      AND event_name = 'contile_impression'
+    ) AS top_sites_contile_impression
   FROM
     `moz-fx-data-shared-prod.fenix.events_unnested`
   WHERE
@@ -940,7 +948,26 @@ SELECT
         THEN client_id
     END
   ) AS home_page_customize_home_clicked_users,
-  distribution_id
+  distribution_id,
+/*Sponsored Tiles*/
+--top_sites_contile_click
+  SUM(top_sites_contile_click) AS top_sites_contile_click,
+  COUNT(
+    DISTINCT
+    CASE
+      WHEN top_sites_contile_click > 0
+        THEN client_id
+    END
+  ) AS top_sites_contile_click_users,
+--top_sites_contile_impression
+  SUM(top_sites_contile_impression) AS top_sites_contile_impression,
+  COUNT(
+    DISTINCT
+    CASE
+      WHEN top_sites_contile_impression > 0
+        THEN client_id
+    END
+  ) AS top_sites_contile_impression_users,
 FROM
   event_ping_clients_feature_usage
 INNER JOIN

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/query.sql
@@ -30,7 +30,7 @@ client_attribution AS (
     client_id,
     channel,
     adjust_network,
-    distribution_id
+    distribution_id,
   FROM
     `moz-fx-data-shared-prod.fenix.firefox_android_clients`
 ),

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/query.sql
@@ -30,6 +30,7 @@ client_attribution AS (
     client_id,
     channel,
     adjust_network,
+    distribution_id
   FROM
     `moz-fx-data-shared-prod.fenix.firefox_android_clients`
 ),
@@ -938,7 +939,8 @@ SELECT
       WHEN home_page_customize_home_clicked > 0
         THEN client_id
     END
-  ) AS home_page_customize_home_clicked_users
+  ) AS home_page_customize_home_clicked_users,
+  distribution_id
 FROM
   event_ping_clients_feature_usage
 INNER JOIN
@@ -956,4 +958,5 @@ GROUP BY
   channel,
   country,
   adjust_network,
-  is_default_browser
+  is_default_browser,
+  distribution_id

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/schema.yaml
@@ -524,3 +524,15 @@ fields:
 - name: distribution_id
   type: STRING
   mode: NULLABLE
+- name: top_sites_contile_click
+  type: INTEGER
+  mode: NULLABLE
+- name: top_sites_contile_click_users
+  type: INTEGER
+  mode: NULLABLE
+- name: top_sites_contile_impression
+  type: INTEGER
+  mode: NULLABLE
+- name: top_sites_contile_impression_users
+  type: INTEGER
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/schema.yaml
@@ -521,3 +521,6 @@ fields:
 - name: home_page_customize_home_clicked_users
   type: INTEGER
   mode: NULLABLE
+- name: distribution_id
+  type: STRING
+  mode: NULLABLE


### PR DESCRIPTION
## Description

This PR adds the client distribution_id. This is necessary to count app push notification events and set to default events to support mobile distribution deals.

Adds engagement with the sponsored tiles feature.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5013)
