### PR TITLE
[DENG-7513] Filter unexpectedload events from desktop derived events

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/query.sql
@@ -70,3 +70,13 @@ WHERE
     AND mozfun.map.get_key(event_map_values, 'feature') IN ('nimbus-qa-1', 'nimbus-qa-2')
     AND mozfun.norm.truncate_version(app_version, 'major') <= 108
   )
+  AND
+  -- See https://mozilla-hub.atlassian.net/browse/DENG-7513
+  NOT (
+    event_category = 'security'
+    AND event_method = 'unexpectedload'
+    AND normalized_channel = 'release'
+    AND mozfun.norm.truncate_version(app_version, 'major')
+    BETWEEN 133
+    AND 135
+  )

--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -136,3 +136,13 @@ FROM
   base
 CROSS JOIN
   UNNEST(events) AS event
+  {% if app_name == "firefox_desktop" %}
+    -- See https://mozilla-hub.atlassian.net/browse/DENG-7513
+    WHERE
+      NOT (
+        normalized_channel = 'release'
+        AND event.category = 'security'
+        AND event.name = 'unexpected_load'
+        AND app_version_major BETWEEN 132 AND 135
+      )
+  {% endif %}


### PR DESCRIPTION
## Description

This event is probably incorrectly being sent and causing a increase in event table size.  The event is going to stop being sent from release clients with https://bugzilla.mozilla.org/show_bug.cgi?id=1942005 so going to do the same thing for older clients.  Filtering these out in the derived events will reduce storage and shredder load.

Some prior art in https://github.com/mozilla/bigquery-etl/pull/1942

## Related Tickets & Documents
* DENG-7513

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7536)
