### PR TITLE
feat: Move baseline_clients_daily_v1 backfill entry to Complete for firefox_ios and fenix beta and release channels

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/baseline_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/baseline_clients_daily_v1/backfill.yaml
@@ -4,5 +4,5 @@
   reason: Backfilling prior to June 2024 to populate geo_subdivision field in the derived table.
   watchers:
   - kik@mozilla.com
-  status: Initiate
+  status: Complete
   override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/baseline_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/baseline_clients_daily_v1/backfill.yaml
@@ -4,5 +4,5 @@
   reason: Backfilling prior to June 2024 to populate geo_subdivision field in the derived table.
   watchers:
   - kik@mozilla.com
-  status: Initiate
+  status: Complete
   override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/baseline_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/baseline_clients_daily_v1/backfill.yaml
@@ -4,5 +4,5 @@
   reason: Backfilling prior to June 2024 to populate geo_subdivision field in the derived table.
   watchers:
   - kik@mozilla.com
-  status: Initiate
+  status: Complete
   override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/baseline_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/baseline_clients_daily_v1/backfill.yaml
@@ -4,5 +4,5 @@
   reason: Backfilling prior to June 2024 to populate geo_subdivision field in the derived table.
   watchers:
   - kik@mozilla.com
-  status: Initiate
+  status: Complete
   override_retention_limit: true


### PR DESCRIPTION
# feat: Move baseline_clients_daily_v1 backfill entry to Complete for firefox_ios and fenix beta and release channels

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7714)
