### PR TITLE
[DENG-6141] Add syndicate configuration and public views for Service Desk Jira data

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -155,6 +155,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v1/view.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/table_partition_expirations_v1/query.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/query.sql
+  - sql/moz-fx-data-shared-prod/jira_service_desk/**/*.sql
   # No matching signature for function IF
   - sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_last_seen/query.sql
   # Duplicate UDF

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Jira Service Desk
+description: |-
+  Views on the Jira Service Desk data pulled from Fivetran.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/issue/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/issue/metadata.yaml
@@ -1,0 +1,4 @@
+---
+friendly_name: Jira Service Desk Issues
+description: |-
+  Jira issues for Service Desk synced via Fivetran.

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/issue/view.sql
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/issue/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.jira_service_desk.issue`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.jira_service_desk_syndicate.issue`

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/issue_type/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/issue_type/metadata.yaml
@@ -1,0 +1,4 @@
+---
+friendly_name: Jira Service Desk Issue Types
+description: |-
+  Jira issues types for Service Desk synced via Fivetran.

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/issue_type/view.sql
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/issue_type/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.jira_service_desk.issue_type`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.jira_service_desk_syndicate.issue_type`

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/project/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/project/metadata.yaml
@@ -1,0 +1,4 @@
+---
+friendly_name: Jira Service Desk Projects
+description: |-
+  Jira projects for Service Desk synced via Fivetran.

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/project/view.sql
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/project/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.jira_service_desk.project`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.jira_service_desk_syndicate.project`

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/resolution/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/resolution/metadata.yaml
@@ -1,0 +1,4 @@
+---
+friendly_name: Jira Service Desk Resolution
+description: |-
+  Jira resolution for Service Desk synced via Fivetran.

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/resolution/view.sql
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/resolution/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.jira_service_desk.resolution`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.jira_service_desk_syndicate.resolution`

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/status/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/status/metadata.yaml
@@ -1,0 +1,4 @@
+---
+friendly_name: Jira Service Desk Status
+description: |-
+  Jira status for Service Desk synced via Fivetran.

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/status/view.sql
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/status/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.jira_service_desk.status`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.jira_service_desk_syndicate.status`

--- a/sql/moz-fx-data-shared-prod/jira_service_desk_syndicate/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk_syndicate/dataset_metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Jira Service Desk Syndicate
+description: |
+  Syndicated Service Desk Jira data from Fivetran. User-facing views into this data can be found
+  in the jira_service_desk dataset.
+dataset_base_acl: syndicate
+user_facing: false
+syndication:
+  prod:
+    syndicated_project: "moz-fx-data-bq-fivetran"
+    syndicated_dataset: "jira"
+  syndicated_tables:
+    - issue
+    - issue_type
+    - project
+    - status
+    - resolution
+  administer_views: true
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DENG-6141

This adds a configuration for syndicating the jira service desk data that is imported via Fivetran. At this moment the data is coming from a Jira sandbox project. Once it has been validated, we'll switch over to the production instance and put some workgroups in place to restrict access.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**