### PR TITLE
DENG-6814 - Create a new legal_derived dataset

### DIFF
--- a/sql/moz-fx-data-shared-prod/legal_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/legal_derived/dataset_metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: Legal tables
+description: |-
+  Reference data
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+default_table_workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/legal_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/legal_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:


### PR DESCRIPTION
We identified legal tables in the analysis dataset as part of the data retention project. Although these tables do not contain sensitive data, it has been decided to relocate them to a more secure location, since the analysis dataset is primarily meant as temporary storage.
The tables will be manually moved once the dataset is created in `shared-prod`