### PR TITLE
fix(DO-1924): wrong struct value set as normalized_app_name_os

### DIFF
--- a/sql/moz-fx-data-shared-prod/search/mobile_search_clients_daily/view.sql
+++ b/sql/moz-fx-data-shared-prod/search/mobile_search_clients_daily/view.sql
@@ -42,7 +42,7 @@ SELECT
   `mozfun.mobile_search.normalize_app_name`(
     app_name,
     os
-  ).normalized_app_name AS normalized_app_name_os
+  ).normalized_app_name_os AS normalized_app_name_os
 FROM
   `moz-fx-data-shared-prod.search_derived.mobile_search_clients_daily_historical_pre202408`
 WHERE
@@ -89,7 +89,7 @@ SELECT
   `mozfun.mobile_search.normalize_app_name`(
     app_name,
     os
-  ).normalized_app_name AS normalized_app_name_os
+  ).normalized_app_name_os AS normalized_app_name_os
 FROM
   `moz-fx-data-shared-prod.search_derived.mobile_search_clients_daily_v2`
 WHERE


### PR DESCRIPTION
# fix(DO-1924): wrong struct value set as normalized_app_name_os

## Description

This PR fixes the value of `normalized_app_name_os` being incorrectly set to `normalized_app_name` insode `mobile_search_clients_daily`

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7597)
