### PR TITLE
Update logic for handling errors when Bigeye partitioning is already set

### DIFF
--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -376,7 +376,10 @@ def _update_bigconfig(
 
                     raise Exception(err_message)
 
-                if metric.metric_type.predefined_metric in default_metrics:
+                if (
+                    metric.metric_type
+                    and metric.metric_type.predefined_metric in default_metrics
+                ):
                     default_metrics.remove(metric.metric_type.predefined_metric)
 
         if metadata.monitoring.collection and collection.collection is None:
@@ -620,7 +623,9 @@ def set_partition_column(
                             f"Set partition column {column_id} for `{project}.{dataset}.{table}`"
                         )
                 except Exception as e:
-                    if "There was an error processing your request" in str(e):
+                    if "There was an error processing your request" in str(
+                        e
+                    ) or "Dataset already requires a partition filter" in str(e):
                         # API throws an error when partition column was already set.
                         # There is no API endpoint to check for partition columns though
                         pass


### PR DESCRIPTION
## Description

It looks like the Bigeye API changed slightly. When setting a partition column for a dataset that already has a partition column set, then Bigeye returns an error. This error message has changed to `Dataset already requires a partition filter` and will just be skipped during deploys.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**