### PR TITLE
Create a backfill for 'moz-fx-data-shared-prod.fxci_der…

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci_derived/worker_costs_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/worker_costs_v1/backfill.yaml
@@ -1,0 +1,8 @@
+2024-10-15:
+  start_date: 2024-09-01
+  end_date: 2024-10-12
+  reason: Bug 1923976 - Data missing from base table due to derived job running too early
+  watchers:
+  - ahalberstadt@mozilla.com
+  status: Initiate
+  shredder_mitigation: false


### PR DESCRIPTION
…ived.worker_costs_v1' to populate missing records

## Description

There was an issue in the ETL where the DAG to populate this derived table was running too early, resulting in many cost records being missed from the billing table.

This backfill should repopulate the derived table with all records.

## Related Tickets & Documents
*  Bug 1923976

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5494)
