### PR TITLE
Create new dataset ltv_state_values_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/ltv_state_values_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ltv_state_values_derived/dataset_metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: LTV State Values Derived
+description: |
+  Dataset where the data science team has write access to write LTV state values from their models
+dataset_base_acl: derived_restricted
+user_facing: false
+labels: {}
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:datascience/developers
+      - workgroup:mozilla-confidential
+  - role: roles/bigquery.dataEditor
+    members:
+      - workgroup:datascience/developers

--- a/sql/moz-fx-data-shared-prod/ltv_state_values_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ltv_state_values_derived/dataset_metadata.yaml
@@ -7,7 +7,6 @@ labels: {}
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
-      - workgroup:datascience/developers
       - workgroup:mozilla-confidential
   - role: roles/bigquery.dataEditor
     members:

--- a/sql/moz-fx-data-shared-prod/ltv_state_values_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ltv_state_values_derived/dataset_metadata.yaml
@@ -1,7 +1,7 @@
 friendly_name: LTV State Values Derived
 description: |
   Dataset where the data science team has write access to write LTV state values from their models
-dataset_base_acl: derived_restricted
+dataset_base_acl: derived
 user_facing: false
 labels: {}
 workgroup_access:


### PR DESCRIPTION
## Description

This PR is intended to create a new dataset in shared-prod where the data science team has write access.
In discussion with Leif, learned that they may be soon replacing these models with new models, so not worth the effort to productionalize their existing models, but rather move them to a safe place in shared-prod until the new ones are ready to replace the old ones.

We will be moving 3 tables from analysis into this dataset since they are used downstream in other production ETL for the Fenix, Firefox Desktop, and iOS LTV models.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6915)
