### PR TITLE
feat: move all bigeye metric definition under the same definition as the same collection is used

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.bigconfig.yml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.bigconfig.yml
@@ -46,12 +46,6 @@ tag_deployments:
             metric_schedule:
               named_schedule:
                 name: default
-
-  - collection:
-      name: Operational Checks
-      notification_channels:
-        - slack: '#de-bigeye-triage'
-    deployments:
       - column_selectors:
         - name: {{ project_id }}.{{ project_id }}.{{ derived_dataset }}.{{ target_table }}.*
         metrics:


### PR DESCRIPTION
# feat: move all bigeye metric definition under the same definition as the same collection is used

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6855)
