### PR TITLE
DENG-6683 & DENG-6884 - Create aggregate tables for installs/uninstalls

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/install_vs_uninstall_by_os/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/install_vs_uninstall_by_os/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.install_vs_uninstall_by_os`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.install_vs_uninstall_by_os_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_to_dau_ratio_by_country/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_to_dau_ratio_by_country/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_to_dau_ratio_by_country`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_to_dau_ratio_by_country_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_by_os_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Install Vs Uninstall By Windows OS
+description: |-
+  Calculates the ratio of installs vs uninstalls for Windows 6.1, 6.2, 6.3, & 10
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_default
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_os_version
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_by_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_by_os_v1/query.sql
@@ -1,0 +1,51 @@
+WITH installs AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    CASE
+      WHEN os_version LIKE "10%"
+        THEN '10.0'
+      WHEN os_version LIKE "6.1%"
+        THEN '6.1'
+      WHEN os_version LIKE "6.2%"
+        THEN '6.2'
+      WHEN os_version LIKE "6.3%"
+        THEN '6.3'
+      ELSE 'other'
+    END AS os_version_bucket,
+    COUNT(*) AS stub_release_installs_count,
+  FROM
+    `moz-fx-data-shared-prod.firefox_installer.install`
+  WHERE
+    update_channel = 'release'
+    AND installer_type = 'stub'
+    AND DATE(submission_timestamp) = @submission_date
+  GROUP BY
+    submission_date,
+    os_version_bucket
+),
+uninstalls AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    normalized_os_version,
+    COUNT(DISTINCT client_id) AS uninstalls_count
+  FROM
+    `moz-fx-data-shared-prod.telemetry.uninstall`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND application.name = 'Firefox'
+    AND application.channel = 'release'
+    AND normalized_os_version IN ('6.1', '6.2', '6.3', '10.0')
+  GROUP BY
+    submission_date,
+    normalized_os_version
+)
+SELECT
+  i.submission_date,
+  u.normalized_os_version,
+  SAFE_DIVIDE(u.uninstalls_count, i.stub_release_installs_count) AS ratio_uninstalls_to_installs,
+FROM
+  installs AS i
+JOIN
+  uninstalls AS u
+  ON i.submission_date = u.submission_date
+  AND i.os_version_bucket = u.normalized_os_version

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/install_vs_uninstall_by_os_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: normalized_os_version
+  type: STRING
+  mode: NULLABLE
+  description: Normalized OS Version
+- name: ratio_uninstalls_to_installs
+  type: FLOAT
+  mode: NULLABLE
+  description: Ratio of uninstalls to installs

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_to_dau_ratio_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_to_dau_ratio_by_country_v1/metadata.yaml
@@ -1,11 +1,12 @@
 friendly_name: Uninstalls To Dau Ratio By Country
 description: |-
-  Please provide a description for the query
+  Aggregate table used in dashboard to show ratio of uninstalls to active users by country
 owners:
 - kwindau@mozilla.com
 labels:
   incremental: true
   owner1: kwindau
+  table_type: aggregate
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_to_dau_ratio_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_to_dau_ratio_by_country_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Uninstalls To Dau Ratio By Country
+description: |-
+  Please provide a description for the query
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_country_code
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_to_dau_ratio_by_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_to_dau_ratio_by_country_v1/query.sql
@@ -1,0 +1,41 @@
+WITH daily_active_users AS (
+  SELECT
+    submission_date,
+    country,
+    COUNT(DISTINCT client_id) AS total_dau
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_daily`
+  WHERE
+    submission_date = @submission_date
+    AND COALESCE(country, '??') <> '??'
+  GROUP BY
+    submission_date,
+    country
+),
+uninstalls AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    normalized_country_code,
+    COUNT(DISTINCT client_id) AS nbr_clients_uninstalling
+  FROM
+    `moz-fx-data-shared-prod.telemetry.uninstall`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND application.name = 'Firefox'
+    AND application.channel = 'release'
+  GROUP BY
+    submission_date,
+    normalized_country_code
+)
+SELECT
+  dau.submission_date,
+  dau.country AS normalized_country_code,
+  dau.total_dau,
+  u.nbr_clients_uninstalling,
+  SAFE_DIVIDE(u.nbr_clients_uninstalling, dau.total_dau) AS ratio_uninstalls_to_dau,
+FROM
+  daily_active_users AS dau
+LEFT JOIN
+  uninstalls AS u
+  ON dau.country = u.normalized_country_code
+  AND dau.submission_date = u.submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_to_dau_ratio_by_country_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_to_dau_ratio_by_country_v1/schema.yaml
@@ -1,0 +1,21 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: normalized_country_code
+  type: STRING
+  mode: NULLABLE
+  description: Normalized Country Code
+- name: total_dau
+  type: INTEGER
+  mode: NULLABLE
+  description: DAU - Daily Active Users
+- name: nbr_clients_uninstalling
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Unique Clients Uninstalling
+- name: ratio_uninstalls_to_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Ratio of the number of unique clients uninstalling to daily active users


### PR DESCRIPTION
## Description

This PR creates the following 2 aggregate tables:
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_to_dau_ratio_by_country_v1
- moz-fx-data-shared-prod.telemetry_derived.install_vs_uninstall_by_os_v1

## Related Tickets & Documents
* [DENG-6883](https://mozilla-hub.atlassian.net/browse/DENG-6883)
* [DENG-6884](https://mozilla-hub.atlassian.net/browse/DENG-6884)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6883]: https://mozilla-hub.atlassian.net/browse/DENG-6883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-6884]: https://mozilla-hub.atlassian.net/browse/DENG-6884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7175)
