### PR TITLE
DENG-5757 add new summary view of metadata completeness by project/schema

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/metadata_completeness_summary/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/metadata_completeness_summary/view.sql
@@ -40,7 +40,7 @@ SELECT
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.metadata_completeness_v1`
 WHERE
-  submission_date >= '2024-10-27'
+  submission_date >= '2024-10-27' --first date we started recording this data
 GROUP BY
   submission_date,
   table_catalog,

--- a/sql/moz-fx-data-shared-prod/monitoring/metadata_completeness_summary/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/metadata_completeness_summary/view.sql
@@ -1,0 +1,48 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.monitoring.metadata_completeness_summary`
+AS
+SELECT
+  submission_date,
+  table_catalog,
+  table_schema,
+  table_type,
+  COUNT(1) AS nbr_objects,
+  SUM(
+    CASE
+      WHEN object_description IS NOT NULL
+        AND object_description <> "\"Please provide a description for the query\""
+        THEN 1
+      ELSE 0
+    END
+  ) AS nbr_objects_with_a_description,
+  SUM(
+    CASE
+      WHEN object_description IS NOT NULL
+        AND object_description <> "\"Please provide a description for the query\""
+        THEN 1
+      ELSE 0
+    END
+  ) / COUNT(1) AS pct_objects_with_a_desc,
+  SUM(
+    CASE
+      WHEN COALESCE(nbr_columns, 0) = COALESCE(nbr_columns_with_non_null_desc, 0)
+        THEN 1
+      ELSE 0
+    END
+  ) AS nbr_objects_where_every_col_has_a_non_null_desc,
+  SUM(
+    CASE
+      WHEN COALESCE(nbr_columns, 0) = COALESCE(nbr_columns_with_non_null_desc, 0)
+        THEN 1
+      ELSE 0
+    END
+  ) / COUNT(1) AS pct_objects_where_every_col_has_a_non_null_desc
+FROM
+  `moz-fx-data-shared-prod.monitoring_derived.metadata_completeness_v1`
+WHERE
+  submission_date >= '2024-10-27'
+GROUP BY
+  submission_date,
+  table_catalog,
+  table_schema,
+  table_type


### PR DESCRIPTION
## Description
This PR creates a new view called: 
- moz-fx-data-shared-prod.monitoring.metadata_completeness_summary

## Related Tickets & Documents
* [DENG-5757](https://mozilla-hub.atlassian.net/browse/DENG-5757)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-5757]: https://mozilla-hub.atlassian.net/browse/DENG-5757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5942)
