### PR TITLE
chore(DO-1886): Add shredder_mitigation to mobile engagement and retention tables

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
@@ -8,6 +8,7 @@ owners:
 labels:
   schedule: daily
   incremental: true
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_mobile_kpi_metrics
   depends_on_past: false

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.schema.yaml
@@ -2,7 +2,7 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
-  description:
+  description: Submission Date
 
 - mode: NULLABLE
   name: first_seen_date

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
@@ -13,6 +13,7 @@ owners:
 labels:
   schedule: daily
   incremental: true
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_mobile_kpi_metrics
   depends_on_past: false


### PR DESCRIPTION
## Description

This PR adds shredder_mitigation = True for the following SQL generated tables: 

- fenix_derived.retention_v1
- firefox_ios_derived.retention_v1
- klar_ios_derived.retention_v1
- focus_android_derived.retention_v1
- focus_ios_derived.retention_v1
- klar_android_derived.retention_v1


- fenix_derived.engagement_v1
- firefox_ios_derived.engagement_v1
- focus_android_derived.engagement_v1
- focus_ios_derived.engagement_v1
- klar_ios_derived.engagement_v1
- klar_android_derived.engagement_v1


## Related Tickets & Documents
* [DO-1886](https://mozilla-hub.atlassian.net/browse/DO-1886)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6465)


[DO-1886]: https://mozilla-hub.atlassian.net/browse/DO-1886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ