### PR TITLE
Add 2 new columns to event_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/query.sql
@@ -82,7 +82,9 @@ SELECT
     AND event_object = 'send_report_submit'
     AND event_category = 'security.ui.protectionspopup'
   ) AS submit_report_cnt,
-  COUNTIF(event_method = 'open' AND event_category = 'security.ui.protectionspopup') AS open_panel
+  COUNTIF(event_method = 'open' AND event_category = 'security.ui.protectionspopup') AS open_panel,
+  COUNT(CLIENT_ID) AS nbr_non_null_client_ids,
+  COUNT(DISTINCT(CLIENT_ID)) AS nbr_distinct_client_ids
 FROM
   `moz-fx-data-shared-prod.telemetry.events`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_aggregates_v1/schema.yaml
@@ -111,3 +111,11 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Clicks on Open Panel
+- name: nbr_non_null_client_ids
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of Non-Null Client IDs
+- name: nbr_distinct_client_ids
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of Distinct Client IDs


### PR DESCRIPTION
## Description

This PR adds 2 new columns to the table:
- moz-fx-data-shared-prod.telemetry_derived.event_aggregates_v1

## Related Tickets & Documents
* [DENG-6892](https://mozilla-hub.atlassian.net/browse/DENG-6892)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6892]: https://mozilla-hub.atlassian.net/browse/DENG-6892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7112)
