### PR TITLE
Prevent shredder sampling for null partition

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -557,7 +557,8 @@ def delete_from_table(
     for partition in list_partitions(
         client, table, partition_expr, end_date, max_single_dml_bytes, partition_limit
     ):
-        if use_sampling and not partition.is_special:  # no sampling for __NULL__ partition
+        # no sampling for __NULL__ partition
+        if use_sampling and not partition.is_special:
             kwargs["sampling_parallelism"] = sampling_parallelism
             delete_func: Callable = delete_from_partition_with_sampling
         else:

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -557,7 +557,7 @@ def delete_from_table(
     for partition in list_partitions(
         client, table, partition_expr, end_date, max_single_dml_bytes, partition_limit
     ):
-        if use_sampling and partition.id is not None:
+        if use_sampling and not partition.is_special:  # no sampling for __NULL__ partition
             kwargs["sampling_parallelism"] = sampling_parallelism
             delete_func: Callable = delete_from_partition_with_sampling
         else:
@@ -566,6 +566,7 @@ def delete_from_table(
                     "Cannot use sampling on full table deletion, "
                     f"{target.dataset_id}.{target.table_id} is too small to use sampling"
                 )
+            kwargs.pop("sampling_parallelism", None)
             delete_func = delete_from_partition
 
         yield Task(


### PR DESCRIPTION
## Description

`partition.id` is actually `"__NULL__"` and not `None` so it's sampling on the null partition and then eventually failing on the final copy.  This didn't fail last run because the null partition was already processed before this change was introduced.  Failing now because the `with-sampling` task has reached the end

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5631)
