### PR TITLE
Add line to empty query.py in CI copy_debug_sql

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -507,6 +507,7 @@ jobs:
             - run:
                 name: Generate SQL content
                 command: |
+                  mkdir -p /tmp/workspace/generated-sql
                   cp -a sql/. /tmp/workspace/generated-sql/sql
                   exit 0
                   # Get commit on main from which this branch diverged

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -187,6 +187,13 @@ jobs:
                 command: |
                   mkdir -p /tmp/debug_artifacts
                   cp -r sql /tmp/debug_artifacts/sql
+
+                  shopt -s globstar
+                  for file in /tmp/debug_artifacts/sql/**/query.py; do
+                    if [ ! -s "$file" ]; then
+                      echo "# empty file; line inserted by CI" >> "$file"
+                    fi
+                  done
                 when: on_fail
             - &copy_debug_tests
               run:
@@ -500,6 +507,8 @@ jobs:
             - run:
                 name: Generate SQL content
                 command: |
+                  cp -a sql/. /tmp/workspace/generated-sql/sql
+                  exit 0
                   # Get commit on main from which this branch diverged
                   MAIN_MERGE_BASE=$(git merge-base main HEAD || true)
                   echo "merge base with main: $MAIN_MERGE_BASE"
@@ -621,6 +630,7 @@ jobs:
             - run:
                 name: Deploy changes to stage
                 command: |
+                  exit 1
                   if [ "<< pipeline.parameters.skip-stage-deploys >>" = "false" ]; then
                     PATHS="$(git diff --no-index --name-only --diff-filter=d generated-sql/sql sql)" || true
                     echo $PATHS

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -188,6 +188,7 @@ jobs:
                   mkdir -p /tmp/debug_artifacts
                   cp -r sql /tmp/debug_artifacts/sql
 
+                  # add line to empty query.py so they get stored
                   shopt -s globstar
                   for file in /tmp/debug_artifacts/sql/**/query.py; do
                     if [ ! -s "$file" ]; then
@@ -507,9 +508,6 @@ jobs:
             - run:
                 name: Generate SQL content
                 command: |
-                  mkdir -p /tmp/workspace/generated-sql
-                  cp -a sql/. /tmp/workspace/generated-sql/sql
-                  exit 0
                   # Get commit on main from which this branch diverged
                   MAIN_MERGE_BASE=$(git merge-base main HEAD || true)
                   echo "merge base with main: $MAIN_MERGE_BASE"
@@ -631,7 +629,6 @@ jobs:
             - run:
                 name: Deploy changes to stage
                 command: |
-                  exit 1
                   if [ "<< pipeline.parameters.skip-stage-deploys >>" = "false" ]; then
                     PATHS="$(git diff --no-index --name-only --diff-filter=d generated-sql/sql sql)" || true
                     echo $PATHS


### PR DESCRIPTION
## Description

I was looking at [this failure](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/40272/workflows/538d222d-570a-4cad-b007-5a1812f61be4/jobs/460435/steps) and noticed that empty files don't get uploaded with the circleci  artifact storage which was confusing because the failure was due to some empty `query.py` getting created during the stage deploy.  This change adds a line to all the empty `query.py` in the sql directory

Tested with [sql/query.py](https://output.circle-artifacts.com/output/job/3027b69e-d7d7-4076-a1fa-48813d4578df/artifacts/0/sql/query.py) in https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/40718/workflows/5dc2c8c4-7f32-4f86-8f16-f2a557a334fa/jobs/466045/artifacts

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**