### PR TITLE
DENG-6883 - build share of user cancelled installs aggregate table

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/user_cancelled_install_share/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/user_cancelled_install_share/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.user_cancelled_install_share`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.user_cancelled_install_share_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/user_cancelled_install_share_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/user_cancelled_install_share_v1/metadata.yaml
@@ -1,0 +1,24 @@
+friendly_name: User Cancelled Install Share
+description: |-
+  Share of attempted installs cancelled by user and or failed w/ timeout by installer type and channel
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - installer_type
+    - update_channel
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/user_cancelled_install_share_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/user_cancelled_install_share_v1/query.sql
@@ -4,7 +4,7 @@ SELECT
   update_channel,
   COUNT(1) AS nbr_install_attempts,
   ROUND(AVG(IF(User_cancelled = TRUE, 1, 0)) * 100, 1) AS user_cancelled,
-  ROUND(AVG(IF(Install_timeout = TRUE, 1, 0)) * 100, 1) AS timeout,
+  ROUND(AVG(IF(Install_timeout = TRUE, 1, 0)) * 100, 1) AS `timeout`,
 FROM
   `moz-fx-data-shared-prod.firefox_installer.install`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/user_cancelled_install_share_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/user_cancelled_install_share_v1/query.sql
@@ -1,0 +1,15 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  installer_type,
+  update_channel,
+  COUNT(1) AS nbr_install_attempts,
+  ROUND(AVG(IF(User_cancelled = TRUE, 1, 0)) * 100, 1) AS user_cancelled,
+  ROUND(AVG(IF(Install_timeout = TRUE, 1, 0)) * 100, 1) AS timeout,
+FROM
+  `moz-fx-data-shared-prod.firefox_installer.install`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+GROUP BY
+  DATE(submission_timestamp),
+  installer_type,
+  update_channel

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/user_cancelled_install_share_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/user_cancelled_install_share_v1/schema.yaml
@@ -1,0 +1,25 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: installer_type
+  type: STRING
+  mode: NULLABLE
+  description: Installer Type - Stub or Full
+- name: update_channel
+  type: STRING
+  mode: NULLABLE
+  description: The channel - for example, release, esr, beta, nightly, etc
+- name: nbr_install_attempts
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of install attempts
+- name: user_cancelled
+  type: FLOAT
+  mode: NULLABLE
+  description: Number of install attempts cancelled by the user
+- name: timeout
+  type: FLOAT
+  mode: NULLABLE
+  description: Number of install attempts failing due to timeout


### PR DESCRIPTION
## Description

This PR creates the new aggregate table: 
- moz-fx-data-shared-prod.telemetry_derived.user_cancelled_install_share_v1 

## Related Tickets & Documents
* DENG-6883 (https://mozilla-hub.atlassian.net/browse/DENG-6883)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7157)
