### PR TITLE
Set retention to 25 months on firefox_desktop_derived.pageload_1pct_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/pageload_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/pageload_1pct_v1/metadata.yaml
@@ -18,6 +18,7 @@ bigquery:
     require_partition_filter: true
     expiration_days: null
   range_partitioning: null
+  expiration_days: 780
   clustering:
     fields:
     - normalized_channel


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DSRE-1639?focusedCommentId=962362

Using the same value for 25mo as in https://github.com/mozilla/bigquery-etl/pull/6509

I don't actually know how this retention mechanism is implemented. Will this metadata update automatically get applied to the existing table?

## Related Tickets & Documents
* DSRE-1639

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6417)
