### PR TITLE
Remove materialized view append from referenced tables in jobs

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.sql
@@ -52,28 +52,7 @@ jobs_by_project AS (
     FROM
       `{{project}}.region-us.INFORMATION_SCHEMA.JOBS_BY_PROJECT` AS jp
     LEFT JOIN
-      UNNEST(
-        ARRAY_CONCAT(
-          referenced_tables,
-          (
-            IFNULL(
-              (
-                SELECT
-                  ARRAY_AGG(
-                    STRUCT(
-                      materialized_view.table_reference.project_id AS project_id,
-                      materialized_view.table_reference.dataset_id AS dataset_id,
-                      materialized_view.table_reference.table_id AS table_id
-                    )
-                  )
-                FROM
-                  UNNEST(materialized_view_statistics.materialized_view) AS materialized_view
-              ),
-              []
-            )
-          )
-        )
-      ) AS referenced_table
+      UNNEST(referenced_tables) AS referenced_table
     WHERE
       DATE(creation_time) = @submission_date
   {%- endfor %}

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
@@ -39,13 +39,7 @@ def create_query(job_date: date, project: str):
           priority,
           project_id,
           project_number,
-          ARRAY_CONCAT(referenced_tables, IFNULL((SELECT ARRAY_AGG(
-            STRUCT(
-              materialized_view.table_reference.project_id AS project_id,
-              materialized_view.table_reference.dataset_id AS dataset_id,
-              materialized_view.table_reference.table_id AS table_id
-            )
-          ) FROM UNNEST(materialized_view_statistics.materialized_view) AS materialized_view), [])) AS referenced_tables,
+          referenced_tables,
           reservation_id,
           start_time,
           state,


### PR DESCRIPTION
## Description

This reverts https://github.com/mozilla/bigquery-etl/pull/4786.  The materialized view already shows up in the referenced tables so the `ARRAY_CONCAT` is adding a duplicate value which gives incorrect results if we do a cross join without deduping. [example](https://sql.telemetry.mozilla.org/queries/104377/source)

I'm guessing that this was needed because the materialized view used to not be included in the array.  @scholtzan do you remember if that was the case?

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
