### PR TITLE
feat: exclude some apps from including bigconfig in glean_usage generator

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -337,6 +337,46 @@ generate:
       events_tables: # overwrite event tables
         pine: # Probe info returns pings that don't have tables, only use events_v1
         - events_v1
+    bigconfig:
+      skip_apps:
+      - firefox_echo_show
+      - firefox_fire_tv
+      - thunderbird_android
+      - org_mozilla_social_nightly
+      - mozilla_vpn
+      - mozillavpn_backend_cirrus
+      - accounts_backend
+      - accounts_cirrus
+      - burnham
+      - firefox_crashreporter
+      - firefox_reality
+      - firefox_reality_pc
+      - lockwise_android
+      - mach
+      - monitor_backend
+      - monitor_cirrus
+      - moso_mastodon_backend
+      - mozphab
+      - mozregression
+      skip_app_metrics:
+      - thunderbird_desktop
+    bqetl_checks:
+      skip_apps:
+      - mozilla_vpn
+      - mozillavpn_backend_cirrus
+      - accounts_backend
+      - accounts_cirrus
+      - burnham
+      - firefox_crashreporter
+      - firefox_reality
+      - firefox_reality_pc
+      - lockwise_android
+      - mach
+      - monitor_backend
+      - monitor_cirrus
+      - moso_mastodon_backend
+      - mozphab
+      - mozregression
 
 retention_exclusion_list:
 - sql/moz-fx-data-shared-prod/search_derived/acer_cohort_v1

--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -289,6 +289,10 @@ class GleanTable:
             app_name=app_name,
             has_distribution_id=app_name in APPS_WITH_DISTRIBUTION_ID,
             has_profile_group_id=app_name in APPS_WITH_PROFILE_GROUP_ID,
+            enable_monitoring=app_name
+            not in list(
+                set(BIGEYE_APP_EXCLUSION_LIST + BIGEYE_APP_EXCLUSION_LIST_METRICS)
+            ),
         )
 
         render_kwargs.update(self.custom_render_kwargs)
@@ -406,8 +410,10 @@ class GleanTable:
         if not self.per_app_enabled:
             return
 
+        app_name = app_info[0]["app_name"]
+
         target_view_name = "_".join(self.target_table_id.split("_")[:-1])
-        target_dataset = app_info[0]["app_name"]
+        target_dataset = app_name
 
         datasets = [
             (a["bq_dataset_family"], a.get("app_channel", "release")) for a in app_info
@@ -430,7 +436,11 @@ class GleanTable:
             datasets=datasets,
             table=target_view_name,
             target_table=f"{target_dataset}_derived.{self.target_table_id}",
-            app_name=app_info[0]["app_name"],
+            app_name=app_name,
+            enable_monitoring=app_name
+            not in list(
+                set(BIGEYE_APP_EXCLUSION_LIST + BIGEYE_APP_EXCLUSION_LIST_METRICS)
+            ),
         )
         render_kwargs.update(self.custom_render_kwargs)
 

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.metadata.yaml
@@ -24,4 +24,4 @@ bigquery:
     - normalized_channel
     - sample_id
 monitoring:
-  enabled: {{% if enable_monitoring %}}true{{% else %}}false{{% endif %}}
+  enabled: {% if enable_monitoring %}true{% else %}false{% endif %}

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.metadata.yaml
@@ -23,3 +23,5 @@ bigquery:
     fields:
     - normalized_channel
     - sample_id
+monitoring:
+  enabled: {{% if enable_monitoring %}}true{{% else %}}false{{% endif %}}

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.metadata.yaml
@@ -37,3 +37,5 @@ bigquery:
     fields:
     - sample_id
     - submission_date
+monitoring:
+  enabled: {{% if enable_monitoring %}}true{{% else %}}false{{% endif %}}

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.metadata.yaml
@@ -38,4 +38,4 @@ bigquery:
     - sample_id
     - submission_date
 monitoring:
-  enabled: {{% if enable_monitoring %}}true{{% else %}}false{{% endif %}}
+  enabled: {% if enable_monitoring %}true{% else %}false{% endif %}

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
@@ -26,7 +26,7 @@ bigquery:
     - normalized_channel
     - sample_id
 monitoring:
-  enabled: {{% if enable_monitoring %}}true{{% else %}}false{{% endif %}}
+  enabled: {% if enable_monitoring %}true{% else %}false{% endif %}
 schema:
   derived_from:
   - table: ['moz-fx-data-shared-prod', '{{ derived_dataset }}', 'baseline_clients_daily_v1']

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
@@ -26,7 +26,7 @@ bigquery:
     - normalized_channel
     - sample_id
 monitoring:
-  enabled: true
+  enabled: {{% if enable_monitoring %}}true{{% else %}}false{{% endif %}}
 schema:
   derived_from:
   - table: ['moz-fx-data-shared-prod', '{{ derived_dataset }}', 'baseline_clients_daily_v1']

--- a/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
@@ -20,4 +20,4 @@ bigquery:
       - normalized_channel
       - sample_id
 monitoring:
-  enabled: {{% if enable_monitoring %}}true{{% else %}}false{{% endif %}}
+  enabled: {% if enable_monitoring %}true{% else %}false{% endif %}

--- a/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
@@ -20,4 +20,4 @@ bigquery:
       - normalized_channel
       - sample_id
 monitoring:
-  enabled: true
+  enabled: {{% if enable_monitoring %}}true{{% else %}}false{{% endif %}}

--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
@@ -25,4 +25,4 @@ bigquery:
       - normalized_channel
       - sample_id
 monitoring:
-  enabled: {{% if enable_monitoring %}}true{{% else %}}false{{% endif %}}
+  enabled: {% if enable_monitoring %}true{% else %}false{% endif %}

--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
@@ -25,4 +25,4 @@ bigquery:
       - normalized_channel
       - sample_id
 monitoring:
-  enabled: true
+  enabled: {{% if enable_monitoring %}}true{{% else %}}false{{% endif %}}


### PR DESCRIPTION
# feat: exclude some apps from including bigconfig in glean_usage generator

## Description

This is preventing Bigconfig from generated for baseline and metrics tables for some of the apps. This could be because some of them are failing due to not actively populating those pings. For example, because it was added accidentally. Or is no longer used, or the app itself has retired.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7088)
