### PR TITLE
Create click event protection aggregate table for Firefox Health Indicator dashboard

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_click_event_protection/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_click_event_protection/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_click_event_protection`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_click_event_protection_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_click_event_protection_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_click_event_protection_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Firefox Health Indicator - Click Event Protection
+description: |-
+  Aggregate table of click events on protections panel; used in Firefox Health Indicator dashboard
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau@mozilla.com
+  shredder_mitigation: true
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_click_event_protection_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_click_event_protection_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  submission_date,
+  COUNTIF(event_method = 'click' AND event_object = 'etp_toggle_off') AS disable_etp_cnt,
+  COUNTIF(event_method = 'click' AND event_object = 'etp_toggle_on') AS enable_etp_cnt,
+  COUNTIF(
+    event_method = 'click'
+    AND event_object = 'sitenotworking_link'
+  ) AS click_site_not_working,
+  COUNTIF(event_method = 'click' AND event_object = 'send_report_link') AS click_report_cnt,
+  COUNTIF(event_method = 'click' AND event_object = 'send_report_submit') AS submit_report_cnt,
+  COUNTIF(event_method = 'open') AS open_panel
+FROM
+  `moz-fx-data-shared-prod.telemetry.events`
+WHERE
+  event_category = 'security.ui.protectionspopup'
+  AND submission_date = @submission_date
+GROUP BY
+  submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_click_event_protection_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_click_event_protection_v1/schema.yaml
@@ -1,0 +1,29 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: disable_etp_cnt
+  type: INTEGER
+  mode: NULLABLE
+  description: Disable ETP Count; i.e. etp_toggle_off clicks
+- name: enable_etp_cnt
+  type: INTEGER
+  mode: NULLABLE
+  description: Enable ETP Count; i.e. etp_toggle_on clicks
+- name: click_site_not_working
+  type: INTEGER
+  mode: NULLABLE
+  description: Clicks on Site Not Working Link
+- name: click_report_cnt
+  type: INTEGER
+  mode: NULLABLE
+  description: Clicks on Send Report Link
+- name: submit_report_cnt
+  type: INTEGER
+  mode: NULLABLE
+  description: Clicks on Send Report Submit
+- name: open_panel
+  type: INTEGER
+  mode: NULLABLE
+  description: Clicks on Open Panel


### PR DESCRIPTION
## Description
This PR creates the following new aggregate table:
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_click_event_protection_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7097)
