### PR TITLE
Backfill `newtab_clients_daily` to revert Pocket click error

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/backfill.yaml
@@ -1,3 +1,11 @@
+2024-11-15:
+  start_date: 2024-11-05
+  end_date: 2024-11-13
+  reason: Backfill dates where error in query caused Pocket clicks to be 0.
+  watchers:
+    - mbowerman@mozilla.com
+  status: Initiate
+
 2024-08-26:
   start_date: 2024-08-01
   end_date: 2024-08-26


### PR DESCRIPTION
Initiates backfill for the dates where the Pocket click error had an effect.