### PR TITLE
Create normalize app channel function

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/event_counts_glean_v1/query.sql
@@ -5,7 +5,7 @@ WITH event_counts_per_app_channel AS (
     event_name,
     event_extra_key,
     normalized_app_name,
-    channel,
+    mozfun.norm.app_channel(channel) AS channel,
     country,
     version,
     SUM(total_events) AS total_events,

--- a/sql/mozfun/norm/app_channel/README.md
+++ b/sql/mozfun/norm/app_channel/README.md
@@ -1,0 +1,4 @@
+Normalize app channel name, returning "Other" for unrecognized values.
+
+Based on the logic used in ingestion:
+https://github.com/mozilla/gcp-ingestion/blob/fb7e9ed9e891e3e2320d85e05d7c1a1aedb57780/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/NormalizeAttributes.java#L34

--- a/sql/mozfun/norm/app_channel/metadata.yaml
+++ b/sql/mozfun/norm/app_channel/metadata.yaml
@@ -1,0 +1,2 @@
+friendly_name: App Channel
+description: Normalize app channel name, returning "Other" for unrecognized values.

--- a/sql/mozfun/norm/app_channel/udf.sql
+++ b/sql/mozfun/norm/app_channel/udf.sql
@@ -1,0 +1,25 @@
+-- This should match https://github.com/mozilla/gcp-ingestion/blob/fb7e9ed9e891e3e2320d85e05d7c1a1aedb57780/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/NormalizeAttributes.java#L34
+CREATE OR REPLACE FUNCTION norm.app_channel(channel_name STRING)
+RETURNS STRING AS (
+  CASE
+    WHEN channel_name IN ("release", "esr", "beta", "aurora", "nightly")
+      THEN channel_name
+    -- The cck suffix was used for various deployments before Firefox Quantum;
+    -- cck refers to the "Client Customization Wizard", see
+    -- https://mike.kaply.com/2012/04/13/customizing-firefox-extensions-and-the-cck-wizard/
+    WHEN STARTS_WITH(channel_name, "nightly-cck-")
+      THEN "nightly"
+    WHEN STARTS_WITH(channel_name, "beta")
+      THEN "beta"
+    ELSE "Other"
+  END
+);
+
+-- Tests
+SELECT
+  assert.equals(norm.app_channel("release"), "release"),
+  assert.equals(norm.app_channel("Release"), "Other"),
+  assert.equals(norm.app_channel("nightly"), "nightly"),
+  assert.equals(norm.app_channel("nightly-cck-1"), "nightly"),
+  assert.equals(norm.app_channel("beta1"), "beta"),
+  assert.equals(norm.app_channel(""), "Other"),


### PR DESCRIPTION
## Description

The dropdown menu in looker has some 😳 words because `event_monitoring_aggregates_v1` uses `client_info.app_channel` instead on `normalized_channel`.

udf based on https://github.com/mozilla/gcp-ingestion/blob/fb7e9ed9e891e3e2320d85e05d7c1a1aedb57780/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/NormalizeAttributes.java#L34

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7182)
