### PR TITLE
feat(DENG-6890): Update mobile kpi support metric aggregates to support dma analysis

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
@@ -3,7 +3,10 @@ CREATE OR REPLACE VIEW
   `{{ project_id }}.{{ dataset }}.{{ name }}`
 AS
 SELECT
-  * EXCEPT (isp),
+  * EXCEPT (isp) REPLACE(
+    -- Lower device_manufacturer as in some cases the same manufacturer value has different casing.
+    LOWER(device_manufacturer) AS device_manufacturer
+  ),
   CASE
     WHEN LOWER(isp) = "browserstack"
       THEN CONCAT("{{ friendly_name }}", " ", isp)

--- a/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
@@ -47,5 +47,15 @@ SELECT
   -- Adding isp at the end because it's in different column index in baseline table for some products.
   -- This is to make sure downstream union works as intended.
   isp,
+  CASE
+    WHEN STARTS_WITH(device_model, "iPad") AND normalized_os = "iOS"
+      THEN "iPad"
+    WHEN STARTS_WITH(device_model, "iPhone") AND normalized_os = "iOS"
+      THEN "iPhone"
+    WHEN normalized_os = "Android"
+      THEN "Android"
+    ELSE
+      CAST(NULL AS STRING)
+  END AS device_type,
 FROM
   `{{ project_id }}.{{ dataset }}.baseline_clients_last_seen`

--- a/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
@@ -48,9 +48,9 @@ SELECT
   -- This is to make sure downstream union works as intended.
   isp,
   CASE
-    WHEN STARTS_WITH(device_model, "iPad") AND normalized_os = "iOS"
+    WHEN normalized_os = "iOS" AND STARTS_WITH(device_model, "iPad")
       THEN "iPad"
-    WHEN STARTS_WITH(device_model, "iPhone") AND normalized_os = "iOS"
+    WHEN normalized_os = "iOS" AND STARTS_WITH(device_model, "iPhone")
       THEN "iPhone"
     WHEN normalized_os = "Android"
       THEN "Android"

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
@@ -14,6 +14,8 @@ SELECT
   COUNTIF(is_dau) AS dau,
   COUNTIF(is_wau) AS wau,
   COUNTIF(is_mau) AS mau,
+  device_type,
+  device_manufacturer,
 FROM
   `{{ project_id }}.{{ dataset }}.engagement_clients`
 WHERE
@@ -32,6 +34,8 @@ GROUP BY
   app_version,
   country,
   locale,
+  device_type,
+  device_manufacturer,
   is_mobile
   {% for field in product_attribution_fields.values() if not field.client_only %}
     {% if loop.first %},{% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
@@ -3,7 +3,7 @@ WITH device_manufacturer_counts AS (
   SELECT
     submission_date,
     device_manufacturer,
-    DENSE_RANK() OVER(PARTITION BY submission_date ORDER BY COUNT(*) DESC) AS manufacturer_rank,
+    RANK() OVER(PARTITION BY submission_date ORDER BY COUNT(*) DESC) AS manufacturer_rank,
   FROM
   `{{ project_id }}.{{ dataset }}.engagement_clients`
   WHERE

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
@@ -3,7 +3,7 @@ WITH device_manufacturer_counts AS (
   SELECT
     submission_date,
     device_manufacturer,
-    COUNT(*) AS device_manufacturer_count,
+    DENSE_RANK() OVER(PARTITION BY submission_date ORDER BY COUNT(*) DESC) AS manufacturer_rank,
   FROM
   `{{ project_id }}.{{ dataset }}.engagement_clients`
   WHERE
@@ -36,7 +36,7 @@ SELECT
   COUNTIF(is_mau) AS mau,
   device_type,
   -- Bucket device manufacturers with low count prior to aggregation
-  IF(device_manufacturer_count <= 2000, "other", device_manufacturer) AS device_manufacturer,
+  IF(manufacturer_rank <= 150, device_manufacturer, "other") AS device_manufacturer,
 FROM
   `{{ project_id }}.{{ dataset }}.engagement_clients`
 LEFT JOIN

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.query.sql
@@ -1,4 +1,24 @@
 {{ header }}
+WITH device_manufacturer_counts AS (
+  SELECT
+    submission_date,
+    device_manufacturer,
+    COUNT(*) AS device_manufacturer_count,
+  FROM
+  `{{ project_id }}.{{ dataset }}.engagement_clients`
+  WHERE
+    {% raw %}
+    {% if is_init() %}
+      submission_date < CURRENT_DATE
+    {% else %}
+      submission_date = @submission_date
+    {% endif %}
+    {% endraw %}
+  GROUP BY
+    submission_date,
+    device_manufacturer
+)
+
 SELECT
   submission_date,
   first_seen_date,
@@ -15,9 +35,13 @@ SELECT
   COUNTIF(is_wau) AS wau,
   COUNTIF(is_mau) AS mau,
   device_type,
-  device_manufacturer,
+  -- Bucket device manufacturers with low count prior to aggregation
+  IF(device_manufacturer_count <= 2000, "other", device_manufacturer) AS device_manufacturer,
 FROM
   `{{ project_id }}.{{ dataset }}.engagement_clients`
+LEFT JOIN
+  device_manufacturer_counts
+  USING(submission_date, device_manufacturer)
 WHERE
   {% raw %}
   {% if is_init() %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.schema.yaml
@@ -58,3 +58,15 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: MAU - Monthly Active Users
+
+- name: device_type
+  type: STRING
+  mode: NULLABLE
+  description: |
+    On Apple devices allows us to differentiate between iPhone and iPad. On Android devices the value is always "Android".
+
+- name: device_manufacturer
+  type: STRING
+  mode: NULLABLE
+  description: |
+    Manufacturer of the device where the client is installed.

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement_clients.view.sql
@@ -18,6 +18,8 @@ WITH active_users AS (
     is_wau,
     is_mau,
     is_mobile,
+    device_type,
+    device_manufacturer,
   FROM
     `{{ project_id }}.{{ dataset }}.active_users`
 ),
@@ -62,6 +64,8 @@ SELECT
       THEN 'existing_user'
     ELSE 'Unknown'
   END AS lifecycle_stage,
+  device_type,
+  device_manufacturer,
 FROM
   active_users
 LEFT JOIN

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_clients.view.sql
@@ -20,6 +20,7 @@ SELECT
   attribution.{{ attribution_field }},
   {% endfor %}
   attribution.paid_vs_organic,
+  device_type,
 FROM
   `{{ project_id }}.{{ dataset }}.active_users` AS active_users
 LEFT JOIN

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.query.sql
@@ -3,7 +3,7 @@ WITH device_manufacturer_counts AS (
   SELECT
     first_seen_date,
     device_manufacturer,
-    COUNT(*) AS device_manufacturer_count,
+    DENSE_RANK() OVER(PARTITION BY submission_date ORDER BY COUNT(*) DESC) AS manufacturer_rank,
   FROM
   `{{ project_id }}.{{ dataset }}.new_profile_clients`
   WHERE
@@ -29,7 +29,7 @@ SELECT
   os,
   os_version,
   -- Bucket device manufacturers with low count prior to aggregation
-  IF(device_manufacturer_count <= 2000, "other", device_manufacturer) AS device_manufacturer,
+  IF(manufacturer_rank <= 150, device_manufacturer, "other") AS device_manufacturer,
   is_mobile,
   {% for field in product_attribution_fields.values() if not field.client_only %}
   {{ field.name }},

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.query.sql
@@ -14,6 +14,7 @@ SELECT
   {{ field.name }},
   {% endfor %}
   COUNT(*) AS new_profiles,
+  device_type,
 FROM
   `{{ project_id }}.{{ dataset }}.new_profile_clients`
 WHERE
@@ -33,6 +34,7 @@ GROUP BY
   locale,
   os,
   os_version,
+  device_type,
   device_manufacturer,
   is_mobile
   {% for field in product_attribution_fields.values() if not field.client_only %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.query.sql
@@ -3,7 +3,7 @@ WITH device_manufacturer_counts AS (
   SELECT
     first_seen_date,
     device_manufacturer,
-    DENSE_RANK() OVER(PARTITION BY submission_date ORDER BY COUNT(*) DESC) AS manufacturer_rank,
+    RANK() OVER(PARTITION BY first_seen_date ORDER BY COUNT(*) DESC) AS manufacturer_rank,
   FROM
   `{{ project_id }}.{{ dataset }}.new_profile_clients`
   WHERE

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.schema.yaml
@@ -58,3 +58,9 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Number of new profiles recorded for the first seen date.
+
+- name: device_type
+  type: STRING
+  mode: NULLABLE
+  description: |
+    On Apple devices allows us to differentiate between iPhone and iPad. On Android devices the value is always "Android".

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
@@ -18,6 +18,8 @@ SELECT
   COUNTIF(retained_week_4_new_profile) AS retained_week_4_new_profiles,
   COUNTIF(new_profile_metric_date) AS new_profiles_metric_date,
   COUNTIF(repeat_profile) AS repeat_profiles,
+  device_type,
+  device_manufacturer,
 FROM
   `{{ project_id }}.{{ dataset }}.retention_clients`
 WHERE
@@ -38,6 +40,8 @@ GROUP BY
   country,
   app_version,
   locale,
+  device_type,
+  device_manufacturer,
   is_mobile
   {% for field in product_attribution_fields.values() if not field.client_only %}
     {% if loop.first %},{% endif %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
@@ -5,7 +5,7 @@ WITH device_manufacturer_counts AS (
     device_manufacturer,
     DENSE_RANK() OVER(PARTITION BY submission_date ORDER BY COUNT(*) DESC) AS manufacturer_rank,
   FROM
-  `{{ project_id }}.{{ dataset }}.engagement_clients`
+  `{{ project_id }}.{{ dataset }}.retention_clients`
   WHERE
     {% raw %}
     {% if is_init() %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
@@ -3,7 +3,7 @@ WITH device_manufacturer_counts AS (
   SELECT
     submission_date,
     device_manufacturer,
-    DENSE_RANK() OVER(PARTITION BY submission_date ORDER BY COUNT(*) DESC) AS manufacturer_rank,
+    RANK() OVER(PARTITION BY submission_date ORDER BY COUNT(*) DESC) AS manufacturer_rank,
   FROM
   `{{ project_id }}.{{ dataset }}.retention_clients`
   WHERE

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.query.sql
@@ -3,7 +3,7 @@ WITH device_manufacturer_counts AS (
   SELECT
     submission_date,
     device_manufacturer,
-    COUNT(*) AS device_manufacturer_count,
+    DENSE_RANK() OVER(PARTITION BY submission_date ORDER BY COUNT(*) DESC) AS manufacturer_rank,
   FROM
   `{{ project_id }}.{{ dataset }}.engagement_clients`
   WHERE
@@ -42,7 +42,7 @@ SELECT
   COUNTIF(repeat_profile) AS repeat_profiles,
   device_type,
   -- Bucket device manufacturers with low count prior to aggregation
-  IF(device_manufacturer_count <= 2000, "other", device_manufacturer) AS device_manufacturer,
+  IF(manufacturer_rank <= 150, device_manufacturer, "other") AS device_manufacturer,
 FROM
   `{{ project_id }}.{{ dataset }}.retention_clients`
 LEFT JOIN

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.schema.yaml
@@ -78,3 +78,15 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Number of new profiles on the metric date that were DAU at least twice in the next 28 days.
+
+- name: device_type
+  type: STRING
+  mode: NULLABLE
+  description: |
+    On Apple devices allows us to differentiate between iPhone and iPad. On Android devices the value is always "Android".
+
+- name: device_manufacturer
+  type: STRING
+  mode: NULLABLE
+  description: |
+    Manufacturer of the device where the client is installed.

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention_clients.view.sql
@@ -83,8 +83,8 @@ SELECT
       THEN 'existing_user'
     ELSE 'Unknown'
   END AS lifecycle_stage,
-  device_type,
-  device_manufacturer,
+  active_users.device_type,
+  active_users.device_manufacturer,
 FROM
   `{{ project_id }}.{{ dataset }}.baseline_clients_daily` AS clients_daily
 INNER JOIN

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention_clients.view.sql
@@ -14,6 +14,8 @@ WITH active_users AS (
     days_seen_bits,
     days_active_bits,
     is_mobile,
+    device_type,
+    device_manufacturer,
   FROM
     `{{ project_id }}.{{ dataset }}.active_users`
 ),
@@ -81,6 +83,8 @@ SELECT
       THEN 'existing_user'
     ELSE 'Unknown'
   END AS lifecycle_stage,
+  device_type,
+  device_manufacturer,
 FROM
   `{{ project_id }}.{{ dataset }}.baseline_clients_daily` AS clients_daily
 INNER JOIN


### PR DESCRIPTION
# feat(DENG-6890): Update mobile kpi support metric aggregates to support dma analysis

## Description

This change aims to add the following two fields to engagement, retention and new_profiles KPI support metric aggregated datasets to support DMA related analysis needed.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7188)
