### PR TITLE
feat(Cloudflare): Switch to using GSM secrets instead of airflow vars

### DIFF
--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/metadata.yaml
@@ -11,7 +11,7 @@ scheduling:
   arguments: ["--date", "{{ds}}"]
   secrets:
   - deploy_target: CLOUDFLARE_AUTH_TOKEN
-    key: CLOUDFLARE_AUTH_TOKEN
+    key: bqetl_cloudflare_browser_market_share__cloudflare_auth_token
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/metadata.yaml
@@ -8,7 +8,10 @@ labels:
 scheduling:
   dag_name: bqetl_cloudflare_browser_market_share
   date_partition_parameter: dte
-  arguments: ["--date", "{{ds}}", "--cloudflare_api_token", "{{ var.value.cloudflare_auth_token}}"]
+  arguments: ["--date", "{{ds}}"]
+  secrets:
+  - deploy_target: CLOUDFLARE_AUTH_TOKEN
+    key: CLOUDFLARE_AUTH_TOKEN
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/query.py
@@ -1,6 +1,8 @@
 # Load libraries
 import json
+import os
 from datetime import datetime, timedelta
+
 import pandas as pd
 import requests
 from argparse import ArgumentParser
@@ -75,6 +77,8 @@ brwsr_usg_configs = {
     "errors_bq_stg_table": "moz-fx-data-shared-prod.cloudflare_derived.browser_errors_stg",
 }
 
+#Load the Cloudflare API Token
+cloudflare_api_token = os.getenv("CLOUDFLARE_AUTH_TOKEN")
 
 # Define a function to move a GCS object then delete the original
 def move_blob(bucket_name, blob_name, destination_bucket_name, destination_blob_name):
@@ -269,7 +273,7 @@ def main():
     """Call the API, save data to GCS, load to BQ staging, delete & load to BQ gold"""
     parser = ArgumentParser(description=__doc__)
     parser.add_argument("--date", required=True)
-    parser.add_argument("--cloudflare_api_token", required=True)
+    parser.add_argument("--cloudflare_api_token", default=cloudflare_api_token, required=True)
     parser.add_argument("--project", default=brwsr_usg_configs["gcp_project_id"])
     parser.add_argument("--dataset", default="cloudflare_derived")
 

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/query.py
@@ -273,7 +273,7 @@ def main():
     """Call the API, save data to GCS, load to BQ staging, delete & load to BQ gold"""
     parser = ArgumentParser(description=__doc__)
     parser.add_argument("--date", required=True)
-    parser.add_argument("--cloudflare_api_token", default=cloudflare_api_token, required=True)
+    parser.add_argument("--cloudflare_api_token", default=cloudflare_api_token)
     parser.add_argument("--project", default=brwsr_usg_configs["gcp_project_id"])
     parser.add_argument("--dataset", default="cloudflare_derived")
 

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/metadata.yaml
@@ -9,7 +9,10 @@ labels:
 scheduling:
   dag_name: bqetl_cloudflare_device_market_share
   date_partition_parameter: dte
-  arguments: ["--date", "{{ds}}", "--cloudflare_api_token", "{{ var.value.cloudflare_auth_token}}"]
+  arguments: ["--date", "{{ds}}"]
+  secrets:
+  - deploy_target: CLOUDFLARE_AUTH_TOKEN
+    key: CLOUDFLARE_AUTH_TOKEN
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/metadata.yaml
@@ -12,7 +12,7 @@ scheduling:
   arguments: ["--date", "{{ds}}"]
   secrets:
   - deploy_target: CLOUDFLARE_AUTH_TOKEN
-    key: CLOUDFLARE_AUTH_TOKEN
+    key: bqetl_cloudflare_device_market_share__cloudflare_auth_token
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/query.py
@@ -1,6 +1,8 @@
 # Load libraries
 import json
+import os
 from datetime import datetime, timedelta
+
 import pandas as pd
 import requests
 from argparse import ArgumentParser
@@ -62,6 +64,8 @@ device_usg_configs = {
     "errors_bq_stg_table": "moz-fx-data-shared-prod.cloudflare_derived.device_errors_stg",
 }
 
+#Load the Cloudflare API Token
+cloudflare_api_token = os.getenv("CLOUDFLARE_AUTH_TOKEN")
 
 # Define a function to move a GCS object then delete the original
 def move_blob(bucket_name, blob_name, destination_bucket_name, destination_blob_name):
@@ -285,7 +289,7 @@ def main():
     """Call the API, save data to GCS, load to BQ staging, delete & load to BQ gold"""
     parser = ArgumentParser(description=__doc__)
     parser.add_argument("--date", required=True)
-    parser.add_argument("--cloudflare_api_token", required=True)
+    parser.add_argument("--cloudflare_api_token", default=cloudflare_api_token, required=True)
     parser.add_argument("--project", default="moz-fx-data-shared-prod")
     parser.add_argument("--dataset", default="cloudflare_derived")
 

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/query.py
@@ -289,7 +289,7 @@ def main():
     """Call the API, save data to GCS, load to BQ staging, delete & load to BQ gold"""
     parser = ArgumentParser(description=__doc__)
     parser.add_argument("--date", required=True)
-    parser.add_argument("--cloudflare_api_token", default=cloudflare_api_token, required=True)
+    parser.add_argument("--cloudflare_api_token", default=cloudflare_api_token)
     parser.add_argument("--project", default="moz-fx-data-shared-prod")
     parser.add_argument("--dataset", default="cloudflare_derived")
 

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/metadata.yaml
@@ -12,7 +12,7 @@ scheduling:
   arguments: ["--date", "{{ds}}"]
   secrets:
   - deploy_target: CLOUDFLARE_AUTH_TOKEN
-    key: CLOUDFLARE_AUTH_TOKEN
+    key: bqetl_cloudflare_os_market_share__cloudflare_auth_token
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/metadata.yaml
@@ -9,7 +9,10 @@ labels:
 scheduling:
   dag_name: bqetl_cloudflare_os_market_share
   date_partition_parameter: dte
-  arguments: ["--date", "{{ds}}", "--cloudflare_api_token", "{{ var.value.cloudflare_auth_token}}"]
+  arguments: ["--date", "{{ds}}"]
+  secrets:
+  - deploy_target: CLOUDFLARE_AUTH_TOKEN
+    key: CLOUDFLARE_AUTH_TOKEN
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/query.py
@@ -1,6 +1,8 @@
 # Load libraries
 import json
+import os
 from datetime import datetime, timedelta
+
 import pandas as pd
 import requests
 from argparse import ArgumentParser
@@ -63,6 +65,8 @@ os_usg_configs = {
     "errors_bq_stg_table": "moz-fx-data-shared-prod.cloudflare_derived.os_errors_stg",
 }
 
+#Load the Cloudflare API Token
+cloudflare_api_token = os.getenv("CLOUDFLARE_AUTH_TOKEN")
 
 # Define a function to move a GCS object then delete the original
 def move_blob(bucket_name, blob_name, destination_bucket_name, destination_blob_name):
@@ -233,7 +237,7 @@ def main():
     """Call the API, save data to GCS, load to BQ staging, delete & load to BQ gold"""
     parser = ArgumentParser(description=__doc__)
     parser.add_argument("--date", required=True)
-    parser.add_argument("--cloudflare_api_token", required=True)
+    parser.add_argument("--cloudflare_api_token", default=cloudflare_api_token, required=True)
     parser.add_argument("--project", default="moz-fx-data-shared-prod")
     parser.add_argument("--dataset", default="cloudflare_derived")
 

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/query.py
@@ -237,7 +237,7 @@ def main():
     """Call the API, save data to GCS, load to BQ staging, delete & load to BQ gold"""
     parser = ArgumentParser(description=__doc__)
     parser.add_argument("--date", required=True)
-    parser.add_argument("--cloudflare_api_token", default=cloudflare_api_token, required=True)
+    parser.add_argument("--cloudflare_api_token", default=cloudflare_api_token)
     parser.add_argument("--project", default="moz-fx-data-shared-prod")
     parser.add_argument("--dataset", default="cloudflare_derived")
 


### PR DESCRIPTION
## Description

* This PR makes use of the new functionality in [PR-6241](https://github.com/mozilla/bigquery-etl/pull/6241/files) 
* It changes from using Airflow environment variables passed in via CLI parameters and now uses Cloudflare auth token pulled from GSM instead.


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5024)
