### PR TITLE
Complete backfill of `subscription_platform_derived.logical_subscription_events_v1`

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -7,5 +7,5 @@
     That bug was fixed in https://github.com/mozilla/bigquery-etl/pull/6458.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false


### PR DESCRIPTION
## Description
Complete backfill initiated in #6461 to propagate the bug fix from #6458 to historical data.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/6458
* https://github.com/mozilla/bigquery-etl/pull/6461
* DENG-974: Stripe subscriptions ETL v2

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6355)
