### PR TITLE
Create clients daily aggregate for Firefox Health Indicators dashboard

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_clients_daily_by_os/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_clients_daily_by_os/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_clients_daily_by_os`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_clients_daily_by_os_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/metadata.yaml
@@ -17,5 +17,6 @@ bigquery:
     expiration_days: null
   range_partitioning: null
   clustering:
-    fields: []
+    fields:
+    - os
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Firefox Health Indicator Clients Daily OS Aggregates
 description: |-
-  Calculates active hrs, subsession hrs, and searches per user by on 1% client sample
+  Calculates active hrs, subsession hrs, and searches per user on a 1% client sample
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Firefox Health Indicator Clients Daily OS Aggregates
+description: |-
+  Calculates active hours, subsession hours, and search per user at OS level
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields: []
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Firefox Health Indicator Clients Daily OS Aggregates
 description: |-
-  Calculates active hours, subsession hours, and search per user at OS level
+  Calculates active hrs, subsession hrs, and searches per user by on 1% client sample
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/query.sql
@@ -1,0 +1,9 @@
+-- Query for telemetry_derived.fx_health_ind_clients_daily_by_os_v1
+            -- For more information on writing queries see:
+            -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
+SELECT
+  *
+FROM
+  table
+WHERE
+  submission_date = @submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/query.sql
@@ -1,82 +1,80 @@
-WITH searches_per_user_by_os_and_date_staging
-AS
-  (
-    SELECT
-      submission_date_s3,
-      os,
-      SUM(search_count_all) AS searches,
-      COUNT(DISTINCT client_id) AS users,
-    FROM
-      `moz-fx-data-shared-prod.telemetry.clients_daily`
-    WHERE
-      submission_date_s3 = @submission_date
-      AND app_name = 'Firefox'
-      AND sample_id = 42
-      AND search_count_all < 10000
-      AND os IN ('Windows_NT', 'Darwin', 'Linux')
-    GROUP BY
-      submission_date_s3,
-      os
-  ),
-  searches_per_user_by_os_and_date AS (
-    SELECT
-      submission_date_s3,
-      os,
-      searches / users AS searches_per_user_ratio,
-    FROM
-      searches_per_user_by_os_and_date_staging
-  ),
-  subsession_hours_per_user_staging AS (
-    SELECT
-      submission_date_s3,
-      os,
-      SUM(subsession_hours_sum) AS `hours`,
-      count(DISTINCT client_id) AS users,
-    FROM
-      `moz-fx-data-shared-prod.telemetry.clients_daily`
-    WHERE
-      submission_date_s3 = @submission_date
-      AND app_name = 'Firefox'
-      AND sample_id = 42
-      AND subsession_hours_sum < 24
-      AND os IN ('Windows_NT', 'Darwin', 'Linux')
-    GROUP BY
-      submission_date_s3,
-      os
-  ),
-  subsession_hours_per_user AS (
-    SELECT
-      submission_date_s3,
-      os,
-      `hours` / users AS subsession_hours_per_user_ratio
-    FROM
-      subsession_hours_per_user_staging
-  ),
-  active_hours_per_user_staging AS (
-    SELECT
-      submission_date_s3,
-      os,
-      SUM(ROUND(active_hours_sum)) AS `hours`,
-      COUNT(DISTINCT(client_id)) AS users,
-    FROM
-      `moz-fx-data-shared-prod.telemetry.clients_daily`
-    WHERE
-      submission_date_s3 = @submission_date
-      AND app_name = 'Firefox'
-      AND sample_id = 42
-      AND os IN ('Windows_NT', 'Darwin', 'Linux')
-    GROUP BY
-      submission_date_s3,
-      os
-  ),
-  active_hours_per_user AS (
-    SELECT
-      submission_date_s3,
-      os,
-      `hours` / users AS active_hours_per_user_ratio
-    FROM
-      active_hours_per_user_staging
-  )
+WITH searches_per_user_by_os_and_date_staging AS (
+  SELECT
+    submission_date_s3,
+    os,
+    SUM(search_count_all) AS searches,
+    COUNT(DISTINCT client_id) AS users,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date_s3 = @submission_date
+    AND app_name = 'Firefox'
+    AND sample_id = 42
+    AND search_count_all < 10000
+    AND os IN ('Windows_NT', 'Darwin', 'Linux')
+  GROUP BY
+    submission_date_s3,
+    os
+),
+searches_per_user_by_os_and_date AS (
+  SELECT
+    submission_date_s3,
+    os,
+    searches / users AS searches_per_user_ratio,
+  FROM
+    searches_per_user_by_os_and_date_staging
+),
+subsession_hours_per_user_staging AS (
+  SELECT
+    submission_date_s3,
+    os,
+    SUM(subsession_hours_sum) AS `hours`,
+    COUNT(DISTINCT client_id) AS users,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date_s3 = @submission_date
+    AND app_name = 'Firefox'
+    AND sample_id = 42
+    AND subsession_hours_sum < 24
+    AND os IN ('Windows_NT', 'Darwin', 'Linux')
+  GROUP BY
+    submission_date_s3,
+    os
+),
+subsession_hours_per_user AS (
+  SELECT
+    submission_date_s3,
+    os,
+    `hours` / users AS subsession_hours_per_user_ratio
+  FROM
+    subsession_hours_per_user_staging
+),
+active_hours_per_user_staging AS (
+  SELECT
+    submission_date_s3,
+    os,
+    SUM(ROUND(active_hours_sum)) AS `hours`,
+    COUNT(DISTINCT(client_id)) AS users,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date_s3 = @submission_date
+    AND app_name = 'Firefox'
+    AND sample_id = 42
+    AND os IN ('Windows_NT', 'Darwin', 'Linux')
+  GROUP BY
+    submission_date_s3,
+    os
+),
+active_hours_per_user AS (
+  SELECT
+    submission_date_s3,
+    os,
+    `hours` / users AS active_hours_per_user_ratio
+  FROM
+    active_hours_per_user_staging
+)
 SELECT
   COALESCE(
     COALESCE(spu.submission_date_s3, sshpu.submission_date_s3),

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/query.sql
@@ -1,9 +1,96 @@
--- Query for telemetry_derived.fx_health_ind_clients_daily_by_os_v1
-            -- For more information on writing queries see:
-            -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
+WITH searches_per_user_by_os_and_date_staging
+AS
+  (
+    SELECT
+      submission_date_s3,
+      os,
+      SUM(search_count_all) AS searches,
+      COUNT(DISTINCT client_id) AS users,
+    FROM
+      `moz-fx-data-shared-prod.telemetry.clients_daily`
+    WHERE
+      submission_date_s3 = @submission_date
+      AND app_name = 'Firefox'
+      AND sample_id = 42
+      AND search_count_all < 10000
+      AND os IN ('Windows_NT', 'Darwin', 'Linux')
+    GROUP BY
+      submission_date_s3,
+      os
+  ),
+  searches_per_user_by_os_and_date AS (
+    SELECT
+      submission_date_s3,
+      os,
+      searches / users AS searches_per_user_ratio,
+    FROM
+      searches_per_user_by_os_and_date_staging
+  ),
+  subsession_hours_per_user_staging AS (
+    SELECT
+      submission_date_s3,
+      os,
+      SUM(subsession_hours_sum) AS `hours`,
+      count(DISTINCT client_id) AS users,
+    FROM
+      `moz-fx-data-shared-prod.telemetry.clients_daily`
+    WHERE
+      submission_date_s3 = @submission_date
+      AND app_name = 'Firefox'
+      AND sample_id = 42
+      AND subsession_hours_sum < 24
+      AND os IN ('Windows_NT', 'Darwin', 'Linux')
+    GROUP BY
+      submission_date_s3,
+      os
+  ),
+  subsession_hours_per_user AS (
+    SELECT
+      submission_date_s3,
+      os,
+      `hours` / users AS subsession_hours_per_user_ratio
+    FROM
+      subsession_hours_per_user_staging
+  ),
+  active_hours_per_user_staging AS (
+    SELECT
+      submission_date_s3,
+      os,
+      SUM(ROUND(active_hours_sum)) AS `hours`,
+      COUNT(DISTINCT(client_id)) AS users,
+    FROM
+      `moz-fx-data-shared-prod.telemetry.clients_daily`
+    WHERE
+      submission_date_s3 = @submission_date
+      AND app_name = 'Firefox'
+      AND sample_id = 42
+      AND os IN ('Windows_NT', 'Darwin', 'Linux')
+    GROUP BY
+      submission_date_s3,
+      os
+  ),
+  active_hours_per_user AS (
+    SELECT
+      submission_date_s3,
+      os,
+      `hours` / users AS active_hours_per_user_ratio
+    FROM
+      active_hours_per_user_staging
+  )
 SELECT
-  *
+  COALESCE(
+    COALESCE(spu.submission_date_s3, sshpu.submission_date_s3),
+    ahpu.submission_date_s3
+  ) AS submission_date,
+  COALESCE(COALESCE(spu.os, sshpu.os), ahpu.os) AS os,
+  spu.searches_per_user_ratio,
+  sshpu.subsession_hours_per_user_ratio,
+  ahpu.active_hours_per_user_ratio
 FROM
-  table
-WHERE
-  submission_date = @submission_date
+  searches_per_user_by_os_and_date AS spu
+FULL OUTER JOIN
+  subsession_hours_per_user AS sshpu
+  ON spu.os = sshpu.os
+FULL OUTER JOIN
+  active_hours_per_user AS ahpu
+  ON COALESCE(spu.os, sshpu.os) = ahpu.os

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
@@ -13,7 +13,7 @@ fields:
   description: Ratio of Searches per User
 - mode: NULLABLE
   name: subsession_hours_per_user_ratio
-  type: FLOAT
+  type: NUMERIC
   description: Ratio of Subsession Hours per User
 - mode: NULLABLE
   name: active_hours_per_user_ratio

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
@@ -1,0 +1,5 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
@@ -12,10 +12,6 @@ fields:
   type: FLOAT
   description: Ratio of Searches per User
 - mode: NULLABLE
-  name: searches_per_user_ratio
-  type: FLOAT
-  description: Ratio of Searches per User
-- mode: NULLABLE
   name: subsession_hours_per_user_ratio
   type: FLOAT
   description: Ratio of Subsession Hours per User

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
@@ -3,3 +3,23 @@ fields:
   name: submission_date
   type: DATE
   description: Submission Date
+- mode: NULLABLE
+  name: os
+  type: STRING
+  description: Operating System
+- mode: NULLABLE
+  name: searches_per_user_ratio
+  type: FLOAT
+  description: Ratio of Searches per User
+- mode: NULLABLE
+  name: searches_per_user_ratio
+  type: FLOAT
+  description: Ratio of Searches per User
+- mode: NULLABLE
+  name: subsession_hours_per_user_ratio
+  type: FLOAT
+  description: Ratio of Subsession Hours per User
+- mode: NULLABLE
+  name: active_hours_per_user_ratio
+  type: FLOAT
+  description: Ratio of Active Hours per User


### PR DESCRIPTION
## Description

This PR creates the new table:
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_clients_daily_by_os_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7034)


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ