### PR TITLE
Create new aggregate table fx_health_ind_searches_by_provider_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_searches_by_provider/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_searches_by_provider/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_searches_by_provider`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_searches_by_provider_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Firefox Health Indicator Searches By Provider
 description: |-
-  Count of searches by provider by day used in Firefox Health Indicator dashboard
+  Count of searches & users by provider/day used in Firefox Health Indicator dashboard
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/metadata.yaml
@@ -1,4 +1,4 @@
-friendly_name: Fx Health Ind Searches By Provider
+friendly_name: Firefox Health Indicator Searches By Provider
 description: |-
   Count of searches by provider by day
 owners:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Firefox Health Indicator Searches By Provider
 description: |-
-  Count of searches by provider by day
+  Count of searches by provider by day used in Firefox Health Indicator dashboard
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Fx Health Ind Searches By Provider
+description: |-
+  Count of searches by provider by day
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - default_search_engine
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   incremental: true
   owner1: kwindau@mozilla.com
   table_type: aggregate
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  submission_date_s3 AS submission_date,
+  default_search_engine,
+  SUM(search_count_all) AS searches
+FROM
+  `moz-fx-data-shared-prod.telemetry.clients_daily`
+WHERE
+  submission_date_s3 = @submission_date
+  AND app_name = 'Firefox'
+GROUP BY
+  submission_date_s3,
+  default_search_engine

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/query.sql
@@ -1,7 +1,8 @@
 SELECT
   submission_date_s3 AS submission_date,
   default_search_engine,
-  SUM(search_count_all) AS searches
+  SUM(search_count_all) AS searches,
+  COUNT(DISTINCT(client_id)) AS users
 FROM
   `moz-fx-data-shared-prod.telemetry.clients_daily`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: default_search_engine
+  type: STRING
+  description: Default Search Engine
+- mode: NULLABLE
+  name: searches
+  type: INTEGER
+  description: Number of Searches

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v1/schema.yaml
@@ -11,3 +11,7 @@ fields:
   name: searches
   type: INTEGER
   description: Number of Searches
+- mode: NULLABLE
+  name: users
+  type: INTEGER
+  description: Number of Users


### PR DESCRIPTION
## Description

This PR creates the following new table: 
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_searches_by_provider_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7078)
