### PR TITLE
adding referenced tables for upstream dependencies

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_to_gcs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_to_gcs_v1/metadata.yaml
@@ -17,8 +17,7 @@ scheduling:
   - --destination-bucket=merino-airflow-data-prodpy
   - --destination-prefix=newtab-merino-exports/engagement
   - --deletion-days-old=3
+  referenced_tables:
+    - ['moz-fx-data-shared-prod', 'telemetry_derived', 'newtab_merino_extract_v1']
 bigquery: null
-references:
-  query.sql:
-  - ..
-  - moz-fx-data-shared-prod.telemetry_derived.newtab_merino_extract_v1
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_to_gcs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_to_gcs_v1/metadata.yaml
@@ -18,8 +18,7 @@ scheduling:
   - --destination-bucket=merino-airflow-data-prodpy
   - --destination-prefix=newtab-merino-exports/priors
   - --deletion-days-old=3
+  referenced_tables:
+    - ['moz-fx-data-shared-prod', 'telemetry_derived', 'newtab_merino_priors_v1']
 bigquery: null
-references:
-  query.sql:
-  - ..
-  - moz-fx-data-shared-prod.telemetry_derived.newtab_merino_priors_v1
+references: {}


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR adds dependencies on tables for the Merino tasks that land files in GCS. Currently, the tasks aren't waiting for the tables to be created.

## Related Tickets & Documents
[MC-1458](https://mozilla-hub.atlassian.net/browse/MC-1458)
[MC-1256](https://mozilla-hub.atlassian.net/browse/MC-1256)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[MC-1458]: https://mozilla-hub.atlassian.net/browse/MC-1458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MC-1256]: https://mozilla-hub.atlassian.net/browse/MC-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5482)
