### PR TITLE
Create query and script for alerts for missing shredder targets

### DIFF
--- a/bigquery_etl/cli/dag.py
+++ b/bigquery_etl/cli/dag.py
@@ -243,7 +243,7 @@ def generate(name, dags_config, sql_dir, output_dir):
             sys.exit(1)
 
         dags.to_airflow_dags(output_dir, dag_to_generate=dag)
-        click.echo(f"Generated {output_dir}{dag.name}.py")
+        click.echo(f"Generated {os.path.join(output_dir, dag.name)}.py")
     else:
         # re-generate all DAGs
         dags.to_airflow_dags(output_dir)

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_alert_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_alert_v1/metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: Shredder Targets Alert
+description: |-
+  Fails when there is a new table that may have a missing or incorrect shredder configuration based
+  on moz-fx-data-shared-prod.monitoring_derived.shredder_targets_new_mismatched_v1.
+  Does not write to a destination table.
+owners:
+  - bewu@mozilla.com
+labels:
+  owner1: benwu
+scheduling:
+  dag_name: bqetl_shredder_monitoring
+  arguments: ["--run-date", "{{ ds }}"]
+  referenced_tables:
+    - ['moz-fx-data-shared-prod', 'monitoring_derived', 'shredder_targets_new_mismatched_v1']

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_alert_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_alert_v1/query.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+"""Raise exception when there are potential new targets to add to shredder."""
+from textwrap import dedent
+
+import click
+from google.cloud import bigquery
+from google.cloud.bigquery import TableReference
+from typing import Dict, List
+
+NEW_TARGETS_QUERY_TEMPLATE = """
+SELECT
+    *
+FROM
+    `{source_table}`
+WHERE
+    run_date = '{run_date}'
+"""
+
+
+def format_sources(sources: List[Dict[str, str]]) -> List[str]:
+    return [f"{source['table']}: {source['field']}" for source in sources]
+
+
+@click.command
+@click.option(
+    "--run-date", type=click.DateTime(), help="The date to to check for new targets."
+)
+@click.option(
+    "--source-table",
+    type=TableReference.from_string,
+    metavar="PROJECT.DATASET.TABLE",
+    default="moz-fx-data-shared-prod.monitoring_derived.shredder_targets_new_mismatched_v1",
+    help="Table to get new shredder targets from, in the form of PROJECT.DATASET.TABLE. "
+    "Defaults to "
+    "`moz-fx-data-shared-prod.monitoring_derived.shredder_targets_new_mismatched_v1`",
+)
+def main(run_date, source_table):
+    """Find tables in the given project that could be added to shredder."""
+    client = bigquery.Client()
+
+    mismatched_tables = list(
+        client.query_and_wait(
+            NEW_TARGETS_QUERY_TEMPLATE.format(
+                source_table=source_table, run_date=run_date.date()
+            )
+        )
+    )
+
+    table_names = []
+
+    for table in mismatched_tables:
+        table_name = f"{table.project_id}.{table.dataset_id}.{table.table_id}"
+        table_names.append(table_name)
+        print(
+            dedent(
+                f"""
+                {table.project_id}.{table.dataset_id}.{table.table_id}: 
+                created on {table.table_creation_date}, owners: {table.owners}
+                current deletion sources:          {format_sources(table.current_sources)}
+                deletion sources based on lineage: {format_sources(table.detected_sources)}
+                """
+            )
+        )
+
+    if len(table_names) > 0:
+        raise RuntimeError(
+            dedent(
+                f"""
+                Found {len(table_names)} new tables that may not be configured correctly in shredder: {table_names}
+                Verify with table owners if these tables need to be configured in shredder.
+                See logs or {source_table} with run_date="{run_date.date()}" for more details.
+                """
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_new_mismatched_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_new_mismatched_v1/metadata.yaml
@@ -1,0 +1,17 @@
+friendly_name: Shredder New Mismatched Targets
+description: |-
+  Daily list of new shredder deletion targets that don't have configured deletion sources
+  or have deletion sources that do not match the sources based on lineage.
+owners:
+  - bewu@mozilla.com
+labels:
+  incremental: true
+  owner1: benwu
+  schedule: daily
+scheduling:
+  dag_name: bqetl_shredder_monitoring
+bigquery:
+  time_partitioning:
+    type: day
+    field: run_date
+    require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_new_mismatched_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_new_mismatched_v1/query.sql
@@ -1,0 +1,29 @@
+WITH unmatching_sources AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.monitoring_derived.shredder_targets_joined_v1`
+  WHERE
+    matching_sources IS FALSE
+    OR ARRAY_LENGTH(current_sources) = 0
+),
+previous_config AS (
+  SELECT
+    project_id,
+    dataset_id,
+    table_id,
+  FROM
+    unmatching_sources
+  WHERE
+    run_date = DATE_SUB(@submission_date, INTERVAL 1 DAY)
+)
+SELECT
+  unmatching_sources.*,
+FROM
+  unmatching_sources
+LEFT JOIN
+  previous_config
+  USING (project_id, dataset_id, table_id)
+WHERE
+  run_date = @submission_date
+  AND previous_config.table_id IS NULL

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_new_mismatched_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_new_mismatched_v1/schema.yaml
@@ -1,0 +1,60 @@
+fields:
+- name: run_date
+  type: DATE
+  mode: NULLABLE
+- name: project_id
+  type: STRING
+  mode: NULLABLE
+- name: dataset_id
+  type: STRING
+  mode: NULLABLE
+- name: table_id
+  type: STRING
+  mode: NULLABLE
+- name: current_sources
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: table
+    type: STRING
+    mode: NULLABLE
+  - name: field
+    type: STRING
+    mode: NULLABLE
+  - name: project
+    type: STRING
+    mode: NULLABLE
+- name: detected_sources
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: table
+    type: STRING
+    mode: NULLABLE
+  - name: field
+    type: STRING
+    mode: NULLABLE
+  - name: project
+    type: STRING
+    mode: NULLABLE
+- name: matching_sources
+  type: BOOLEAN
+  mode: NULLABLE
+- name: owners
+  type: STRING
+  mode: REPEATED
+- name: query_count_last_30d
+  type: INTEGER
+  mode: NULLABLE
+- name: write_count_last_30d
+  type: INTEGER
+  mode: NULLABLE
+- name: table_size_tib
+  type: FLOAT
+  mode: NULLABLE
+- name: table_creation_date
+  type: DATE
+  mode: NULLABLE
+- name: deprecated
+  type: BOOLEAN
+  mode: NULLABLE


### PR DESCRIPTION
## Description

Script that fails when there are new potentially misconfigured tables in `monitoring_derived.shredder_targets_v1` compared to the previous day.  The plan is to have these fail in airflow so they can be triaged but I'm not sure if this is going to be noisy so dag is still tagged with `no_triage`

example output:
```
moz-fx-data-shared-prod.mozilla_vpn_derived.events_daily_v1: 
created on 2021-10-13, owners: ['wlachance', 'akomar']
current deletion sources:          ['org_mozilla_firefox_vpn_stable.deletion_request_v1: client_info.client_id', 'org_mozilla_ios_firefoxvpn_stable.deletion_request_v1: client_info.client_id', 'mozillavpn_stable.deletion_request_v1: client_info.client_id', 'org_mozilla_ios_firefoxvpn_network_extension_stable.deletion_request_v1: client_info.client_id']
deletion sources based on lineage: ['org_mozilla_firefox_vpn_stable.deletion_request_v1: client_info.client_id', 'org_mozilla_ios_firefoxvpn_stable.deletion_request_v1: client_info.client_id', 'mozillavpn_stable.deletion_request_v1: client_info.client_id', 'org_mozilla_ios_firefoxvpn_network_extension_stable.deletion_request_v1: client_info.client_id', 'field: moz-fx-data-shared-prod']

Traceback (most recent call last):
    ...
    raise RuntimeError(
RuntimeError: 
Found 1 new tables that may not be configured correctly in shredder: ['moz-fx-data-shared-prod.mozilla_vpn_derived.events_daily_v1']
Verify with table owners if these tables need to be configured in shredder.
See logs or moz-fx-data-shared-prod.monitoring_derived.shredder_targets_new_mismatched_v1 with run_date="2024-10-21" for more details.
```

## Related Tickets & Documents
* DENG-4256

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**