### PR TITLE
Create monitoring_derived.table_storage_v1

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -43,6 +43,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/accounts_backend_external/nonprod_emails_v1/query.sql
   - sql/moz-fx-data-shared-prod/accounts_backend_external/accounts_v1/query.sql
   - sql/moz-fx-data-shared-prod/accounts_backend_external/emails_v1/query.sql
+  - sql/moz-fx-data-shared-prod/monitoring_derived/table_storage_v1/query.sql
   # uses time travel, will error on dates prior to the time travel window
   - sql/moz-fx-data-shared-prod/accounts_backend_derived/monitoring_db_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/accounts_db_external/**/*.sql

--- a/dags.yaml
+++ b/dags.yaml
@@ -431,7 +431,7 @@ bqetl_monitoring:
     used for monitoring of the data platform.
   default_args:
     owner: ascholtz@mozilla.com
-    email: ["ascholtz@mozilla.com"]
+    email: ["ascholtz@mozilla.com", "kwindau@mozilla.com"]
     start_date: "2018-10-30"
     retries: 2
     retry_delay: 30m

--- a/sql/moz-fx-data-shared-prod/monitoring/table_storage/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/table_storage/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.monitoring.table_storage`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.monitoring_derived.table_storage_v1`

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/table_storage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/table_storage_v1/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Table Storage
+description: |-
+  Runs weekly and saves the size of tables in moz-fx-data-shared-prod
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_monitoring_weekly
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - table_catalog
+    - table_schema
+references: {}

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/table_storage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/table_storage_v1/metadata.yaml
@@ -1,13 +1,13 @@
 friendly_name: Table Storage
 description: |-
-  Runs weekly and saves the size of tables in moz-fx-data-shared-prod
+  Runs daily and saves the size of tables in moz-fx-data-shared-prod
 owners:
 - kwindau@mozilla.com
 labels:
   incremental: true
   owner1: kwindau
 scheduling:
-  dag_name: bqetl_monitoring_weekly
+  dag_name: bqetl_monitoring
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/table_storage_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/table_storage_v1/query.sql
@@ -1,0 +1,23 @@
+SELECT
+  @submission_date AS submission_date,
+  project_id,
+  table_catalog,
+  table_schema,
+  table_name,
+  creation_time,
+  total_rows,
+  total_partitions,
+  total_logical_bytes,
+  active_logical_bytes,
+  long_term_logical_bytes,
+  current_physical_bytes,
+  total_physical_bytes,
+  active_physical_bytes,
+  long_term_physical_bytes,
+  time_travel_physical_bytes,
+  storage_last_modified_time,
+  deleted,
+  table_type,
+  fail_safe_physical_bytes
+FROM
+  `moz-fx-data-shared-prod.region-US.INFORMATION_SCHEMA.TABLE_STORAGE`

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/table_storage_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/table_storage_v1/schema.yaml
@@ -1,0 +1,81 @@
+fields:
+- description: Submission Date
+  mode: NULLABLE
+  name: submission_date
+  type: DATE
+- description: Project ID
+  mode: NULLABLE
+  name: project_id
+  type: STRING
+- description: Table Catalog
+  mode: NULLABLE
+  name: table_catalog
+  type: STRING
+- description: Table Schema
+  mode: NULLABLE
+  name: table_schema
+  type: STRING
+- description: Table Name
+  mode: NULLABLE
+  name: table_name
+  type: STRING
+- description: Creation Time
+  mode: NULLABLE
+  name: creation_time
+  type: TIMESTAMP
+- description: Total Rows
+  mode: NULLABLE
+  name: total_rows
+  type: INTEGER
+- description: Total Partitions
+  mode: NULLABLE
+  name: total_partitions
+  type: INTEGER
+- description: Total Logical Bytes
+  mode: NULLABLE
+  name: total_logical_bytes
+  type: INTEGER
+- description: Active Logical Bytes
+  mode: NULLABLE
+  name: active_logical_bytes
+  type: INTEGER
+- description: Long Term Logical Bytes
+  mode: NULLABLE
+  name: long_term_logical_bytes
+  type: INTEGER
+- description: Current Physical Bytes
+  mode: NULLABLE
+  name: current_physical_bytes
+  type: INTEGER
+- description: Total Physical Bytes
+  mode: NULLABLE
+  name: total_physical_bytes
+  type: INTEGER
+- description: Active Physical Bytes
+  mode: NULLABLE
+  name: active_physical_bytes
+  type: INTEGER
+- description: Long Term Physical Bytes
+  mode: NULLABLE
+  name: long_term_physical_bytes
+  type: INTEGER
+- description: Time Travel Physical Bytes
+  mode: NULLABLE
+  name: time_travel_physical_bytes
+  type: INTEGER
+- description: Storage Last Modified Time
+  mode: NULLABLE
+  name: storage_last_modified_time
+  type: TIMESTAMP
+- description: Deleted
+  mode: NULLABLE
+  name: deleted
+  type: BOOLEAN
+- description: Table Type
+  mode: NULLABLE
+  name: table_type
+  type: STRING
+- description: Fail Safe Physical Bytes
+  mode: NULLABLE
+  name: fail_safe_physical_bytes
+  type: INTEGER

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_retention_aggregates_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_retention_aggregates_v2/backfill.yaml
@@ -7,4 +7,3 @@
   - wchan@mozilla.com
   - vsabino@mozilla.com
   status: Complete
-  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_retention_aggregates_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_retention_aggregates_v2/backfill.yaml
@@ -7,3 +7,4 @@
   - wchan@mozilla.com
   - vsabino@mozilla.com
   status: Complete
+  shredder_mitigation: false


### PR DESCRIPTION
## Description
This PR creates a new table that will, once a week, record the size of data in each table in shared-prod, along with # of partitions in it: 
- moz-fx-data-shared-prod.monitoring_derived.table_storage_v1

## Related Tickets & Documents
* DENG-7601(https://mozilla-hub.atlassian.net/browse/DENG-7601)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7634)
