### PR TITLE
Extend timeout for no output for private-generate-sql CI step

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -772,6 +772,7 @@ jobs:
                   rsync --archive ~/private-bigquery-etl/dags.yaml dags.yaml
             - run:
                 name: Generate SQL content
+                no_output_timeout: 30m
                 command: |
                   mkdir -p /tmp/workspace/private-generated-sql
 


### PR DESCRIPTION
## Description

We've hit the no-output timeout in the `private-generate-sql` CI step a few times in recent days. I don't like doing this, but I think this is necessary.

## Related Tickets & Documents

recent CI failure: https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/40085/workflows/33829912-f544-48de-a040-f84db3ef0d33/jobs/458121

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5429)
