### PR TITLE
Add retention mitigation to aggregate tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/funnel_retention_week_4_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   schedule: daily
   incremental: true
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_firefox_ios
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_new_profiles_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_new_profiles_aggregates_v1/metadata.yaml
@@ -12,6 +12,7 @@ labels:
   schedule: daily
   depends_on_past: false
   owner1: mhirose
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_analytics_tables
   task_name: desktop_new_profiles_aggregates

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_retention_aggregates_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_retention_aggregates_v2/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   incremental: true
   owner1: mhirose
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_desktop_retention_model
   date_partition_parameter: metric_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_compressed_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_fxa_compressed_v2/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   incremental: true
   schedule: daily
   shredder_mitigation: true
+  table_type: aggregate
   dag: bqetl_gud
   owner1: jklukas
 scheduling:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_new_profiles_compressed_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_new_profiles_compressed_v2/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_gud
 bigquery:

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.metadata.yaml
@@ -8,6 +8,8 @@ owners:
 labels:
   schedule: daily
   incremental: true
+  shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_mobile_kpi_metrics
   depends_on_past: false


### PR DESCRIPTION
## Description

This PR adds table_type: aggregate labels to the following tables: 

- moz-fx-data-shared-prod.firefox_ios_derived.funnel_retention_week_4_v1
- moz-fx-data-shared-prod.telemetry_derived.desktop_new_profiles_aggregates_v1
- moz-fx-data-shared-prod.telemetry_derived.desktop_retention_aggregates_v2
- moz-fx-data-shared-prod.telemetry_derived.smoot_usage_fxa_compressed_v2
- moz-fx-data-shared-prod.telemetry_derived.smoot_usage_new_profiles_compressed_v2

It also adds the aggregate label & shredder mitigation to the SQL generator for mobile new_profiles_v1:
- sql_generators/mobile_kpi_support_metrics/templates/new_profiles.metadata.yaml

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7018)
