### PR TITLE
chore(monitoring): fix schema errors notes URI

### DIFF
--- a/sql/moz-fx-data-shared-prod/static/monitoring_schema_errors_notes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/monitoring_schema_errors_notes_v1/metadata.yaml
@@ -10,6 +10,6 @@ labels:
 external_data:
   format: google_sheets
   source_uris:
-    - https://docs.google.com/spreadsheets/d/1wMKyIyzp8yW7YpNz6hpFe0sHueeeLHdHr3p-1br2TbA]
+    - https://docs.google.com/spreadsheets/d/1wMKyIyzp8yW7YpNz6hpFe0sHueeeLHdHr3p-1br2TbA
   options:
     skip_leading_rows: 2


### PR DESCRIPTION
## Description

I'm not sure why this is working currently, but I noticed in https://github.com/mozilla-services/cloudops-infra/pull/6012 that the plan included what looks like this bogus value. Other references to the same spreadsheet don't have the trailing `]`.

```
static/monitoring_schema_errors_notes_v1/metadata.yaml:13:    - https://docs.google.com/spreadsheets/d/1wMKyIyzp8yW7YpNz6hpFe0sHueeeLHdHr3p-1br2TbA]
static/monitoring_missing_document_namespaces_notes_v1/metadata.yaml:13:    - https://docs.google.com/spreadsheets/d/1wMKyIyzp8yW7YpNz6hpFe0sHueeeLHdHr3p-1br2TbA
static/monitoring_missing_columns_notes_v1/metadata.yaml:13:    - https://docs.google.com/spreadsheets/d/1wMKyIyzp8yW7YpNz6hpFe0sHueeeLHdHr3p-1br2TbA
static/monitoring_distinct_docids_notes_v1/metadata.yaml:13:    - https://docs.google.com/spreadsheets/d/1wMKyIyzp8yW7YpNz6hpFe0sHueeeLHdHr3p-1br2TbA
```

## Related Tickets & Documents
* DSRE-1780


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**