### PR TITLE
Fix bigeye checks to de-dup metric names

### DIFF
--- a/sql/moz-fx-data-shared-prod/net_thunderbird_android_beta_derived/baseline_clients_last_seen_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/net_thunderbird_android_beta_derived/baseline_clients_last_seen_v1/bigconfig.yml
@@ -6,7 +6,7 @@ row_creation_times:
 
 saved_metric_definitions:
   metrics:
-  - saved_metric_id: PERCENT_NULL
+  - saved_metric_id: PERCENT_NULL_net_thunderbird_android_beta_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: PERCENT_NULL
@@ -28,7 +28,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: COUNT_VALUE_IN_LIST
+  - saved_metric_id: COUNT_VALUE_IN_LIST_net_thunderbird_android_beta_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: COUNT_VALUE_IN_LIST
@@ -56,7 +56,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: COUNTRY_REGEX_CHECK
+  - saved_metric_id: COUNTRY_REGEX_CHECK_net_thunderbird_android_beta_derived
     metric_type:
       type: TEMPLATE
       template_id: 945
@@ -86,7 +86,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: FRESHNESS
+  - saved_metric_id: FRESHNESS_net_thunderbird_android_beta_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: FRESHNESS
@@ -107,7 +107,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: VOLUME
+  - saved_metric_id: VOLUME_net_thunderbird_android_beta_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: VOLUME
@@ -128,7 +128,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: COUNT_DUPLICATES
+  - saved_metric_id: COUNT_DUPLICATES_net_thunderbird_android_beta_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: COUNT_DUPLICATES
@@ -151,7 +151,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: STRING_LENGTH_MAX
+  - saved_metric_id: STRING_LENGTH_MAX_net_thunderbird_android_beta_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: STRING_LENGTH_MAX
@@ -187,22 +187,22 @@ tag_deployments:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_beta_derived.baseline_clients_last_seen_v1.days_active_bits
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_beta_derived.baseline_clients_last_seen_v1.client_id
     metrics:
-    - saved_metric_id: PERCENT_NULL
+    - saved_metric_id: PERCENT_NULL_net_thunderbird_android_beta_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_beta_derived.baseline_clients_last_seen_v1.normalized_channel
     metrics:
-    - saved_metric_id: COUNT_VALUE_IN_LIST
+    - saved_metric_id: COUNT_VALUE_IN_LIST_net_thunderbird_android_beta_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_beta_derived.baseline_clients_last_seen_v1
     metrics:
-    - saved_metric_id: COUNTRY_REGEX_CHECK
+    - saved_metric_id: COUNTRY_REGEX_CHECK_net_thunderbird_android_beta_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_beta_derived.baseline_clients_last_seen_v1.*
     metrics:
-    - saved_metric_id: FRESHNESS
-    - saved_metric_id: VOLUME
+    - saved_metric_id: FRESHNESS_net_thunderbird_android_beta_derived
+    - saved_metric_id: VOLUME_net_thunderbird_android_beta_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_beta_derived.baseline_clients_last_seen_v1.client_id
     metrics:
-    - saved_metric_id: COUNT_DUPLICATES
-    - saved_metric_id: STRING_LENGTH_MAX
+    - saved_metric_id: COUNT_DUPLICATES_net_thunderbird_android_beta_derived
+    - saved_metric_id: STRING_LENGTH_MAX_net_thunderbird_android_beta_derived

--- a/sql/moz-fx-data-shared-prod/net_thunderbird_android_daily_derived/baseline_clients_last_seen_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/net_thunderbird_android_daily_derived/baseline_clients_last_seen_v1/bigconfig.yml
@@ -6,7 +6,7 @@ row_creation_times:
 
 saved_metric_definitions:
   metrics:
-  - saved_metric_id: PERCENT_NULL
+  - saved_metric_id: PERCENT_NULL_net_thunderbird_android_daily_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: PERCENT_NULL
@@ -28,7 +28,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: FRESHNESS
+  - saved_metric_id: FRESHNESS_net_thunderbird_android_daily_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: FRESHNESS
@@ -49,7 +49,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: VOLUME
+  - saved_metric_id: VOLUME_net_thunderbird_android_daily_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: VOLUME
@@ -70,7 +70,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: COUNT_DUPLICATES
+  - saved_metric_id: COUNT_DUPLICATES_net_thunderbird_android_daily_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: COUNT_DUPLICATES
@@ -93,7 +93,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: STRING_LENGTH_MAX
+  - saved_metric_id: STRING_LENGTH_MAX_net_thunderbird_android_daily_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: STRING_LENGTH_MAX
@@ -129,14 +129,14 @@ tag_deployments:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_daily_derived.baseline_clients_last_seen_v1.days_active_bits
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_daily_derived.baseline_clients_last_seen_v1.client_id
     metrics:
-    - saved_metric_id: PERCENT_NULL
+    - saved_metric_id: PERCENT_NULL_net_thunderbird_android_daily_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_daily_derived.baseline_clients_last_seen_v1.*
     metrics:
-    - saved_metric_id: FRESHNESS
-    - saved_metric_id: VOLUME
+    - saved_metric_id: FRESHNESS_net_thunderbird_android_daily_derived
+    - saved_metric_id: VOLUME_net_thunderbird_android_daily_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_daily_derived.baseline_clients_last_seen_v1.client_id
     metrics:
-    - saved_metric_id: COUNT_DUPLICATES
-    - saved_metric_id: STRING_LENGTH_MAX
+    - saved_metric_id: COUNT_DUPLICATES_net_thunderbird_android_daily_derived
+    - saved_metric_id: STRING_LENGTH_MAX_net_thunderbird_android_daily_derived

--- a/sql/moz-fx-data-shared-prod/net_thunderbird_android_derived/baseline_clients_last_seen_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/net_thunderbird_android_derived/baseline_clients_last_seen_v1/bigconfig.yml
@@ -6,7 +6,7 @@ row_creation_times:
 
 saved_metric_definitions:
   metrics:
-  - saved_metric_id: PERCENT_NULL
+  - saved_metric_id: PERCENT_NULL_net_thunderbird_android_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: PERCENT_NULL
@@ -28,7 +28,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: COUNT_VALUE_IN_LIST
+  - saved_metric_id: COUNT_VALUE_IN_LIST_net_thunderbird_android_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: COUNT_VALUE_IN_LIST
@@ -56,7 +56,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: COUNTRY_REGEX_CHECK
+  - saved_metric_id: COUNTRY_REGEX_CHECK_net_thunderbird_android_derived
     metric_type:
       type: TEMPLATE
       template_id: 945
@@ -86,7 +86,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: FRESHNESS
+  - saved_metric_id: FRESHNESS_net_thunderbird_android_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: FRESHNESS
@@ -107,7 +107,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: VOLUME
+  - saved_metric_id: VOLUME_net_thunderbird_android_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: VOLUME
@@ -128,7 +128,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: COUNT_DUPLICATES
+  - saved_metric_id: COUNT_DUPLICATES_net_thunderbird_android_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: COUNT_DUPLICATES
@@ -151,7 +151,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: STRING_LENGTH_MAX
+  - saved_metric_id: STRING_LENGTH_MAX_net_thunderbird_android_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: STRING_LENGTH_MAX
@@ -187,22 +187,22 @@ tag_deployments:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_derived.baseline_clients_last_seen_v1.days_active_bits
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_derived.baseline_clients_last_seen_v1.client_id
     metrics:
-    - saved_metric_id: PERCENT_NULL
+    - saved_metric_id: PERCENT_NULL_net_thunderbird_android_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_derived.baseline_clients_last_seen_v1.normalized_channel
     metrics:
-    - saved_metric_id: COUNT_VALUE_IN_LIST
+    - saved_metric_id: COUNT_VALUE_IN_LIST_net_thunderbird_android_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_derived.baseline_clients_last_seen_v1
     metrics:
-    - saved_metric_id: COUNTRY_REGEX_CHECK
+    - saved_metric_id: COUNTRY_REGEX_CHECK_net_thunderbird_android_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_derived.baseline_clients_last_seen_v1.*
     metrics:
-    - saved_metric_id: FRESHNESS
-    - saved_metric_id: VOLUME
+    - saved_metric_id: FRESHNESS_net_thunderbird_android_derived
+    - saved_metric_id: VOLUME_net_thunderbird_android_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.net_thunderbird_android_derived.baseline_clients_last_seen_v1.client_id
     metrics:
-    - saved_metric_id: COUNT_DUPLICATES
-    - saved_metric_id: STRING_LENGTH_MAX
+    - saved_metric_id: COUNT_DUPLICATES_net_thunderbird_android_derived
+    - saved_metric_id: STRING_LENGTH_MAX_net_thunderbird_android_derived

--- a/sql/moz-fx-data-shared-prod/thunderbird_desktop_derived/baseline_clients_last_seen_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/thunderbird_desktop_derived/baseline_clients_last_seen_v1/bigconfig.yml
@@ -6,7 +6,7 @@ row_creation_times:
 
 saved_metric_definitions:
   metrics:
-  - saved_metric_id: PERCENT_NULL
+  - saved_metric_id: PERCENT_NULL_thunderbird_desktop_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: PERCENT_NULL
@@ -28,7 +28,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: COUNT_VALUE_IN_LIST
+  - saved_metric_id: COUNT_VALUE_IN_LIST_thunderbird_desktop_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: COUNT_VALUE_IN_LIST
@@ -56,7 +56,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: COUNTRY_REGEX_CHECK
+  - saved_metric_id: COUNTRY_REGEX_CHECK_thunderbird_desktop_derived
     metric_type:
       type: TEMPLATE
       template_id: 945
@@ -86,7 +86,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: FRESHNESS
+  - saved_metric_id: FRESHNESS_thunderbird_desktop_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: FRESHNESS
@@ -107,7 +107,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: VOLUME
+  - saved_metric_id: VOLUME_thunderbird_desktop_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: VOLUME
@@ -128,7 +128,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: COUNT_DUPLICATES
+  - saved_metric_id: COUNT_DUPLICATES_thunderbird_desktop_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: COUNT_DUPLICATES
@@ -151,7 +151,7 @@ saved_metric_definitions:
     metric_schedule:
       named_schedule:
         name: Default Schedule - 13:00 UTC
-  - saved_metric_id: STRING_LENGTH_MAX
+  - saved_metric_id: STRING_LENGTH_MAX_thunderbird_desktop_derived
     metric_type:
       type: PREDEFINED
       predefined_metric: STRING_LENGTH_MAX
@@ -187,22 +187,22 @@ tag_deployments:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.thunderbird_desktop_derived.baseline_clients_last_seen_v1.days_active_bits
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.thunderbird_desktop_derived.baseline_clients_last_seen_v1.client_id
     metrics:
-    - saved_metric_id: PERCENT_NULL
+    - saved_metric_id: PERCENT_NULL_thunderbird_desktop_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.thunderbird_desktop_derived.baseline_clients_last_seen_v1.normalized_channel
     metrics:
-    - saved_metric_id: COUNT_VALUE_IN_LIST
+    - saved_metric_id: COUNT_VALUE_IN_LIST_thunderbird_desktop_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.thunderbird_desktop_derived.baseline_clients_last_seen_v1
     metrics:
-    - saved_metric_id: COUNTRY_REGEX_CHECK
+    - saved_metric_id: COUNTRY_REGEX_CHECK_thunderbird_desktop_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.thunderbird_desktop_derived.baseline_clients_last_seen_v1.*
     metrics:
-    - saved_metric_id: FRESHNESS
-    - saved_metric_id: VOLUME
+    - saved_metric_id: FRESHNESS_thunderbird_desktop_derived
+    - saved_metric_id: VOLUME_thunderbird_desktop_derived
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.thunderbird_desktop_derived.baseline_clients_last_seen_v1.client_id
     metrics:
-    - saved_metric_id: COUNT_DUPLICATES
-    - saved_metric_id: STRING_LENGTH_MAX
+    - saved_metric_id: COUNT_DUPLICATES_thunderbird_desktop_derived
+    - saved_metric_id: STRING_LENGTH_MAX_thunderbird_desktop_derived


### PR DESCRIPTION
The[ Bigeye monitors ](https://workflow.telemetry.mozilla.org/dags/bqetl_artifact_deployment/grid?dag_run_id=manual__2024-11-13T05%3A04%3A56.400545%2B00%3A00&task_id=publish_bigeye_monitors&tab=logs)are failing with error `Duplicate saved_metric_id`
This PR should fix.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6367)
