### PR TITLE
Add missing dataset_metadata.yaml for jira_service_desk_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/jira_service_desk_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk_derived/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Jira Service Desk Derived
+description: |-
+  Jira Service Desk data pulled from Fivetran.
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential


### PR DESCRIPTION
## Description

The `dataset_metadata.yaml` is missing for the `jira_service_desk_derived` dataset. This should unblock artifact deploys.



<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7090)
