### PR TITLE
Add more columns to event aggregate table

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/metadata.yaml
@@ -5,8 +5,9 @@ owners:
 - kwindau@mozilla.com
 labels:
   incremental: true
-  owner1: kwindau@mozilla.com
+  owner1: kwindau
   table_type: aggregate
+  dag: bqetl_event_aggregates
 scheduling:
   dag_name: bqetl_event_aggregates
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/query.sql
@@ -56,7 +56,33 @@ SELECT
     event_category = 'intl.ui.browserLanguage'
     AND event_object = 'language_item'
   ) AS browser_language_language_item_cnt,
-  COUNT(1) AS nbr_events
+  COUNT(1) AS nbr_events,
+  COUNTIF(
+    event_method = 'click'
+    AND event_object = 'etp_toggle_off'
+    AND event_category = 'security.ui.protectionspopup'
+  ) AS disable_etp_cnt,
+  COUNTIF(
+    event_method = 'click'
+    AND event_object = 'etp_toggle_on'
+    AND event_category = 'security.ui.protectionspopup'
+  ) AS enable_etp_cnt,
+  COUNTIF(
+    event_method = 'click'
+    AND event_object = 'sitenotworking_link'
+    AND event_category = 'security.ui.protectionspopup'
+  ) AS click_site_not_working,
+  COUNTIF(
+    event_method = 'click'
+    AND event_object = 'send_report_link'
+    AND event_category = 'security.ui.protectionspopup'
+  ) AS click_report_cnt,
+  COUNTIF(
+    event_method = 'click'
+    AND event_object = 'send_report_submit'
+    AND event_category = 'security.ui.protectionspopup'
+  ) AS submit_report_cnt,
+  COUNTIF(event_method = 'open' AND event_category = 'security.ui.protectionspopup') AS open_panel
 FROM
   `moz-fx-data-shared-prod.telemetry.events`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/schema.yaml
@@ -87,3 +87,27 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Number of Events
+- name: disable_etp_cnt
+  type: INTEGER
+  mode: NULLABLE
+  description: Disable ETP Count; i.e. etp_toggle_off clicks
+- name: enable_etp_cnt
+  type: INTEGER
+  mode: NULLABLE
+  description: Enable ETP Count; i.e. etp_toggle_on clicks
+- name: click_site_not_working
+  type: INTEGER
+  mode: NULLABLE
+  description: Clicks on Site Not Working Link
+- name: click_report_cnt
+  type: INTEGER
+  mode: NULLABLE
+  description: Clicks on Send Report Link
+- name: submit_report_cnt
+  type: INTEGER
+  mode: NULLABLE
+  description: Clicks on Send Report Submit
+- name: open_panel
+  type: INTEGER
+  mode: NULLABLE
+  description: Clicks on Open Panel


### PR DESCRIPTION
## Description
This PR adds more columns to the moz-fx-data-shared-prod.telemetry_derived.event_aggregates_v1, since these are needed for use in the Firefox Health Indicator dashboard.

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7098)
