### PR TITLE
Skip formatting of Ads table which is passed via python file.

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -227,6 +227,7 @@ format:
   - sql/moz-fx-data-shared-prod/udf_legacy/date_trunc.sql
   - sql/moz-fx-data-shared-prod/udf_legacy/to_iso8601.sql
   - stored_procedures/safe_crc32_uuid.sql
+  - sql/moz-fx-data-shared-prod/ads_derived/kevel_metadata_v2/query_for_kevel_metadata.sql
   skip_qualifying_references:
   - sql/mozfun/**/examples/*.sql
 


### PR DESCRIPTION
## Description
This PR skips formatting a private-bigquery-etl's query file to fix the [incorrect parsing when adding project.dataset to](https://github.com/mozilla/private-bigquery-etl/blob/private-generated-sql/sql/moz-fx-data-shared-prod/ads_derived/kevel_metadata_v2/query_for_kevel_metadata.sql#L29) the table ids.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* [AD-295](https://mozilla-hub.atlassian.net/browse/AD-295)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7093)


[AD-295]: https://mozilla-hub.atlassian.net/browse/AD-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ