### PR TITLE
Grant mozilla-confidential access to socorro views

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/socorro_crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/socorro_crash/metadata.yaml
@@ -13,3 +13,4 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:ci-and-quality-tools/taskcluster
+      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/telemetry/socorro_crash_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/socorro_crash_v2/metadata.yaml
@@ -13,3 +13,4 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:ci-and-quality-tools/taskcluster
+      - workgroup:mozilla-confidential


### PR DESCRIPTION
## Description

Should fix https://mozilla.slack.com/archives/C4D5ZA91B/p1736538436459249.  These are the only non-default access views in `telemetry` so we shouldn't see this again for now.  Related to https://github.com/mozilla/bigquery-etl/issues/5830

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
