### PR TITLE
add depends on past = true to metadata

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v3/metadata.yaml
@@ -11,6 +11,7 @@ scheduling:
   dag_name: bqetl_analytics_tables
   date_partition_offset: -27
   date_partition_parameter: null
+  depends_on_past: true
   parameters:
   - submission_date:DATE:{{ds}}
 bigquery:


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR adds `depends_on_past: true` to the metadata. the table clients_first_seen_v3 depends on past, we need to make sure that clients_first_seen_28_days_later_v3 will be backfilled properly, so it also needs depends_on_past set to true.
-->

## Related Tickets & Documents
* DENG-6985
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7079)
