### PR TITLE
fix: add missing project id prefix in the bigconfig templates in the fq_table_name

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/__init__.py
+++ b/sql_generators/mobile_kpi_support_metrics/__init__.py
@@ -33,7 +33,7 @@ TEMPLATES = (
     ("AGGREGATE", "new_profiles.view.sql"),
     ("AGGREGATE", "new_profiles.query.sql"),
 )
-BIGEYE_COLLECTION = "Browser KPI Metrics"
+BIGEYE_COLLECTION = "Browser Metrics (non-KPI)"
 
 
 class AttributionPings(Enum):

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.bigconfig.yml
@@ -3,7 +3,7 @@ table_deployments:
 - collection:
     name: {{ bigeye_collection }}
   deployments:
-  - fq_table_name: {{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
+  - fq_table_name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
     table_metrics:
     - metric_type:
         type: PREDEFINED

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.bigconfig.yml
@@ -3,7 +3,7 @@ table_deployments:
 - collection:
     name: {{ bigeye_collection }}
   deployments:
-  - fq_table_name: {{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
+  - fq_table_name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
     table_metrics:
     - metric_type:
         type: PREDEFINED

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.bigconfig.yml
@@ -3,7 +3,7 @@ table_deployments:
 - collection:
     name: {{ bigeye_collection }}
   deployments:
-  - fq_table_name: {{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
+  - fq_table_name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
     table_metrics:
     - metric_type:
         type: PREDEFINED

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.bigconfig.yml
@@ -3,7 +3,7 @@ table_deployments:
 - collection:
     name: {{ bigeye_collection }}
   deployments:
-  - fq_table_name: {{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
+  - fq_table_name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
     table_metrics:
     - metric_type:
         type: PREDEFINED


### PR DESCRIPTION
# fix: add missing project id prefix in the bigconfig templates in the fq_table_name

## Description

This is a follow-up to: https://github.com/mozilla/bigquery-etl/pull/6337 where we forgot to include this prefix.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5499)
