### PR TITLE
CLI command to automate some migration of ETL checks to Bigeye

### DIFF
--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -2,14 +2,15 @@
 
 import json
 import os
+import re
 import sys
+from collections import defaultdict
 from pathlib import Path
 from typing import Optional
-import re
-from collections import defaultdict
 
 import click
 from bigeye_sdk.authentication.api_authentication import APIKeyAuth
+from bigeye_sdk.bigconfig_validation.validation_context import _BIGEYE_YAML_FILE_IX
 from bigeye_sdk.client.datawatch_client import datawatch_client_factory
 from bigeye_sdk.client.enum import Method
 from bigeye_sdk.controller.metric_suite_controller import MetricSuiteController
@@ -23,14 +24,13 @@ from bigeye_sdk.model.big_config import (
 )
 from bigeye_sdk.model.protobuf_message_facade import (
     SimpleCollection,
+    SimpleConstantThreshold,
     SimpleMetricDefinition,
     SimpleMetricSchedule,
     SimpleNamedSchedule,
     SimplePredefinedMetric,
     SimplePredefinedMetricName,
-    SimpleConstantThreshold,
 )
-from bigeye_sdk.bigconfig_validation.validation_context import _BIGEYE_YAML_FILE_IX
 
 from bigquery_etl.config import ConfigLoader
 from bigquery_etl.metadata.parse_metadata import METADATA_FILE, Metadata
@@ -157,7 +157,6 @@ def _update_bigconfig(
     default_metrics,
 ):
     """Update the BigConfig file to monitor a view."""
-
     for collection in bigconfig.tag_deployments:
         for deployment in collection.deployments:
             for metric in deployment.metrics:

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/releases_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/releases_v1/bigconfig.yml
@@ -1,19 +1,20 @@
 type: BIGCONFIG_FILE
-table_deployments:
+tag_deployments:
 - collection:
     name: Test
   deployments:
-  - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.org_mozilla_fenix_derived.releases_v1
-    table_metrics:
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.org_mozilla_fenix_derived.releases_v1.*
+    metrics:
     - metric_type:
         type: PREDEFINED
         predefined_metric: FRESHNESS
       metric_schedule:
         named_schedule:
-          name: Default Schedule - 17:00 UTC
+          name: Default Schedule - 13:00 UTC
     - metric_type:
         type: PREDEFINED
         predefined_metric: VOLUME
       metric_schedule:
         named_schedule:
-          name: Default Schedule - 17:00 UTC
+          name: Default Schedule - 13:00 UTC

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_focus_derived/baseline_clients_last_seen_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_focus_derived/baseline_clients_last_seen_v1/bigconfig.yml
@@ -1,10 +1,9 @@
 type: BIGCONFIG_FILE
-table_deployments:
-- collection:
-    name: Test
-  deployments:
-  - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.org_mozilla_ios_focus_derived.baseline_clients_last_seen_v1
-    table_metrics:
+tag_deployments:
+- deployments:
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.org_mozilla_ios_focus_derived.baseline_clients_last_seen_v1.*
+    metrics:
     - metric_type:
         type: PREDEFINED
         predefined_metric: FRESHNESS

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/bigconfig.yml
@@ -1,0 +1,368 @@
+type: BIGCONFIG_FILE
+tag_deployments:
+- deployments:
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.submission_date
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: PERCENT_NOT_NULL
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_DUPLICATES
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: PERCENT_NOT_NULL
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_DUPLICATES
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_ROWS
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+- deployments:
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: FRESHNESS_DATA
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 13:00 UTC
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: VOLUME_DATA
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 13:00 UTC
+- deployments:
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.submission_date
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: PERCENT_NOT_NULL
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_DUPLICATES
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: PERCENT_NOT_NULL
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_DUPLICATES
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_ROWS
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+- deployments:
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.submission_date
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: PERCENT_NOT_NULL
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_DUPLICATES
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: PERCENT_NOT_NULL
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_DUPLICATES
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_ROWS
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+- deployments:
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.submission_date
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: PERCENT_NOT_NULL
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_DUPLICATES
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: PERCENT_NOT_NULL
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_DUPLICATES
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_ROWS
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+- deployments:
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.submission_date
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: PERCENT_NOT_NULL
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_DUPLICATES
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: PERCENT_NOT_NULL
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_DUPLICATES
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: COUNT_ROWS
+      threshold:
+        type: CONSTANT
+        lower_bound: 1.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: MIN
+      metric_name: Range
+      threshold:
+        type: CONSTANT
+        lower_bound: 0.0

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -3,19 +3,16 @@ description: |-
   Percentages of page loads Firefox users have performed that were
   conducted over SSL broken down by country.
 owners:
-- chutten@mozilla.com
+  - chutten@mozilla.com
 labels:
   application: firefox
   incremental: true
   public_json: true
   public_bigquery: true
   review_bugs:
-  - '1414839'
-  dag: bqetl_ssl_ratios
-  owner1: chutten
+    - 1414839
+  incremental_export: false
 scheduling:
   dag_name: bqetl_ssl_ratios
-bigquery: null
-references: {}
 monitoring:
   enabled: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -1,17 +1,21 @@
----
 friendly_name: SSL Ratios
 description: |-
   Percentages of page loads Firefox users have performed that were
   conducted over SSL broken down by country.
 owners:
-  - chutten@mozilla.com
+- chutten@mozilla.com
 labels:
   application: firefox
   incremental: true
   public_json: true
   public_bigquery: true
   review_bugs:
-    - 1414839
-  incremental_export: false
+  - '1414839'
+  dag: bqetl_ssl_ratios
+  owner1: chutten
 scheduling:
   dag_name: bqetl_ssl_ratios
+bigquery: null
+references: {}
+monitoring:
+  enabled: true


### PR DESCRIPTION
## Description

This adds a temporary CLI `bqetl monitoring migrate` command which will translate default ETL checks to BigConfig configurations. This is not 100% accurate and doesn't support custom SQL (as BigConfig doesn't support it). Migrated checks should still be checked manually for correctness. But this is at least a starting point and should cover a large portion of default ETL checks


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5548)
