### PR TITLE
DENG-5180 (mlops) Add a table to record Flow descriptions

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_flow_description_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_flow_description_v1/metadata.yaml
@@ -1,0 +1,13 @@
+friendly_name: Outerbounds Flow description spreadsheet
+description: >
+  The description of Outerbounds Flows
+owners:
+  - ctroy@mozilla.com
+  - aplacitelli@mozilla.com
+  - aaggarwal@mozilla.com
+external_data:
+  format: google_sheets
+  source_uris:
+    - https://docs.google.com/spreadsheets/d/1E0kDpHwwtDnkMxAXbeEIzMTajckSHWJ2swF39JdRR1g # URL to the spreadsheet
+  options:
+    skip_leading_rows: 1 # number of rows that should be skipped, e.g if there are header rows

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_flow_description_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_flow_description_v1/schema.yaml
@@ -1,0 +1,7 @@
+fields:
+  - mode: NULLABLE
+    name: flow_name
+    type: STRING
+  - mode: NULLABLE
+    name: flow_description
+    type: STRING


### PR DESCRIPTION
## Description

In service of [this ticket](https://mozilla-hub.atlassian.net/browse/DENG-5180) to surface Flow descriptions on the MLOps cost dashboard, this PR adds a table to yoink data from [this google sheet](https://docs.google.com/spreadsheets/d/1E0kDpHwwtDnkMxAXbeEIzMTajckSHWJ2swF39JdRR1g) into Bigquery. I followed [this documentation](https://docs.telemetry.mozilla.org/cookbooks/operational/connecting_external_data_bigquery.html?highlight=spreadsh#connecting-sheets) to execute the task.

I have added the service account listed in the documentation as an editor to the spreadsheet.

## Related Tickets & Documents
* DENG-5180


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
