### PR TITLE
Add time partitioning spec to mobile_search_clients_daily_historical_pre202408

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_historical_pre202408/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_historical_pre202408/metadata.yaml
@@ -10,3 +10,9 @@ description: |-
 owners:
   - akommasani@mozilla.com
   - mbowerman@mozilla.com
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null


### PR DESCRIPTION
## Description

[Dry runs have been failing](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/40882/workflows/d34c3981-9994-4666-a0dd-03646fab9a77/jobs/468103) because [the deployed table](https://console.cloud.google.com/bigquery?ws=!1m5!1m4!4m3!1smoz-fx-data-shared-prod!2ssearch_derived!3smobile_search_clients_daily_historical_pre202408) has a required partition filter but metadata doesn't

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6162)
