### PR TITLE
Skip updating schemas of tables that are skipped for deploys

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1775,6 +1775,13 @@ def update(
     query_files = paths_matching_name_pattern(
         name, sql_dir, project_id, files=["query.sql"]
     )
+    # skip updating schemas that are not to be deployed
+    query_files = [
+        query_file
+        for query_file in query_files
+        if str(query_file)
+        not in ConfigLoader.get("schema", "deploy", "skip", fallback=[])
+    ]
     dependency_graph = get_dependency_graph([sql_dir], without_views=True)
     manager = multiprocessing.Manager()
     tmp_tables = manager.dict({})


### PR DESCRIPTION
## Description

Follow up to https://github.com/mozilla/bigquery-etl/pull/6404#issuecomment-2439055682
We recently introduced a skip list for skipping schema deploys. This PR ensures that these skipped schemas also do not get updated.



<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5934)
