### PR TITLE
Add submission_date partition to ref table number in bigquery_usage

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/bigquery_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/bigquery_usage/view.sql
@@ -30,6 +30,6 @@ SELECT
   username = "Scheduled" AS is_scheduled,
   (total_slot_ms * 0.06) / (60 * 60 * 1000) AS cost,
   total_slot_ms / (60 * 60 * 1000) AS total_slot_hours,
-  ROW_NUMBER() OVER (PARTITION BY job_id) AS referenced_table_number,
+  ROW_NUMBER() OVER (PARTITION BY job_id, submission_date) AS referenced_table_number,
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.bigquery_usage_v2`


### PR DESCRIPTION
## Description

Fix for https://github.com/mozilla/bigquery-etl/pull/6439 which gives an error when trying to query that column: `Cannot query over table 'moz-fx-data-shared-prod.monitoring_derived.bigquery_usage_v2' without a filter over column(s) 'submission_date' that can be used for partition elimination`

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6242)
