### PR TITLE
DENG-7723: Add OS and OS version to group by on fx_health_ind_bookmarks_by_os_version_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_os_version/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_os_version/view.sql
@@ -5,3 +5,6 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.fx_health_ind_bookmarks_by_os_version_v1`
+WHERE
+  normalized_os = 'Windows'
+  AND normalized_channel = 'release'

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Firefox Health Indicator - Bookmarks By Windows OS Version
 description: |-
-  Bookmarks per DAU by PS, for release channel only, OS = Windows, app version >= 84
+  Bookmarks per DAU by OS and channel, app version >= 84
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/query.sql
@@ -1,5 +1,7 @@
 SELECT
   DATE(submission_timestamp) AS submission_date,
+  normalized_channel,
+  normalized_os,
   normalized_os_version,
   SUM(payload.processes.parent.scalars.browser_engagement_bookmarks_toolbar_bookmark_added) / COUNT(
     DISTINCT client_id
@@ -12,8 +14,8 @@ FROM
 WHERE
   DATE(submission_timestamp) = @submission_date
   AND SUBSTR(application.version, 0, 2) >= '84'
-  AND normalized_channel = 'release'
-  AND normalized_os = 'Windows'
 GROUP BY
   submission_date,
+  normalized_channel,
+  normalized_os,
   normalized_os_version

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/schema.yaml
@@ -3,6 +3,14 @@ fields:
   name: submission_date
   type: DATE
   description: Submission Date
+- name: normalized_channel
+  type: STRING
+  mode: NULLABLE
+  description: Normalized Channel
+- name: normalized_os
+  type: STRING
+  mode: NULLABLE
+  description: Normalized Operating System
 - name: normalized_os_version
   type: STRING
   mode: NULLABLE


### PR DESCRIPTION
## Description

This PR adds the normalized_os and normalized_os_version to the group by on the table telemetry_derived.fx_health_ind_bookmarks_by_os_version, while adding the old filters to the view level so as not to impact the existing dashboard.  This will help us have a historical table of bookmarks by different OS types and versions over time.

## Related Tickets & Documents
* [DENG-7723](https://mozilla-hub.atlassian.net/browse/DENG-7723)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7723]: https://mozilla-hub.atlassian.net/browse/DENG-7723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7760)
