### PR TITLE
Remove legacy Accounts event analysis tables

### DIFF
--- a/sql_generators/events_daily/templates/event_types/templating.yaml
+++ b/sql_generators/events_daily/templates/event_types/templating.yaml
@@ -9,9 +9,6 @@ telemetry:
 messaging_system:
   base_dataset: messaging_system_derived
   view_dataset: messaging_system
-firefox_accounts:
-  base_dataset: firefox_accounts_derived
-  view_dataset: firefox_accounts
 # Mozilla VPN
 mozilla_vpn:
   base_dataset: mozilla_vpn_derived

--- a/sql_generators/events_daily/templates/event_types_history_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/event_types_history_v1/templating.yaml
@@ -24,13 +24,6 @@ messaging_system_derived:
   start_date: 2020-01-01
   max_property_values: 1000
   dag_name: bqetl_event_rollup
-firefox_accounts_derived:
-  name: Firefox Accounts
-  dataset: firefox_accounts
-  source_table: firefox_accounts_derived.funnel_events_source_v1
-  start_date: 2020-01-01
-  max_property_values: 1000
-  dag_name: bqetl_event_rollup
 mozilla_vpn_derived:
   name: Mozilla VPN
   dataset: mozilla_vpn

--- a/sql_generators/events_daily/templates/event_types_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/event_types_v1/templating.yaml
@@ -11,10 +11,6 @@ messaging_system_derived:
   name: Firefox Messaging System
   dataset: messaging_system
   dag_name: bqetl_event_rollup
-firefox_accounts_derived:
-  name: Firefox Accounts
-  dataset: firefox_accounts
-  dag_name: bqetl_event_rollup
 mozilla_vpn_derived:
   name: Mozilla VPN
   dataset: mozilla_vpn

--- a/sql_generators/events_daily/templates/events_daily/templating.yaml
+++ b/sql_generators/events_daily/templates/events_daily/templating.yaml
@@ -9,9 +9,6 @@ telemetry:
 messaging_system:
   base_dataset: messaging_system_derived
   view_dataset: messaging_system
-firefox_accounts:
-  base_dataset: firefox_accounts_derived
-  view_dataset: firefox_accounts
 mozilla_vpn:
   base_dataset: mozilla_vpn_derived
   view_dataset: mozilla_vpn

--- a/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
@@ -82,50 +82,6 @@ messaging_system_derived:
       dest: locale
     - src: normalized_channel
       dest: normalized_channel
-firefox_accounts_derived:
-  name: Firefox Accounts
-  include_normalized_fields: False
-  include_metadata_fields: False
-  glean: False
-  dataset: firefox_accounts
-  source_table: firefox_accounts_derived.funnel_events_source_v1
-  start_date: 2020-01-01
-  dag_name: bqetl_event_rollup
-  user_properties:
-    - src: utm_term
-      dest: utm_term
-    - src: utm_source
-      dest: utm_source
-    - src: utm_medium
-      dest: utm_medium
-    - src: utm_campaign
-      dest: utm_campaign
-    - src: ua_version
-      dest: ua_version
-    - src: ua_browser
-      dest: ua_browser
-    - src: entrypoint
-      dest: entrypoint
-    - src: flow_id
-      dest: flow_id
-    - src: sync_device_count
-      dest: sync_device_count
-    - src: sync_active_devices_day
-      dest: sync_active_devices_day
-    - src: sync_active_devices_week
-      dest: sync_active_devices_week
-    - src: sync_active_devices_month
-      dest: sync_active_devices_month
-    - src: app_version
-      dest: app_version
-    - src: os_name
-      dest: os_name
-    - src: os_version
-      dest: os_version
-    - src: country
-      dest: country
-    - src: language
-      dest: language
 mozilla_vpn_derived:
   name: Mozilla VPN
   include_normalized_fields: True


### PR DESCRIPTION
Events Daily tables for legacy Accounts data are [no longer in use](https://mozilla.acryl.io/dataset/urn:li:dataset:(urn:li:dataPlatform:bigquery,moz-fx-data-shared-prod.firefox_accounts_derived.events_daily_v1,PROD)/Lineage?is_lineage_mode=false) after Glean migration and switch to bqetl-generated funnel tables.

This needs https://github.com/mozilla/lookml-generator/pull/1141 to land first to avoid LookML generation errors.