### PR TITLE
Specify partition column for Bigeye monitoring for ssl_ratios

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -16,3 +16,4 @@ scheduling:
   dag_name: bqetl_ssl_ratios
 monitoring:
   enabled: true
+  partition_column: submission_date


### PR DESCRIPTION
`ssl_ratios_v1` is actually a view (pointing to the public `ssl_ratios_v1` table), and Bigeye requires a partition column to be configured explicitly on views. This should fix the failing Airflow deployment task


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6161)
