### PR TITLE
fix(glam): properly fetch labeled_distribution metadata

### DIFF
--- a/bigquery_etl/glam/templates/histogram_bucket_counts_v1.sql
+++ b/bigquery_etl/glam/templates/histogram_bucket_counts_v1.sql
@@ -72,7 +72,7 @@ distribution_metadata AS (
         [
             {% for meta in custom_distribution_metadata_list %}
                 STRUCT(
-                    "custom_distribution" as metric_type,
+                    "{{ meta.type }}" as metric_type,
                     "{{ meta.name.replace('.', '_') }}" as metric,
                     {{ meta.range_min }} as range_min,
                     {{ meta.range_max }} as range_max,
@@ -94,7 +94,7 @@ distribution_metadata AS (
     FROM
       unnested
     WHERE
-      metric_type <> "custom_distribution"
+      NOT ENDS_WITH(metric_type, "custom_distribution")
     GROUP BY
       metric_type,
       metric

--- a/bigquery_etl/glam/templates/probe_counts_v1.sql
+++ b/bigquery_etl/glam/templates/probe_counts_v1.sql
@@ -11,19 +11,20 @@
       WITH buckets AS (
         SELECT
           CASE
-            WHEN metric_type = 'timing_distribution'
+            -- We use ENDS_WITH here to accommodate for types prefixed with "labeled_"
+            WHEN ENDS_WITH(metric_type, 'timing_distribution')
             -- https://mozilla.github.io/glean/book/user/metrics/timing_distribution.html
               THEN mozfun.glam.histogram_generate_functional_buckets(2, 8, range_max)
-            WHEN metric_type = 'memory_distribution'
+            WHEN ENDS_WITH(metric_type, 'memory_distribution')
             -- https://mozilla.github.io/glean/book/user/metrics/memory_distribution.html
               THEN mozfun.glam.histogram_generate_functional_buckets(2, 16, range_max)
-            WHEN metric_type = 'custom_distribution_exponential'
+            WHEN ENDS_WITH(metric_type, 'custom_distribution_exponential')
               THEN mozfun.glam.histogram_generate_exponential_buckets(
                   range_min,
                   range_max,
                   bucket_count
                 )
-            WHEN metric_type = 'custom_distribution_linear'
+            WHEN ENDS_WITH(metric_type, 'custom_distribution_linear')
               THEN mozfun.glam.histogram_generate_linear_buckets(range_min, range_max, bucket_count)
             ELSE []
           END AS arr

--- a/bigquery_etl/glam/utils.py
+++ b/bigquery_etl/glam/utils.py
@@ -10,7 +10,7 @@ from mozilla_schema_generator.glean_ping import GleanPing
 
 CustomDistributionMeta = namedtuple(
     "CustomDistributionMeta",
-    ["name", "range_min", "range_max", "bucket_count", "histogram_type"],
+    ["name", "type", "range_min", "range_max", "bucket_count", "histogram_type"],
 )
 
 
@@ -72,10 +72,12 @@ def get_custom_distribution_metadata(product_name) -> List[CustomDistributionMet
 
     custom = []
     for probe in probes:
-        if probe.get_type() != "custom_distribution":
+        # We use endswith here to accommodate for types prefixed with "labeled"
+        if not probe.get_type().endswith("custom_distribution"):
             continue
         meta = CustomDistributionMeta(
             probe.get_name(),
+            probe.get_type(),
             probe.get("range_min"),
             probe.get("range_max"),
             probe.get("bucket_count"),


### PR DESCRIPTION
## Description

This PR adds support to `labeled_distributions` to the GLAM ETL mechanism that fetches metric metadata.

## Related Tickets & Documents
* DENG-6817

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


