### PR TITLE
fix: normalized_app_name_os definition in mobile_search_clients_engines_sources_daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/search/mobile_search_clients_engines_sources_daily/view.sql
+++ b/sql/moz-fx-data-shared-prod/search/mobile_search_clients_engines_sources_daily/view.sql
@@ -42,7 +42,7 @@ SELECT
   `mozfun.mobile_search.normalize_app_name`(
     app_name,
     os
-  ).normalized_app_name AS normalized_app_name_os
+  ).normalized_app_name_os AS normalized_app_name_os
 FROM
   `moz-fx-data-shared-prod.search_derived.mobile_search_clients_daily_historical_pre202408`
 WHERE
@@ -113,7 +113,7 @@ SELECT
   `mozfun.mobile_search.normalize_app_name`(
     app_name,
     os
-  ).normalized_app_name AS normalized_app_name_os
+  ).normalized_app_name_os AS normalized_app_name_os
 FROM
   `moz-fx-data-shared-prod.search_derived.mobile_search_clients_daily_v2`
 WHERE


### PR DESCRIPTION
## Description

This PR fixes the `normalized_app_name_os` column in the `mobile_search_clients_engines_sources_daily` view definition by getting `normalized_app_name_os` instead of `normalized_app_name`. Currently, both `normalized_app_name` and `normalized_app_name_os` columns in the view are the same.

## Related Tickets & Documents
Preventing `search_count` results for experiment analysis in iOS experiments (example: https://experimenter.services.mozilla.com/nimbus/ios-optimize-onboarding-card-order/results) because none of the records in this view have `normalized_app_name_os` populated with `"Firefox iOS"` as expected.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7146)
