### PR TITLE
DENG-6884 - Create some uninstall aggregate tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_account_signed_in_status/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_account_signed_in_status/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_on_day_of_install_by_account_signed_in_status`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_account_signed_in_status_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_addon/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_addon/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_on_day_of_install_by_addon`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_addon_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_attr_src/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_attr_src/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_on_day_of_install_by_attr_src`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_attr_src_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_browser/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_browser/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_on_day_of_install_by_browser`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_browser_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_country/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_country/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_on_day_of_install_by_country`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_country_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_dflt_srch/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_dflt_srch/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_on_day_of_install_by_dflt_srch`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_dflt_srch_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_dlsource/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_dlsource/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_on_day_of_install_by_dlsource`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_dlsource_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_os_ver/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_os_ver/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_on_day_of_install_by_os_ver`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_os_ver_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_account_signed_in_status_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_account_signed_in_status_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls On Day Of Install By Account Signed In Status
+description: |-
+  Uninstalls by account enabled status by if the uninstall was on date of installation or not
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - account_enabled
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_account_signed_in_status_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_account_signed_in_status_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  IF(
+    DATE(creation_date) = DATE(submission_timestamp),
+    TRUE,
+    FALSE
+  ) AS uninstall_same_day_as_install,
+  environment.services.account_enabled AS account_enabled,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  uninstall_same_day_as_install,
+  account_enabled

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_account_signed_in_status_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_account_signed_in_status_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: uninstall_same_day_as_install
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Flag indicating if the uninstall was on the same date as the install
+- name: account_enabled
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Flag indicating if account enabled (i.e. signed in)
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Unique Clients Uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_addon_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_addon_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Uninstalls On Day Of Install By Addon
+description: |-
+  Uninstalls by addon split by if the uninstall was on date of installation or not
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_addon_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_addon_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  IF(
+    DATE(creation_date) = DATE(submission_timestamp),
+    TRUE,
+    FALSE
+  ) AS uninstall_same_day_as_install,
+  environment.addons.`active_addons`[SAFE_OFFSET(0)].value.name AS active_addon_name,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  uninstall_same_day_as_install,
+  active_addon_name

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_addon_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_addon_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: uninstall_same_day_as_install
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Flag indicating if the uninstall was on the same date as the install
+- name: active_addon_name
+  type: STRING
+  mode: NULLABLE
+  description: Name of the active add on
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Unique Clients Uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_attr_src_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_attr_src_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls On Day Of Install By Attribution Source
+description: |-
+  Uninstalls by attribution source split by if the uninstall was on date of installation or not
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - attribution_source
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_attr_src_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_attr_src_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  IF(
+    DATE(creation_date) = DATE(submission_timestamp),
+    TRUE,
+    FALSE
+  ) AS uninstall_same_day_as_install,
+  environment.settings.attribution.`source` AS attribution_source,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  uninstall_same_day_as_install,
+  attribution_source

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_attr_src_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_attr_src_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: uninstall_same_day_as_install
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Flag indicating if the uninstall was on the same date as the install
+- name: attribution_source
+  type: STRING
+  mode: NULLABLE
+  description: Attribution Source
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Unique Clients Uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_browser_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_browser_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls On Day Of Install By Browser
+description: |-
+  Uninstalls by browser split by if the uninstall was on date of installation or not
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - user_agent
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_browser_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_browser_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  IF(
+    DATE(creation_date) = DATE(submission_timestamp),
+    TRUE,
+    FALSE
+  ) AS uninstall_same_day_as_install,
+  environment.settings.attribution.ua AS user_agent,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  uninstall_same_day_as_install,
+  user_agent

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_browser_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_browser_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: uninstall_same_day_as_install
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Flag indicating if the uninstall was on the same date as the install
+- name: user_agent
+  type: STRING
+  mode: NULLABLE
+  description: Browser name
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Unique Clients Uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_country_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls On Day Of Install By Country
+description: |-
+  Uninstalls by country split by if the uninstall was on date of installation or not
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_country_code
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_country_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  IF(
+    DATE(creation_date) = DATE(submission_timestamp),
+    TRUE,
+    FALSE
+  ) AS uninstall_same_day_as_install,
+  normalized_country_code,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  uninstall_same_day_as_install,
+  normalized_country_code

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_country_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_country_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: uninstall_same_day_as_install
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Flag indicating if the uninstall was on the same date as the install
+- name: normalized_country_code
+  type: STRING
+  mode: NULLABLE
+  description: Normalized Country Code
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique client IDs uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dflt_srch_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dflt_srch_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls On Day Of Install By Default Search Engine
+description: |-
+  Uninstalls by default search engine split by if the uninstall was on date of installation or not
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - default_search_engine
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dflt_srch_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dflt_srch_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  IF(
+    DATE(creation_date) = DATE(submission_timestamp),
+    TRUE,
+    FALSE
+  ) AS uninstall_same_day_as_install,
+  environment.settings.default_search_engine AS default_search_engine,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  uninstall_same_day_as_install,
+  default_search_engine

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dflt_srch_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dflt_srch_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: uninstall_same_day_as_install
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Flag indicating if the uninstall was on the same date as the install
+- name: default_search_engine
+  type: STRING
+  mode: NULLABLE
+  description: Default Search Engine
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique client IDs uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dlsource_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dlsource_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Uninstalls On Day Of Install By Dlsource
+description: |-
+  Uninstalls by attribution_dlsource split by if the uninstall was on date of installation or not
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - attribution_dlsource
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dlsource_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dlsource_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  IF(
+    DATE(creation_date) = DATE(submission_timestamp),
+    TRUE,
+    FALSE
+  ) AS uninstall_same_day_as_install,
+  environment.settings.attribution.dlsource AS attribution_dlsource,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  uninstall_same_day_as_install,
+  attribution_dlsource

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dlsource_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dlsource_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: uninstall_same_day_as_install
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Flag indicating if the uninstall was on the same date as the install
+- name: attribution_dlsource
+  type: STRING
+  mode: NULLABLE
+  description: Attribution Download Source
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique client IDs uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_ver_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_ver_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls On Day Of Install by Os Version
+description: |-
+  Uninstalls by OS version split by if the uninstall was on date of installation or not
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_os_version
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_ver_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_ver_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  IF(
+    DATE(creation_date) = DATE(submission_timestamp),
+    TRUE,
+    FALSE
+  ) AS uninstall_same_day_as_install,
+  normalized_os_version,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  uninstall_same_day_as_install,
+  normalized_os_version

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_ver_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_ver_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: uninstall_same_day_as_install
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Flag indicating if the uninstall was on the same date as the install
+- name: normalized_os_version
+  type: STRING
+  mode: NULLABLE
+  description: Normalized Operating System Version
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique client IDs uninstalling


### PR DESCRIPTION
## Description

This PR creates the following new aggregate tables for uninstall trends:
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_country_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_os_ver_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_addon_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_browser_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_dflt_srch_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_attr_src_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_dlsource_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_account_signed_in_status_v1

## Related Tickets & Documents
* [DENG-6884](https://mozilla-hub.atlassian.net/browse/DENG-6884)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6884]: https://mozilla-hub.atlassian.net/browse/DENG-6884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ