### PR TITLE
DENG-7723: Add OS group by to fx_health_ind_antivirus_v1 

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_antivirus/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_antivirus/view.sql
@@ -5,3 +5,5 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_antivirus_v1`
+WHERE
+  normalized_os = 'Windows'

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Firefox Health Indicator - Antivirus Trends
 description: |-
-  Aggregate table based on 1% user sample showing antivirus software usage on Windows
+  Aggregate table based on 1% user sample showing antivirus software usage by OS
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/query.sql
@@ -1,12 +1,13 @@
 SELECT
   DATE(submission_timestamp) AS submission_date,
+  normalized_os,
   environment.system.sec.antivirus,
   COUNT(DISTINCT client_id) AS unique_clients
 FROM
   `moz-fx-data-shared-prod.telemetry.main_1pct`
 WHERE
-  normalized_os = 'Windows'
-  AND DATE(submission_timestamp) = @submission_date
+  DATE(submission_timestamp) = @submission_date
 GROUP BY
   submission_date,
+  normalized_os,
   environment.system.sec.antivirus

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/schema.yaml
@@ -3,6 +3,10 @@ fields:
   name: submission_date
   type: DATE
   description: Submission Date
+- mode: NULLABLE
+  name: normalized_os
+  type: STRING
+  description: Normalized Operating System
 - name: antivirus
   type: STRING
   mode: REPEATED


### PR DESCRIPTION
## Description

This PR adds the normalized OS column to the group by in fx_health_ind_antivirus_v1 to make the table more usable for other use cases, while keeping the filter in the view to the same as before so the Firefox Health Indicator dashboard continues to work as expected.

## Related Tickets & Documents
* [DENG-7723](https://mozilla-hub.atlassian.net/browse/DENG-7723)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7723]: https://mozilla-hub.atlassian.net/browse/DENG-7723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7756)
