### PR TITLE
feat(DO-1935): add activation_clients and activations templates

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/__init__.py
+++ b/sql_generators/mobile_kpi_support_metrics/__init__.py
@@ -32,6 +32,10 @@ TEMPLATES = (
     ("CLIENT", "new_profile_clients.view.sql"),
     ("AGGREGATE", "new_profiles.view.sql"),
     ("AGGREGATE", "new_profiles.query.sql"),
+    ("CLIENT", "new_profile_activation_clients.view.sql"),
+    ("CLIENT", "new_profile_activation_clients.query.sql"),
+    ("AGGREGATE", "new_profile_activations.view.sql"),
+    ("AGGREGATE", "new_profile_activations.query.sql"),
 )
 BIGEYE_COLLECTION = "Operational Checks"
 BIGEYE_NOTIFICATION_SLACK_CHANNEL = "#de-bigeye-triage"

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.bigconfig.yml
@@ -1,0 +1,24 @@
+type: BIGCONFIG_FILE
+
+tag_deployments:
+  - collection:
+      name: {{ bigeye_collection }}
+      notification_channels:
+        - slack: '{{ bigeye_notification_slack_channel }}'
+    deployments:
+      - column_selectors:
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.submission_date
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.first_seen_date
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.app_name
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.is_mobile
+        metrics:
+          - saved_metric_id: is_not_null
+      - column_selectors:
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.normalized_channel
+        metrics:
+          - saved_metric_id: is_valid_channel
+      - column_selectors:
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.*
+        metrics:
+          - saved_metric_id: volume
+          - saved_metric_id: freshness

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.metadata.yaml
@@ -1,0 +1,34 @@
+friendly_name: Activation Clients - {{ friendly_name }}
+description: |-
+  Activation Clients ({{ friendly_name }}).
+
+  {% if app_name in ['fenix', 'firefox_ios'] -%}
+  device_type and device_manufacturer fields were added in 2024-03-05.
+  {%- else -%}
+  device_type and device_manufacturer fields were added on 2025-01-18.
+  {%- endif %}
+
+owners:
+  - mozilla/kpi_table_reviewers
+  - kik@mozilla.com
+labels:
+  schedule: daily
+  incremental: true
+  shredder_mitigation: false
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_mobile_kpi_metrics
+  depends_on_past: false
+  task_group: {{ app_name }}
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+  clustering:
+    fields:
+      - normalized_channel
+      - country
+monitoring:
+  enabled: true
+  collection: {{ bigeye_collection }}

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.query.sql
@@ -1,0 +1,87 @@
+WITH new_profiles AS (
+  SELECT
+    first_seen_date,
+    client_id,
+    normalized_channel,
+    app_name,
+    app_version,
+    country,
+    city,
+    geo_subdivision,
+    locale,
+    isp,
+    os,
+    os_version,
+    device_model,
+    device_manufacturer,
+    is_mobile,
+    {% for attribution_field in product_attribution_fields %}
+    {{ attribution_field }},
+    {% endfor %}
+    device_type,
+  FROM
+    `{{ project_id }}.{{ dataset }}.new_profile_clients`
+  WHERE
+    first_seen_date = DATE_SUB(@submission_date, INTERVAL 6 DAY)
+),
+active_users AS (
+  SELECT
+    first_seen_date,
+    client_id,
+    ARRAY_LENGTH(
+      mozfun.bits28.to_dates(mozfun.bits28.range(days_seen_bits, -5, 6), submission_date)
+    ) AS num_days_seen_day_2_7,
+    ARRAY_LENGTH(
+      mozfun.bits28.to_dates(mozfun.bits28.range(days_active_bits, -5, 6), submission_date)
+    ) AS num_days_active_day_2_7,
+  FROM
+    `{{ project_id }}.{{ dataset }}.active_users`
+  WHERE
+    submission_date = @submission_date
+    AND DATE_DIFF(submission_date, first_seen_date, DAY) = 6
+),
+client_search AS (
+  SELECT
+    client_id,
+    SUM(search_count) AS search_count,
+  FROM
+    `{{ project_id }}.search.mobile_search_clients_daily`
+  WHERE
+    submission_date BETWEEN DATE_SUB(@submission_date, INTERVAL 3 DAY) AND @submission_date
+    AND normalized_app_name_os = "{{ friendly_name }}"
+  GROUP BY
+    client_id
+)
+
+SELECT
+  @submission_date AS submission_date,
+  first_seen_date,
+  client_id,
+  normalized_channel,
+  app_name,
+  app_version,
+  country,
+  city,
+  geo_subdivision,
+  locale,
+  isp,
+  os,
+  os_version,
+  device_model,
+  device_manufacturer,
+  is_mobile,
+  {% for attribution_field in product_attribution_fields %}
+  {{ attribution_field }},
+  {% endfor %}
+  device_type,
+  COALESCE(num_days_seen_day_2_7, 0) AS num_days_seen_day_2_7,
+  COALESCE(num_days_active_day_2_7, 0) AS num_days_active_day_2_7,
+  COALESCE(search_count, 0) AS search_count,
+FROM
+  new_profiles
+INNER JOIN
+  active_users
+  USING(first_seen_date, client_id)
+LEFT JOIN
+  client_search
+  USING(client_id)

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.schema.yaml
@@ -1,0 +1,84 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Date corresponding to processing date.
+
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+  description: Date we first received a baseline ping from the profile.
+
+- mode: NULLABLE
+  name: normalized_channel
+  type: STRING
+  description: Release channel of the app the profile is using.
+
+- name: app_name
+  type: STRING
+  mode: NULLABLE
+  description: App name the profile is using.
+
+- name: app_version
+  type: STRING
+  mode: NULLABLE
+  description: Client's app version on the first seen date.
+
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Client's country on the first seen date.
+
+- name: locale
+  type: STRING
+  mode: NULLABLE
+  description: Client's locale on the first seen date.
+
+- name: os
+  type: STRING
+  mode: NULLABLE
+  description: Client's os on the first seen date.
+
+- name: os_version
+  type: STRING
+  mode: NULLABLE
+  description: Client's os version on the first seen date.
+
+- name: device_manufacturer
+  type: STRING
+  mode: NULLABLE
+  description: Client's device manufacturer on the first seen date.
+
+- name: is_mobile
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Indicates if this specific entry is used towards calculating mobile DAU.
+{% for field in product_attribution_fields.values() if not field.client_only %}
+- name: {{ field.name }}
+  type: {{ field.type }}
+  mode: NULLABLE
+  description: {{ field.description }}
+{% endfor %}
+- name: device_type
+  type: STRING
+  mode: NULLABLE
+  description: |
+    On Apple devices allows us to differentiate between iPhone and iPad. On Android devices the value is always "Android".
+
+- name: num_days_seen_day_2_7
+  type: INTEGER
+  mode: NULLABLE
+  description: |
+    Number of days we saw the client in between 2nd and 7th days since first_seen_date.
+
+- name: num_days_active_day_2_7
+  type: INTEGER
+  mode: NULLABLE
+  description: |
+    Number of days the client was active between day 2 and 7 since first_seen_date.
+
+- name: search_count
+  type: INTEGER
+  mode: NULLABLE
+  description: |
+    Number of searches performed by the client in the last 3 days.

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.view.sql
@@ -1,0 +1,18 @@
+{{ header }}
+CREATE OR REPLACE VIEW
+  `{{ project_id }}.{{ dataset }}.{{ name }}`
+AS
+SELECT
+  *,
+  {% if 'adjust_network' in product_attribution_fields %}
+    `moz-fx-data-shared-prod.udf.organic_vs_paid_mobile`(adjust_network) AS paid_vs_organic,
+  {% else %}
+    "Organic" AS paid_vs_organic,
+  {% endif %}
+  -- Checking if the client was seen more than once in the first 2 - 7 days
+  -- and if they had more than 0 searches within the time window (3 days).
+  IF(num_days_seen_day_2_7 > 1 AND search_count > 0, TRUE, FALSE) AS is_activated,
+  -- This is based on the more recent DAU definition that takes duration into consideration.
+  IF(num_days_active_day_2_7 > 1 AND search_count > 0, TRUE, FALSE) AS is_early_engagement,
+FROM
+  `{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}`

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.bigconfig.yml
@@ -1,0 +1,23 @@
+type: BIGCONFIG_FILE
+
+tag_deployments:
+  - collection:
+      name: {{ bigeye_collection }}
+      notification_channels:
+        - slack: '{{ bigeye_notification_slack_channel }}'
+    deployments:
+      - column_selectors:
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.first_seen_date
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.app_name
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.is_mobile
+        metrics:
+          - saved_metric_id: is_not_null
+      - column_selectors:
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.normalized_channel
+        metrics:
+          - saved_metric_id: is_valid_channel
+      - column_selectors:
+        - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.*
+        metrics:
+          - saved_metric_id: volume
+          - saved_metric_id: freshness

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.metadata.yaml
@@ -1,0 +1,34 @@
+friendly_name: Activations - {{ friendly_name }} (Aggregated)
+description: |-
+  Activations ({{ friendly_name }}) aggregated metrics
+
+  {% if app_name in ['fenix', 'firefox_ios'] -%}
+  device_type and device_manufacturer fields were added in 2024-03-05.
+  {%- else -%}
+  device_type and device_manufacturer fields were added on 2025-01-18.
+  {%- endif %}
+
+owners:
+  - mozilla/kpi_table_reviewers
+  - kik@mozilla.com
+labels:
+  schedule: daily
+  incremental: true
+  shredder_mitigation: false
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_mobile_kpi_metrics
+  depends_on_past: false
+  task_group: {{ app_name }}
+bigquery:
+  time_partitioning:
+    type: day
+    field: first_seen_date
+    require_partition_filter: false
+  clustering:
+    fields:
+      - normalized_channel
+      - country
+monitoring:
+  enabled: true
+  collection: {{ bigeye_collection }}

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.query.sql
@@ -1,0 +1,59 @@
+{{ header }}
+WITH device_manufacturer_counts AS (
+  SELECT
+    submission_date,
+    device_manufacturer,
+    RANK() OVER(PARTITION BY submission_date ORDER BY COUNT(*) DESC) AS manufacturer_rank,
+  FROM
+  `{{ project_id }}.{{ dataset }}.new_profile_activation_clients`
+  WHERE
+    submission_date = @submission_date
+  GROUP BY
+    submission_date,
+    device_manufacturer
+)
+
+SELECT
+  submission_date,
+  first_seen_date,
+  normalized_channel,
+  app_name,
+  app_version,
+  country,
+  locale,
+  os,
+  os_version,
+  -- Bucket device manufacturers with low count prior to aggregation
+  IF(manufacturer_rank <= 150, device_manufacturer, "other") AS device_manufacturer,
+  is_mobile,
+  {% for field in product_attribution_fields.values() if not field.client_only %}
+  {{ field.name }},
+  {% endfor %}
+  device_type,
+  COALESCE(COUNTIF(is_activated), 0) AS activations,
+  COALESCE(COUNTIF(is_early_engagement), 0) AS early_engagements,
+FROM
+  `{{ project_id }}.{{ dataset }}.new_profile_activation_clients`
+LEFT JOIN
+  device_manufacturer_counts
+  USING(submission_date, device_manufacturer)
+WHERE
+  submission_date = @submission_date
+GROUP BY
+  submission_date,
+  first_seen_date,
+  normalized_channel,
+  app_name,
+  app_version,
+  country,
+  locale,
+  os,
+  os_version,
+  device_type,
+  device_manufacturer,
+  is_mobile
+  {% for field in product_attribution_fields.values() if not field.client_only %}
+    {% if loop.first %},{% endif %}
+    {{ field.name }}
+    {% if not loop.last %},{% endif %}
+  {% endfor %}

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.schema.yaml
@@ -1,0 +1,76 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Date corresponding to processing date which is 7 days after the first_seen_date.
+
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+  description: Date we first received a baseline ping from the profile.
+
+- mode: NULLABLE
+  name: normalized_channel
+  type: STRING
+  description: Release channel of the app the profile is using.
+
+- name: app_name
+  type: STRING
+  mode: NULLABLE
+  description: App name the profile is using.
+
+- name: app_version
+  type: STRING
+  mode: NULLABLE
+  description: Client's app version on the first seen date.
+
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Client's country on the first seen date.
+
+- name: locale
+  type: STRING
+  mode: NULLABLE
+  description: Client's locale on the first seen date.
+
+- name: os
+  type: STRING
+  mode: NULLABLE
+  description: Client's os on the first seen date.
+
+- name: os_version
+  type: STRING
+  mode: NULLABLE
+  description: Client's os version on the first seen date.
+
+- name: device_manufacturer
+  type: STRING
+  mode: NULLABLE
+  description: Client's device manufacturer on the first seen date.
+
+- name: is_mobile
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Indicates if this specific entry is used towards calculating mobile DAU.
+{% for field in product_attribution_fields.values() if not field.client_only %}
+- name: {{ field.name }}
+  type: {{ field.type }}
+  mode: NULLABLE
+  description: {{ field.description }}
+{% endfor %}
+- name: device_type
+  type: STRING
+  mode: NULLABLE
+  description: |
+    On Apple devices allows us to differentiate between iPhone and iPad. On Android devices the value is always "Android".
+
+- name: activations
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of activations for the first seen date.
+
+- name: early_engagements
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of early_engagements for the first seen date.

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.view.sql
@@ -1,0 +1,13 @@
+{{ header }}
+CREATE OR REPLACE VIEW
+  `{{ project_id }}.{{ dataset }}.{{ name }}`
+AS
+SELECT
+  *,
+  {% if 'adjust_network' in product_attribution_fields %}
+    `moz-fx-data-shared-prod.udf.organic_vs_paid_mobile`(adjust_network) AS paid_vs_organic,
+  {% else %}
+    "Organic" AS paid_vs_organic,
+  {% endif %}
+FROM
+  `{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}`


### PR DESCRIPTION
# feat(DO-1935): add activation_clients and activations templates

## Description

This PR introduced the following templates to `mobile_kpi_support_metrics` generator:

- activation_clients.query.sql
- activation_clients.view.sql
- activation_clients.metadata.yaml
- activation_clients.bigconfig.yaml
- activation_clients.schema.yaml
- activations.query.sql
- activations.view.sql
- activations.metadata.yaml
- activations.bigconfig.yaml
- activations.schema.yaml

The fields used in these is consistent with all the other templates in this generator.

Here's an overview of each template type:

- `query.sql` - for creating a query used to generate new partitions.
- `metadata.yaml` - for defining table definition and scheduling options.
- `bigconfig.yaml` - for generating bigeye metrics.
- `schema.yaml` - for defining table schema, also used to create empty tables in combination with metadata.yaml config.


---

Follow up work:
- Backfill activation_clients tables starting 2021
- Backfill activations tables starting 2021
- Create a new marketing aggregate with more dimensions for firefox_ios and fenix.
- Backfill marketing aggregate tables starting 2021
- Deprecate firefox_ios_derived.new_profile_activations_v1 and v2
- Work towards deprecating firefox_android_clients_v1 and firefox_ios_clients_v1
- Deprecate firefox_ios_derived.clients_activation_v1



---

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7795)