### PR TITLE
Skip list for schema deploys

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -2215,6 +2215,8 @@ def deploy(
         future_to_query = {
             executor.submit(_deploy, query_file): query_file
             for query_file in query_files
+            if str(query_file)
+            not in ConfigLoader.get("schema", "deploy", "skip", fallback=[])
         }
         for future in futures.as_completed(future_to_query):
             query_file = future_to_query[future]

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -253,14 +253,16 @@ view:
     - sql/glam-fenix-dev/glam_etl/**/view.sql
     # tests
     - sql/moz-fx-data-test-project/test/simple_view/view.sql
-    # see comment in query file
-    - sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/query.sql
 
 schema:
   mozilla_pipeline_schemas_uri: https://github.com/mozilla-services/mozilla-pipeline-schemas
   skip_prefixes:
   - pioneer
   - rally
+  deploy:
+    skip:
+    # see comment in query file
+    - sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/query.sql
 
 docs:
   docs_dir: docs


### PR DESCRIPTION
## Description

This introduces a skip list for skipping deploys of certain query schemas. This is a follow-up to https://github.com/mozilla/bigquery-etl/pull/6402#issuecomment-2438949491 where the table is deployed through a different process.


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
