### PR TITLE
Fix PR checklist link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,4 +15,4 @@ configured to automatically insert hyperlinks for DSRE and DENG tickets.
 See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
 -->
 
-**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)**
+**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


### PR DESCRIPTION
This landed nearly a month ago so is a somewhat strong signal that most reviewers don't actually follow the checklist. I was looking at it because I'm about to review https://github.com/mozilla/bigquery-etl/pull/6330 which needs CI to run via the second item on the checklist.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/.github/reviewer_checklist.md)** <- fixed by this PR

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5433)
