### PR TITLE
Support for deploying queries consisting of only metadata.yaml and schema.yaml

### DIFF
--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -432,7 +432,7 @@ def initiate(
 
     try:
         deploy_table(
-            query_file=query_path,
+            artifact_file=query_path,
             destination_table=backfill_staging_qualified_table_name,
             respect_dryrun_skip=False,
         )

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -79,6 +79,8 @@ DESTINATION_TABLE_RE = re.compile(r"^[a-zA-Z0-9_$]{0,1024}$")
 DEFAULT_DAG_NAME = "bqetl_default"
 DEFAULT_INIT_PARALLELISM = 10
 DEFAULT_CHECKS_FILE_NAME = "checks.sql"
+VIEW_FILE = "view.sql"
+MATERIALIZED_VIEW = "materialized_view.sql"
 
 
 @click.group(help="Commands for managing queries.")
@@ -2217,6 +2219,8 @@ def deploy(
         metadata_file
         for metadata_file in metadata_files
         if metadata_file.parent not in query_file_paths
+        and not (metadata_file.parent / VIEW_FILE).exists()
+        and not (metadata_file.parent / MATERIALIZED_VIEW).exists()
     ]
 
     _deploy = partial(

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -2189,7 +2189,11 @@ def deploy(
         name, sql_dir, project_id, ["query.*", "script.sql"]
     )
 
-    if not query_files:
+    metadata_files = paths_matching_name_pattern(
+        name, sql_dir, project_id, ["metadata.yaml"]
+    )
+
+    if not query_files and not metadata_files:
         # run SQL generators if no matching query has been found
         ctx.invoke(
             generate_all,
@@ -2199,11 +2203,21 @@ def deploy(
         query_files = paths_matching_name_pattern(
             name, ctx.obj["TMP_DIR"], project_id, ["query.*", "script.sql"]
         )
-        if not query_files:
+        metadata_files = paths_matching_name_pattern(
+            name, ctx.obj["TMP_DIR"], project_id, ["metadata.yaml"]
+        )
+        if not query_files and not metadata_files:
             raise click.ClickException(f"No queries matching `{name}` were found.")
 
     credentials = get_credentials()
     id_token = get_id_token(credentials=credentials)
+
+    query_file_paths = [query_file.parent for query_file in query_files]
+    metadata_files_without_query_file = [
+        metadata_file
+        for metadata_file in metadata_files
+        if metadata_file.parent not in query_file_paths
+    ]
 
     _deploy = partial(
         deploy_table,
@@ -2220,23 +2234,23 @@ def deploy(
     failed_deploys, skipped_deploys = [], []
     with concurrent.futures.ThreadPoolExecutor(max_workers=parallelism) as executor:
         future_to_query = {
-            executor.submit(_deploy, query_file): query_file
-            for query_file in query_files
-            if str(query_file)
+            executor.submit(_deploy, artifact_file): artifact_file
+            for artifact_file in query_files + metadata_files_without_query_file
+            if str(artifact_file)
             not in ConfigLoader.get("schema", "deploy", "skip", fallback=[])
         }
         for future in futures.as_completed(future_to_query):
-            query_file = future_to_query[future]
+            artifact_file = future_to_query[future]
             try:
                 future.result()
             except SkippedDeployException as e:
-                print(f"Skipped deploy for {query_file}: ({e})")
-                skipped_deploys.append(query_file)
+                print(f"Skipped deploy for {artifact_file}: ({e})")
+                skipped_deploys.append(artifact_file)
             except FailedDeployException as e:
-                print(f"Failed deploy for {query_file}: ({e})")
-                failed_deploys.append(query_file)
+                print(f"Failed deploy for {artifact_file}: ({e})")
+                failed_deploys.append(artifact_file)
             else:
-                print(f"{query_file} successfully deployed!")
+                print(f"{artifact_file} successfully deployed!")
 
     if not skip_external_data:
         failed_external_deploys = _deploy_external_data(

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -2219,8 +2219,11 @@ def deploy(
         metadata_file
         for metadata_file in metadata_files
         if metadata_file.parent not in query_file_paths
-        and not (metadata_file.parent / VIEW_FILE).exists()
-        and not (metadata_file.parent / MATERIALIZED_VIEW).exists()
+        and not any(
+            file.suffix == ".sql" or file.name == "query.py"
+            for file in metadata_file.parent.iterdir()
+            if file.is_file()
+        )
     ]
 
     _deploy = partial(

--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -148,7 +148,7 @@ def paths_matching_name_pattern(
                     matching_files.append(query_file)
 
     if len(matching_files) == 0:
-        print(f"No files matching: {pattern}")
+        print(f"No files matching: {pattern}, {files}")
 
     return matching_files
 

--- a/bigquery_etl/deploy.py
+++ b/bigquery_etl/deploy.py
@@ -25,7 +25,7 @@ class FailedDeployException(Exception):
 
 
 def deploy_table(
-    query_file: Path,
+    artifact_file: Path,
     destination_table: Optional[str] = None,
     force: bool = False,
     use_cloud_function: bool = False,
@@ -37,14 +37,14 @@ def deploy_table(
     id_token=None,
 ) -> None:
     """Deploy a query to a destination."""
-    if respect_dryrun_skip and str(query_file) in DryRun.skipped_files():
-        raise SkippedDeployException(f"Dry run skipped for {query_file}.")
+    if respect_dryrun_skip and str(artifact_file) in DryRun.skipped_files():
+        raise SkippedDeployException(f"Dry run skipped for {artifact_file}.")
 
     try:
-        if query_file.name == METADATA_FILE:
-            metadata = Metadata.from_file(query_file)
+        if artifact_file.name == METADATA_FILE:
+            metadata = Metadata.from_file(artifact_file)
         else:
-            metadata = Metadata.of_query_file(query_file)
+            metadata = Metadata.of_query_file(artifact_file)
 
         if (
             metadata.scheduling
@@ -52,28 +52,28 @@ def deploy_table(
             and metadata.scheduling["destination_table"] is None
         ):
             raise SkippedDeployException(
-                f"Skipping deploy for {query_file}, null destination_table configured."
+                f"Skipping deploy for {artifact_file}, null destination_table configured."
             )
     except FileNotFoundError:
-        log.warning(f"No metadata found for {query_file}.")
+        log.warning(f"No metadata found for {artifact_file}.")
 
-    table_name = query_file.parent.name
-    dataset_name = query_file.parent.parent.name
-    project_name = query_file.parent.parent.parent.name
+    table_name = artifact_file.parent.name
+    dataset_name = artifact_file.parent.parent.name
+    project_name = artifact_file.parent.parent.parent.name
 
     if destination_table is None:
         destination_table = f"{project_name}.{dataset_name}.{table_name}"
 
-    existing_schema_path = query_file.parent / SCHEMA_FILE
+    existing_schema_path = artifact_file.parent / SCHEMA_FILE
     try:
         existing_schema = Schema.from_schema_file(existing_schema_path)
     except Exception as e:  # TODO: Raise/catch more specific exception
-        raise SkippedDeployException(f"Schema missing for {query_file}.") from e
+        raise SkippedDeployException(f"Schema missing for {artifact_file}.") from e
 
     client = bigquery.Client(credentials=credentials)
-    if not force and str(query_file).endswith("query.sql"):
+    if not force and str(artifact_file).endswith("query.sql"):
         query_schema = Schema.from_query_file(
-            query_file,
+            artifact_file,
             use_cloud_function=use_cloud_function,
             respect_skip=respect_dryrun_skip,
             sql_dir=sql_dir,
@@ -82,7 +82,7 @@ def deploy_table(
         )
         if not existing_schema.equal(query_schema):
             raise FailedDeployException(
-                f"Query {query_file} does not match "
+                f"Query {artifact_file} does not match "
                 f"schema in {existing_schema_path}. "
                 f"To update the local schema file, "
                 f"run `./bqetl query schema update "
@@ -96,7 +96,7 @@ def deploy_table(
     table.schema = existing_schema.to_bigquery_schema()
 
     if update_metadata:
-        attach_metadata(query_file, table)
+        attach_metadata(artifact_file, table)
 
     _create_or_update(client, table, skip_existing)
 

--- a/bigquery_etl/deploy.py
+++ b/bigquery_etl/deploy.py
@@ -9,7 +9,7 @@ from google.cloud.exceptions import NotFound
 
 from .config import ConfigLoader
 from .dryrun import DryRun, get_id_token
-from .metadata.parse_metadata import Metadata
+from .metadata.parse_metadata import METADATA_FILE, Metadata
 from .metadata.publish_metadata import attach_metadata
 from .schema import SCHEMA_FILE, Schema
 
@@ -41,7 +41,11 @@ def deploy_table(
         raise SkippedDeployException(f"Dry run skipped for {query_file}.")
 
     try:
-        metadata = Metadata.of_query_file(query_file)
+        if query_file.name == METADATA_FILE:
+            metadata = Metadata.from_file(query_file)
+        else:
+            metadata = Metadata.of_query_file(query_file)
+
         if (
             metadata.scheduling
             and "destination_table" in metadata.scheduling

--- a/bigquery_etl/metadata/publish_metadata.py
+++ b/bigquery_etl/metadata/publish_metadata.py
@@ -61,10 +61,13 @@ def publish_metadata(client, project, dataset, table, metadata):
         print(e)
 
 
-def attach_metadata(query_file_path: Path, table: bigquery.Table) -> None:
+def attach_metadata(artifact_file_path: Path, table: bigquery.Table) -> None:
     """Add metadata from query file's metadata.yaml to table object."""
     try:
-        metadata = Metadata.of_query_file(query_file_path)
+        if artifact_file_path.is_file() and artifact_file_path.name == METADATA_FILE:
+            metadata = Metadata.from_file(artifact_file_path)
+        else:
+            metadata = Metadata.of_query_file(artifact_file_path)
     except FileNotFoundError:
         return
 

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -2292,7 +2292,7 @@ class TestBackfill:
             assert not mock_from_query_file.called  # schema exists
 
             mock_deploy_table.assert_called_with(
-                query_file=query_path,
+                artifact_file=query_path,
                 destination_table=f"{backfill_staging_table_name}_2021_05_03",
                 respect_dryrun_skip=False,
             )
@@ -2385,7 +2385,7 @@ class TestBackfill:
             )
 
             mock_deploy_table.assert_called_with(
-                query_file=query_path,
+                artifact_file=query_path,
                 destination_table=f"{backfill_staging_table_name}_2021_05_03",
                 respect_dryrun_skip=False,
             )
@@ -2482,7 +2482,7 @@ class TestBackfill:
             assert not mock_from_query_file.called  # schema exists
 
             mock_deploy_table.assert_called_with(
-                query_file=query_path,
+                artifact_file=query_path,
                 destination_table=f"{backfill_staging_table_name}_2021_05_03",
                 respect_dryrun_skip=False,
             )
@@ -2579,7 +2579,7 @@ class TestBackfill:
             )
 
             mock_deploy_table.assert_called_with(
-                query_file=query_path,
+                artifact_file=query_path,
                 destination_table=f"{backfill_staging_table_name}_2021_05_03",
                 respect_dryrun_skip=False,
             )

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -36,7 +36,7 @@ class TestDeploy:
         client.get_table.side_effect = NotFound("table not found")
 
         deploy.deploy_table(
-            query_file=query_path / "query.sql",
+            artifact_file=query_path / "query.sql",
         )
 
         client.create_table.assert_called_once()
@@ -61,7 +61,7 @@ class TestDeploy:
         with pytest.raises(
             deploy.FailedDeployException, match="Unable to create table"
         ):
-            deploy.deploy_table(query_file=query_path / "query.sql")
+            deploy.deploy_table(artifact_file=query_path / "query.sql")
 
     def test_deploy_table_without_schema_raises_skip(self, tmp_path):
         query_path = (
@@ -71,7 +71,7 @@ class TestDeploy:
         (query_path / "query.sql").write_text("SELECT 1")
 
         with pytest.raises(deploy.SkippedDeployException, match="Schema missing"):
-            deploy.deploy_table(query_file=query_path / "query.sql")
+            deploy.deploy_table(artifact_file=query_path / "query.sql")
 
     def test_deploy_with_null_destination_raises_skip(self, tmp_path):
         query_path = (
@@ -89,7 +89,7 @@ class TestDeploy:
         with pytest.raises(
             deploy.SkippedDeployException, match="null destination_table configured"
         ):
-            deploy.deploy_table(query_file=query_path / "query.sql")
+            deploy.deploy_table(artifact_file=query_path / "query.sql")
 
     @patch("google.cloud.bigquery.Client")
     @patch("bigquery_etl.dryrun.DryRun")
@@ -100,7 +100,7 @@ class TestDeploy:
 
         client = mock_client.return_value
         deploy.deploy_table(
-            query_file=query_path / "query.sql",
+            artifact_file=query_path / "query.sql",
         )
 
         client.update_table.assert_called_once()
@@ -116,7 +116,9 @@ class TestDeploy:
         }
 
         with pytest.raises(deploy.SkippedDeployException, match="already exists"):
-            deploy.deploy_table(query_file=query_path / "query.sql", skip_existing=True)
+            deploy.deploy_table(
+                artifact_file=query_path / "query.sql", skip_existing=True
+            )
 
     @patch("bigquery_etl.dryrun.DryRun")
     def test_deploy_fails_when_schemas_dont_match(self, mock_dryrun, query_path):
@@ -125,7 +127,7 @@ class TestDeploy:
         }
         with pytest.raises(deploy.FailedDeployException, match="does not match schema"):
             deploy.deploy_table(
-                query_file=query_path / "query.sql",
+                artifact_file=query_path / "query.sql",
             )
 
     @patch("google.cloud.bigquery.Client")
@@ -139,7 +141,7 @@ class TestDeploy:
         client = mock_client.return_value
         client.get_table.side_effect = NotFound("table not found")
 
-        deploy.deploy_table(query_file=query_path / "query.sql", force=True)
+        deploy.deploy_table(artifact_file=query_path / "query.sql", force=True)
 
         client.create_table.assert_called_once()
 
@@ -157,7 +159,7 @@ class TestDeploy:
         client.get_table.side_effect = NotFound("table not found")
 
         deploy.deploy_table(
-            query_file=query_path / "metadata.yaml",
+            artifact_file=query_path / "metadata.yaml",
         )
 
         client.create_table.assert_called_once()


### PR DESCRIPTION
## Description

This adds support for deploying queries that do not have a query file. We have more instances where tables get populated outside of bigquery-etl (e.g. through outerbounds), but still get deployed through bigquery-etl. The current workaround is to add an empty `query.py` file. This PR removes the requirement for that.

One such example where this happened is: https://github.com/mozilla/private-bigquery-etl/pull/487

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6438)
