### PR TITLE
Reschedule bqetl_search_dashboard DAG

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -497,7 +497,7 @@ bqetl_search_dashboard:
     retries: 2
     retry_delay: 30m
     start_date: "2020-12-14"
-  schedule_interval: 30 4 * * *
+  schedule_interval: 30 5 * * *
   tags:
     - impact/tier_2
 


### PR DESCRIPTION
bqetl_glean_usage which is a dependency now runs longer than before. This will make search_dashboard start after glean_usage usually finishes.
