### PR TITLE
Update bqetl_project.yaml: added clients first seen 28 days later V3 file to exclusion list

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -391,6 +391,7 @@ retention_exclusion_list:
 - sql/moz-fx-data-shared-prod/search_derived/acer_cohort_v1
 - sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v3
 - sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1
+- sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v3
 - sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/baseline_clients_first_seen_v1
 - sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/baseline_clients_first_seen_v1
 - sql/moz-fx-data-shared-prod/fenix_derived/ltv_states_v1


### PR DESCRIPTION
added clients first seen 28 days later V3 file to exclusion list

## Description

Adds moz-fx-data-shared-prod.telemetry_derived.clients_first_seen_28_days_later_v3 tp exclusions list

## Related Tickets & Documents


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7783)
