### PR TITLE
fix is_list_card filters

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/query.sql
@@ -232,57 +232,40 @@ pocket_events AS (
     SAFE_CAST(mozfun.map.get_key(event_details, "position") AS INT64) AS pocket_story_position,
     mozfun.map.get_key(event_details, "tile_id") AS pocket_tile_id,
     mozfun.map.get_key(event_details, "recommendation_id") AS pocket_recommendation_id,
-    COUNTIF(
-      event_name = 'save'
-      AND mozfun.map.get_key(event_details, "is_list_card") != "true"
-    ) AS pocket_saves,
-    COUNTIF(
-      event_name = 'click'
-      AND mozfun.map.get_key(event_details, "is_list_card") != "true"
-    ) AS pocket_clicks,
-    COUNTIF(
-      event_name = 'impression'
-      AND mozfun.map.get_key(event_details, "is_list_card") != "true"
-    ) AS pocket_impressions,
+    COUNTIF(event_name = 'save') AS pocket_saves,
+    COUNTIF(event_name = 'click') AS pocket_clicks,
+    COUNTIF(event_name = 'impression') AS pocket_impressions,
     COUNTIF(
       event_name = 'click'
       AND mozfun.map.get_key(event_details, "is_sponsored") = "true"
-      AND mozfun.map.get_key(event_details, "is_list_card") != "true"
     ) AS sponsored_pocket_clicks,
     COUNTIF(
       event_name = 'click'
       AND mozfun.map.get_key(event_details, "is_sponsored") != "true"
-      AND mozfun.map.get_key(event_details, "is_list_card") != "true"
     ) AS organic_pocket_clicks,
     COUNTIF(
       event_name = 'impression'
       AND mozfun.map.get_key(event_details, "is_sponsored") = "true"
-      AND mozfun.map.get_key(event_details, "is_list_card") != "true"
     ) AS sponsored_pocket_impressions,
     COUNTIF(
       event_name = 'impression'
       AND mozfun.map.get_key(event_details, "is_sponsored") != "true"
-      AND mozfun.map.get_key(event_details, "is_list_card") != "true"
     ) AS organic_pocket_impressions,
     COUNTIF(
       event_name = 'save'
       AND mozfun.map.get_key(event_details, "is_sponsored") = "true"
-      AND mozfun.map.get_key(event_details, "is_list_card") != "true"
     ) AS sponsored_pocket_saves,
     COUNTIF(
       event_name = 'save'
       AND mozfun.map.get_key(event_details, "is_sponsored") != "true"
-      AND mozfun.map.get_key(event_details, "is_list_card") != "true"
     ) AS organic_pocket_saves,
     COUNTIF(
       event_name = 'dismiss'
       AND mozfun.map.get_key(event_details, "is_sponsored") = "true"
-      AND mozfun.map.get_key(event_details, "is_list_card") != "true"
     ) AS sponsored_pocket_dismissals,
     COUNTIF(
       event_name = 'dismiss'
       AND mozfun.map.get_key(event_details, "is_sponsored") != "true"
-      AND mozfun.map.get_key(event_details, "is_list_card") != "true"
     ) AS organic_pocket_dismissals,
     COUNTIF(
       event_name = 'thumb_voting_interaction'


### PR DESCRIPTION
Removes filters causing 0 values in `pocket` event counts.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6399)
