### PR TITLE
Fix client id field in accounts_frontend events_stream shredder config

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -390,7 +390,7 @@ DELETE_TARGETS: DeleteIndex = {
     ): (FXA_SRC, FXA_FRONTEND_GLEAN_SRC),
     DeleteTarget(
         table="accounts_frontend_derived.events_stream_v1",
-        field=("metrics.string.account_user_id_sha256", GLEAN_CLIENT_ID),
+        field=("metrics.string.account_user_id_sha256", CLIENT_ID),
     ): (FXA_SRC, FXA_FRONTEND_GLEAN_SRC),
     # legacy mobile
     DeleteTarget(


### PR DESCRIPTION
## Description

client id field in events stream is at the top-level, not in  `client_info`.  This has been causing shredder to repeatedly crash but it wasn't noticed until now because this is the first full run that has been completed in the last couple of months due to bigquery issues in August

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5312)
