### PR TITLE
Create new antivirus aggregate table for Firefox Health Indicator dashboard

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_antivirus/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_antivirus/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.fx_health_ind_antivirus`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_antivirus_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Firefox Health Indicator - Antivirus Trends
+description: |-
+  Aggregate table based on 1% user sample showing antivirus software usage on Windows
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - antivirus_name
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/metadata.yaml
@@ -17,7 +17,4 @@ bigquery:
     require_partition_filter: false
     expiration_days: null
   range_partitioning: null
-  clustering:
-    fields:
-    - antivirus_name
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/query.sql
@@ -1,7 +1,7 @@
 SELECT
   DATE(submission_timestamp) AS submission_date,
-  environment.system.sec.antivirus AS antivirus_name,
-  COUNT(DISTINCT client_id) AS dau
+  environment.system.sec.antivirus,
+  COUNT(DISTINCT client_id) AS unique_clients
 FROM
   `moz-fx-data-shared-prod.telemetry.main_1pct`
 WHERE
@@ -9,4 +9,4 @@ WHERE
   AND DATE(submission_timestamp) = @submission_date
 GROUP BY
   submission_date,
-  antivirus_name
+  environment.system.sec.antivirus

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  environment.system.sec.antivirus AS antivirus_name,
+  COUNT(DISTINCT client_id) AS dau
+FROM
+  `moz-fx-data-shared-prod.telemetry.main_1pct`
+WHERE
+  normalized_os = 'Windows'
+  AND DATE(submission_timestamp) = @submission_date
+GROUP BY
+  submission_date,
+  antivirus_name

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: antivirus_name
+  type: STRING
+  mode: REPEATED
+  description: Antivirus Software Array - Array of Antivirus Software Installed on Client
+- name: dau
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Unique Clients

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/schema.yaml
@@ -3,11 +3,11 @@ fields:
   name: submission_date
   type: DATE
   description: Submission Date
-- name: antivirus_name
+- name: antivirus
   type: STRING
   mode: REPEATED
   description: Antivirus Software Array - Array of Antivirus Software Installed on Client
-- name: dau
+- name: unique_clients
   type: INTEGER
   mode: NULLABLE
   description: Number of Unique Clients


### PR DESCRIPTION
## Description
This PR creates the new aggregate table for the Firefox Health Indicator dashboard: 
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_antivirus_v1

## Related Tickets & Documents
* [DENG-7021](https://mozilla-hub.atlassian.net/browse/DENG-7021)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7021]: https://mozilla-hub.atlassian.net/browse/DENG-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7143)
