### PR TITLE
Revert "Remove experiment search monitoring"

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_ad_clicks/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_ad_clicks/metadata.yaml
@@ -1,0 +1,4 @@
+friendly_name: Experiment Cumulative Ad Clicks
+description: Cumulative ad click data related to experiments
+owners:
+- ascholtz@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_ad_clicks/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_ad_clicks/metadata.yaml
@@ -1,5 +1,0 @@
-friendly_name: Experiment Cumulative Ad Clicks
-description: Cumulative ad click data related to experiments
-owners:
-- ascholtz@mozilla.com
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_count/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_count/metadata.yaml
@@ -1,0 +1,4 @@
+friendly_name: Experiment Cumulative Search Count
+description: Cumulative search count data related to experiments
+owners:
+- ascholtz@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_count/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_count/metadata.yaml
@@ -1,5 +1,0 @@
-friendly_name: Experiment Cumulative Search Count
-description: Cumulative search count data related to experiments
-owners:
-- ascholtz@mozilla.com
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_with_ads_count/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_with_ads_count/metadata.yaml
@@ -1,0 +1,4 @@
+friendly_name: Experiment Cumulative Search with Ads Count
+description: Cumulative data of searches that had ad clicks related to experiments
+owners:
+- ascholtz@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_with_ads_count/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/experiment_cumulative_search_with_ads_count/metadata.yaml
@@ -1,5 +1,0 @@
-friendly_name: Experiment Cumulative Search with Ads Count
-description: Cumulative data of searches that had ad clicks related to experiments
-owners:
-- ascholtz@mozilla.com
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_ad_clicks_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_ad_clicks_v1/metadata.yaml
@@ -4,4 +4,3 @@ labels:
   incremental: false
 owners:
 - ascholtz@mozilla.com
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_search_count_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_search_count_v1/metadata.yaml
@@ -4,4 +4,3 @@ labels:
   incremental: false
 owners:
 - ascholtz@mozilla.com
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_search_with_ads_count_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_cumulative_search_with_ads_count_v1/metadata.yaml
@@ -5,4 +5,3 @@ labels:
   incremental: false
 owners:
 - ascholtz@mozilla.com
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/metadata.yaml
@@ -1,0 +1,4 @@
+friendly_name: Experiment Search Aggregates Live
+description: Live search data related to experiments
+owners:
+- ascholtz@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/metadata.yaml
@@ -1,5 +1,0 @@
-friendly_name: Experiment Search Aggregates Live
-description: Live search data related to experiments
-owners:
-- ascholtz@mozilla.com
-deprecated: true

--- a/sql_generators/experiment_monitoring/templates/experiment_search_aggregates_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_search_aggregates_v1/metadata.yaml
@@ -20,4 +20,3 @@ bigquery:
     fields:
     - experiment
     - branch
-deprecated: true

--- a/sql_generators/experiment_monitoring/templates/experiment_search_events_live_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_search_events_live_v1/metadata.yaml
@@ -6,4 +6,3 @@ owners:
 - ascholtz@mozilla.com
 labels:
   materialized_view: true
-deprecated: true


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#6647

We want to add them back to experiment enrollment monitoring

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-7803)
