### PR TITLE
[#6716] Retain workgroup permissions

### DIFF
--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -57,6 +57,9 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
     table_metadata_files = paths_matching_name_pattern(
         name, sql_dir, project_id=project_id, files=["metadata.yaml"]
     )
+    retained_dataset_roles = ConfigLoader.get(
+        "deprecation", "retain_dataset_roles", fallback=[]
+    )
 
     # create and populate the dataset metadata yaml file if it does not exist
     for table_metadata_file in table_metadata_files:
@@ -83,7 +86,11 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
             # this overwrites existing workgroups
             table_metadata.workgroup_access = []
             table_metadata_updated = True
-            dataset_metadata.workgroup_access = []
+            dataset_metadata.workgroup_access = [
+                workgroup
+                for workgroup in dataset_metadata.workgroup_access
+                if workgroup.get("role") in retained_dataset_roles
+            ]
             dataset_metadata_updated = True
         else:
             if table_metadata.workgroup_access is None:

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -214,6 +214,9 @@ dry_run:
   # Tests
   - sql/moz-fx-data-test-project/test/simple_view/view.sql
 
+deprecation:
+  retain_dataset_roles: # the following roles are retain permissions on datasets when a dataset table is deprecated
+  - roles/bigquery.dataEditor  # operational access
 
 format:
   skip:

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -233,7 +233,12 @@ class TestMetadata:
 
         assert metadata["workgroup_access"] == []
         assert metadata["deprecated"]
-        assert dataset_metadata["workgroup_access"] == []
+        assert dataset_metadata["workgroup_access"] == [
+            {
+                "members": ["workgroup:mozilla-test"],
+                "role": "roles/bigquery.dataEditor",
+            }
+        ]
         assert dataset_metadata["default_table_workgroup_access"] == [
             {
                 "members": ["workgroup:mozilla-confidential"],

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/dataset_metadata.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/dataset_metadata.yaml
@@ -7,6 +7,9 @@ workgroup_access:
 - role: roles/bigquery.metadataViewer
   members:
   - workgroup:mozilla-confidential
+- role: roles/bigquery.dataEditor
+  members:
+  - workgroup:mozilla-test
 default_table_workgroup_access:
 - role: roles/bigquery.dataViewer
   members:


### PR DESCRIPTION
## Description

See https://github.com/mozilla/bigquery-etl/issues/6716

If I understand the issue correctly, we want to retain dataset permissions of some roles when tables get deprecated. Currently, `workgroup_access` is set to `[]` in `dataset_metadata.yaml` when a table gets deprecated. 

This change adds a configuration option where we can list roles whose permissions should be retained on deprecation. I added `roles/bigquery.dataEditor` for now. 

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7186)
