### PR TITLE
feat: remove the condition resulting in exception if no metric_type value is defined

### DIFF
--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -368,16 +368,8 @@ def _update_bigconfig(
     for collection in bigconfig.tag_deployments:
         for deployment in collection.deployments:
             for metric in deployment.metrics:
-                if metric.metric_type is None:
-                    err_message = f"""There appears to be an issue parsing \
-                    a metric type definition for `{project}.{dataset}.{table}` \
-                    metric: {str(metric)} \
-                    deployment: {str(deployment)}."""
-
-                    raise Exception(err_message)
-
                 if (
-                    metric.metric_type
+                    metric.metric_type is not None
                     and metric.metric_type.predefined_metric in default_metrics
                 ):
                     default_metrics.remove(metric.metric_type.predefined_metric)


### PR DESCRIPTION
# feat: remove the condition resulting in exception if no metric_type value is defined

## Description

This condition made a wrong assumption that the `metric_type` must always be a not null value after parsing the config. This is incorrect, for example when `saved_metric_id` is referenced in the config the object created will have `metric_type` value of `None`.