### PR TITLE
take out scheduling in metadata.yaml file

### DIFF
--- a/sql/moz-fx-data-marketing-prod/adjust_derived/firefox_mobile_installs_v1/metadata.yaml
+++ b/sql/moz-fx-data-marketing-prod/adjust_derived/firefox_mobile_installs_v1/metadata.yaml
@@ -2,7 +2,6 @@ description: Aggregated metrics from Adjust data
 friendly_name: Adjust Firefox mobile installs
 labels:
   incremental: false
-  schedule: daily
 owners:
   - rbaffourawuah@mozilla.com
 bigquery:


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR takes out the scheduling from the metadata.yaml file to turn off the DAG/job to run this script.
`moz-fx-data-marketing-prod/adjust_derived/firefox_mobile_installs_v1` hasn't been used in at least 2 years
-->

## Related Tickets & Documents
* DENG-3047
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
