### PR TITLE
pocket_usage table fix - removing the order by clause

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/query.sql
@@ -44,7 +44,3 @@ LEFT JOIN
   pocket_activity AS b
   ON submission_date = events_submission_date
   AND channel = events_channel
-ORDER BY
-  1,
-  2,
-  3


### PR DESCRIPTION
## Description

Fix for pocket_usage_v1 table. Removing the order by clause

## Related Tickets & Documents
* DENG-7061

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7151)
