### PR TITLE
Update table owners for ads and search tables

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1298,10 +1298,13 @@ bqetl_ads:
     email:
       - telemetry-alerts@mozilla.com
       - cmorales@mozilla.com
+      - cbeck@mozilla.com
+      - lvargas@mozilla.com
+      - sbetancourt@mozilla.com
     email_on_failure: true
     email_on_retry: true
     end_date: null
-    owner: cmorales@mozilla.com
+    owner: cbeck@mozilla.com
     retries: 2
     retry_delay: 30m
     start_date: '2023-10-10'

--- a/sql/moz-fx-data-shared-prod/ads/fakespot_daily_events_rollup/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads/fakespot_daily_events_rollup/metadata.yaml
@@ -3,6 +3,8 @@ description: |-
   Daily events rollup from Fakespot, pulled from syndicate dataset
 owners:
   - cmorales@mozilla.com
+  - cbeck@mozilla.com
+  - lvargas@mozilla.com
 labels:
   authorized: true
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/ads/nt_visits_to_sessions_conversion_factors_daily/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads/nt_visits_to_sessions_conversion_factors_daily/metadata.yaml
@@ -5,6 +5,8 @@ description: |-
 owners:
   - sbetancourt@mozilla.com
   - cmorales@mozilla.com
+  - cbeck@mozilla.com
+  - lvargas@mozilla.com
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:

--- a/sql/moz-fx-data-shared-prod/ads/ppa_measurements/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads/ppa_measurements/metadata.yaml
@@ -7,6 +7,8 @@ description: |-
   telemetry-airflow and docker-etl)
 owners:
   - cmorales@mozilla.com
+  - cbeck@mozilla.com
+  - lvargas@mozilla.com
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:

--- a/sql/moz-fx-data-shared-prod/ads/ppa_measurements_limited/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads/ppa_measurements_limited/metadata.yaml
@@ -10,6 +10,8 @@ description: |-
   telemetry-airflow and docker-etl)
 owners:
   - cmorales@mozilla.com
+  - cbeck@mozilla.com
+  - lvargas@mozilla.com
 labels:
   authorized: true
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/ads_derived/nt_visits_to_sessions_conversion_factors_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/nt_visits_to_sessions_conversion_factors_daily_v1/metadata.yaml
@@ -5,6 +5,8 @@ description: |-
 owners:
   - sbetancourt@mozilla.com
   - cmorales@mozilla.com
+  - cbeck@mozilla.com
+  - lvargas@mozilla.com
 labels:
   incremental: true
   schedule: daily

--- a/sql/moz-fx-data-shared-prod/reference/macroeconomic_indices/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/reference/macroeconomic_indices/metadata.yaml
@@ -11,9 +11,11 @@ description: |-
   We have a FinancialModelingPrep account that allows us to use this data for
   internal use. Contact the Search and Revenue team and/or the owners of this
   table for more information
-owners: [cmorales@mozilla.com, xluo@mozilla.com]
+owners:
+  - cmorales@mozilla.com
+  - akommasani@mozilla.com
 labels:
   schedule: daily
   incremental: true
   owner1: cmorales@mozilla.com
-  owner2: xluo@mozilla.com
+  owner2: akommasani@mozilla.com

--- a/sql/moz-fx-data-shared-prod/reference_derived/macroeconomic_indices_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/reference_derived/macroeconomic_indices_v1/metadata.yaml
@@ -11,17 +11,19 @@ description: |-
   We have a FinancialModelingPrep account that allows us to use this data for
   internal use. Contact the Search and Revenue team and/or the owners of this
   table for more information
-owners: [cmorales@mozilla.com, xluo@mozilla.com]
+owners:
+  - cmorales@mozilla.com
+  - akommasani@mozilla.com
 labels:
   schedule: daily
   incremental: true
   owner1: cmorales@mozilla.com
-  owner2: xluo@mozilla.com
+  owner2: akommasani@mozilla.com
 scheduling:
   dag_name: bqetl_reference
   arguments:
-  - --market-date={{ ds }}
-  - --api-key={{ var.value.fmp_api_key }}
+    - --market-date={{ ds }}
+    - --api-key={{ var.value.fmp_api_key }}
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/search_derived/acer_cohort_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/acer_cohort_v1/metadata.yaml
@@ -5,6 +5,7 @@ description: |-
   in the future
 owners:
 - cmorales@mozilla.com
+- akommasani@mozilla.com
 labels:
   owner1: cmorales
 bigquery: null

--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/metadata.yaml
@@ -6,13 +6,13 @@ description: |-
   Originally created for the search report dashboard.
 owners:
 - cmorales@mozilla.com
-- xluo@mozilla.com
+- akommasani@mozilla.com
 labels:
   incremental: true
   schedule: daily
   dag: bqetl_search_dashboard
   owner1: cmorales
-  owner2: xluo
+  owner2: akommasani
   shredder_mitigation: true
 scheduling:
   dag_name: bqetl_search_dashboard

--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_for_searchreport_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_for_searchreport_v1/metadata.yaml
@@ -6,13 +6,13 @@ description: |-
   Originally created for the search report dashboard.
 owners:
 - cmorales@mozilla.com
-- xluo@mozilla.com
+- akommasani@mozilla.com
 labels:
   incremental: true
   schedule: daily
   dag: bqetl_search_dashboard
   owner1: cmorales
-  owner2: xluo
+  owner2: akommasani
   shredder_mitigation: true
 scheduling:
   dag_name: bqetl_search_dashboard

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_for_searchreport_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_for_searchreport_v1/metadata.yaml
@@ -7,13 +7,13 @@ description: |-
   Originally created for the search report dashboard.
 owners:
 - cmorales@mozilla.com
-- xluo@mozilla.com
+- akommasani@mozilla.com
 labels:
   incremental: true
   schedule: daily
   dag: bqetl_search_dashboard
   owner1: cmorales
-  owner2: xluo
+  owner2: akommasani
   shredder_mitigation: true
 scheduling:
   dag_name: bqetl_search_dashboard

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/metadata.yaml
@@ -4,7 +4,7 @@ description: >
   Daily mobile clients sending pings that have searches,
   aggregated across unique sets of dimensions and partitioned by day
 owners:
-  - akomar@mozilla.com
+  - akommasani@mozilla.com
   - cmorales@mozilla.com
 labels:
   schedule: daily

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_last_seen_v1/metadata.yaml
@@ -6,12 +6,12 @@ description: |
   Exposed to users as view `search.mobile_search_clients_last_seen` and used
   as the basis for mobile LTV calculations.
 owners:
-- akomar@mozilla.com
+- akommasani@mozilla.com
 - cmorales@mozilla.com
 labels:
   schedule: daily
   dag: bqetl_mobile_search
-  owner1: akomar
+  owner1: akommasani
   owner2: cmorales
 scheduling:
   dag_name: bqetl_mobile_search

--- a/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_aggregates_v8/metadata.yaml
@@ -3,7 +3,7 @@ description: |-
   Daily search clients, aggregated across unique sets of dimensions
   and partitioned by day.
 owners:
-- akomar@mozilla.com
+- akommasani@mozilla.com
 - cmorales@mozilla.com
 labels:
   schedule: daily

--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/metadata.yaml
@@ -4,7 +4,7 @@ description: |
 
   Exposed to users as view `search.search_clients_engines_sources_daily`.
 owners:
-- akomar@mozilla.com
+- akommasani@mozilla.com
 - cmorales@mozilla.com
 labels:
   schedule: daily

--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_last_seen_v1/metadata.yaml
@@ -6,12 +6,12 @@ description: |
   Exposed to users as view `search.search_clients_last_seen` and used
   as the basis for LTV calculations.
 owners:
-- akomar@mozilla.com
+- akommasani@mozilla.com
 - cmorales@mozilla.com
 labels:
   schedule: daily
   dag: bqetl_search
-  owner1: akomar
+  owner1: akommasani
   owner2: cmorales
 scheduling:
   dag_name: bqetl_search

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
@@ -6,6 +6,7 @@ description: |-
 owners:
 - skahmann@mozilla.com
 - cmorales@mozilla.com
+- akommasani@mozilla.com
 labels:
   incremental: true
 scheduling:


### PR DESCRIPTION
## Description

Adds @chelseybeck @lucia-vargas-a and @sergiosonline to table owners and airflow notification emails for Ads tables, and also adds @alekhyamoz to table owners for search tables

## Related Tickets & Documents

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7004)
