### PR TITLE
Specify ping_info fields in event_monitoring_aggregates

### DIFF
--- a/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
@@ -69,7 +69,26 @@
       normalized_country_code,
       client_info.app_channel AS channel,
       client_info.app_display_version AS version,
-      ping_info
+      STRUCT (
+        ping_info.end_time,
+        ARRAY(
+          SELECT AS STRUCT
+            key,
+            STRUCT(
+              value.branch,
+              STRUCT(
+                value.extra.type,
+                value.extra.enrollment_id
+              ) AS extra
+            ) AS value
+          FROM
+            UNNEST(ping_info.experiments)
+        ) AS experiments,
+        ping_info.ping_type,
+        ping_info.seq,
+        ping_info.start_time,
+        ping_info.reason
+      ) AS ping_info,
     FROM
       `{{ project_id }}.{{ dataset['bq_dataset_family'] }}_stable.{{ events_table }}`
     {{ "UNION ALL" if not loop.last }}

--- a/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
@@ -82,7 +82,9 @@
               ) AS extra
             ) AS value
           FROM
-            UNNEST(ping_info.experiments)
+            UNNEST(ping_info.experiments) WITH OFFSET
+          ORDER BY
+            offset
         ) AS experiments,
         ping_info.ping_type,
         ping_info.seq,


### PR DESCRIPTION
## Description

[Dry run](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/44269/workflows/4b6ec306-8298-405a-bb6c-e3eacedbae88/jobs/513223) is failing with
```
[{'code': 400, 'errors': [{'message': 'Column 6 in UNION ALL has incompatible types: STRUCT<end_time STRING, ...> at [627:5]'
```
because of the new `home_v1` table which has a different order of fields in `ping_info`.  

Sean pointed out that we could reuse [Schema.generate_compatible_select_expression()](https://github.com/mozilla/bigquery-etl/blob/fcc07de2d2f982d1f573b284e5de9be035a21ec7/bigquery_etl/schema/__init__.py#L299-L426) here but due to urgency I'm putting this PR up for now

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7676)
