### PR TITLE
Add mobile search deletion source to shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -144,6 +144,23 @@ LEGACY_MOBILE_SOURCES = tuple(
         "mozilla_lockbox",
     )
 )
+MOBILE_SEARCH_SOURCES = (
+    tuple(
+        DeleteSource(
+            table=f"{app_name}.deletion_request",
+            field=GLEAN_CLIENT_ID,
+        )
+        for app_name in (
+            "fenix",
+            "firefox_ios",
+            "focus_android",
+            "focus_ios",
+            "klar_android",
+            "klar_ios",
+        )
+    )
+    + LEGACY_MOBILE_SOURCES
+)
 USER_CHARACTERISTICS_SRC = DeleteSource(
     table="firefox_desktop_stable.deletion_request_v1",
     field=USER_CHARACTERISTICS_ID,
@@ -161,7 +178,7 @@ SOURCES = (
 )
 
 LEGACY_MOBILE_IDS = tuple(CLIENT_ID for _ in LEGACY_MOBILE_SOURCES)
-
+MOBILE_SEARCH_IDS = tuple(CLIENT_ID for _ in MOBILE_SEARCH_SOURCES)
 
 client_id_target = partial(DeleteTarget, field=CLIENT_ID)
 glean_target = partial(DeleteTarget, field=GLEAN_CLIENT_ID)
@@ -175,10 +192,11 @@ DELETE_TARGETS: DeleteIndex = {
     client_id_target(table="search_derived.acer_cohort_v1"): DESKTOP_SRC,
     client_id_target(
         table="search_derived.mobile_search_clients_daily_v1"
-    ): DESKTOP_SRC,
-    client_id_target(
-        table="search_derived.mobile_search_clients_daily_v2"
-    ): DESKTOP_SRC,
+    ): DESKTOP_SRC,  # incorrectly set: https://mozilla-hub.atlassian.net/browse/DENG-4255
+    DeleteTarget(
+        table="search_derived.mobile_search_clients_daily_v2",
+        field=MOBILE_SEARCH_IDS,
+    ): MOBILE_SEARCH_SOURCES,
     client_id_target(table="search_derived.search_clients_daily_v8"): DESKTOP_SRC,
     client_id_target(
         table="telemetry_derived.desktop_engagement_clients_v1"


### PR DESCRIPTION
## Description

Follow-up for https://github.com/mozilla/bigquery-etl/pull/6425, setting `mobile_search_clients_daily_v2` to a source that contains all the related mobile deletion requests

## Related Tickets & Documents

- DENG-4255

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
