### PR TITLE
Update `mozilla_vpn_derived.exchange_rates_v1` to include VPN wave 7 expansion country currencies (DENG-5883)

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/exchange_rates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/exchange_rates_v1/metadata.yaml
@@ -57,6 +57,24 @@ scheduling:
       "HUF",
       "PLN",
       "RON",
+      # Starting 2024-10-30:
+      "AUD",
+      "BDT",
+      "IDR",
+      "INR",
+      "KES",
+      "KRW",
+      "MAD",
+      "MXN",
+      "NGN",
+      "NOK",
+      "SAR",
+      "THB",
+      "TRY",
+      "TWD",
+      "UAH",
+      "VND",
+      "ZAR",
     ]
 bigquery:
   time_partitioning:


### PR DESCRIPTION
## Description
USD exchange rates for 17 additional currencies need to be added for the VPN wave 7 expansion scheduled to launch Nov 4 ([VPN-6623](https://mozilla-hub.atlassian.net/browse/VPN-6623)).

## Related Tickets & Documents
* DENG-5883: Update the `mozilla_vpn_derived.exchange_rates_v1` ETL to include VPN wave 7 expansion country currencies
* [VPN-6623](https://mozilla-hub.atlassian.net/browse/VPN-6623): Wave 7 Mozilla VPN Expansion

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[VPN-6623]: https://mozilla-hub.atlassian.net/browse/VPN-6623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-6623]: https://mozilla-hub.atlassian.net/browse/VPN-6623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6155)
