### PR TITLE
Fix detected shredder sources for tables not in shredder config

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_v1/query.py
@@ -281,9 +281,9 @@ def get_missing_deletions(
                 "table_id": table,
                 "current_sources": [],
                 "detected_sources": [
-                    delete_source_to_dict(detected) for detected in detected_deletions
+                    delete_source_to_dict(detected) for detected in srcs
                 ],
-                "matching_sources": False,
+                "matching_sources": len(srcs) == 0,
             }
         )
 


### PR DESCRIPTION
## Description

Currently reading from the wrong delete source set so all the `detected_sources` here have the same wrong value

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
