### PR TITLE
Add clients_first_seen_28_days_later_v3 to retention exclusion

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -391,6 +391,7 @@ retention_exclusion_list:
 - sql/moz-fx-data-shared-prod/search_derived/acer_cohort_v1
 - sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v3
 - sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1
+- sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v3
 - sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/baseline_clients_first_seen_v1
 - sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/baseline_clients_first_seen_v1
 - sql/moz-fx-data-shared-prod/fenix_derived/ltv_states_v1


### PR DESCRIPTION
## Description

This PR adds the table moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v3 to the retention exclusion list, per Su's request.


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7801)
