### PR TITLE
Add partitioning and clustering for event_monitoring materialized views

### DIFF
--- a/sql_generators/glean_usage/templates/event_monitoring_live.view.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_live.view.sql
@@ -21,7 +21,7 @@ CREATE OR REPLACE VIEW
         FROM
           `{{ project_id }}.{{ dataset['bq_dataset_family'] }}_derived.event_monitoring_live_v1`
         WHERE
-          submission_date > DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+          DATE(submission_date) > DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
         UNION ALL
       {% endif %}
     {% endfor %}
@@ -42,4 +42,4 @@ SELECT
 FROM
   `{{ project_id }}.{{ target_table }}`
 WHERE
-  submission_date <= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+  DATE(submission_date) <= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)

--- a/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
@@ -1,15 +1,13 @@
 CREATE MATERIALIZED VIEW
 IF
   NOT EXISTS `{{ project_id }}.{{ derived_dataset }}.event_monitoring_live_v1`
-  PARTITION BY DATE(submission_date_timestamp)
-  CLUSTER BY channel, event_category
+  PARTITION BY DATE(submission_date)
+  CLUSTER BY channel, event_category, event_name
   OPTIONS
     (enable_refresh = TRUE, refresh_interval_minutes = 60) AS
-    {% if dataset_id not in ["telemetry"] %}
     SELECT
       -- used for partitioning, only allows TIMESTAMP columns
-      TIMESTAMP_TRUNC(submission_timestamp, DAY) AS submission_date_timestamp,
-      DATE(submission_timestamp) AS submission_date,
+      TIMESTAMP_TRUNC(submission_timestamp, DAY) AS submission_date,
       TIMESTAMP_ADD(
         TIMESTAMP_TRUNC(submission_timestamp, HOUR),
         -- Aggregates event counts over 60-minute intervals
@@ -83,11 +81,9 @@ IF
       UNNEST(GENERATE_ARRAY(0, ARRAY_LENGTH(ping_info.experiments))) AS experiment_index
     LEFT JOIN
       UNNEST(event.extra) AS event_extra
-    {% endif %}
     WHERE
       DATE(submission_timestamp) >= "{{ current_date }}"
     GROUP BY
-      submission_date_timestamp,
       submission_date,
       window_start,
       window_end,


### PR DESCRIPTION
## Description

Set partitioning and clustering for `event_monitoring` materialized views to improve refresh performance. Partitioning is recommended, especially when underlying tables have partition expiration set (which is the case for live tables): https://cloud.google.com/bigquery/docs/materialized-views-create#partitioned_materialized_views

## Related Tickets & Documents

https://mozilla.slack.com/archives/GE83ZMSAW/p1727875140069709

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5034)
