### PR TITLE
Add reference table number to bigquery_usage view

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/bigquery_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/bigquery_usage/view.sql
@@ -29,5 +29,7 @@ SELECT
   'https://sql.telemetry.mozilla.org/queries/' || query_id || '/source' AS query_url,
   username = "Scheduled" AS is_scheduled,
   (total_slot_ms * 0.06) / (60 * 60 * 1000) AS cost,
+  total_slot_ms / (60 * 60 * 1000) AS total_slot_hours,
+  ROW_NUMBER() OVER (PARTITION BY job_id) AS referenced_table_number,
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.bigquery_usage_v2`


### PR DESCRIPTION
## Description

The base table has one row per referenced table per job id which makes the looker explore hard to work with because the cost values are duplicated.  This adds a referenced table number to make it easier to dedupe without using custom measures

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6195)
