### PR TITLE
remove partition from schema.yaml file

### DIFF
--- a/sql/moz-fx-data-shared-prod/addon_moderations_derived/cinder_decisions_raw_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addon_moderations_derived/cinder_decisions_raw_v1/metadata.yaml
@@ -12,11 +12,3 @@ scheduling:
   secrets:
   - deploy_target: CINDER_TOKEN
     key: bqetl_addons__cinder_bearer_token
-bigquery:
-  time_partitioning:
-    type: day
-    field: 'date'
-    require_partition_filter: false
-    expiration_days: null
-  range_partitioning: null
-references: {}


### PR DESCRIPTION
## Description

<!--
Publish tables is failing because the original addon moderations table was supposed to be created with partitions. Currently
The error is:
_Failed deploy for sql/moz-fx-data-shared-prod/addon_moderations_derived/cinder_decisions_raw_v1/query.py: (Unable to update table moz-fx-data-shared-prod.addon_moderations_derived.cinder_decisions_raw_v1: 400 PATCH https://bigquery.googleapis.com/bigquery/v2/projects/moz-fx-data-shared-prod/datasets/addon_moderations_derived/tables/cinder_decisions_raw_v1?prettyPrint=false: Cannot convert non partitioned table to partitioned table.)_

-->

## Related Tickets & Documents
* DENG-6360
* DSRE-XXXX

<!--
[Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources](fixes: https://bugzilla.mozilla.org/show_bug.cgi?id=1937677)
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7054)
