### PR TITLE
fix: log a more useful message in cases where no reports are found and add 2 day lag to the date of the report being pulled

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/metadata.yaml
@@ -17,7 +17,7 @@ scheduling:
   dag_name: bqetl_firefox_ios
   depends_on_past: false
   arguments:
-  - --date={{macros.ds_add(ds, -2)}}
+  - --date={{macros.ds_add(ds, -5)}}
   - --connect_app_id=989804926
   - --partition_field=logical_date
 
@@ -29,7 +29,7 @@ scheduling:
   - deploy_target: CONNECT_KEY
     key: bqetl_firefox_ios__app_store_connect_key
 
-  date_partition_offset: -2
+  date_partition_offset: -5
   retry_delay: 30m
   retries: 2
   email_on_retry: false

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/metadata.yaml
@@ -17,7 +17,7 @@ scheduling:
   dag_name: bqetl_firefox_ios
   depends_on_past: false
   arguments:
-  - --date={{ds}}
+  - --date={{macros.ds_add(ds, -2)}}
   - --connect_app_id=989804926
   - --partition_field=logical_date
 
@@ -28,6 +28,11 @@ scheduling:
     key: bqetl_firefox_ios__app_store_connect_key_id
   - deploy_target: CONNECT_KEY
     key: bqetl_firefox_ios__app_store_connect_key
+
+  date_partition_offset: -2
+  retry_delay: 30m
+  retries: 2
+  email_on_retry: false
 
 bigquery:
   time_partitioning:

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/query.py
@@ -8,6 +8,7 @@ import tempfile
 import time
 from argparse import ArgumentParser
 from pathlib import Path
+from sys import exit
 
 import jwt
 import pandas as pd
@@ -142,11 +143,19 @@ def fetch_report_data(app_id, date, jwt_token, target_file_path):
     daily_report_instances = list(
         filter(lambda x: x["attributes"]["granularity"] == "DAILY", report_instances)
     )
-    specific_date_report_instance = list(
-        filter(
-            lambda x: x["attributes"]["processingDate"] == date, daily_report_instances
+
+    try:
+        specific_date_report_instance = list(
+            filter(
+                lambda x: x["attributes"]["processingDate"] == date,
+                daily_report_instances,
+            )
+        )[0]
+    except IndexError:
+        logging.error(
+            f"It appears that report: `{REPORT_TITLE}` for date: `{date}` does not exist, potentially it has not yet been made available."
         )
-    )[0]
+        exit(1)
 
     analytics_report_segments = api_call(
         specific_date_report_instance["relationships"]["segments"]["links"]["related"],


### PR DESCRIPTION
# fix: log a more useful message in cases where no reports are found and add 2 day lag to the date of the report being pulled

This is to make it easier to understand the issue and handle the reports arriving with a 2 day delay.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7371)
