### PR TITLE
Create last aggregate table for retention of PBM users

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/prvt_brwsng_mode_retention/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/prvt_brwsng_mode_retention/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.prvt_brwsng_mode_retention`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.prvt_brwsng_mode_retention_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/prvt_brwsng_mode_retention_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/prvt_brwsng_mode_retention_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Private Browsing Mode Retention
+description: |-
+  Calculates retention over time for PBM users
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+  depends_on_past: false
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/prvt_brwsng_mode_retention_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/prvt_brwsng_mode_retention_v1/query.sql
@@ -1,0 +1,70 @@
+--Get clients who had the first seen date 8 days prior to submission date
+WITH cfs AS (
+  SELECT
+    client_id,
+    first_seen_date
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_first_seen`
+  WHERE
+    first_seen_date = DATE_SUB(@submission_date, INTERVAL 8 DAY)
+),
+--Get clients who saw onboarding between 8-10 days prior to submission date
+onboarding AS (
+  SELECT DISTINCT
+    client_id,
+    TRUE AS saw_onboarding
+  FROM
+    `moz-fx-data-shared-prod.messaging_system.onboarding`
+  WHERE
+    DATE(submission_timestamp) <= DATE_SUB(@submission_date, INTERVAL 8 DAY)
+    AND event_context LIKE '%about:welcome%'
+    AND event = 'IMPRESSION'
+),
+--Get a flag for if the client used private browsing mode on their first seen date
+--i.e. 8 days prior to submision date
+pbm_usage_on_first_seen_date AS (
+  SELECT
+    client_id,
+    dom_parentprocess_private_window_used AS used_pbm_on_first_seen_date
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_last_seen`
+  WHERE
+    submission_date = DATE_SUB(@submission_date, INTERVAL 8 DAY)
+),
+is_dau_in_next_7_days AS (
+  SELECT
+    client_id,
+    MAX(is_dau) AS active_in_next_7_days
+  FROM
+    `moz-fx-data-shared-prod.telemetry.desktop_active_users`
+  WHERE
+    submission_date
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 7 DAY)
+    AND DATE_SUB(@submission_date, INTERVAL 1 DAY)
+  GROUP BY
+    client_id
+)
+SELECT
+  @submission_date AS submission_date,
+  c.first_seen_date,
+  COALESCE(o.saw_onboarding, FALSE) AS saw_onboarding,
+  p.used_pbm_on_first_seen_date,
+  r.active_in_next_7_days,
+  COUNT(DISTINCT(c.client_id)) AS nbr_clients
+FROM
+  cfs AS c
+JOIN
+  pbm_usage_on_first_seen_date AS p
+  ON c.client_id = p.client_id
+LEFT JOIN
+  onboarding AS o
+  ON c.client_id = o.client_id
+LEFT JOIN
+  is_dau_in_next_7_days AS r
+  ON c.client_id = r.client_id
+GROUP BY
+  @submission_date,
+  c.first_seen_date,
+  o.saw_onboarding,
+  p.used_pbm_on_first_seen_date,
+  r.active_in_next_7_days

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/prvt_brwsng_mode_retention_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/prvt_brwsng_mode_retention_v1/schema.yaml
@@ -1,0 +1,25 @@
+fields:
+- description: Submission Date - Date of the DAG run - always 8 days after first seen date
+  mode: NULLABLE
+  name: submission_date
+  type: DATE
+- name: first_seen_date
+  type: DATE
+  mode: NULLABLE
+  description: First Seen Date - Date client was first seen
+- name: saw_onboarding
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Saw Onboarding - Flag indicating if the client saw "'about:welcome" on or before first seen date
+- name: used_pbm_on_first_seen_date
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Used Private Browsing Mode on First Seen Date
+- name: active_in_next_7_days
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active in Next 7 Days - Indicates if the client was a daily active user on 1 or more days
+- name: nbr_clients
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Clients


### PR DESCRIPTION
## Description

This PR creates the following new aggregate table that calculates retention over time for private browsing mode users vs not.  

- moz-fx-data-shared-prod.telemetry_derived.prvt_brwsng_mode_retention_v1

## Related Tickets & Documents
* [DENG-6893](https://mozilla-hub.atlassian.net/browse/DENG-6893)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-6893]: https://mozilla-hub.atlassian.net/browse/DENG-6893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7627)
