### PR TITLE
Initial commit, work in progress

### DIFF
--- a/bigquery_etl/backfill/parse.py
+++ b/bigquery_etl/backfill/parse.py
@@ -72,6 +72,7 @@ class Backfill:
     status: BackfillStatus = attr.ib()
     custom_query_path: Optional[str] = attr.ib(None)
     shredder_mitigation: Optional[bool] = attr.ib(False)
+    override_retention_limit: Optional[bool] = attr.ib(False)
     billing_project: Optional[str] = attr.ib(None)
 
     def __str__(self):
@@ -93,6 +94,7 @@ class Backfill:
             status = {self.status.value}
             custom_query_path = {self.custom_query_path}
             shredder_mitigation = {self.shredder_mitigation}
+            override_retention_limit = {self.override_retention_limit}
             """
 
         return backfill_str.replace("'", "")
@@ -201,6 +203,9 @@ class Backfill:
                         status=BackfillStatus[entry["status"].upper()],
                         custom_query_path=entry.get("custom_query_path", None),
                         shredder_mitigation=entry.get("shredder_mitigation", False),
+                        override_retention_limit=entry.get(
+                            "override_retention_limit", False
+                        ),
                         billing_project=entry.get("billing_project", None),
                     )
 
@@ -225,6 +230,7 @@ class Backfill:
                 "status": self.status.value,
                 "custom_query_path": self.custom_query_path,
                 "shredder_mitigation": self.shredder_mitigation,
+                "override_retention_limit": self.override_retention_limit,
                 "billing_project": self.billing_project,
             }
         }
@@ -237,6 +243,9 @@ class Backfill:
 
         if yaml_dict[self.entry_date]["shredder_mitigation"] is None:
             del yaml_dict[self.entry_date]["shredder_mitigation"]
+
+        if yaml_dict[self.entry_date]["override_retention_limit"] is None:
+            del yaml_dict[self.entry_date]["override_retention_limit"]
 
         if yaml_dict[self.entry_date]["billing_project"] is None:
             del yaml_dict[self.entry_date]["billing_project"]

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -122,6 +122,13 @@ def backfill(ctx):
     "--shredder_mitigation/--no_shredder_mitigation",
     help="Wether to run a backfill using an auto-generated query that mitigates shredder effect.",
 )
+@click.option(
+    "--override-retention-range-limit",
+    required=True,
+    type=bool,
+    help="True to allow running a backfill outside the retention policy limit.",
+    default=False,
+)
 # If not specified, the billing project will be set to the default billing project when the backfill is initiated.
 @billing_project_option()
 @click.pass_context
@@ -135,6 +142,7 @@ def create(
     watcher,
     custom_query_path,
     shredder_mitigation,
+    override_retention_range_limit,
     billing_project,
 ):
     """CLI command for creating a new backfill entry in backfill.yaml file.
@@ -163,6 +171,7 @@ def create(
         status=BackfillStatus.INITIATE,
         custom_query_path=custom_query_path,
         shredder_mitigation=shredder_mitigation,
+        override_retention_limit=override_retention_range_limit,
         billing_project=billing_project,
     )
 
@@ -539,6 +548,8 @@ def _initiate_backfill(
     elif entry.custom_query_path:
         custom_query_path = Path(entry.custom_query_path)
 
+    override_retention_limit = entry.override_retention_limit
+
     # Backfill table
     # in the long-run we should remove the query backfill command and require a backfill entry for all backfills
     try:
@@ -564,6 +575,7 @@ def _initiate_backfill(
                 }
             ),
             billing_project=billing_project,
+            override_retention_range_limit=override_retention_limit,
         )
     except subprocess.CalledProcessError as e:
         raise ValueError(

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -81,6 +81,7 @@ DEFAULT_INIT_PARALLELISM = 10
 DEFAULT_CHECKS_FILE_NAME = "checks.sql"
 VIEW_FILE = "view.sql"
 MATERIALIZED_VIEW = "materialized_view.sql"
+NBR_DAYS_RETAINED = 775
 
 
 @click.group(help="Commands for managing queries.")
@@ -658,6 +659,13 @@ def _backfill_query(
         "parameters and/or date_partition_parameter as needed."
     ),
 )
+@click.option(
+    "--override-retention-range-limit",
+    required=True,
+    type=bool,
+    help="True to allow running a backfill outside the retention policy limit.",
+    default=False,
+)
 @click.pass_context
 def backfill(
     ctx,
@@ -676,6 +684,7 @@ def backfill(
     checks_file_name,
     custom_query_path,
     scheduling_overrides,
+    override_retention_range_limit,
 ):
     """Run a backfill."""
     if not is_authenticated():
@@ -684,6 +693,21 @@ def backfill(
             "and check that the project is set correctly."
         )
         sys.exit(1)
+
+    # If override retention policy is False, and the start date is less than NBR_DAYS_RETAINED
+    if (
+        not override_retention_range_limit
+        and start_date.date() < date.today() - timedelta(days=NBR_DAYS_RETAINED)
+    ):
+        # Exit - cannot backfill due to risk of losing data
+        click.echo(
+            f"Cannot backfill more than {NBR_DAYS_RETAINED} days prior to current date due to retention policies"
+        )
+        sys.exit(1)
+
+    # If override retention policy is true, continue to run the backfill
+    if override_retention_range_limit:
+        click.echo("Over-riding retention limit - ensure data exists in source tables")
 
     if custom_query_path:
         query_files = paths_matching_name_pattern(

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -2232,7 +2232,12 @@ class TestBackfill:
     @patch("bigquery_etl.cli.backfill.deploy_table")
     @patch("bigquery_etl.cli.backfill.Schema.from_query_file")
     def test_initiate_partitioned_backfill(
-        self, mock_from_query_file, mock_deploy_table, check_call, mock_client, runner
+        self,
+        mock_from_query_file,
+        mock_deploy_table,
+        check_call,
+        mock_client,
+        runner,
     ):
         backfill_staging_table_name = (
             "moz-fx-data-shared-prod.backfills_staging_derived.test__test_query_v1"
@@ -2279,12 +2284,16 @@ class TestBackfill:
               reason: test_reason
               watchers:
               - test@example.org
-              status: Initiate"""
+              status: Initiate
+              override_retention_limit: True"""
             )
 
             result = runner.invoke(
                 initiate,
-                ["moz-fx-data-shared-prod.test.test_query_v1", "--parallelism=0"],
+                [
+                    "moz-fx-data-shared-prod.test.test_query_v1",
+                    "--parallelism=0",
+                ],
             )
 
             assert result.exit_code == 0
@@ -2368,7 +2377,8 @@ class TestBackfill:
               reason: test_reason
               watchers:
               - test@example.org
-              status: Initiate"""
+              status: Initiate
+              override_retention_limit: true"""
             )
 
             result = runner.invoke(
@@ -2468,6 +2478,7 @@ class TestBackfill:
               - test@example.org
               status: Initiate
               billing_project: {VALID_BILLING_PROJECT}
+              override_retention_limit: true
               """
             )
 

--- a/tests/cli/test_cli_query.py
+++ b/tests/cli/test_cli_query.py
@@ -542,6 +542,7 @@ class TestQuery:
                     "--exclude=2021-01-06",
                     "--parallelism=0",
                     "--billing-project=backfill-project",
+                    "--override-retention-range-limit=True",
                 ],
             )
 
@@ -604,6 +605,7 @@ class TestQuery:
                     "--end_date=2021-01-06",
                     "--parallelism=0",
                     """--scheduling_overrides={"parameters": ["test:INT64:30"], "date_partition_parameter": "submission_date"}""",
+                    "--override-retention-range-limit=True",
                 ],
             )
             assert result.exit_code == 0
@@ -668,6 +670,7 @@ class TestQuery:
                     "--start_date=2021-01-05",
                     "--end_date=2021-01-09",
                     "--parallelism=0",
+                    "--override-retention-range-limit=True",
                 ],
             )
 


### PR DESCRIPTION
## Description

This PR adds a new boolean option to the backfill CLI command, which is to prevent accidental deletion of data when running backfills starting more than a set number of days back.

## Related Tickets & Documents
* DENG-XXXX
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
