### PR TITLE
fix(Fenix LTV): Switch source from analysis to DS project

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v2/query.sql
@@ -5,4 +5,4 @@ SELECT
   country,
   state_function,
 FROM
-  mozdata.analysis.android_state_ltvs_v2
+  `moz-fx-data-bq-data-science.loines.android_state_ltvs_v2`


### PR DESCRIPTION
## Description

This PR updates the source for Fenix LTV values from the analysis space to the Data science project.


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6900)
