### PR TITLE
DENG-4835 - delete 3 views missed in previous PR

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_error_aggregates_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_error_aggregates_v1/view.sql
@@ -1,8 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.telemetry.experiment_error_aggregates_v1`
-AS
-SELECT
-  submission_date AS submission_date_s3,
-  *
-FROM
-  `moz-fx-data-shared-prod.telemetry_derived.experiment_error_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_new_profile_parquet/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_new_profile_parquet/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.telemetry.telemetry_new_profile_parquet`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.telemetry.telemetry_new_profile_parquet_v2`

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_shield_study_parquet/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_shield_study_parquet/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.telemetry.telemetry_shield_study_parquet`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.telemetry.telemetry_shield_study_parquet_v1`


### PR DESCRIPTION
## Description

This PR is a follow up to [PR-6455](https://github.com/mozilla/bigquery-etl/pull/6455) , related to deleting a set of deprecated views and tables.  This PR deletes 3 views that were missed in the previous PR.

- telemetry.experiment_error_aggregates_v1
- telemetry.telemetry_new_profile_parquet
- telemetry.telemetry_shield_study_parquet


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6340)
