### PR TITLE
Set additional_deletion_requests_v1 retention to 775 days

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_focus_beta_derived/additional_deletion_requests_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_focus_beta_derived/additional_deletion_requests_v1/metadata.yaml
@@ -8,6 +8,7 @@ owners:
 - akomar@mozilla.com
 labels:
   schedule: daily
+  table_type: client_level
 scheduling:
   dag_name: bqetl_org_mozilla_focus_derived
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_focus_beta_derived/additional_deletion_requests_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_focus_beta_derived/additional_deletion_requests_v1/metadata.yaml
@@ -16,3 +16,4 @@ bigquery:
     type: day
     field: submission_timestamp
     require_partition_filter: false
+    expiration_days: 775

--- a/sql/moz-fx-data-shared-prod/org_mozilla_focus_derived/additional_deletion_requests_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_focus_derived/additional_deletion_requests_v1/metadata.yaml
@@ -8,6 +8,7 @@ owners:
 - akomar@mozilla.com
 labels:
   schedule: daily
+  table_type: client_level
 scheduling:
   dag_name: bqetl_org_mozilla_focus_derived
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_focus_derived/additional_deletion_requests_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_focus_derived/additional_deletion_requests_v1/metadata.yaml
@@ -16,3 +16,4 @@ bigquery:
     type: day
     field: submission_timestamp
     require_partition_filter: false
+    expiration_days: 775

--- a/sql/moz-fx-data-shared-prod/org_mozilla_focus_nightly_derived/additional_deletion_requests_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_focus_nightly_derived/additional_deletion_requests_v1/metadata.yaml
@@ -8,6 +8,7 @@ owners:
 - akomar@mozilla.com
 labels:
   schedule: daily
+  table_type: client_level
 scheduling:
   dag_name: bqetl_org_mozilla_focus_derived
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/org_mozilla_focus_nightly_derived/additional_deletion_requests_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_focus_nightly_derived/additional_deletion_requests_v1/metadata.yaml
@@ -16,3 +16,4 @@ bigquery:
     type: day
     field: submission_timestamp
     require_partition_filter: false
+    expiration_days: 775


### PR DESCRIPTION
## Description

Per policy discussion in https://mozilla-hub.atlassian.net/browse/DSRE-1799, the retention of deletion requests should be equal to the longest retained data subject to the deletion request.  That would be 760 for pings https://github.com/mozilla/probe-scraper/blob/cf4abcf2e94e1453315f44e2b2d45ab1ba8a29d2/repositories.yaml#L1336-L1342 and eventually 775 for derived data

cc @akkomar 

## Related Tickets & Documents
* DSRE-1799

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7726)
