### PR TITLE
Update VPN ETL `in_available_geos` logic for when VPN became available in various countries (DENG-5484)

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v1/query.sql
@@ -4,6 +4,27 @@ CREATE TEMP FUNCTION in_available_geos(`date` DATE, country STRING) AS (
   OR (`date` >= "2021-07-12" AND country IN ("Austria", "Belgium", "Spain", "Italy", "Switzerland"))
   OR (`date` >= "2021-10-05" AND country IN ("Ireland", "Netherlands"))
   OR (`date` >= "2022-03-08" AND country IN ("Finland", "Sweden"))
+  OR (
+    `date` >= "2023-07-04"
+    AND country IN (
+      "Bulgaria",
+      "Croatia",
+      "Cyprus",
+      "Czechia",
+      "Denmark",
+      "Estonia",
+      "Hungary",
+      "Latvia",
+      "Lithuania",
+      "Luxembourg",
+      "Malta",
+      "Poland",
+      "Portugal",
+      "Romania",
+      "Slovakia",
+      "Slovenia"
+    )
+  )
 );
 
 WITH website_base AS (

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v2/query.sql
@@ -25,6 +25,35 @@ CREATE TEMP FUNCTION in_available_geos(`date` DATE, country STRING) AS (
       "Slovenia"
     )
   )
+  OR (
+    `date` >= "2024-11-04"
+    AND country IN (
+      "Australia",
+      "Bangladesh",
+      "Brazil",
+      "Chile",
+      "Colombia",
+      "Egypt",
+      "Greece",
+      "India",
+      "Indonesia",
+      "Kenya",
+      "Mexico",
+      "Morocco",
+      "Nigeria",
+      "Norway",
+      "Saudi Arabia",
+      "Senegal",
+      "South Africa",
+      "South Korea",
+      "Taiwan",
+      "Thailand",
+      "Türkiye",
+      "Uganda",
+      "Ukraine",
+      "Vietnam"
+    )
+  )
 );
 
 WITH website_base AS (

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/funnel_ga_to_subscriptions_v2/query.sql
@@ -4,6 +4,27 @@ CREATE TEMP FUNCTION in_available_geos(`date` DATE, country STRING) AS (
   OR (`date` >= "2021-07-12" AND country IN ("Austria", "Belgium", "Spain", "Italy", "Switzerland"))
   OR (`date` >= "2021-10-05" AND country IN ("Ireland", "Netherlands"))
   OR (`date` >= "2022-03-08" AND country IN ("Finland", "Sweden"))
+  OR (
+    `date` >= "2023-07-04"
+    AND country IN (
+      "Bulgaria",
+      "Croatia",
+      "Cyprus",
+      "Czechia",
+      "Denmark",
+      "Estonia",
+      "Hungary",
+      "Latvia",
+      "Lithuania",
+      "Luxembourg",
+      "Malta",
+      "Poland",
+      "Portugal",
+      "Romania",
+      "Slovakia",
+      "Slovenia"
+    )
+  )
 );
 
 WITH website_base AS (


### PR DESCRIPTION
## Description
VPN is launching in 24 new countries today ([VPN-6623](https://mozilla-hub.atlassian.net/browse/VPN-6623)), so the `in_available_geos` ETL logic needs to be updated to reflect that.

Also, VPN previously launched in 16 countries in July 2023 ([VPN-4948](https://mozilla-hub.atlassian.net/browse/VPN-4948)), but the `in_available_geos` ETL logic wasn't updated at that time, so I'm taking this opportunity to update it for those 16 countries as well now.

## Related Tickets & Documents
* DENG-5484: Update VPN ETL `in_available_geos` logic for when VPN became available in various countries
* [VPN-4948](https://mozilla-hub.atlassian.net/browse/VPN-4948): Wave 6 Mozilla VPN Expansion
* [VPN-6623](https://mozilla-hub.atlassian.net/browse/VPN-6623): Wave 7 Mozilla VPN Expansion

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[VPN-6623]: https://mozilla-hub.atlassian.net/browse/VPN-6623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-4948]: https://mozilla-hub.atlassian.net/browse/VPN-4948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-4948]: https://mozilla-hub.atlassian.net/browse/VPN-4948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-6623]: https://mozilla-hub.atlassian.net/browse/VPN-6623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6244)
