### PR TITLE
[Bug 1932709] Disable monitoring for telemetry.releases

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/releases/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/releases/metadata.yaml
@@ -7,6 +7,3 @@ description: |-
   https://wiki.mozilla.org/Release_Management/Product_details
 owners:
 - ascholtz@mozilla.com
-monitoring:
-  enabled: true
-  partition_column: date


### PR DESCRIPTION
## Description

https://bugzilla.mozilla.org/show_bug.cgi?id=1932709
`telemetry.releases` does not need to be monitored. Remove Bigeye monitoring, which will also fix failing Airflow tasks.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
