### PR TITLE
chore(DSRE-1886): add treeherder access to glam_etl data

### DIFF
--- a/sql/moz-fx-data-shared-prod/glam_etl/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/dataset_metadata.yaml
@@ -23,3 +23,4 @@ workgroup_access:
     members:
       - workgroup:mozilla-confidential
       - workgroup:dataops-managed/glam
+      - workgroup:treeherder/service


### PR DESCRIPTION
## Description

Requires https://github.com/mozilla-services/cloudops-infra/pull/6201 and  https://github.com/mozilla-services/cloudops-infra/pull/6202/. See https://mozilla-hub.atlassian.net/browse/DSRE-1886 for details.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DSRE-1886

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7686)
