### PR TITLE
Create new webcompat_v1 aggregate table

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_webcompat/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_webcompat/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_webcompat`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_webcompat_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_webcompat_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_webcompat_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: ETP Disablement by Country and Date
+description: |-
+  Aggregate table of count of unique users setting ETP disablement by day/country; used in Firefox Health Indicator dashboard
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  shredder_mitigation: true
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - country
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_webcompat_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_webcompat_v1/query.sql
@@ -1,0 +1,13 @@
+SELECT
+  submission_date AS submission_date,
+  country,
+  COUNT(DISTINCT client_id) AS nbr_unique_clients_etp_disablement
+FROM
+  `moz-fx-data-shared-prod.telemetry.events`
+WHERE
+  event_category = 'security.ui.protectionspopup'
+  AND submission_date = @submission_date
+  AND event_object = 'etp_toggle_off'
+GROUP BY
+  submission_date,
+  country

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_webcompat_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_webcompat_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Country
+- name: nbr_unique_clients_etp_disablement
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of Unique Clients

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_webcompat_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_webcompat_v1/schema.yaml
@@ -10,4 +10,4 @@ fields:
 - name: nbr_unique_clients_etp_disablement
   type: INTEGER
   mode: NULLABLE
-  description: Count of Unique Clients
+  description: Count of Unique Clients Setting ETP Disablement


### PR DESCRIPTION
## Description
This PR creates the new table:
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_webcompat_v1

Note: This one can't fit into the existing new desktop `events_aggregate_v1` table because it counts unique users by day and country, so it's a different grain; that's why a new table is needed

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ