### PR TITLE
Disable Bigeye monitoring for telemetry.releases

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/releases/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/releases/metadata.yaml
@@ -8,5 +8,5 @@ description: |-
 owners:
 - ascholtz@mozilla.com
 monitoring:
-  enabled: true
+  enabled: false
   partition_column: date


### PR DESCRIPTION
Turns out when deploying monitors to views in Bigeye `table_deployments` aren't supported. Instead we'll have to deploy a config similar to this:

```
type: BIGCONFIG_FILE

row_creation_times:
  column_selectors:
  - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry.releases.date

saved_metric_definitions:
  metrics:
  - saved_metric_id: FRESHNESS_DATA
    metric_type:
      type: PREDEFINED
      predefined_metric: FRESHNESS_DATA
    metric_name: Freshness (data)
    threshold:
      type: AUTO
      sensitivity: MEDIUM
      upper_bound_only: true
      lower_bound_only: false
    lookback:
      lookback_window:
        interval_type: DAYS
        interval_value: 2
      lookback_type: METRIC_TIME
      bucket_size: HOUR
    rct_overrides:
    - date
  - saved_metric_id: VOLUME_DATA
    metric_type:
      type: PREDEFINED
      predefined_metric: VOLUME_DATA
    metric_name: Volume (data)
    threshold:
      type: AUTO
      sensitivity: MEDIUM
      upper_bound_only: false
      lower_bound_only: true
    lookback:
      lookback_window:
        interval_type: DAYS
        interval_value: 2
      lookback_type: METRIC_TIME
      bucket_size: HOUR
    rct_overrides:
    - date

tag_deployments:
- collection:
    name: releases
    description: SDK Generated
  deployments:
  - column_selectors:
    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry.releases.*
    metrics:
    - saved_metric_id: FRESHNESS_DATA
    - saved_metric_id: VOLUME_DATA
```

Oddly enough, this was working fine last week...

Disabling monitoring for now to make Airflow happy. I'll look into this further tomorrow.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5308)
