### PR TITLE
Revert "Un-schedule Bigeye metrics that get triggered via Airflow"

### DIFF
--- a/sql/bigconfig.yml
+++ b/sql/bigconfig.yml
@@ -8,9 +8,9 @@ saved_metric_definitions:
       threshold:
         type: CONSTANT
         upper_bound: 0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
+      metric_schedule:
+        named_schedule:
+          name: default
       lookback:
         lookback_type: DATA_TIME
         lookback_window:
@@ -24,9 +24,9 @@ saved_metric_definitions:
       threshold:
         type: CONSTANT
         upper_bound: 0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
+      metric_schedule:
+        named_schedule:
+          name: default
       rct_overrides:
         - submission_date
     - saved_metric_id: freshness_fail
@@ -71,9 +71,9 @@ saved_metric_definitions:
         type: CONSTANT
         lower_bound: 1
         upper_bound: 1
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
+      metric_schedule:
+        named_schedule:
+          name: default
       lookback:
         lookback_type: DATA_TIME
         lookback_window:
@@ -88,9 +88,9 @@ saved_metric_definitions:
         type: CONSTANT
         lower_bound: 2
         upper_bound: 2
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
+      metric_schedule:
+        named_schedule:
+          name: default
       lookback:
         lookback_type: DATA_TIME
         lookback_window:
@@ -105,9 +105,9 @@ saved_metric_definitions:
         type: CONSTANT
         lower_bound: 1
         upper_bound: 1
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
+      metric_schedule:
+        named_schedule:
+          name: default
       lookback:
         lookback_type: DATA_TIME
         lookback_window:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/bigconfig.yml
@@ -10,18 +10,12 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
     metrics:
@@ -31,18 +25,12 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
     metrics:
@@ -52,9 +40,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
     metrics:
@@ -65,9 +50,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
     metrics:
@@ -78,9 +60,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
     metrics:
@@ -91,9 +70,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
 - deployments:
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
@@ -120,18 +96,12 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
     metrics:
@@ -141,18 +111,12 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
     metrics:
@@ -162,9 +126,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
     metrics:
@@ -175,9 +136,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
     metrics:
@@ -188,9 +146,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
     metrics:
@@ -201,9 +156,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
 - deployments:
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.submission_date
@@ -214,18 +166,12 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
     metrics:
@@ -235,18 +181,12 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
     metrics:
@@ -256,9 +196,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
     metrics:
@@ -269,9 +206,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
     metrics:
@@ -282,9 +216,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
     metrics:
@@ -295,9 +226,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
 - deployments:
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.submission_date
@@ -308,18 +236,12 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
     metrics:
@@ -329,18 +251,12 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
     metrics:
@@ -350,9 +266,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
     metrics:
@@ -363,9 +276,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
     metrics:
@@ -376,9 +286,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
     metrics:
@@ -389,9 +296,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
 - deployments:
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.submission_date
@@ -402,18 +306,12 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.os
     metrics:
@@ -423,18 +321,12 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
     - metric_type:
         type: PREDEFINED
         predefined_metric: COUNT_DUPLICATES
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.*
     metrics:
@@ -444,9 +336,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 1.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.non_ssl_loads
     metrics:
@@ -457,9 +346,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.ssl_loads
     metrics:
@@ -470,9 +356,6 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.telemetry_derived.ssl_ratios_v1.reporting_ratio
     metrics:
@@ -483,6 +366,3 @@ tag_deployments:
       threshold:
         type: CONSTANT
         lower_bound: 0.0
-      schedule_frequency:
-        interval_type: MINUTES
-        interval_value: 0


### PR DESCRIPTION
This seems to break Bigconfig deploys. The config is valid but the deploy doesn't support 
```
      schedule_frequency:
        interval_type: MINUTES
        interval_value: 0
```
I will open an issue with Bigeye

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7030)
