### PR TITLE
feat: adding an additional case for when metric.metric_type is null inside _update_bigconfig

### DIFF
--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -342,6 +342,14 @@ def _update_bigconfig(
     for collection in bigconfig.tag_deployments:
         for deployment in collection.deployments:
             for metric in deployment.metrics:
+                if metric.metric_type is None:
+                    err_message = f"""There appears to be an issue parsing \
+                    a metric type definition for `{project}.{dataset}.{table}` \
+                    metric: {str(metric)} \
+                    deployment: {str(deployment)}."""
+
+                    raise Exception(err_message)
+
                 if metric.metric_type.predefined_metric in default_metrics:
                     default_metrics.remove(metric.metric_type.predefined_metric)
 


### PR DESCRIPTION
# feat: adding an additional case for when metric.metric_type is null inside _update_bigconfig

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-XXXX
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
