### PR TITLE
DENG-7092 Add shredder mitigation and table type to certain ads tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads_derived/nt_visits_to_sessions_conversion_factors_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/nt_visits_to_sessions_conversion_factors_daily_v1/metadata.yaml
@@ -10,6 +10,8 @@ owners:
 labels:
   incremental: true
   schedule: daily
+  shredder_mitigation: true
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_ads
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/adm_engagements_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/adm_engagements_daily_v1/metadata.yaml
@@ -10,6 +10,9 @@ description: |-
     - partner
     - version
     - normalized_channel
+labels:
+  shredder_mitigation: true
+  table_type: aggregate
 owners:
   - akomar@mozilla.com
 bigquery:


### PR DESCRIPTION
## Description

Adds shredder mitigation and `table_type: aggregate` to 2 tables per https://docs.google.com/spreadsheets/d/1L78FtSaNoVowGhNU_-OJruoNFZalqBeo/edit?gid=1929010979#gid=1929010979

## Related Tickets & Documents
* DENG-7092

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7094)
