### PR TITLE
DENG-6884 - Uninstall aggregates continued

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_browser_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_browser_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_by_browser_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_browser_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_day/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_day/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_by_day`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_day_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_browser_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_browser_aggregates_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls By Browser Aggregates
+description: |-
+  Aggregate table calculating uninstalls by browser and date
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - user_agent
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_browser_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_browser_aggregates_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  environment.settings.attribution.ua AS user_agent,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  user_agent

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_browser_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_browser_aggregates_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: user_agent
+  type: STRING
+  mode: NULLABLE
+  description: User Agent - i.e. the browser name
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique clients uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/query.sql
@@ -1,14 +1,27 @@
 SELECT
   DATE(submission_timestamp) AS submission_date,
   normalized_country_code,
-  COUNT(DISTINCT client_id) AS nbr_unique_fx_release_channel_clients_with_uninstalls,
-  AVG(environment.profile.creation_date) AS avg_profile_creation_date
+  COUNT(
+    DISTINCT
+    CASE
+      WHEN application.channel = 'release'
+        THEN client_id
+      ELSE NULL
+    END
+  ) AS nbr_unique_fx_release_channel_clients_with_uninstalls,
+  AVG(
+    CASE
+      WHEN application.channel = 'release'
+        THEN environment.profile.creation_date
+      ELSE NULL
+    END
+  ) AS avg_profile_creation_date,
+  COUNT(DISTINCT(client_id)) AS nbr_unique_clients_with_uninstalls
 FROM
   `moz-fx-data-shared-prod.telemetry.uninstall`
 WHERE
   DATE(submission_timestamp) = @submission_date
   AND application.name = 'Firefox'
-  AND application.channel = 'release'
 GROUP BY
   submission_date,
   normalized_country_code

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/schema.yaml
@@ -14,4 +14,9 @@ fields:
 - name: avg_profile_creation_date
   type: FLOAT
   mode: NULLABLE
-  description: The average profile creation date for those uninstalling, expressed numerically
+  description: The average profile creation date for those uninstalling, expressed
+    numerically
+- name: nbr_unique_clients_with_uninstalls
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique clients with uninstalls

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_day_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_day_v1/metadata.yaml
@@ -1,0 +1,18 @@
+friendly_name: Uninstalls By Day
+description: |-
+  Records number of unique clients uninstalling by day
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_day_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_day_v1/query.sql
@@ -1,0 +1,10 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  COUNT(DISTINCT client_id) AS nbr_unique_clients_uninstalling
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_day_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_day_v1/schema.yaml
@@ -1,0 +1,9 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: nbr_unique_clients_uninstalling
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Unique Clients Uninstalling Firefox


### PR DESCRIPTION
## Description

This PR creates the 2 following uninstall aggregate table: 
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_day_v1
- moz-fx-data-shard-prod.telemetry_derived.uninstalls_by_browser_aggregates_v1

It also adds a new column to the table
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_country_aggregates_v1

## Related Tickets & Documents
* [DENG-6884](https://mozilla-hub.atlassian.net/browse/DENG-6884)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7282)


[DENG-6884]: https://mozilla-hub.atlassian.net/browse/DENG-6884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ