### PR TITLE
chore(DO-1887): Add shredder mitigation to search aggregate tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/metadata.yaml
@@ -13,6 +13,7 @@ labels:
   dag: bqetl_search_dashboard
   owner1: cmorales
   owner2: xluo
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_search_dashboard
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/query.sql
@@ -33,6 +33,6 @@ WHERE
   AND COALESCE(search_count_tagged_sap, 0) < 10000
   AND COALESCE(search_count_organic, 0) < 10000
 GROUP BY
-  1,
-  2,
-  3;
+  submission_date,
+  geo,
+  user_state;

--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/schema.yaml
@@ -2,33 +2,44 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
+  description: Submission Date
 - mode: NULLABLE
   name: geo
   type: STRING
+  description: Geographical Area
 - mode: NULLABLE
   name: user_state
   type: STRING
+  description: User State
 - mode: NULLABLE
   name: client_count
   type: INTEGER
+  description: Client Count
 - mode: NULLABLE
   name: search_client_count
   type: INTEGER
+  description: Search Client Count
 - mode: NULLABLE
   name: sap
   type: INTEGER
+  description: SAP
 - mode: NULLABLE
   name: search_with_ads
   type: INTEGER
+  description: Number of Searches with Ads
 - mode: NULLABLE
   name: ad_clicks
   type: INTEGER
+  description: Number of Ad Clicks
 - mode: NULLABLE
   name: tagged_follow_on
   type: INTEGER
+  description: Number of Tagged Follow-Ons
 - mode: NULLABLE
   name: tagged_sap
   type: INTEGER
+  description: Number of Tagged SAP
 - mode: NULLABLE
   name: organic
   type: INTEGER
+  description: Number of Organic Searches

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/metadata.yaml
@@ -8,6 +8,7 @@ owners:
   - cmorales@mozilla.com
 labels:
   schedule: daily
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_mobile_search
 bigquery:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/metadata.yaml
@@ -7,6 +7,7 @@ owners:
 - cmorales@mozilla.com
 labels:
   schedule: daily
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_search
 bigquery:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/schema.yaml
@@ -2,90 +2,120 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
+  description: Submission Date
 - mode: NULLABLE
   name: addon_version
   type: STRING
+  description: Add-On Version
 - mode: NULLABLE
   name: app_version
   type: STRING
+  description: App Version
 - mode: NULLABLE
   name: country
   type: STRING
+  description: Country
 - mode: NULLABLE
   name: distribution_id
   type: STRING
+  description: Distribution ID
 - mode: NULLABLE
   name: engine
   type: STRING
+  description: Search Engine
 - mode: NULLABLE
   name: locale
   type: STRING
+  description: Locale
 - mode: NULLABLE
   name: search_cohort
   type: STRING
+  description: Search Cohort
 - mode: NULLABLE
   name: source
   type: STRING
+  description: Source
 - mode: NULLABLE
   name: default_search_engine
   type: STRING
+  description: Default Search Engine
 - mode: NULLABLE
   name: default_private_search_engine
   type: STRING
+  description: Default Private Search Engine
 - mode: NULLABLE
   name: os
   type: STRING
+  description: Operating System
 - mode: NULLABLE
   name: os_version
   type: STRING
+  description: Operating System Version
 - mode: NULLABLE
   name: is_default_browser
   type: BOOLEAN
+  description: Is Default Browser
 - mode: NULLABLE
   name: policies_is_enterprise
   type: BOOLEAN
+  description: Policies Is Enterprise
 - mode: NULLABLE
   name: channel
   type: STRING
+  description: Channel
 - mode: NULLABLE
   name: normalized_engine
   type: STRING
+  description: Normalized Search Engine
 - mode: NULLABLE
   name: normalized_default_search_engine
   type: STRING
+  description: Normalized Default Search Engine
 - mode: NULLABLE
   name: is_sap_monetizable
   type: BOOLEAN
+  description: Is SAP Monetizable
 - mode: NULLABLE
   name: client_count
   type: INTEGER
+  description: Client Count
 - mode: NULLABLE
   name: organic
   type: INTEGER
+  description: Number of Organic Searches
 - mode: NULLABLE
   name: tagged_sap
   type: INTEGER
+  description: Tagged SAP
 - mode: NULLABLE
   name: tagged_follow_on
   type: INTEGER
+  description: Tagged Follow On
 - mode: NULLABLE
   name: sap
   type: INTEGER
+  description: SAP
 - mode: NULLABLE
   name: ad_click
   type: INTEGER
+  description: Ad Click
 - mode: NULLABLE
   name: ad_click_organic
   type: INTEGER
+  description: Ad Click Organic
 - mode: NULLABLE
   name: search_with_ads
   type: INTEGER
+  description: Number of Searches with Ads
 - mode: NULLABLE
   name: search_with_ads_organic
   type: INTEGER
+  description: Number of Organic Searches with Ads
 - mode: NULLABLE
   name: unknown
   type: INTEGER
+  description: Unknown
 - mode: NULLABLE
   name: is_acer_cohort
   type: BOOLEAN
+  description: Is Acer Cohort

--- a/sql/moz-fx-data-shared-prod/search_derived/search_dau_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_dau_aggregates_v1/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   incremental: true
   schedule: daily
   change_controlled: true
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_search_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_dau_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_dau_aggregates_v1/schema.yaml
@@ -2,36 +2,48 @@ fields:
   - mode: NULLABLE
     name: partner
     type: STRING
+    description: Partner
   - mode: NULLABLE
     name: submission_date
     type: DATE
+    description: Submission Date
   - mode: NULLABLE
     name: device
     type: STRING
+    description: Device
   - mode: NULLABLE
     name: country
     type: STRING
+    description: Country
   - mode: NULLABLE
     name: normalized_channel
     type: STRING
+    description: Normalized Channel
   - mode: NULLABLE
     name: distribution_id
     type: STRING
+    description: Distribution ID
   - mode: NULLABLE
     name: normalized_default_search_engine
     type: STRING
+    description: Normalized Default Search Engine
   - mode: NULLABLE
     name: normalized_engine
     type: STRING
+    description: Normalized Search Engine
   - mode: NULLABLE
     name: sap_category
     type: INTEGER
+    description: SAP Category
   - mode: NULLABLE
     name: ad_click_category
     type: INTEGER
+    description: Ad Click Category
   - mode: NULLABLE
     name: dau_w_engine_as_default
     type: INTEGER
+    description: DAU with Engine as Default
   - mode: NULLABLE
     name: dau_engaged_w_sap
     type: INTEGER
+    description: DAU Engaged with SAP

--- a/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/metadata.yaml
@@ -11,6 +11,7 @@ labels:
   schedule: daily
   change_controlled: true
   dag: bqetl_search_dashboard
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_search_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/schema.yaml
@@ -2,90 +2,120 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
+  description: Submission Date
 - mode: NULLABLE
   name: partner
   type: STRING
+  description: Partner
 - mode: NULLABLE
   name: device
   type: STRING
+  description: Device
 - mode: NULLABLE
   name: channel
   type: STRING
+  description: Channel
 - mode: NULLABLE
   name: country
   type: STRING
+  description: Country
 - mode: NULLABLE
   name: dau
   type: INTEGER
+  description: DAU
 - mode: NULLABLE
   name: dau_engaged_w_sap
   type: INTEGER
+  description: DAU Engaged with SAP
 - mode: NULLABLE
   name: sap
   type: INTEGER
+  description: SAP
 - mode: NULLABLE
   name: tagged_sap
   type: INTEGER
+  description: Tagged SAP
 - mode: NULLABLE
   name: tagged_follow_on
   type: INTEGER
+  description: Tagged Follow On
 - mode: NULLABLE
   name: search_with_ads
   type: INTEGER
+  description: Search with Ads
 - mode: NULLABLE
   name: ad_click
   type: INTEGER
+  description: Ad Click
 - mode: NULLABLE
   name: organic
   type: INTEGER
+  description: Organic
 - mode: NULLABLE
   name: ad_click_organic
   type: INTEGER
+  description: Ad Click Organic
 - mode: NULLABLE
   name: search_with_ads_organic
   type: INTEGER
+  description: Number of Organic Searches with Ads
 - mode: NULLABLE
   name: monetizable_sap
   type: INTEGER
+  description: Monetizable SAP
 - mode: NULLABLE
   name: dau_w_engine_as_default
   type: INTEGER
+  description: DAU with Engine as Default
 - name: serp_events_client_count
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events Client Count
 - name: serp_events_clients_with_ad_blocker_inferred
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events Clients with Ad Blocker Inferred
 - name: serp_events_sap
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events SAP
 - name: serp_events_tagged_sap
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events Tagged SAP
 - name: serp_events_tagged_follow_on
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events Tagged Follow On
 - name: serp_events_ad_click
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events Ad Click
 - name: serp_events_search_with_ads
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events Search with Ads
 - name: serp_events_organic
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events Organic
 - name: serp_events_ad_click_organic
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events Ad Click Organic
 - name: serp_events_search_with_ads_organic
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events Search with Ads Organic
 - name: serp_events_sap_with_ad_blocker_inferred
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events SAP with Inferred Ad Blocker
 - name: serp_events_num_ads_visible
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events Number of Ads Visible
 - name: serp_events_num_ads_blocked
   type: INTEGER
   mode: NULLABLE
+  description: SERP Events Number of Ads Blocked


### PR DESCRIPTION
## Description

This PR adds shredder_mitigation = True (which requires explicit group bys and all columns to have a column description) to the following tables: 

- search_derived.desktop_search_aggregates_by_userstate_v1
- search_derived.mobile_search_aggregates_v1
- search_derived.search_aggregates_v8
- search_derived.search_dau_aggregates_v1
- search_revenue_levers_daily_v1

## Related Tickets & Documents
* [DO-1887](https://mozilla-hub.atlassian.net/browse/DO-1887)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6440)


[DO-1887]: https://mozilla-hub.atlassian.net/browse/DO-1887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ