### PR TITLE
fix: make sure the correct filter is applied when selecting search counts when calculating profile activation

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_v1/query.sql
@@ -35,9 +35,9 @@ client_search AS (
     USING (client_id)
   WHERE
     (submission_date BETWEEN DATE_SUB(@submission_date, INTERVAL 3 DAY) AND @submission_date)
-    AND normalized_app_name = 'Fenix'
+    AND normalized_app_name_os = "Firefox Android"
   GROUP BY
-    1
+    client_id
 ),
 dou AS (
   SELECT
@@ -71,7 +71,7 @@ adjust_client AS (
     AND metrics.string.first_session_network IS NOT NULL
     AND metrics.string.first_session_network <> ''
   GROUP BY
-    1
+    client_id
 )
 SELECT
   client_id,
@@ -93,7 +93,7 @@ SELECT
   first_seen_date,
   submission_date,
   1 AS new_profile,
-  CAST(days_2_7 > 1 AND COALESCE(search_count, 0) > 0 AS integer) AS activated
+  CAST(days_2_7 > 1 AND COALESCE(search_count, 0) > 0 AS INTEGER) AS activated
 FROM
   dou
 INNER JOIN

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v1/query.sql
@@ -35,10 +35,9 @@ client_search AS (
     USING (client_id)
   WHERE
     (submission_date BETWEEN DATE_SUB(@submission_date, INTERVAL 3 DAY) AND @submission_date)
-    AND normalized_app_name = 'Fennec'
-    AND os = 'iOS'
+    AND normalized_app_name_os = "Firefox iOS"
   GROUP BY
-    1
+    client_id
 ),
 dou AS (
   SELECT
@@ -70,7 +69,7 @@ SELECT
   first_seen_date,
   submission_date,
   1 AS new_profile,
-  CAST(days_2_7 > 1 AND COALESCE(search_count, 0) > 0 AS integer) AS activated
+  CAST(days_2_7 > 1 AND COALESCE(search_count, 0) > 0 AS INTEGER) AS activated
 FROM
   dou
 INNER JOIN

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_v2/query.sql
@@ -27,8 +27,7 @@ client_search AS (
     `moz-fx-data-shared-prod.search.mobile_search_clients_daily`
   WHERE
     (submission_date BETWEEN DATE_SUB(@submission_date, INTERVAL 3 DAY) AND @submission_date)
-    AND os = 'iOS'
-    AND normalized_app_name = 'Fennec'
+    AND normalized_app_name_os = 'Firefox iOS'
   GROUP BY
     client_id
 ),


### PR DESCRIPTION
depends on: https://github.com/mozilla/bigquery-etl/pull/6841

---

# fix: make sure the correct filter is applied when selecting search counts when calculating profile activation

## Description

Making sure we are filtering for the correct application when pulling out client's search counts for activation calculation.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7599)
