### PR TITLE
DENG-4835 - Deprecate views associated with already deprecated tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/active_profiles/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/active_profiles/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_error_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_error_aggregates/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/experiments/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiments/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/experiments_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiments_v1/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/main_summary/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_summary/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/main_summary_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_summary_v3/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/main_summary_v4/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_summary_v4/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/simpleprophet_forecasts/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/simpleprophet_forecasts/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_anonymous_parquet/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_anonymous_parquet/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_downgrade_parquet/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_downgrade_parquet/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_heartbeat_parquet/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_heartbeat_parquet/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_new_profile_parquet_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_new_profile_parquet_v2/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_shield_study_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_shield_study_parquet_v1/metadata.yaml
@@ -1,0 +1,1 @@
+deprecated: true


### PR DESCRIPTION
## Description

We're planning to delete some tables and associated views soon that have been marked as deprecated for some time now, all with a deletion date of May 2024.  See list here: https://docs.google.com/spreadsheets/d/1bdixeOSfss90jTxy0wGpcma7g1xs0UjKDrOt22axCuA/edit?usp=sharing

To prepare for this, first we want to mark these views as "deprecated" so anyone currently using them has warning before they get truly deleted soon.

This works spun out of the Ethyca work, since we have to classify data, we want to delete deprecated tables that we can so we don't have to spend time classifying their data unnecessarily.


## Related Tickets & Documents
* [DENG-4835](https://mozilla-hub.atlassian.net/browse/DENG-4835)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-4835]: https://mozilla-hub.atlassian.net/browse/DENG-4835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6316)
