### PR TITLE
Fix dataset in ios_app_campaign_stats_v1 bigconfig.yml

### DIFF
--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/bigconfig.yml
@@ -5,16 +5,16 @@ tag_deployments:
       name: Growth Program
     deployments:
       - column_selectors:
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.date
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.campaign
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.campaign_id
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.campaign_country_code
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.ad_group_name
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.ad_group_id
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.date
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.campaign
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.campaign_id
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.campaign_country_code
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.ad_group_name
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.ad_group_id
         metrics:
           - saved_metric_id: is_not_null
       - column_selectors:
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.*
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.*
         metrics:
           - saved_metric_id: freshness
           - saved_metric_id: volume
@@ -23,7 +23,7 @@ tag_deployments:
       name: Operational Checks
     deployments:
       - column_selectors:
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external_derived.ios_app_campaign_stats_v1.*
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.*
         metrics:
           - saved_metric_id: freshness
           - saved_metric_id: volume


### PR DESCRIPTION
## Description

Dataset name doesn't have `_derived` so [publish_bigeye_monitors](https://workflow.telemetry.mozilla.org/dags/bqetl_artifact_deployment/grid?dag_run_id=manual__2024-12-02T17%3A50%3A58.875840%2B00%3A00&task_id=publish_bigeye_monitors&tab=logs) is failing with 
```
- invalidCohort:
  entityType: CATALOG_ENTITY_TYPE_FIELD
  schemaNamePattern: moz-fx-data-shared-prod.apple_ads_external_derived
  tableNamePattern: ios_app_campaign_stats_v1
  columnNamePattern: date
errorMessage: No matching schemas found.
...
```

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6734)
