### PR TITLE
CI check to apply label for shredder mitigation

### DIFF
--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -8,13 +8,13 @@ from pathlib import Path
 
 import click
 import yaml
-
-from bigquery_etl.config import ConfigLoader
-from bigquery_etl.schema import SCHEMA_FILE, Schema
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 
-from ..util import standard_args, extract_from_query_path
+from bigquery_etl.config import ConfigLoader
+from bigquery_etl.schema import SCHEMA_FILE, Schema
+
+from ..util import extract_from_query_path, standard_args
 from ..util.common import extract_last_group_by_from_query, project_dirs
 from .parse_metadata import DatasetMetadata, Metadata
 
@@ -132,7 +132,6 @@ def validate_shredder_mitigation(query_dir, metadata):
         )
 
         # Check that the table exists and it's not empty.
-        table_exists = True
         try:
             bq_table = client.get_table(f"{project}.{dataset}.{table}")
         except NotFound:

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -4,12 +4,12 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
-from google.cloud.exceptions import NotFound
 
 import pytest
 import yaml
 from click.testing import CliRunner
 from dateutil.relativedelta import relativedelta
+from google.cloud.exceptions import NotFound
 
 from bigquery_etl.cli.metadata import deprecate, publish, update
 from bigquery_etl.metadata.parse_metadata import Metadata


### PR DESCRIPTION
## Description
CI check to apply the label shredder-mitigation only to existing and non-empty tables.


## Related Tickets & Documents
* DENG-7625

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7626)
