### PR TITLE
DSRE-1774 fix workgroup names

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/metadata.yaml
@@ -2,5 +2,5 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
-  - workgroup:external-ads-datafusion
-  - workgroup:external-ads-dataproc
+  - workgroup:google-managed/external-ads-datafusion
+  - workgroup:google-managed/external-ads-dataproc

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v1/metadata.yaml
@@ -28,5 +28,5 @@ workgroup_access:
   members:
   - workgroup:dataops-managed/external-census
   - workgroup:mozilla-confidential
-  - workgroup:external-ads-datafusion
-  - workgroup:external-ads-dataproc
+  - workgroup:google-managed/external-ads-datafusion
+  - workgroup:google-managed/external-ads-dataproc

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/metadata.yaml
@@ -29,5 +29,5 @@ workgroup_access:
   members:
   - workgroup:dataops-managed/external-census
   - workgroup:mozilla-confidential
-  - workgroup:external-ads-datafusion
-  - workgroup:external-ads-dataproc
+  - workgroup:google-managed/external-ads-datafusion
+  - workgroup:google-managed/external-ads-dataproc

--- a/sql/moz-fx-data-shared-prod/static/country_codes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/country_codes_v1/metadata.yaml
@@ -8,5 +8,5 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:dataops-managed/external-census
-  - workgroup:external-ads-datafusion
-  - workgroup:external-ads-dataproc
+  - workgroup:google-managed/external-ads-datafusion
+  - workgroup:google-managed/external-ads-dataproc


### PR DESCRIPTION
## Description

This PR fixes the workgroup names that were incorrectly put in via [PR-6361](https://github.com/mozilla/bigquery-etl/pull/6361/files)

## Related Tickets & Documents
* [DSRE-1774](https://mozilla-hub.atlassian.net/browse/DSRE-1774)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DSRE-1774]: https://mozilla-hub.atlassian.net/browse/DSRE-1774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5563)
