### PR TITLE
Bug 1923976 - Mark fxci worker_costs_v1 backfill complete

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci_derived/worker_costs_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/worker_costs_v1/backfill.yaml
@@ -4,5 +4,5 @@
   reason: Bug 1923976 - Data missing from base table due to derived job running too early
   watchers:
   - ahalberstadt@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false


### PR DESCRIPTION
## Description

I've verified that the data in the `backfills_staging_derived` table is exactly what I expect.

## Related Tickets & Documents
Bug 1923976

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5544)
