### PR TITLE
Simplify experiment crash rates view logic

### DIFF
--- a/sql_generators/experiment_monitoring/templates/experiment_crash_rates_live/view.sql
+++ b/sql_generators/experiment_monitoring/templates/experiment_crash_rates_live/view.sql
@@ -2,7 +2,6 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.experiment_crash_rates_live`
 AS
-WITH crash_events AS (
 {% for app_dataset in applications %}
   SELECT
     experiment,
@@ -28,21 +27,3 @@ FROM
   `moz-fx-data-shared-prod.telemetry_derived.experiment_crash_aggregates_v1`
 WHERE
   window_start <= TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
-)
-SELECT
-  crash_events.experiment AS experiment,
-  crash_events.branch AS branch,
-  window_start,
-  window_end,
-  crash_process_type,
-  crash_count,
-  crash_count / enrollments.value AS estimated_crash_rate
-  FROM
-    crash_events
-  LEFT JOIN
-    `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_cumulative_population_estimate_v1` AS enrollments
-  ON enrollments.time = crash_events.window_start AND
-    enrollments.branch = crash_events.branch AND
-    enrollments.experiment = crash_events.experiment
-  WHERE
-    enrollments.time > TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))


### PR DESCRIPTION
## Description

The number of crashes per enrolled user is not super useful and is slowing down the `experiment_crash_rates_live` view quite significantly. Sticking to total crash counts per experiment for now, so the logic of the view can be simplified.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7184)
