### PR TITLE
feat(dryrun): Pass all query parameters when dry-running queries

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -45,7 +45,9 @@ QUERY_PARAMETER_TYPE_VALUES = {
     "STRING": "foo",
     "BOOL": True,
     "FLOAT64": 1,
+    "FLOAT": 1,
     "INT64": 1,
+    "INTEGER": 1,
     "NUMERIC": 1,
     "BIGNUMERIC": 1,
 }


### PR DESCRIPTION
## Description
The `bqetl dryrun` command doesn't currently support queries which use any non-date query parameters.  This PR adds support for such queries by passing all expected query parameters when dry-running queries.

This depends on mozilla-services/cloudops-infra#6189 to update the `bigquery_etl_dryrun` Google Cloud function to accept query parameters as an argument.

## Related Tickets & Documents
* https://github.com/mozilla-services/cloudops-infra/pull/6189

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7559)
