### PR TITLE
Add missing last_modified_date to bigquery_tables_inventory

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_tables_inventory_v1/query.py
@@ -130,6 +130,7 @@ def create_query(date, source_project, tmp_table_name):
             dataset_id,
             table_id,
             table_type,
+            last_modified_date,
             owners,
             deprecated,
             deletion_date,


### PR DESCRIPTION
## Description

The column is all null since https://github.com/mozilla/bigquery-etl/pull/4179

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5597)
