### PR TITLE
initiate backfill

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_clients_daily_v1/backfill.yaml
@@ -1,3 +1,11 @@
+2024-11-18:
+  start_date: 2024-11-05
+  end_date: 2024-11-13
+  reason: Backfill dates where error in query caused Pocket clicks to be 0.
+  watchers:
+    - mbowerman@mozilla.com
+  status: Initiate
+
 2024-10-24:
   start_date: 2022-11-01
   end_date: 2024-10-23


### PR DESCRIPTION
Initiate `newtab_clients_daily` backfill to fix the Pocket click error

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6421)
