### PR TITLE
bug(1926038): remove check causing a lot of noise that is unactionable from app_store_funnel_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/checks.sql
@@ -52,25 +52,6 @@ FROM
   base;
 
 #warn
-WITH base AS (
-  SELECT
-    SUM(new_profiles) AS new_funnel_new_profiles,
-    SUM(total_downloads) AS total_downloads,
-  FROM
-    `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
-  WHERE
-    submission_date = @submission_date
-)
-SELECT
-  IF(
-    new_funnel_new_profiles > total_downloads,
-    ERROR("There are more new_profiles than app downloads."),
-    NULL
-  )
-FROM
-  base;
-
-#warn
 SELECT
   IF(
     DATE_DIFF(submission_date, first_seen_date, DAY) <> 7,


### PR DESCRIPTION
# bug(1926038): remove check causing a lot of noise that is unactionable from app_store_funnel_v1

## Description

Removing this check as it is not something we can act upon and is quite noisy causing a lot of duplicate bugs to be created during the triage process resulting in confusion.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6268)
