### PR TITLE
DENG-6883 & DENG-6884 - Create desktop_acquisition_funnel_aggregates table

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2075,3 +2075,22 @@ bqetl_default_browser_aggregates:
   schedule_interval: 0 22 * * *
   tags:
     - impact/tier_3
+
+bqetl_dsktp_acqstn_fnnl:
+  description: |
+    This DAG builds the Desktop Acquisiton Funnel aggregate table
+  default_args:
+    depends_on_past: false
+    owner: kwindau@mozilla.com
+    email:
+      - telemetry-alerts@mozilla.com
+      - kwindau@mozilla.com
+    email_on_failure: true
+    email_on_retry: false
+    start_date: "2025-01-08"
+    retries: 2
+    retry_delay: 5m
+  tags:
+    - impact/tier_2
+  repo: bigquery-etl
+  schedule_interval: 30 11 * * *

--- a/sql/moz-fx-data-shared-prod/telemetry/desktop_acquisition_funnel_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/desktop_acquisition_funnel_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.desktop_acquisition_funnel_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.desktop_acquisition_funnel_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_acquisition_funnel_aggregates_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_acquisition_funnel_aggregates_v1/checks.sql
@@ -1,0 +1,2 @@
+#fail
+{{ min_row_count(1, "first_seen_date = @fsd") }}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_acquisition_funnel_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_acquisition_funnel_aggregates_v1/metadata.yaml
@@ -1,0 +1,24 @@
+friendly_name: Desktop Acquisition Funnel Aggregates
+description: |-
+  Aggregate table 
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_dsktp_acqstn_fnnl
+  date_partition_offset: -29
+  date_partition_parameter: fsd
+  parameters:
+  - submission_date:DATE:{{ds}}
+bigquery:
+  time_partitioning:
+    type: day
+    field: first_seen_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_acquisition_funnel_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_acquisition_funnel_aggregates_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Desktop Acquisition Funnel Aggregates
 description: |-
-  Aggregate table 
+  Aggregate table used to track desktop installation and retention 28 days later
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_acquisition_funnel_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_acquisition_funnel_aggregates_v1/query.sql
@@ -1,0 +1,64 @@
+SELECT
+  first_seen_date,
+  country_code,
+  channel,
+  os,
+  os_version,
+  distribution_id,
+  attribution_ua,
+  CASE
+    WHEN attribution_source = "%2528not%2Bset%2529"
+      THEN "(not set)"
+    ELSE attribution_source
+  END AS attribution_source,
+  CASE
+    WHEN attribution_medium = "%2528not%2Bset%2529"
+      THEN "(not set)"
+    ELSE attribution_medium
+  END AS attribution_medium,
+  CASE
+    WHEN attribution_campaign = "%2528not%2Bset%2529"
+      THEN "(not set)"
+    ELSE attribution_campaign
+  END AS attribution_campaign,
+  CASE
+    WHEN attribution_content = "%2528not%2Bset%2529"
+      THEN "(not set)"
+    ELSE attribution_content
+  END AS attribution_content,
+  CASE
+    WHEN attribution_experiment = "%2528not%2Bset%2529"
+      THEN "(not set)"
+    ELSE attribution_experiment
+  END AS attribution_experiment,
+  CASE
+    WHEN attribution_dlsource = "%2528not%2Bset%2529"
+      THEN "(not set)"
+    ELSE attribution_dlsource
+  END AS attribution_dlsource,
+  startup_profile_selection_reason,
+  COUNT(client_id) AS cohort,
+  COUNTIF(activated) AS activated,
+  COUNTIF(returned_second_day) AS returned_second_day,
+  COUNTIF(qualified_second_day) AS qualified_second_day,
+  COUNTIF(retained_week4) AS retained_week4,
+  COUNTIF(qualified_week4) AS qualified_week4
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.clients_first_seen_28_days_later_v1`
+WHERE
+  first_seen_date = @fsd
+GROUP BY
+  first_seen_date,
+  country_code,
+  channel,
+  os,
+  os_version,
+  distribution_id,
+  attribution_source,
+  attribution_ua,
+  attribution_medium,
+  attribution_campaign,
+  attribution_content,
+  attribution_experiment,
+  attribution_dlsource,
+  startup_profile_selection_reason

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_acquisition_funnel_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_acquisition_funnel_aggregates_v1/schema.yaml
@@ -1,0 +1,81 @@
+fields:
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+  description: First Seen Date
+- name: country_code
+  type: STRING
+  mode: NULLABLE
+  description: Country Code
+- name: channel
+  type: STRING
+  mode: NULLABLE
+  description: Channel
+- name: os
+  type: STRING
+  mode: NULLABLE
+  description: Operating System
+- name: os_version
+  type: NUMERIC
+  mode: NULLABLE
+  description: Operating System Version
+- name: distribution_id
+  type: STRING
+  mode: NULLABLE
+  description: Distribution ID
+- name: attribution_ua
+  type: STRING
+  mode: NULLABLE
+  description: Attribution User Agent
+- name: attribution_source
+  type: STRING
+  mode: NULLABLE
+  description: Attribution Source
+- name: attribution_medium
+  type: STRING
+  mode: NULLABLE
+  description: Attribution Medium
+- name: attribution_campaign
+  type: STRING
+  mode: NULLABLE
+  description: Attribution Campaign
+- name: attribution_content
+  type: STRING
+  mode: NULLABLE
+  description: Attribution Content
+- name: attribution_experiment
+  type: STRING
+  mode: NULLABLE
+  description: Attribution Experiment
+- name: attribution_dlsource
+  type: STRING
+  mode: NULLABLE
+  description: Attribution Download Source
+- name: startup_profile_selection_reason
+  type: STRING
+  mode: NULLABLE
+  description: Startup Profile Selection Reason
+- name: cohort
+  type: INTEGER
+  mode: NULLABLE
+  description: Cohort
+- name: activated
+  type: INTEGER
+  mode: NULLABLE
+  description: Activated
+- name: returned_second_day
+  type: INTEGER
+  mode: NULLABLE
+  description: Returned Second Day
+- name: qualified_second_day
+  type: INTEGER
+  mode: NULLABLE
+  description: Qualified Second Day
+- name: retained_week4
+  type: INTEGER
+  mode: NULLABLE
+  description: Retained Week 4
+- name: qualified_week4
+  type: INTEGER
+  mode: NULLABLE
+  description: Qualified Week 4


### PR DESCRIPTION
## Description

This PR creates the following new table: 
- moz-fx-data-shared-prod.telemetry_derived.desktop_acquisition_funnel_aggregates_v1

And it also creates a new DAG:  `bqetl_dsktp_acqstn_fnnl` which runs daily

## Related Tickets & Documents
* [DENG-6883](https://mozilla-hub.atlassian.net/browse/DENG-6883)
* [DENG-6884](https://mozilla-hub.atlassian.net/browse/DENG-6884)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6883]: https://mozilla-hub.atlassian.net/browse/DENG-6883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-6884]: https://mozilla-hub.atlassian.net/browse/DENG-6884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7183)
