### PR TITLE
fix: Temporarily remove bigeye checks on android_app_campaign_stats_v1 & ios_app_campaign_stats_v1 until we can update with 28 day lookback

### DIFF
--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
@@ -21,5 +21,3 @@ bigquery:
   clustering:
     fields:
     - campaign
-monitoring:
-  enabled: true

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/checks.sql
@@ -1,2 +1,2 @@
 #fail
-{{ is_unique(["date", "campaign", "ad_group"], "date = DATE_SUB(@submission_date, INTERVAL 27 DAY)") }}
+{{ is_unique(["date", "campaign", "ad_group"]) }}

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/metadata.yaml
@@ -24,5 +24,3 @@ bigquery:
     type: day
     field: date
     require_partition_filter: false
-monitoring:
-  enabled: true


### PR DESCRIPTION
This PR removes the Bigeye checks for the table `android_app_campaign_stats_v1` & `ios_app_campaign_stats_v1` since they don't work out of the box because this table has a 28 day lag, so we need to write a new bigeye config YAML file to make this check work properly (otherwise it is failing the DAG in airflow). For now removing until we have the time to write this new YAML file - made a ticket so we don't lose track of adding it back - https://mozilla-hub.atlassian.net/browse/DENG-6886



**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6885)
