### PR TITLE
chore(glam): generalize refresh_agg_release and move fenix_release there

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1490,7 +1490,7 @@ bqetl_glam_refresh_aggregates:
     - impact/tier_2
     - repo/bigquery-etl
 
-bqetl_glam_refresh_aggregates_fog_release:
+bqetl_glam_refresh_aggregates_release:
   default_args:
     depends_on_past: false
     email:
@@ -1501,7 +1501,7 @@ bqetl_glam_refresh_aggregates_fog_release:
     retries: 2
     retry_delay: 30m
     start_date: '2024-12-10'
-  description: Update GLAM FOG release tables that serve aggregated data.
+  description: Update GLAM FOG and Fenix release tables that serve aggregated data.
   repo: bigquery-etl
   schedule_interval: 0 18 * * 6
   tags:

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fenix_release_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fenix_release_aggregates_v1/metadata.yaml
@@ -7,9 +7,9 @@ labels:
   incremental: false
   owner1: efilho@mozilla.com
 scheduling:
-  dag_name: bqetl_glam_refresh_aggregates
+  dag_name: bqetl_glam_refresh_aggregates_release
   date_partition_parameter: null
   depends_on:
-  - task_id: query_org_mozilla_fenix_glam_release__extract_probe_counts_v1
-    dag_name: glam_fenix
-    execution_delta: 6h
+  - task_id: fenix_release_done
+    dag_name: glam_fenix_release
+    execution_delta: 8h

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fog_release_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fog_release_aggregates_v1/metadata.yaml
@@ -7,7 +7,7 @@ labels:
   incremental: false
   owner1: efilho@mozilla.com
 scheduling:
-  dag_name: bqetl_glam_refresh_aggregates_fog_release
+  dag_name: bqetl_glam_refresh_aggregates_release
   date_partition_parameter: null
   depends_on:
   - task_id: fog_release_done


### PR DESCRIPTION
fixes https://github.com/mozilla/bigquery-etl/issues/6849
## Description

Similar to https://github.com/mozilla/bigquery-etl/pull/6646, this PR:
* Transforms `bqetl_glam_refresh_aggregates_fog_release` into `bqetl_glam_refresh_aggregates_release` so both Fenix and FOG load jobs can run there
* Extracts `bqetl_refresh_aggregates.glam_fenix_release_aggregates` into `bqetl_glam_refresh_aggregates_release` so it can follow `glam_fenix_release`'s schedule.

## Related Tickets & Documents
* DENG-7623

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**