### PR TITLE
DENG-4768 update schemas to include 3 new columns

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/pageload_1pct_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/pageload_1pct_v1/schema.yaml
@@ -301,3 +301,12 @@ fields:
 - name: submission_timestamp
   type: TIMESTAMP
   mode: NULLABLE
+- name: app_version_major
+  type: NUMERIC
+  mode: NULLABLE
+- name: app_version_minor
+  type: NUMERIC
+  mode: NULLABLE
+- name: app_version_patch
+  type: NUMERIC
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/pageload_1pct_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/pageload_1pct_v1/schema.yaml
@@ -304,9 +304,12 @@ fields:
 - name: app_version_major
   type: NUMERIC
   mode: NULLABLE
+  description: The major version parsed from client_info.app_display_version, for example, 130.0.3 would return 130
 - name: app_version_minor
   type: NUMERIC
   mode: NULLABLE
+  description: The minor version parsed from client_info.app_display_version, for example, 130.0.3 would return 0
 - name: app_version_patch
   type: NUMERIC
   mode: NULLABLE
+  description: The patch number parsed from client_info.app_display_version, for example, 130.0.3 would return 3.

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/pageload_nightly_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/pageload_nightly_v1/schema.yaml
@@ -301,3 +301,12 @@ fields:
 - name: submission_timestamp
   type: TIMESTAMP
   mode: NULLABLE
+- name: app_version_major
+  type: NUMERIC
+  mode: NULLABLE
+- name: app_version_minor
+  type: NUMERIC
+  mode: NULLABLE
+- name: app_version_patch
+  type: NUMERIC
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/pageload_nightly_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/pageload_nightly_v1/schema.yaml
@@ -304,9 +304,12 @@ fields:
 - name: app_version_major
   type: NUMERIC
   mode: NULLABLE
+  description: The major version parsed from client_info.app_display_version, for example, 130.0.3 would return 130
 - name: app_version_minor
   type: NUMERIC
   mode: NULLABLE
+  description: The minor version parsed from client_info.app_display_version, for example, 130.0.3 would return 0
 - name: app_version_patch
   type: NUMERIC
   mode: NULLABLE
+  description: The patch number parsed from client_info.app_display_version, for example, 130.0.3 would return 3.


### PR DESCRIPTION
## Description

This PR is a follow-up to [PR-6390](https://github.com/mozilla/bigquery-etl/pull/6390), it updates the schema of 2 downstream tables that now pull in the 3 columns added to the Glean stable views.

## Related Tickets & Documents
* [DENG-4678](https://mozilla-hub.atlassian.net/browse/DENG-4768)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5688)
