### PR TITLE
Set retention to 25 months on firefox_ios_derived.active_users_aggreg…

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/active_users_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/active_users_aggregates_v1/metadata.yaml
@@ -19,4 +19,6 @@ description: |-
 owners:
 - lvargas@mozilla.com
 - mozilla/kpi_table_reviewers
+bigquery:
+  expiration_days: 780
 deprecated: true


### PR DESCRIPTION
This is a test PR for setting the retention policy to 25 months. 
The table `firefox_ios_derived.active_users_aggregatess_v1` is not in use and so is a good test case.

The mininum submission_date on this table now is `2021-01-01`