### PR TITLE
fix: update percentage thresholds from 100 to 1 (1 == 100 percent in the tool) in bigconfig

### DIFF
--- a/sql/bigconfig.yml
+++ b/sql/bigconfig.yml
@@ -69,8 +69,8 @@ saved_metric_definitions:
           string_value: "release,beta,nightly,aurora,esr,Other"
       threshold:
         type: CONSTANT
-        lower_bound: 100
-        upper_bound: 100
+        lower_bound: 1
+        upper_bound: 1
       metric_schedule:
         named_schedule:
           name: default
@@ -103,8 +103,8 @@ saved_metric_definitions:
         predefined_metric: PERCENT_UUID
       threshold:
         type: CONSTANT
-        lower_bound: 100
-        upper_bound: 100
+        lower_bound: 1
+        upper_bound: 1
       metric_schedule:
         named_schedule:
           name: default


### PR DESCRIPTION
# fix: update percentage thresholds from 100 to 1 (1 == 100 percent in the tool) in bigconfig

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-XXXX
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6957)
