### PR TITLE
DENG-6756 - Fix the schema for the new profile clients activation tables and update fenix friendly name

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/__init__.py
+++ b/sql_generators/mobile_kpi_support_metrics/__init__.py
@@ -245,7 +245,7 @@ class MobileProducts(Enum):
     """Enumeration with browser names and equivalent dataset names."""
 
     fenix = Product(
-        friendly_name="Fenix",
+        friendly_name="Firefox Android",
         is_mobile_kpi=True,
         attribution_groups=[
             AttributionFields.play_store,

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.metadata.yaml
@@ -15,7 +15,7 @@ labels:
   schedule: daily
   incremental: true
   shredder_mitigation: false
-  table_type: aggregate
+  table_type: client_level
 scheduling:
   dag_name: bqetl_mobile_kpi_metrics
   depends_on_past: false

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.schema.yaml
@@ -29,30 +29,30 @@ fields:
   mode: NULLABLE
   description: Client's app version on the first seen date.
 
-- name: city
-  type: STRING
-  mode: NULLABLE
-  description: Client's city on the first seen date.
-
 - name: country
   type: STRING
   mode: NULLABLE
   description: Client's country on the first seen date.
+
+- name: city
+  type: STRING
+  mode: NULLABLE
+  description: Client's city on the first seen date.
 
 - name: geo_subdivision
   type: STRING
   mode: NULLABLE
   description: Client's geo subdivision on the first seen date.
 
-- name: isp
-  type: STRING
-  mode: NULLABLE
-  description: Client's isp subdivision on the first seen date.
-
 - name: locale
   type: STRING
   mode: NULLABLE
   description: Client's locale on the first seen date.
+
+- name: isp
+  type: STRING
+  mode: NULLABLE
+  description: Client's isp subdivision on the first seen date.
 
 - name: os
   type: STRING

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.schema.yaml
@@ -10,6 +10,11 @@ fields:
   description: Date we first received a baseline ping from the profile.
 
 - mode: NULLABLE
+  name: client_id
+  type: STRING
+  description: Client ID
+
+- mode: NULLABLE
   name: normalized_channel
   type: STRING
   description: Release channel of the app the profile is using.
@@ -24,10 +29,25 @@ fields:
   mode: NULLABLE
   description: Client's app version on the first seen date.
 
+- name: city
+  type: STRING
+  mode: NULLABLE
+  description: Client's city on the first seen date.
+
 - name: country
   type: STRING
   mode: NULLABLE
   description: Client's country on the first seen date.
+
+- name: geo_subdivision
+  type: STRING
+  mode: NULLABLE
+  description: Client's geo subdivision on the first seen date.
+
+- name: isp
+  type: STRING
+  mode: NULLABLE
+  description: Client's isp subdivision on the first seen date.
 
 - name: locale
   type: STRING
@@ -44,6 +64,11 @@ fields:
   mode: NULLABLE
   description: Client's os version on the first seen date.
 
+- name: device_model
+  type: STRING
+  mode: NULLABLE
+  description: Client's device model on the first seen date.
+
 - name: device_manufacturer
   type: STRING
   mode: NULLABLE
@@ -53,7 +78,7 @@ fields:
   type: BOOLEAN
   mode: NULLABLE
   description: Indicates if this specific entry is used towards calculating mobile DAU.
-{% for field in product_attribution_fields.values() if not field.client_only %}
+{% for field in product_attribution_fields.values() %}
 - name: {{ field.name }}
   type: {{ field.type }}
   mode: NULLABLE


### PR DESCRIPTION
The schema deploy for the new tables is failing with https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/44834/workflows/958b330c-4780-4ddb-997c-1c200290cbfa/jobs/520487
This should fix the issue.

And update fenix friendly name to work as a join key with the search data.