### PR TITLE
Exclude Fivetran's incorrect Stripe customer discount records from non-prod SubPlat ETLs

### DIFF
--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_discount_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_discount_v1/query.sql
@@ -17,3 +17,6 @@ SELECT
   subscription_id,
 FROM
   `dev-fivetran.stripe_nonprod.discount`
+WHERE
+  -- Fivetran used to have a bug where it synced subscription discounts as customer discounts.
+  NOT (type = 'CUSTOMER' AND subscription_id IS NOT NULL)


### PR DESCRIPTION
## Description
Follow-up to #6443, as I forgot to update the non-prod ETLs as well.

## Related Tickets & Documents
* [DENG-2116](https://mozilla-hub.atlassian.net/browse/DENG-2116): Handle Fivetran changing how Stripe discounts are synced

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-2116]: https://mozilla-hub.atlassian.net/browse/DENG-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6265)
