### PR TITLE
Update Desktop Conversion Events View to reference new V2 table

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
@@ -26,7 +26,7 @@ SELECT
   UNIX_SECONDS(CAST(MIN(a.activity_datetime) AS TIMESTAMP)) AS activity_date,
   CAST(MIN(a.activity_datetime) AS TIMESTAMP) AS activity_date_timestamp
 FROM
-  `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v1` a
+  `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v2` a
 JOIN
   all_clicks_from_united_states b
   ON a.gclid = b.gclid


### PR DESCRIPTION
## Description

This PR updates the desktop_conversion_events view to point to the new V2 desktop conversions table instead of the old V1 table.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6362)
