### PR TITLE
Specify ping info fields in event_monitoring_live

### DIFF
--- a/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
@@ -82,9 +82,7 @@
               ) AS extra
             ) AS value
           FROM
-            UNNEST(ping_info.experiments) WITH OFFSET
-          ORDER BY
-            offset
+            UNNEST(ping_info.experiments)
         ) AS experiments,
         ping_info.ping_type,
         ping_info.seq,

--- a/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
@@ -68,7 +68,26 @@ IF
         normalized_country_code,
         client_info.app_channel AS channel,
         client_info.app_display_version AS version,
-        ping_info
+        STRUCT (
+          ping_info.end_time,
+          ARRAY(
+            SELECT AS STRUCT
+              key,
+              STRUCT(
+                value.branch,
+                STRUCT(
+                  value.extra.type,
+                  value.extra.enrollment_id
+                ) AS extra
+              ) AS value
+            FROM
+              UNNEST(ping_info.experiments)
+          ) AS experiments,
+          ping_info.ping_type,
+          ping_info.seq,
+          ping_info.start_time,
+          ping_info.reason
+        ) AS ping_info,
       FROM
       `{{ project_id }}.{{ dataset }}_live.{{ events_table }}`
       {{ "UNION ALL" if not loop.last }}

--- a/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
@@ -68,7 +68,7 @@ IF
         normalized_country_code,
         client_info.app_channel AS channel,
         client_info.app_display_version AS version,
-        STRUCT (
+        STRUCT(
           ping_info.end_time,
           ARRAY(
             SELECT AS STRUCT


### PR DESCRIPTION
## Description

Same issue as https://github.com/mozilla/bigquery-etl/pull/6878 where the ping_info fields don't match for the union.  This is just failing dry run because the materialized views don't get redeployed.  This seems to have a significant impact on query performance for `event_monitoring_aggregates_v1` (+200 to 250 slot hours comparing week-over-week but it runs with on-demand) so there's some risk if `firefox_desktop_derived.event_monitoring_live_v1` gets redeployed since it's already expensive.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7695)
