### PR TITLE
feat(DENG-4602): add BigEye RunMetricOperator to DAG generation

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -383,6 +383,7 @@ jobs:
                   source .venv/bin/activate
                   pip install -r requirements.txt
                   pip install -r requirements-dev.txt
+                  pip install -r requirements-override.txt
             - run:
                 name: 🧪 Test valid DAGs
                 command: |

--- a/bigquery_etl/query_scheduling/dag.py
+++ b/bigquery_etl/query_scheduling/dag.py
@@ -17,6 +17,8 @@ from bigquery_etl.query_scheduling.utils import (
     validate_timedelta_string,
 )
 
+from bigquery_etl.config import ConfigLoader
+
 AIRFLOW_DAG_TEMPLATE = "airflow_dag.j2"
 PUBLIC_DATA_JSON_DAG_TEMPLATE = "public_data_json_airflow_dag.j2"
 PUBLIC_DATA_JSON_DAG = "bqetl_public_data_json"
@@ -248,6 +250,12 @@ class Dag:
         dag_template = env.get_template(AIRFLOW_DAG_TEMPLATE)
         args = self.__dict__
         args["task_groups"] = self.task_groups
+        args["bigeye_warehouse_id"] = ConfigLoader.get(
+            "monitoring", "bigeye_warehouse_id", fallback=1817
+        )
+        args["bigeye_conn_id"] = ConfigLoader.get(
+            "monitoring", "bigeye_conn_id", fallback="bigeye_connection"
+        )
 
         return dag_template.render(args)
 

--- a/bigquery_etl/query_scheduling/dag.py
+++ b/bigquery_etl/query_scheduling/dag.py
@@ -6,6 +6,7 @@ import attr
 import cattrs
 from jinja2 import Environment, PackageLoader
 
+from bigquery_etl.config import ConfigLoader
 from bigquery_etl.query_scheduling import formatters
 from bigquery_etl.query_scheduling.task import Task, TaskRef
 from bigquery_etl.query_scheduling.utils import (
@@ -16,8 +17,6 @@ from bigquery_etl.query_scheduling.utils import (
     schedule_interval_delta,
     validate_timedelta_string,
 )
-
-from bigquery_etl.config import ConfigLoader
 
 AIRFLOW_DAG_TEMPLATE = "airflow_dag.j2"
 PUBLIC_DATA_JSON_DAG_TEMPLATE = "public_data_json_airflow_dag.j2"

--- a/bigquery_etl/query_scheduling/formatters.py
+++ b/bigquery_etl/query_scheduling/formatters.py
@@ -19,10 +19,16 @@ def format_schedule_interval(interval):
 def format_attr(d, attribute, formatter_name):
     """Apply a formatter to a dict attribute."""
     for name in dir(query_scheduling.formatters):
+        if name != formatter_name:
+            continue
+
         formatter_func = getattr(query_scheduling.formatters, name)
-        if callable(formatter_func) and name == formatter_name:
-            if attribute in d:
-                d[attribute] = formatter_func(d[attribute])
+
+        if callable(formatter_func) is None:
+            continue
+
+        if attribute in d:
+            d[attribute] = formatter_func(d[attribute])
 
     return d
 
@@ -31,6 +37,7 @@ def format_date(date_string):
     """Format a date string to a datetime object."""
     if date_string is None:
         return None
+
     return datetime.strptime(date_string, "%Y-%m-%d")
 
 

--- a/bigquery_etl/query_scheduling/generate_airflow_dags.py
+++ b/bigquery_etl/query_scheduling/generate_airflow_dags.py
@@ -18,6 +18,7 @@ SCRIPT_FILE = "script.sql"
 PYTHON_SCRIPT_FILE = "query.py"
 DEFAULT_DAGS_DIR = "dags"
 CHECKS_FILE = "checks.sql"
+BIGEYE_FILE = "bigconfig.yml"
 
 parser = ArgumentParser(description=__doc__)
 parser.add_argument(
@@ -93,6 +94,16 @@ def get_dags(project_id, dags_config, sql_dir=None):
                     logging.error(f"Error processing task for query {query_file}")
                     raise e
                 else:
+                    if BIGEYE_FILE in files:
+                        bigeye_file = os.path.join(root, BIGEYE_FILE)
+                        bigeye_task = copy.deepcopy(
+                            Task.of_bigeye_check(
+                                bigeye_file,
+                                dag_collection=dag_collection,
+                            )
+                        )
+                        tasks.append(bigeye_task)
+
                     if CHECKS_FILE in files:
                         checks_file = os.path.join(root, CHECKS_FILE)
                         # todo: validate checks file

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -12,6 +12,8 @@
     {% set ns.uses_secrets = True -%}
   {% endif -%}
 {% endfor -%}
+{% set bigeye_conn_id = "bigeye_connection" -%}
+{% set bigeye_warehouse_id = 1817 -%}
 
 from airflow import DAG
 {% if ns.uses_bq_sensors -%}
@@ -30,6 +32,7 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
+from bigeye_airflow.operators.run_metrics_operator import RunMetricsOperator
 
 {% if ns.uses_fivetran -%}
 from fivetran_provider_async.operators import FivetranOperator
@@ -270,6 +273,14 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             {%+ if task.gke_cluster_name != None -%}
             cluster_name={{ task.gke_cluster_name | format_repr }},
             {%+ endif -%}
+    {% elif task.is_bigeye_check -%}
+        {{ task.task_name }} = RunMetricsOperator(
+            task_id="{{ task.task_name }}",
+            connection_id="{{ bigeye_conn_id }}",
+            warehouse_id={{ bigeye_warehouse_id }},
+            schema_name="{{ task.project }}.{{ task.dataset }}",
+            table_name="{{ task.destination_table }}",
+            circuit_breaker_mode=False,
     {%+ else -%}
         {{ task.task_name }} = bigquery_etl_query(
             {% if name == "bqetl_default" -%}

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -12,8 +12,6 @@
     {% set ns.uses_secrets = True -%}
   {% endif -%}
 {% endfor -%}
-{% set bigeye_conn_id = "bigeye_connection" -%}
-{% set bigeye_warehouse_id = 1817 -%}
 
 from airflow import DAG
 {% if ns.uses_bq_sensors -%}
@@ -279,7 +277,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             connection_id="{{ bigeye_conn_id }}",
             warehouse_id={{ bigeye_warehouse_id }},
             schema_name="{{ task.project }}.{{ task.dataset }}",
-            table_name="{{ task.destination_table }}",
+            table_name="{{ task.table }}_{{ task.version }}",
             circuit_breaker_mode=False,
     {%+ else -%}
         {{ task.task_name }} = bigquery_etl_query(

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -17,6 +17,9 @@ default:
   - moz-fx-data-glam-prod-fca7
   public_project: mozilla-public-data
 
+monitoring:
+  bigeye_warehouse_id: 1817
+  bigeye_conn_id: bigeye_connection
 
 dry_run:
   function: https://us-central1-moz-fx-data-shared-prod.cloudfunctions.net/bigquery-etl-dryrun

--- a/tests/data/dags/python_script_test_dag
+++ b/tests/data/dags/python_script_test_dag
@@ -8,6 +8,7 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
+from bigeye_airflow.operators.run_metrics_operator import RunMetricsOperator
 
 docs = """
 ### bqetl_test_dag
@@ -48,6 +49,17 @@ with DAG(
 
     task_group_test_group = TaskGroup("test_group")
 
+    bigeye__test__python_script_query__v1 = RunMetricsOperator(
+        task_id="bigeye__test__python_script_query__v1",
+        connection_id="bigeye_connection",
+        warehouse_id=1817,
+        schema_name="moz-fx-data-test-project.test",
+        table_name="None",
+        circuit_breaker_mode=False,
+        retries=0,
+        task_group=task_group_test_group,
+    )
+
     test__python_script_query__v1 = GKEPodOperator(
         task_id="test__python_script_query__v1",
         arguments=[
@@ -60,3 +72,5 @@ with DAG(
         email=["test@example.com"],
         task_group=task_group_test_group,
     )
+
+    bigeye__test__python_script_query__v1.set_upstream(test__python_script_query__v1)

--- a/tests/data/dags/python_script_test_dag
+++ b/tests/data/dags/python_script_test_dag
@@ -54,7 +54,7 @@ with DAG(
         connection_id="bigeye_connection",
         warehouse_id=1817,
         schema_name="moz-fx-data-test-project.test",
-        table_name="None",
+        table_name="python_script_query_v1",
         circuit_breaker_mode=False,
         retries=0,
         task_group=task_group_test_group,

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -8,6 +8,7 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
+from bigeye_airflow.operators.run_metrics_operator import RunMetricsOperator
 
 from fivetran_provider_async.operators import FivetranOperator
 

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -1,3 +1,4 @@
+
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
@@ -8,6 +9,7 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
+from bigeye_airflow.operators.run_metrics_operator import RunMetricsOperator
 
 docs = """
 ### bqetl_test_dag

--- a/tests/data/dags/test_dag_external_check_dependency
+++ b/tests/data/dags/test_dag_external_check_dependency
@@ -8,6 +8,7 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
+from bigeye_airflow.operators.run_metrics_operator import RunMetricsOperator
 
 docs = """
 ### bqetl_external_test_dag

--- a/tests/data/dags/test_dag_external_dependency
+++ b/tests/data/dags/test_dag_external_dependency
@@ -8,6 +8,7 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
+from bigeye_airflow.operators.run_metrics_operator import RunMetricsOperator
 
 docs = """
 ### bqetl_external_test_dag

--- a/tests/data/dags/test_dag_with_bigquery_table_sensors
+++ b/tests/data/dags/test_dag_with_bigquery_table_sensors
@@ -12,6 +12,7 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
+from bigeye_airflow.operators.run_metrics_operator import RunMetricsOperator
 
 docs = """
 ### bqetl_test_dag

--- a/tests/data/dags/test_dag_with_check_dependencies
+++ b/tests/data/dags/test_dag_with_check_dependencies
@@ -8,6 +8,7 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
+from bigeye_airflow.operators.run_metrics_operator import RunMetricsOperator
 
 docs = """
 ### bqetl_test_dag

--- a/tests/data/dags/test_dag_with_check_table_dependencies
+++ b/tests/data/dags/test_dag_with_check_table_dependencies
@@ -8,6 +8,7 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
+from bigeye_airflow.operators.run_metrics_operator import RunMetricsOperator
 
 docs = """
 ### bqetl_test_dag

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -8,6 +8,7 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
+from bigeye_airflow.operators.run_metrics_operator import RunMetricsOperator
 
 docs = """
 ### bqetl_test_dag

--- a/tests/data/dags/test_dag_with_secrets
+++ b/tests/data/dags/test_dag_with_secrets
@@ -9,6 +9,7 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
+from bigeye_airflow.operators.run_metrics_operator import RunMetricsOperator
 
 docs = """
 ### bqetl_events

--- a/tests/data/test_sql/moz-fx-data-test-project/test/python_script_query_v1/bigconfig.yml
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/python_script_query_v1/bigconfig.yml
@@ -1,0 +1,20 @@
+---
+type: BIGCONFIG_FILE
+table_deployments:
+- collection:
+    name: Test
+  deployments:
+  - fq_table_name: moz-fx-data-test-project.test.python_script_query_v1
+    table_metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: FRESHNESS
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 17:00 UTC
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: VOLUME
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 17:00 UTC

--- a/tests/query_scheduling/test_dag_collection.py
+++ b/tests/query_scheduling/test_dag_collection.py
@@ -308,7 +308,10 @@ class TestDagCollection:
             },
         )
 
-        tasks = [Task.of_python_script(query_file, metadata)]
+        tasks = [
+            Task.of_python_script(query_file, metadata),
+            Task.of_bigeye_check(query_file, metadata),
+        ]
 
         default_args = {
             "depends_on_past": False,

--- a/tests/query_scheduling/test_generate_airflow_dags.py
+++ b/tests/query_scheduling/test_generate_airflow_dags.py
@@ -23,4 +23,4 @@ class TestGenerateAirflowDags(object):
         assert events_dag.tasks[1].depends_on_past is False
 
         core_dag = dags.dag_by_name("bqetl_core")
-        assert len(core_dag.tasks) == 3
+        assert len(core_dag.tasks) == 4


### PR DESCRIPTION
# feat(DENG-4602): add BigEye RunMetricOperator to DAG generation

## Description

Changes to add bigeye tasks to trigger BigEye Metric runs for a specific dataset if a corresponding `bigconfig.yml` exists in the datasets directory.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5031)
