### PR TITLE
Complete backfill of logical subscription ETLs to populate new discount fields (DENG-974)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
     https://github.com/mozilla/bigquery-etl/pull/6474.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
 
 2024-11-07:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -5,7 +5,7 @@
     https://github.com/mozilla/bigquery-etl/pull/6474.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
 
 2024-11-07:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
     https://github.com/mozilla/bigquery-etl/pull/6474.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
 
 2024-11-07:


### PR DESCRIPTION
## Description
Complete backfill initiated in #6495 to populate the new subscription discount fields which were added in #6474.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/6474
* https://github.com/mozilla/bigquery-etl/pull/6495
* [DENG-974](https://mozilla-hub.atlassian.net/browse/DENG-974): Stripe subscriptions ETL v2

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-974]: https://mozilla-hub.atlassian.net/browse/DENG-974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6407)
