### PR TITLE
fix: Update pre-commit dependencies to match `requirements.txt`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
   - id: no-commit-to-branch
     args: [--branch, main, --branch, master]
 - repo: https://github.com/psf/black
-  rev: 24.8.0
+  rev: 24.10.0
   hooks:
   - id: black
 - repo: https://github.com/PyCQA/flake8
-  rev: 7.0.0
+  rev: 4.0.1
   hooks:
   - id: flake8
     exclude: dags/
@@ -20,7 +20,7 @@ repos:
   - id: yamllint
     args: [-c, .yamllint.yaml, .]
 - repo: https://github.com/PyCQA/isort
-  rev: 5.13.2
+  rev: 5.12.0
   hooks:
   - id: isort
 # This pre-commit hook has been archived on Nov 2023
@@ -35,9 +35,9 @@ repos:
   hooks:
   - id: mypy
     exclude: sql/.+/.+/.+/query\.py$
-    additional_dependencies: [types-pytz==2024.2.0.20240913,
+    additional_dependencies: [types-pytz==2024.2.0.20241003,
                               types-ujson==5.10.0.20240515,
-                              types-python-dateutil==2.9.0.20240906,
-                              types-requests==2.32.0.20240914,
+                              types-python-dateutil==2.9.0.20241206,
+                              types-requests==2.32.0.20241016,
                               types-attrs==19.1.0,
                               types-PyYAML==6.0.12.20240917]


### PR DESCRIPTION
## Description
Dependabot updates `requirements.txt`, so we periodically need to update the pre-commit dependencies to match.

Also, in #5195 the `flake8` and `isort` pre-commit dependencies were upgraded beyond what's in `requirements.txt`, so this downgrades those back to match `requirements.txt`.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/5195

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
