### PR TITLE
Add firefox_ios_derived.client_adclicks_history_v1 to exclusion list …

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -463,3 +463,4 @@ retention_exclusion_list:
 - sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_first_seen_v2
 - sql/moz-fx-data-shared-prod/fenix_derived/attributable_clients_v1
 - sql/moz-fx-data-shared-prod/fenix_derived/attributable_clients_v2
+- sql/moz-fx-data-shared-prod/firefox_ios_derived/client_adclicks_history_v1


### PR DESCRIPTION
Added to exclusion list since used in Firefox iOS LTV calculation


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7744)
