### PR TITLE
search_levers_daily initiate backfill

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/backfill.yaml
@@ -1,3 +1,12 @@
+2024-09-25:
+  start_date: 2023-07-14
+  end_date: 2024-10-01
+  reason: Add serp_events history
+  watchers:
+  - mbowerman@mozilla.com
+  - akommasani@mozilla.com
+  status: Initiate
+
 2024-09-04:
   start_date: 2018-01-01
   end_date: 2024-09-04

--- a/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/backfill.yaml
@@ -1,6 +1,6 @@
 2024-09-25:
   start_date: 2023-07-14
-  end_date: 2024-10-01
+  end_date: 2024-09-30
   reason: Add serp_events history
   watchers:
   - mbowerman@mozilla.com


### PR DESCRIPTION
Kicks off a backfill of `search_revenue_levers_daily_v1` to populate the `serp_events` fields with historical data.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5063)
