### PR TITLE
Remove project from DeleteSource table in shredder_targets

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -31,6 +31,10 @@ class DeleteSource:
     project: str = SHARED_PROD
     conditions: tuple[str, ...] = ()
 
+    def __post_init__(self):
+        if len(self.table.split(".")) != 2:
+            raise ValueError("DeleteSource table must be in the 'dataset.table' format.")
+
     @property
     def table_id(self):
         """Table Id."""
@@ -54,6 +58,10 @@ class DeleteTarget:
     table: str
     field: str | tuple[str, ...]
     project: str = SHARED_PROD
+
+    def __post_init__(self):
+        if len(self.table.split(".")) != 2:
+            raise ValueError("DeleteTarget table must be in the 'dataset.table' format.")
 
     @property
     def table_id(self):

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -32,8 +32,11 @@ class DeleteSource:
     conditions: tuple[str, ...] = ()
 
     def __post_init__(self):
+        """Validate the table string."""
         if len(self.table.split(".")) != 2:
-            raise ValueError("DeleteSource table must be in the 'dataset.table' format.")
+            raise ValueError(
+                "DeleteSource table must be in the 'dataset.table' format."
+            )
 
     @property
     def table_id(self):
@@ -60,8 +63,11 @@ class DeleteTarget:
     project: str = SHARED_PROD
 
     def __post_init__(self):
+        """Validate the table string."""
         if len(self.table.split(".")) != 2:
-            raise ValueError("DeleteTarget table must be in the 'dataset.table' format.")
+            raise ValueError(
+                "DeleteTarget table must be in the 'dataset.table' format."
+            )
 
     @property
     def table_id(self):

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_v1/query.py
@@ -185,13 +185,13 @@ def get_associated_deletions(
                     stable_table_ref.dataset_id[: -len("_stable")]
                     in glean_channel_names
                 ):
-                    deletion_request_table = (
-                        f"{stable_table_ref.project}.{stable_table_ref.dataset_id}.deletion_request_v1"
-                    )
-                    if table_exists(client, deletion_request_table):
+                    if table_exists(
+                        client,
+                        f"{stable_table_ref.project}.{stable_table_ref.dataset_id}.deletion_request_v1",
+                    ):
                         table_to_deletions[stable_table] = {
                             DeleteSource(
-                                table=deletion_request_table,
+                                table=f"{stable_table_ref.dataset_id}.deletion_request_v1",
                                 field=GLEAN_CLIENT_ID,
                                 project=SHARED_PROD,
                             )

--- a/tests/shredder/test_config.py
+++ b/tests/shredder/test_config.py
@@ -1,6 +1,7 @@
 from multiprocessing.pool import ThreadPool
 from unittest import mock
 
+import pytest
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 from google.cloud.bigquery import DatasetReference
@@ -419,3 +420,50 @@ def test_delete_target_fields_match_sources():
             f"Invalid delete target for {target.table}: number of fields in target "
             f"(found {field_count}) must match number of sources (found {source_count})"
         )
+
+
+def test_delete_source_invalid():
+    """DeleteSource constructor should fail when the given table is invalid."""
+    DeleteSource(
+        table=f"dataset.deletion_request_v1",
+        field="client_id",
+        project="project",
+    )
+
+    with pytest.raises(ValueError):
+        DeleteSource(
+            table=f"deletion_request_v1",
+            field="client_id",
+            project="project",
+        )
+
+    with pytest.raises(ValueError):
+        DeleteSource(
+            table=f"project.dataset.deletion_request_v1",
+            field="client_id",
+            project="project",
+        )
+
+
+def test_delete_target_invalid():
+    """DeleteTarget constructor should fail when the given table is invalid."""
+    DeleteSource(
+        table=f"dataset.deletion_request_v1",
+        field="client_id",
+        project="project",
+    )
+
+    with pytest.raises(ValueError):
+        DeleteSource(
+            table=f"deletion_request_v1",
+            field="client_id",
+            project="project",
+        )
+
+    with pytest.raises(ValueError):
+        DeleteSource(
+            table=f"project.dataset.deletion_request_v1",
+            field="client_id",
+            project="project",
+        )
+

--- a/tests/shredder/test_config.py
+++ b/tests/shredder/test_config.py
@@ -425,21 +425,21 @@ def test_delete_target_fields_match_sources():
 def test_delete_source_invalid():
     """DeleteSource constructor should fail when the given table is invalid."""
     DeleteSource(
-        table=f"dataset.deletion_request_v1",
+        table="dataset.deletion_request_v1",
         field="client_id",
         project="project",
     )
 
     with pytest.raises(ValueError):
         DeleteSource(
-            table=f"deletion_request_v1",
+            table="deletion_request_v1",
             field="client_id",
             project="project",
         )
 
     with pytest.raises(ValueError):
         DeleteSource(
-            table=f"project.dataset.deletion_request_v1",
+            table="project.dataset.deletion_request_v1",
             field="client_id",
             project="project",
         )
@@ -447,23 +447,22 @@ def test_delete_source_invalid():
 
 def test_delete_target_invalid():
     """DeleteTarget constructor should fail when the given table is invalid."""
-    DeleteSource(
-        table=f"dataset.deletion_request_v1",
+    DeleteTarget(
+        table="dataset.deletion_request_v1",
         field="client_id",
         project="project",
     )
 
     with pytest.raises(ValueError):
-        DeleteSource(
-            table=f"deletion_request_v1",
+        DeleteTarget(
+            table="deletion_request_v1",
             field="client_id",
             project="project",
         )
 
     with pytest.raises(ValueError):
-        DeleteSource(
-            table=f"project.dataset.deletion_request_v1",
+        DeleteTarget(
+            table="project.dataset.deletion_request_v1",
             field="client_id",
             project="project",
         )
-


### PR DESCRIPTION
## Description

Fix for https://github.com/mozilla/bigquery-etl/pull/6541

project shouldn't be in the DeleteSource because it doesn't match what's in the shredder config.py and also breaks the table and dataset properties of the object.  I also added a check to the constructor to validate the table value

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6620)
