### PR TITLE
Update campaign stats bigconfigs with `bqetl monitoring update sql`

### DIFF
--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/bigconfig.yml
@@ -1,62 +1,61 @@
 type: BIGCONFIG_FILE
-
 tag_deployments:
-  - collection:
-      name: Operational Checks
-      notification_channels:
-        - slack: '#de-bigeye-triage'
-    deployments:
-      - column_selectors:
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.date
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.campaign
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.campaign_id
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.ad_group_name
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.ad_group_id
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.impressions
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.clicks
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.downloads
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.new_profiles
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.activated_profiles
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.repeat_users
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.week_4_retained_users
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.spend
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.lifetime_value
-        metrics:
-          - saved_metric_id: is_not_null
-            lookback:
-              lookback_type: DATA_TIME
-              lookback_window:
-                interval_type: DAYS
-                interval_value: 28
-            rct_overrides:
-              - date
-      - column_selectors:
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.campaign_country_code
-        metrics:
-          - saved_metric_id: is_2_char_len
-            lookback:
-              lookback_type: DATA_TIME
-              lookback_window:
-                interval_type: DAYS
-                interval_value: 28
-            rct_overrides:
-              - date
-      - column_selectors:
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.*
-        metrics:
-          - saved_metric_id: volume
-            lookback:
-              lookback_type: DATA_TIME
-              lookback_window:
-                interval_type: DAYS
-                interval_value: 28
-            rct_overrides:
-              - date
-          - saved_metric_id: freshness
-            lookback:
-              lookback_type: DATA_TIME
-              lookback_window:
-                interval_type: DAYS
-                interval_value: 28
-            rct_overrides:
-              - date
+- collection:
+    name: Operational Checks
+    notification_channels:
+    - slack: '#de-bigeye-triage'
+  deployments:
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.date
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.campaign
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.campaign_id
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.ad_group_name
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.ad_group_id
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.impressions
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.clicks
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.downloads
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.new_profiles
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.activated_profiles
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.repeat_users
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.week_4_retained_users
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.spend
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.lifetime_value
+    metrics:
+    - saved_metric_id: is_not_null
+      lookback:
+        lookback_window:
+          interval_type: DAYS
+          interval_value: 28
+        lookback_type: DATA_TIME
+      rct_overrides:
+      - date
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.campaign_country_code
+    metrics:
+    - saved_metric_id: is_2_char_len
+      lookback:
+        lookback_window:
+          interval_type: DAYS
+          interval_value: 28
+        lookback_type: DATA_TIME
+      rct_overrides:
+      - date
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1.*
+    metrics:
+    - saved_metric_id: volume
+      lookback:
+        lookback_window:
+          interval_type: DAYS
+          interval_value: 28
+        lookback_type: DATA_TIME
+      rct_overrides:
+      - date
+    - saved_metric_id: freshness
+      lookback:
+        lookback_window:
+          interval_type: DAYS
+          interval_value: 28
+        lookback_type: DATA_TIME
+      rct_overrides:
+      - date

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/bigconfig.yml
@@ -1,61 +1,60 @@
 type: BIGCONFIG_FILE
-
 tag_deployments:
-  - collection:
-      name: Operational Checks
-      notification_channels:
-        - slack: '#de-bigeye-triage'
-    deployments:
-      - column_selectors:
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.date
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.campaign_region
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.campaign_country_code
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.campaign_language
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.ad_group
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.impressions
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.clicks
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.new_profiles
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.activated_profiles
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.repeat_users
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.week_4_retained_users
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.spend
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.lifetime_value
-        metrics:
-          - saved_metric_id: is_not_null
-            lookback:
-              lookback_type: DATA_TIME
-              lookback_window:
-                interval_type: DAYS
-                interval_value: 28
-            rct_overrides:
-              - date
-      - column_selectors:
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.campaign_country_code
-        metrics:
-          - saved_metric_id: is_2_char_len
-            lookback:
-              lookback_type: DATA_TIME
-              lookback_window:
-                interval_type: DAYS
-                interval_value: 28
-            rct_overrides:
-              - date
-      - column_selectors:
-          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.*
-        metrics:
-          - saved_metric_id: volume
-            lookback:
-              lookback_type: DATA_TIME
-              lookback_window:
-                interval_type: DAYS
-                interval_value: 28
-            rct_overrides:
-              - date
-          - saved_metric_id: freshness
-            lookback:
-              lookback_type: DATA_TIME
-              lookback_window:
-                interval_type: DAYS
-                interval_value: 28
-            rct_overrides:
-              - date
+- collection:
+    name: Operational Checks
+    notification_channels:
+    - slack: '#de-bigeye-triage'
+  deployments:
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.date
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.campaign_region
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.campaign_country_code
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.campaign_language
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.ad_group
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.impressions
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.clicks
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.new_profiles
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.activated_profiles
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.repeat_users
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.week_4_retained_users
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.spend
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.lifetime_value
+    metrics:
+    - saved_metric_id: is_not_null
+      lookback:
+        lookback_window:
+          interval_type: DAYS
+          interval_value: 28
+        lookback_type: DATA_TIME
+      rct_overrides:
+      - date
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.campaign_country_code
+    metrics:
+    - saved_metric_id: is_2_char_len
+      lookback:
+        lookback_window:
+          interval_type: DAYS
+          interval_value: 28
+        lookback_type: DATA_TIME
+      rct_overrides:
+      - date
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.google_ads_derived.android_app_campaign_stats_v1.*
+    metrics:
+    - saved_metric_id: volume
+      lookback:
+        lookback_window:
+          interval_type: DAYS
+          interval_value: 28
+        lookback_type: DATA_TIME
+      rct_overrides:
+      - date
+    - saved_metric_id: freshness
+      lookback:
+        lookback_window:
+          interval_type: DAYS
+          interval_value: 28
+        lookback_type: DATA_TIME
+      rct_overrides:
+      - date


### PR DESCRIPTION
## Description

These `bigconfig.yml` have been showing up in every `sql.diff` because generate-sql in CI runs `bqetl monitoring update` but `main-generate-sql-and-dags` doesn't so the checked in files don't match the [generated sql](https://github.com/mozilla/bigquery-etl/blob/generated-sql/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/bigconfig.yml).

Might make sense to validate this as part of CI but I'm not sure how the files are made/used.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7166)
