### PR TITLE
feat: Add Census permissions to desktop_conversion_events

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/metadata.yaml
@@ -4,3 +4,4 @@ workgroup_access:
   - workgroup:mozilla-confidential
   - workgroup:google-managed/external-ads-datafusion
   - workgroup:google-managed/external-ads-dataproc
+  - workgroup:dataops-managed/external-census


### PR DESCRIPTION
## Description

This PR adds permissions for the Census tool to access the data in this view `moz-fx-data-shared-prod.mozilla_org.desktop_conversion_events`

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6970)
