### PR TITLE
Update checks.sql for android_app_campaign_stats_v1 since this was changed to run incrementally

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -974,9 +974,9 @@ bqetl_fivetran_google_ads:
     depends_on_past: false
     email:
       - telemetry-alerts@mozilla.com
-      - frank@mozilla.com
+      - kwindau@mozilla.com
     email_on_failure: true
-    email_on_retry: true
+    email_on_retry: false
     end_date: null
     owner: frank@mozilla.com
     retries: 2

--- a/dags.yaml
+++ b/dags.yaml
@@ -978,7 +978,7 @@ bqetl_fivetran_google_ads:
     email_on_failure: true
     email_on_retry: false
     end_date: null
-    owner: frank@mozilla.com
+    owner: kwindau@mozilla.com
     retries: 2
     retry_delay: 30m
     start_date: '2023-01-01'

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/checks.sql
@@ -1,2 +1,2 @@
 #fail
-{{ is_unique(["date", "campaign", "ad_group"]) }}
+{{ is_unique(["date", "campaign", "ad_group"], "date = DATE_SUB(@submission_date, INTERVAL 27 DAY)") }}


### PR DESCRIPTION
## Description
Recently, we changed this table to load in increments with a 28 day delay, as opposed to full rebuilds each day (due to the retention project).  This is a fix to make sure the QA check runs with the same 28 day delay.

This PR also changes ownership of the DAG `bqetl_fivetran_google_ads` from Frank to Katie.


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6878)
