### PR TITLE
Initiate backfill of `subscription_platform_derived.daily_active_logical_subscriptions_v1`

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2024-11-07:
+  start_date: 2019-10-10
+  end_date: 2024-11-06
+  reason:
+    A bug was causing conflicting `stripe_subscriptions_revised_changelog_v1` records,
+    which ended up causing incorrect subscription records in this table.
+    That bug was fixed in https://github.com/mozilla/bigquery-etl/pull/6458.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false


### PR DESCRIPTION
## Description
To propagate the bug fix from #6458 to historical data.

This backfill shouldn't be initiated until the `stripe_subscriptions_revised_changelog_v1` backfill started in #6460 has been completed and the latest daily `stripe_subscriptions_revised_changelog_v1` ETL has been (re)run plus downstream ETLs to rebuild the intermediate subscription history tables.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/6458
* https://github.com/mozilla/bigquery-etl/pull/6460
* DENG-974: Stripe subscriptions ETL v2

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6331)
