### PR TITLE
Add new column counting # of events to table

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/backfill.yaml
@@ -1,9 +1,0 @@
-2024-12-18:
-  start_date: 2019-01-01
-  end_date: 2024-12-16
-  reason: https://mozilla-hub.atlassian.net/browse/DENG-6892
-  watchers:
-  - kwindau@mozilla.com
-  status: Complete
-  shredder_mitigation: false
-  override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/query.sql
@@ -55,7 +55,8 @@ SELECT
   COUNTIF(
     event_category = 'intl.ui.browserLanguage'
     AND event_object = 'language_item'
-  ) AS browser_language_language_item_cnt
+  ) AS browser_language_language_item_cnt,
+  COUNT(1) AS nbr_events
 FROM
   `moz-fx-data-shared-prod.telemetry.events`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/schema.yaml
@@ -83,3 +83,7 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Browser Language Language Item Count
+- name: nbr_events
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Events


### PR DESCRIPTION
## Description

This PR adds a new column to the following table:
- moz-fx-data-shared-prod.telemetry_derived.event_aggregates_v1

It also removes the old managed backfill YAML since we will need to redo the backfill again with the new column.

## Related Tickets & Documents
* [DENG-6892](https://mozilla-hub.atlassian.net/browse/DENG-6892)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6892]: https://mozilla-hub.atlassian.net/browse/DENG-6892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7089)
