### PR TITLE
Add accounts health lighthouse data

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/health_lighthouse_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/health_lighthouse_v1/metadata.yaml
@@ -1,0 +1,12 @@
+friendly_name: Accounts Health Lighthouse
+description: >
+  Front-end health metrics for Firefox Accounts, calculated from Lighthouse reports.
+owners:
+  - wclouser@mozilla.com
+external_data:
+  format: google_sheets
+  source_uris:
+    - https://docs.google.com/spreadsheets/d/1uGHOS-cY_OUqicbBkS2Z20EK0hLq3PDw28TZcxP5RHI/edit?gid=1783447085 # URL to the spreadsheet
+  options:
+    skip_leading_rows: 1
+    range: Lighthouse

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/health_lighthouse_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/health_lighthouse_v1/schema.yaml
@@ -1,0 +1,19 @@
+fields:
+  - mode: NULLABLE
+    name: fetchTime
+    type: TIMESTAMP
+  - mode: NULLABLE
+    name: url
+    type: STRING
+  - mode: NULLABLE
+    name: category
+    type: STRING
+  - mode: NULLABLE
+    name: audit
+    type: STRING
+  - mode: NULLABLE
+    name: score
+    type: NUMERIC
+  - mode: NULLABLE
+    name: numVal
+    type: NUMERIC


### PR DESCRIPTION
## Description

Adds Accounts Lighthouse Health data.  This is my first PR here so please let me know if I did anything wrong.

When I add a spreadsheet as a source directly in bigquery I can specify what tab to use.  I didn't see that in [the instructions](https://docs.telemetry.mozilla.org/cookbooks/operational/connecting_external_data_bigquery.html#connecting-sheets) and I'm not sure where to add it to the yaml.  The data is on the "Lighthouse" tab in my spreadsheet.  

Tagging @sean-rose because we were already discussing this earlier.  Thanks

## Related Tickets & Documents
none

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7600)
