### PR TITLE
DSRE-1681 Create 2 new SUMO Google Analytics views in shared prod

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -183,6 +183,8 @@ dry_run:
   - sql/moz-fx-data-shared-prod/telemetry/client_probe_counts/view.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_etl_sql_run_check_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
+  - sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/view.sql
+  - sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/view.sql
   # Dataset sql/glam-fenix-dev:glam_etl was not found
   - sql/glam-fenix-dev/glam_etl/**/*.sql
   - sql/moz-fx-data-glam-prod-fca7/glam_etl/**/*.sql

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Analytics 314096102
 description: |-
-  Google Analytics Data
+  SUMO Prod Google Analytics Data
 owners:
   - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/metadata.yaml
@@ -1,6 +1,6 @@
-friendly_name: Analytics 314096102
+friendly_name: SUMO Prod Google Analytics Data (314096102)
 description: |-
-  SUMO Prod Google Analytics Data
+  SUMO Prod Google Analytics Data (Analytics 314096102)
 owners:
   - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/metadata.yaml
@@ -5,7 +5,3 @@ owners:
   - kwindau@mozilla.com
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:data-sumo/automation

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: Analytics 314096102
+description: |-
+  Google Analytics Data
+owners:
+  - kwindau@mozilla.com
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/metadata.yaml
@@ -5,3 +5,7 @@ owners:
   - kwindau@mozilla.com
 labels:
   authorized: true
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:data-sumo/automation

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/view.sql
@@ -1,6 +1,6 @@
-CREATE OR REPLACE VIEW 
-    `moz-fx-data-shared-prod.sumo_ga.analytics_314096102`
-AS 
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.sumo_ga.analytics_314096102`
+AS
 SELECT
   *
 FROM

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/view.sql
@@ -5,3 +5,5 @@ SELECT
   *
 FROM
   `moz-fx-data-marketing-prod.analytics_314096102.events_*`
+WHERE
+  _TABLE_SUFFIX >= '20240130' --first date with data available

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW 
+    `moz-fx-data-shared-prod.sumo_ga.analytics_314096102`
+AS 
+SELECT
+  *
+FROM
+  `moz-fx-data-marketing-prod.analytics_314096102.events_*`

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/metadata.yaml
@@ -5,7 +5,3 @@ owners:
   - kwindau@mozilla.com
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:data-sumo/automation

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: Analytics 432581103
+description: |-
+  Google Analytics Data
+owners:
+  - kwindau@mozilla.com
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Analytics 432581103
 description: |-
-  Google Analytics Data
+  SUMO Non-Prod Google Analytics Data
 owners:
   - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/metadata.yaml
@@ -1,6 +1,6 @@
-friendly_name: Analytics 432581103
+friendly_name: SUMO Non-Prod Google Analytics Data (432581103)
 description: |-
-  SUMO Non-Prod Google Analytics Data
+  SUMO Non-Prod Google Analytics Data (Analytics 432581103)
 owners:
   - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/metadata.yaml
@@ -5,3 +5,7 @@ owners:
   - kwindau@mozilla.com
 labels:
   authorized: true
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:data-sumo/automation

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/view.sql
@@ -5,3 +5,5 @@ SELECT
   *
 FROM
   `moz-fx-data-marketing-prod.analytics_432581103.events_*`
+WHERE
+  _TABLE_SUFFIX >= '20240503' --first date with data available

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/view.sql
@@ -1,7 +1,7 @@
-CREATE OR REPLACE VIEW 
-    `moz-fx-data-shared-prod.sumo_ga.analytics_432581103`
-AS 
-SELECT 
-  * 
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.sumo_ga.analytics_432581103`
+AS
+SELECT
+  *
 FROM
   `moz-fx-data-marketing-prod.analytics_432581103.events_*`

--- a/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW 
+    `moz-fx-data-shared-prod.sumo_ga.analytics_432581103`
+AS 
+SELECT 
+  * 
+FROM
+  `moz-fx-data-marketing-prod.analytics_432581103.events_*`


### PR DESCRIPTION
## Description

This PR creates 2 new views in the sumo_ga schema, that read from moz-fx-data-marketing-prod, since we no longer want to allow end users to query directly from moz-fx-data-marketing-prod.

## Related Tickets & Documents
* [DSRE-1681](https://mozilla-hub.atlassian.net/browse/DSRE-1681)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

[DSRE-1681]: https://mozilla-hub.atlassian.net/browse/DSRE-1681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5014)
