### PR TITLE
Change Stripe tax transaction exchange rate to BIGNUMERIC type

### DIFF
--- a/bigquery_etl/stripe/tax.transactions.itemized.1.schema.json
+++ b/bigquery_etl/stripe/tax.transactions.itemized.1.schema.json
@@ -133,7 +133,7 @@
   },
   {
     "name": "filing_exchange_rate",
-    "type": "NUMERIC"
+    "type": "BIGNUMERIC"
   },
   {
     "name": "filing_total",

--- a/sql/moz-fx-data-shared-prod/stripe_external/itemized_tax_transactions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/itemized_tax_transactions_v1/schema.yaml
@@ -100,7 +100,7 @@ fields:
   type: STRING
   mode: NULLABLE
 - name: filing_exchange_rate
-  type: NUMERIC
+  type: BIGNUMERIC
   mode: NULLABLE
 - name: filing_total
   type: NUMERIC


### PR DESCRIPTION
## Description
Some historical Stripe tax transactions contain exchange rates with 16 digits after the decimal, which exceeds the normal NUMERIC type's maximum scale of 9 digits after the decimal.

This is currently preventing 13 days of data from being [backfilled](https://github.com/mozilla/telemetry-airflow/pull/2117) into the `stripe_external.itemized_tax_transactions_v1` table to support the response to the SubPlat tax incident ([FXA-10591](https://mozilla-hub.atlassian.net/browse/FXA-10591)):
* 2022-12-14
* 2022-12-28
* 2022-12-29
* 2023-01-01
* 2023-01-13
* 2023-01-15
* 2023-01-22
* 2023-01-24
* 2023-02-03
* 2023-02-08
* 2023-02-13
* 2023-02-15
* 2023-02-27

## Related Tickets & Documents
* https://github.com/mozilla/telemetry-airflow/pull/2117
* [FXA-10591](https://mozilla-hub.atlassian.net/browse/FXA-10591): 2024 10 17 Incident: Tax Location Irregularities

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[FXA-10591]: https://mozilla-hub.atlassian.net/browse/FXA-10591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXA-10591]: https://mozilla-hub.atlassian.net/browse/FXA-10591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ