### PR TITLE
Add Key_Tentpoles

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
@@ -40,7 +40,7 @@ FROM
   `moz-fx-data-shared-prod.telemetry.active_users_aggregates_mobile`
 LEFT JOIN `mozdata.static.key_tentpole_dates` ktd
   ON submission_date >= ktd.start_date
-  OR submission_date <= ktd.start_date
+  AND submission_date <= ktd.end_date
 UNION ALL
 SELECT
   segment,
@@ -81,4 +81,4 @@ FROM
   `moz-fx-data-shared-prod.firefox_desktop.active_users_aggregates`
 LEFT JOIN `mozdata.static.key_tentpole_dates` ktd
   ON submission_date >= ktd.start_date
-  OR submission_date <= ktd.start_date
+  AND submission_date <= ktd.end_date

--- a/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
@@ -32,9 +32,15 @@ SELECT
   app_version_minor,
   app_version_patch_revision,
   app_version_is_major_release,
-  os_grouped
+  os_grouped,
+  ktd.key_tentpole,
+  ktd.start_date,
+  ktd.end_date
 FROM
   `moz-fx-data-shared-prod.telemetry.active_users_aggregates_mobile`
+LEFT JOIN `mozdata.static.key_tentpole_dates` ktd
+  ON submission_date >= ktd.start_date
+  OR submission_date <= ktd.start_date
 UNION ALL
 SELECT
   segment,
@@ -67,6 +73,12 @@ SELECT
   app_version_minor,
   app_version_patch_revision,
   app_version_is_major_release,
-  os_grouped
+  os_grouped,
+  ktd.key_tentpole,
+  ktd.start_date,
+  ktd.end_date
 FROM
   `moz-fx-data-shared-prod.firefox_desktop.active_users_aggregates`
+LEFT JOIN `mozdata.static.key_tentpole_dates` ktd
+  ON submission_date >= ktd.start_date
+  OR submission_date <= ktd.start_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_clients_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_clients_daily_v1/query.sql
@@ -364,7 +364,7 @@ joined AS (
     USING (client_id)
   LEFT JOIN `mozdata.static.key_tentpole_dates` ktd
     ON submission_date >= ktd.start_date
-    OR submission_date <= ktd.start_date
+    AND submission_date <= ktd.end_date
 )
 SELECT
   *,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_clients_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_clients_daily_v1/query.sql
@@ -250,6 +250,9 @@ joined AS (
     visits_data.visits_with_non_default_ui,
     visits_data.is_new_profile,
     visits_data.activity_segment,
+    ktd.key_tentpole,
+    ktd.start_date,
+    ktd.end_date,
     -- COALESCE calls for visits where no interactions with a surface were performed and are all Null
     COALESCE(search_data.searches, 0) AS searches,
     COALESCE(search_data.tagged_search_ad_clicks, 0) AS tagged_search_ad_clicks,
@@ -359,6 +362,9 @@ joined AS (
   LEFT JOIN
     topic_selection_data
     USING (client_id)
+  LEFT JOIN `mozdata.static.key_tentpole_dates` ktd
+    ON submission_date >= ktd.start_date
+    OR submission_date <= ktd.start_date
 )
 SELECT
   *,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
@@ -297,9 +297,15 @@ side_filled AS (
     USING (legacy_telemetry_client_id)
 )
 SELECT
-  * EXCEPT (visit_had_any_interaction)
+  * EXCEPT (visit_had_any_interaction),
+  ktd.key_tentpole,
+  ktd.start_date,
+  ktd.end_date
 FROM
   side_filled
+LEFT JOIN `mozdata.static.key_tentpole_dates` ktd
+  ON submission_date >= ktd.start_date
+  OR submission_date <= ktd.start_date
 WHERE
    -- Keep only rows with interactions, unless we receive a valid newtab.opened event.
    -- This is meant to drop only interactions that only have a newtab.closed event on the same partition

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_v1/query.sql
@@ -305,7 +305,7 @@ FROM
   side_filled
 LEFT JOIN `mozdata.static.key_tentpole_dates` ktd
   ON submission_date >= ktd.start_date
-  OR submission_date <= ktd.start_date
+  AND submission_date <= ktd.end_date
 WHERE
    -- Keep only rows with interactions, unless we receive a valid newtab.opened event.
    -- This is meant to drop only interactions that only have a newtab.closed event on the same partition

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
@@ -624,4 +624,4 @@ LEFT JOIN
   USING (legacy_telemetry_client_id)
 LEFT JOIN `mozdata.static.key_tentpole_dates` ktd
   ON submission_date >= ktd.start_date
-  OR submission_date <= ktd.start_date
+  AND submission_date <= ktd.end_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
@@ -614,8 +614,14 @@ SELECT
       THEN "default"
     ELSE "non-default"
   END AS newtab_default_ui,
+  ktd.key_tentpole,
+  ktd.start_date,
+  ktd.end_date
 FROM
   combined_newtab_activity
 LEFT JOIN
   client_profile_info
   USING (legacy_telemetry_client_id)
+LEFT JOIN `mozdata.static.key_tentpole_dates` ktd
+  ON submission_date >= ktd.start_date
+  OR submission_date <= ktd.start_date


### PR DESCRIPTION
Add key_tentpoles in order to surface this field in Looker for M9 Dashboard

## Description

<!--
Please do not leave this blank
This PR adds new fields from the static.key_tentpoles table to surface these fields in this dashboard: https://mozilla.cloud.looker.com/dashboards/1943?Country+Name=&Surface=&Product=&Submission+Date=7+day+ago+for+7+day
-->

## Related Tickets & Documents
[AD-208](https://mozilla-hub.atlassian.net/browse/AD-208)


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[AD-208]: https://mozilla-hub.atlassian.net/browse/AD-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ