### PR TITLE
Reschedule mobile_feature_usage DAG

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1408,7 +1408,7 @@ bqetl_mobile_feature_usage:
     retry_delay: 30m
     start_date: '2023-10-24'
   description: Schedule run for mobile feature usage tables
-  schedule_interval: 0 6 * * *
+  schedule_interval: 0 12 * * *
   tags:
     - impact/tier_3
 


### PR DESCRIPTION
bqetl_mobile_feature_usage depends on bqetl_mobile_kpi_metrics which is scheduled to run at 12:00. Having the first one scheduled at 6:00 caused its sensors to idle for 6 hours. This reschedules it at 12:00.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6806)
