### PR TITLE
[DENG-6141] Syndicate additional Service Desk Jira tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/jira_service_desk/field/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/field/metadata.yaml
@@ -1,0 +1,4 @@
+---
+friendly_name: Jira Service Desk Fields
+description: |-
+  Jira fields for Service Desk synced via Fivetran.

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/field/view.sql
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/field/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.jira_service_desk.field`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.jira_service_desk_syndicate.field`

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/issue_field_history/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/issue_field_history/metadata.yaml
@@ -1,0 +1,4 @@
+---
+friendly_name: Jira Service Desk Issue Field History
+description: |-
+  Jira issue field history for Service Desk synced via Fivetran.

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/issue_field_history/view.sql
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/issue_field_history/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.jira_service_desk.issue_field_history`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.jira_service_desk_syndicate.issue_field_history`

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/request/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/request/metadata.yaml
@@ -1,0 +1,4 @@
+---
+friendly_name: Jira Service Desk Requests
+description: |-
+  Jira requests for Service Desk synced via Fivetran.

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/request/view.sql
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/request/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.jira_service_desk.request`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.jira_service_desk_syndicate.request`

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/request_type/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/request_type/metadata.yaml
@@ -1,0 +1,4 @@
+---
+friendly_name: Jira Service Desk Request Types
+description: |-
+  Jira request types for Service Desk synced via Fivetran.

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/request_type/view.sql
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/request_type/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.jira_service_desk.request_type`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.jira_service_desk_syndicate.request_type`

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/status_category/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/status_category/metadata.yaml
@@ -1,0 +1,4 @@
+---
+friendly_name: Jira Service Desk Status Category
+description: |-
+  Jira status category for Service Desk synced via Fivetran.

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/status_category/view.sql
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/status_category/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.jira_service_desk.status_category`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.jira_service_desk_syndicate.status_category`

--- a/sql/moz-fx-data-shared-prod/jira_service_desk_syndicate/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk_syndicate/dataset_metadata.yaml
@@ -14,6 +14,11 @@ syndication:
     - project
     - status
     - resolution
+    - field
+    - issue_field_history
+    - status_category
+    - request
+    - request_type
   administer_views: true
 workgroup_access:
   - role: roles/bigquery.dataViewer


### PR DESCRIPTION
## Description
https://mozilla-hub.atlassian.net/browse/DENG-6141

There was a request to add syndication configurations for additional tables that are synced from Jira via Fivetran


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6896)
