### PR TITLE
Create aggregate tables for Firefox Health Indicator dashboard

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1959,3 +1959,22 @@ bqetl_newtab_engagement_hourly:
     retry_delay: 5m
   tags:
     - impact/tier_2
+
+bqetl_fx_health_ind_dashboard:
+  description: |
+    This DAG builds aggregate tables used in the Firefox Health dashboard
+  default_args:
+    depends_on_past: false
+    owner: kwindau@mozilla.com
+    email:
+    - telemetry-alerts@mozilla.com
+    - kwindau@mozilla.com
+    email_on_failure: true
+    email_on_retry: false
+    start_date: "2024-12-15"
+    retries: 2
+    retry_delay: 5m
+  tags:
+    - impact/tier_2
+  repo: bigquery-etl
+  schedule_interval: 0 16 * * *

--- a/dags.yaml
+++ b/dags.yaml
@@ -1971,7 +1971,7 @@ bqetl_fx_health_ind_dashboard:
       - kwindau@mozilla.com
     email_on_failure: true
     email_on_retry: false
-    start_date: "2024-12-15"
+    start_date: "2024-12-13"
     retries: 2
     retry_delay: 5m
   tags:

--- a/dags.yaml
+++ b/dags.yaml
@@ -1967,8 +1967,8 @@ bqetl_fx_health_ind_dashboard:
     depends_on_past: false
     owner: kwindau@mozilla.com
     email:
-    - telemetry-alerts@mozilla.com
-    - kwindau@mozilla.com
+      - telemetry-alerts@mozilla.com
+      - kwindau@mozilla.com
     email_on_failure: true
     email_on_retry: false
     start_date: "2024-12-15"

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_desktop_dau_by_device_type/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_desktop_dau_by_device_type/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_desktop_dau_by_device_type`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_desktop_dau_by_device_type_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_fqueze_cpu_info/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_fqueze_cpu_info/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_fqueze_cpu_info`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_fqueze_cpu_info_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_mau_per_os/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_mau_per_os/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_mau_per_os`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_mau_per_os_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_win_instll_by_instll_typ/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_win_instll_by_instll_typ/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_win_instll_by_instll_typ`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_win_instll_by_instll_typ_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_win_uninstll/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_win_uninstll/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_win_uninstll`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_win_uninstll_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_desktop_dau_by_device_type_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_desktop_dau_by_device_type_v1/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Fx Health Ind Desktop Dau By Device Type
+description: |-
+  Aggregate table that calculates desktop DAU by device type
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields: []
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_desktop_dau_by_device_type_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_desktop_dau_by_device_type_v1/metadata.yaml
@@ -9,7 +9,7 @@ labels:
   table_type: aggregate
   shredder_mitigation: true
 scheduling:
-  dag_name: fx_health_ind_dashboard
+  dag_name: bqetl_fx_health_ind_dashboard
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_desktop_dau_by_device_type_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_desktop_dau_by_device_type_v1/metadata.yaml
@@ -18,5 +18,6 @@ bigquery:
     expiration_days: null
   range_partitioning: null
   clustering:
-    fields: []
+    fields:
+    - TDP
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_desktop_dau_by_device_type_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_desktop_dau_by_device_type_v1/query.sql
@@ -1,0 +1,15 @@
+SELECT
+  DATE(t.submission_timestamp) AS submission_date,
+  cpu.cpu_type AS TDP,
+  100 * COUNT(DISTINCT(client_id)) AS users
+FROM
+  `moz-fx-data-shared-prod.telemetry.main_1pct` AS t
+JOIN
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_fqueze_cpu_info_v1` AS cpu
+  ON cpu.cpu_name = environment.system.cpu.name
+  AND environment.system.cpu.name IS NOT NULL
+WHERE
+  DATE(t.submission_timestamp) = @submission_date
+GROUP BY
+  DATE(t.submission_timestamp),
+  cpu.cpu_type

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_desktop_dau_by_device_type_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_desktop_dau_by_device_type_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: TDP
+  type: STRING
+  description: TDP
+- mode: NULLABLE
+  name: users
+  type: INTEGER
+  description: Number of Users

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_fqueze_cpu_info_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_fqueze_cpu_info_v1/metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: Fx Health Ind Fqueze Cpu Info
+description: |-
+  Static table of CPU Information used in Firefox Health Indicators dashboard
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+bigquery:
+  range_partitioning: null
+  clustering:
+    fields:
+    - cpu_name
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_fqueze_cpu_info_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_fqueze_cpu_info_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: REQUIRED
+  name: cpu_name
+  type: STRING
+  description: CPU Name
+- mode: REQUIRED
+  name: cpu_tdp
+  type: FLOAT
+  description: CPU TDP
+- mode: REQUIRED
+  name: cpu_cores
+  type: INTEGER
+  description: CPU Cores
+- mode: NULLABLE
+  name: cpu_type
+  type: STRING
+  description: CPU Type

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_os_v1/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Fx Health Indicator Mau by OS
+description: |-
+  Aggregate table calculating MAU and DAU per OS
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - os
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_os_v1/metadata.yaml
@@ -13,7 +13,7 @@ bigquery:
   time_partitioning:
     type: day
     field: submission_date
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: null
   range_partitioning: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_os_v1/query.sql
@@ -1,0 +1,54 @@
+WITH sample_cte AS (
+  SELECT
+    submission_date,
+    os,
+    SUM(dau) AS tot_dau,
+    SUM(mau) AS tot_mau
+  FROM
+    `moz-fx-data-shared-prod.telemetry.active_users_aggregates` --telemetry.firefox_desktop_exact_mau28_by_client_count_dimensions
+  WHERE
+    app_name = 'Firefox Desktop'
+    AND submission_date
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 6 DAY)
+    AND @submission_date
+  GROUP BY
+    submission_date,
+    os
+  HAVING
+    SUM(mau) > 1000
+),
+smoothed AS (
+  SELECT
+    *,
+    AVG(tot_dau) OVER (
+      PARTITION BY
+        os
+      ORDER BY
+        submission_date
+      ROWS BETWEEN
+        6 PRECEDING
+        AND 0 FOLLOWING
+    ) AS smoothed_dau,
+    COUNT(1) OVER (
+      PARTITION BY
+        os
+      ORDER BY
+        submission_date
+      ROWS BETWEEN
+        6 PRECEDING
+        AND 0 FOLLOWING
+    ) AS nbr_Days_included
+  FROM
+    sample_cte
+)
+SELECT
+  submission_date,
+  os,
+  tot_dau AS dau,
+  tot_mau AS mau,
+  smoothed_dau,
+  smoothed_dau / tot_mau AS ER
+FROM
+  smoothed
+WHERE
+  nbr_days_included = 7 --only include those operating systems that have at least 1000 MAU on all 7 days

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_os_v1/schema.yaml
@@ -1,0 +1,25 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: os
+  type: STRING
+  description: Operating System
+- mode: NULLABLE
+  name: dau
+  type: INTEGER
+  description: DAU
+- mode: NULLABLE
+  name: mau
+  type: INTEGER
+  description: MAU
+- mode: NULLABLE
+  name: smoothed_dau
+  type: FLOAT
+  description: Smoothed DAU
+- mode: NULLABLE
+  name: ER
+  type: FLOAT
+  description: ER - Smoothed DAU Divided by MAU

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Firefox Health Indicator Windows Installs
+description: |-
+  Aggregate table of windows installs by installer type, used in Firefox Health dashboard
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - installer_type
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/metadata.yaml
@@ -6,6 +6,8 @@ owners:
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/query.sql
@@ -9,4 +9,4 @@ WHERE
   AND update_channel = 'release'
 GROUP BY
   CAST(submission_timestamp AS DATE),
-  installer_type,
+  installer_type

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  CAST(submission_timestamp AS DATE) AS submission_date,
+  installer_type,
+  COUNT(1) AS install_count,
+FROM
+  `moz-fx-data-shared-prod.firefox_installer.install`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND update_channel = 'release'
+GROUP BY
+  CAST(submission_timestamp AS DATE),
+  installer_type,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: REQUIRED
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: REQUIRED
+  name: installer_type
+  type: STRING
+  description: Installer Type
+- mode: REQUIRED
+  name: install_count
+  type: INTEGER
+  description: Install Count

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_instll_by_instll_typ_v1/schema.yaml
@@ -1,13 +1,13 @@
 fields:
-- mode: REQUIRED
+- mode: NULLABLE
   name: submission_date
   type: DATE
   description: Submission Date
-- mode: REQUIRED
+- mode: NULLABLE
   name: installer_type
   type: STRING
   description: Installer Type
-- mode: REQUIRED
+- mode: NULLABLE
   name: install_count
   type: INTEGER
   description: Install Count

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/metadata.yaml
@@ -1,20 +1,18 @@
 friendly_name: Fx Health Ind Win Uninstll
 description: |-
-  Please provide a description for the query
+  Aggregate view of Windows uninstalls by day
 owners:
-- example@mozilla.com
+- kwindau@mozilla.com
 labels:
   incremental: true
-  owner1: example
+  owner1: kwindau@mozilla.com
 scheduling:
-  dag_name: bqetl_default
+  dag_name: bqetl_fx_health_ind_dashboard
 bigquery:
   time_partitioning:
     type: day
-    field: ''
-    require_partition_filter: true
+    field: submission_date
+    require_partition_filter: false
     expiration_days: null
   range_partitioning: null
-  clustering:
-    fields: []
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Fx Health Ind Win Uninstll
+description: |-
+  Please provide a description for the query
+owners:
+- example@mozilla.com
+labels:
+  incremental: true
+  owner1: example
+scheduling:
+  dag_name: bqetl_default
+bigquery:
+  time_partitioning:
+    type: day
+    field: ''
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields: []
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/query.sql
@@ -1,0 +1,11 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  COUNT(DISTINCT(client_id)) AS uninstall_client_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+  AND application.channel = 'release'
+GROUP BY
+  DATE(submission_timestamp)

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/schema.yaml
@@ -1,0 +1,9 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: uninstall_client_count
+  type: INTEGER
+  description: Count of Clients with Uninstalls


### PR DESCRIPTION
## Description

This PR creates the following new tables:
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_desktop_dau_by_device_type_v1
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_win_instll_by_instll_typ_v1
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_win_uninstll_v1
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_fqueze_cpu_info_v1 (static table, they used to keep in analysis, copied here to be safer)
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_mau_per_os_v1

It also creates the new DAG: 
- bqetl_fx_health_ind_dashboard - starting 2024-12-15, with a schedule of  `0 16 * * *`

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ