### PR TITLE
[DENG-7550] Remove submission_date parameter from ltv aggregates

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_android_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_android_aggregates_v1/metadata.yaml
@@ -12,8 +12,6 @@ labels:
 scheduling:
   dag_name: bqetl_ltv
   date_partition_parameter: submission_date
-  parameters:
-    - "submission_date:DATE:{{ds}}"
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/ltv_ios_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/ltv_ios_aggregates_v1/metadata.yaml
@@ -12,8 +12,6 @@ labels:
 scheduling:
   dag_name: bqetl_ltv
   date_partition_parameter: submission_date
-  parameters:
-    - "submission_date:DATE:{{ds}}"
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ltv_desktop_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ltv_desktop_aggregates_v1/metadata.yaml
@@ -12,8 +12,6 @@ labels:
 scheduling:
   dag_name: bqetl_ltv
   date_partition_parameter: submission_date
-  parameters:
-    - "submission_date:DATE:{{ds}}"
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description

Follow-up to https://github.com/mozilla/bigquery-etl/pull/6934, I just tested a backfill locally with 
```
bqetl query backfill moz-fx-data-shared-prod.firefox_ios_derived.ltv_ios_aggregates_v1 --dry-run --project-id moz-fx-data-shared-prod --start-date 2025-01-20 --end-date 2025-01-22 --destination_table=benwubenwutest.tmp.backfill_test
```
and I got `BigQuery error in query operation: Duplicate query parameters named submission_date` so this might be needed

## Related Tickets & Documents
* DENG-7550

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7797)
