### PR TITLE
DENG-6887-broken site reports-aggregations and weekly trends

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1811,6 +1811,26 @@ bqetl_merino_newtab_extract_to_gcs:
     - repo/bigquery-etl
     - impact/tier_1
 
+bqetl_broken_reports_agg:
+  default_args:
+    depends_on_past: false
+    email:
+      - telemetry-alerts@mozilla.com
+      - gkatre@mozilla.com
+    email_on_failure: true
+    email_on_retry: true
+    end_date: null
+    owner: gkatre@mozilla.com
+    retries: 2
+    retry_delay: 30m
+    start_date: '2024-12-18'
+  description: Tables associated with broken site reports.
+  repo: bigquery-etl
+  schedule_interval: 0 6 * * *
+  tags:
+    - impact/tier_3
+    - repo/bigquery-etl
+
 bqetl_merino_newtab_priors_to_gcs:
   default_args:
     depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/broken_site_root_domain_daily_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/broken_site_root_domain_daily_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_broken_site_report.broken_site_root_domain_daily_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.org_mozilla_broken_site_report_derived.broken_site_root_domain_daily_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/broken_site_root_domain_weekly_trend/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/broken_site_root_domain_weekly_trend/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_broken_site_report.broken_site_root_domain_weekly_trend`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.org_mozilla_broken_site_report_derived.broken_site_root_domain_weekly_trend_v1`

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_daily_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_daily_aggregates_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Broken site Root Domain Daily Aggregates
+description: |-
+  A daily aggregation for broken site root domains.
+owners:
+  - gkatre@mozilla.com
+labels:
+  incremental: true
+  schedule: daily
+  table_type: aggregate
+  owner1: gkatre@mozilla.com
+scheduling:
+  dag_name: bqetl_broken_reports_agg
+bigquery:
+  time_partitioning:
+    type: day
+    field: report_date
+    require_partition_filter: true
+  clustering:
+    fields:
+      - root_domain

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_daily_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_daily_aggregates_v1/query.sql
@@ -1,0 +1,28 @@
+WITH reports AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_stable.broken_site_report_v1`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND metrics.text2.broken_site_report_description != "" -- Exclude empty descriptions
+  QUALIFY
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        document_id
+      ORDER BY
+        submission_timestamp
+    ) = 1 -- Only include the first submission for each document_id
+)
+SELECT
+  DATE(submission_timestamp) AS report_date,
+  REGEXP_EXTRACT(
+    metrics.url2.broken_site_report_url,
+    r'https?://(?:www\.)?([^/]+)'
+  ) AS root_domain, -- Extract root domain
+  COUNT(*) AS daily_domain_reports
+FROM
+  reports
+GROUP BY
+  report_date,
+  root_domain

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_daily_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_daily_aggregates_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- description: Report Date
+  mode: NULLABLE
+  name: report_date
+  type: DATE
+- description: Root Domain
+  mode: NULLABLE
+  name: root_domain
+  type: STRING
+- description: Daily count of root domain reports
+  mode: NULLABLE
+  name: daily_domain_reports
+  type: INT64

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_weekly_trend_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_weekly_trend_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Broken site Root Domain Weekly Trends
+description: |-
+  Weekly trend computation for broken site reports.
+owners:
+  - gkatre@mozilla.com
+labels:
+  incremental: true
+  schedule: daily
+  depends_on_past: true
+  owner1: gkatre@mozilla.com
+scheduling:
+  dag_name: bqetl_broken_reports_agg
+  depends_on_past: true
+bigquery:
+  time_partitioning:
+    type: day
+    field: report_date
+    require_partition_filter: true
+  clustering:
+    fields:
+      - root_domain

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_weekly_trend_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_weekly_trend_v1/query.sql
@@ -1,0 +1,36 @@
+WITH daily_aggregates AS (
+  SELECT
+    report_date,
+    root_domain,
+    daily_domain_reports,
+    SUM(daily_domain_reports) OVER (
+      PARTITION BY
+        root_domain
+      ORDER BY
+        report_date
+      ROWS BETWEEN
+        6 PRECEDING
+        AND CURRENT ROW
+    ) AS weekly_trend, -- Weekly trend for comparison
+    COUNT(1) OVER (
+      PARTITION BY
+        root_domain
+      ORDER BY
+        report_date
+      ROWS BETWEEN
+        6 PRECEDING
+        AND CURRENT ROW
+    ) AS weekly_recurrence_count -- Count of weekly recurrence
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_broken_site_report_derived.broken_site_root_domain_daily_aggregates_v1`
+  WHERE
+    report_date
+    BETWEEN @submission_date - 6
+    AND @submission_date
+)
+SELECT
+  *
+FROM
+  daily_aggregates
+WHERE
+  report_date = @submission_date

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_weekly_trend_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/broken_site_root_domain_weekly_trend_v1/schema.yaml
@@ -1,0 +1,21 @@
+fields:
+- description: Report Date
+  mode: NULLABLE
+  name: report_date
+  type: DATE
+- description: Root Domain
+  mode: NULLABLE
+  name: root_domain
+  type: STRING
+- description: Daily count of root domain reports
+  mode: NULLABLE
+  name: daily_domain_reports
+  type: INT64
+- description: 7 day count of root domain reports
+  mode: NULLABLE
+  name: weekly_trend
+  type: INT64
+- description: Recurrence count of root domain over last 7 days
+  mode: NULLABLE
+  name: weekly_recurrence_count
+  type: INT64

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report_derived/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Broken Site Reports Derived
+description: |-
+  Derived data based on broken site reports
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential


### PR DESCRIPTION
## Description

Aggregations and Weekly trends for broken site reporting

- broken_site_root_domain_daily_aggregates: Has the daily aggregations by root domain
- broken_site_root_domain_weekly_trend: Computes the weekly trends

## Related Tickets & Documents
* [DENG-6887](https://mozilla-hub.atlassian.net/browse/DENG-6887)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6887]: https://mozilla-hub.atlassian.net/browse/DENG-6887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7077)
