### PR TITLE
Add active_users v3 to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,13 @@
 # These datasets are subject to the additional change control procedures
 # described in https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/
 # Active Users
+/sql_generators/active_users_aggregates_v3/templates/ @mozilla/kpi_table_reviewers
+/sql/moz-fx-data-shared-prod/fenix_derived/active_users_aggregates_v3/ @mozilla/kpi_table_reviewers
+/sql/moz-fx-data-shared-prod/firefox_desktop_derived/active_users_aggregates_v3/ @mozilla/kpi_table_reviewers
+/sql/moz-fx-data-shared-prod/firefox_ios_derived/active_users_aggregates_v3/ @mozilla/kpi_table_reviewers
+/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v3/ @mozilla/kpi_table_reviewers
+/sql/moz-fx-data-shared-prod/focus_ios_derived/active_users_aggregates_v3/ @mozilla/kpi_table_reviewers
+/sql/moz-fx-data-shared-prod/klar_ios_derived/active_users_aggregates_v3/ @mozilla/kpi_table_reviewers
 /sql_generators/active_users_aggregates_v4/templates/ @mozilla/kpi_table_reviewers
 /sql/moz-fx-data-shared-prod/fenix_derived/active_users_aggregates_v4/ @mozilla/kpi_table_reviewers
 /sql/moz-fx-data-shared-prod/firefox_desktop_derived/active_users_aggregates_v4/ @mozilla/kpi_table_reviewers


### PR DESCRIPTION
## Description
This PR temporarily adds  active_users v3 to the codeowners until v4's backfill is completed via a separate PR.

## Related Tickets & Documents
Resolves [CI error](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/41579/workflows/faed17de-a448-44b0-a72c-ef4398d12f03/jobs/477106).

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6447)
