### PR TITLE
Add shredder_mitigation to KPI and search related tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_spons_tiles_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_spons_tiles_v1/metadata.yaml
@@ -8,6 +8,8 @@ labels:
   schedule: daily
   dag: bqetl_ctxsvc_derived
   owner1: rburwei
+  shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_ctxsvc_derived
 bigquery:

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/metadata.yaml
@@ -7,6 +7,8 @@ labels:
   incremental: true
   schedule: daily
   dag: bqetl_ctxsvc_derived
+  shredder_mitigation: true
+  table_type: aggregate
   owner1: rburwei
 scheduling:
   dag_name: bqetl_ctxsvc_derived

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/metadata.yaml
@@ -6,6 +6,8 @@ owners:
 labels:
   incremental: true
   schedule: daily
+  shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_ctxsvc_derived
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_suggest_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_suggest_v2/metadata.yaml
@@ -12,6 +12,8 @@ labels:
   incremental: true
   schedule: daily
   change_controlled: true
+  shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_ctxsvc_derived
 bigquery:

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_tiles_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_tiles_v2/metadata.yaml
@@ -12,6 +12,7 @@ labels:
   incremental: true
   schedule: daily
   change_controlled: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_ctxsvc_derived
 bigquery:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_metric_contribution_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_metric_contribution_v1/metadata.yaml
@@ -10,6 +10,7 @@ owners:
   - jklukas@mozilla.com
 labels:
   schedule: daily
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_search
 bigquery:

--- a/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_revenue_levers_daily_v1/metadata.yaml
@@ -12,6 +12,7 @@ labels:
   change_controlled: true
   dag: bqetl_search_dashboard
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_search_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_attribution_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_attribution_v1/metadata.yaml
@@ -22,6 +22,8 @@ owners:
 - lvargas@mozilla.com
 labels:
   incremental: true
+  shredder_mitigation: true
+  table_type: aggregate
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_device_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_device_v1/metadata.yaml
@@ -12,6 +12,8 @@ owners:
 - lvargas@mozilla.com
 labels:
   incremental: true
+  shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_analytics_aggregations
   task_name: active_users_aggregates_device_v1

--- a/sql_generators/active_users_aggregates_v4/templates/metadata.yaml
+++ b/sql_generators/active_users_aggregates_v4/templates/metadata.yaml
@@ -27,6 +27,7 @@ labels:
   incremental: true
   change_controlled: true
   shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_analytics_aggregations
   task_name: {{ app_name }}_{{ table_name }}

--- a/sql_generators/active_users_deletion_requests/templates/metadata_deletion_request.yaml
+++ b/sql_generators/active_users_deletion_requests/templates/metadata_deletion_request.yaml
@@ -10,6 +10,8 @@ owners:
   - lvargas@mozilla.com
 labels:
   incremental: true
+  table_type: aggregate
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_kpis_shredder
   task_name: {{ app_name }}_active_users_aggregates_for_deletion_requests


### PR DESCRIPTION
Adding `shredder_mitigation` and `table_type` lables to the search and KPI AUA tables