### PR TITLE
Undeprecate these as data science would still like to use the old data

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_daily_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_daily_summary_v1/metadata.yaml
@@ -23,4 +23,3 @@ bigquery:
     - blog
     - subblog
 references: {}
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_goals_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_goals_v1/metadata.yaml
@@ -18,4 +18,3 @@ bigquery:
     expiration_days: null
   clustering: null
 references: {}
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_landing_page_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_landing_page_summary_v1/metadata.yaml
@@ -23,4 +23,3 @@ bigquery:
     - blog
     - subblog
 references: {}
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_sessions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_sessions_v1/metadata.yaml
@@ -18,4 +18,3 @@ bigquery:
     expiration_days: null
   clustering: null
 references: {}
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/firefox_whatsnew_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/firefox_whatsnew_summary_v1/metadata.yaml
@@ -17,4 +17,3 @@ bigquery:
       - country
       - locale
       - version
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v1/metadata.yaml
@@ -18,4 +18,3 @@ bigquery:
   clustering:
     fields: ["country"]
 references: {}
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_downloads_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_downloads_v1/metadata.yaml
@@ -18,4 +18,3 @@ bigquery:
     expiration_days: null
   clustering: null
 references: {}
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_events_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_events_metrics_v1/metadata.yaml
@@ -23,4 +23,3 @@ bigquery:
     - event_action
     - event_label
 references: {}
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_hits_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_hits_v1/metadata.yaml
@@ -18,4 +18,3 @@ bigquery:
     expiration_days: null
   clustering: null
 references: {}
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_landing_page_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_landing_page_metrics_v1/metadata.yaml
@@ -23,4 +23,3 @@ bigquery:
     - locale
     - medium
 references: {}
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_metrics_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_metrics_summary_v1/metadata.yaml
@@ -23,4 +23,3 @@ bigquery:
     - source
     - medium
 references: {}
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_page_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_page_metrics_v1/metadata.yaml
@@ -23,4 +23,3 @@ bigquery:
     - locale
     - medium
 references: {}
-deprecated: true


### PR DESCRIPTION
## Description

This PR undeprecates the old GA3 tables so that data science can still have permissions to query them and use them for analysis, even though they are no longer updated, for historical analysis.


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**