### PR TITLE
Add metadata labels to aggregate tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
@@ -6,6 +6,8 @@ owners:
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_ios_campaign_reporting
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/browser_usage_v1/metadata.yaml
@@ -5,6 +5,7 @@ owners:
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_cloudflare_browser_market_share
   date_partition_parameter: dte

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/device_usage_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: false
   owner1: kwindau@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_cloudflare_device_market_share
   date_partition_parameter: dte

--- a/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/cloudflare_derived/os_usage_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_cloudflare_os_market_share
   date_partition_parameter: dte

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_daily_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_daily_summary_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   schedule: daily
   dag: bqetl_google_analytics_derived
   owner1: ascholtz
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_google_analytics_derived
 bigquery:

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_daily_summary_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_daily_summary_v2/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: mhirose@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_google_analytics_derived_ga4
 bigquery:

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_landing_page_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_landing_page_summary_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   schedule: daily
   dag: bqetl_google_analytics_derived
   owner1: ascholtz
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_google_analytics_derived
 bigquery:

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_landing_page_summary_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/blogs_landing_page_summary_v2/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: mhirose@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_google_analytics_derived_ga4
   depends_on:

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_landing_page_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_landing_page_metrics_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   schedule: daily
   dag: bqetl_google_analytics_derived
   owner1: ascholtz
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_google_analytics_derived
 bigquery:

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_landing_page_metrics_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_landing_page_metrics_v2/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: mhirose@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_google_analytics_derived_ga4
 bigquery:

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_metrics_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_metrics_summary_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   schedule: daily
   dag: bqetl_google_analytics_derived
   owner1: ascholtz
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_google_analytics_derived
 bigquery:

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_metrics_summary_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_metrics_summary_v2/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: mhirose@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_google_analytics_derived_ga4
   depends_on_tables_existing:

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_page_metrics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_page_metrics_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   schedule: daily
   dag: bqetl_google_analytics_derived
   owner1: ascholtz
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_google_analytics_derived
 bigquery:

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_page_metrics_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/www_site_page_metrics_v2/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_google_analytics_derived_ga4
 bigquery:

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/site_metrics_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/site_metrics_summary_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   application: mozilla_vpn
   schedule: daily
+  table_type: aggregate
 scheduling:
   # No longer scheduled because we're no longer getting GA3 data from Google.
   # https://bugzilla.mozilla.org/show_bug.cgi?id=1905989

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/site_metrics_summary_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/site_metrics_summary_v2/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_mozilla_vpn_site_metrics
   depends_on:

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/metadata.yaml
@@ -9,6 +9,7 @@ owners:
 labels:
   schedule: daily
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_mobile_search
 bigquery:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/metadata.yaml
@@ -8,6 +8,7 @@ owners:
 labels:
   schedule: daily
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_search
 bigquery:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_dau_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_dau_aggregates_v1/metadata.yaml
@@ -11,6 +11,7 @@ labels:
   schedule: daily
   change_controlled: true
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_search_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_engagement_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_engagement_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   incremental: true
   owner1: kwindau@mozilla.com
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_desktop_engagement_model
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_retention_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_retention_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   incremental: true
   owner1: example
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_desktop_retention_model
   date_partition_parameter: metric_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_installer_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_installer_aggregates_v1/metadata.yaml
@@ -6,6 +6,8 @@ owners:
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_firefox_installer_aggregates
 bigquery:

--- a/sql_generators/use_counters/templates/metadata.yaml
+++ b/sql_generators/use_counters/templates/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   public_bigquery: true
   public_json: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
   review_bugs:
   - 1866834 
 scheduling:


### PR DESCRIPTION
## Description

This PR adds labels to the following aggregate tables:
**Aggregate Table Only (since these aren't impacted by shredder)**
* moz-fx-data-shared-prod.cloudflare_derived.browser_usage_v1
* moz-fx-data-shared-prod.cloudflare_derived.device_usage_v1
* moz-fx-data-shared-prod.cloudflare_derived.os_usage_v1
* moz-fx-data-shared-prod.mozilla_org_derived.blogs_daily_summary_v1
* moz-fx-data-shared-prod.mozilla_org_derived.blogs_daily_summary_v2
* moz-fx-data-shared-prod.mozilla_org_derived.blogs_landing_page_summary_v1
* moz-fx-data-shared-prod.mozilla_org_derived.blogs_landing_page_summary_v2
* moz-fx-data-shared-prod.mozilla_org_derived.www_site_landing_page_metrics_v1
* moz-fx-data-shared-prod.mozilla_org_derived.www_site_landing_page_metrics_v2
* moz-fx-data-shared-prod.mozilla_org_derived.www_site_metrics_summary_v1
* moz-fx-data-shared-prod.mozilla_org_derived.www_site_metrics_summary_v2
* moz-fx-data-shared-prod.mozilla_org_derived.www_site_page_metrics_v1
* moz-fx-data-shared-prod.mozilla_org_derived.www_site_page_metrics_v2
* moz-fx-data-shared-prod.mozilla_vpn_derived.site_metrics_summary_v1
* moz-fx-data-shared-prod.mozilla_vpn_derived.site_metrics_summary_v2

**Aggregate Table Only (May add shredder mitigation in the future):** 
The following 2 ARE impacted by shredder but the queries are a bit complicated (not a simple group by), so leaving shredder mitigation tag off for now
* moz-fx-data-shared-prod.firefox_desktop_derived.firefox_desktop_use_counters
* moz-fx-data-shared-prod.fenix_derived.fenix_use_counters_v2

**Aggregate Table + Shredder Mitigation**
* moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1
* moz-fx-data-shared-prod.search_derived.mobile_search_aggregates_v1
* moz-fx-data-shared-prod.search_derived.search_aggregates_v8
* moz-fx-data-shared-prod.search_derived.search_dau_aggregates_v1
* moz-fx-data-shared-prod.telemetry_derived.desktop_engagement_v1
* moz-fx-data-shared-prod.telemetry_derived.desktop_retention_v1
* moz-fx-data-shared-prod.telemetry_derived.firefox_installer_aggregates_v1
