### PR TITLE
Exclude Fivetran's incorrect Stripe customer discount records from SubPlat ETLs

### DIFF
--- a/sql/moz-fx-data-shared-prod/stripe_external/customer_discount_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/customer_discount_v1/query.sql
@@ -12,3 +12,6 @@ SELECT
   subscription_id,
 FROM
   `moz-fx-data-bq-fivetran`.stripe.customer_discount
+WHERE
+  -- Fivetran used to have a bug where it synced subscription discounts as customer discounts.
+  subscription_id IS NULL

--- a/sql/moz-fx-data-shared-prod/stripe_external/discount_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/discount_v1/query.sql
@@ -17,3 +17,6 @@ SELECT
   subscription_id,
 FROM
   `moz-fx-data-bq-fivetran.stripe.discount`
+WHERE
+  -- Fivetran used to have a bug where it synced subscription discounts as customer discounts.
+  NOT (type = 'CUSTOMER' AND subscription_id IS NOT NULL)


### PR DESCRIPTION
## Description
In the process of handling Fivetran changing how Stripe discounts are synced (DENG-2116) it was discovered that Fivetran's Stripe connector used to have a bug where it synced subscription discounts as customer discounts.  This PR excludes those incorrect records in the SubPlat ETLs that copy Fivetran's raw Stripe records into the `stripe_external` dataset.

The downstream incremental ETLs `stripe_external.customers_changelog_v1` and `subscription_platform_derived.stripe_customers_revised_changelog_v1` shouldn't be rebuilt unless absolutely necessary, so I plan to remove the incorrect customer discounts with the following `UPDATE` statements:
```sql
UPDATE `moz-fx-data-shared-prod.stripe_external.customers_changelog_v1`
SET customer.discount = NULL
WHERE customer.discount.subscription_id IS NOT NULL;

UPDATE `moz-fx-data-shared-prod.subscription_platform_derived.stripe_customers_revised_changelog_v1`
SET customer.discount = NULL
WHERE customer.discount.subscription_id IS NOT NULL;
```

## Related Tickets & Documents
* DENG-2116: Handle Fivetran changing how Stripe discounts are synced

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6246)
