### PR TITLE
Add date partitioning to experiment_search_events materialized views

### DIFF
--- a/sql_generators/experiment_monitoring/templates/experiment_search_events_live_v1/materialized_view.sql
+++ b/sql_generators/experiment_monitoring/templates/experiment_search_events_live_v1/materialized_view.sql
@@ -2,10 +2,12 @@
 CREATE MATERIALIZED VIEW
 IF
   NOT EXISTS `moz-fx-data-shared-prod.{{ dataset }}_derived.{{ destination_table }}`
+  PARTITION BY DATE(partition_date)
   OPTIONS
     (enable_refresh = TRUE, refresh_interval_minutes = 5)
   AS
   SELECT
+    TIMESTAMP_TRUNC(submission_timestamp, DAY) AS partition_date,
     DATE(submission_timestamp) AS submission_date,
     experiment.key AS experiment,
     experiment.value.branch AS branch,
@@ -108,6 +110,7 @@ IF
     -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
     DATE(submission_timestamp) > '{{ start_date }}'
   GROUP BY
+    partition_date,
     submission_date,
     experiment,
     branch,


### PR DESCRIPTION
## Description
https://github.com/mozilla/bigquery-etl/pull/6286 seems to be doing something positive for `firefox_desktop_derived.event_monitoring_live_v1`:
![image](https://github.com/user-attachments/assets/23351a90-aa23-47a4-bf69-583441a55530)

Although it takes 30 days for slot time to actually blow up:
![image](https://github.com/user-attachments/assets/e0ba51d7-9304-4a40-aeb3-3fedeaba8021)

from

```sql
SELECT
  creation_time,
  project_id,
  job_id,
  total_bytes_processed / 1024 / 1024 / 1024 / 1024 AS tib_processed,
  total_slot_ms / 1000 / 60 / 60 AS slot_hours,
FROM
  `moz-fx-data-shared-prod.region-us.INFORMATION_SCHEMA.JOBS`
WHERE
  creation_time > '2024-08-01'
  AND query = "CALL BQ.REFRESH_MATERIALIZED_VIEW('moz-fx-data-shared-prod.firefox_desktop_derived.event_monitoring_live_v1')"
```

I noticed the materialized views are doing one expensive query per day, usually a little after midnight UTC possibly coinciding with the live partition being dropped. `telemetry_derived.experiment_search_events_live_v1` in particular is very expensive so I want to see if partitioning would fix it and it should only take a day to find out because the view reads all of the live table.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5703)
