### PR TITLE
Update moz-fx-data-shared-prod.mozilla_org.desktop_conversion_events

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
@@ -21,9 +21,9 @@ WITH all_clicks_not_originating_in_europe AS (
 --where the click ID did not originate in Europe
 --and the click's first seen session date is more recent than 89 days ago
 SELECT
-  a.activity_datetime AS activity_date,
   a.gclid,
-  a.conversion_name
+  a.conversion_name,
+  MAX(a.activity_datetime) AS activity_date,
 FROM
   `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v1` a
 JOIN
@@ -32,3 +32,6 @@ JOIN
 WHERE
   a.activity_date >= DATE_SUB(CURRENT_DATE, INTERVAL 89 DAY)
   AND b.first_session_date >= DATE_SUB(current_date, INTERVAL 89 day)
+GROUP BY
+  a.gclid,
+  a.conversion_name

--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
@@ -35,4 +35,4 @@ GROUP BY
   a.gclid,
   a.conversion_name
 HAVING
-  MIN(a.activity_datetime) >= DATE_SUB(CURRENT_DATE, INTERVAL 89 DAY)
+  MIN(a.activity_date) >= DATE_SUB(CURRENT_DATE, INTERVAL 89 DAY)

--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
@@ -23,15 +23,16 @@ WITH all_clicks_not_originating_in_europe AS (
 SELECT
   a.gclid,
   a.conversion_name,
-  MAX(a.activity_datetime) AS activity_date,
+  MIN(a.activity_datetime) AS activity_date,
 FROM
   `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v1` a
 JOIN
   all_clicks_not_originating_in_europe b
   ON a.gclid = b.gclid
 WHERE
-  a.activity_date >= DATE_SUB(CURRENT_DATE, INTERVAL 89 DAY)
-  AND b.first_session_date >= DATE_SUB(current_date, INTERVAL 89 day)
+  b.first_session_date >= DATE_SUB(current_date, INTERVAL 89 day)
 GROUP BY
   a.gclid,
   a.conversion_name
+HAVING
+  MIN(a.activity_datetime) >= DATE_SUB(CURRENT_DATE, INTERVAL 89 DAY)


### PR DESCRIPTION
## Description

This change ensures we only send 1 row per google click ID and conversion event name, instead of multiple rows.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5318)
