### PR TITLE
[DENG-6141] Add Jira issue multiselect history table

### DIFF
--- a/sql/moz-fx-data-shared-prod/jira_service_desk/issue_multiselect_history/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/issue_multiselect_history/metadata.yaml
@@ -1,0 +1,4 @@
+---
+friendly_name: Jira Service Desk Issue Multiselect History
+description: |-
+  Jira issue multiselect history for Service Desk synced via Fivetran.

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/issue_multiselect_history/view.sql
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/issue_multiselect_history/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.jira_service_desk.issue_multiselect_history`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.jira_service_desk_syndicate.issue_multiselect_history`

--- a/sql/moz-fx-data-shared-prod/jira_service_desk_syndicate/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk_syndicate/dataset_metadata.yaml
@@ -16,6 +16,7 @@ syndication:
     - resolution
     - field
     - issue_field_history
+    - issue_multiselect_history
     - status_category
     - request
     - request_type


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DENG-6141

This adds syndication configuration for the Jira issue multiselect history table synced via Fivetran



<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7006)
