### PR TITLE
Fully-qualify INFORMATION_SCHEMA datasets in ./bqetl view clean

### DIFF
--- a/bigquery_etl/cli/view.py
+++ b/bigquery_etl/cli/view.py
@@ -387,9 +387,9 @@ def _list_managed_views(client, dataset, pattern, skip_authorized):
         table_catalog || "." || table_schema || "." || table_name AS table_id,
         CONTAINS_SUBSTR(option_value, 'STRUCT("authorized", "")') AS is_authorized
       FROM
-        `{dataset.dataset_id}.INFORMATION_SCHEMA.VIEWS`
+        `{dataset.project}.{dataset.dataset_id}.INFORMATION_SCHEMA.VIEWS`
       INNER JOIN
-        `{dataset.dataset_id}.INFORMATION_SCHEMA.TABLE_OPTIONS`
+        `{dataset.project}.{dataset.dataset_id}.INFORMATION_SCHEMA.TABLE_OPTIONS`
       USING
         (table_catalog,
          table_schema,


### PR DESCRIPTION
## Description

This fixes view deploys. The `INFORMATION_SCHEMA` tables need to be fully qualified.


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6093)
