### PR TITLE
feat: add backfill entry for mobile products for new_profile_activations

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-02-01:
+2025-02-03:
   start_date: 2021-01-01
-  end_date: 2025-02-04
+  end_date: 2025-02-03
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2025-02-01:
+  start_date: 2021-01-01
+  end_date: 2025-02-01
+  reason: Initial backfill for the table
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
 2025-02-01:
   start_date: 2021-01-01
-  end_date: 2025-02-01
+  end_date: 2025-02-04
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-02-01:
+2025-02-03:
   start_date: 2021-01-01
-  end_date: 2025-02-04
+  end_date: 2025-02-03
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activations_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2025-02-01:
+  start_date: 2021-01-01
+  end_date: 2025-02-01
+  reason: Initial backfill for the table
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
 2025-02-01:
   start_date: 2021-01-01
-  end_date: 2025-02-01
+  end_date: 2025-02-04
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-02-01:
+2025-02-03:
   start_date: 2021-01-01
-  end_date: 2025-02-04
+  end_date: 2025-02-03
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/new_profile_activations_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2025-02-01:
+  start_date: 2021-01-01
+  end_date: 2025-02-01
+  reason: Initial backfill for the table
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
 2025-02-01:
   start_date: 2021-01-01
-  end_date: 2025-02-01
+  end_date: 2025-02-04
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/focus_ios_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_ios_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-02-01:
+2025-02-03:
   start_date: 2021-01-01
-  end_date: 2025-02-04
+  end_date: 2025-02-03
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/focus_ios_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_ios_derived/new_profile_activations_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2025-02-01:
+  start_date: 2021-01-01
+  end_date: 2025-02-01
+  reason: Initial backfill for the table
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/focus_ios_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_ios_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
 2025-02-01:
   start_date: 2021-01-01
-  end_date: 2025-02-01
+  end_date: 2025-02-04
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/klar_android_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/klar_android_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-02-01:
+2025-02-03:
   start_date: 2021-01-01
-  end_date: 2025-02-04
+  end_date: 2025-02-03
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/klar_android_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/klar_android_derived/new_profile_activations_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2025-02-01:
+  start_date: 2021-01-01
+  end_date: 2025-02-01
+  reason: Initial backfill for the table
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/klar_android_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/klar_android_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
 2025-02-01:
   start_date: 2021-01-01
-  end_date: 2025-02-01
+  end_date: 2025-02-04
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/klar_ios_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/klar_ios_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-02-01:
+2025-02-03:
   start_date: 2021-01-01
-  end_date: 2025-02-04
+  end_date: 2025-02-03
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/klar_ios_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/klar_ios_derived/new_profile_activations_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2025-02-01:
+  start_date: 2021-01-01
+  end_date: 2025-02-01
+  reason: Initial backfill for the table
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/klar_ios_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/klar_ios_derived/new_profile_activations_v1/backfill.yaml
@@ -1,6 +1,6 @@
 2025-02-01:
   start_date: 2021-01-01
-  end_date: 2025-02-01
+  end_date: 2025-02-04
   reason: Initial backfill for the table
   watchers:
   - kik@mozilla.com


### PR DESCRIPTION
# feat: add backfill entry for mobile products for new_profile_activations

Wait until backfill via: https://github.com/mozilla/bigquery-etl/pull/6941 is completed prior to merging.

Do not merge until the following change is merged: https://github.com/mozilla/bigquery-etl/pull/6965