### PR TITLE
Revert "DENG-7329 Added shredder mitigation backfill validation"

### DIFF
--- a/bigquery_etl/backfill/validate.py
+++ b/bigquery_etl/backfill/validate.py
@@ -3,15 +3,7 @@
 from pathlib import Path
 from typing import List
 
-from ..backfill.parse import (
-    BACKFILL_FILE,
-    DEFAULT_REASON,
-    DEFAULT_WATCHER,
-    Backfill,
-    BackfillStatus,
-)
-from ..metadata.parse_metadata import METADATA_FILE, Metadata
-from ..metadata.validate_metadata import SHREDDER_MITIGATION_LABEL
+from ..backfill.parse import DEFAULT_REASON, DEFAULT_WATCHER, Backfill, BackfillStatus
 
 
 def validate_duplicate_entry_dates(
@@ -56,22 +48,10 @@ def validate_entries_are_sorted(backfills: List[Backfill]) -> None:
         raise ValueError("Backfill entries are not sorted by entry dates")
 
 
-def validate_shredder_mitigation(entry: Backfill, backfill_file: Path) -> None:
-    """Check if shredder mitigation in backfill entry and metadata label matches."""
-    metadata_file = Path(str(backfill_file).replace(BACKFILL_FILE, METADATA_FILE))
-    metadata = Metadata.from_file(metadata_file)
-    has_shredder_mitigation_label = SHREDDER_MITIGATION_LABEL in metadata.labels
-
-    if has_shredder_mitigation_label != entry.shredder_mitigation:
-        raise ValueError(
-            f"{SHREDDER_MITIGATION_LABEL} label in {METADATA_FILE} and {BACKFILL_FILE} should match."
-        )
-
-
 def validate_file(file: Path) -> None:
     """Validate all entries from a given backfill.yaml file."""
     backfills = Backfill.entries_from_file(file)
-    validate_entries(backfills, file)
+    validate_entries(backfills)
 
 
 def validate_duplicate_entry_with_initiate_status(
@@ -86,14 +66,13 @@ def validate_duplicate_entry_with_initiate_status(
                 )
 
 
-def validate_entries(backfills: list, file: Path) -> None:
+def validate_entries(backfills: list) -> None:
     """Validate a list of backfill entries."""
     for i, backfill_entry in enumerate(backfills):
         validate_default_watchers(backfill_entry)
         validate_default_reason(backfill_entry)
         validate_duplicate_entry_dates(backfill_entry, backfills[i + 1 :])
         validate_excluded_dates(backfill_entry)
-        validate_shredder_mitigation(backfill_entry, file)
         validate_duplicate_entry_with_initiate_status(
             backfill_entry, backfills[i + 1 :]
         )

--- a/tests/backfill/test_dir_valid/metadata.yaml
+++ b/tests/backfill/test_dir_valid/metadata.yaml
@@ -1,7 +1,0 @@
-friendly_name: Metadata file for backfill validation testing
-description: |-
-  Metadata file for backfill validation testing
-owners:
-- nobody@mozilla.com
-labels:
-  owner1: nobody@mozilla.com

--- a/tests/backfill/test_dir_valid_1/backfill.yaml
+++ b/tests/backfill/test_dir_valid_1/backfill.yaml
@@ -1,9 +1,0 @@
-2023-05-03:
-  start_date: 2021-01-03
-  end_date: 2021-05-03
-  excluded_dates:
-  - 2021-02-03
-  reason: no_reason
-  watchers:
-  - test@example.org
-  status: Initiate

--- a/tests/backfill/test_dir_valid_1/metadata.yaml
+++ b/tests/backfill/test_dir_valid_1/metadata.yaml
@@ -1,8 +1,0 @@
-friendly_name: Metadata file for backfill validation testing
-description: |-
-  Metadata file for backfill validation testing
-owners:
-- nobody@mozilla.com
-labels:
-  owner1: nobody@mozilla.com
-  shredder_mitigation: true

--- a/tests/backfill/test_validate_backfill.py
+++ b/tests/backfill/test_validate_backfill.py
@@ -16,18 +16,13 @@ from bigquery_etl.backfill.validate import (
     validate_entries,
     validate_entries_are_sorted,
     validate_file,
-    validate_shredder_mitigation,
 )
-from bigquery_etl.metadata.parse_metadata import METADATA_FILE
-from bigquery_etl.metadata.validate_metadata import SHREDDER_MITIGATION_LABEL
 from tests.backfill.test_parse_backfill import TEST_BACKFILL_1, TEST_BACKFILL_2
 
 TEST_DIR = Path(__file__).parent.parent
 
 VALID_REASON = "test_reason"
 VALID_WATCHER = "test@example.org"
-TEST_BACKFILL_FILE = TEST_DIR / "backfill" / "test_dir_valid" / BACKFILL_FILE
-TEST_BACKFILL_FILE_1 = TEST_DIR / "backfill" / "test_dir_valid_1" / BACKFILL_FILE
 
 
 class TestValidateBackfill(object):
@@ -94,7 +89,7 @@ class TestValidateBackfill(object):
         TEST_BACKFILL_2.reason = VALID_REASON
         backfills = [TEST_BACKFILL_2, TEST_BACKFILL_1]
         with pytest.raises(ValueError) as e:
-            validate_entries(backfills, TEST_BACKFILL_FILE)
+            validate_entries(backfills)
         assert (
             "Backfill entries cannot contain more than one entry with Initiate status"
             in str(e.value)
@@ -107,66 +102,8 @@ class TestValidateBackfill(object):
         TEST_BACKFILL_2.reason = VALID_REASON
         TEST_BACKFILL_2.status = BackfillStatus.COMPLETE.value
         backfills = [TEST_BACKFILL_2, TEST_BACKFILL_1]
-        validate_entries(backfills, TEST_BACKFILL_FILE)
+        validate_entries(backfills)
 
     def test_validate_file(self):
-        validate_file(TEST_BACKFILL_FILE)
-
-    def test_validate_backfill_with_shredder_mitigation_and_without_metadata_label_should_fail(
-        self,
-    ):
-        valid_backfill = Backfill(
-            TEST_BACKFILL_1.entry_date,
-            TEST_BACKFILL_1.start_date,
-            TEST_BACKFILL_1.end_date,
-            TEST_BACKFILL_1.excluded_dates,
-            VALID_REASON,
-            TEST_BACKFILL_1.watchers,
-            TEST_BACKFILL_1.status,
-            shredder_mitigation=True,
-        )
-
-        with pytest.raises(ValueError) as e:
-            validate_shredder_mitigation(valid_backfill, TEST_BACKFILL_FILE)
-
-        assert (
-            f"{SHREDDER_MITIGATION_LABEL} label in {METADATA_FILE} and {BACKFILL_FILE} should match."
-            in str(e.value)
-        )
-
-    def test_validate_backfill_without_shredder_mitigation_and_with_metadata_label_should_fail(
-        self,
-    ):
-        valid_backfill = Backfill(
-            TEST_BACKFILL_1.entry_date,
-            TEST_BACKFILL_1.start_date,
-            TEST_BACKFILL_1.end_date,
-            TEST_BACKFILL_1.excluded_dates,
-            VALID_REASON,
-            TEST_BACKFILL_1.watchers,
-            TEST_BACKFILL_1.status,
-        )
-
-        with pytest.raises(ValueError) as e:
-            validate_shredder_mitigation(valid_backfill, TEST_BACKFILL_FILE_1)
-
-        assert (
-            f"{SHREDDER_MITIGATION_LABEL} label in {METADATA_FILE} and {BACKFILL_FILE} should match."
-            in str(e.value)
-        )
-
-    def test_validate_backfill_with_shredder_mitigation_and_metadata_label_should_pass(
-        self,
-    ):
-        valid_backfill = Backfill(
-            TEST_BACKFILL_1.entry_date,
-            TEST_BACKFILL_1.start_date,
-            TEST_BACKFILL_1.end_date,
-            TEST_BACKFILL_1.excluded_dates,
-            VALID_REASON,
-            TEST_BACKFILL_1.watchers,
-            TEST_BACKFILL_1.status,
-            shredder_mitigation=True,
-        )
-
-        validate_shredder_mitigation(valid_backfill, TEST_BACKFILL_FILE_1)
+        backfill_file = TEST_DIR / "backfill" / "test_dir_valid" / BACKFILL_FILE
+        validate_file(backfill_file)


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#6821

For some reason the backfill validation checks are failing in main but not caught in the PR CI instead as intended.
Will revert for now and investigate.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7635)
