### PR TITLE
DENG-6884 uninstall aggregates

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_addon/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_addon/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_by_addon`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_addon_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_attr_src/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_attr_src/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_by_attr_src`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_attr_src_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_dflt_srch/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_dflt_srch/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_by_dflt_srch`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_dflt_srch_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_dlsource/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_dlsource/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_by_dlsource`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_dlsource_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_addon_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_addon_v1/metadata.yaml
@@ -6,6 +6,8 @@ owners:
 labels:
   incremental: true
   owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_addon_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_addon_v1/metadata.yaml
@@ -1,0 +1,18 @@
+friendly_name: Uninstalls By Addon
+description: |-
+  Aggregate table calculating # unique clients with uninstalls by add on and date
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_addon_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_addon_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  environment.addons.`active_addons`[SAFE_OFFSET(0)].value.name AS active_addon_name,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  active_addon_name

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_addon_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_addon_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: active_addon_name
+  type: STRING
+  mode: NULLABLE
+  description: Active Addon Name
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique clients uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_attr_src_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_attr_src_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls By Attribution Source
+description: |-
+  Aggregate table calculating # unique clients with uninstalls by attribution source and date
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - attribution_source
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_attr_src_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_attr_src_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  environment.settings.attribution.`source` AS attribution_source,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  attribution_source

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_attr_src_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_attr_src_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: attribution_source
+  type: STRING
+  mode: NULLABLE
+  description: Attribution Source
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique clients uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dflt_srch_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dflt_srch_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls By Default Search Engine
+description: |-
+  Number of unique clients uninstalling by date and default search engine
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - default_search_engine
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dflt_srch_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dflt_srch_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  environment.settings.default_search_engine AS default_search_engine,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  default_search_engine

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dflt_srch_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dflt_srch_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: default_search_engine
+  type: STRING
+  mode: NULLABLE
+  description: Default Search Engine
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique client IDs uninstalling

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dlsource_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dlsource_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Uninstalls By Download Source
+description: |-
+  Number of unique clients uninstalling by submission date and download source
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - attribution_dlsource
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dlsource_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dlsource_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  environment.settings.attribution.dlsource AS attribution_dlsource,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  attribution_dlsource

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dlsource_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dlsource_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: attribution_dlsource
+  type: STRING
+  mode: NULLABLE
+  description: Attribution Download Source
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of unique clients uninstalling


### PR DESCRIPTION
## Description

This PR creates the following aggregate tables: 
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_addon_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_attr_src_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_dflt_srch_v1
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_dlsource_v1

## Related Tickets & Documents
* [DENG-6884](https://mozilla-hub.atlassian.net/browse/DENG-6884)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6884]: https://mozilla-hub.atlassian.net/browse/DENG-6884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7301)
