### PR TITLE
Add more memory for private-generate-sql task

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -743,6 +743,7 @@ jobs:
             -d "{\"dagrun_note\": \"${DAGRUN_NOTE}\", \"dag_id\": \"bqetl_artifact_deployment\"}"
   private-generate-sql:
     docker: *docker
+    resource_class: large
     steps:
       - when:
           condition: *deploy


### PR DESCRIPTION
## Description

Bumps up the resource class size used for the `private-generate-sql` CI task that is currently failing running out of memory

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5476)
