### PR TITLE
Sort query references result when parallelism > 0

### DIFF
--- a/bigquery_etl/dependency.py
+++ b/bigquery_etl/dependency.py
@@ -177,6 +177,8 @@ def _get_references(
                 result = pool.map(
                     partial(_extract_table_references, without_views), file_paths
                 )
+                # sort by path for itertools.groupby
+                result.sort(key=lambda ref: ref[0])
                 return result
             except ValueError as e:
                 fail = True


### PR DESCRIPTION
## Description

follow-up for https://github.com/mozilla/bigquery-etl/pull/6418.  The references in the generated sql flipping around (https://github.com/mozilla/bigquery-etl/commit/d8eb3ad214af684d13e612368d6370289611999b) because the `itertools.groupby` in the dependency updating expects identical keys to be consecutive


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
