### PR TITLE
RS_1247 Removed backfill file for mobile_search_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_aggregates_v1/backfill.yaml
@@ -1,9 +1,0 @@
-2024-06-27:
-  start_date: 2024-04-01
-  end_date: 2024-05-31
-  reason: https://mozilla-hub.atlassian.net/browse/RS-1247
-  watchers:
-  - akommasani@mozilla.com
-  - skahmann@mozilla.com
-  - pissac@mozilla.com
-  status: Initiate


### PR DESCRIPTION
## Description

This backfill entry was added in PR #5862 
This PR removes the backfill entry that is no longer needed.

## Related Tickets & Documents
* RS_1247

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7698)
