### PR TITLE
Add column descriptions to deal with CI shredder mitigation error

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_metrics_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_metrics_v2/schema.yaml
@@ -14,207 +14,276 @@ fields:
 - name: channel
   type: STRING
   mode: NULLABLE
+  description: Channel
 - name: country
   type: STRING
   mode: NULLABLE
+  description: Country
 - name: adjust_network
   type: STRING
   mode: NULLABLE
+  description: Adjust Network
 - name: is_default_browser
   type: BOOLEAN
   mode: NULLABLE
+  description: Is Default Browser
 - name: logins_deleted_users
   type: INTEGER
   mode: NULLABLE
+  description: Logins Deleted Users
 - name: logins_deleted
   type: INTEGER
   mode: NULLABLE
+  description: Logins Deleted
 - name: logins_modified_users
   type: INTEGER
   mode: NULLABLE
+  description: Logins Modified Users
 - name: logins_modified
   type: INTEGER
   mode: NULLABLE
+  description: Logins Modified
 - name: currently_stored_logins_users
   type: INTEGER
   mode: NULLABLE
+  description: Currently Stored Logins Users
 - name: currently_stored_logins
   type: INTEGER
   mode: NULLABLE
+  description: Currently Stored Logins
 - name: credit_cards_deleted_users
   type: INTEGER
   mode: NULLABLE
+  description: Credit Cards Deleted Users
 - name: credit_cards_deleted
   type: INTEGER
   mode: NULLABLE
+  description: Credit Cards Deleted
 - name: currently_stored_credit_cards_users
   type: INTEGER
   mode: NULLABLE
+  description: Currently Stored Credit Cards Users
 - name: currently_stored_credit_cards
   type: INTEGER
   mode: NULLABLE
+  description: Currently Stored Credit Cards
 - name: addresses_deleted_users
   type: INTEGER
   mode: NULLABLE
+  description: Addresses Deleted Users
 - name: addresses_deleted
   type: INTEGER
   mode: NULLABLE
+  description: Addresses Deleted
 - name: addresses_modified_users
   type: INTEGER
   mode: NULLABLE
+  description: Addresses Modified Users
 - name: addresses_modified
   type: INTEGER
   mode: NULLABLE
+  description: Addresses Modified
 - name: currently_stored_addresses_users
   type: INTEGER
   mode: NULLABLE
+  description: Currently Stored Addresses Users
 - name: currently_stored_addresses
   type: INTEGER
   mode: NULLABLE
+  description: Currently Stored Addresses
 - name: bookmarks_add_users
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Add Users
 - name: bookmarks_add
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Add
 - name: bookmarks_delete_users
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Delete Users
 - name: bookmarks_delete
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Delete
 - name: bookmarks_edit_users
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Edit Users
 - name: bookmarks_edit
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Edit
 - name: bookmarks_open_users
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Open Users
 - name: bookmarks_open
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Open
 - name: metrics_desktop_bookmarks_count_users
   type: INTEGER
   mode: NULLABLE
+  description: metrics_desktop_bookmarks_count_users
 - name: metrics_desktop_bookmarks_count
   type: INTEGER
   mode: NULLABLE
+  description: metrics_desktop_bookmarks_count
 - name: metrics_mobile_bookmarks_count_users
   type: INTEGER
   mode: NULLABLE
+  description: metrics_mobile_bookmarks_count_users
 - name: metrics_mobile_bookmarks_count
   type: INTEGER
   mode: NULLABLE
+  description: metrics_mobile_bookmarks_count
 - name: metrics_has_desktop_bookmarks_users
   type: INTEGER
   mode: NULLABLE
+  description: metrics_has_desktop_bookmarks_users
 - name: metrics_has_desktop_bookmarks
   type: INTEGER
   mode: NULLABLE
+  description: Metric Has Desktop Bookmarks
 - name: metrics_has_mobile_bookmarks_users
   type: INTEGER
   mode: NULLABLE
+  description: Metrics Has Mobile Bookmarks Users
 - name: metrics_has_mobile_bookmarks
   type: INTEGER
   mode: NULLABLE
+  description: Metrics Has Mobile Bookmarks
 - name: etp_standard_users
   type: INTEGER
   mode: NULLABLE
+  description: ETP Standard Users
 - name: etp_standard
   type: INTEGER
   mode: NULLABLE
+  description: ETP Standard
 - name: etp_strict_users
   type: INTEGER
   mode: NULLABLE
+  description: ETP Strict Users
 - name: etp_strict
   type: INTEGER
   mode: NULLABLE
+  description: ETP Strict
 - name: etp_custom_users
   type: INTEGER
   mode: NULLABLE
+  description: ETP Custom Users
 - name: etp_custom
   type: INTEGER
   mode: NULLABLE
+  description: ETP Custom
 - name: etp_disabled_users
   type: INTEGER
   mode: NULLABLE
+  description: ETP Disabled Users
 - name: etp_disabled
   type: INTEGER
   mode: NULLABLE
+  description: ETP Disabled
 - name: metrics_private_tabs_open_count_users
   type: INTEGER
   mode: NULLABLE
+  description: metrics_private_tabs_open_count_users
 - name: metrics_private_tabs_open_count
   type: INTEGER
   mode: NULLABLE
+  description: metrics_private_tabs_open_count
 - name: metrics_tabs_open_count_users
   type: INTEGER
   mode: NULLABLE
+  description: metrics_tabs_open_count_users
 - name: metrics_tabs_open_count
   type: INTEGER
   mode: NULLABLE
+  description: metrics_tabs_open_count
 - name: metrics_default_browser_users
   type: INTEGER
   mode: NULLABLE
+  description: metrics_default_browser_users
 - name: metrics_default_browser
   type: INTEGER
   mode: NULLABLE
+  description: metrics_default_browser
 - name: awesomebar_top_users
   type: INTEGER
   mode: NULLABLE
+  description: awesomebar_top_users
 - name: awesomebar_bottom_users
   type: INTEGER
   mode: NULLABLE
+  description: awesomebar_bottom_users
 - name: awesomebar_null_users
   type: INTEGER
   mode: NULLABLE
+  description: awesomebar_null_users
 - name: metrics_notifications_allowed_users
   type: INTEGER
   mode: NULLABLE
+  description: metrics_notifications_allowed_users
 - name: metrics_notifications_allowed
   type: INTEGER
   mode: NULLABLE
+  description: metrics_notifications_allowed
 - name: events_marketing_notification_allowed_users
   type: INTEGER
   mode: NULLABLE
+  description: events_marketing_notification_allowed_users
 - name: events_marketing_notification_allowed
   type: INTEGER
   mode: NULLABLE
+  description: Events Marketing Notification Allowed
 - name: customize_home_contile_users
   type: INTEGER
   mode: NULLABLE
+  description: customize_home_contile_users
 - name: customize_home_contile
   type: INTEGER
   mode: NULLABLE
+  description: customize_home_contile
 - name: customize_home_jump_back_in_users
   type: INTEGER
   mode: NULLABLE
+  description: customize_home_jump_back_in_users
 - name: customize_home_jump_back_in
   type: INTEGER
   mode: NULLABLE
+  description: customize_home_jump_back_in
 - name: customize_home_most_visited_sites_users
   type: INTEGER
   mode: NULLABLE
+  description: customize_home_most_visited_sites_users
 - name: customize_home_most_visited_sites
   type: INTEGER
   mode: NULLABLE
+  description: customize_home_most_visited_sites
 - name: customize_home_pocket_users
   type: INTEGER
   mode: NULLABLE
+  description: customize_home_pocket_users
 - name: customize_home_pocket
   type: INTEGER
   mode: NULLABLE
+  description: customize_home_pocket
 - name: customize_home_recently_saved_users
   type: INTEGER
   mode: NULLABLE
+  description: customize_home_recently_saved_users
 - name: customize_home_recently_saved
   type: INTEGER
   mode: NULLABLE
+  description: customize_home_recently_saved
 - name: customize_home_recently_visited_users
   type: INTEGER
   mode: NULLABLE
+  description: Customize Home Recently Visited Users
 - name: customize_home_recently_visited
   type: INTEGER
   mode: NULLABLE
+  description: Customize Home Recently Visited

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v2/schema.yaml
@@ -14,234 +14,312 @@ fields:
 - name: channel
   type: STRING
   mode: NULLABLE
+  description: Channel
 - name: country
   type: STRING
   mode: NULLABLE
+  description: Country
 - name: adjust_network
   type: STRING
   mode: NULLABLE
+  description: Adjust Network
 - name: is_default_browser
   type: BOOLEAN
   mode: NULLABLE
+  description: Is Default Browser
 - name: logins_deleted_users
   type: INTEGER
   mode: NULLABLE
+  description: Logins Deleted Users
 - name: logins_deleted
   type: INTEGER
   mode: NULLABLE
+  description: Logins Deleted
 - name: logins_modified_users
   type: INTEGER
   mode: NULLABLE
+  description: Logins Modified Users
 - name: logins_modified
   type: INTEGER
   mode: NULLABLE
+  description: Logins Modified
 - name: logins_saved_users
   type: INTEGER
   mode: NULLABLE
+  description: Logins Saved Users
 - name: logins_saved
   type: INTEGER
   mode: NULLABLE
+  description: Logins Saved
 - name: logins_saved_all_users
   type: INTEGER
   mode: NULLABLE
+  description: Logins Saved All Users
 - name: logins_saved_all
   type: INTEGER
   mode: NULLABLE
+  description: Logins Saved All
 - name: credit_card_autofill_enabled_users
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Autofill Enabled Users
 - name: credit_card_autofill_enabled
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Autofill Enabled
 - name: credit_card_sync_enabled_users
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Sync Enabled Users
 - name: credit_card_sync_enabled
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Sync Enabled
 - name: credit_card_deleted_users
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Deleted Users
 - name: credit_card_deleted
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Deleted
 - name: credit_card_modified_users
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Modified Users
 - name: credit_card_modified
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Modified
 - name: credit_card_saved_users
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Saved Users
 - name: credit_card_saved
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Saved
 - name: credit_card_saved_all_users
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Saved All Users
 - name: credit_card_saved_all
   type: INTEGER
   mode: NULLABLE
+  description: Credit Card Saved All
 - name: bookmarks_add_users
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Add Users
 - name: bookmarks_add
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Add
 - name: bookmarks_delete_users
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Delete Users
 - name: bookmarks_delete
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Delete
 - name: bookmarks_edit_users
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Edit Users
 - name: bookmarks_edit
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Edit
 - name: has_mobile_bookmarks_users
   type: INTEGER
   mode: NULLABLE
+  description: Has Mobile Bookmarks Users
 - name: has_mobile_bookmarks
   type: INTEGER
   mode: NULLABLE
+  description: Has Mobile Bookmarks
 - name: mobile_bookmarks_count_users
   type: INTEGER
   mode: NULLABLE
+  description: Mobile Bookmarks Count Users
 - name: mobile_bookmarks_count
   type: INTEGER
   mode: NULLABLE
+  description: Mobile Bookmarks Count
 - name: bookmarks_open_users
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Open Users
 - name: bookmarks_open
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks Open
 - name: bookmarks_view_list_users
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks View List Users
 - name: bookmarks_view_list
   type: INTEGER
   mode: NULLABLE
+  description: Bookmarks View List
 - name: sync_create_account_pressed_users
   type: INTEGER
   mode: NULLABLE
+  description: Sync Create Account Pressed Users
 - name: sync_create_account_pressed
   type: INTEGER
   mode: NULLABLE
+  description: Sync Create Account Pressed
 - name: sync_open_tab_users
   type: INTEGER
   mode: NULLABLE
+  description: Sync Open Tab Users
 - name: sync_open_tab
   type: INTEGER
   mode: NULLABLE
+  description: Sync Open Tab
 - name: sync_sign_in_sync_pressed_users
   type: INTEGER
   mode: NULLABLE
+  description: Sync Sign In Sync Pressed Users
 - name: sync_sign_in_sync_pressed
   type: INTEGER
   mode: NULLABLE
+  description: Sync Sign In Sync Pressed
 - name: tabs_private_tabs_quantity_users
   type: INTEGER
   mode: NULLABLE
+  description: Tabs Private Tabs Quantity Users
 - name: tabs_private_tabs_quantity
   type: INTEGER
   mode: NULLABLE
+  description: Tabs Private Tabs Quantity
 - name: preferences_close_private_tabs_users
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Close Private Tabs Users
 - name: preferences_close_private_tabs
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Close Private Tabs
 - name: tracking_protection_enabled_users
   type: INTEGER
   mode: NULLABLE
+  description: Tracking Protection Enabled Users
 - name: tracking_protection_enabled
   type: INTEGER
   mode: NULLABLE
+  description: Tracking Protection Enabled
 - name: tracking_protection_strict_users
   type: INTEGER
   mode: NULLABLE
+  description: Tracking Protection Strict Users
 - name: tracking_protection_strict
   type: INTEGER
   mode: NULLABLE
+  description: Tracking Protection Strict
 - name: tabs_normal_tabs_quantity_users
   type: INTEGER
   mode: NULLABLE
+  description: Tabs Normal Tabs Quantity Users
 - name: tabs_normal_tabs_quantity
   type: INTEGER
   mode: NULLABLE
+  description: Tabs Normal Tabs Quantity
 - name: tabs_inactive_tabs_count_users
   type: INTEGER
   mode: NULLABLE
+  description: Tabs Inactive Tabs Count Users
 - name: tabs_inactive_tabs_count
   type: INTEGER
   mode: NULLABLE
+  description: Tabs Inactive Tabs Count
 - name: app_opened_as_default_browser_users
   type: INTEGER
   mode: NULLABLE
+  description: App Opened as Default Browser Users
 - name: app_opened_as_default_browser
   type: INTEGER
   mode: NULLABLE
+  description: App Opened as Default Browser
 - name: settings_menu_set_as_default_browser_pressed_users
   type: INTEGER
   mode: NULLABLE
+  description: Settings Menu Set as Default Browser Pressed Users
 - name: settings_menu_set_as_default_browser_pressed
   type: INTEGER
   mode: NULLABLE
+  description: Settings Menu Set as Default Browser Pressed
 - name: preferences_sync_notifs_users
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Sync Notifs Users
 - name: preferences_sync_notifs
   type: INTEGER
   mode: NULLABLE
+  description: preferences_sync_notifs
 - name: preferences_tips_and_features_notifs_users
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Tips & Features Notifs Users
 - name: preferences_tips_and_features_notifs
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Tips & Features Notifs
 - name: preferences_jump_back_in_users
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Jump Back in Users
 - name: preferences_jump_back_in
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Jump Back In
 - name: preferences_recently_visited_users
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Recently Visited Users
 - name: preferences_recently_visited
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Recently Visited
 - name: preferences_recently_saved_users
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Recently Saved Users
 - name: preferences_recently_saved
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Recently Saved
 - name: preferences_pocket_users
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Pocket Users
 - name: preferences_pocket
   type: INTEGER
   mode: NULLABLE
+  description: Preferences Pocket
 - name: app_menu_customize_homepage_users
   type: INTEGER
   mode: NULLABLE
+  description: App Menu Customize Homepage Users
 - name: app_menu_customize_homepage
   type: INTEGER
   mode: NULLABLE
+  description: App Menu Customize Homepage
 - name: firefox_home_page_customize_homepage_button_users
   type: INTEGER
   mode: NULLABLE
+  description: Firefox Home Page Customize Homepage Button Users
 - name: firefox_home_page_customize_homepage_button
   type: INTEGER
   mode: NULLABLE
+  description: Firefox Home Page Customize Homepage Button
 - name: addresses_saved_all_users
   type: INTEGER
   mode: NULLABLE
+  description: Addresses Saved All Users
 - name: addresses_saved_all
   type: INTEGER
   mode: NULLABLE
+  description: Addresses Saved All


### PR DESCRIPTION
## Description

This PR is a follow up PR to [PR-6834](https://github.com/mozilla/bigquery-etl/pull/6834) that adds column descriptions to 2 new tables to fix the shredder mitigation error:
- moz-fx-data-shared-prod.fenix_derived.feature_usage_metrics_v2
- moz-fx-data-shared-prod.firefox_ios_derived.feature_usage_metrics_v2



**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7605)
