### PR TITLE
Deploy all BigConfig files at once

### DIFF
--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -115,14 +115,6 @@ def deploy(
                     sql_dir=sql_dir,
                     project_id=project_id,
                 )
-                mc.execute_bigconfig(
-                    input_path=[metadata_file.parent / BIGCONFIG_FILE],
-                    output_path=Path(sql_dir).parent if sql_dir else None,
-                    apply=True,
-                    recursive=False,
-                    strict_mode=True,
-                    auto_approve=True,
-                )
 
                 if (metadata_file.parent / VIEW_FILE).exists():
                     # monitoring to be deployed on a view
@@ -136,6 +128,20 @@ def deploy(
 
         except FileNotFoundError:
             print("No metadata file for: {}.{}.{}".format(project, dataset, table))
+
+    # Deploy BigConfig files at once.
+    # Deploying BigConfig files separately can lead to previously deployed metrics being removed.
+    mc.execute_bigconfig(
+        input_path=[
+            metadata_file.parent / BIGCONFIG_FILE
+            for metadata_file in list(set(metadata_files))
+        ],
+        output_path=Path(sql_dir).parent if sql_dir else None,
+        apply=True,
+        recursive=False,
+        strict_mode=True,
+        auto_approve=True,
+    )
 
 
 def _update_table_bigconfig(


### PR DESCRIPTION
## Description
This ensures that BigConfig files are deployed in a single API call. Somehow, deploying them separately will results in metrics that have been deployed separately being removed. 


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
