### PR TITLE
Add shredder mitigation

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_installs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_installs_v1/metadata.yaml
@@ -6,6 +6,8 @@ owners:
 labels:
   incremental: true
   owner1: example
+  table_type: aggregate
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_desktop_installs_v1
 bigquery:

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/metadata.yaml
@@ -12,6 +12,8 @@ owners:
 labels:
   incremental: true
   owner1: kwindau@mozilla.com
+  table_type: aggregate
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_fivetran_google_ads
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_nondesktop_day_2_7_activation_v1/metadata.yaml
@@ -10,6 +10,8 @@ labels:
   application: nondesktop
   incremental: true
   schedule: daily
+  table_type: aggregate
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_nondesktop
   email: ['jklukas@mozilla.com']

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/segmented_dau_28_day_rolling_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/segmented_dau_28_day_rolling_v1/metadata.yaml
@@ -6,6 +6,8 @@ owners:
 labels:
   incremental: true
   owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_dynamic_dau
 bigquery:


### PR DESCRIPTION
## Description

This PR adds shredder mitigation & an aggregate table label to: 
- moz-fx-data-shared-prod.telemetry_derived.segmented_dau_28_day_rolling_v1
- moz-fx-data-shared-prod.firefox_desktop_derived.desktop_installs_v1
- moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1
- moz-fx-data-shared-prod.telemetry_derived.firefox_nondesktop_day_2_7_activation_v1


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7117)
