### PR TITLE
feat: Add minimum row count check to google ads table google_ads_derived.daily_campaign_stats_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/checks.sql
@@ -1,2 +1,2 @@
 #fail
-{{ min_row_count(1, "date = @submission_date") }}
+{{ min_row_count(1, "`date` = @submission_date") }}

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/checks.sql
@@ -1,2 +1,2 @@
-# fail
+#fail
 {{ min_row_count(1, "last_updated_date = @submission_date") }}

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/checks.sql
@@ -1,2 +1,2 @@
 #fail
-{{ min_row_count(1, "last_updated_date = @submission_date") }}
+{{ min_row_count(1, "date = @submission_date") }}

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/checks.sql
@@ -1,0 +1,2 @@
+# fail
+{{ min_row_count(1, "last_updated_date = @submission_date") }}

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/metadata.yaml
@@ -4,13 +4,15 @@ description: |-
   This is written directly from Fivetran's ETL.
   https://github.com/fivetran/dbt_google_ads
 owners:
-- frank@mozilla.com
+- kwindau@mozilla.com
 labels:
   incremental: false
 scheduling:
   dag_name: bqetl_fivetran_google_ads
   depends_on_past: false
   date_partition_parameter: null
+  parameters: 
+  - submission_date:DATE:{{ds}}
 bigquery:
   clustering:
     fields: ["date"]

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/metadata.yaml
@@ -11,7 +11,7 @@ scheduling:
   dag_name: bqetl_fivetran_google_ads
   depends_on_past: false
   date_partition_parameter: null
-  parameters: 
+  parameters:
   - submission_date:DATE:{{ds}}
 bigquery:
   clustering:

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/query.sql
@@ -1,6 +1,6 @@
 SELECT
   date_day AS `date`,
-  * EXCEPT (date_day), 
+  * EXCEPT (date_day),
   @submission_date AS last_updated_date
 FROM
   `moz-fx-data-bq-fivetran.ads_google_mmc_google_ads.google_ads__campaign_report`

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/query.sql
@@ -1,5 +1,6 @@
 SELECT
   date_day AS `date`,
-  * EXCEPT (date_day)
+  * EXCEPT (date_day), 
+  @submission_date AS last_updated_date
 FROM
   `moz-fx-data-bq-fivetran.ads_google_mmc_google_ads.google_ads__campaign_report`

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/schema.yaml
@@ -32,3 +32,6 @@ fields:
 - mode: NULLABLE
   name: impressions
   type: INTEGER
+- mode: NULLABLE
+  name: last_updated_date
+  type: DATE

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/daily_campaign_stats_v1/schema.yaml
@@ -9,6 +9,9 @@ fields:
   name: account_id
   type: INTEGER
 - mode: NULLABLE
+  name: currency_code
+  type: STRING
+- mode: NULLABLE
   name: campaign_name
   type: STRING
 - mode: NULLABLE


### PR DESCRIPTION
## Description

This table is a full delete and rebuild each day from Google Ads.  When the connection breaks, the DAG doesn't throw an error, it still marks the run as successful.  This logic change should ensure that if no data is loaded for the current submission date, an error will be thrown in the future.


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**