### PR TITLE
Support results with no rows in matches_pattern check

### DIFF
--- a/tests/checks/matches_pattern.jinja
+++ b/tests/checks/matches_pattern.jinja
@@ -4,7 +4,10 @@
 
   SELECT
     IF(
-      ROUND((COUNTIF(NOT REGEXP_CONTAINS({{ column }}, r"{{ pattern }}"))) / COUNT(*) * 100, 2) > {{ threshold_fail_percentage }},
+      ROUND(
+        COUNTIF(NOT REGEXP_CONTAINS({{ column }}, r"{{ pattern }}"))) / GREATEST(COUNT(*), 1) * 100,
+        2
+      ) > {{ threshold_fail_percentage }},
       ERROR("{{ message }}"),
       NULL
     )

--- a/tests/checks/matches_pattern.jinja
+++ b/tests/checks/matches_pattern.jinja
@@ -5,7 +5,7 @@
   SELECT
     IF(
       ROUND(
-        COUNTIF(NOT REGEXP_CONTAINS({{ column }}, r"{{ pattern }}"))) / GREATEST(COUNT(*), 1) * 100,
+        COUNTIF(NOT REGEXP_CONTAINS({{ column }}, r"{{ pattern }}")) / GREATEST(COUNT(*), 1) * 100,
         2
       ) > {{ threshold_fail_percentage }},
       ERROR("{{ message }}"),


### PR DESCRIPTION
## Description

The check divides by zero if there are no rows matching the where clause which I don't think is the right behaviour when we have the `min_row_count` check that should be used for that case.  This changes it so the the fail rate is 0 when there are no rows

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6427)
