### PR TITLE
Deprecate telemetry_derived.clients_profile_per_install_affected_v1

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -207,9 +207,6 @@ DELETE_TARGETS: DeleteIndex = {
     client_id_target(
         table="telemetry_derived.clients_last_seen_joined_v1"
     ): DESKTOP_SRC,
-    client_id_target(
-        table="telemetry_derived.clients_profile_per_install_affected_v1"
-    ): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.core_clients_daily_v1"): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.core_clients_last_seen_v1"): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.event_events_v1"): DESKTOP_SRC,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_profile_per_install_affected_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_profile_per_install_affected_v1/metadata.yaml
@@ -4,3 +4,5 @@ description: |-
   Client profiles affected by shredder. Populated by shredder.
 owners:
 - ascholtz@mozilla.com
+deprecated: true
+deletion_date: 2025-01-27


### PR DESCRIPTION
## Description

Looked at this as part of DENG-7480.  This table doesn't have any queries in the last two years and no code references.  I don't know what this is for but the data is from 2019-01-31 to 2019-08-04 which is pre-shredder/deletion requests so I don't know what the description means.  I'm pretty sure it's not used for anything though

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7594)
