### PR TITLE
DENG-7811-Calendar Table

### DIFF
--- a/sql/moz-fx-data-shared-prod/external/calendar/view.sql
+++ b/sql/moz-fx-data-shared-prod/external/calendar/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.external.calendar`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.external_derived.calendar_v1`

--- a/sql/moz-fx-data-shared-prod/external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external/dataset_metadata.yaml
@@ -1,6 +1,6 @@
-friendly_name: External
+friendly_name: External Data
 description: |-
-  Please provide a description for the dataset
+  Data from external sources, such as calendar data, inflation data, GDP data, etc.
 dataset_base_acl: view
 user_facing: true
 labels: {}

--- a/sql/moz-fx-data-shared-prod/external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external/dataset_metadata.yaml
@@ -1,0 +1,16 @@
+friendly_name: External
+description: |-
+  Please provide a description for the dataset
+dataset_base_acl: view
+user_facing: true
+labels: {}
+default_table_workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+default_table_expiration_ms: null
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+syndication: {}

--- a/sql/moz-fx-data-shared-prod/external_derived/calendar_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/calendar_v1/metadata.yaml
@@ -1,0 +1,17 @@
+friendly_name: Calendar
+description: |-
+  Contains all dates from 3/31/98 - 12/31/2100
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/external_derived/calendar_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/external_derived/calendar_v1/query.sql
@@ -1,0 +1,49 @@
+SELECT
+  submission_date,
+  EXTRACT(YEAR FROM submission_date) AS calendar_year,
+  EXTRACT(MONTH FROM submission_date) AS calendar_month,
+  CASE
+    WHEN EXTRACT(MONTH FROM submission_date)
+      BETWEEN 1
+      AND 3
+      THEN 1
+    WHEN EXTRACT(MONTH FROM submission_date)
+      BETWEEN 4
+      AND 6
+      THEN 2
+    WHEN EXTRACT(MONTH FROM submission_date)
+      BETWEEN 7
+      AND 9
+      THEN 3
+    WHEN EXTRACT(MONTH FROM submission_date)
+      BETWEEN 10
+      AND 12
+      THEN 4
+    ELSE NULL
+  END AS calendar_quarter,
+  DATE(
+    EXTRACT(YEAR FROM submission_date),
+    EXTRACT(MONTH FROM submission_date),
+    1
+  ) AS first_date_of_month,
+  CASE
+    WHEN EXTRACT(MONTH FROM submission_date)
+      BETWEEN 1
+      AND 3
+      THEN DATE(EXTRACT(YEAR FROM submission_date), 1, 1)
+    WHEN EXTRACT(MONTH FROM submission_date)
+      BETWEEN 4
+      AND 6
+      THEN DATE(EXTRACT(YEAR FROM submission_date), 4, 1)
+    WHEN EXTRACT(MONTH FROM submission_date)
+      BETWEEN 7
+      AND 9
+      THEN DATE(EXTRACT(YEAR FROM submission_date), 7, 1)
+    WHEN EXTRACT(MONTH FROM submission_date)
+      BETWEEN 10
+      AND 12
+      THEN DATE(EXTRACT(YEAR FROM submission_date), 10, 1)
+    ELSE NULL
+  END AS first_date_of_quarter
+FROM
+  UNNEST(GENERATE_DATE_ARRAY('1998-03-31', '2100-12-31')) AS submission_date

--- a/sql/moz-fx-data-shared-prod/external_derived/calendar_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/calendar_v1/schema.yaml
@@ -1,0 +1,25 @@
+fields:
+- name: submission_date
+  mode: NULLABLE
+  type: DATE
+  description: Submission Date
+- name: calendar_year
+  mode: NULLABLE
+  type: INTEGER
+  description: Calendar Year
+- name: calendar_month
+  mode: NULLABLE
+  type: INTEGER
+  description: Calendar Month
+- name: calendar_quarter
+  mode: NULLABLE
+  type: INTEGER
+  description: Calendar Quarter
+- name: first_date_of_month
+  mode: NULLABLE
+  type: DATE
+  description: First Date of Month
+- name: first_date_of_quarter
+  mode: NULLABLE
+  type: DATE
+  description: First Date of Quarter

--- a/sql/moz-fx-data-shared-prod/external_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/dataset_metadata.yaml
@@ -1,0 +1,16 @@
+friendly_name: External Derived Data
+description: |-
+  Data from external sources, such as calendar data, inflation data, GDP data, etc.
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+default_table_workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+default_table_expiration_ms: null
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+syndication: {}


### PR DESCRIPTION
## Description

This PR creates a new dataset which will be used to store a variety of new tables being pulled from external sources, such as, CPI data, GDP data, exchange rate data, population data, and holiday data.

This first PR does 3 things: 
- Creates the new datasets - external_derived and external
- Creates the new calendar table that has 1 row for every date from start of Mozilla to end of year 2100
- This table is a prequisite for DENG-7810 (creating a global holiday/event table which will flag key dates to help better understand deviances in Firefox usage due to holidays, internet outages, large events, etc.)


## Related Tickets & Documents
* [DENG-7811](https://mozilla-hub.atlassian.net/browse/DENG-7811)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7811]: https://mozilla-hub.atlassian.net/browse/DENG-7811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ