### PR TITLE
Remove unused telescope access

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/clients_daily/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_daily/metadata.yaml
@@ -11,7 +11,3 @@ labels:
   application: firefox
 owners:
   - ascholtz@mozilla.com
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:cloudops-managed/telescope

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_daily_joined/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_daily_joined/metadata.yaml
@@ -1,6 +1,2 @@
 friendly_name: Clients Daily Joined
 description: Joined clients_daily view
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:cloudops-managed/telescope

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_daily_v6/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_daily_v6/metadata.yaml
@@ -1,5 +1,0 @@
----
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:cloudops-managed/telescope

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
@@ -40,9 +40,4 @@ bigquery:
     fields:
     - normalized_channel
     - sample_id
-workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
-  - workgroup:cloudops-managed/telescope
 references: {}


### PR DESCRIPTION
## Description

[Slack discussion](https://mozilla.slack.com/archives/C4D5ZA91B/p1736357134311699)
Caused by https://github.com/mozilla/bigquery-etl/issues/5830. I've opted to fix this by removing telescope's access to this data, since [it isn't using it](https://github.com/search?q=repo%3Amozilla-services%2Ftelescope%20moz-fx-data-shared-prod&type=code). That should ensure that the default `default_table_workgroup_access` gets applied to all these tables.

I'm a bit surprised that this started to be an issue recently, since https://sql.telemetry.mozilla.org/queries/101394/source#249849 was working until this year. I found that 465dcee33fc is what actually triggered the issue, since before that the user-facing telemetry dataset didn't have any deprecated tables. We've gone back and forth about whether we should use deprecation metadata for user-facing views (deprecating the underlying tables should have the same user-facing behavior unless the views are authorized), but the proper fix to the specific issue here is IMO https://github.com/mozilla/bigquery-etl/issues/5830 and wouldn't preclude user-facing deprecations.

## Related Tickets & Documents
* DENG-4143


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7177)
