### PR TITLE
fix: Do not add default freshness and volume checks to bigconfig if freshness or volume saved metric are already used

### DIFF
--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -374,6 +374,11 @@ def _update_bigconfig(
                     and metric.metric_type.predefined_metric in default_metrics
                 ):
                     default_metrics.remove(metric.metric_type.predefined_metric)
+                elif (
+                    metric.saved_metric_id is not None
+                    and (metric_id := metric.saved_metric_id.upper()) in default_metrics
+                ):
+                    default_metrics.remove(metric_id)
 
         if metadata.monitoring.collection and collection.collection is None:
             collection.collection = SimpleCollection(
@@ -389,7 +394,7 @@ def _update_bigconfig(
                 metrics=[
                     SimpleMetricDefinition(
                         metric_name=(
-                            f"{metric.name} [warn]"
+                            f"{metric.name}"
                             if "volume" not in metric.name.lower()
                             else f"{metric.name} [fail]"
                         ),


### PR DESCRIPTION
# fix: Do not add default freshness and volume checks to bigconfig if freshness or volume saved metric are already used

Currently, the logic does not consider that freshness or volume checks could come from a saved_metric. This change prevents freshness and volume metric definitions from being appended to the bigconfig in such cases.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6906)
