### PR TITLE
Skip stable view generation for firefox_accounts

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -386,6 +386,7 @@ generate:
   stable_views:
     skip_datasets:
     - mlhackweek_search
+    - firefox_accounts
 
 retention_exclusion_list:
 - sql/moz-fx-data-shared-prod/search_derived/acer_cohort_v1


### PR DESCRIPTION
## Description

telemetry block autoplay v1 doesn't need to be excluded because it's already shadowed by v4.

Note that `firefox_accounts` exists and has plenty of data in it, it's just not data collected via MPS. This means that dataset will need to be recharacterized on the cloudops-infra side via `terraform state mv` but that's not important to this PR.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DSRE-1832

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7641)
