### PR TITLE
[DENG-5931] Add partitioning to experiment_events_live_v1

### DIFF
--- a/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/materialized_view.sql
+++ b/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/materialized_view.sql
@@ -2,6 +2,7 @@
 CREATE MATERIALIZED VIEW
 IF
   NOT EXISTS {{ dataset }}_derived.{{ destination_table }}
+  PARTITION BY DATE(partition_date)
   OPTIONS
     (enable_refresh = TRUE, refresh_interval_minutes = 5)
   AS
@@ -102,6 +103,7 @@ IF
   )
   {% endif %}
   SELECT
+    TIMESTAMP_TRUNC(`timestamp`, DAY) AS partition_date,
     DATE(`timestamp`) AS submission_date,
     `type`,
     experiment,
@@ -132,6 +134,7 @@ IF
     -- This date can be moved forward whenever new changes of the materialized views need to be deployed.
     timestamp > TIMESTAMP('{{ start_date }}')
   GROUP BY
+    partition_date,
     submission_date,
     `type`,
     experiment,


### PR DESCRIPTION
## Description

`experiment_events_live_v1` is one of the less expensive materialized views (~140 slots hours per day across all apps) but adding partitioning should be an easy improvement

## Related Tickets & Documents
* DENG-5931

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5946)
