### PR TITLE
Create new aggregate table fx_health_ind_page_reloads_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_page_reloads/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_page_reloads/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_page_reloads`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_page_reloads_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_page_reloads_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_page_reloads_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Firefox Health Indicator - Page Reloads by Country
+description: |-
+  Aggregate table used in Firefox Health Indicator dashboard, calculates number of users doing page reloads per country per day
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_country_code
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_page_reloads_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_page_reloads_v1/query.sql
@@ -1,0 +1,15 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_country_code,
+  count(DISTINCT client_id) AS nbr_distinct_clients
+FROM
+  `moz-fx-data-shared-prod.telemetry.main`
+CROSS JOIN
+  UNNEST(payload.processes.parent.keyed_scalars.browser_ui_interaction_nav_bar) AS a
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND a.key LIKE('%reload%')
+  AND normalized_channel = 'release'
+GROUP BY
+  DATE(submission_timestamp),
+  normalized_country_code

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_page_reloads_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_page_reloads_v1/query.sql
@@ -1,7 +1,7 @@
 SELECT
   DATE(submission_timestamp) AS submission_date,
   normalized_country_code,
-  count(DISTINCT client_id) AS nbr_distinct_clients
+  COUNT(DISTINCT client_id) AS nbr_distinct_clients
 FROM
   `moz-fx-data-shared-prod.telemetry.main`
 CROSS JOIN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_page_reloads_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_page_reloads_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: normalized_country_code
+  type: STRING
+  description: Normalized Country Code
+- mode: NULLABLE
+  name: nbr_distinct_clients
+  type: INTEGER
+  description: Count of Distinct Clients


### PR DESCRIPTION
## Description

This PR creates a new aggregate table for the Firefox Health Indicator dashboard
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_page_reloads_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7119)
