### PR TITLE
DENG-7650 Added override retention limit flag to backfill entry

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_fennec_derived/baseline_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_fennec_derived/baseline_clients_daily_v1/backfill.yaml
@@ -5,3 +5,4 @@
   watchers:
   - kik@mozilla.com
   status: Initiate
+  override_retention_limit: true


### PR DESCRIPTION
## Description

Managed backfills PR #6876 failed in [airflow](https://workflow.telemetry.mozilla.org/dags/bqetl_backfill_initiate/grid?search=bqetl_backfill_initiate&dag_run_id=scheduled__2025-01-24T21%3A00%3A00%2B00%3A00&task_id=initiate_backfill.process_backfill&tab=mapped_tasks&map_index=0) with the following error: `Cannot backfill more than 775 days prior to current date due to retention policies`

This PR adds the `override_retention_limit` flag to the backfll entry in order to bypass this restriction.


## Related Tickets & Documents
* DENG-7650

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7683)
