### PR TITLE
fix: remove shredder_mitigation lavel from telemetry_derived/addon_aggregates_v2 as this is client_level table

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/addon_aggregates_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/addon_aggregates_v2/metadata.yaml
@@ -10,7 +10,6 @@ labels:
   schedule: daily
   incremental: true
   table_type: client_level
-  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_addons
 bigquery:


### PR DESCRIPTION
# fix: remove shredder_mitigation lavel from telemetry_derived/addon_aggregates_v2 as this is client_level table 

This was set to true by a mistake.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7106)
