### PR TITLE
Add shell completion script for bqetl

### DIFF
--- a/docs/bqetl.md
+++ b/docs/bqetl.md
@@ -50,3 +50,29 @@ $ ./bqetl [command] --help
 ```
 
 <!--- Documentation for comments is generated via ./bqetl docs generate -->
+
+## Autocomplete
+
+CLI autocomplete for `bqetl` can be enabled for bash and zsh shells using the `script/bqetl_complete` script:
+
+```sh
+source script/bqetl_complete
+```
+
+Then pressing tab after `bqetl` commands should print possible commands, e.g. for zsh:
+```sh
+% bqetl query<TAB><TAB>
+backfill       -- Run a backfill for a query.
+create         -- Create a new query with name...
+info           -- Get information about all or specific...
+initialize     -- Run a full backfill on the destination...
+render         -- Render a query Jinja template.
+run            -- Run a query.
+...
+```
+
+`source script/bqetl_complete` can also be added to `~/.bashrc` or `~/.zshrc` to persist settings
+across shell instances.
+
+For more details on shell completion, see the [click documentation](https://click.palletsprojects.com/en/8.1.x/shell-completion/).
+

--- a/script/.bqetl_complete.zsh
+++ b/script/.bqetl_complete.zsh
@@ -1,0 +1,32 @@
+# Created from output of _BQETL_COMPLETE=zsh_source bqetl
+
+_bqetl_completion_zsh() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[bqetl] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _BQETL_COMPLETE=zsh_complete bqetl)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}

--- a/script/bqetl_complete
+++ b/script/bqetl_complete
@@ -1,0 +1,47 @@
+# Created from output of _BQETL_COMPLETE=zsh_source bqetl and _BQETL_COMPLETE=bash_source bqetl
+
+#compdef bqetl
+
+_bqetl_completion_bash() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _BQETL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_bqetl_completion_setup() {
+    complete -F _bqetl_completion_bash bqetl
+}
+
+if [[ -n $BASH ]]; then
+    _bqetl_completion_setup;
+elif [[ -n $ZSH_NAME ]]; then
+    # zsh function moved to separate script because syntax is incompatible with bash
+    source "$(dirname $0)/.bqetl_complete.zsh"
+    if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+          # autoload from fpath, call function directly
+          _bqetl_completion_zsh "$@"
+    else
+          # eval/source/. command, register function for later
+          compdef _bqetl_completion_zsh bqetl
+    fi
+else
+    echo "Could not enable bqetl completion for unrecognized shell: $SHELL"
+fi
+


### PR DESCRIPTION
## Description

I often forget the exact command names while writing them so I think this would be useful. Based on these [click docs](https://click.palletsprojects.com/en/8.1.x/shell-completion/) combining the bash and zsh scripts into one.  This works for me on macos with bash and zsh but it's kind of slow (like `bqetl --help`) possibly due to all the imports in the cli files

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5622)
