### PR TITLE
Add and update VPN VAT rates (DENG-2707)

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/data.csv
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/data.csv
@@ -3,7 +3,9 @@ AT,Austria,0.2,2021-01-01
 BE,Belgium,0.21,2021-01-01
 BG,Bulgaria,0.2,2022-05-10
 CA,Canada,0.1,2021-01-01
+CA,Canada,0,2022-12-01
 CH,Switzerland,0.077,2021-01-01
+CH,Switzerland,0.081,2024-01-01
 CY,Cyprus,0.19,2022-05-10
 CZ,Czech Republic,0.21,2022-05-10
 DE,Germany,0.19,2021-01-01
@@ -22,7 +24,8 @@ LT,Lithuania,0.21,2022-05-10
 LU,Luxembourg,0.17,2022-05-10
 LV,Latvia,0.21,2022-05-10
 MT,Malta,0.18,2022-05-10
-MY,Malaysia,0.05,2021-01-01
+MY,Malaysia,0.06,2021-01-01
+MY,Malaysia,0.08,2024-03-01
 NL,Netherlands,0.21,2021-01-01
 NZ,New Zealand,0.15,2021-01-01
 PL,Poland,0.23,2022-05-10
@@ -30,6 +33,8 @@ PT,Portugal,0.23,2022-05-10
 RO,Romania,0.19,2022-05-10
 SE,Sweden,0.25,2022-01-01
 SG,Singapore,0.07,2021-01-01
+SG,Singapore,0.08,2023-01-01
+SG,Singapore,0.09,2024-01-01
 SI,Slovenia,0.22,2022-05-10
 SK,Slovakia,0.2,2022-05-10
 US,United States,0,2021-01-01

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/data.csv
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/vat_rates_v2/data.csv
@@ -1,40 +1,86 @@
 country_code,country,vat,effective_date
+AE,United Arab Emirates,0.05,2024-02-07
+AL,Albania,0.2,2024-02-07
+AM,Armenia,0.2,2024-02-07
+AR,Argentina,0.21,2024-02-07
+AS,American Samoa,0,2024-02-07
 AT,Austria,0.2,2021-01-01
+AU,Australia,0.1,2024-02-07
+BA,Bosnia and Herzegovina,0.17,2024-02-07
+BD,Bangladesh,0.15,2024-10-22
 BE,Belgium,0.21,2021-01-01
 BG,Bulgaria,0.2,2022-05-10
+BH,Bahrain,0.1,2024-02-07
+BR,Brazil,0.17,2024-10-22
+BY,Belarus,0.2,2024-02-07
 CA,Canada,0.1,2021-01-01
 CA,Canada,0,2022-12-01
 CH,Switzerland,0.077,2021-01-01
 CH,Switzerland,0.081,2024-01-01
+CL,Chile,0.19,2024-02-07
+CM,Cameroon,0.1925,2024-02-07
+CN,China,0.13,2024-02-07
+CO,Colombia,0.19,2024-02-07
 CY,Cyprus,0.19,2022-05-10
 CZ,Czech Republic,0.21,2022-05-10
 DE,Germany,0.19,2021-01-01
 DK,Denmark,0.25,2022-05-10
 EE,Estonia,0.2,2022-05-10
+EG,Egypt,0.14,2024-02-07
 ES,Spain,0.21,2021-01-01
 FI,Finland,0.24,2022-01-01
 FR,France,0.2,2021-01-01
 GB,United Kingdom,0.2,2021-01-01
 GR,Greece,0.24,2022-05-10
+GU,Guam,0,2024-02-07
+HK,Hong Kong,0,2024-02-07
 HR,Croatia,0.25,2022-05-10
 HU,Hungary,0.27,2022-05-10
+ID,Indonesia,0.11,2024-02-07
 IE,Ireland,0.23,2021-01-01
+IL,Israel,0.17,2024-02-07
+IN,India,0.18,2024-02-07
+IS,Iceland,0.24,2024-02-07
 IT,Italy,0.22,2021-01-01
+JP,Japan,0.1,2024-02-07
+KE,Kenya,0.16,2024-10-22
+KR,Korea,0.1,2024-02-07
 LT,Lithuania,0.21,2022-05-10
 LU,Luxembourg,0.17,2022-05-10
 LV,Latvia,0.21,2022-05-10
+MA,Morocco,0.2,2024-10-22
+MD,Moldova,0.2,2024-02-07
 MT,Malta,0.18,2022-05-10
+MX,Mexico,0.16,2024-02-07
 MY,Malaysia,0.06,2021-01-01
 MY,Malaysia,0.08,2024-03-01
+NG,Nigeria,0.075,2024-10-22
 NL,Netherlands,0.21,2021-01-01
+NO,Norway,0.25,2024-02-07
 NZ,New Zealand,0.15,2021-01-01
 PL,Poland,0.23,2022-05-10
+PR,Puerto Rico,0.115,2024-02-07
 PT,Portugal,0.23,2022-05-10
 RO,Romania,0.19,2022-05-10
+RS,Serbia,0.2,2024-02-07
+RU,Russia,0.2,2024-02-07
+SA,Saudi Arabia,0.15,2024-02-07
 SE,Sweden,0.25,2022-01-01
 SG,Singapore,0.07,2021-01-01
 SG,Singapore,0.08,2023-01-01
 SG,Singapore,0.09,2024-01-01
 SI,Slovenia,0.22,2022-05-10
 SK,Slovakia,0.2,2022-05-10
+SN,Senegal,0.18,2024-10-22
+TH,Thailand,0.07,2024-10-22
+TR,Turkey,0.2,2024-02-07
+TW,Taiwan,0.05,2024-02-07
+UA,Ukraine,0.2,2024-10-22
+UG,Uganda,0.18,2024-10-22
 US,United States,0,2021-01-01
+UY,Uruguay,0.22,2024-02-07
+UZ,Uzbekistan,0.12,2024-02-07
+VT,Vietnam,0.1,2024-10-22
+XK,Kosovo,0.18,2024-02-07
+ZA,South Africa,0.15,2024-02-07
+ZW,Zimbabwe,0.145,2024-02-07


### PR DESCRIPTION
## Description
Some VPN VAT rates which are outdated or incorrect need to be updated, some new VAT rates need to be added for countries that VPN will soon be expanding to ([VPN-6623](https://mozilla-hub.atlassian.net/browse/VPN-6623)), and I also decided to preemptively add all other VAT rates which Accounting has provided to us even if VPN isn't currently technically available in those countries just to help cover the bases for potential future market expansions.

## Related Tickets & Documents
* DENG-2707: Update VPN VAT rates
* [VPN-6623](https://mozilla-hub.atlassian.net/browse/VPN-6623): Wave 7 Mozilla VPN Expansion

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[VPN-6623]: https://mozilla-hub.atlassian.net/browse/VPN-6623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-6623]: https://mozilla-hub.atlassian.net/browse/VPN-6623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6064)
