### PR TITLE
Create aggregate tables for Firefox Health Indicators dashboard

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_country/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_country/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_vid_plybck_by_country`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_vid_plybck_by_country_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_os/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_os/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_vid_plybck_by_os`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_vid_plybck_by_os_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_os_version/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_os_version/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_vid_plybck_by_os_version`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_vid_plybck_by_os_version_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_country_v1/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Fx Health Ind Vid Plybck By Os
+description: |-
+  Aggregate table of video playback minutes per user per OS
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_country_code
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_country_v1/query.sql
@@ -1,0 +1,15 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_country_code,
+  SUM(
+    `moz-fx-data-shared-prod.udf.histogram_max_key_with_nonzero_value`(
+      payload.processes.content.histograms.video_play_time_ms
+    )
+  ) / count(DISTINCT client_id) / 60000 AS play_time_ratio
+FROM
+  `moz-fx-data-shared-prod.telemetry.main_1pct`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+GROUP BY
+  DATE(submission_timestamp),
+  normalized_country_code

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_country_v1/query.sql
@@ -5,7 +5,7 @@ SELECT
     `moz-fx-data-shared-prod.udf.histogram_max_key_with_nonzero_value`(
       payload.processes.content.histograms.video_play_time_ms
     )
-  ) / count(DISTINCT client_id) / 60000 AS play_time_ratio
+  ) / COUNT(DISTINCT client_id) / 60000 AS play_time_ratio
 FROM
   `moz-fx-data-shared-prod.telemetry.main_1pct`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_country_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_country_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: normalized_country_code
+  type: STRING
+  description: Normalized Country Code
+- mode: NULLABLE
+  name: play_time_ratio
+  type: FLOAT
+  description: Play Time Ratio

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_v1/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Fx Health Ind Vid Plybck By Os
+description: |-
+  Aggregate table of video playback minutes per user per OS
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_os
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_v1/query.sql
@@ -5,7 +5,7 @@ SELECT
     `moz-fx-data-shared-prod.udf.histogram_max_key_with_nonzero_value`(
       payload.processes.content.histograms.video_play_time_ms
     )
-  ) / count(DISTINCT client_id) / 60000 AS play_time_ratio
+  ) / COUNT(DISTINCT client_id) / 60000 AS play_time_ratio
 FROM
   `moz-fx-data-shared-prod.telemetry.main`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_v1/query.sql
@@ -1,0 +1,17 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_os,
+  SUM(
+    `moz-fx-data-shared-prod.udf.histogram_max_key_with_nonzero_value`(
+      payload.processes.content.histograms.video_play_time_ms
+    )
+  ) / count(DISTINCT client_id) / 60000 AS play_time_ratio
+FROM
+  `moz-fx-data-shared-prod.telemetry.main`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND normalized_os IN ('Windows', 'Linux', 'Mac')
+  AND sample_id = 42
+GROUP BY
+  DATE(submission_timestamp),
+  normalized_os

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: normalized_os
+  type: STRING
+  description: Normalized Operating System
+- mode: NULLABLE
+  name: play_time_ratio
+  type: FLOAT
+  description: Play Time Ratio

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_version_v1/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Fx Health Ind Vid Plybck By Os
+description: |-
+  Aggregate table of video playback minutes per user per OS
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_os_version
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_version_v1/query.sql
@@ -1,0 +1,16 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_os_version,
+  SUM(
+    `moz-fx-data-shared-prod.udf.histogram_max_key_with_nonzero_value`(
+      payload.processes.content.histograms.video_play_time_ms
+    )
+  ) / count(DISTINCT client_id) / 60000 AS play_time_ratio
+FROM
+  `moz-fx-data-shared-prod.telemetry.main_1pct`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND normalized_os = 'Windows'
+GROUP BY
+  DATE(submission_timestamp),
+  normalized_os_version

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_version_v1/query.sql
@@ -5,7 +5,7 @@ SELECT
     `moz-fx-data-shared-prod.udf.histogram_max_key_with_nonzero_value`(
       payload.processes.content.histograms.video_play_time_ms
     )
-  ) / count(DISTINCT client_id) / 60000 AS play_time_ratio
+  ) / COUNT(DISTINCT client_id) / 60000 AS play_time_ratio
 FROM
   `moz-fx-data-shared-prod.telemetry.main_1pct`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_version_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_version_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: normalized_os_version
+  type: STRING
+  description: Normalized Operating System Version
+- mode: NULLABLE
+  name: play_time_ratio
+  type: FLOAT
+  description: Play Time Ratio


### PR DESCRIPTION
## Description

This PR creates 3 new aggregate tables:
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_vid_plybck_by_country_v1
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_vid_plybck_by_os_v1
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_vid_plybck_by_os_version_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7074)
