### PR TITLE
adding write access to ads derived dataset

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
@@ -7,4 +7,4 @@ labels: {}
 workgroup_access:
   - role: roles/bigquery.dataEditor
     members:
-      - workgroup:revenue/writers
+      - workgroup:ads/writers

--- a/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
@@ -4,4 +4,7 @@ description: |-
 dataset_base_acl: derived_restricted
 user_facing: false
 labels: {}
-workgroup_access: []
+workgroup_access:
+  - role: roles/bigquery.dataEditor
+    members:
+      - workgroup:revenue/writers


### PR DESCRIPTION
## Description
This PR adds write access to `ads_derived` dataset to the `ads/writers` workgroup subgroup as added [here](https://github.com/mozilla-it/global-platform-admin/blob/1832540ce4b6b86804322db30bf6b65679667dff/google-workspace-management/tf/workgroups/ads.yaml#L90)
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DSRE-1852

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7096)
