### PR TITLE
[DENG-5962] Change shredder state to only use end_date

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -643,8 +643,7 @@ def main():
                         FROM
                           `{args.state_table}`
                         WHERE
-                          start_date = '{args.start_date}'
-                          AND end_date = '{args.end_date}'
+                          end_date = '{args.end_date}'
                         ORDER BY
                           job_created
                         """


### PR DESCRIPTION
## Description

shredder-all is taking a very long time to finish due to the increase in data over the last few months but I still want to test https://github.com/mozilla/telemetry-airflow/pull/2109 in prod, especially to see if it affects [writes to clustered tables](https://mozilla-hub.atlassian.net/browse/DENG-5962) at all.  Changing the state query to only look at end_date should safely make it not restart the current run

## Related Tickets & Documents
* DENG-6308
* DENG-5962

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6312)
