### PR TITLE
Redundant workgroup metadata CI check

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -289,6 +289,10 @@ jobs:
             - checkout
             - *restore_venv_cache
             - *build
+            - run:
+                name: Validate workgroup access configuration on main
+                command: |
+                  PATH="venv/bin:$PATH" script/bqetl metadata validate-workgroups
             - *attach_generated_sql
             - *copy_staged_sql
             - *authenticate

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -292,7 +292,7 @@ jobs:
             - run:
                 name: Validate workgroup access configuration on main
                 command: |
-                  PATH="venv/bin:$PATH" script/bqetl metadata validate-workgroups
+                  PATH="venv/bin:$PATH" script/bqetl metadata validate-workgroups sql/
             - *attach_generated_sql
             - *copy_staged_sql
             - *authenticate

--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -259,7 +259,7 @@ def validate_workgroups(
     project_id: str,
 ):
     """Validate workgroup_access and default_table_workgroup_access configuration."""
-    failed = False
+    failed_files = set()
 
     table_metadata_files = paths_matching_name_pattern(
         name, sql_dir, project_id=project_id, files=["metadata.yaml"]
@@ -271,10 +271,15 @@ def validate_workgroups(
             if Metadata.is_metadata_file(file):
                 metadata = Metadata.from_file(file)
                 if not validate_workgroup_access(metadata, file):
-                    failed = True
+                    failed_files.add(file)
 
                 if not validate_default_table_workgroup_access(file):
-                    failed = True
+                    failed_files.add(file)
 
-    if failed:
-        raise MetadataValidationError(f"Metadata workgroup validation failed for {file}")
+    if len(failed_files) > 0:
+        click.echo(click.style("Metadata workgroup validation failed for:", fg="red"))
+        for file in failed_files:
+            click.echo(click.style(str(file), fg="red"))
+        raise MetadataValidationError(
+            f"Metadata workgroup validation failed for: {failed_files}"
+        )

--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -264,16 +264,17 @@ def validate_workgroups(
     table_metadata_files = paths_matching_name_pattern(
         name, sql_dir, project_id=project_id, files=["metadata.yaml"]
     )
+    skip_validation = ConfigLoader.get("metadata", "validation", "skip", fallback=[])
 
     for file in table_metadata_files:
-        if Metadata.is_metadata_file(file):
-            metadata = Metadata.from_file(file)
-            if not validate_workgroup_access(metadata, file):
-                failed = True
+        if str(file) not in skip_validation:
+            if Metadata.is_metadata_file(file):
+                metadata = Metadata.from_file(file)
+                if not validate_workgroup_access(metadata, file):
+                    failed = True
 
-            if not validate_default_table_workgroup_access(file):
-                failed = True
+                if not validate_default_table_workgroup_access(file):
+                    failed = True
 
     if failed:
-        # TODO: add failed checks to message
-        raise MetadataValidationError(f"Metadata validation failed for {file}")
+        raise MetadataValidationError(f"Metadata workgroup validation failed for {file}")

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -408,8 +408,6 @@ def validate(target):
                     if not validate_col_desc_enforced(root, metadata):
                         failed = True
 
-                    if not validate_workgroup_access(metadata, path):
-                        failed = True
                     # todo more validation
                     # e.g. https://github.com/mozilla/bigquery-etl/issues/924
     else:

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -295,6 +295,7 @@ def validate_workgroup_access(metadata, path):
     default_table_workgroup_access_dict = {
         workgroup_access.get("role"): workgroup_access.get("members", [])
         for workgroup_access in dataset_metadata.default_table_workgroup_access
+        if dataset_metadata.default_table_workgroup_access
     }
 
     if metadata.workgroup_access:
@@ -315,6 +316,37 @@ def validate_workgroup_access(metadata, path):
                                 fg="red",
                             )
                         )
+
+    return is_valid
+
+
+def validate_default_table_workgroup_access(path):
+    """
+    Check that default_table_workgroup_access does not exist in metadata.
+
+    default_table_workgroup_access will be generated from workgroup_access and
+    should not be overridden.
+    """
+    is_valid = True
+    dataset_metadata_path = Path(path).parent.parent / "dataset_metadata.yaml"
+    if not dataset_metadata_path.exists():
+        return is_valid
+
+    with open(dataset_metadata_path, "r") as yaml_stream:
+        try:
+            metadata = yaml.safe_load(yaml_stream)
+        except yaml.YAMLError as e:
+            raise e
+
+    if "default_table_workgroup_access" in metadata:
+        is_valid = False
+        click.echo(
+            click.style(
+                f"ERROR: default_table_workgroup_access should not be explicity specified in {dataset_metadata_path}. "
+                + f"The default_table_workgroup_access configuration will be automatically generated.",
+                fg="red",
+            )
+        )
 
     return is_valid
 

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -401,12 +401,17 @@ class MetadataValidationError(Exception):
 def validate(target):
     """Validate metadata files."""
     failed = False
+    skip_validation = ConfigLoader.get("metadata", "validation", "skip", fallback=[])
 
     if os.path.isdir(target):
         for root, dirs, files in os.walk(target, followlinks=True):
             for file in files:
                 if Metadata.is_metadata_file(file):
                     path = os.path.join(root, file)
+
+                    if path in skip_validation:
+                        continue
+
                     metadata = Metadata.from_file(path)
 
                     if not validate_public_data(metadata, path):

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -343,7 +343,7 @@ def validate_default_table_workgroup_access(path):
         click.echo(
             click.style(
                 f"ERROR: default_table_workgroup_access should not be explicity specified in {dataset_metadata_path}. "
-                + f"The default_table_workgroup_access configuration will be automatically generated.",
+                + "The default_table_workgroup_access configuration will be automatically generated.",
                 fg="red",
             )
         )

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -296,6 +296,11 @@ render:
   # uses {%s} which results in unknown tag exception
   - sql/mozfun/hist/string_to_json/udf.sql
 
+metadata:
+  validation:
+    skip:
+    - sql/moz-fx-data-shared-prod/addons_derived/search_detection_v1/metadata.yaml # backfill compatibility issue
+
 generate:
   glean_usage:
     skip_existing: # Skip automatically updating the following artifacts

--- a/sql/moz-fx-data-marketing-prod/ga/dataset_metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-marketing-prod/ga_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/ga_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/accounts_backend/accounts/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_backend/accounts/metadata.yaml
@@ -11,7 +11,3 @@ description: |-
   See https://mozilla.github.io/ecosystem-platform/reference/database-structure#database-fxa
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/accounts_backend/nonprod_accounts/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_backend/nonprod_accounts/metadata.yaml
@@ -11,7 +11,3 @@ description: |-
   See https://mozilla.github.io/ecosystem-platform/reference/database-structure#database-fxa
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/accounts_db/fxa_accounts/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_db/fxa_accounts/metadata.yaml
@@ -11,7 +11,3 @@ description: |-
   See https://mozilla.github.io/ecosystem-platform/reference/database-structure#database-fxa
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/accounts_db/fxa_oauth_clients/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_db/fxa_oauth_clients/metadata.yaml
@@ -9,7 +9,3 @@ description: |-
   See https://mozilla.github.io/ecosystem-platform/reference/database-structure#database-fxa
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/accounts_db_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_db_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/acoustic/contact/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/acoustic/contact/metadata.yaml
@@ -10,7 +10,3 @@ description: |-
 
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/acoustic/contact_current_snapshot/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/acoustic/contact_current_snapshot/metadata.yaml
@@ -10,7 +10,3 @@ description: |-
 
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/acoustic/raw_recipient/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/acoustic/raw_recipient/metadata.yaml
@@ -10,7 +10,3 @@ description: |-
 
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_by_experiment_v1/metadata.yaml
@@ -19,8 +19,4 @@ bigquery:
   clustering:
     fields:
     - experiment_id
-workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:pocket/external
 references: {}

--- a/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/activity_stream_bi/impression_stats_flat_v1/metadata.yaml
@@ -18,10 +18,3 @@ bigquery:
     fields:
       - release_channel
       - sample_id
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      # to avoid permissions desync mozilla-confidential access is only granted
-      # at the dataset-level for now
-      # - workgroup:mozilla-confidential
-      - workgroup:pocket/external

--- a/sql/moz-fx-data-shared-prod/addon_moderations_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addon_moderations_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/addons_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/dataset_metadata.yaml
@@ -4,15 +4,9 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
-  - workgroup:amo/prod
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
-  # Removed for now to allow compatibility with managed backfills.
-  # - workgroup:amo/prod
+  - workgroup:amo/prod
 syndication: {}

--- a/sql/moz-fx-data-shared-prod/addons_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/dataset_metadata.yaml
@@ -4,9 +4,15 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-workgroup_access:
+default_table_workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
   - workgroup:amo/prod
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+  # Removed for now to allow compatibility with managed backfills.
+  # - workgroup:amo/prod
 syndication: {}

--- a/sql/moz-fx-data-shared-prod/ads/fakespot_daily_events_rollup/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads/fakespot_daily_events_rollup/metadata.yaml
@@ -7,7 +7,3 @@ owners:
   - lvargas@mozilla.com
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:ads

--- a/sql/moz-fx-data-shared-prod/ads/ppa_measurements/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads/ppa_measurements/metadata.yaml
@@ -9,7 +9,3 @@ owners:
   - cmorales@mozilla.com
   - cbeck@mozilla.com
   - lvargas@mozilla.com
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:ads

--- a/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_map_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_map_v2/metadata.yaml
@@ -17,7 +17,3 @@ external_data:
   - https://docs.google.com/spreadsheets/d/1ilLz0THm5gzzqaBqfzIa_83b74Y-ElykPed_bOLoy9s
   options:
     skip_leading_rows: 1
-workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:braze

--- a/sql/moz-fx-data-shared-prod/default_browser_agent/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/default_browser_agent/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 default_table_expiration_ms: null
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/default_browser_agent_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/default_browser_agent_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 default_table_expiration_ms: null
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/domain_metadata_derived/top_domains_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/domain_metadata_derived/top_domains_v1/metadata.yaml
@@ -19,8 +19,3 @@ bigquery:
 
 scheduling:
   dag_name: bqetl_domain_meta
-
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 default_table_expiration_ms: null
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/external_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 default_table_expiration_ms: null
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/client_ltv_v1/metadata.yaml
@@ -20,8 +20,4 @@ bigquery:
     fields:
     - sample_id
     - first_reported_country
-workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/broken_site_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/broken_site_report/metadata.yaml
@@ -3,5 +3,4 @@ labels:
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
-  - workgroup:mozilla-confidential
   - workgroup:webcompat/dashboard-service

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/newtab/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/newtab/metadata.yaml
@@ -5,4 +5,3 @@ workgroup_access:
   - workgroup:pocket/prefect
   - workgroup:mozsocial/prefect
   - workgroup:mozsoc-ml/service
-  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_live/metadata.yaml
@@ -13,4 +13,3 @@ workgroup_access:
   - workgroup:pocket/prefect
   - workgroup:mozsocial/prefect
   - workgroup:mozsoc-ml/service
-  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_background_defaultagent/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_background_defaultagent/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 default_table_expiration_ms: null
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_background_defaultagent_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_background_defaultagent_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 default_table_expiration_ms: null
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/fx_quant_user_research/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fx_quant_user_research/dataset_metadata.yaml
@@ -4,6 +4,7 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
+default_table_expiration_ms: null
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/fx_quant_user_research_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fx_quant_user_research_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 default_table_expiration_ms: null
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/fxci/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/fxci_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/glean_auto_events/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_auto_events/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/glean_auto_events_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_auto_events_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/monitoring/payload_bytes_error_structured/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/payload_bytes_error_structured/metadata.yaml
@@ -9,7 +9,3 @@ description: |-
   Clustering fields: `submission_timestamp`
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring/suggest_click_rate_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/suggest_click_rate_live/metadata.yaml
@@ -4,7 +4,3 @@ description: |-
   A live view of submissions intended for operational monitoring use cases.
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring/suggest_impression_rate_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/suggest_impression_rate_live/metadata.yaml
@@ -4,7 +4,3 @@ description: |-
   A live view of submissions intended for operational monitoring use cases.
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring/topsites_click_rate_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/topsites_click_rate_live/metadata.yaml
@@ -4,7 +4,3 @@ description: |-
   A live view of submissions intended for operational monitoring use cases.
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring/topsites_impression_rate_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/topsites_impression_rate_live/metadata.yaml
@@ -4,7 +4,3 @@ description: |-
   A live view of submissions intended for operational monitoring use cases.
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring/topsites_rate_fenix_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/topsites_rate_fenix_live/metadata.yaml
@@ -5,7 +5,3 @@ description: |-
   use cases.
 labels:
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_click_rate_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_click_rate_live_v1/metadata.yaml
@@ -7,7 +7,3 @@ owners:
 labels:
   materialized_view: true
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/suggest_impression_rate_live_v1/metadata.yaml
@@ -7,7 +7,3 @@ owners:
 labels:
   materialized_view: true
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/topsites_click_rate_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/topsites_click_rate_live_v1/metadata.yaml
@@ -7,7 +7,3 @@ owners:
 labels:
   materialized_view: true
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/topsites_impression_rate_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/topsites_impression_rate_live_v1/metadata.yaml
@@ -7,7 +7,3 @@ owners:
 labels:
   materialized_view: true
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/topsites_rate_fenix_beta_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/topsites_rate_fenix_beta_live_v1/metadata.yaml
@@ -7,7 +7,3 @@ owners:
 labels:
   materialized_view: true
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/topsites_rate_fenix_nightly_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/topsites_rate_fenix_nightly_live_v1/metadata.yaml
@@ -7,7 +7,3 @@ owners:
 labels:
   materialized_view: true
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/topsites_rate_fenix_release_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/topsites_rate_fenix_release_live_v1/metadata.yaml
@@ -7,7 +7,3 @@ owners:
 labels:
   materialized_view: true
   authorized: true
-workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/mozilla_org/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/desktop_conversion_events/metadata.yaml
@@ -1,7 +1,6 @@
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
-  - workgroup:mozilla-confidential
   - workgroup:google-managed/external-ads-datafusion
   - workgroup:google-managed/external-ads-dataproc
   - workgroup:dataops-managed/external-census

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v1/metadata.yaml
@@ -27,6 +27,5 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:dataops-managed/external-census
-  - workgroup:mozilla-confidential
   - workgroup:google-managed/external-ads-datafusion
   - workgroup:google-managed/external-ads-dataproc

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v2/metadata.yaml
@@ -28,6 +28,5 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:dataops-managed/external-census
-  - workgroup:mozilla-confidential
   - workgroup:google-managed/external-ads-datafusion
   - workgroup:google-managed/external-ads-dataproc

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v2/metadata.yaml
@@ -29,6 +29,5 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:dataops-managed/external-census
-  - workgroup:mozilla-confidential
   - workgroup:google-managed/external-ads-datafusion
   - workgroup:google-managed/external-ads-dataproc

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/metadata.yaml
@@ -1,5 +1,4 @@
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
-  - workgroup:mozilla-confidential
   - workgroup:webcompat/dashboard-service

--- a/sql/moz-fx-data-shared-prod/pocket/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:mozilla-confidential
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:

--- a/sql/moz-fx-data-shared-prod/reference/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/reference/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/reference_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/reference_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/stub_attribution_service/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stub_attribution_service/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view_restricted
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:data-science/duet
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dataset_metadata.yaml
@@ -5,10 +5,6 @@ description: |-
 dataset_base_acl: derived_restricted
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:data-science/duet
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/sumo_ga/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/sumo_ga_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_ga_derived/dataset_metadata.yaml
@@ -4,10 +4,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/telemetry/socorro_crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/socorro_crash/metadata.yaml
@@ -13,4 +13,3 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:ci-and-quality-tools/taskcluster
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/telemetry/socorro_crash_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/socorro_crash_v2/metadata.yaml
@@ -13,4 +13,3 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:ci-and-quality-tools/taskcluster
-      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
@@ -46,6 +46,5 @@ schema:
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
-  - workgroup:mozilla-confidential
   - workgroup:dataops-managed/taar
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
@@ -53,6 +53,5 @@ schema:
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
-  - workgroup:mozilla-confidential
   - workgroup:dataops-managed/taar
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_live/metadata.yaml
@@ -2,5 +2,4 @@
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
-      - workgroup:mozilla-confidential
       - workgroup:cloudops-managed/telescope


### PR DESCRIPTION
## Description
Follow-up to https://github.com/mozilla/bigquery-etl/pull/6811#issuecomment-2593766594

This adds a new CI check to ensure that there are no table-level access definitions that are redundant with dataset access definitions. This PR also removes configs that are redundant

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7402)
