### PR TITLE
DENG-6884 Create last 2 uninstall aggregate tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_cpu_core_count/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_cpu_core_count/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_on_day_of_install_by_cpu_core_count`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_cpu_core_count_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_os_install_yr/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_os_install_yr/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_on_day_of_install_by_os_install_yr`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_os_install_yr_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_cpu_core_count_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_cpu_core_count_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Uninstalls On Day Of Install By Cpu Core Count
+description: |-
+  Uninstalls by CPU cores split by if the uninstall was on date of installation or not
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_cpu_core_count_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_cpu_core_count_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  IF(
+    DATE(creation_date) = DATE(submission_timestamp),
+    TRUE,
+    FALSE
+  ) AS uninstall_same_day_as_install,
+  environment.system.cpu.cores AS nbr_cpu_cores,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  uninstall_same_day_as_install,
+  nbr_cpu_cores

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_cpu_core_count_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_cpu_core_count_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: uninstall_same_day_as_install
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Flag indicating if the uninstall was on the same date as the install
+- name: nbr_cpu_cores
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of CPU cores
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique client IDs uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_install_yr_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_install_yr_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Uninstalls On Day Of Install By Os Install Yr
+description: |-
+  Uninstalls by OS install year split by if the uninstall was on date of installation or not
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_install_yr_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_install_yr_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  IF(
+    DATE(creation_date) = DATE(submission_timestamp),
+    TRUE,
+    FALSE
+  ) AS uninstall_same_day_as_install,
+  environment.system.os.install_year AS os_install_year,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  uninstall_same_day_as_install,
+  os_install_year

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_install_yr_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_install_yr_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: uninstall_same_day_as_install
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Flag indicating if the uninstall was on the same date as the install
+- name: os_install_year
+  type: FLOAT
+  mode: NULLABLE
+  description: Operating System Installation Year
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique client IDs uninstalling


### PR DESCRIPTION
## Description

This PR creates 2 uninstall aggregate tables:
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_os_install_yr_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_on_day_of_install_by_cpu_core_count_v1

## Related Tickets & Documents
* [DENG-6884](https://mozilla-hub.atlassian.net/browse/DENG-6884)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6884]: https://mozilla-hub.atlassian.net/browse/DENG-6884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ