### PR TITLE
Create aggregate tables for Firefox Health Indicator dashboard

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_mau_per_tier1_country/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_mau_per_tier1_country/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_mau_per_tier1_country`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_mau_per_tier1_country_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_windows_versions_mau_per_os/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_windows_versions_mau_per_os/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_windows_versions_mau_per_os`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_windows_versions_mau_per_os_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_os_v1/query.sql
@@ -5,7 +5,7 @@ WITH sample_cte AS (
     SUM(dau) AS tot_dau,
     SUM(mau) AS tot_mau
   FROM
-    `moz-fx-data-shared-prod.telemetry.active_users_aggregates` --telemetry.firefox_desktop_exact_mau28_by_client_count_dimensions
+    `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
   WHERE
     app_name = 'Firefox Desktop'
     AND submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_tier1_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_tier1_country_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_tier1_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_tier1_country_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Firefox Health Indicators MAU Per Tier1 Country
+description: |-
+  Aggregate of MAU per tier 1 country used in dashboard
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - country
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_tier1_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_tier1_country_v1/query.sql
@@ -1,0 +1,55 @@
+WITH sample_cte AS (
+  SELECT
+    submission_date,
+    country,
+    SUM(dau) AS tot_dau,
+    SUM(mau) AS tot_mau,
+  FROM
+    `mozdata.telemetry.active_users_aggregates`
+  WHERE
+    app_name = 'Firefox Desktop'
+    AND submission_date
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 6 DAY)
+    AND @submission_date
+    AND country IN ('US', 'DE', 'FR', 'CA', 'GB', 'CN', 'ID', 'IN', 'RU', 'PL', 'BR', 'ES')
+  GROUP BY
+    submission_date,
+    country
+  HAVING
+    SUM(mau) > 1000
+),
+smoothed AS (
+  SELECT
+    *,
+    AVG(tot_dau) OVER (
+      PARTITION BY
+        country
+      ORDER BY
+        submission_date
+      ROWS BETWEEN
+        6 PRECEDING
+        AND 0 FOLLOWING
+    ) AS smoothed_dau,
+    COUNT(1) OVER (
+      PARTITION BY
+        country
+      ORDER BY
+        submission_date
+      ROWS BETWEEN
+        6 PRECEDING
+        AND 0 FOLLOWING
+    ) AS nbr_days_included
+  FROM
+    sample_cte
+)
+SELECT
+  submission_date,
+  country,
+  tot_mau AS mau,
+  tot_dau AS dau,
+  smoothed_dau,
+  smoothed_dau / tot_mau AS ER
+FROM
+  smoothed
+WHERE
+  nbr_days_included = 7 --only include those with at least 1000 MAU on all 7 days

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_tier1_country_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_mau_per_tier1_country_v1/schema.yaml
@@ -1,0 +1,25 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: Country
+- mode: NULLABLE
+  name: mau
+  type: INTEGER
+  description: MAU
+- mode: NULLABLE
+  name: dau
+  type: INTEGER
+  description: DAU
+- mode: NULLABLE
+  name: smoothed_dau
+  type: FLOAT
+  description: Smoothed DAU
+- mode: NULLABLE
+  name: ER
+  type: FLOAT
+  description: ER - Smoothed DAU Divided by MAU

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/metadata.yaml
@@ -18,5 +18,5 @@ bigquery:
   range_partitioning: null
   clustering:
     fields:
-    - os_version
+    - windows_os_version
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Fx Health Ind Windows Versions Mau Per Os
+description: |-
+  Please provide a description for the query
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - os_version
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Fx Health Ind Windows Versions Mau Per Os
 description: |-
-  Please provide a description for the query
+  Aggregate table that calculates MAU, DAU and ER for different Windows versions
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/query.sql
@@ -28,7 +28,7 @@ WITH sample_cte AS (
 smoothed AS (
   SELECT
     *,
-    AVG(dau) OVER (
+    AVG(tot_dau) OVER (
       PARTITION BY
         os_version
       ORDER BY
@@ -54,8 +54,8 @@ smoothed AS (
 SELECT
   submission_date,
   os_version AS windows_os_version,
-  mau,
-  dau,
+  tot_mau AS mau,
+  tot_dau AS dau,
   smoothed_dau,
   smoothed_dau / mau AS ER
 FROM

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/query.sql
@@ -39,7 +39,7 @@ smoothed AS (
     ) AS smoothed_dau,
     COUNT(1) OVER (
       PARTITION BY
-        os
+        os_version
       ORDER BY
         submission_date
       ROWS BETWEEN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/query.sql
@@ -57,7 +57,7 @@ SELECT
   tot_mau AS mau,
   tot_dau AS dau,
   smoothed_dau,
-  smoothed_dau / mau AS ER
+  smoothed_dau / tot_mau AS ER
 FROM
   smoothed
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/query.sql
@@ -1,0 +1,64 @@
+WITH sample_cte AS (
+  SELECT
+    submission_date,
+    CASE
+      WHEN os_version IN ('Windows 10', 'Windows 11', "10.0")
+        THEN 'Win10 or Win11'
+      WHEN LOWER(os_version) LIKE "windows%"
+        THEN os_version
+      ELSE COALESCE(`mozfun.norm.windows_version_info`(os, os_version, NULL), "Unknown")
+    END AS os_version,
+    SUM(dau) AS tot_dau,
+    SUM(mau) AS tot_mau
+  FROM
+    `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
+  WHERE
+    app_name = 'Firefox Desktop'
+    AND submission_date
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 6 DAY)
+    AND @submission_date
+    AND LOWER(os) LIKE '%windows%'
+    AND os_version_major + (os_version_minor / 100) > 6  --filter Windows 7+
+  GROUP BY
+    submission_date,
+    os_version
+  HAVING
+    SUM(mau) > 1000
+),
+smoothed AS (
+  SELECT
+    *,
+    AVG(dau) OVER (
+      PARTITION BY
+        os_version
+      ORDER BY
+        submission_date
+      ROWS BETWEEN
+        6 PRECEDING
+        AND 0 FOLLOWING
+    ) AS smoothed_dau,
+    COUNT(1) OVER (
+      PARTITION BY
+        os
+      ORDER BY
+        submission_date
+      ROWS BETWEEN
+        6 PRECEDING
+        AND 0 FOLLOWING
+    ) AS nbr_days_included
+  FROM
+    sample_cte
+  WHERE
+    os_version <> "Unknown"
+)
+SELECT
+  submission_date,
+  os_version AS windows_os_version,
+  mau,
+  dau,
+  smoothed_dau,
+  smoothed_dau / mau AS ER
+FROM
+  smoothed
+WHERE
+  nbr_days_included = 7 --only include those versions that have at least 1000 MAU on all 7 days

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_windows_versions_mau_per_os_v1/schema.yaml
@@ -1,0 +1,25 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: windows_os_version
+  type: STRING
+  description: Windows Operating System Version
+- mode: NULLABLE
+  name: mau
+  type: INTEGER
+  description: MAU
+- mode: NULLABLE
+  name: dau
+  type: INTEGER
+  description: DAU
+- mode: NULLABLE
+  name: smoothed_dau
+  type: FLOAT
+  description: Smoothed DAU
+- mode: NULLABLE
+  name: ER
+  type: FLOAT
+  description: ER - Smoothed DAU Divided by MAU


### PR DESCRIPTION
## Description

This PR creates the 2 new tables: 
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_windows_versions_mau_per_os_v1
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_mau_per_tier1_country_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7028)


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ