### PR TITLE
Desktop Conversion Events - Add depends on past = true

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v2/metadata.yaml
@@ -12,6 +12,7 @@ scheduling:
   date_partition_offset: -2
   parameters:
   - submission_date:DATE:{{ds}}
+  depends_on_past: true
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description
This PR adds "depends on past" = True to ga_desktop_conversions_v2 so that it runs in order during backfills.


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6402)
