### PR TITLE
Revert "feat: add row_creation_times to sql/bigconfig.yml (#6630)"

### DIFF
--- a/sql/bigconfig.yml
+++ b/sql/bigconfig.yml
@@ -1,14 +1,5 @@
 type: BIGCONFIG_FILE
 
-tag_definitions:
-  - tag_id: PARTITION_DATE_FIELDS
-    column_selectors:
-      - name: moz-fx-data-shared-prod.*.*.submission_date
-
-row_creation_times:
-  tag_ids:
-    - PARTITION_DATE_FIELDS
-
 saved_metric_definitions:
   metrics:
     - saved_metric_id: is_not_null
@@ -26,7 +17,7 @@ saved_metric_definitions:
           interval_type: DAYS
           interval_value: 0
       rct_overrides:
-        - PARTITION_DATE_FIELDS
+        - submission_date
     - saved_metric_id: is_unique
       metric_type:
         predefined_metric: COUNT_DUPLICATES
@@ -37,7 +28,7 @@ saved_metric_definitions:
         named_schedule:
           name: default
       rct_overrides:
-        - PARTITION_DATE_FIELDS
+        - submission_date
     - saved_metric_id: freshness_fail
       metric_name: FRESHNESS [fail]
       metric_type:
@@ -89,7 +80,7 @@ saved_metric_definitions:
           interval_type: DAYS
           interval_value: 0
       rct_overrides:
-        - PARTITION_DATE_FIELDS
+        - submission_date
     - saved_metric_id: is_2_char_len
       metric_type:
         predefined_metric: STRING_LENGTH_MIN
@@ -106,7 +97,7 @@ saved_metric_definitions:
           interval_type: DAYS
           interval_value: 0
       rct_overrides:
-        - PARTITION_DATE_FIELDS
+        - submission_date
     - saved_metric_id: is_valid_client_id
       metric_type:
         predefined_metric: PERCENT_UUID
@@ -123,4 +114,4 @@ saved_metric_definitions:
           interval_type: DAYS
           interval_value: 0
       rct_overrides:
-        - PARTITION_DATE_FIELDS
+        - submission_date

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.bigconfig.yml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.bigconfig.yml
@@ -38,7 +38,7 @@ tag_deployments:
       #           interval_type: DAYS
       #           interval_value: 0
       #       rct_overrides:
-      #         - PARTITION_DATE_FIELDS
+      #         - submission_date
       - column_selectors:
         - name: {{ project_id }}.{{ project_id }}.{{ derived_dataset }}.{{ target_table }}.*
         metrics:


### PR DESCRIPTION
This reverts commit 3e5f14493965eda1aea5d4b8da1e363448f2cc45.

## Description

This config change seems to cause the Bigeye monitor deploy to hang

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7013)
