### PR TITLE
Adding dataproc and datafusion permissions to gclid_conversions_v3

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/gclid_conversions_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/gclid_conversions_v3/metadata.yaml
@@ -23,4 +23,8 @@ bigquery:
 references: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer
-  members: [workgroup:dataops-managed/external-census]
+  members:
+  - workgroup:dataops-managed/external-census
+  - workgroup:mozilla-confidential
+  - workgroup:google-managed/external-ads-datafusion
+  - workgroup:google-managed/external-ads-dataproc


### PR DESCRIPTION
## Description

This PR grants read access to gclid conversions v3 so that the Google ads account can read from the end view mozdata.mozilla_org.desktop_conversion_events

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
