### PR TITLE
feat(DENG-6549): Convert campaign stats to be incremental (ios)

### DIFF
--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/bigconfig.yml
@@ -1,0 +1,20 @@
+type: BIGCONFIG_FILE
+
+tag_deployments:
+  - collection:
+      name: {{ bigeye_collection }}
+    deployments:
+      - column_selectors:
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.date
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.campaign
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.campaign_id
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.campaign_country_code
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.ad_group_name
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.ad_group_id
+        metrics:
+          - saved_metric_id: is_not_null
+      - column_selectors:
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.*
+        metrics:
+          - saved_metric_id: freshness
+          - saved_metric_id: volume

--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/bigconfig.yml
@@ -2,19 +2,28 @@ type: BIGCONFIG_FILE
 
 tag_deployments:
   - collection:
-      name: {{ bigeye_collection }}
+      name: Growth Program
     deployments:
       - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.date
-        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.campaign
-        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.campaign_id
-        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.campaign_country_code
-        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.ad_group_name
-        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.ad_group_id
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.date
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.campaign
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.campaign_id
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.campaign_country_code
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.ad_group_name
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.ad_group_id
         metrics:
           - saved_metric_id: is_not_null
       - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.*
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.*
+        metrics:
+          - saved_metric_id: freshness
+          - saved_metric_id: volume
+
+  - collection:
+      name: Operational Checks
+    deployments:
+      - column_selectors:
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.*
         metrics:
           - saved_metric_id: freshness
           - saved_metric_id: volume

--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
@@ -19,4 +19,3 @@ bigquery:
     - campaign
 monitoring:
   enabled: true
-  collection: Growth Program

--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
@@ -4,14 +4,19 @@ description: |-
 owners:
 - kwindau@mozilla.com
 labels:
-  incremental: false
+  incremental: true
   owner1: kwindau@mozilla.com
 scheduling:
   dag_name: bqetl_ios_campaign_reporting
   depends_on_past: false
-  date_partition_parameter: null
 bigquery:
-  time_partitioning: null
+  time_partitioning:
+    type: day
+    field: date
+    require_partition_filter: false
   clustering:
-    fields: [campaign]
-references: {}
+    fields:
+    - campaign
+monitoring:
+  enabled: true
+  collection: Growth Program

--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
@@ -9,6 +9,10 @@ labels:
 scheduling:
   dag_name: bqetl_ios_campaign_reporting
   depends_on_past: false
+  date_partition_parameter: date
+  date_partition_offset: -27
+  parameters:
+  - submission_date:DATE:{{ds}}
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/query.sql
@@ -16,7 +16,11 @@ WITH daily_stats AS (
   FROM
     `moz-fx-data-shared-prod.apple_ads.ad_group_report`
   WHERE
-    date_day = DATE_SUB(@submission_date, INTERVAL 27 DAY)
+    {% if is_init() %}
+      date_day <= DATE_SUB(CURRENT_DATE, INTERVAL 27 DAY)
+    {% else %}
+      date_day = DATE_SUB(@submission_date, INTERVAL 27 DAY)
+    {% endif %}
   GROUP BY
     `date`,
     campaign_name,
@@ -56,7 +60,11 @@ retention_aggs AS (
     -- TODO: we should update this to use retention_clients view instead
     `moz-fx-data-shared-prod.firefox_ios.funnel_retention_week_4`
   WHERE
-    submission_date = @submission_date
+    {% if is_init() %}
+      submission_date <= CURRENT_DATE
+    {% else %}
+      submission_date = @submission_date
+    {% endif %}
   GROUP BY
     `date`,
     campaign_id,

--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/query.sql
@@ -9,12 +9,9 @@ WITH daily_stats AS (
     ) AS campaign_country_code,
     ad_group_name,
     ad_group_id,
-    -- DATE_TRUNC(date_day, WEEK) AS week_start, -- TODO: this doesn't appear to be used later on, should it be?
-    -- FORMAT_DATE("%b", date_day) AS `month`, -- TODO: this doesn't appear to be used later on, should it be?
     SUM(spend) AS spend,
     SUM(taps) AS clicks,
     SUM(impressions) AS impressions,
-    SUM(redownloads) AS redownloads, -- TODO: this doesn't appear to be used later on, is this needed?
     SUM(total_downloads) AS total_downloads,
   FROM
     `moz-fx-data-shared-prod.apple_ads.ad_group_report`
@@ -27,8 +24,6 @@ WITH daily_stats AS (
     campaign_country_code,
     ad_group_name,
     ad_group_id
-    -- week_start,
-    -- `month`
 ),
 activations AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/query.sql
@@ -2,52 +2,53 @@ WITH daily_stats AS (
   SELECT
     date_day AS `date`,
     campaign_name AS campaign,
-    campaign_id AS campaign_id,
+    campaign_id,
     REGEXP_EXTRACT(
       campaign_name,
       r'Mozilla_(?:FF|Firefox)_ASA_(?:iOSGeoTest_)?([\w]{2,3})_.*'
     ) AS campaign_country_code,
     ad_group_name,
     ad_group_id,
-    DATE_TRUNC(date_day, WEEK) AS week_start,
-    FORMAT_DATE("%b", date_day) AS `month`,
+    -- DATE_TRUNC(date_day, WEEK) AS week_start, -- TODO: this doesn't appear to be used later on, should it be?
+    -- FORMAT_DATE("%b", date_day) AS `month`, -- TODO: this doesn't appear to be used later on, should it be?
     SUM(spend) AS spend,
     SUM(taps) AS clicks,
     SUM(impressions) AS impressions,
-    SUM(redownloads) AS redownloads,
-    SUM(total_downloads) AS total_downloads
+    SUM(redownloads) AS redownloads, -- TODO: this doesn't appear to be used later on, is this needed?
+    SUM(total_downloads) AS total_downloads,
   FROM
     `moz-fx-data-shared-prod.apple_ads.ad_group_report`
+  WHERE
+    date_day = @submission_date
   GROUP BY
-    date_day,
+    `date`,
     campaign_name,
     campaign_id,
-    REGEXP_EXTRACT(campaign_name, r'Mozilla_(?:FF|Firefox)_ASA_(?:iOSGeoTest_)?([\w]{2,3})_.*'),
+    campaign_country_code,
     ad_group_name,
-    ad_group_id,
-    week_start,
-    `month`
+    ad_group_id
+    -- week_start,
+    -- `month`
 ),
 activations AS (
   SELECT
-    CAST(REGEXP_EXTRACT(cl.adjust_campaign, r' \((\d+)\)$') AS INT64) AS campaign_id,
+    clients.first_seen_date AS `date`,
+    CAST(REGEXP_EXTRACT(clients.adjust_campaign, r' \((\d+)\)$') AS INT64) AS campaign_id,
     CAST(REGEXP_EXTRACT(adjust_ad_group, r' \((\d+)\)$') AS INT64) AS ad_group_id,
-    cl.first_seen_date AS date,
     COUNT(DISTINCT ltv.client_id) AS new_profiles,
-    COUNTIF(cl.is_activated) AS activated,
-    SUM(ltv.lifetime_value) AS lifetime_value
+    COUNTIF(clients.is_activated) AS activated,
+    SUM(ltv.lifetime_value) AS lifetime_value,
   FROM
-    `mozdata.ltv.firefox_ios_client_ltv` ltv
+    `mozdata.ltv.firefox_ios_client_ltv` AS ltv
   INNER JOIN
-    `moz-fx-data-shared-prod.firefox_ios.firefox_ios_clients` cl
-    ON ltv.client_id = cl.client_id
-    AND ltv.sample_id = cl.sample_id
+    `moz-fx-data-shared-prod.firefox_ios.firefox_ios_clients` AS clients
+    USING(client_id, sample_id)
   WHERE
-    cl.channel = "release"
+    clients.channel = "release"
   GROUP BY
-    1,
-    2,
-    3
+    `date`,
+    campaign_id,
+    ad_group_id
 ),
 retention_aggs AS (
   SELECT
@@ -55,8 +56,9 @@ retention_aggs AS (
     CAST(REGEXP_EXTRACT(adjust_campaign, r' \((\d+)\)$') AS INT64) AS campaign_id,
     CAST(REGEXP_EXTRACT(adjust_ad_group, r' \((\d+)\)$') AS INT64) AS ad_group_id,
     SUM(repeat_user) AS repeat_users,
-    SUM(retained_week_4) AS retained_week_4
+    SUM(retained_week_4) AS retained_week_4,
   FROM
+    -- TODO: we should update this to use retention_clients view instead
     `moz-fx-data-shared-prod.firefox_ios.funnel_retention_week_4`
   GROUP BY
     `date`,
@@ -83,14 +85,14 @@ FROM
   daily_stats
 LEFT JOIN
   activations
-  USING (date, campaign_id, ad_group_id)
+  USING (`date`, campaign_id, ad_group_id)
 LEFT JOIN
   retention_aggs
-  USING (date, campaign_id, ad_group_id)
+  USING (`date`, campaign_id, ad_group_id)
 GROUP BY
-  date,
+  `date`,
   campaign,
   campaign_id,
   campaign_country_code,
   ad_group_name,
-  ad_group_id;
+  ad_group_id

--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/query.sql
@@ -37,7 +37,7 @@ activations AS (
     `mozdata.ltv.firefox_ios_client_ltv` AS ltv
   INNER JOIN
     `moz-fx-data-shared-prod.firefox_ios.firefox_ios_clients` AS clients
-    USING(client_id, sample_id)
+    USING (client_id, sample_id)
   WHERE
     clients.channel = "release"
   GROUP BY

--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/query.sql
@@ -16,7 +16,7 @@ WITH daily_stats AS (
   FROM
     `moz-fx-data-shared-prod.apple_ads.ad_group_report`
   WHERE
-    date_day = @submission_date
+    date_day = DATE_SUB(@submission_date, INTERVAL 27 DAY)
   GROUP BY
     `date`,
     campaign_name,
@@ -55,6 +55,8 @@ retention_aggs AS (
   FROM
     -- TODO: we should update this to use retention_clients view instead
     `moz-fx-data-shared-prod.firefox_ios.funnel_retention_week_4`
+  WHERE
+    submission_date = @submission_date
   GROUP BY
     `date`,
     campaign_id,

--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/schema.yaml
@@ -1,61 +1,77 @@
+# apple fields definitions source: https://searchads.apple.com/help/reporting/0023-reporting-options-and-definitions
 fields:
-- description: Date
+- description: |-
+    Date
   mode: NULLABLE
   name: date
   type: DATE
-- description: Campaign Name
+- description: |-
+    Campaign Name
   mode: NULLABLE
   name: campaign
   type: STRING
-- description: Campaign ID
+- description: |-
+    Campaign ID
   mode: NULLABLE
   name: campaign_id
   type: INT64
-- description: Campaign Country Code
+- description: |-
+    Campaign country code (normalized).
   mode: NULLABLE
   name: campaign_country_code
   type: STRING
-- description: Ad Group Name
+- description: |-
+    Ad Group Name
   mode: NULLABLE
   name: ad_group_name
   type: STRING
-- description: Ad Group ID
+- description: |-
+    Ad Group ID
   mode: NULLABLE
   name: ad_group_id
   type: INT64
-- description: Number of Impressions
+- description: |-
+    The number of times your ad appeared on the App Store within the reporting time period.
   mode: NULLABLE
   name: impressions
   type: INT64
-- description: Number of Clicks
+- description: |-
+    The number of times your ad was tapped by users within the reporting time period.
   mode: NULLABLE
   name: clicks
   type: INT64
-- description: Number of Downloads
+- description: |-
+    The total number of tap-through and view-through new downloads within the reporting period.
   mode: NULLABLE
   name: downloads
   type: INT64
-- description: Number of New Profiles
+- description: |-
+    Number of New Profiles
   mode: NULLABLE
   name: new_profiles
   type: INT64
-- description: Number of Activated Profiles
+- description: |-
+    Number of Activated Profiles
   mode: NULLABLE
   name: activated_profiles
   type: INT64
-- description: Number of Repeat Users
+- description: |-
+    Number of Repeat Users
   mode: NULLABLE
   name: repeat_users
   type: INT64
-- description: Number of Week 4 Retained Users
+- description: |-
+    Number of Week 4 Retained Users
   mode: NULLABLE
   name: week_4_retained_users
   type: INT64
-- description: Marketing Spend
+- description: |-
+    The sum of the cost of each customer tap on your ad over the period of time set for your reporting.
   mode: NULLABLE
   name: spend
   type: BIGNUMERIC
-- description: Lifetime Value
+- description: |-
+    Lifetime Value of the specific client.
   mode: NULLABLE
   name: lifetime_value
   type: FLOAT


### PR DESCRIPTION
# feat(DENG-6549): Convert campaign stats to be incremental (ios)

## Description


This PR aims to update the `apple_ads_external.ios_app_campaign_stats_v1` query to be incremental query instead of rebuilding the complete table on each run (overwriting).

This PR also:

- Updated the field descriptions coming from Apple to use the Apple provided definitions.
- Adds `bigconfig.yml` config file to this query and enabled monitoring.