### PR TITLE
Exclude files from bigquery_etl project_dirs listing

### DIFF
--- a/bigquery_etl/util/common.py
+++ b/bigquery_etl/util/common.py
@@ -56,7 +56,10 @@ def project_dirs(project_id=None, sql_dir=None) -> List[str]:
         sql_dir = ConfigLoader.get("default", "sql_dir", fallback="sql")
     if project_id is None:
         return [
-            os.path.join(sql_dir, project_dir) for project_dir in os.listdir(sql_dir)
+            os.path.join(sql_dir, project_dir)
+            for project_dir in os.listdir(sql_dir)
+            # sql/ can contain files like bigconfig.yml
+            if os.path.isdir(os.path.join(sql_dir, project_dir))
         ]
     else:
         return [os.path.join(sql_dir, project_id)]

--- a/tests/util/test_common.py
+++ b/tests/util/test_common.py
@@ -23,6 +23,7 @@ class TestUtilCommon:
 
         existing_projects = project_dirs()
         assert "sql/moz-fx-data-shared-prod" in existing_projects
+        assert "sql/bigconfig.yml" not in existing_projects
 
     def test_metrics_render(self, tmp_path):
         file_path = tmp_path / "test_query.sql"


### PR DESCRIPTION
## Description

`bigconfig.yml` is causing a non-fatal error in dag generation ([example](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/43407/workflows/1f33549d-cc8b-4009-89cb-4a64329969f6/jobs/501846?invite=true#step-108-6354_11)) because it's being returned by the `project_dirs` function

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7160)
