### PR TITLE
DENG-6889: Add shredder mitigation true for default browser tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/default_browser_agent_derived/default_browser_agg_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/default_browser_agent_derived/default_browser_agg_by_os_v1/metadata.yaml
@@ -7,7 +7,7 @@ labels:
   incremental: true
   owner1: wichan@mozilla.com
   table_type: aggregate
-  shredder_mitigation: false
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_default_browser_aggregates
 bigquery:

--- a/sql/moz-fx-data-shared-prod/default_browser_agent_derived/default_browser_agg_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/default_browser_agent_derived/default_browser_agg_v1/metadata.yaml
@@ -7,7 +7,7 @@ labels:
   incremental: true
   owner1: wichan@mozilla.com
   table_type: aggregate
-  shredder_mitigation: false
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_default_browser_aggregates
 bigquery:

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_background_defaultagent_derived/default_agent_agg_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_background_defaultagent_derived/default_agent_agg_v1/metadata.yaml
@@ -7,7 +7,7 @@ labels:
   incremental: true
   owner1: wichan@mozilla.com
   table_type: aggregate
-  shredder_mitigation: false
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_default_browser_aggregates
 bigquery:


### PR DESCRIPTION
## Description

This PR sets shredder mitigation to true for the new default browser aggregate tables.

## Related Tickets & Documents
* DENG-6889

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**