### PR TITLE
DENG-6892 - backfill new event_aggregates_v1 table

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2024-12-18:
+  start_date: 2020-01-01
+  end_date: 2024-12-16
+  reason: https://mozilla-hub.atlassian.net/browse/DENG-6892
+  watchers:
+  - kwindau@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true


### PR DESCRIPTION
## Description

This PR initiates a backfill for the new table:
- moz-fx-data-shared-prod.telemetry_derived.event_aggregates_v1

## Related Tickets & Documents
* [DENG-6892](https://mozilla-hub.atlassian.net/browse/DENG-6892)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
