### PR TITLE
chore: fix app_store_choice_screen_engagement_v1 secrets

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_engagement_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_engagement_v1/metadata.yaml
@@ -19,9 +19,9 @@ scheduling:
 
   secrets:
   - deploy_target: CONNECT_ISSUER_ID
-    key: bqetl_firefox_ios__app_store_connect_key_id
-  - deploy_target: CONNECT_KEY_ID
     key: bqetl_firefox_ios__app_store_connect_issuer_id
+  - deploy_target: CONNECT_KEY_ID
+    key: bqetl_firefox_ios__app_store_connect_key_id
   - deploy_target: CONNECT_KEY
     key: bqetl_firefox_ios__app_store_connect_key
 


### PR DESCRIPTION
## Description

I double checked the secret values in GSM look fine.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6588)
