### PR TITLE
Remove experiment search monitoring

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_ad_clicks/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_ad_clicks/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Experiment Cumulative Ad Clicks
+description: Cumulative ad click data related to experiments
+owners:
+- ascholtz@mozilla.com
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_count/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_count/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Experiment Cumulative Search Count
+description: Cumulative search count data related to experiments
+owners:
+- ascholtz@mozilla.com
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_with_ads_count/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_with_ads_count/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Experiment Cumulative Search with Ads Count
+description: Cumulative data of searches that had ad clicks related to experiments
+owners:
+- ascholtz@mozilla.com
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_ad_clicks_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_ad_clicks_v1/metadata.yaml
@@ -4,3 +4,4 @@ labels:
   incremental: false
 owners:
 - ascholtz@mozilla.com
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_search_count_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_search_count_v1/metadata.yaml
@@ -4,3 +4,4 @@ labels:
   incremental: false
 owners:
 - ascholtz@mozilla.com
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_search_with_ads_count_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_search_with_ads_count_v1/metadata.yaml
@@ -5,3 +5,4 @@ labels:
   incremental: false
 owners:
 - ascholtz@mozilla.com
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Experiment Search Aggregates Live
+description: Live search data related to experiments
+owners:
+- ascholtz@mozilla.com
+deprecated: true

--- a/sql_generators/experiment_monitoring/templates/experiment_search_aggregates_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_search_aggregates_v1/metadata.yaml
@@ -18,3 +18,4 @@ bigquery:
     fields:
     - experiment
     - branch
+deprecated: true

--- a/sql_generators/experiment_monitoring/templates/experiment_search_events_live_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_search_events_live_v1/metadata.yaml
@@ -6,3 +6,4 @@ owners:
 - ascholtz@mozilla.com
 labels:
   materialized_view: true
+deprecated: true


### PR DESCRIPTION
## Description

Merge after https://github.com/mozilla/lookml-generator/pull/1122 has been merged

Experiment search monitoring is no longer needed and looked at by stakeholders, so we can deprecate all the related datasets to delete them eventually.



<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-6993)
