### PR TITLE
DENG-6884 Create uninstalls_by_cpu_cores_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_cpu_cores/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_cpu_cores/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.uninstalls_by_cpu_cores`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_cpu_cores_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_cpu_cores_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_cpu_cores_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Uninstalls By Cpu Cores
+description: |-
+  Records number of unique clients uninstalling by day and CPU core count
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  shedder_mitigation: true
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_cpu_cores_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_cpu_cores_v1/query.sql
@@ -1,0 +1,12 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  environment.system.cpu.cores AS nbr_cpu_cores,
+  COUNT(DISTINCT client_id) AS uninstalls_count
+FROM
+  `moz-fx-data-shared-prod.telemetry.uninstall`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND application.name = 'Firefox'
+GROUP BY
+  submission_date,
+  nbr_cpu_cores

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_cpu_cores_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_cpu_cores_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: nbr_cpu_cores
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of CPU cores on device
+- name: uninstalls_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Unique Clients Uninstalling Firefox


### PR DESCRIPTION
## Description

This PR creates the table: 
- moz-fx-data-shared-prod.telemetry_derived.uninstalls_by_cpu_cores_v1

## Related Tickets & Documents
* [DENG-6884](https://mozilla-hub.atlassian.net/browse/DENG-6884)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6884]: https://mozilla-hub.atlassian.net/browse/DENG-6884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7334)
