### PR TITLE
Add aggregate table labels to aggregate tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_week_4_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/funnel_retention_week_4_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   schedule: daily
   incremental: true
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_analytics_tables
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_position_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_position_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   incremental: true
   schedule: daily
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_urlbar
 bigquery:

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   incremental: true
   schedule: daily
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_urlbar
 bigquery:

--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/metadata.yaml
@@ -14,6 +14,7 @@ labels:
   owner1: cmorales
   owner2: xluo
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_search_dashboard
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_for_searchreport_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_for_searchreport_v1/metadata.yaml
@@ -14,6 +14,7 @@ labels:
   owner1: cmorales
   owner2: xluo
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_search_dashboard
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_for_searchreport_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_for_searchreport_v1/metadata.yaml
@@ -15,6 +15,7 @@ labels:
   owner1: cmorales
   owner2: xluo
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_search_dashboard
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/metadata.yaml
@@ -11,6 +11,8 @@ owners:
 - mhirose@mozilla.com
 labels:
   incremental: true
+  shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_analytics_aggregations
   date_partition_parameter: activity_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v1/schema.yaml
@@ -2,72 +2,96 @@ fields:
 - mode: NULLABLE
   name: cohort_date
   type: DATE
+  description: Cohort Date
 - mode: NULLABLE
   name: activity_date
   type: DATE
+  description: Activity Date
 - mode: NULLABLE
   name: activity_segment
   type: STRING
+  description: Activity Segment
 - mode: NULLABLE
   name: app_version
   type: STRING
+  description: App Version
 - mode: NULLABLE
   name: attribution_campaign
   type: STRING
+  description: Attribution Campaign
 - mode: NULLABLE
   name: attribution_content
   type: STRING
+  description: Attribution Content
 - mode: NULLABLE
   name: attribution_experiment
   type: STRING
+  description: Attribution Experiment
 - mode: NULLABLE
   name: attribution_medium
   type: STRING
+  description: Attribution Medium
 - mode: NULLABLE
   name: attribution_source
   type: STRING
+  description: Attribution Source
 - mode: NULLABLE
   name: attribution_variation
   type: STRING
+  description: Attribution Variation
 - mode: NULLABLE
   name: city
   type: STRING
+  description: City
 - mode: NULLABLE
   name: country
   type: STRING
+  description: Country
 - mode: NULLABLE
   name: device_model
   type: STRING
+  description: Device Model
 - mode: NULLABLE
   name: distribution_id
   type: STRING
+  description: Distribution ID
 - mode: NULLABLE
   name: is_default_browser
   type: BOOLEAN
+  description: Is Default Browser
 - mode: NULLABLE
   name: locale
   type: STRING
+  description: Locale
 - mode: NULLABLE
   name: normalized_app_name
   type: STRING
+  description: Normalized App Name
 - mode: NULLABLE
   name: normalized_channel
   type: STRING
+  description: Normalized Channel
 - mode: NULLABLE
   name: normalized_os
   type: STRING
+  description: Normalized Operating System
 - mode: NULLABLE
   name: normalized_os_version
   type: STRING
+  description: Normalized Operating System Version
 - mode: NULLABLE
   name: os_version_major
   type: INTEGER
+  description: Operating System Major Version
 - mode: NULLABLE
   name: os_version_minor
   type: INTEGER
+  description: Operating System Minor Version
 - mode: NULLABLE
   name: num_clients_in_cohort
   type: INTEGER
+  description: Number of Clients in Cohort
 - mode: NULLABLE
   name: num_clients_active_on_day
   type: INTEGER
+  description: Number of Clients Active on Day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_cohort_daily_retention_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_cohort_daily_retention_v1/metadata.yaml
@@ -15,6 +15,7 @@ owners:
 - mhirose@mozilla.com
 labels:
   incremental: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_analytics_aggregations
   date_partition_parameter: submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_installs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_funnel_installs_v1/metadata.yaml
@@ -5,6 +5,7 @@ friendly_name: Desktop Funnel Installs
 labels:
   incremental: true
   shredder_mitigation: true
+  table_type: aggregate
 owners:
   - ascholtz@mozilla.com
 scheduling:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_client_count_dimensions_v1/metadata.yaml
@@ -8,6 +8,8 @@ labels:
   application: desktop
   schedule: daily
   incremental: true
+  shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_main_summary
   task_name: firefox_desktop_exact_mau28_by_client_count_dimensions

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_client_count_dimensions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_client_count_dimensions_v1/schema.yaml
@@ -2,57 +2,76 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
+  description: Submission Date
 - mode: NULLABLE
   name: mau
   type: INTEGER
+  description: Monthly Active Users
 - mode: NULLABLE
   name: wau
   type: INTEGER
+  description: Weekly Active Users
 - mode: NULLABLE
   name: dau
   type: INTEGER
+  description: Daily Active Users
 - mode: NULLABLE
   name: visited_5_uri_mau
   type: INTEGER
+  description: Visited 5 URI MAU
 - mode: NULLABLE
   name: visited_5_uri_wau
   type: INTEGER
+  description: Visited 5 URI WAU
 - mode: NULLABLE
   name: visited_5_uri_dau
   type: INTEGER
+  description: Visited 5 URI DAU
 - mode: NULLABLE
   name: dev_tools_mau
   type: INTEGER
+  description: Dev Tools MAU
 - mode: NULLABLE
   name: dev_tools_wau
   type: INTEGER
+  description: Dev Tools WAU
 - mode: NULLABLE
   name: dev_tools_dau
   type: INTEGER
+  description: Dev Tools DAU
 - mode: NULLABLE
   name: app_name
   type: STRING
+  description: App Name
 - mode: NULLABLE
   name: app_version
   type: STRING
+  description: App Version
 - mode: NULLABLE
   name: country
   type: STRING
+  description: Country
 - mode: NULLABLE
   name: locale
   type: STRING
+  description: Locale
 - mode: NULLABLE
   name: normalized_channel
   type: STRING
+  description: Normalized Channel
 - mode: NULLABLE
   name: os
   type: STRING
+  description: Operating System
 - mode: NULLABLE
   name: os_version
   type: STRING
+  description: Operating System Version
 - mode: NULLABLE
   name: distribution_id
   type: STRING
+  description: Distribution ID
 - mode: NULLABLE
   name: country_name
   type: STRING
+  description: Country Name

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v2/metadata.yaml
@@ -9,6 +9,8 @@ labels:
   application: desktop
   schedule: daily
   incremental: true
+  shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_main_summary
   task_name: firefox_desktop_exact_mau28_by_dimensions_v2

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v2/schema.yaml
@@ -2,45 +2,60 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
+  description: Submission Date
 - mode: NULLABLE
   name: mau
   type: INTEGER
+  description: Monthly Active Users
 - mode: NULLABLE
   name: wau
   type: INTEGER
+  description: Weekly Active Users
 - mode: NULLABLE
   name: dau
   type: INTEGER
+  description: Daily Active Users
 - mode: NULLABLE
   name: new_profiles
   type: INTEGER
+  description: New Profiles
 - mode: NULLABLE
   name: id_bucket
   type: INTEGER
+  description: ID Bucket
 - mode: NULLABLE
   name: activity_segment
   type: STRING
+  description: Activity Segment
 - mode: NULLABLE
   name: os
   type: STRING
+  description: Operating System
 - mode: NULLABLE
   name: channel
   type: STRING
+  description: Channel
 - mode: NULLABLE
   name: source
   type: STRING
+  description: Source
 - mode: NULLABLE
   name: medium
   type: STRING
+  description: Medium
 - mode: NULLABLE
   name: campaign
   type: STRING
+  description: Campaign
 - mode: NULLABLE
   name: content
   type: STRING
+  description: Content
 - mode: NULLABLE
   name: country
   type: STRING
+  description: Country
 - mode: NULLABLE
   name: distribution_id
   type: STRING
+  description: Distribution ID

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_usage_v1/metadata.yaml
@@ -18,6 +18,7 @@ labels:
   application: desktop
   schedule: daily
   incremental: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_main_summary
   # The source table is already small here, so we completely recreate this

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_exact_mau28_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   schedule: daily
   incremental: true
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_nondesktop
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_compressed_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_compressed_v2/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   application: desktop
   incremental: true
   schedule: daily
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_gud
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_v2/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   application: desktop
   incremental: true
   schedule: daily
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_gud
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_v2/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   application: desktop
   incremental: true
   schedule: daily
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_gud
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_new_profiles_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_new_profiles_v2/metadata.yaml
@@ -5,6 +5,7 @@ owners:
 - jklukas@mozilla.com
 labels:
   incremental: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_gud
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_compressed_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_compressed_v2/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   application: nondesktop
   incremental: true
   schedule: daily
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_gud
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_nondesktop_v2/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   application: nondesktop
   incremental: true
   schedule: daily
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_gud
 bigquery:

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
@@ -9,6 +9,7 @@ labels:
   schedule: daily
   incremental: true
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_mobile_kpi_metrics
   depends_on_past: false

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
@@ -14,6 +14,7 @@ labels:
   schedule: daily
   incremental: true
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_mobile_kpi_metrics
   depends_on_past: false


### PR DESCRIPTION
## Description
This PR adds aggregate table labels to the following tables:
- moz-fx-data-shared-prod.fenix_derived.funnel_retention_week_4_v1
- moz-fx-data-shared-prod.search_derived.desktop_search_aggregates_by_userstate_v1
- moz-fx-data-shared-prod.search_derived.desktop_search_aggregates_for_searchreport_v1
- moz-fx-data-shared-prod.search_derived.mobile_search_aggregates_for_searchreport_v1
- moz-fx-data-shared-prod.telemetry_derived.desktop_funnel_installs_v1
- moz-fx-data-shared-prod.telemetry_derived.firefox_nondesktop_exact_mau28_v1
- moz-fx-data-shared-prod.telemetry_derived.desktop_cohort_daily_retention_v1
- moz-fx-data-shared-prod.telemetry_derived.firefox_desktop_usage_v1
- moz-fx-data-shared-prod.telemetry_derived.smoot_usage_desktop_v2
- moz-fx-data-shared-prod.telemetry_derived.smoot_usage_fxa_v2
- moz-fx-data-shared-prod.telemetry_derived.smoot_usage_nondesktop_compressed_v2
- moz-fx-data-shared-prod.telemetry_derived.smoot_usage_nondesktop_v2
- moz-fx-data-shared-prod.telemetry_derived.smoot_usage_new_profiles_v2
- moz-fx-data-shared-prod.firefox_desktop_derived.urlbar_events_daily_v1
- moz-fx-data-shared-prod.firefox_desktop_derived.urlbar_events_daily_engagement_by_position_v1
- moz-fx-data-shared-prod.telemetry_derived.smoot_usage_desktop_compressed_v2

This PR adds shredder mitigation & aggregate table label to the following tables:
- moz-fx-data-shared-prod.telemetry_derived.cohort_daily_statistics_v1
- moz-fx-data-shared-prod.telemetry_derived.firefox_desktop_exact_mau28_by_client_count_dimensions_v1

And to the SQL generator for the aggregate mobile engagement & retention tables


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7007)
