### PR TITLE
[DENG-7019] Create glean event count table

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/event_counts_glean/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/event_counts_glean/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Event Counts Glean
+description: |-
+  Daily event counts for all Glean apps, derived from monitoring_derived.event_monitoring_aggregates_v1
+owners:
+- bewu@mozilla.com

--- a/sql/moz-fx-data-shared-prod/monitoring/event_counts_glean/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/event_counts_glean/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.monitoring.event_counts_glean`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.monitoring_derived.event_counts_glean_v1`

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/metadata.yaml
@@ -1,0 +1,19 @@
+friendly_name: Event Counts Glean
+description: |-
+  Daily event counts for all Glean apps, derived from monitoring_derived.event_monitoring_aggregates_v1
+owners:
+- bewu@mozilla.com
+labels:
+  incremental: true
+  owner1: benwu
+scheduling:
+  dag_name: bqetl_monitoring
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  clustering:
+    fields:
+    - normalized_app_name

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/query.sql
@@ -1,0 +1,61 @@
+WITH event_counts_per_app_channel AS (
+  SELECT
+    submission_date,
+    event_category,
+    event_name,
+    event_extra_key,
+    normalized_app_name,
+    channel,
+    country,
+    version,
+    SUM(total_events) AS total_events,
+  FROM
+    `moz-fx-data-shared-prod.monitoring_derived.event_monitoring_aggregates_v1`
+  WHERE
+    submission_date = @submission_date
+    AND experiment = "*"
+    AND experiment_branch = "*"
+  GROUP BY
+    submission_date,
+    event_category,
+    event_name,
+    event_extra_key,
+    normalized_app_name,
+    channel,
+    country,
+    version
+  QUALIFY
+    -- Get total events by summing events with extras and events with no extras
+    FIRST_VALUE(event_extra_key IGNORE NULLS) OVER (
+      PARTITION BY
+        submission_date,
+        event_category,
+        event_name,
+        normalized_app_name,
+        channel,
+        country,
+        version
+      ORDER BY
+        total_events DESC
+    ) = event_extra_key
+    OR event_extra_key IS NULL
+)
+SELECT
+  submission_date,
+  event_category,
+  event_name,
+  normalized_app_name,
+  channel,
+  country,
+  version,
+  SUM(total_events) AS total_events,
+FROM
+  event_counts_per_app_channel
+GROUP BY
+  submission_date,
+  event_category,
+  event_name,
+  normalized_app_name,
+  channel,
+  country,
+  version

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/schema.yaml
@@ -1,0 +1,27 @@
+fields:
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+- name: event_category
+  type: STRING
+  mode: NULLABLE
+- name: event_name
+  type: STRING
+  mode: NULLABLE
+- name: normalized_app_name
+  type: STRING
+  mode: NULLABLE
+  description: Friendly app name defined in probe scraper, e.g. "Firefox for Desktop"
+- name: channel
+  type: STRING
+  mode: NULLABLE
+- name: country
+  type: STRING
+  mode: NULLABLE
+- name: version
+  type: STRING
+  mode: NULLABLE
+- name: total_events
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of events with the current dimension set

--- a/tests/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/test_aggregation/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/test_aggregation/expect.yaml
@@ -1,0 +1,36 @@
+# release desktop, opened event
+- submission_date: 2025-01-01
+  event_category: action
+  event_name: opened
+  country: US
+  normalized_app_name: Firefox for Desktop
+  channel: release
+  version: 130.0.0
+  total_events: 15
+# beta desktop, opened event
+- submission_date: 2025-01-01
+  event_category: action
+  event_name: opened
+  country: US
+  normalized_app_name: Firefox for Desktop
+  channel: beta
+  version: 130.0.0
+  total_events: 14
+# release desktop, closed event
+- submission_date: 2025-01-01
+  event_category: action
+  event_name: closed
+  country: US
+  normalized_app_name: Firefox for Desktop
+  channel: release
+  version: 130.0.0
+  total_events: 2
+# release android, opened event
+- submission_date: 2025-01-01
+  event_category: action
+  event_name: opened
+  country: US
+  normalized_app_name: Firefox for Android
+  channel: release
+  version: 130.0.0
+  total_events: 12

--- a/tests/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/test_aggregation/moz-fx-data-shared-prod.monitoring_derived.event_monitoring_aggregates_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/test_aggregation/moz-fx-data-shared-prod.monitoring_derived.event_monitoring_aggregates_v1.yaml
@@ -1,0 +1,45 @@
+- &base
+  submission_date: 2025-01-01
+  window_start: 2025-01-01 00:00:00 UTC
+  window_end: 2025-01-01 00:00:00 UTC
+  event_category: action
+  event_name: opened
+  event_extra_key: null
+  country: US
+  normalized_app_name: Firefox for Desktop
+  channel: release
+  version: 130.0.0
+  experiment: '*'
+  experiment_branch: '*'
+  total_events: 10
+# highest count non-null event extra
+- <<: *base
+  event_extra_key: abc
+  total_events: 5
+# lower count non-null event extra, should be ignored
+- <<: *base
+  event_extra_key: def
+  total_events: 4
+# specific experiment, should be ignored
+- <<: *base
+  experiment: exp
+  experiment_branch: a
+  total_events: 10
+# different channel, non-null extra
+- <<: *base
+  channel: beta
+  event_extra_key: abc
+  total_events: 8
+# different channel, null extra
+- <<: *base
+  channel: beta
+  event_extra_key: abc
+  total_events: 6
+# different event
+- <<: *base
+  event_name: closed
+  total_events: 2
+# different app
+- <<: *base
+  normalized_app_name: Firefox for Android
+  total_events: 12

--- a/tests/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/test_aggregation/query_params.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/test_aggregation/query_params.yaml
@@ -1,0 +1,3 @@
+- name: submission_date
+  type: DATE
+  value: 2025-01-01


### PR DESCRIPTION
## Description

Monitoring table with event counts for glean apps.  Based on `monitoring_derived.event_monitoring_aggregates_v1` because it's a lot cheaper and simpler than using events stream.

## Related Tickets & Documents
* DENG-7019

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7163)
