### PR TITLE
DENG-6883: Create new aggregate table for uninstalls by country

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_channel_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_channel_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_by_channel_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_channel_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_country_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_country_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_by_country_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_country_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_os_ver_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_os_ver_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_by_os_ver_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_os_ver_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_channel_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_channel_aggregates_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls By Channel Aggregates
+description: |-
+  Aggregate table calculating uninstalls by channel and submission date
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - channel
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_channel_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_channel_aggregates_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  application.channel AS channel,
+  COUNT(DISTINCT client_id) AS nbr_unique_clients_uninstalling
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  channel

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_channel_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_channel_aggregates_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: channel
+  type: STRING
+  mode: NULLABLE
+  description: Channel
+- name: nbr_unique_clients_uninstalling
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Unique Clients Uninstalling Firefox

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls By Country Aggregates
+description: |-
+  Calculates uninstalls by country and submission date
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_country_code
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kwindau
   table_type: aggregate
   shredder_mitigation: true
+  dag: bqetl_fx_health_ind_dashboard
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/query.sql
@@ -1,0 +1,13 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_country_code,
+  COUNT(DISTINCT client_id) AS nbr_unique_fx_release_channel_clients_with_uninstalls
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+  AND application.channel = 'release'
+GROUP BY
+  submission_date,
+  normalized_country_code

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/query.sql
@@ -1,7 +1,8 @@
 SELECT
   DATE(submission_timestamp) AS submission_date,
   normalized_country_code,
-  COUNT(DISTINCT client_id) AS nbr_unique_fx_release_channel_clients_with_uninstalls
+  COUNT(DISTINCT client_id) AS nbr_unique_fx_release_channel_clients_with_uninstalls,
+  AVG(environment.profile.creation_date) AS avg_profile_creation_date
 FROM
   `moz-fx-data-shared-prod.telemetry.uninstall`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/schema.yaml
@@ -11,3 +11,7 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Count of unique client IDs with uninstalls for Firefox release channel
+- name: avg_profile_creation_date
+  type: FLOAT
+  mode: NULLABLE
+  description: The average profile creation date for those uninstalling, expressed numerically

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: normalized_country_code
+  type: STRING
+  mode: NULLABLE
+  description: Normalized Country Code
+- name: nbr_unique_fx_release_channel_clients_with_uninstalls
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique client IDs with uninstalls for Firefox release channel

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_ver_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_ver_aggregates_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls By OS Version
+description: |-
+  Aggregate table with uninstalls by normalized OS version and date
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_os_version
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_ver_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_ver_aggregates_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_os_version,
+  COUNT(DISTINCT client_id) AS nbr_unique_clients_uninstalling
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  normalized_os_version

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_ver_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_ver_aggregates_v1/schema.yaml
@@ -1,0 +1,11 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: normalized_os_version
+  type: STRING
+  mode: NULLABLE
+- name: nbr_unique_clients_uninstalling
+  type: INTEGER
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_ver_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_ver_aggregates_v1/schema.yaml
@@ -6,6 +6,8 @@ fields:
 - name: normalized_os_version
   type: STRING
   mode: NULLABLE
+  description: Normalized OS Version
 - name: nbr_unique_clients_uninstalling
   type: INTEGER
   mode: NULLABLE
+  description: Number of Unique Clients Uninstalling


### PR DESCRIPTION
## Description

This PR creates the following new aggregate tables: 
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_country_aggregates_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_channel_aggregates_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_os_ver_aggregates_v1

## Related Tickets & Documents
* [DENG-6883](https://mozilla-hub.atlassian.net/browse/DENG-6883)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6883]: https://mozilla-hub.atlassian.net/browse/DENG-6883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7159)
