### PR TITLE
feat: Add distribution_id and is_default_browser to baseline_clients_daily and last_seen templates

### DIFF
--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -33,8 +33,6 @@ BIGCONFIG_SKIP_APPS_METRICS = ConfigLoader.get(
     "generate", "glean_usage", "bigconfig", "skip_app_metrics", fallback=[]
 )
 
-APPS_WITH_DISTRIBUTION_ID = ("fenix",)
-
 APPS_WITH_PROFILE_GROUP_ID = ("firefox_desktop",)
 
 
@@ -268,7 +266,6 @@ class GleanTable:
             derived_dataset=derived_dataset,
             target_table=self.target_table_id,
             app_name=app_name,
-            has_distribution_id=app_name in APPS_WITH_DISTRIBUTION_ID,
             has_profile_group_id=app_name in APPS_WITH_PROFILE_GROUP_ID,
             enable_monitoring=enable_monitoring,
         )

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.query.sql
@@ -24,15 +24,18 @@ WITH base AS (
     normalized_channel,
     normalized_os,
     normalized_os_version,
-    {% if has_distribution_id %}
+    {% if app_name == "fenix" %}
     metrics.string.metrics_distribution_id AS distribution_id,
+    metrics.string.first_session_install_source AS install_source,
+    CAST(NULL AS BOOLEAN) AS is_default_browser,
+    {% elif app_name == "firefox_desktop" %}
+    metrics.string.usage_distribution_id AS distribution_id,
+    CAST(NULL AS STRING) AS install_source,
+    metrics.boolean.usage_is_default_browser AS is_default_browser,
     {% else %}
     CAST(NULL AS STRING) AS distribution_id,
-    {% endif %}
-    {% if app_name == "fenix" %}
-    metrics.string.first_session_install_source AS install_source,
-    {% else %}
     CAST(NULL AS STRING) AS install_source,
+    CAST(NULL AS BOOLEAN) AS is_default_browser,
     {% endif %}
     metadata.geo.subdivision1 AS geo_subdivision,
     {% if has_profile_group_id %}
@@ -137,6 +140,7 @@ windowed AS (
     udf.mode_last(ARRAY_AGG(install_source) OVER w1) AS install_source,
     udf.mode_last(ARRAY_AGG(geo_subdivision) OVER w1) AS geo_subdivision,
     udf.mode_last(ARRAY_AGG(profile_group_id) OVER w1) AS profile_group_id,
+    udf.mode_last(ARRAY_AGG(is_default_browser) OVER w1) AS is_default_browser,
   FROM
     with_date_offsets
   LEFT JOIN

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.schema.yaml
@@ -83,3 +83,6 @@ fields:
 - mode: NULLABLE
   name: install_source
   type: STRING
+- mode: NULLABLE
+  name: is_default_browser
+  type: BOOLEAN

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
@@ -66,3 +66,6 @@ fields:
 - mode: NULLABLE
   name: install_source
   type: STRING
+- mode: NULLABLE
+  name: is_default_browser
+  type: BOOLEAN


### PR DESCRIPTION
# feat: Add distribution_id and is_default_browser to baseline_clients_daily and last_seen templates

## Description

The following two fields have been introduced to firefox_desktop baseline ping:

- metrics.string.usage_distribution_id
- metrics.boolean.usage_is_default_browser

This information is needed for us for two reasons, 1. we need this information to support our ToS efforts. 2. This is an additional step towards us being able to move away from legacy telemetry.

This change affects two templates:

- baseline_clients_daily_v1 - So that we use the new distribution_id value for coming via baseline for firefox_desktop, and add is_default_browser field (only arriving for firefox_desktop currently).
- baseline_clients_last_seen_v1 - Since it consumes all fields from the daily baseline table.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7753)
