### PR TITLE
DENG-6884 Create new aggregate table install_vs_uninstall_ratio

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/install_vs_uninstall_ratio/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/install_vs_uninstall_ratio/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.install_vs_uninstall_ratio`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.install_vs_uninstall_ratio_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_ratio_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_ratio_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Install Vs Uninstall Ratio
+description: |-
+  Calculates ratio of installs v uninstalls; query provided by rtestard
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_ratio_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_ratio_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Install Vs Uninstall Ratio
 description: |-
-  Calculates ratio of installs v uninstalls; query provided by rtestard
+  Calculates ratio of installs v uninstalls
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_ratio_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_ratio_v1/query.sql
@@ -21,28 +21,6 @@ uninstalls AS (
     DATE(submission_timestamp) = @submission_date
     AND application.name = 'Firefox'
     AND application.channel = 'release'
-    AND normalized_country_code IN (
-      'BR',
-      'ID',
-      'DE',
-      'US',
-      'IN',
-      'FR',
-      'PL',
-      'ES',
-      'CN',
-      'IT',
-      'MX',
-      'GB',
-      'TR',
-      'JP',
-      'CO',
-      'RU',
-      'CA',
-      'TH',
-      'EG',
-      'AU'
-    )
   GROUP BY
     DATE(submission_timestamp)
 )

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_ratio_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_ratio_v1/query.sql
@@ -1,0 +1,61 @@
+WITH installs AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    COUNT(1) AS release_channel_stub_installs_count
+  FROM
+    `moz-fx-data-shared-prod.firefox_installer.install`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND update_channel = 'release'
+    AND installer_type = 'stub'
+  GROUP BY
+    DATE(submission_timestamp)
+),
+uninstalls AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    COUNT(DISTINCT client_id) AS uninstalls_count,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.uninstall`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND application.name = 'Firefox'
+    AND application.channel = 'release'
+    AND normalized_country_code IN (
+      'BR',
+      'ID',
+      'DE',
+      'US',
+      'IN',
+      'FR',
+      'PL',
+      'ES',
+      'CN',
+      'IT',
+      'MX',
+      'GB',
+      'TR',
+      'JP',
+      'CO',
+      'RU',
+      'CA',
+      'TH',
+      'EG',
+      'AU'
+    )
+  GROUP BY
+    DATE(submission_timestamp)
+)
+SELECT
+  COALESCE(i.submission_date, u.submission_date) AS submission_date,
+  i.release_channel_stub_installs_count,
+  u.uninstalls_count,
+  SAFE_DIVIDE(
+    u.uninstalls_count,
+    i.release_channel_stub_installs_count
+  ) AS uninstall_to_install_ratio
+FROM
+  installs i
+FULL OUTER JOIN
+  uninstalls u
+  ON i.submission_date = u.submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_ratio_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_ratio_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: release_channel_stub_installs_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of release channel stub installs
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of release channel uninstalls for a specific set of countries
+- name: uninstall_to_install_ratio
+  type: FLOAT
+  mode: NULLABLE
+  description: Ratio resulting from dividing uninstalls_count by release_channel_stub_installs_count


### PR DESCRIPTION
## Description

This PR creates the following new aggregate table: 
- moz-fx-data-shared-prod.telemetry_derived.install_vs_uninstall_ratio_v1

## Related Tickets & Documents
* [DENG-6883](https://mozilla-hub.atlassian.net/browse/DENG-6883)
* [DENG-6884](https://mozilla-hub.atlassian.net/browse/DENG-6884)



**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6883]: https://mozilla-hub.atlassian.net/browse/DENG-6883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-6884]: https://mozilla-hub.atlassian.net/browse/DENG-6884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7161)
