### PR TITLE
Create new aggregate table for Firefox Health indicator dashboard

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_ratios_smooth/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_ratios_smooth/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_ratios_smooth`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_ratios_smooth_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_ratios_smooth_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_ratios_smooth_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Firefox Health Indicator Dashboard - Ratios Smooth
 description: |-
-  Calculates share of Firefox clients with Firefox set as default over time based on a 1% sample for Windows OS 10, release channel only; used in Firefox Health Indicator dashboard
+  Calculates % of clients with Firefox set as default based on a 1% sample for Windows OS 10, release channel only; used in Firefox Health Indicator dashboard
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_ratios_smooth_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_ratios_smooth_v1/metadata.yaml
@@ -1,0 +1,18 @@
+friendly_name: Firefox Health Indicator Dashboard - Ratios Smooth
+description: |-
+  Calculates share of Firefox clients with Firefox set as default over time based on a 1% sample for Windows OS 10, release channel only; used in Firefox Health Indicator dashboard
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_ratios_smooth_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_ratios_smooth_v1/query.sql
@@ -1,0 +1,25 @@
+SELECT
+  submission_date,
+  COUNTIF(is_default_browser) total_default,
+  COUNTIF(is_default_browser AND days_since_first_seen < 28) default_new,
+  COUNTIF(is_default_browser AND days_since_first_seen >= 28) default_old,
+  COUNT(*) dau,
+  SAFE_DIVIDE(
+    COUNTIF(is_default_browser AND days_since_first_seen < 28),
+    COUNTIF(days_since_first_seen < 28)
+  ) share_new_default,
+  SAFE_DIVIDE(
+    COUNTIF(is_default_browser AND days_since_first_seen >= 28),
+    COUNTIF(days_since_first_seen >= 28)
+  ) share_old_default
+FROM
+  `moz-fx-data-shared-prod.telemetry.clients_last_seen`
+WHERE
+  sample_id = 53
+  AND days_since_seen = 0
+  AND submission_date = @submission_date
+  AND LEFT(normalized_os_version, 2) = '10'
+  AND os LIKE '%Win%'
+  AND normalized_channel = 'release'
+GROUP BY
+  submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_ratios_smooth_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_ratios_smooth_v1/schema.yaml
@@ -1,0 +1,29 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: total_default
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Windows 10 clients with Firefox as default browser with days since seen = 0
+- name: default_new
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Windows 10 clients with Firefox as default browswer with days since seen = 0 and first seen < 28 days ago
+- name: default_old
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Windows 10 clients with Firefox as default browser with days since seen = 0 and first seen >= 28 days ago
+- name: dau
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Windows 10 clients with days since seen = 0
+- name: share_new_default
+  type: FLOAT
+  mode: NULLABLE
+  description: Percent of Windows 10 clients with a first seen date < 28 days ago with Firefox as default
+- name: share_old_default
+  type: FLOAT
+  mode: NULLABLE
+  description: Percent of Windows 10 clients with a first seen date >= 28 days ago with Firefox as default browser


### PR DESCRIPTION
## Description

This PR creates the following new aggregate table for use in the Firefox Health Indicator dashboard: 
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_ratios_smooth_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7138)
