### PR TITLE
feat(DENG-6890): mobile kpi support metrics managed backfill 20250122

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/engagement_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/engagement_v1/backfill.yaml
@@ -5,11 +5,3 @@
   watchers:
   - kik@mozilla.com
   status: Initiate
-
-2024-05-31:
-  start_date: 2021-01-01
-  end_date: 2024-05-31
-  reason: The table is created, this is to populate it with data.
-  watchers:
-  - kik@mozilla.com
-  status: Complete

--- a/sql/moz-fx-data-shared-prod/fenix_derived/engagement_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/engagement_v1/backfill.yaml
@@ -5,3 +5,4 @@
   watchers:
   - kik@mozilla.com
   status: Initiate
+  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profiles_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profiles_v1/backfill.yaml
@@ -5,11 +5,3 @@
   watchers:
   - kik@mozilla.com
   status: Initiate
-
-2024-05-31:
-  start_date: 2021-01-01
-  end_date: 2024-05-31
-  reason: The table is created, this is to populate it with data.
-  watchers:
-  - kik@mozilla.com
-  status: Complete

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profiles_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profiles_v1/backfill.yaml
@@ -5,3 +5,4 @@
   watchers:
   - kik@mozilla.com
   status: Initiate
+  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
@@ -5,6 +5,7 @@
   watchers:
   - kik@mozilla.com
   status: Initiate
+  shredder_mitigation: false
 
 2024-05-31:
   start_date: 2021-01-01

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/engagement_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/engagement_v1/backfill.yaml
@@ -5,11 +5,3 @@
   watchers:
   - kik@mozilla.com
   status: Initiate
-
-2024-06-04:
-  start_date: 2021-01-01
-  end_date: 2024-06-04
-  reason: The table is created, this is to populate it with data.
-  watchers:
-  - kik@mozilla.com
-  status: Complete

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/engagement_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/engagement_v1/backfill.yaml
@@ -5,3 +5,4 @@
   watchers:
   - kik@mozilla.com
   status: Initiate
+  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profiles_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profiles_v1/backfill.yaml
@@ -5,11 +5,3 @@
   watchers:
   - kik@mozilla.com
   status: Initiate
-
-2024-06-04:
-  start_date: 2021-01-01
-  end_date: 2024-06-04
-  reason: The table is created, this is to populate it with data.
-  watchers:
-  - kik@mozilla.com
-  status: Complete

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profiles_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profiles_v1/backfill.yaml
@@ -5,3 +5,4 @@
   watchers:
   - kik@mozilla.com
   status: Initiate
+  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/backfill.yaml
@@ -5,6 +5,7 @@
   watchers:
   - kik@mozilla.com
   status: Initiate
+  shredder_mitigation: false
 
 2024-06-04:
   start_date: 2021-01-01

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
@@ -2,6 +2,12 @@ friendly_name: Profile / Client Engagement - {{ friendly_name }} (Aggregated)
 description: |-
   Profile / Client Engagement ({{ friendly_name }}) aggregated metrics
 
+  {% if app_name in ['fenix', 'firefox_ios'] -%}
+  device_type and device_manufacturer fields were added in 2024-03-05.
+  {%- else -%}
+  device_type and device_manufacturer fields were added on 2025-01-18.
+  {%- endif %}
+
 owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
@@ -14,7 +14,7 @@ owners:
 labels:
   schedule: daily
   incremental: true
-  shredder_mitigation: true
+  shredder_mitigation: false
   table_type: aggregate
 scheduling:
   dag_name: bqetl_mobile_kpi_metrics

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.metadata.yaml
@@ -2,6 +2,12 @@ friendly_name: New profiles - {{ friendly_name }} (Aggregated)
 description: |-
   New profiles ({{ friendly_name }}) aggregated metrics
 
+  {% if app_name in ['fenix', 'firefox_ios'] -%}
+  device_type and device_manufacturer fields were added in 2024-03-05.
+  {%- else -%}
+  device_type and device_manufacturer fields were added on 2025-01-18.
+  {%- endif %}
+
 owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.metadata.yaml
@@ -14,7 +14,7 @@ owners:
 labels:
   schedule: daily
   incremental: true
-  shredder_mitigation: true
+  shredder_mitigation: false
   table_type: aggregate
 scheduling:
   dag_name: bqetl_mobile_kpi_metrics

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
@@ -19,7 +19,7 @@ owners:
 labels:
   schedule: daily
   incremental: true
-  shredder_mitigation: true
+  shredder_mitigation: false
   table_type: aggregate
 scheduling:
   dag_name: bqetl_mobile_kpi_metrics

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
@@ -7,6 +7,12 @@ description: |-
 
   see: DENG-3183 for more information.
 
+  {% if app_name in ['fenix', 'firefox_ios'] -%}
+  device_type and device_manufacturer fields were added in 2024-03-05.
+  {%- else -%}
+  device_type and device_manufacturer fields were added on 2025-01-18.
+  {%- endif %}
+
 owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com


### PR DESCRIPTION
# feat(DENG-6890): mobile kpi support metrics managed backfill 20250122

New fields were added to the tables in order to support DMA analysis. As part of this we need to backfill the corresponding tables for both firefox_ios and fenix. This includes backfill the following tables for both products with data starting 2024-03-05:

- engagement_v1
- retention_v1
- new_profiles_v1

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7618)
