### PR TITLE
Parallelize metadata publish

### DIFF
--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -1,6 +1,8 @@
 """bigquery-etl CLI metadata command."""
 
 from datetime import datetime
+from functools import partial
+from multiprocessing.pool import Pool
 from pathlib import Path
 from typing import Optional
 
@@ -11,8 +13,14 @@ from google.cloud import bigquery
 from bigquery_etl.metadata.parse_metadata import DatasetMetadata, Metadata
 from bigquery_etl.metadata.publish_metadata import publish_metadata
 
-from ..cli.utils import paths_matching_name_pattern, project_id_option, sql_dir_option
+from ..cli.utils import (
+    parallelism_option,
+    paths_matching_name_pattern,
+    project_id_option,
+    sql_dir_option,
+)
 from ..config import ConfigLoader
+from ..dryrun import get_credentials
 from ..util import extract_from_query_path
 
 
@@ -111,23 +119,41 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
     ConfigLoader.get("default", "project", fallback="moz-fx-data-shared-prod")
 )
 @sql_dir_option
-def publish(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None:
+@parallelism_option()
+def publish(
+    name: str, sql_dir: Optional[str], project_id: Optional[str], parallelism: int
+) -> None:
     """Publish Bigquery metadata."""
-    client = bigquery.Client(project_id)
-
     table_metadata_files = paths_matching_name_pattern(
         name, sql_dir, project_id=project_id, files=["metadata.yaml"]
     )
 
-    for metadata_file in table_metadata_files:
-        project, dataset, table = extract_from_query_path(metadata_file)
-        try:
-            metadata = Metadata.from_file(metadata_file)
-            publish_metadata(client, project, dataset, table, metadata)
-        except FileNotFoundError:
-            print("No metadata file for: {}.{}.{}".format(project, dataset, table))
+    if parallelism > 0:
+        credentials = get_credentials()
 
-    return None
+        with Pool(parallelism) as pool:
+            pool.map(
+                partial(_publish_metadata, project_id, credentials),
+                table_metadata_files,
+            )
+    else:
+        for metadata_file in table_metadata_files:
+            _publish_metadata(project_id, credentials=None, metadata_file=metadata_file)
+
+
+def _publish_metadata(project_id, credentials, metadata_file):
+    project, dataset, table = extract_from_query_path(metadata_file)
+    try:
+        metadata = Metadata.from_file(metadata_file)
+        publish_metadata(
+            bigquery.Client(project=project_id, credentials=credentials),
+            project,
+            dataset,
+            table,
+            metadata,
+        )
+    except FileNotFoundError:
+        print("No metadata file for: {}.{}.{}".format(project, dataset, table))
 
 
 @metadata.command(

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -264,14 +264,23 @@ class TestMetadata:
     @patch("google.cloud.bigquery.Table")
     def test_metadata_publish(self, mock_bigquery_table, mock_bigquery_client, runner):
         mock_bigquery_client().get_table.return_value = mock_bigquery_table()
+        from distutils import log
+
+        log.set_verbosity(log.WARN)
+        log.set_threshold(log.WARN)
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             distutils.dir_util.copy_tree(str(TEST_DIR), str(tmpdirname))
-            name = [
+            name = (
                 str(tmpdirname)
                 + "/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/"
-            ]
-            runner.invoke(publish, name, "--sql_dir=" + str(tmpdirname) + "/sql")
+            )
+
+            runner.invoke(
+                publish,
+                [name, "--parallelism=0", "--sql_dir=" + str(tmpdirname) + "/sql"],
+                catch_exceptions=False,
+            )
 
         assert mock_bigquery_client().update_table.call_count == 1
         assert (


### PR DESCRIPTION
## Description

This runs the metadata for multiple artifacts in parallel. Locally I got a significant speed up. Publishing metadata for shared-prod only takes around a minute now (though that is without generated SQL content, down from 5 minutes).


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5832)
