### PR TITLE
Change `subscriptions_changelog_v1` ETL to add all available incremental records in append-only mode

### DIFF
--- a/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/metadata.yaml
@@ -16,7 +16,11 @@ labels:
   schedule: daily
 scheduling:
   dag_name: bqetl_subplat
-  date_partition_parameter: date
+  # The table as a whole is appended to each time, not a specific date partition.
+  date_partition_parameter: null
+  arguments:
+  - --append_table
+  - --noreplace
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/query.sql
@@ -29,12 +29,34 @@ WITH subscriptions_history AS (
     trial_start,
   FROM
     `moz-fx-data-shared-prod`.stripe_external.subscription_history_v1
-  WHERE
-    {% if is_init() %}
-      TRUE
-    {% else %}
-      DATE(_fivetran_start) >= @date
-    {% endif %}
+),
+new_subscriptions_history AS (
+  {% if is_init() %}
+    SELECT
+      *
+    FROM
+      subscriptions_history
+  {% else %}
+    WITH latest_subscriptions_changelog AS (
+      SELECT
+        subscription.id AS subscription_id,
+        MAX(`timestamp`) AS max_timestamp
+      FROM
+        `moz-fx-data-shared-prod`.stripe_external.subscriptions_changelog_v1
+      GROUP BY
+        subscription.id
+    )
+    SELECT
+      subscriptions_history.*
+    FROM
+      subscriptions_history
+    LEFT JOIN
+      latest_subscriptions_changelog
+      USING (subscription_id)
+    WHERE
+      subscriptions_history._fivetran_start > latest_subscriptions_changelog.max_timestamp
+      OR latest_subscriptions_changelog.max_timestamp IS NULL
+  {% endif %}
 ),
 subscription_items AS (
   SELECT
@@ -93,7 +115,7 @@ subscriptions_history_with_plan_metadata AS (
         _fivetran_start
     ) AS lead_previous_plan_id
   FROM
-    subscriptions_history
+    new_subscriptions_history
 ),
 subscriptions_history_with_end_plan_ids AS (
   -- Determine the plan ID for the last record in each time span that a subscription had a particular plan.
@@ -148,7 +170,7 @@ subscriptions_history_tax_rates AS (
         tax_rates.created
     ) AS tax_rates
   FROM
-    subscriptions_history
+    new_subscriptions_history AS subscriptions_history
   JOIN
     `moz-fx-data-shared-prod`.stripe_external.subscription_tax_rate_v1 AS subscription_tax_rates
     ON subscriptions_history.subscription_id = subscription_tax_rates.subscription_id
@@ -189,7 +211,7 @@ subscriptions_history_latest_discounts AS (
         1
     )[SAFE_ORDINAL(1)] AS discount
   FROM
-    subscriptions_history
+    new_subscriptions_history AS subscriptions_history
   JOIN
     `moz-fx-data-shared-prod`.stripe_external.subscription_discount_v2 AS subscription_discounts
     ON subscriptions_history.subscription_id = subscription_discounts.subscription_id
@@ -280,9 +302,3 @@ LEFT JOIN
 LEFT JOIN
   subscriptions_history_latest_discounts
   ON subscriptions_history.id = subscriptions_history_latest_discounts.subscription_history_id
-WHERE
-  {% if is_init() %}
-    DATE(subscriptions_history._fivetran_start) < CURRENT_DATE()
-  {% else %}
-    DATE(subscriptions_history._fivetran_start) = @date
-  {% endif %}


### PR DESCRIPTION
## Description
While [QAing a backfill of `stripe_subscriptions_revised_changelog_v1`](https://github.com/mozilla/bigquery-etl/pull/6464#issuecomment-2465659329) I discovered that because the `subscriptions_changelog_v1` ETL was only getting the records from the previous date rather than all available records, the `stripe_subscriptions_revised_changelog_v1` ETL ended up missing records that [got adjusted](https://github.com/mozilla/bigquery-etl/blob/d0e6d6c1ee146c931e5f530061e1b96e7a5439e7/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/query.sql#L131-L141) across a date boundary and ended up in the prior day.
 
This PR tries to avoid that problem by changing the `subscriptions_changelog_v1` ETL to add all available incremental records in append-only mode.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/6464
* DENG-974: Stripe subscriptions ETL v2

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6339)
