### PR TITLE
chore(glam): Load aggregates to GCP V2

### DIFF
--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_beta_aggregates_v1/script.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_beta_aggregates_v1/script.sql
@@ -2,7 +2,7 @@
             -- For more information on writing queries see:
             -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
 MERGE INTO
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_beta_aggregates_v1` T
+  `moz-fx-glam-prod.glam_etl.glam_desktop_beta_aggregates_v1` T
   USING (SELECT * FROM `moz-fx-data-shared-prod.telemetry_derived.glam_extract_firefox_beta_v1`) S
   ON T.version = S.app_version
   AND T.os = S.os

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_nightly_aggregates_v1/script.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_nightly_aggregates_v1/script.sql
@@ -2,7 +2,7 @@
             -- For more information on writing queries see:
             -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
 MERGE INTO
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_nightly_aggregates_v1` T
+  `moz-fx-glam-prod.glam_etl.glam_desktop_nightly_aggregates_v1` T
   USING (
     SELECT
       *

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_release_aggregates_v1/script.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_desktop_release_aggregates_v1/script.sql
@@ -2,7 +2,7 @@
             -- For more information on writing queries see:
             -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
 MERGE INTO
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_desktop_release_aggregates_v1` T
+  `moz-fx-glam-prod.glam_etl.glam_desktop_release_aggregates_v1` T
   USING (
     SELECT
       *

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates_v1/script.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates_v1/script.sql
@@ -2,7 +2,7 @@
             -- For more information on writing queries see:
             -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
 MERGE INTO
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_beta_aggregates_v1` T
+  `moz-fx-glam-prod.glam_etl.glam_fenix_beta_aggregates_v1` T
   USING (
     SELECT
       *

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates_v1/script.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates_v1/script.sql
@@ -2,7 +2,7 @@
             -- For more information on writing queries see:
             -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
 MERGE INTO
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_nightly_aggregates_v1` T
+  `moz-fx-glam-prod.glam_etl.glam_fenix_nightly_aggregates_v1` T
   USING (
     SELECT
       *

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates_v1/script.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates_v1/script.sql
@@ -2,7 +2,7 @@
             -- For more information on writing queries see:
             -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
 MERGE INTO
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fenix_release_aggregates_v1` T
+  `moz-fx-glam-prod.glam_etl.glam_fenix_release_aggregates_v1` T
   USING (
     SELECT
       *

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates_v1/script.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates_v1/script.sql
@@ -2,7 +2,7 @@
             -- For more information on writing queries see:
             -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
 MERGE INTO
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_beta_aggregates_v1` T
+  `moz-fx-glam-prod.glam_etl.glam_fog_beta_aggregates_v1` T
   USING (
     SELECT
       *

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates_v1/script.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates_v1/script.sql
@@ -2,7 +2,7 @@
             -- For more information on writing queries see:
             -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
 MERGE INTO
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_nightly_aggregates_v1` T
+  `moz-fx-glam-prod.glam_etl.glam_fog_nightly_aggregates_v1` T
   USING (
     SELECT
       *

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates_v1/script.sql
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_release_aggregates_v1/script.sql
@@ -2,7 +2,7 @@
             -- For more information on writing queries see:
             -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
 MERGE INTO
-  `moz-fx-data-glam-prod-fca7.glam_etl.glam_fog_release_aggregates_v1` T
+  `moz-fx-glam-prod.glam_etl.glam_fog_release_aggregates_v1` T
   USING (
     SELECT
       *


### PR DESCRIPTION
## Description

This is the first step to migrate GLAM ETL to GCP V2.

This PR loads GLAM ETL data to GCP V2, so GLAM (the app) can fetch up-to-date data, since it's already on GCP V2.
I'll file another PR tomorrow with more changes that will make GLAM ETL execute entirely on GCP V2.

## Related Tickets & Documents
* DSRE-1783

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


