### PR TITLE
feat: add partnership field to the active_users_aggregates view template

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/active_users_aggregates/view.sql
@@ -32,7 +32,12 @@ SELECT
   app_version_minor,
   app_version_patch_revision,
   app_version_is_major_release,
-  os_grouped
+  os_grouped,
+  CASE
+    WHEN distribution_id LIKE "%vivo%"
+      THEN "vivo"
+    ELSE "other"
+  END AS partnership,
 FROM
   `moz-fx-data-shared-prod.telemetry.active_users_aggregates_mobile`
 UNION ALL
@@ -68,6 +73,11 @@ SELECT
   app_version_minor,
   app_version_patch_revision,
   app_version_is_major_release,
-  os_grouped
+  os_grouped,
+  CASE
+    WHEN distribution_id LIKE "%vivo%"
+      THEN "vivo"
+    ELSE "other"
+  END AS partnership,
 FROM
   `moz-fx-data-shared-prod.firefox_desktop.active_users_aggregates`

--- a/sql_generators/active_users_aggregates_v4/templates/mobile_view.sql
+++ b/sql_generators/active_users_aggregates_v4/templates/mobile_view.sql
@@ -44,6 +44,11 @@ CREATE OR REPLACE VIEW
       app_version_patch_revision,
       app_version_is_major_release,
       os_grouped,
+      CASE 
+        WHEN distribution_id LIKE "%vivo%"
+          THEN "vivo"
+        ELSE "other"
+      END AS partnership,
     FROM
       `{{ project_id }}.{{ app_dataset_id }}.active_users_aggregates`
   {% endfor %}

--- a/sql_generators/active_users_aggregates_v4/templates/mobile_view.sql
+++ b/sql_generators/active_users_aggregates_v4/templates/mobile_view.sql
@@ -44,11 +44,6 @@ CREATE OR REPLACE VIEW
       app_version_patch_revision,
       app_version_is_major_release,
       os_grouped,
-      CASE 
-        WHEN distribution_id LIKE "%vivo%"
-          THEN "vivo"
-        ELSE "other"
-      END AS partnership,
     FROM
       `{{ project_id }}.{{ app_dataset_id }}.active_users_aggregates`
   {% endfor %}

--- a/sql_generators/active_users_aggregates_v4/templates/view.sql
+++ b/sql_generators/active_users_aggregates_v4/templates/view.sql
@@ -11,10 +11,5 @@ SELECT
   `mozfun.norm.browser_version_info`(app_version).patch_revision AS app_version_patch_revision,
   `mozfun.norm.browser_version_info`(app_version).is_major_release AS app_version_is_major_release,
   `mozfun.norm.os`(os) AS os_grouped,
-  CASE 
-    WHEN distribution_id LIKE "%vivo%"
-      THEN "vivo"
-    ELSE "other"
-  END AS partnership,
 FROM
   `{{ project_id }}.{{ app_name }}_derived.{{ table_name }}`

--- a/sql_generators/active_users_aggregates_v4/templates/view.sql
+++ b/sql_generators/active_users_aggregates_v4/templates/view.sql
@@ -10,6 +10,11 @@ SELECT
   `mozfun.norm.browser_version_info`(app_version).minor_version AS app_version_minor,
   `mozfun.norm.browser_version_info`(app_version).patch_revision AS app_version_patch_revision,
   `mozfun.norm.browser_version_info`(app_version).is_major_release AS app_version_is_major_release,
-  `mozfun.norm.os`(os) AS os_grouped
+  `mozfun.norm.os`(os) AS os_grouped,
+  CASE 
+    WHEN distribution_id LIKE "%vivo%"
+      THEN "vivo"
+    ELSE "other"
+  END AS partnership,
 FROM
   `{{ project_id }}.{{ app_name }}_derived.{{ table_name }}`


### PR DESCRIPTION
# feat: add partnership field to the active_users_aggregates view template

## Description

This change ads an additional field to the active_users_aggregates view which maps the distribution_id to a device partner to enable filtering of the KPI dashboards for this specific user segment.

This is an alternative to turning the active_users_aggregates in lookml to support this filtering. For more info on this approach see: https://github.com/mozilla/looker-spoke-default/pull/984