### PR TITLE
Remove hardcoded dataset in baseline clients last seen check

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.checks.sql
@@ -61,7 +61,7 @@ WITH daily AS
      submission_date,
      COUNT(DISTINCT client_id) AS client_count
  FROM
-    `moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.baseline_clients_daily_v1`
+    `{{ project_id }}.{{ dataset_id }}..baseline_clients_daily_v1`
  WHERE
     submission_date = @submission_date
     AND sample_id IS NOT NULL
@@ -73,7 +73,7 @@ WITH daily AS
   submission_date,
   COUNT(DISTINCT client_id) AS client_count
  FROM
-  `moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.baseline_clients_last_seen_v1`
+  `{{ project_id }}.{{ dataset_id }}..baseline_clients_last_seen_v1`
  WHERE
   submission_date = @submission_date
   AND mozfun.bits28.days_since_seen(days_seen_bits) = 0


### PR DESCRIPTION
## Description

Check is hardcoded to run on the `org_mozilla_ios_firefox_derived` tables for every dataset

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
