### PR TITLE
Fix GKE container resource, node selector, and startup timeout configs so they work properly

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -224,6 +224,7 @@ class Secret:
 class TaskContainerResources:
     """Represents the Kubernetes container resources configuration for a task."""
 
+    # example dict: {"memory": "4Gi", "cpu": "500m"}
     requests: Optional[Dict[str, str]] = attr.ib(None)
     limits: Optional[Dict[str, str]] = attr.ib(None)
 

--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -220,6 +220,14 @@ class Secret:
             )
 
 
+@attr.s(auto_attribs=True, frozen=True)
+class TaskContainerResources:
+    """Represents the Kubernetes container resources configuration for a task."""
+
+    requests: Optional[Dict[str, str]] = attr.ib(None)
+    limits: Optional[Dict[str, str]] = attr.ib(None)
+
+
 # Known tasks in telemetry-airflow, like stable table tasks
 # https://github.com/mozilla/telemetry-airflow/blob/main/dags/copy_deduplicate.py
 EXTERNAL_TASKS = {
@@ -333,7 +341,7 @@ class Task:
     gke_cluster_name: Optional[str] = attr.ib(None)
     query_project: Optional[str] = attr.ib(None)
     task_group: Optional[str] = attr.ib(None)
-    container_resources: Optional[Dict[str, str]] = attr.ib(None)
+    container_resources: Optional[TaskContainerResources] = attr.ib(None)
     node_selector: Optional[Dict[str, str]] = attr.ib(None)
     startup_timeout_seconds: Optional[int] = attr.ib(None)
     secrets: Optional[List[Secret]] = attr.ib(None)

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -1,6 +1,6 @@
 # Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
-{% set ns = namespace(uses_bq_sensors=False, uses_fivetran=False, uses_secrets=False) -%}
+{% set ns = namespace(uses_bq_sensors=False, uses_fivetran=False, uses_secrets=False, uses_k8s_models=False) -%}
 {% for task in tasks -%}
   {% if task.depends_on_tables_existing or task.depends_on_table_partitions_existing -%}
     {% set ns.uses_bq_sensors = True -%}
@@ -10,6 +10,9 @@
   {% endif -%}
   {% if task.secrets|length > 0 -%}
     {% set ns.uses_secrets = True -%}
+  {% endif -%}
+  {% if task.container_resources -%}
+    {% set ns.uses_k8s_models = True -%}
   {% endif -%}
 {% endfor -%}
 
@@ -27,6 +30,9 @@ from airflow.utils.task_group import TaskGroup
 from airflow.providers.cncf.kubernetes.secret import Secret
 {% endif -%}
 import datetime
+{% if ns.uses_k8s_models -%}
+from kubernetes.client import models as k8s
+{% endif -%}
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check, bigquery_bigeye_check
@@ -198,6 +204,22 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             image='gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest',
             owner='{{ task.owner }}',
             email={{ task.email | sort }},
+            {%+ if task.container_resources -%}
+            container_resources=k8s.V1ResourceRequirements(
+                {%+ if task.container_resources.requests -%}
+                    requests={{ task.container_resources.requests }},
+                {%- endif +%}
+                {%+ if task.container_resources.limits -%}
+                    limits={{ task.container_resources.limits }},
+                {%- endif +%}
+            ),
+            {%+ endif -%}
+            {%+ if task.node_selector -%}
+            node_selector={{ task.node_selector }},
+            {%+ endif -%}
+            {%+ if task.startup_timeout_seconds -%}
+            startup_timeout_seconds={{ task.startup_timeout_seconds }},
+            {%+ endif -%}
             {%+ if task.secrets != [] -%}
             secrets=[
                 {% for secret in task.secrets -%}
@@ -252,15 +274,6 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             {%+ endif -%}
             {%+ elif task.date_partition_parameter -%}
             parameters=["{{ task.date_partition_parameter }}:DATE:{% raw %}{{ds}}{% endraw %}"],
-            {%+ endif -%}
-            {%+ if task.container_resources -%}
-            container_resources={{ task.container_resources }},
-            {%+ endif -%}
-            {%+ if task.node_selector -%}
-            node_selector={{ task.node_selector }},
-            {%+ endif -%}
-            {%+ if task.startup_timeout_seconds -%}
-            startup_timeout_seconds={{ task.startup_timeout_seconds }},
             {%+ endif -%}
             {%+ if task.gke_project_id != None -%}
             project_id={{ task.gke_project_id | format_repr }},
@@ -369,6 +382,22 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             {%+ endif -%}
             {%+ if task.gke_cluster_name != None -%}
             gke_cluster_name={{ task.gke_cluster_name | format_repr }},
+            {%+ endif -%}
+            {%+ if task.container_resources -%}
+            container_resources=k8s.V1ResourceRequirements(
+                {%+ if task.container_resources.requests -%}
+                    requests={{ task.container_resources.requests }},
+                {%- endif +%}
+                {%+ if task.container_resources.limits -%}
+                    limits={{ task.container_resources.limits }},
+                {%- endif +%}
+            ),
+            {%+ endif -%}
+            {%+ if task.node_selector -%}
+            node_selector={{ task.node_selector }},
+            {%+ endif -%}
+            {%+ if task.startup_timeout_seconds -%}
+            startup_timeout_seconds={{ task.startup_timeout_seconds }},
             {%+ endif -%}
             {%+ if task.secrets != [] -%}
             secrets=[

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/crash_symbols_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/crash_symbols_v1/metadata.yaml
@@ -18,11 +18,10 @@ scheduling:
   # Needed to scale the highmem-16 pool from 0 -> 1, because cluster autoscaling
   # works on pod resource requests, instead of usage
   container_resources:
-    request_memory: 102400Mi
-    request_cpu: null
-    limit_memory: 102400Mi
-    limit_cpu: null
-    limit_gpu: null
+    requests:
+      memory: 102400Mi
+    limits:
+      memory: 102400Mi
   # This job needs up to 100 GiB to complete in a reasonable time frame
   node_selector:
     nodepool: highmem-16


### PR DESCRIPTION
## Description
This PR fixes two issues:
* When per-ETL configs for GKE container resources, node selectors, and startup timeouts were added in #4642 the DAG logic was accidentally added for data quality check tasks, not for ETL tasks as intended.
* Specifying GKE container resources as a dictionary apparently doesn't work anymore. This PR switches to the new way using `kubernetes.client.models.V1ResourceRequirements` objects, which I've verified works in mozilla/telemetry-airflow#2131.
  * A similar change is being made for manually maintained DAGs in mozilla/telemetry-airflow#2133.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/4642
* https://github.com/mozilla/telemetry-airflow/pull/2133


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6898)
