### PR TITLE
#5830 Union default_table_workgroup_access with table-level workgroup_accesss in metadata generation logic

### DIFF
--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -10,7 +10,11 @@ import click
 from dateutil.relativedelta import relativedelta
 from google.cloud import bigquery
 
-from bigquery_etl.metadata.parse_metadata import DatasetMetadata, Metadata
+from bigquery_etl.metadata.parse_metadata import (
+    DatasetMetadata,
+    Metadata,
+    WorkgroupAccessMetadata,
+)
 from bigquery_etl.metadata.publish_metadata import publish_metadata
 
 from ..cli.utils import (
@@ -94,10 +98,41 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
             dataset_metadata_updated = True
         else:
             if table_metadata.workgroup_access is None:
-                table_metadata.workgroup_access = (
-                    dataset_metadata.default_table_workgroup_access
-                )
-                table_metadata_updated = True
+                table_metadata.workgroup_access = []
+
+            for (
+                default_workgroup_access
+            ) in dataset_metadata.default_table_workgroup_access:
+                role_exists = False
+                for i, table_workgroup_access in enumerate(
+                    table_metadata.workgroup_access
+                ):
+                    if table_workgroup_access.role == default_workgroup_access.get(
+                        "role"
+                    ):
+                        role_exists = True
+                        table_metadata_members = table_workgroup_access.members
+                        table_metadata_members.extend(
+                            default_workgroup_member
+                            for default_workgroup_member in default_workgroup_access.get(
+                                "members", []
+                            )
+                            if default_workgroup_member not in table_metadata_members
+                        )
+
+                        table_metadata.workgroup_access[i].members = (
+                            table_metadata_members
+                        )
+                        table_metadata_updated = True
+
+                if not role_exists:
+                    table_metadata.workgroup_access.append(
+                        WorkgroupAccessMetadata(
+                            role=default_workgroup_access["role"],
+                            members=default_workgroup_access.get("members", []),
+                        )
+                    )
+                    table_metadata_updated = True
 
         if dataset_metadata_updated:
             dataset_metadata.write(dataset_metadata_path)

--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -111,17 +111,9 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
                         "role"
                     ):
                         role_exists = True
-                        table_metadata_members = table_workgroup_access.members
-                        table_metadata_members.extend(
-                            default_workgroup_member
-                            for default_workgroup_member in default_workgroup_access.get(
-                                "members", []
-                            )
-                            if default_workgroup_member not in table_metadata_members
-                        )
-
-                        table_metadata.workgroup_access[i].members = (
-                            table_metadata_members
+                        table_metadata.workgroup_access[i].members = sorted(
+                            set(table_workgroup_access.members)
+                            | set(default_workgroup_access.get("members", []))
                         )
                         table_metadata_updated = True
 

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -205,7 +205,8 @@ class TestMetadata:
                 metadata = yaml.safe_load(stream)
         assert metadata["workgroup_access"][0]["role"] == "roles/bigquery.dataViewer"
         assert metadata["workgroup_access"][0]["members"] == [
-            "workgroup:mozilla-confidential"
+            "workgroup:test/test",
+            "workgroup:mozilla-confidential",
         ]
         assert "deprecated" not in metadata
 
@@ -245,25 +246,6 @@ class TestMetadata:
                 "role": "roles/bigquery.dataViewer",
             }
         ]
-
-    def test_metadata_update_do_not_update(self, runner):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            distutils.dir_util.copy_tree(str(TEST_DIR), str(tmpdirname))
-            name = [
-                str(tmpdirname)
-                + "/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_scalar_aggregates_v1/"
-            ]
-            runner.invoke(update, name, "--sql_dir=" + str(tmpdirname) + "/sql")
-            with open(
-                tmpdirname
-                + "/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_keyed_scalar_aggregates_v1/metadata.yaml",
-                "r",
-            ) as stream:
-                metadata = yaml.safe_load(stream)
-
-        assert metadata["workgroup_access"][0]["role"] == "roles/bigquery.dataViewer"
-        assert metadata["workgroup_access"][0]["members"] == ["workgroup:revenue/cat4"]
-        assert "deprecated" not in metadata
 
     @patch("google.cloud.bigquery.Client")
     @patch("google.cloud.bigquery.Table")

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -205,8 +205,8 @@ class TestMetadata:
                 metadata = yaml.safe_load(stream)
         assert metadata["workgroup_access"][0]["role"] == "roles/bigquery.dataViewer"
         assert metadata["workgroup_access"][0]["members"] == [
-            "workgroup:test/test",
             "workgroup:mozilla-confidential",
+            "workgroup:test/test",
         ]
         assert "deprecated" not in metadata
 

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
@@ -4,3 +4,8 @@ description: |-
   Clustering fields: `column1`
 owners:
   - test@mozilla.com
+
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:test/test


### PR DESCRIPTION
Fixes https://github.com/mozilla/bigquery-etl/issues/5830

Update the `metadata update` logic to union `default_table_workgroup_access` entries with table-level `workgroup_access` entries

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**