### PR TITLE
Filter overactive clients for `baseline_clients_daily` and `sponsored_tiles_clients_daily`

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/query.sql
@@ -155,7 +155,7 @@ ios_data AS (
     2
 ),
 overactive_android_clients AS (
-  -- Find client_ids with over 3 000 000 pings in a day,
+  -- Find client_ids with over 3 000 000 events in a day,
   -- which could cause errors in the next step due to aggregation overflows.
   SELECT
     client_info.client_id AS client_id

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/query.sql
@@ -155,7 +155,7 @@ ios_data AS (
     2
 ),
 overactive_android_clients AS (
-  -- Find client_ids with over 150 000 pings in a day,
+  -- Find client_ids with over 3 000 000 pings in a day,
   -- which could cause errors in the next step due to aggregation overflows.
   SELECT
     client_info.client_id AS client_id
@@ -166,7 +166,7 @@ overactive_android_clients AS (
   GROUP BY
     client_id
   HAVING
-    COUNT(*) > 150000
+    COUNT(*) > 3000000
 ),
 --- ANDROID SPONSORED TILES
 android_events AS (


### PR DESCRIPTION
## Description

This filters out overactive clients for `baseline_clients_daily` and `sponsored_tiles_clients_daily` causing memory limits to be exceeded during aggregation steps.


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5945)
