### PR TITLE
Create v2 agg table to test shredder mitigated backfill

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v2/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Firefox Health Indicator Searches By Provider
+description: |-
+  Count of searches & users by provider/day used in Firefox Health Indicator dashboard
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - default_search_engine
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v2/query.sql
@@ -1,0 +1,15 @@
+SELECT
+  submission_date_s3 AS submission_date,
+  default_search_engine,
+  channel,
+  SUM(search_count_all) AS searches,
+  COUNT(DISTINCT(client_id)) AS users
+FROM
+  `moz-fx-data-shared-prod.telemetry.clients_daily`
+WHERE
+  submission_date_s3 = @submission_date
+  AND app_name = 'Firefox'
+GROUP BY
+  submission_date_s3,
+  default_search_engine,
+  channel

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v2/schema.yaml
@@ -1,0 +1,20 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: default_search_engine
+  type: STRING
+  description: Default Search Engine
+- name: channel
+  type: STRING
+  mode: NULLABLE
+- mode: NULLABLE
+  name: searches
+  type: INTEGER
+  description: Number of Searches
+- mode: NULLABLE
+  name: users
+  type: INTEGER
+  description: Number of Users

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_searches_by_provider_v2/schema.yaml
@@ -10,6 +10,7 @@ fields:
 - name: channel
   type: STRING
   mode: NULLABLE
+  description: Channel
 - mode: NULLABLE
   name: searches
   type: INTEGER


### PR DESCRIPTION
## Description

This PR creates a new aggregate table:
- moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_searches_by_provider_v2 

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7663)
