### PR TITLE
Create fx_health_ind_bookmarks_by_os_v1, by_os_version, and by country

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_country/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_country/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_bookmarks_by_country`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_bookmarks_by_country_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_os/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_os/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_bookmarks_by_os`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_bookmarks_by_os_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_os_version/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_os_version/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_bookmarks_by_os_version`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_bookmarks_by_os_version_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Firefox Health Indicator - Bookmarks By Country
+description: |-
+  Please provide a description for the query
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_country_code
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/query.sql
@@ -1,0 +1,15 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_country_code,
+  SUM(payload.processes.parent.scalars.browser_engagement_bookmarks_toolbar_bookmark_added) / COUNT(
+    DISTINCT client_id
+  ) AS bookmarks_added_per_dau
+FROM
+  `moz-fx-data-shared-prod.telemetry.main_1pct`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND SUBSTR(application.version, 0, 2) >= '84'
+  AND normalized_channel = 'release'
+GROUP BY
+  submission_date,
+  normalized_country_code

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/query.sql
@@ -3,7 +3,10 @@ SELECT
   normalized_country_code,
   SUM(payload.processes.parent.scalars.browser_engagement_bookmarks_toolbar_bookmark_added) / COUNT(
     DISTINCT client_id
-  ) AS bookmarks_added_per_dau
+  ) AS bookmarks_added_per_dau,
+  SUM(
+    payload.processes.parent.scalars.browser_engagement_bookmarks_toolbar_bookmark_opened
+  ) / COUNT(DISTINCT client_id) AS bookmarks_opened_per_dau
 FROM
   `moz-fx-data-shared-prod.telemetry.main_1pct`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: normalized_country_code
+  type: STRING
+  description: Normalized Country Code
+- name: bookmarks_added_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Added per DAU

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/schema.yaml
@@ -11,3 +11,7 @@ fields:
   type: FLOAT
   mode: NULLABLE
   description: Bookmarks Added per DAU
+- name: bookmarks_opened_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Opened per DAU

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Firefox Health Indicators - Bookmarks By OS by DAU
+description: |-
+  Bookmarks per DAU by PS, for release channel only, app version >= 84
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_os
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/query.sql
@@ -1,0 +1,15 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_os,
+  SUM(payload.processes.parent.scalars.browser_engagement_bookmarks_toolbar_bookmark_added) / COUNT(
+    DISTINCT client_id
+  ) AS bookmarks_added_per_dau
+FROM
+  `moz-fx-data-shared-prod.telemetry.main_1pct`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND SUBSTR(application.version, 0, 2) >= '84'
+  AND normalized_channel = 'release'
+GROUP BY
+  DATE(submission_timestamp),
+  normalized_os

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/query.sql
@@ -3,7 +3,10 @@ SELECT
   normalized_os,
   SUM(payload.processes.parent.scalars.browser_engagement_bookmarks_toolbar_bookmark_added) / COUNT(
     DISTINCT client_id
-  ) AS bookmarks_added_per_dau
+  ) AS bookmarks_added_per_dau,
+  SUM(
+    payload.processes.parent.scalars.browser_engagement_bookmarks_toolbar_bookmark_opened
+  ) / COUNT(DISTINCT client_id) AS bookmarks_opened_per_dau
 FROM
   `moz-fx-data-shared-prod.telemetry.main_1pct`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: normalized_os
+  type: STRING
+  description: Normalized Operating System
+- name: bookmarks_added_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Added per Daily Active User

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/schema.yaml
@@ -11,3 +11,7 @@ fields:
   type: FLOAT
   mode: NULLABLE
   description: Bookmarks Added per Daily Active User
+- name: bookmarks_opened_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Opened per DAU

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Firefox Health Indicator - Bookmarks By Windows OS Version
+description: |-
+  Bookmarks per DAU by PS, for release channel only, OS = Windows, app version >= 84
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_os_version
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/query.sql
@@ -3,7 +3,10 @@ SELECT
   normalized_os_version,
   SUM(payload.processes.parent.scalars.browser_engagement_bookmarks_toolbar_bookmark_added) / COUNT(
     DISTINCT client_id
-  ) AS bookmarks_added_per_dau
+  ) AS bookmarks_added_per_dau,
+  SUM(
+    payload.processes.parent.scalars.browser_engagement_bookmarks_toolbar_bookmark_opened
+  ) / COUNT(DISTINCT client_id) AS bookmarks_opened_per_dau
 FROM
   `moz-fx-data-shared-prod.telemetry.main_1pct`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/query.sql
@@ -1,0 +1,16 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_os_version,
+  SUM(payload.processes.parent.scalars.browser_engagement_bookmarks_toolbar_bookmark_added) / COUNT(
+    DISTINCT client_id
+  ) AS bookmarks_added_per_dau
+FROM
+  `moz-fx-data-shared-prod.telemetry.main_1pct`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND SUBSTR(application.version, 0, 2) >= '84'
+  AND normalized_channel = 'release'
+  AND normalized_os = 'Windows'
+GROUP BY
+  submission_date,
+  normalized_os_version

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/schema.yaml
@@ -11,3 +11,7 @@ fields:
   type: FLOAT
   mode: NULLABLE
   description: Bookmarks Added per DAU
+- name: bookmarks_opened_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Opened per DAU

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: normalized_os_version
+  type: STRING
+  mode: NULLABLE
+  description: Normalized Operating System Version
+- name: bookmarks_added_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Added per DAU


### PR DESCRIPTION
## Description

This PR creates the 3 new tables:
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_bookmarks_by_os_v1
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_bookmarks_by_os_version_v1
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_bookmarks_by_country_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7107)
