### PR TITLE
Make validate-metadata run on all files

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -297,7 +297,7 @@ jobs:
                 command: |
                   # TODO: Add check here to make sure all queries have metadata.yaml
                   PATH="venv/bin:$PATH" script/bqetl query validate \
-                    --respect-dryrun-skip
+                    --no-dryrun --skip-format-sql
             - *copy_debug_sql
             - *store_debug_artifacts
       - unless:

--- a/bigquery_etl/cli/dryrun.py
+++ b/bigquery_etl/cli/dryrun.py
@@ -99,7 +99,7 @@ def dryrun(
 
     if not sql_files:
         click.echo("Skipping dry run because no queries matched")
-        sys.exit(0)
+        return
 
     if not use_cloud_function and not is_authenticated():
         click.echo(


### PR DESCRIPTION
## Description

fixes #6875.  `sys.exit(0)` in the dry run command causes the metadata validation to exit early so it doesn't actually validate more than one metadata file ([example](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/44363/workflows/f0517bc1-771b-4591-8b97-bd7d914ccdf4/jobs/514580)).

CI step changes:
- added `--no-dryrun` to the `validate-metadata` CI step because it's redundant in CI
- added `--skip-format-sql` option because it takes too long to run for every query
- removed `--respect-dryrun-skip` becaus queries aren't run so it should work

I didn't find any other uses of dryrun or `sys.exit(0)` that would have similar behaviour.

## Related Tickets & Documents
* #6875

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7706)
