### PR TITLE
Reuse GCP API credentials for view updates

### DIFF
--- a/bigquery_etl/cli/view.py
+++ b/bigquery_etl/cli/view.py
@@ -21,7 +21,7 @@ from ..cli.utils import (
     sql_dir_option,
 )
 from ..config import ConfigLoader
-from ..dryrun import DryRun, get_id_token, get_credentials
+from ..dryrun import DryRun, get_credentials, get_id_token
 from ..metadata.parse_metadata import METADATA_FILE, Metadata
 from ..util.bigquery_id import sql_table_id
 from ..util.client_queue import ClientQueue

--- a/bigquery_etl/cli/view.py
+++ b/bigquery_etl/cli/view.py
@@ -21,7 +21,7 @@ from ..cli.utils import (
     sql_dir_option,
 )
 from ..config import ConfigLoader
-from ..dryrun import DryRun, get_id_token
+from ..dryrun import DryRun, get_id_token, get_credentials
 from ..metadata.parse_metadata import METADATA_FILE, Metadata
 from ..util.bigquery_id import sql_table_id
 from ..util.client_queue import ClientQueue
@@ -200,6 +200,7 @@ def publish(
         logging.basicConfig(level=log_level, format="%(levelname)s %(message)s")
     except ValueError as e:
         raise click.ClickException(f"argument --log-level: {e}")
+    credentials = get_credentials()
 
     views = _collect_views(name, sql_dir, project_id, user_facing_only, skip_authorized)
     if respect_dryrun_skip:
@@ -208,7 +209,7 @@ def publish(
         for view in views:
             view.labels["managed"] = ""
     if not force:
-        has_changes = partial(_view_has_changes, target_project)
+        has_changes = partial(_view_has_changes, target_project, credentials)
 
         # only views with changes
         with Pool(parallelism) as p:
@@ -225,7 +226,7 @@ def publish(
 
     view_id_order = TopologicalSorter(view_id_graph).static_order()
 
-    client = bigquery.Client()
+    client = bigquery.Client(credentials=credentials)
 
     result = []
     for view_id in view_id_order:
@@ -242,8 +243,8 @@ def publish(
     click.echo("All have been published.")
 
 
-def _view_has_changes(target_project, view):
-    return view.has_changes(target_project)
+def _view_has_changes(target_project, credentials, view):
+    return view.has_changes(target_project, credentials)
 
 
 def _collect_views(name, sql_dir, project_id, user_facing_only, skip_authorized):

--- a/bigquery_etl/view/__init__.py
+++ b/bigquery_etl/view/__init__.py
@@ -292,7 +292,7 @@ class View:
             return self.view_identifier.replace(self.project, target_project, 1)
         return self.view_identifier
 
-    def has_changes(self, target_project=None):
+    def has_changes(self, target_project=None, credentials=None):
         """Determine whether there are any changes that would be published."""
         if any(str(self.path).endswith(p) for p in self.skip_publish()):
             return False
@@ -303,7 +303,10 @@ class View:
             # view would be skipped because --target-project is set
             return False
 
-        client = bigquery.Client()
+        if credentials:
+            client = bigquery.Client(credentials=credentials)
+        else:
+            client = bigquery.Client()
         target_view_id = self.target_view_identifier(target_project)
         try:
             table = client.get_table(target_view_id)


### PR DESCRIPTION
## Description

This makes some more tweaks to the view deploy/update process by re-using the credentials for instantiating `bigquery.Client` instances. Testing this locally I got speedups of around 15%. 


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-5961)
