### PR TITLE
Change timestamp format in desktop_conversion_events view

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
@@ -23,7 +23,10 @@ WITH all_clicks_from_united_states AS (
 SELECT
   a.gclid,
   a.conversion_name,
-  FORMAT_TIMESTAMP("%Y-%m-%d %X %EZ", CAST(MIN(a.activity_datetime) AS TIMESTAMP)) AS activity_date_timestamp
+  FORMAT_TIMESTAMP(
+    "%Y-%m-%d %X %EZ",
+    CAST(MIN(a.activity_datetime) AS TIMESTAMP)
+  ) AS activity_date_timestamp
 FROM
   `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v2` a
 JOIN

--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/view.sql
@@ -23,8 +23,7 @@ WITH all_clicks_from_united_states AS (
 SELECT
   a.gclid,
   a.conversion_name,
-  UNIX_SECONDS(CAST(MIN(a.activity_datetime) AS TIMESTAMP)) AS activity_date,
-  CAST(MIN(a.activity_datetime) AS TIMESTAMP) AS activity_date_timestamp
+  FORMAT_TIMESTAMP("%Y-%m-%d %X %EZ", CAST(MIN(a.activity_datetime) AS TIMESTAMP)) AS activity_date_timestamp
 FROM
   `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v2` a
 JOIN


### PR DESCRIPTION
## Description
This PR updates the view: `moz-fx-data-shared-prod.mozilla_org.desktop_conversion_events`

It: 
* removes the activity_date column (the unix seconds version of the timestamp) 
* changes the activity_date_timestamp column to use a different formatting that works better in Google Ads


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7169)
