### PR TITLE
Remove default schedule for Bigeye metrics (except freshness and volume)

### DIFF
--- a/sql/bigconfig.yml
+++ b/sql/bigconfig.yml
@@ -8,9 +8,9 @@ saved_metric_definitions:
       threshold:
         type: CONSTANT
         upper_bound: 0
-      metric_schedule:
-        named_schedule:
-          name: default
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
       lookback:
         lookback_type: DATA_TIME
         lookback_window:
@@ -24,9 +24,9 @@ saved_metric_definitions:
       threshold:
         type: CONSTANT
         upper_bound: 0
-      metric_schedule:
-        named_schedule:
-          name: default
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
       rct_overrides:
         - submission_date
     - saved_metric_id: freshness_fail
@@ -71,9 +71,9 @@ saved_metric_definitions:
         type: CONSTANT
         lower_bound: 1
         upper_bound: 1
-      metric_schedule:
-        named_schedule:
-          name: default
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
       lookback:
         lookback_type: DATA_TIME
         lookback_window:
@@ -88,9 +88,9 @@ saved_metric_definitions:
         type: CONSTANT
         lower_bound: 2
         upper_bound: 2
-      metric_schedule:
-        named_schedule:
-          name: default
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
       lookback:
         lookback_type: DATA_TIME
         lookback_window:
@@ -105,9 +105,9 @@ saved_metric_definitions:
         type: CONSTANT
         lower_bound: 1
         upper_bound: 1
-      metric_schedule:
-        named_schedule:
-          name: default
+      schedule_frequency:
+        interval_type: MINUTES
+        interval_value: 0
       lookback:
         lookback_type: DATA_TIME
         lookback_window:


### PR DESCRIPTION
This removes schedules for Bigeye metrics that are already being triggered via Airflow runs. This should save some money as we no longer run them twice.

Previously, there was a bug which caused the Bigeye deploy to stall, however Bigeye fixed this on their side: https://portal.usepylon.com/bigeye?durationMs=31536000000&tab=issues&conversationID=c1ba0bd5-8929-4faf-bf28-8a530625a584 

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7140)
