### PR TITLE
feat(DENG-7656): add backfill.yaml to addons_derived.search_detection_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/addons_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/dataset_metadata.yaml
@@ -13,5 +13,6 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
-  - workgroup:amo/prod
+  # Removed for now to allow compatibility with managed backfills.
+  # - workgroup:amo/prod
 syndication: {}

--- a/sql/moz-fx-data-shared-prod/addons_derived/search_detection_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/search_detection_v1/backfill.yaml
@@ -1,0 +1,8 @@
+2025-01-24:
+  start_date: 2021-08-06
+  end_date: 2025-01-24
+  reason: New table, backfill to populate it with historical data.
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/addons_derived/search_detection_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/search_detection_v1/metadata.yaml
@@ -15,7 +15,7 @@ labels:
   incremental: true
   schedule: daily
   table_type: aggregate
-  shredder_mitigation: true
+  shredder_mitigation: false
 scheduling:
   dag_name: bqetl_amo_stats
 bigquery:


### PR DESCRIPTION
# feat(DENG-7656): add backfill.yaml to addons_derived.search_detection_v1

## Description

Adding the backfill entry to populate the new table with historical data.

depends on: https://github.com/mozilla/bigquery-etl/pull/6869

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7658)
