### PR TITLE
Add table to record GPU hours used

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_gpu_hours_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_gpu_hours_v1/metadata.yaml
@@ -1,0 +1,13 @@
+friendly_name: Outerbounds GPU Hours Spreadsheet
+description: >
+  The hours we use on Outerbounds GPU
+owners:
+  - ctroy@mozilla.com
+  - aplacitelli@mozilla.com
+  - aaggarwal@mozilla.com
+external_data:
+  format: google_sheets
+  source_uris:
+    - https://docs.google.com/spreadsheets/d/1j-tBTKOMlDxjbdEtn9EvH8KN99I5_jE5F0TSXvFuND4 # URL to the spreadsheet
+  options:
+    skip_leading_rows: 1 # number of rows that should be skipped, e.g if there are header rows

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_gpu_hours_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_gpu_hours_v1/schema.yaml
@@ -1,0 +1,38 @@
+fields:
+  - mode: NULLABLE
+    name: event_date
+    type: DATE
+  - mode: NULLABLE
+    name: nca_id
+    type: STRING
+  - mode: NULLABLE
+    name: org_name
+    type: STRING
+  - mode: NULLABLE
+    name: email_domain
+    type: STRING
+  - mode: NULLABLE
+    name: function_id
+    type: STRING
+  - mode: NULLABLE
+    name: gpu_type
+    type: STRING
+  - mode: NULLABLE
+    name: gpus
+    type: INTEGER
+  - mode: NULLABLE
+    name: backend
+    type: STRING
+  - mode: NULLABLE
+    name: gpu_hours
+    type: FLOAT64
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
## Description

In service of [this ticket](https://mozilla-hub.atlassian.net/browse/DENG-4871) to surface GPU usage hours on the MLOps cost dashboard, this PR adds a table to yoink data from [this google sheet provided by our vendor]() into Bigquery. I followed [this documentation](https://docs.telemetry.mozilla.org/cookbooks/operational/connecting_external_data_bigquery.html?highlight=spreadsh#connecting-sheets) to execute the task. 

**Confirming in writing** that I have asked the vendor to add the service account listed in the documentation as an editor to the spreadsheet.

## Related Tickets & Documents
* [DENG-4871](https://mozilla-hub.atlassian.net/browse/DENG-4871)
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**