### PR TITLE
chore: fix workgroup identifiers for google ads access

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/metadata.yaml
@@ -2,5 +2,5 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
-  - workgroup:external-ads-datafusion
-  - workgroup:external-ads-dataproc
+  - workgroup:google-managed/external-ads-datafusion
+  - workgroup:google-managed/external-ads-dataproc

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v1/metadata.yaml
@@ -28,5 +28,5 @@ workgroup_access:
   members:
   - workgroup:dataops-managed/external-census
   - workgroup:mozilla-confidential
-  - workgroup:external-ads-datafusion
-  - workgroup:external-ads-dataproc
+  - workgroup:google-managed/external-ads-datafusion
+  - workgroup:google-managed/external-ads-dataproc

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/metadata.yaml
@@ -29,5 +29,5 @@ workgroup_access:
   members:
   - workgroup:dataops-managed/external-census
   - workgroup:mozilla-confidential
-  - workgroup:external-ads-datafusion
-  - workgroup:external-ads-dataproc
+  - workgroup:google-managed/external-ads-datafusion
+  - workgroup:google-managed/external-ads-dataproc

--- a/sql/moz-fx-data-shared-prod/static/country_codes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/country_codes_v1/metadata.yaml
@@ -8,5 +8,5 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:dataops-managed/external-census
-  - workgroup:external-ads-datafusion
-  - workgroup:external-ads-dataproc
+  - workgroup:google-managed/external-ads-datafusion
+  - workgroup:google-managed/external-ads-dataproc


### PR DESCRIPTION
I didn't review https://github.com/mozilla/bigquery-etl/pull/6361/files very closely. The identifiers were correct on the datasets but not the tables, so I've disabled `update-modules` which applies table ACLs until this PR is merged to avoid spam in `#dataops-alerts`

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5549)
