### PR TITLE
Create new aggregate table for Firefox Health Indicator dashboard

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_clients_daily_by_os_version/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_clients_daily_by_os_version/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_clients_daily_by_os_version`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_clients_daily_by_os_version_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Firefox Health Indicator Clients Daily By OS Version
 description: |-
-  Calculates active hrs, subsession hrs, and searches per user on a 1% client sample by OS version
+  Calculates active hrs, subsession hrs, & searches per user on a 1% client sample by OS version for Windows NT
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/metadata.yaml
@@ -12,7 +12,7 @@ bigquery:
   time_partitioning:
     type: day
     field: submission_date
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: null
   range_partitioning: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Firefox Health Indicator Clients Daily By OS Version
+description: |-
+  Calculates active hrs, subsession hrs, and searches per user on a 1% client sample by OS version
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - os_version
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
@@ -52,7 +52,6 @@ subsession_hours_per_user AS (
   FROM
     subsession_hours_per_user_staging
 ),
---good above here
 active_hours_per_user_staging AS (
   SELECT
     submission_date_s3,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
@@ -12,7 +12,7 @@ WITH searches_per_user_by_os_version_and_date_staging AS (
     AND sample_id = 42
     AND search_count_all < 10000
     AND os = 'Windows_NT'
-    and os_version IN ('6.1','6.2','6.3','10.0')
+    AND os_version IN ('6.1', '6.2', '6.3', '10.0')
   GROUP BY
     submission_date_s3,
     os_version
@@ -39,7 +39,7 @@ subsession_hours_per_user_staging AS (
     AND sample_id = 42
     AND subsession_hours_sum < 24
     AND os = 'Windows_NT'
-    AND os_version IN ('6.1','6.2','6.3','10.0')
+    AND os_version IN ('6.1', '6.2', '6.3', '10.0')
   GROUP BY
     submission_date_s3,
     os_version
@@ -52,7 +52,7 @@ subsession_hours_per_user AS (
   FROM
     subsession_hours_per_user_staging
 ),
---good above here 
+--good above here
 active_hours_per_user_staging AS (
   SELECT
     submission_date_s3,
@@ -66,7 +66,7 @@ active_hours_per_user_staging AS (
     AND app_name = 'Firefox'
     AND sample_id = 42
     AND os = 'Windows_NT'
-    AND os_version IN ('6.1','6.2','6.3','10.0')
+    AND os_version IN ('6.1', '6.2', '6.3', '10.0')
   GROUP BY
     submission_date_s3,
     os_version

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
@@ -1,0 +1,98 @@
+WITH searches_per_user_by_os_version_and_date_staging AS (
+  SELECT
+    submission_date_s3,
+    os_version,
+    SUM(search_count_all) AS searches,
+    COUNT(DISTINCT client_id) AS users,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date_s3 = @submission_date
+    AND app_name = 'Firefox'
+    AND sample_id = 42
+    AND search_count_all < 10000
+    AND os = 'Windows_NT'
+    and os_version IN ('6.1','6.2','6.3','10.0')
+  GROUP BY
+    submission_date_s3,
+    os_version
+),
+searches_per_user_by_os_and_date AS (
+  SELECT
+    submission_date_s3,
+    os_version,
+    searches / users AS searches_per_user_ratio,
+  FROM
+    searches_per_user_by_os_version_and_date_staging
+),
+subsession_hours_per_user_staging AS (
+  SELECT
+    submission_date_s3,
+    os_version,
+    SUM(subsession_hours_sum) AS `hours`,
+    COUNT(DISTINCT client_id) AS users,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date_s3 = @submission_date
+    AND app_name = 'Firefox'
+    AND sample_id = 42
+    AND subsession_hours_sum < 24
+    AND os = 'Windows_NT'
+    AND os_version IN ('6.1','6.2','6.3','10.0')
+  GROUP BY
+    submission_date_s3,
+    os_version
+),
+subsession_hours_per_user AS (
+  SELECT
+    submission_date_s3,
+    os_version,
+    `hours` / users AS subsession_hours_per_user_ratio
+  FROM
+    subsession_hours_per_user_staging
+),
+--good above here 
+active_hours_per_user_staging AS (
+  SELECT
+    submission_date_s3,
+    os_version,
+    SUM(active_hours_sum) AS `hours`,
+    COUNT(DISTINCT(client_id)) AS users,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date_s3 = @submission_date
+    AND app_name = 'Firefox'
+    AND sample_id = 42
+    AND os = 'Windows_NT'
+    AND os_version IN ('6.1','6.2','6.3','10.0')
+  GROUP BY
+    submission_date_s3,
+    os_version
+),
+active_hours_per_user AS (
+  SELECT
+    submission_date_s3,
+    os_version,
+    `hours` / users AS active_hours_per_user_ratio
+  FROM
+    active_hours_per_user_staging
+)
+SELECT
+  COALESCE(
+    COALESCE(spu.submission_date_s3, sshpu.submission_date_s3),
+    ahpu.submission_date_s3
+  ) AS submission_date,
+  COALESCE(COALESCE(spu.os_version, sshpu.os_version), ahpu.os_version) AS os_version,
+  spu.searches_per_user_ratio,
+  sshpu.subsession_hours_per_user_ratio,
+  ahpu.active_hours_per_user_ratio
+FROM
+  searches_per_user_by_os_and_date AS spu
+FULL OUTER JOIN
+  subsession_hours_per_user AS sshpu
+  ON spu.os_version = sshpu.os_version
+FULL OUTER JOIN
+  active_hours_per_user AS ahpu
+  ON COALESCE(spu.os_version, sshpu.os_version) = ahpu.os_version

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/schema.yaml
@@ -1,0 +1,21 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: os_version
+  type: STRING
+  description: Operating System Version
+- mode: NULLABLE
+  name: searches_per_user_ratio
+  type: FLOAT
+  description: Ratio of Searches per User
+- mode: NULLABLE
+  name: subsession_hours_per_user_ratio
+  type: NUMERIC
+  description: Ratio of Subsession Hours per User
+- mode: NULLABLE
+  name: active_hours_per_user_ratio
+  type: FLOAT
+  description: Ratio of Active Hours per User


### PR DESCRIPTION
## Description

This PR creates the following new aggregate table: 
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_clients_daily_by_os_version_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7043)
