### PR TITLE
feat(org_mozilla_broken_site_report): Add mobile reports to the unified view.

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
@@ -7,7 +7,7 @@ SELECT
   metrics.text2.broken_site_report_description AS comments,
   metrics.url2.broken_site_report_url AS url,
   metrics.string.broken_site_report_breakage_category AS breakage_category,
-  normalized_app_name AS app_name,
+  app_name,
   client_info.app_display_version AS app_version,
   normalized_channel AS app_channel,
   normalized_os AS os,
@@ -65,8 +65,32 @@ SELECT
     )
   ) AS details
 FROM
-  `moz-fx-data-shared-prod.firefox_desktop.broken_site_report`
-WHERE
-  DATE(submission_timestamp) > "2023-11-01"
+  (
+    SELECT
+      "Firefox" AS app_name,
+      client_info,
+      document_id,
+      metrics,
+      normalized_channel,
+      normalized_os,
+      submission_timestamp
+    FROM
+      `moz-fx-data-shared-prod.firefox_desktop.broken_site_report`
+    WHERE
+      DATE(submission_timestamp) > "2023-11-01"
+    UNION ALL
+    SELECT
+      "Fenix" AS app_name,
+      client_info,
+      document_id,
+      metrics,
+      normalized_channel,
+      normalized_os,
+      submission_timestamp
+    FROM
+      `moz-fx-data-shared-prod.fenix.broken_site_report`
+    WHERE
+      DATE(submission_timestamp) > "2025-01-01"
+  )
 ORDER BY
   submission_timestamp ASC

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
@@ -4,11 +4,21 @@ AS
 WITH live_reports AS (
   SELECT
     *,
+    "Firefox" AS app_name,
     ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp ASC) AS rn
   FROM
     `moz-fx-data-shared-prod.firefox_desktop_live.broken_site_report_v1`
   WHERE
     DATE(submission_timestamp) > "2023-11-01"
+  UNION ALL
+  SELECT
+    *,
+    "Fenix" AS app_name,
+    ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp ASC) AS rn
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_fenix_live.broken_site_report_v1`
+  WHERE
+    DATE(submission_timestamp) > "2025-01-01"
 )
 SELECT
   document_id AS uuid,
@@ -16,7 +26,7 @@ SELECT
   metrics.text2.broken_site_report_description AS comments,
   metrics.url2.broken_site_report_url AS url,
   metrics.string.broken_site_report_breakage_category AS breakage_category,
-  "Firefox" AS app_name,
+  app_name,
   client_info.app_display_version AS app_version,
   normalized_channel AS app_channel,
   normalized_os AS os,


### PR DESCRIPTION
## Description

We use this view as our point of ingestion for user reports. Recently, we also shipped the reporter to Fenix, and we want to ingest that data, too. Not sure if this is the most efficient way of doing this - I originally wanted to UNION the main query, but that'd have me duplicate everything, which felt wrong.

This also replaces the `app_name` with a static string for desktop and mobile. For desktop, this is not changing anything - but for mobile, the `normalized_app_name` column is always `null`. After chatting with @badboy, I learned that [this column is kinda legacy anyway](https://bugzilla.mozilla.org/show_bug.cgi?id=1672191#c1), and we only really need it to see which product the reports came from, so this is an easy way to make sure this is set right.

r? @scholtzan, please :)

## Related Tickets & Documents
n/a

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7524)
