### PR TITLE
Add related files to set Freshness and Volume on all glean tables

### DIFF
--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -15,7 +15,7 @@ from bigquery_etl.dryrun import DryRun
 from bigquery_etl.schema.stable_table_schema import get_stable_table_schemas
 from bigquery_etl.util.common import get_table_dir, render, write_sql
 
-APP_LISTINGS_URL = "https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings"
+APP_LISTINGS_URL =  "https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings"
 PATH = Path(os.path.dirname(__file__))
 
 # added as the result of baseline checks being added to the template,
@@ -227,6 +227,7 @@ class GleanTable:
         view_metadata_filename = f"{self.target_table_id[:-3]}.metadata.yaml"
         table_metadata_filename = f"{self.target_table_id}.metadata.yaml"
         schema_filename = f"{self.target_table_id}.schema.yaml"
+        bigconfig_filename = f"{self.target_table_id}.bigconfig.yml"
 
         table = tables[f"{self.prefix}_table"]
         view = tables[f"{self.prefix}_view"]
@@ -248,6 +249,7 @@ class GleanTable:
             app_name=app_name,
             has_distribution_id=app_name in APPS_WITH_DISTRIBUTION_ID,
             has_profile_group_id= app_name in APPS_WITH_PROFILE_GROUP_ID,
+            target_table=f"{self.target_table_id}",
         )
 
         render_kwargs.update(self.custom_render_kwargs)
@@ -291,6 +293,17 @@ class GleanTable:
             )
         except TemplateNotFound:
             schema = None
+        
+         # Bigconfig files are optional
+        try:
+            bigconfig = render(
+                bigconfig_filename,
+                format=False,
+                template_folder=PATH / "templates",
+                **render_kwargs,
+            )
+        except TemplateNotFound:
+            bigconfig = None
 
         # generated files to update
         Artifact = namedtuple("Artifact", "table_id basename sql")
@@ -319,6 +332,9 @@ class GleanTable:
 
             if schema:
                 artifacts.append(Artifact(table, "schema.yaml", schema))
+            
+            if bigconfig:
+                artifacts.append(Artifact(table, "bigconfig.yml", bigconfig))
 
             for artifact in artifacts:
                 destination = (

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.bigconfig.yml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.bigconfig.yml
@@ -1,0 +1,20 @@
+type: BIGCONFIG_FILE
+table_deployments:
+- collection:
+    name: Test
+  deployments:
+  - fq_table_name: {{ project_id }}.{{ derived_dataset }}.{{ target_table }}
+    table_metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: FRESHNESS
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 17:00 UTC
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: VOLUME
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 17:00 UTC
+

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
@@ -28,3 +28,6 @@ bigquery:
 schema:
   derived_from:
   - table: ['moz-fx-data-shared-prod', '{{ derived_dataset }}', 'baseline_clients_daily_v1']
+monitoring:
+  enabled: true
+


### PR DESCRIPTION
The PR add bigconfig yaml files to set Freshness and Volume on all glean tables.
Checks are configured to be run at `Default Schedule - 17:00 UTC`