### PR TITLE
fix(glam): update beta and nightly refresh aggregates upstream task_id

### DIFF
--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_beta_aggregates_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_glam_refresh_aggregates
   date_partition_parameter: null
   depends_on:
-  - task_id: export_org_mozilla_fenix_glam_beta
+  - task_id: query_org_mozilla_fenix_glam_beta__extract_probe_counts_v1
     dag_name: glam_fenix
     execution_delta: 6h

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_nightly_aggregates_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_glam_refresh_aggregates
   date_partition_parameter: null
   depends_on:
-  - task_id: export_org_mozilla_fenix_glam_nightly
+  - task_id: query_org_mozilla_fenix_glam_nightly__extract_probe_counts_v1
     dag_name: glam_fenix
     execution_delta: 6h

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fenix_release_aggregates_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_glam_refresh_aggregates
   date_partition_parameter: null
   depends_on:
-  - task_id: export_org_mozilla_fenix_glam_release
+  - task_id: query_org_mozilla_fenix_glam_release__extract_probe_counts_v1
     dag_name: glam_fenix
     execution_delta: 6h

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_glam_refresh_aggregates
   date_partition_parameter: null
   depends_on:
-  - task_id: export_firefox_desktop_glam_beta
+  - task_id: query_firefox_desktop_glam_beta__extract_probe_counts_v1
     dag_name: glam_fog
     execution_delta: 6h

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_beta_aggregates_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_glam_refresh_aggregates
   date_partition_parameter: null
   depends_on:
-  - task_id: query_firefox_desktop_glam_beta__extract_probe_counts_v1
+  - task_id: firefox_desktop_glam_beta_done
     dag_name: glam_fog
     execution_delta: 6h

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_glam_refresh_aggregates
   date_partition_parameter: null
   depends_on:
-  - task_id: export_firefox_desktop_glam_nightly
+  - task_id: query_firefox_desktop_glam_nightly__extract_probe_counts_v1
     dag_name: glam_fog
     execution_delta: 6h

--- a/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-glam-prod-fca7/glam_etl/glam_fog_nightly_aggregates_v1/metadata.yaml
@@ -10,6 +10,6 @@ scheduling:
   dag_name: bqetl_glam_refresh_aggregates
   date_partition_parameter: null
   depends_on:
-  - task_id: query_firefox_desktop_glam_nightly__extract_probe_counts_v1
+  - task_id: firefox_desktop_glam_nightly_done
     dag_name: glam_fog
     execution_delta: 6h


### PR DESCRIPTION
## Description

This PR fixes the upstream dependency for `bqetl_glam_refresh_aggregates`.`glam_fog_nightly_aggregates` after https://github.com/mozilla/telemetry-airflow/pull/2135 removed the `export` task, which used to be the upstream.

## Related Tickets & Documents
* DENG-6752

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7045)
