### PR TITLE
Experiment validation errors version filter

### DIFF
--- a/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/materialized_view.sql
+++ b/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/materialized_view.sql
@@ -43,9 +43,9 @@ IF
     SELECT
       submission_timestamp,
       events,
-      -- Before version 109, clients evaluated schema before targeting,
-      -- so validation_errors are invalid
-      IF(mozfun.norm.extract_version(client_info.app_display_version, 'major') >= 109, TRUE, FALSE) AS validation_errors_valid
+      -- Before version 109 (in desktop), clients evaluated schema
+      -- before targeting, so validation_errors are invalid
+      IF(mozfun.norm.extract_version(client_info.app_display_version, 'major') >= 109 OR normalized_app_name != 'firefox_desktop', TRUE, FALSE) AS validation_errors_valid
     FROM
       `moz-fx-data-shared-prod.{{ dataset }}_live.events_v1`
   ),
@@ -80,8 +80,8 @@ IF
       event.f3_ AS `type`,
       event.f4_ AS experiment,
       IF(event_map_value.key = 'branch', event_map_value.value, NULL) AS branch,
-      -- Before version 109, clients evaluated schema before targeting,
-      -- so validation_errors are invalid
+      -- Before version 109 (in desktop), clients evaluated schema
+      -- before targeting, so validation_errors are invalid
       IF(mozfun.norm.extract_version(application.version, 'major') >= 109, TRUE, FALSE) AS validation_errors_valid
     FROM
       `moz-fx-data-shared-prod.{{ dataset }}_live.event_v4`

--- a/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/materialized_view.sql
+++ b/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/materialized_view.sql
@@ -12,7 +12,7 @@ IF
     SELECT
       submission_timestamp,
       events,
-      true as validation_errors_valid
+      TRUE as validation_errors_valid
     FROM
        `moz-fx-data-shared-prod.{{ dataset }}_live.enrollment_v1`
   ),

--- a/sql_generators/experiment_monitoring/templates/templating.yaml
+++ b/sql_generators/experiment_monitoring/templates/templating.yaml
@@ -13,7 +13,7 @@ queries:
     destination_dataset: telemetry_derived
   experiment_events_live_v1:
     per_app: true
-    start_date: "2023-10-10"
+    start_date: "2025-01-10"
   experiment_search_events_live_v1:
     per_app: true
     start_date: "2023-10-10"


### PR DESCRIPTION
Experiment validation was fixed in Fx 109, so validation error events before that version are not useful and can cause confusion in experiment monitoring. This PR ignores them in counts.
- for Cirrus apps, we keep all validation errors

## Related Tickets & Documents
* validation fix: https://bugzilla.mozilla.org/show_bug.cgi?id=1803838


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7224)
