### PR TITLE
Add minimum row count check for at least 100 rows

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_v1/checks.sql
@@ -1,0 +1,2 @@
+#fail
+{{ min_row_count(100, "submission_date = @submission_date") }}


### PR DESCRIPTION
## Description

This PR adds a check for a minimum row count of at least 100 per day.  We were alerted in the data-help channel that this ETL job was silently failing with very small # of rows for over a year, so we'd like to add a row count check to be alerted sooner next time if row counts start to drop.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7782)
