### PR TITLE
Delete new check, failing due to extra parameter being passed in

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_v1/checks.sql
@@ -1,2 +1,0 @@
-#fail
-{{ min_row_count(100, "submission_date = @submission_date") }}


### PR DESCRIPTION
## Description

This PR reverts [PR-6928](https://github.com/mozilla/bigquery-etl/pull/6928) - after implementing, we found that the generated task was passing in an extra argument which caused the data check step to fail.
<img width="838" alt="Screenshot 2025-02-03 at 10 06 13 AM" src="https://github.com/user-attachments/assets/dde1435d-d22e-41ab-b5a0-d25f474150aa" />

When the task ran, even though there were more than 100 rows, it still failed due to the argument.
`INFO - [base] BigQuery error in query operation: allowed_schema_update_option requires destination_table.`

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
