### PR TITLE
feat(glam): extract refresh_aggregates_fog_release

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1490,6 +1490,24 @@ bqetl_glam_refresh_aggregates:
     - impact/tier_2
     - repo/bigquery-etl
 
+  bqetl_glam_refresh_aggregates_fog_release:
+    default_args:
+      depends_on_past: false
+      email:
+        - efilho@mozilla.com
+      email_on_failure: true
+      email_on_retry: false
+      owner: efilho@mozilla.com
+      retries: 2
+      retry_delay: 30m
+      start_date: '2024-12-10'
+    description: Update GLAM FOG release tables that serve aggregated data.
+    repo: bigquery-etl
+    schedule_interval: 0 18 * * 6
+    tags:
+      - impact/tier_2
+      - repo/bigquery-etl
+
 bqetl_google_search_console:
   schedule_interval: 0 8 * * *
   description: |

--- a/dags.yaml
+++ b/dags.yaml
@@ -1490,23 +1490,23 @@ bqetl_glam_refresh_aggregates:
     - impact/tier_2
     - repo/bigquery-etl
 
-  bqetl_glam_refresh_aggregates_fog_release:
-    default_args:
-      depends_on_past: false
-      email:
-        - efilho@mozilla.com
-      email_on_failure: true
-      email_on_retry: false
-      owner: efilho@mozilla.com
-      retries: 2
-      retry_delay: 30m
-      start_date: '2024-12-10'
-    description: Update GLAM FOG release tables that serve aggregated data.
-    repo: bigquery-etl
-    schedule_interval: 0 18 * * 6
-    tags:
-      - impact/tier_2
-      - repo/bigquery-etl
+bqetl_glam_refresh_aggregates_fog_release:
+  default_args:
+    depends_on_past: false
+    email:
+      - efilho@mozilla.com
+    email_on_failure: true
+    email_on_retry: false
+    owner: efilho@mozilla.com
+    retries: 2
+    retry_delay: 30m
+    start_date: '2024-12-10'
+  description: Update GLAM FOG release tables that serve aggregated data.
+  repo: bigquery-etl
+  schedule_interval: 0 18 * * 6
+  tags:
+    - impact/tier_2
+    - repo/bigquery-etl
 
 bqetl_google_search_console:
   schedule_interval: 0 8 * * *

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates_v1/metadata.yaml
@@ -7,9 +7,8 @@ labels:
   incremental: false
   owner1: efilho@mozilla.com
 scheduling:
-  dag_name: bqetl_glam_refresh_aggregates
+  dag_name: bqetl_glam_refresh_aggregates_fog_release
   date_partition_parameter: null
   depends_on:
-  - task_id: export_firefox_desktop_glam_release
-    dag_name: glam_fog
-    execution_delta: 6h
+  - task_id: fog_release_done
+    dag_name: glam_fog_release

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates_v1/metadata.yaml
@@ -12,3 +12,4 @@ scheduling:
   depends_on:
   - task_id: fog_release_done
     dag_name: glam_fog_release
+    execution_delta: 8h


### PR DESCRIPTION
## Description


The release aggregates table is being recalculated nightly, but release channel builds happen infrequently enough that we can reduce this cadence to weekly without meaningful loss in usability.

This PR extracts `bqetl_refresh_aggregates`.`release` into `bqetl_glam_refresh_aggregates_fog_release` so it can follow `glam_fog_release`'s schedule. (https://github.com/mozilla/telemetry-airflow/pull/2135)

## Related Tickets & Documents
* DENG-6752


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6992)
