### PR TITLE
DENG-877 enforce backfills with mitigation

### DIFF
--- a/bigquery_etl/backfill/shredder_mitigation.py
+++ b/bigquery_etl/backfill/shredder_mitigation.py
@@ -234,7 +234,7 @@ class Subset:
         partition_type = (
             "DATE" if self.partitioning["type"] == "DAY" else self.partitioning["type"]
         )
-        parameters = None
+        parameters = []
         if partition_field is not None:
             parameters = [
                 bigquery.ScalarQueryParameter(
@@ -537,9 +537,9 @@ def generate_query_with_shredder_mitigation(
         ) = classify_columns(
             new_table_row, previous_group_by, new_group_by, existing_schema, new_schema
         )
-    except TypeError as e:
+    except TypeError:
         raise click.ClickException(
-            f"Table {destination_table} did not return any rows for {backfill_date}.\n{e}"
+            f"Table {destination_table} did not return any rows for {backfill_date}."
         )
 
     if not common_dimensions or not added_dimensions or not metrics:

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -535,9 +535,11 @@ def _initiate_backfill(
         and entry.shredder_mitigation is False
     ):
         click.echo(
-            "Failed to initiate backfill. This table is labeled to use shredder mitigation."
-            " Please ensure the backfill is created using `shredder_mitigation = true`.",
-            err=True,
+            click.style(
+                f"This backfill cannot continue.\nManaged backfills for tables with metadata label"
+                f" {SHREDDER_MITIGATION_LABEL} require using --shredder_mitigation.",
+                fg="yellow",
+            )
         )
         sys.exit(1)
 

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -52,6 +52,7 @@ from ..cli.utils import (
 from ..config import ConfigLoader
 from ..deploy import FailedDeployException, SkippedDeployException, deploy_table
 from ..metadata.parse_metadata import METADATA_FILE, Metadata
+from ..metadata.validate_metadata import SHREDDER_MITIGATION_LABEL
 from ..schema import SCHEMA_FILE, Schema
 
 logging.basicConfig(level=logging.INFO)
@@ -523,6 +524,23 @@ def _initiate_backfill(
     custom_query_path = None
     checks = None
     custom_checks_name = None
+
+    metadata = Metadata.from_file(
+        Path("sql") / project / dataset / table / METADATA_FILE
+    )
+
+    # Stop if the metadata contains shredder mitigation label and the backfill doesn't.
+    if (
+        SHREDDER_MITIGATION_LABEL in metadata.labels
+        and entry.shredder_mitigation is False
+    ):
+        click.echo(
+            "Failed to initiate backfill. This table is labeled to use shredder mitigation."
+            " Please ensure the backfill is created using `shredder_mitigation = true`.",
+            err=True,
+        )
+        sys.exit(1)
+
     if entry.shredder_mitigation is True:
         click.echo(
             click.style(

--- a/tests/backfill/test_shredder_mitigation.py
+++ b/tests/backfill/test_shredder_mitigation.py
@@ -1153,10 +1153,10 @@ class TestGenerateQueryWithShredderMitigation:
     @patch("google.cloud.bigquery.Client")
     @patch("bigquery_etl.backfill.shredder_mitigation.classify_columns")
     def test_generate_query_failed_for_missing_partitioning(
-        self, mock_classify_columns, mock_client, runner
+        self, mock_classify_columns, mock_client, runner, capfd
     ):
-        """Test that function raises exception for required query parameter missing
-        in metadata, instead of generating wrong query."""
+        """Test that function raises exception for required query parameter -partitioning-
+        missing in metadata, instead of generating wrong query."""
         existing_schema = {
             "fields": [
                 {"name": "column_1", "type": "DATE", "mode": "NULLABLE"},
@@ -1229,7 +1229,7 @@ class TestGenerateQueryWithShredderMitigation:
                 [],
             )
 
-            with pytest.raises(TypeError) as e:
+            with pytest.raises((TypeError, IndexError)) as e:
                 generate_query_with_shredder_mitigation(
                     client=mock_client,
                     project_id=self.project_id,
@@ -1238,7 +1238,13 @@ class TestGenerateQueryWithShredderMitigation:
                     staging_table_name=self.staging_table_name,
                     backfill_date=PREVIOUS_DATE,
                 )
-            assert str(e.value) == "'NoneType' object is not iterable"
+
+            assert isinstance(e.value, (TypeError, IndexError))
+            assert str(e.value) in {
+                "'NoneType' object is not iterable",
+                "Invalid type",
+                "list index out of range",
+            }
 
     @patch("google.cloud.bigquery.Client")
     @patch("bigquery_etl.backfill.shredder_mitigation.classify_columns")

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -1029,7 +1029,6 @@ class TestBackfill:
             assert result.exit_code == 1
             assert "Invalid start date" in str(result.exception)
 
-    #
     def test_validate_backfill_invalid_start_date_greater_than_entry_date(self, runner):
         with runner.isolated_filesystem():
             SQL_DIR = "sql/moz-fx-data-shared-prod/test/test_query_v1"
@@ -2657,3 +2656,130 @@ class TestBackfill:
 
             assert result.exit_code == 1
             assert "Invalid billing project" in str(result.exception)
+
+    @patch("bigquery_etl.cli.backfill.deploy_table")
+    @patch("bigquery_etl.backfill.utils._should_initiate")
+    def test_dont_initiate_if_label_and_backfill_entry_dont_match(
+        self, mock_should_initiate, mock_deploy_table, runner
+    ):
+        """Test that process stops if the table has label shredder_mitigation and the backfill doesn't."""
+        path = Path("sql/moz-fx-data-shared-prod/test/test_query_v1")
+        mock_should_initiate.return_value = True
+        mock_deploy_table.return_value = None
+        expected_error_output = ("Failed to initiate backfill. This table is labeled to use"
+                                 " shredder mitigation. Please ensure the backfill is "
+                                 "created using `shredder_mitigation = true`.")
+
+        with (runner.isolated_filesystem()):
+            os.makedirs(path, exist_ok=True)
+
+            with open(
+                    "sql/moz-fx-data-shared-prod/test/test_query_v1/query.sql", "w"
+            ) as f:
+                f.write("SELECT 1")
+
+            with open(path / "metadata.yaml", "w") as f:
+                f.write(
+                    "friendly_name: Test\ndescription: Test\nlabels:\n  incremental: true\n  shredder_mitigation: true"
+                )
+
+            with open(
+                "sql/moz-fx-data-shared-prod/test/dataset_metadata.yaml", "w"
+            ) as f:
+                f.write(yaml.dump(DATASET_METADATA_CONF))
+
+            backfill_entry_1 = Backfill(
+                date(2021, 5, 3),
+                date(2021, 1, 3),
+                date(2021, 5, 3),
+                [date(2021, 2, 3)],
+                VALID_REASON,
+                [VALID_WATCHER],
+                BackfillStatus.INITIATE,
+                shredder_mitigation=False
+            )
+
+            backfill_file = (
+                    Path("sql/moz-fx-data-shared-prod/test/test_query_v1") / BACKFILL_FILE
+            )
+            backfill_file.write_text(backfill_entry_1.to_yaml())
+            assert BACKFILL_FILE in os.listdir(
+                "sql/moz-fx-data-shared-prod/test/test_query_v1"
+            )
+            backfills = Backfill.entries_from_file(backfill_file)
+            assert backfills[0] == backfill_entry_1
+
+            result = runner.invoke(
+                initiate,
+                [
+                    "moz-fx-data-shared-prod.test.test_query_v1",
+                    "--parallelism=0",
+                ],
+                )
+
+            assert result.exit_code == 1
+            assert expected_error_output in result.output
+
+    @patch("bigquery_etl.cli.backfill.deploy_table")
+    @patch("bigquery_etl.backfill.utils._should_initiate")
+    def test_initiate_if_label_and_backfill_entry_match(
+            self, mock_should_initiate, mock_deploy_table, runner, capfd
+    ):
+        """Test that process continues if both the table and the backfill entry use shredder_mitigation."""
+        path = Path("sql/moz-fx-data-shared-prod/test/test_query_v1")
+        mock_should_initiate.return_value = True
+        mock_deploy_table.return_value = None
+
+        with (runner.isolated_filesystem()):
+            os.makedirs(path, exist_ok=True)
+
+            with open(
+                    "sql/moz-fx-data-shared-prod/test/test_query_v1/query.sql", "w"
+            ) as f:
+                f.write("SELECT 1")
+
+            with open(path / "metadata.yaml", "w") as f:
+                f.write(
+                    "friendly_name: Test\ndescription: Test\nlabels:\n  incremental: true\n  shredder_mitigation: true"
+                )
+
+            with open(
+                    "sql/moz-fx-data-shared-prod/test/dataset_metadata.yaml", "w"
+            ) as f:
+                f.write(yaml.dump(DATASET_METADATA_CONF))
+
+            backfill_entry_1 = Backfill(
+                date(2021, 5, 3),
+                date(2021, 1, 3),
+                date(2021, 5, 3),
+                [date(2021, 2, 3)],
+                VALID_REASON,
+                [VALID_WATCHER],
+                BackfillStatus.INITIATE,
+                shredder_mitigation=True
+            )
+
+            backfill_file = (
+                    Path("sql/moz-fx-data-shared-prod/test/test_query_v1") / BACKFILL_FILE
+            )
+            backfill_file.write_text(backfill_entry_1.to_yaml())
+            assert BACKFILL_FILE in os.listdir(
+                "sql/moz-fx-data-shared-prod/test/test_query_v1"
+            )
+            backfills = Backfill.entries_from_file(backfill_file)
+            assert backfills[0] == backfill_entry_1
+
+            with patch("bigquery_etl.cli.backfill.query_backfill", return_value=None) as mock_backfill:
+                with patch("bigquery_etl.cli.backfill.generate_query_with_shredder_mitigation",
+                           return_value=('a', 'b')) as mock_shredder_mitigation:
+                    result = runner.invoke(
+                        initiate,
+                        [
+                            "moz-fx-data-shared-prod.test.test_query_v1",
+                            "--parallelism=0",
+                        ],
+                    )
+
+                assert result.exit_code == 0
+                mock_shredder_mitigation.call_count == 2
+                mock_backfill.call_count == 2


### PR DESCRIPTION
## Description

This PR:
- Updates classes to use attrs instead of attr.
- Stops a managed backfill if the shredder_mitigation option is not used for  tables with shredder mitigation label in the metadata.

## Related Tickets & Documents
* DENG-877

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
