### PR TITLE
Microsoft add delay when job is run for all three scripts

### DIFF
--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_acquisitions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_acquisitions_v1/metadata.yaml
@@ -9,8 +9,6 @@ labels:
   owner1: mhirose@mozilla.com
   table_type: aggregate
 scheduling:
-  dag_name: microsoft_store
-  date_partition_parameter: date
   arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:

--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_acquisitions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_acquisitions_v1/metadata.yaml
@@ -8,6 +8,10 @@ labels:
   incremental: false
   owner1: mhirose@mozilla.com
   table_type: aggregate
+scheduling:
+  dag_name: microsoft_store
+  date_partition_parameter: date
+  arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_acquisitions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_acquisitions_v1/query.py
@@ -5,6 +5,7 @@ import json
 import os
 import tempfile
 from argparse import ArgumentParser
+from datetime import timedelta
 from time import sleep
 
 import requests
@@ -91,8 +92,9 @@ def microsoft_authorization(tenant_id, client_id, client_secret, resource_url):
 
 def download_microsoft_store_data(date, application_id, bearer_token):
     """Download data from Microsoft - application_id, bearer_token are called here."""
-    start_date = date  #
-    end_date = date
+    # Need to delay the running of the job to ensure data is present.
+    start_date = date - timedelta(days=3)
+    end_date = date - timedelta(days=3)
     token = bearer_token
     app_id = application_id
     groupBy = [

--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_conversions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_conversions_v1/metadata.yaml
@@ -9,8 +9,6 @@ labels:
   owner1: mhirose@mozilla.com
   table_type: aggregate
 scheduling:
-  dag_name: microsoft_store
-  date_partition_parameter: date
   arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:

--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_conversions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_conversions_v1/metadata.yaml
@@ -8,6 +8,10 @@ labels:
   incremental: false
   owner1: mhirose@mozilla.com
   table_type: aggregate
+scheduling:
+  dag_name: microsoft_store
+  date_partition_parameter: date
+  arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_conversions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_conversions_v1/query.py
@@ -6,6 +6,7 @@ import os
 import re
 import tempfile
 from argparse import ArgumentParser
+from datetime import timedelta
 from time import sleep
 
 import requests
@@ -96,8 +97,9 @@ def microsoft_authorization(tenant_id, client_id, client_secret, resource_url):
 
 def download_microsoft_store_data(date, application_id, bearer_token):
     """Download data from Microsoft - application_id, bearer_token are called here."""
-    start_date = date  #
-    end_date = date
+    # Need to delay the running of the job to ensure data is present.
+    start_date = date - timedelta(days=3)
+    end_date = date - timedelta(days=3)
     token = bearer_token
     app_id = application_id
     # getting overview metrics for different kpis / Deliverables

--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/metadata.yaml
@@ -9,8 +9,6 @@ labels:
   owner1: mhirose@mozilla.com
   table_type: aggregate
 scheduling:
-  dag_name: microsoft_store
-  date_partition_parameter: date
   arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:

--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/metadata.yaml
@@ -8,6 +8,10 @@ labels:
   incremental: false
   owner1: mhirose@mozilla.com
   table_type: aggregate
+scheduling:
+  dag_name: microsoft_store
+  date_partition_parameter: date
+  arguments: ["--date", "{{ ds }}"]
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/query.py
@@ -5,6 +5,7 @@ import json
 import os
 import tempfile
 from argparse import ArgumentParser
+from datetime import timedelta
 from time import sleep
 
 import requests
@@ -85,8 +86,9 @@ def microsoft_authorization(tenant_id, client_id, client_secret, resource_url):
 
 def download_microsoft_store_data(date, application_id, bearer_token):
     """Download data from Microsoft - application_id, bearer_token are called here."""
-    start_date = date  #
-    end_date = date
+    # Need to delay the running of the job to ensure data is present.
+    start_date = date - timedelta(days=3)
+    end_date = date - timedelta(days=3)
     token = bearer_token
     app_id = application_id
     groupBy = [


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR fixes the timing when the Microsoft Store data download occurs. On occasion, data is not present when job is run. It is random when the data is missing. This PR will have the query download data 3 days before the current data. This should alleviate the missing data issue.
-->

## Related Tickets & Documents
* [DENG-7011](https://mozilla-hub.atlassian.net/browse/DENG-7011)
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7011]: https://mozilla-hub.atlassian.net/browse/DENG-7011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ