### PR TITLE
Fix `stripe_subscriptions_history_v2.valid_to` getting cut short for ended subscriptions with subsequent customer changes

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/query.sql
@@ -23,7 +23,8 @@ subscriptions_customers_history AS (
     subscriptions_history.id,
     subscriptions_history.valid_from,
     IF(
-      customers_history.valid_to IS NOT NULL,
+      subscriptions_history.subscription.ended_at IS NULL
+      AND customers_history.valid_to IS NOT NULL,
       LEAST(subscriptions_history.valid_to, customers_history.valid_to),
       subscriptions_history.valid_to
     ) AS valid_to,


### PR DESCRIPTION
## Description
In #6458 I tweaked the `stripe_subscriptions_history_v2` ETL to exclude customer changes that occur after the subscription has ended ([code change](https://github.com/mozilla/bigquery-etl/pull/6458/files#diff-10bf24b2789e1a1c6268b8a35001967b785ee431c5d271b824751341c0df63aeR62-R63)).  However, I neglected to update the logic for the `valid_to` column to compensate, which resulted in ended subscriptions with subsequent customer changes having their final `stripe_subscriptions_history_v2` record with `valid_to` set to the timestamp of the next customer change rather than the max timestamp value as intended.  This PR fixes that issue.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/6458
* DENG-974: Stripe subscriptions ETL v2

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6382)
