### PR TITLE
Initiate backfill of logical subscription ETLs to populate new discount fields (DENG-974)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -1,9 +1,18 @@
+2024-11-13:
+  start_date: 2019-10-10
+  end_date: 2024-11-12
+  reason: To populate the new subscription discount fields which were added in
+    https://github.com/mozilla/bigquery-etl/pull/6474.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+
 2024-11-07:
   start_date: 2019-10-10
   end_date: 2024-11-06
-  reason:
-    A bug was causing conflicting `stripe_subscriptions_revised_changelog_v1` records,
-    which ended up causing incorrect subscription records in this table.
+  reason: A bug was causing conflicting `stripe_subscriptions_revised_changelog_v1`
+    records, which ended up causing incorrect subscription records in this table.
     That bug was fixed in https://github.com/mozilla/bigquery-etl/pull/6458.
   watchers:
   - srose@mozilla.com

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -1,9 +1,18 @@
+2024-11-13:
+  start_date: 2019-10-10
+  end_date: 2024-11-12
+  reason: To populate the new subscription discount fields which were added in
+    https://github.com/mozilla/bigquery-etl/pull/6474.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+
 2024-11-07:
   start_date: 2019-10-10
   end_date: 2024-11-06
-  reason:
-    A bug was causing conflicting `stripe_subscriptions_revised_changelog_v1` records,
-    which ended up causing missing/incorrect event records in this table.
+  reason: A bug was causing conflicting `stripe_subscriptions_revised_changelog_v1`
+    records, which ended up causing missing/incorrect event records in this table.
     That bug was fixed in https://github.com/mozilla/bigquery-etl/pull/6458.
   watchers:
   - srose@mozilla.com

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
@@ -1,9 +1,18 @@
+2024-11-13:
+  start_date: 2019-10-01
+  end_date: 2024-10-01
+  reason: To populate the new subscription discount fields which were added in
+    https://github.com/mozilla/bigquery-etl/pull/6474.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+
 2024-11-07:
   start_date: 2019-10-01
   end_date: 2024-10-01
-  reason:
-    A bug was causing conflicting `stripe_subscriptions_revised_changelog_v1` records,
-    which ended up causing incorrect subscription records in this table.
+  reason: A bug was causing conflicting `stripe_subscriptions_revised_changelog_v1`
+    records, which ended up causing incorrect subscription records in this table.
     That bug was fixed in https://github.com/mozilla/bigquery-etl/pull/6458.
   watchers:
   - srose@mozilla.com


### PR DESCRIPTION
## Description
To populate the new subscription discount fields which were added in #6474.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/6474
* DENG-974: Stripe subscriptions ETL v2

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6394)
