### PR TITLE
Bug 1905938 Support events with no metrics in glean_usage generator

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -298,8 +298,6 @@ generate:
     - org_mozilla_ios_tiktok_reporter
     - org_mozilla_ios_tiktok_reporter_tiktok_reportershare
     - org_mozilla_tiktokreporter
-    - relay_backend  # see https://mozilla-hub.atlassian.net/browse/DENG-3720
-    - monitor_backend  # see https://bugzilla.mozilla.org/show_bug.cgi?id=1905444
     events_stream:
       skip_apps:
       - bergamot

--- a/sql_generators/glean_usage/event_error_monitoring.py
+++ b/sql_generators/glean_usage/event_error_monitoring.py
@@ -64,7 +64,7 @@ class EventErrorMonitoring(GleanTable):
             if app[0]["app_name"] not in skip_apps
             # errors are from metrics in glean-core/js; nothing to monitor for server apps
             and "glean-server" not in app[0]["dependencies"]
-            and "glean-server-metrics-compat" in app[0]["dependencies"]
+            and "glean-server-metrics-compat" not in app[0]["dependencies"]
         ]
 
         render_kwargs = dict(

--- a/sql_generators/glean_usage/event_error_monitoring.py
+++ b/sql_generators/glean_usage/event_error_monitoring.py
@@ -11,6 +11,7 @@ from sql_generators.glean_usage.common import (
     get_table_dir,
     render,
     write_sql,
+    ping_has_metrics,
 )
 
 AGGREGATE_TABLE_NAME = "event_error_monitoring_aggregates_v1"
@@ -45,15 +46,12 @@ class EventErrorMonitoring(GleanTable):
             and s.bq_table == "events_v1"
         ]
 
-        default_events_table = ConfigLoader.get(
+        default_event_table = ConfigLoader.get(
             "generate",
             "glean_usage",
             "events_monitoring",
             "default_event_table",
             fallback="events_v1",
-        )
-        events_table_overwrites = ConfigLoader.get(
-            "generate", "glean_usage", "events_monitoring", "event_table", fallback={}
         )
 
         # Skip any not-allowed app.
@@ -61,15 +59,26 @@ class EventErrorMonitoring(GleanTable):
             "generate", "glean_usage", "events_monitoring", "skip_apps", fallback=[]
         )
 
-        apps = [app for app in apps if app[0]["app_name"] not in skip_apps]
+        # error monitoring is based on metrics in glean-core; nothing to monitor for server apps
+        no_metric_apps = [
+            app[0]["app_name"]
+            for app in apps
+            if ping_has_metrics(app[0]["bq_dataset_family"], default_event_table)
+        ]
+
+        apps = [
+            app
+            for app in apps
+            if app[0]["app_name"] not in (skip_apps + no_metric_apps)
+        ]
 
         render_kwargs = dict(
             project_id=project_id,
             target_table=f"{TARGET_DATASET_CROSS_APP}_derived.{AGGREGATE_TABLE_NAME}",
             apps=apps,
             prod_datasets=prod_datasets_with_event,
-            default_events_table=default_events_table,
-            events_table_overwrites=events_table_overwrites,
+            default_events_table=default_event_table,
+            no_metric_apps=no_metric_apps,
         )
         render_kwargs.update(self.custom_render_kwargs)
 

--- a/sql_generators/glean_usage/events_stream.py
+++ b/sql_generators/glean_usage/events_stream.py
@@ -61,7 +61,7 @@ class EventsStreamTable(GleanTable):
         else:
             has_profile_group_id = False
 
-        unversioned_table_name = re.sub(r"_v[0-9]+", "", baseline_table.split(".")[-1])
+        unversioned_table_name = re.sub(r"_v[0-9]+$", "", baseline_table.split(".")[-1])
 
         self.custom_render_kwargs = {
             "has_profile_group_id": has_profile_group_id,

--- a/sql_generators/glean_usage/events_stream.py
+++ b/sql_generators/glean_usage/events_stream.py
@@ -3,7 +3,7 @@
 import re
 
 from bigquery_etl.config import ConfigLoader
-from sql_generators.glean_usage.common import GleanTable
+from sql_generators.glean_usage.common import GleanTable, ping_has_metrics
 
 TARGET_TABLE_ID = "events_stream_v1"
 PREFIX = "events_stream"
@@ -61,10 +61,13 @@ class EventsStreamTable(GleanTable):
         else:
             has_profile_group_id = False
 
+        unversioned_table_name = re.sub(r"_v[0-9]+", "", baseline_table.split(".")[-1])
+
         self.custom_render_kwargs = {
             "has_profile_group_id": has_profile_group_id,
             "has_legacy_telemetry_client_id": has_legacy_telemetry_client_id,
             "metrics_as_struct": metrics_as_struct,
+            "has_metrics": ping_has_metrics(app_id, unversioned_table_name),
         }
 
         super().generate_per_app_id(

--- a/sql_generators/glean_usage/events_unnested.py
+++ b/sql_generators/glean_usage/events_unnested.py
@@ -1,6 +1,6 @@
 """Generate unnested events queries for Glean apps."""
 
-from sql_generators.glean_usage.common import GleanTable
+from sql_generators.glean_usage.common import GleanTable, ping_has_metrics
 
 TARGET_TABLE_ID = "events_unnested_v1"
 PREFIX = "events_unnested"
@@ -34,4 +34,9 @@ class EventsUnnestedTable(GleanTable):
         """Generate the events_unnested table query per app_name."""
         target_dataset = app_info[0]["app_name"]
         if target_dataset not in DATASET_SKIP:
+            self.custom_render_kwargs = {
+                "has_metrics": ping_has_metrics(
+                    app_info[0]["bq_dataset_family"], "events"
+                )
+            }
             super().generate_per_app(project_id, app_info, output_dir, id_token=id_token)

--- a/sql_generators/glean_usage/templates/cross_channel_events_unnested.view.sql
+++ b/sql_generators/glean_usage/templates/cross_channel_events_unnested.view.sql
@@ -9,7 +9,7 @@ UNION ALL
 SELECT
   "{{ dataset }}" AS normalized_app_id,
   e.*
-  EXCEPT (events, metrics)
+  EXCEPT (events {% if has_metrics -%}, metrics{% endif -%})
   REPLACE(
     {% if app_name == "fenix" -%}
     mozfun.norm.fenix_app_info("{{ dataset }}", client_info.app_build).channel AS normalized_channel,

--- a/sql_generators/glean_usage/templates/cross_channel_events_unnested.view.sql
+++ b/sql_generators/glean_usage/templates/cross_channel_events_unnested.view.sql
@@ -9,7 +9,7 @@ UNION ALL
 SELECT
   "{{ dataset }}" AS normalized_app_id,
   e.*
-  EXCEPT (events {% if has_metrics -%}, metrics{% endif -%})
+  EXCEPT (events {%- if has_metrics %}, metrics{% endif %})
   REPLACE(
     {% if app_name == "fenix" -%}
     mozfun.norm.fenix_app_info("{{ dataset }}", client_info.app_build).channel AS normalized_channel,

--- a/sql_generators/glean_usage/templates/event_error_monitoring_aggregates_v1.query.sql
+++ b/sql_generators/glean_usage/templates/event_error_monitoring_aggregates_v1.query.sql
@@ -17,11 +17,7 @@
       client_info.app_channel AS channel,
       metrics.labeled_counter
     FROM
-      `{{ project_id }}.{{ dataset['bq_dataset_family'] }}_stable.{{
-        default_events_table
-        if dataset['bq_dataset_family'] not in events_table_overwrites
-        else events_table_overwrites[dataset['bq_dataset_family']]
-      }}`
+      `{{ project_id }}.{{ dataset['bq_dataset_family'] }}_stable.{{ default_events_table }}`
     WHERE
         DATE(submission_timestamp) = @submission_date
   )

--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -92,7 +92,7 @@ WITH base AS (
         ping_info.parsed_end_time,
         ping_info.ping_type
       ) AS ping_info
-      {% if not metrics_as_struct %}
+      {% if not metrics_as_struct and has_metrics %}
       ,
       metrics_to_json(TO_JSON(metrics)) AS metrics
       {% endif %}


### PR DESCRIPTION
## Description

This adds glean apps that have events with no metrics to glean usage (currently just relay_backend since monitor_backend now has metrics).  Metrics with events are determined using the mps generated schemas

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1905938

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5519)
