### PR TITLE
Remove scheduler for active_users_aggregates_v4

### DIFF
--- a/sql_generators/active_users_aggregates_v4/templates/metadata.yaml
+++ b/sql_generators/active_users_aggregates_v4/templates/metadata.yaml
@@ -27,10 +27,6 @@ labels:
   incremental: true
   change_controlled: true
   shredder_mitigation: true
-scheduling:
-  dag_name: bqetl_analytics_aggregations
-  task_name: {{ app_name }}_active_users_aggregates_v4
-  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description
This PR removes the scheduler for v4, as the tables must be moved to production via a backfill with shredder mitigation.
The scheduler for v4 will be added with the PR that completes this backfill.
This PR doesn't fix the forecasting failure, that is fixed in [PR-2126](https://github.com/mozilla/telemetry-airflow/pull/2126).

## Related Tickets & Documents
PR 2/2 for [Bug-1932176](https://bugzilla.mozilla.org/show_bug.cgi?id=1932176).

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6439)
