### PR TITLE
Move event_monitoring_aggregates_v1 to run in on-demand billing

### DIFF
--- a/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.metadata.yaml
@@ -9,6 +9,10 @@ labels:
   incremental: true 
 scheduling:
   dag_name: bqetl_monitoring
+  # Use backfill-2 project for on-demand query billing
+  arguments: [
+    "--billing-project", "moz-fx-data-backfill-2"
+  ]
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description

This is our most expensive etl due to event size going up and there's a large difference between slot and on-demand cost (see DENG-6243).  This would have saved ~$80 on 2024-11-05.

DENG-6243 also proposes a way to make this more efficient but it requires a bit more testing so moving it to on-demand will work in the meantime

## Related Tickets & Documents

- DENG-6243

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6276)
