### PR TITLE
feat: add bigconfig.yml to all mobile_kpi_metric tables only

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/__init__.py
+++ b/sql_generators/mobile_kpi_support_metrics/__init__.py
@@ -6,6 +6,7 @@ from dataclasses import asdict, dataclass, field
 from enum import Enum
 from os import path
 from pathlib import Path
+from typing import Any
 
 import click
 from jinja2 import Environment, FileSystemLoader
@@ -32,6 +33,7 @@ TEMPLATES = (
     ("AGGREGATE", "new_profiles.view.sql"),
     ("AGGREGATE", "new_profiles.query.sql"),
 )
+BIGEYE_COLLECTION = "Browser KPI Metrics"
 
 
 class AttributionPings(Enum):
@@ -48,7 +50,7 @@ class AttributionFieldGroup:
 
     name: str
     source_pings: list[AttributionPings]
-    fields: list[dict[str, str]]
+    fields: list[dict[str, Any]]
 
 
 class AttributionFields:
@@ -202,7 +204,7 @@ class Product:
         default_factory=list[AttributionFields.empty]  # type: ignore[valid-type]
     )
 
-    def get_product_attribution_fields(self) -> dict[str, dict[str, str]]:
+    def get_product_attribution_fields(self) -> dict[str, dict[str, Any]]:
         """Merge all AttributionFieldGroups assigned to a product into a single map containing all attribution fields set for that product."""
         return {
             field["name"]: field
@@ -299,12 +301,14 @@ def generate(target_project, output_dir, use_cloud_function):
         "header": HEADER,
         "version": VERSION,
         "project_id": target_project,
+        "bigeye_collection": BIGEYE_COLLECTION,
     }
 
     query_support_configs = (
         "checks.sql",
         "metadata.yaml",
         "schema.yaml",
+        "bigconfig.yml",
     )
 
     all_possible_attribution_fields = dict(

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.bigconfig.yml
@@ -1,0 +1,19 @@
+type: BIGCONFIG_FILE
+table_deployments:
+- collection:
+    name: {{ bigeye_collection }}
+  deployments:
+  - fq_table_name: {{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
+    table_metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: FRESHNESS
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 12:30 UTC
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: VOLUME
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 12:30 UTC

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.bigconfig.yml
@@ -10,10 +10,10 @@ table_deployments:
         predefined_metric: FRESHNESS
       metric_schedule:
         named_schedule:
-          name: Default Schedule - 12:30 UTC
+          name: Default Schedule - 13:00 UTC
     - metric_type:
         type: PREDEFINED
         predefined_metric: VOLUME
       metric_schedule:
         named_schedule:
-          name: Default Schedule - 12:30 UTC
+          name: Default Schedule - 13:00 UTC

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.metadata.yaml
@@ -17,3 +17,6 @@ bigquery:
     type: day
     field: submission_date
     require_partition_filter: false
+monitoring:
+  enabled: true
+  collection: {{ bigeye_collection }}

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.bigconfig.yml
@@ -1,0 +1,19 @@
+type: BIGCONFIG_FILE
+table_deployments:
+- collection:
+    name: {{ bigeye_collection }}
+  deployments:
+  - fq_table_name: {{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
+    table_metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: FRESHNESS
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 12:30 UTC
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: VOLUME
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 12:30 UTC

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.bigconfig.yml
@@ -10,10 +10,10 @@ table_deployments:
         predefined_metric: FRESHNESS
       metric_schedule:
         named_schedule:
-          name: Default Schedule - 12:30 UTC
+          name: Default Schedule - 13:00 UTC
     - metric_type:
         type: PREDEFINED
         predefined_metric: VOLUME
       metric_schedule:
         named_schedule:
-          name: Default Schedule - 12:30 UTC
+          name: Default Schedule - 13:00 UTC

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
@@ -22,3 +22,6 @@ bigquery:
       - app_name
       - country
       - first_seen_date
+monitoring:
+  enabled: true
+  collection: {{ bigeye_collection }}

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.bigconfig.yml
@@ -1,0 +1,19 @@
+type: BIGCONFIG_FILE
+table_deployments:
+- collection:
+    name: {{ bigeye_collection }}
+  deployments:
+  - fq_table_name: {{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
+    table_metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: FRESHNESS
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 12:30 UTC
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: VOLUME
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 12:30 UTC

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.bigconfig.yml
@@ -10,10 +10,10 @@ table_deployments:
         predefined_metric: FRESHNESS
       metric_schedule:
         named_schedule:
-          name: Default Schedule - 12:30 UTC
+          name: Default Schedule - 13:00 UTC
     - metric_type:
         type: PREDEFINED
         predefined_metric: VOLUME
       metric_schedule:
         named_schedule:
-          name: Default Schedule - 12:30 UTC
+          name: Default Schedule - 13:00 UTC

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.metadata.yaml
@@ -21,3 +21,6 @@ bigquery:
     fields:
       - normalized_channel
       - country
+monitoring:
+  enabled: true
+  collection: {{ bigeye_collection }}

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.bigconfig.yml
@@ -1,0 +1,19 @@
+type: BIGCONFIG_FILE
+table_deployments:
+- collection:
+    name: {{ bigeye_collection }}
+  deployments:
+  - fq_table_name: {{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
+    table_metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: FRESHNESS
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 12:30 UTC
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: VOLUME
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 12:30 UTC

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.bigconfig.yml
@@ -10,10 +10,10 @@ table_deployments:
         predefined_metric: FRESHNESS
       metric_schedule:
         named_schedule:
-          name: Default Schedule - 12:30 UTC
+          name: Default Schedule - 13:00 UTC
     - metric_type:
         type: PREDEFINED
         predefined_metric: VOLUME
       metric_schedule:
         named_schedule:
-          name: Default Schedule - 12:30 UTC
+          name: Default Schedule - 13:00 UTC

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
@@ -31,3 +31,6 @@ bigquery:
       - app_name
       - country
       - first_seen_date
+monitoring:
+  enabled: true
+  collection: {{ bigeye_collection }}


### PR DESCRIPTION
# feat: add bigconfig.yml to all mobile_kpi_metric tables only

## Description

This adds a bigeye config to all tables in the template to have freshness and volume checks.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5430)
