### PR TITLE
Create new aggregate table for Firefox Health Indicators dashboard

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_clients_daily_by_country/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_clients_daily_by_country/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_clients_daily_by_country`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_clients_daily_by_country_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/metadata.yaml
@@ -13,7 +13,7 @@ bigquery:
   time_partitioning:
     type: day
     field: submission_date
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: null
   range_partitioning: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/metadata.yaml
@@ -1,11 +1,12 @@
 friendly_name: Fx Health Ind Clients Daily By Country
 description: |-
-  Please provide a description for the query
+  Calculates active hrs, subsession hrs, and searches per user by country on a 1% client sample
 owners:
 - kwindau@mozilla.com
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Fx Health Ind Clients Daily By Country
+description: |-
+  Please provide a description for the query
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - country
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/query.sql
@@ -1,0 +1,92 @@
+WITH searches_per_user_by_country_and_date_staging AS (
+  SELECT
+    submission_date_s3,
+    country,
+    SUM(search_count_all) AS searches,
+    COUNT(DISTINCT client_id) AS users,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date_s3 = @submission_date
+    AND app_name = 'Firefox'
+    AND sample_id = 42
+    AND search_count_all < 10000
+  GROUP BY
+    submission_date_s3,
+    country
+),
+searches_per_user_by_country_and_date AS (
+  SELECT
+    submission_date_s3,
+    country,
+    searches / users AS searches_per_user_ratio,
+  FROM
+    searches_per_user_by_country_and_date_staging
+),
+subsession_hours_per_user_staging AS (
+  SELECT
+    submission_date_s3,
+    country,
+    SUM(subsession_hours_sum) AS `hours`,
+    COUNT(DISTINCT client_id) AS users,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date_s3 = @submission_date
+    AND app_name = 'Firefox'
+    AND sample_id = 42
+    AND subsession_hours_sum < 24
+  GROUP BY
+    submission_date_s3,
+    country
+),
+subsession_hours_per_user AS (
+  SELECT
+    submission_date_s3,
+    country,
+    `hours` / users AS subsession_hours_per_user_ratio
+  FROM
+    subsession_hours_per_user_staging
+),
+active_hours_per_user_staging AS (
+  SELECT
+    submission_date_s3,
+    country,
+    SUM(active_hours_sum) AS `hours`,
+    COUNT(DISTINCT(client_id)) AS users,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date_s3 = @submission_date
+    AND app_name = 'Firefox'
+    AND sample_id = 42
+    AND active_hours_sum < 24
+  GROUP BY
+    submission_date_s3,
+    country
+),
+active_hours_per_user AS (
+  SELECT
+    submission_date_s3,
+    country,
+    `hours` / users AS active_hours_per_user_ratio
+  FROM
+    active_hours_per_user_staging
+)
+SELECT
+  COALESCE(
+    COALESCE(spu.submission_date_s3, sshpu.submission_date_s3),
+    ahpu.submission_date_s3
+  ) AS submission_date,
+  COALESCE(COALESCE(spu.country, sshpu.country), ahpu.country) AS country,
+  spu.searches_per_user_ratio,
+  sshpu.subsession_hours_per_user_ratio,
+  ahpu.active_hours_per_user_ratio
+FROM
+  searches_per_user_by_country_and_date AS spu
+FULL OUTER JOIN
+  subsession_hours_per_user AS sshpu
+  ON spu.country = sshpu.country
+FULL OUTER JOIN
+  active_hours_per_user AS ahpu
+  ON COALESCE(spu.country, sshpu.country) = ahpu.country

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/schema.yaml
@@ -1,0 +1,21 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: Country
+- mode: NULLABLE
+  name: searches_per_user_ratio
+  type: FLOAT
+  description: Ratio of Searches per User
+- mode: NULLABLE
+  name: subsession_hours_per_user_ratio
+  type: NUMERIC
+  description: Ratio of Subsession Hours per User
+- mode: NULLABLE
+  name: active_hours_per_user_ratio
+  type: FLOAT
+  description: Ratio of Active Hours per User


### PR DESCRIPTION
## Description

This PR creates the new aggregate table called: 
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_clients_daily_by_country_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7046)
