### PR TITLE
Set Bigeye Airflow task timeouts to 1h

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -622,7 +622,7 @@ class Task:
         task.is_bigeye_check = True
         task.depends_on_past = False
         task.destination_table = None
-        task.retries = 0
+        task.retries = 1
         task.depends_on_fivetran = []
         task.referenced_tables = None
         task.depends_on = []

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -308,6 +308,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             {#+ Avoid having concurrent tasks for ETLs that target the whole table. -#}
             task_concurrency=1,
             {%+ endif -%}
+            execution_timeout=datetime.timedelta(hours=1),
     {%+ else -%}
         {{ task.task_name }} = bigquery_etl_query(
             {% if name == "bqetl_default" -%}

--- a/tests/data/dags/python_script_test_dag
+++ b/tests/data/dags/python_script_test_dag
@@ -56,7 +56,7 @@ with DAG(
         email=["test@example.com"],
         depends_on_past=False,
         execution_timeout=datetime.timedelta(hours=1),
-        retries=0,
+        retries=1,
         task_group=task_group_test_group,
     )
 

--- a/tests/data/dags/python_script_test_dag
+++ b/tests/data/dags/python_script_test_dag
@@ -55,6 +55,7 @@ with DAG(
         owner="test@example.com",
         email=["test@example.com"],
         depends_on_past=False,
+        execution_timeout=datetime.timedelta(hours=1),
         retries=0,
         task_group=task_group_test_group,
     )


### PR DESCRIPTION
## Description

Sets the Bigeye task execution timeout to an hour. We have had instances were these tasks get stuck, blocking downstream tasks. Usually restarting them does the trick.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7286)
