### PR TITLE
fix: remove trailing slash and add issued at to payload (ios engagement choice screen)

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_engagement_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_engagement_v1/query.py
@@ -22,7 +22,7 @@ CONNECT_ISSUER_ID = os.environ.get("CONNECT_ISSUER_ID")
 CONNECT_KEY_ID = os.environ.get("CONNECT_KEY_ID")
 CONNECT_KEY = os.environ.get("CONNECT_KEY")
 
-HOST = "https://api.appstoreconnect.apple.com/"
+HOST = "https://api.appstoreconnect.apple.com"
 REPORT_TITLE = "Browser Choice Screen Engagement"
 REPORT_DATA_DELIMITER = "\t"
 
@@ -34,15 +34,17 @@ def generate_jwt_token(issuer_id, key_id, private_key):
     """Generate jtw token to be used for API authentication."""
     payload = {
         "iss": issuer_id,
+        "iat": int(time.time()),
         "exp": int(time.time()) + 20 * 60,  # Token valid for 20 minutes
         "aud": "appstoreconnect-v1",
     }
+    algorithm = "ES256"
 
     return jwt.encode(
         payload,
         private_key,
-        algorithm="ES256",
-        headers={"kid": key_id, "alg": "ES256", "typ": "JWT"},
+        algorithm=algorithm,
+        headers={"kid": key_id, "alg": algorithm, "typ": "JWT"},
     )
 
 


### PR DESCRIPTION
fix: remove trailing slash and add issued at to payload (ios engagement choice screen)

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-XXXX
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6587)
