### PR TITLE
Add additional columns to new fx_health_indicator aggregate tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/query.sql
@@ -78,7 +78,17 @@ default_percent_and_avg_age_by_country AS (
     submission_date_s3,
     country,
     ROUND(AVG(IF(is_default_browser, 1, 0)) * 100, 1) AS default_percent,
-    SUM(ROUND(profile_age_in_days)) / COUNT(DISTINCT(client_id)) AS average_profile_age
+    SUM(ROUND(profile_age_in_days)) / COUNT(DISTINCT(client_id)) AS average_profile_age,
+    COUNT(DISTINCT(client_id)) AS total_nbr_users,
+    COUNT(
+      DISTINCT(CASE WHEN profile_age_in_days <= 7 THEN client_id ELSE NULL END)
+    ) AS nbr_users_profile_age_less_than_7,
+    COUNT(
+      DISTINCT(CASE WHEN profile_age_in_days BETWEEN 8 AND 365 THEN client_id ELSE NULL END)
+    ) AS nbr_users_profile_age_between_8_and_365,
+    COUNT(
+      DISTINCT(CASE WHEN profile_age_in_days > 365 THEN client_id ELSE NULL END)
+    ) AS nbr_users_profile_age_over_365
   FROM
     `moz-fx-data-shared-prod.telemetry.clients_daily`
   WHERE
@@ -99,7 +109,10 @@ SELECT
   sshpu.subsession_hours_per_user_ratio,
   ahpu.active_hours_per_user_ratio,
   dflt.default_percent,
-  dflt.average_profile_age
+  dflt.average_profile_age,
+  dflt.nbr_users_profile_age_less_than_7 / dflt.total_nbr_users AS pct_users_profile_age_less_than_7_days,
+  dflt.nbr_users_profile_age_between_8_and_365 / dflt.total_nbr_users AS pct_users_profile_age_8_to_365_days,
+  dflt.nbr_users_profile_age_over_365 / dflt.total_nbr_users AS pct_users_profile_age_over_365_days
 FROM
   searches_per_user_by_country_and_date AS spu
 FULL OUTER JOIN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/query.sql
@@ -107,5 +107,5 @@ FULL OUTER JOIN
   active_hours_per_user AS ahpu
   ON COALESCE(spu.country, sshpu.country) = ahpu.country
 FULL OUTER JOIN
-  default_percent_by_country dflt
+  default_percent_by_country AS dflt
   ON COALESCE(COALESCE(spu.country, sshpu.country), ahpu.country) = dflt.country

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/query.sql
@@ -73,11 +73,12 @@ active_hours_per_user AS (
   FROM
     active_hours_per_user_staging
 ),
-default_percent_by_country AS (
+default_percent_and_avg_age_by_country AS (
   SELECT
     submission_date_s3,
     country,
-    ROUND(AVG(IF(is_default_browser, 1, 0)) * 100, 1) AS default_percent
+    ROUND(AVG(IF(is_default_browser, 1, 0)) * 100, 1) AS default_percent,
+    SUM(ROUND(profile_age_in_days)) / COUNT(DISTINCT(client_id)) AS average_profile_age
   FROM
     `moz-fx-data-shared-prod.telemetry.clients_daily`
   WHERE
@@ -97,7 +98,8 @@ SELECT
   spu.searches_per_user_ratio,
   sshpu.subsession_hours_per_user_ratio,
   ahpu.active_hours_per_user_ratio,
-  dflt.default_percent
+  dflt.default_percent,
+  dflt.average_profile_age
 FROM
   searches_per_user_by_country_and_date AS spu
 FULL OUTER JOIN
@@ -107,5 +109,5 @@ FULL OUTER JOIN
   active_hours_per_user AS ahpu
   ON COALESCE(spu.country, sshpu.country) = ahpu.country
 FULL OUTER JOIN
-  default_percent_by_country AS dflt
+  default_percent_and_avg_age_by_country AS dflt
   ON COALESCE(COALESCE(spu.country, sshpu.country), ahpu.country) = dflt.country

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/schema.yaml
@@ -19,3 +19,7 @@ fields:
   name: active_hours_per_user_ratio
   type: FLOAT
   description: Ratio of Active Hours per User
+- mode: NULLABLE
+  name: default_percent
+  type: FLOAT
+  description: Percent of Users with Firefox as Default Browser

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/schema.yaml
@@ -27,3 +27,15 @@ fields:
   name: average_profile_age
   type: FLOAT
   description: Average Profile Age
+- mode: NULLABLE
+  name: pct_users_profile_age_less_than_7_days
+  type: FLOAT
+  description: Percent of Users with Profile Age Less than 7 Days
+- mode: NULLABLE
+  name: pct_users_profile_age_8_to_365_days
+  type: FLOAT
+  description: Percent of Users with Profile Age Between 8 and 365 Days
+- mode: NULLABLE
+  name: pct_users_profile_age_over_365_days
+  type: FLOAT
+  description: Percent of Users with Profile Age Over 365 Days

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_country_v1/schema.yaml
@@ -23,3 +23,7 @@ fields:
   name: default_percent
   type: FLOAT
   description: Percent of Users with Firefox as Default Browser
+- mode: NULLABLE
+  name: average_profile_age
+  type: FLOAT
+  description: Average Profile Age

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/query.sql
@@ -80,7 +80,17 @@ default_percent_by_os AS (
     submission_date_s3,
     os,
     ROUND(AVG(IF(is_default_browser, 1, 0)) * 100, 1) AS default_percent,
-    SUM(ROUND(profile_age_in_days)) / COUNT(DISTINCT(client_id)) AS average_profile_age
+    SUM(ROUND(profile_age_in_days)) / COUNT(DISTINCT(client_id)) AS average_profile_age,
+    COUNT(DISTINCT(client_id)) AS total_nbr_users,
+    COUNT(
+      DISTINCT(CASE WHEN profile_age_in_days <= 7 THEN client_id ELSE NULL END)
+    ) AS nbr_users_profile_age_less_than_7,
+    COUNT(
+      DISTINCT(CASE WHEN profile_age_in_days BETWEEN 8 AND 365 THEN client_id ELSE NULL END)
+    ) AS nbr_users_profile_age_between_8_and_365,
+    COUNT(
+      DISTINCT(CASE WHEN profile_age_in_days > 365 THEN client_id ELSE NULL END)
+    ) AS nbr_users_profile_age_over_365
   FROM
     `moz-fx-data-shared-prod.telemetry.clients_daily`
   WHERE
@@ -102,7 +112,10 @@ SELECT
   sshpu.subsession_hours_per_user_ratio,
   ahpu.active_hours_per_user_ratio,
   dflt.default_percent,
-  dflt.average_profile_age
+  dflt.average_profile_age,
+  dflt.nbr_users_profile_age_less_than_7 / dflt.total_nbr_users AS pct_users_profile_age_less_than_7_days,
+  dflt.nbr_users_profile_age_between_8_and_365 / dflt.total_nbr_users AS pct_users_profile_age_8_to_365_days,
+  dflt.nbr_users_profile_age_over_365 / dflt.total_nbr_users AS pct_users_profile_age_over_365_days
 FROM
   searches_per_user_by_os_and_date AS spu
 FULL OUTER JOIN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/query.sql
@@ -79,7 +79,8 @@ default_percent_by_os AS (
   SELECT
     submission_date_s3,
     os,
-    ROUND(AVG(IF(is_default_browser, 1, 0)) * 100, 1) AS default_percent
+    ROUND(AVG(IF(is_default_browser, 1, 0)) * 100, 1) AS default_percent,
+    SUM(ROUND(profile_age_in_days)) / COUNT(DISTINCT(client_id)) AS average_profile_age
   FROM
     `moz-fx-data-shared-prod.telemetry.clients_daily`
   WHERE
@@ -100,7 +101,8 @@ SELECT
   spu.searches_per_user_ratio,
   sshpu.subsession_hours_per_user_ratio,
   ahpu.active_hours_per_user_ratio,
-  dflt.default_percent
+  dflt.default_percent,
+  dflt.average_profile_age
 FROM
   searches_per_user_by_os_and_date AS spu
 FULL OUTER JOIN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
@@ -19,3 +19,7 @@ fields:
   name: active_hours_per_user_ratio
   type: FLOAT
   description: Ratio of Active Hours per User
+- mode: NULLABLE
+  name: default_percent
+  type: FLOAT
+  description: Percent of Users with Firefox as Default Browser

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
@@ -27,3 +27,15 @@ fields:
   name: average_profile_age
   type: FLOAT
   description: Average Profile Age
+- mode: NULLABLE
+  name: pct_users_profile_age_less_than_7_days
+  type: FLOAT
+  description: Percent of Users with Profile Age Less than 7 Days
+- mode: NULLABLE
+  name: pct_users_profile_age_8_to_365_days
+  type: FLOAT
+  description: Percent of Users with Profile Age Between 8 and 365 Days
+- mode: NULLABLE
+  name: pct_users_profile_age_over_365_days
+  type: FLOAT
+  description: Percent of Users with Profile Age Over 365 Days

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_v1/schema.yaml
@@ -23,3 +23,7 @@ fields:
   name: default_percent
   type: FLOAT
   description: Percent of Users with Firefox as Default Browser
+- mode: NULLABLE
+  name: average_profile_age
+  type: FLOAT
+  description: Average Profile Age

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
@@ -84,8 +84,16 @@ default_percent_by_os_version AS (
     os_version,
     ROUND(AVG(IF(is_default_browser, 1, 0)) * 100, 1) AS default_percent,
     SUM(ROUND(profile_age_in_days)) / COUNT(DISTINCT(client_id)) AS average_profile_age,
-    COUNT(DISTINCT(client_id)) AS nbr_clients,
-    count(distinct(CASE WHEN profile_age_in_days < 365 THAN ))
+    COUNT(DISTINCT(client_id)) AS total_nbr_users,
+    COUNT(
+      DISTINCT(CASE WHEN profile_age_in_days <= 7 THEN client_id ELSE NULL END)
+    ) AS nbr_users_profile_age_less_than_7,
+    COUNT(
+      DISTINCT(CASE WHEN profile_age_in_days BETWEEN 8 AND 365 THEN client_id ELSE NULL END)
+    ) AS nbr_users_profile_age_between_8_and_365,
+    COUNT(
+      DISTINCT(CASE WHEN profile_age_in_days > 365 THEN client_id ELSE NULL END)
+    ) AS nbr_users_profile_age_over_365
   FROM
     `moz-fx-data-shared-prod.telemetry.clients_daily`
   WHERE
@@ -108,7 +116,10 @@ SELECT
   sshpu.subsession_hours_per_user_ratio,
   ahpu.active_hours_per_user_ratio,
   dflt.default_percent,
-  dflt.average_profile_age
+  dflt.average_profile_age,
+  dflt.nbr_users_profile_age_less_than_7 / dflt.total_nbr_users AS pct_users_profile_age_less_than_7_days,
+  dflt.nbr_users_profile_age_between_8_and_365 / dflt.total_nbr_users AS pct_users_profile_age_8_to_365_days,
+  dflt.nbr_users_profile_age_over_365 / dflt.total_nbr_users AS pct_users_profile_age_over_365_days
 FROM
   searches_per_user_by_os_and_date AS spu
 FULL OUTER JOIN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
@@ -82,7 +82,8 @@ default_percent_by_os_version AS (
   SELECT
     submission_date_s3,
     os_version,
-    ROUND(AVG(IF(is_default_browser, 1, 0)) * 100, 1) AS default_percent
+    ROUND(AVG(IF(is_default_browser, 1, 0)) * 100, 1) AS default_percent,
+    SUM(ROUND(profile_age_in_days)) / COUNT(DISTINCT(client_id)) AS average_profile_age
   FROM
     `moz-fx-data-shared-prod.telemetry.clients_daily`
   WHERE
@@ -104,7 +105,8 @@ SELECT
   spu.searches_per_user_ratio,
   sshpu.subsession_hours_per_user_ratio,
   ahpu.active_hours_per_user_ratio,
-  dflt.default_percent
+  dflt.default_percent,
+  dflt.average_profile_age
 FROM
   searches_per_user_by_os_and_date AS spu
 FULL OUTER JOIN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/query.sql
@@ -83,7 +83,9 @@ default_percent_by_os_version AS (
     submission_date_s3,
     os_version,
     ROUND(AVG(IF(is_default_browser, 1, 0)) * 100, 1) AS default_percent,
-    SUM(ROUND(profile_age_in_days)) / COUNT(DISTINCT(client_id)) AS average_profile_age
+    SUM(ROUND(profile_age_in_days)) / COUNT(DISTINCT(client_id)) AS average_profile_age,
+    COUNT(DISTINCT(client_id)) AS nbr_clients,
+    count(distinct(CASE WHEN profile_age_in_days < 365 THAN ))
   FROM
     `moz-fx-data-shared-prod.telemetry.clients_daily`
   WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/schema.yaml
@@ -19,3 +19,7 @@ fields:
   name: active_hours_per_user_ratio
   type: FLOAT
   description: Ratio of Active Hours per User
+- mode: NULLABLE
+  name: default_percent
+  type: FLOAT
+  description: Percent of Users with Firefox as Default Browser

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/schema.yaml
@@ -27,3 +27,15 @@ fields:
   name: average_profile_age
   type: FLOAT
   description: Average Profile Age
+- mode: NULLABLE
+  name: pct_users_profile_age_less_than_7_days
+  type: FLOAT
+  description: Percent of Users with Profile Age Less than 7 Days
+- mode: NULLABLE
+  name: pct_users_profile_age_8_to_365_days
+  type: FLOAT
+  description: Percent of Users with Profile Age Between 8 and 365 Days
+- mode: NULLABLE
+  name: pct_users_profile_age_over_365_days
+  type: FLOAT
+  description: Percent of Users with Profile Age Over 365 Days

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_clients_daily_by_os_version_v1/schema.yaml
@@ -23,3 +23,7 @@ fields:
   name: default_percent
   type: FLOAT
   description: Percent of Users with Firefox as Default Browser
+- mode: NULLABLE
+  name: average_profile_age
+  type: FLOAT
+  description: Average Profile Age


### PR DESCRIPTION
## Description

This PR adds 5 new columns to 3 tables: 
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_clients_daily_by_country_v1
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_clients_daily_by_os_v1
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_clients_daily_by_os_version_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7047)


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ