### PR TITLE
Update cinder_decisions_raw_v1 schema

### DIFF
--- a/sql/moz-fx-data-shared-prod/addon_moderations_derived/cinder_decisions_raw_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/addon_moderations_derived/cinder_decisions_raw_v1/schema.yaml
@@ -123,7 +123,7 @@ fields:
 
 - mode: NULLABLE
   name: entity_id
-  type: STRING
+  type: INTEGER
   description: Entity ID
 
 - mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/addon_moderations_derived/cinder_decisions_raw_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/addon_moderations_derived/cinder_decisions_raw_v1/schema.yaml
@@ -58,7 +58,7 @@ fields:
   - fields:
     - mode: NULLABLE
       name: id
-      type: STRING
+      type: INTEGER
       description: Attribute ID
     - mode: NULLABLE
       name: slug

--- a/sql/moz-fx-data-shared-prod/addon_moderations_derived/cinder_decisions_raw_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/addon_moderations_derived/cinder_decisions_raw_v1/schema.yaml
@@ -17,7 +17,7 @@ fields:
 
 - mode: NULLABLE
   name: created_at
-  type: STRING
+  type: TIMESTAMP
   description: Date decision made
 
 - mode: NULLABLE


### PR DESCRIPTION
## Description

Fixes schema deploy failures for `moz-fx-data-shared-prod.addon_moderations_derived.cinder_decisions_raw_v1`: `Schema does not match Table moz-fx-data-shared-prod:addon_moderations_derived.cinder_decisions_raw_v1. Field created_at has changed type from TIMESTAMP to STRING)`


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7718)
