### PR TITLE
Update schema for newtab_daily_interactions_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_daily_interactions_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_daily_interactions_aggregates_v1/metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: Newtab Interactions Daily Aggregates
 description: |-
   A daily aggregation of newtab interactions, partitioned by day.
 owners:
-  - gkatre@mozilla.com
+- gkatre@mozilla.com
 labels:
   application: firefox
   incremental: true
@@ -17,8 +17,9 @@ bigquery:
     field: submission_date
     require_partition_filter: true
     expiration_days: null
+  range_partitioning: null
   clustering:
     fields:
-      - channel
-      - country_code
+    - channel
+    - country_code
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_daily_interactions_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_daily_interactions_aggregates_v1/schema.yaml
@@ -143,3 +143,12 @@ fields:
 - name: organic_pocket_saves
   type: INTEGER
   mode: NULLABLE
+- name: os
+  type: STRING
+  mode: NULLABLE
+- name: os_version
+  type: STRING
+  mode: NULLABLE
+- name: newtab_search_enabled
+  type: BOOLEAN
+  mode: NULLABLE


### PR DESCRIPTION
## Description

This is failing dry run because of missing columns in the schema: https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/44507/workflows/1fc67c4c-0ff4-4b28-8e12-d497e258f1d1/jobs/516324

I updated it with: `bqetl query schema update telemetry_derived.newtab_daily_interactions_aggregates_v1`

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7737)
