### PR TITLE
Speed up schema updates

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1782,7 +1782,9 @@ def update(
         if str(query_file)
         not in ConfigLoader.get("schema", "deploy", "skip", fallback=[])
     ]
-    dependency_graph = get_dependency_graph([sql_dir], without_views=True)
+    dependency_graph = get_dependency_graph(
+        [sql_dir], without_views=True, parallelism=parallelism
+    )
     manager = multiprocessing.Manager()
     tmp_tables = manager.dict({})
 
@@ -1884,7 +1886,7 @@ def _update_query_schema_with_downstream(
                 # create temporary table with updated schema
                 if identifier not in tmp_tables:
                     schema = Schema.from_schema_file(query_file.parent / SCHEMA_FILE)
-                    schema.deploy(tmp_identifier)
+                    schema.deploy(tmp_identifier, credentials)
                     tmp_tables[identifier] = tmp_identifier
 
                 # get downstream dependencies that will be updated in the next iteration
@@ -1966,7 +1968,7 @@ def _update_query_schema(
                         f"{parent_project}.{tmp_dataset}.{parent_table}_"
                         + random_str(12)
                     )
-                    parent_schema.deploy(tmp_parent_identifier)
+                    parent_schema.deploy(tmp_parent_identifier, credentials=credentials)
                     tmp_tables[parent_identifier] = tmp_parent_identifier
 
                 if existing_schema_path.is_file():
@@ -1980,7 +1982,7 @@ def _update_query_schema(
                 tmp_identifier = (
                     f"{project_name}.{tmp_dataset}.{table_name}_{random_str(12)}"
                 )
-                existing_schema.deploy(tmp_identifier)
+                existing_schema.deploy(tmp_identifier, credentials=credentials)
                 tmp_tables[f"{project_name}.{dataset_name}.{table_name}"] = (
                     tmp_identifier
                 )

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -2095,6 +2095,8 @@ def _update_query_schema(
         id_token=id_token,
     )
 
+    changed = True
+
     if existing_schema_path.is_file():
         existing_schema = Schema.from_schema_file(existing_schema_path)
         old_schema = copy.deepcopy(existing_schema)

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -2093,8 +2093,6 @@ def _update_query_schema(
         id_token=id_token,
     )
 
-    changed = True
-
     if existing_schema_path.is_file():
         existing_schema = Schema.from_schema_file(existing_schema_path)
         old_schema = copy.deepcopy(existing_schema)

--- a/bigquery_etl/dependency.py
+++ b/bigquery_etl/dependency.py
@@ -148,7 +148,7 @@ def _extract_table_references(without_views, path):
 
 
 def _get_references(
-    paths: Tuple[str, ...], without_views: bool = False
+    paths: Tuple[str, ...], without_views: bool = False, parallelism: int = 8
 ) -> Iterator[Tuple[Path, List[str]]]:
     file_paths = {
         path
@@ -162,7 +162,7 @@ def _get_references(
     }
     fail = False
 
-    with Pool(8) as pool:
+    with Pool(parallelism) as pool:
         try:
             result = pool.map(
                 partial(_extract_table_references, without_views), file_paths
@@ -177,10 +177,10 @@ def _get_references(
 
 
 def get_dependency_graph(
-    paths: Tuple[str, ...], without_views: bool = False
+    paths: Tuple[str, ...], without_views: bool = False, parallelism: int = 8
 ) -> Dict[str, List[str]]:
     """Return the query dependency graph."""
-    refs = _get_references(paths, without_views=without_views)
+    refs = _get_references(paths, without_views=without_views, parallelism=parallelism)
     dependency_graph = {}
 
     for ref in refs:

--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -61,7 +61,6 @@ class Schema:
     def for_table(cls, project, dataset, table, partitioned_by=None, *args, **kwargs):
         """Get the schema for a BigQuery table."""
         try:
-            print(kwargs["use_cloud_function"])
             if (
                 "use_cloud_function" not in kwargs
                 or kwargs["use_cloud_function"] is False

--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -64,7 +64,7 @@ class Schema:
             print(kwargs["use_cloud_function"])
             if (
                 "use_cloud_function" not in kwargs
-                or kwargs["use_cloud_function"] == False
+                or kwargs["use_cloud_function"] is False
             ):
                 if "credentials" in kwargs:
                     client = bigquery.Client(credentials=kwargs["credentials"])
@@ -95,9 +95,12 @@ class Schema:
             print(f"Cannot get schema for {project}.{dataset}.{table}: {e}")
             return cls({"fields": []})
 
-    def deploy(self, destination_table: str) -> bigquery.Table:
+    def deploy(self, destination_table: str, credentials: None) -> bigquery.Table:
         """Deploy the schema to BigQuery named after destination_table."""
-        client = bigquery.Client()
+        if credentials:
+            client = bigquery.Client(credentials=credentials)
+        else:
+            client = bigquery.Client()
         tmp_schema_file = NamedTemporaryFile()
         self.to_json_file(Path(tmp_schema_file.name))
         bigquery_schema = client.schema_from_json(tmp_schema_file.name)

--- a/tests/cli/test_cli_dependency.py
+++ b/tests/cli/test_cli_dependency.py
@@ -22,7 +22,7 @@ class TestDependency:
             with open("foo.sql", "w") as f:
                 f.write("SELECT 1 FROM test")
 
-            result = runner.invoke(dependency_show, ["foo.sql"])
+            result = runner.invoke(dependency_show, ["foo.sql", "--parallelism=1"])
             assert "foo.sql: test\n" == result.output
             assert result.exit_code == 0
 
@@ -32,6 +32,6 @@ class TestDependency:
             with open("test/bar.sql", "w") as f:
                 f.write("SELECT 1 FROM test_bar")
 
-            result = runner.invoke(dependency_show, ["test"])
+            result = runner.invoke(dependency_show, ["test", "--parallelism=1"])
             assert "test/bar.sql: test_bar\ntest/foo.sql: test_foo\n" == result.output
             assert result.exit_code == 0


### PR DESCRIPTION
## Description

This makes some optimizations to speed up table deploys:
- build the table dependency graph in parallel 
- reuse GCP client credentials
- use the GCP API to get table schemas when not using the cloud function, instead of doing a dry run 

These improvements shave off a few minutes for `./bqetl schema update` runs (around 10-15% faster in local runs). The main bottleneck for schema updates are the query dry runs though.


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6011)
