### PR TITLE
Un-schedule Bigeye metrics that get triggered via Airflow

### DIFF
--- a/sql/bigconfig.yml
+++ b/sql/bigconfig.yml
@@ -17,9 +17,9 @@ saved_metric_definitions:
       threshold:
         type: CONSTANT
         upper_bound: 0
-      metric_schedule:
-        named_schedule:
-          name: default
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
       lookback:
         lookback_type: DATA_TIME
         lookback_window:
@@ -33,9 +33,9 @@ saved_metric_definitions:
       threshold:
         type: CONSTANT
         upper_bound: 0
-      metric_schedule:
-        named_schedule:
-          name: default
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
       rct_overrides:
         - PARTITION_DATE_FIELDS
     - saved_metric_id: freshness_fail
@@ -80,9 +80,9 @@ saved_metric_definitions:
         type: CONSTANT
         lower_bound: 1
         upper_bound: 1
-      metric_schedule:
-        named_schedule:
-          name: default
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
       lookback:
         lookback_type: DATA_TIME
         lookback_window:
@@ -97,9 +97,9 @@ saved_metric_definitions:
         type: CONSTANT
         lower_bound: 2
         upper_bound: 2
-      metric_schedule:
-        named_schedule:
-          name: default
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
       lookback:
         lookback_type: DATA_TIME
         lookback_window:
@@ -114,9 +114,9 @@ saved_metric_definitions:
         type: CONSTANT
         lower_bound: 1
         upper_bound: 1
-      metric_schedule:
-        named_schedule:
-          name: default
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
       lookback:
         lookback_type: DATA_TIME
         lookback_window:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/bigconfig.yml
@@ -10,12 +10,18 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
     metrics:
@@ -25,12 +31,18 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
     metrics:
@@ -40,6 +52,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
     metrics:
@@ -50,6 +65,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
     metrics:
@@ -60,6 +78,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
     metrics:
@@ -70,6 +91,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
 - deployments:
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
@@ -96,12 +120,18 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
     metrics:
@@ -111,12 +141,18 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
     metrics:
@@ -126,6 +162,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
     metrics:
@@ -136,6 +175,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
     metrics:
@@ -146,6 +188,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
     metrics:
@@ -156,6 +201,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
 - deployments:
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.submission_date
@@ -166,12 +214,18 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
     metrics:
@@ -181,12 +235,18 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
     metrics:
@@ -196,6 +256,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
     metrics:
@@ -206,6 +269,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
     metrics:
@@ -216,6 +282,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
     metrics:
@@ -226,6 +295,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
 - deployments:
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.submission_date
@@ -236,12 +308,18 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
     metrics:
@@ -251,12 +329,18 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
     metrics:
@@ -266,6 +350,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
     metrics:
@@ -276,6 +363,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
     metrics:
@@ -286,6 +376,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
     metrics:
@@ -296,6 +389,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
 - deployments:
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.submission_date
@@ -306,12 +402,18 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
     metrics:
@@ -321,12 +423,18 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
     metrics:
@@ -336,6 +444,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
     metrics:
@@ -346,6 +457,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
     metrics:
@@ -356,6 +470,9 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
     metrics:
@@ -366,3 +483,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0


### PR DESCRIPTION
## Description

This sets the schedule for metrics to "No" that will be triggered via Airflow. This way we don't run checks twice. 

Volume and freshness checks are still run independently.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7014)
