### PR TITLE
feat: add a new field task_duration_seconds to bigeye_config

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/bigeye_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/bigeye_usage/view.sql
@@ -8,6 +8,11 @@ SELECT
   reference_table_id,
   creation_date,
   task_duration,
+  EXTRACT(HOUR FROM task_duration) * 3600 + EXTRACT(MINUTE FROM task_duration) * 60 + EXTRACT(
+    SECOND
+    FROM
+      task_duration
+  ) AS task_duration_seconds,
   total_terabytes_processed,
   total_terabytes_billed,
   total_slot_ms,


### PR DESCRIPTION
# feat: add a new field task_duration_seconds to bigeye_config

This is to enable usage of this field in a Looker dashboard.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7102)
