### PR TITLE
Update new "desktop conversion events" view to be more compatible with Google Ads expected format

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
@@ -24,6 +24,7 @@ SELECT
   a.gclid,
   a.conversion_name,
   UNIX_SECONDS(CAST(MIN(a.activity_datetime) AS TIMESTAMP)) AS activity_date,
+  CAST(MIN(a.activity_datetime) AS TIMESTAMP) AS activity_date_ts
 FROM
   `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v1` a
 JOIN

--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
@@ -23,7 +23,7 @@ WITH all_clicks_not_originating_in_europe AS (
 SELECT
   a.gclid,
   a.conversion_name,
-  MIN(a.activity_datetime) AS activity_date,
+  UNIX_SECONDS(CAST(MIN(a.activity_datetime) AS TIMESTAMP)) AS activity_date,
 FROM
   `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v1` a
 JOIN

--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
@@ -24,7 +24,7 @@ SELECT
   a.gclid,
   a.conversion_name,
   UNIX_SECONDS(CAST(MIN(a.activity_datetime) AS TIMESTAMP)) AS activity_date,
-  CAST(MIN(a.activity_datetime) AS TIMESTAMP) AS activity_date_ts
+  CAST(MIN(a.activity_datetime) AS TIMESTAMP) AS activity_date_timestamp
 FROM
   `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v1` a
 JOIN


### PR DESCRIPTION
## Description

To better integrate with Google Ads, we made the "activity_date" column an integer in terms of unix seconds, and then added the new column "activity_date_ts" so we also have a more human readable column of the actual event timestamp.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5628)
