### PR TITLE
Fix stage deploys, explicitly use cloud function for schema dry runs

### DIFF
--- a/bigquery_etl/cli/stage.py
+++ b/bigquery_etl/cli/stage.py
@@ -312,6 +312,7 @@ def _view_dependencies(artifact_files, sql_dir):
                             table=name,
                             id_token=id_token,
                             partitioned_by=partitioned_by,
+                            use_cloud_function=True,
                         )
                         schema.to_yaml_file(path / SCHEMA_FILE)
 

--- a/sql/moz-fx-data-shared-prod/telemetry/ssl_ratios_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/ssl_ratios_v1/view.sql
@@ -29,3 +29,5 @@ FROM
   windowed
 WHERE
   non_ssl_loads + ssl_loads > 5000
+
+-- todo remove


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/mozilla/bigquery-etl/pull/6418 and should fix the CI failures.  
This is now explicitly using the cloud function during stage deploys to get table schemas, otherwise it tries to use the service account.


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6039)
