### PR TITLE
DENG-5180 (mlops) Add outerbounds flow description to cost per flow View

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_cost_per_flow_run_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_cost_per_flow_run_v1/view.sql
@@ -30,7 +30,7 @@ SELECT
 FROM
   cost_per_flow_run
 LEFT JOIN
-  `moz-fx-data-shared-prod.monitoring_derived.outerbounds_flow_description_v1` as descriptions
+  `moz-fx-data-shared-prod.monitoring_derived.outerbounds_flow_description_v1` AS descriptions
   ON LOWER(cost_per_flow_run.flow_name) LIKE CONCAT('%', LOWER(descriptions.flow_name), '%')
 ORDER BY
   flow_name DESC

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_cost_per_flow_run_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_cost_per_flow_run_v1/view.sql
@@ -1,36 +1,21 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.monitoring_derived.outerbounds_cost_per_flow_run_v1`
 AS
-WITH cost_per_flow_run AS (
-  SELECT
-    DATE_TRUNC(usage_start_time, DAY) AS invoice_day,
-    labels.value AS run_id,
-    IFNULL(SAFE.LEFT(labels.value, INSTR(labels.value, '-', -1) - 1), labels.value) AS flow_name,
-    SUM(cost) + SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) AS cost_usd
-  FROM
-    `moz-fx-data-shared-prod.billing_syndicate.gcp_billing_export_resource_v1_01E7D5_97288E_E2EBA0`
-  JOIN
-    UNNEST(labels) AS labels
-    ON labels.key = "k8s-label/workflows.argoproj.io/workflow"
-  WHERE
-    project.id = "moz-fx-mfouterbounds-prod-f98d"
-    AND usage_start_time >= '2024-07-10'
-  GROUP BY
-    invoice_day,
-    run_id
-  ORDER BY
-    flow_name DESC
-)
 SELECT
-  cost_per_flow_run.invoice_day,
-  cost_per_flow_run.run_id,
-  cost_per_flow_run.flow_name,
-  cost_per_flow_run.cost_usd,
-  descriptions.flow_description,
+  DATE_TRUNC(usage_start_time, DAY) AS invoice_day,
+  labels.value AS run_id,
+  IFNULL(SAFE.LEFT(labels.value, INSTR(labels.value, '-', -1) - 1), labels.value) AS flow_name,
+  SUM(cost) + SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) AS cost_usd
 FROM
-  cost_per_flow_run
-LEFT JOIN
-  `moz-fx-data-shared-prod.monitoring_derived.outerbounds_flow_description_v1` AS descriptions
-  ON LOWER(cost_per_flow_run.flow_name) LIKE CONCAT('%', LOWER(descriptions.flow_name), '%')
+  `moz-fx-data-shared-prod.billing_syndicate.gcp_billing_export_resource_v1_01E7D5_97288E_E2EBA0`
+JOIN
+  UNNEST(labels) AS labels
+  ON labels.key = "k8s-label/workflows.argoproj.io/workflow"
+WHERE
+  project.id = "moz-fx-mfouterbounds-prod-f98d"
+  AND usage_start_time >= '2024-07-10'
+GROUP BY
+  invoice_day,
+  run_id
 ORDER BY
   flow_name DESC

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_cost_per_flow_run_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_cost_per_flow_run_v1/view.sql
@@ -1,21 +1,36 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.monitoring_derived.outerbounds_cost_per_flow_run_v1`
 AS
+WITH cost_per_flow_run AS (
+  SELECT
+    DATE_TRUNC(usage_start_time, DAY) AS invoice_day,
+    labels.value AS run_id,
+    IFNULL(SAFE.LEFT(labels.value, INSTR(labels.value, '-', -1) - 1), labels.value) AS flow_name,
+    SUM(cost) + SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) AS cost_usd
+  FROM
+    `moz-fx-data-shared-prod.billing_syndicate.gcp_billing_export_resource_v1_01E7D5_97288E_E2EBA0`
+  JOIN
+    UNNEST(labels) AS labels
+    ON labels.key = "k8s-label/workflows.argoproj.io/workflow"
+  WHERE
+    project.id = "moz-fx-mfouterbounds-prod-f98d"
+    AND usage_start_time >= '2024-07-10'
+  GROUP BY
+    invoice_day,
+    run_id
+  ORDER BY
+    flow_name DESC
+)
 SELECT
-  DATE_TRUNC(usage_start_time, DAY) AS invoice_day,
-  labels.value AS run_id,
-  IFNULL(SAFE.LEFT(labels.value, INSTR(labels.value, '-', -1) - 1), labels.value) AS flow_name,
-  SUM(cost) + SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) AS cost_usd
+  cost_per_flow_run.invoice_day,
+  cost_per_flow_run.run_id,
+  cost_per_flow_run.flow_name,
+  cost_per_flow_run.cost_usd,
+  descriptions.flow_description,
 FROM
-  `moz-fx-data-shared-prod.billing_syndicate.gcp_billing_export_resource_v1_01E7D5_97288E_E2EBA0`
-JOIN
-  UNNEST(labels) AS labels
-  ON labels.key = "k8s-label/workflows.argoproj.io/workflow"
-WHERE
-  project.id = "moz-fx-mfouterbounds-prod-f98d"
-  AND usage_start_time >= '2024-07-10'
-GROUP BY
-  invoice_day,
-  run_id
+  cost_per_flow_run
+LEFT JOIN
+  `moz-fx-data-shared-prod.monitoring_derived.outerbounds_flow_description_v1` as descriptions
+  ON LOWER(cost_per_flow_run.flow_name) LIKE CONCAT('%', LOWER(descriptions.flow_name), '%')
 ORDER BY
   flow_name DESC

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_cost_per_flow_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_cost_per_flow_v1/view.sql
@@ -1,13 +1,25 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.monitoring_derived.outerbounds_cost_per_flow_v1`
 AS
+WITH cost_per_flow AS (
+  SELECT
+    flow_name,
+    SUM(cost_usd) AS total_cost_usd,
+    COUNT(flow_name) AS num_runs
+  FROM
+    `moz-fx-data-shared-prod.monitoring_derived.outerbounds_cost_per_flow_run_v1`
+  GROUP BY
+    flow_name
+)
 SELECT
-  flow_name,
-  SUM(cost_usd) AS total_cost_usd,
-  COUNT(flow_name) AS num_runs
+  cost_per_flow.flow_name,
+  cost_per_flow.total_cost_usd,
+  cost_per_flow.num_runs,
+  descriptions.flow_description,
 FROM
-  `moz-fx-data-shared-prod.monitoring_derived.outerbounds_cost_per_flow_run_v1`
-GROUP BY
-  flow_name
+  cost_per_flow
+LEFT JOIN
+  `moz-fx-data-shared-prod.monitoring_derived.outerbounds_flow_description_v1` AS descriptions
+  ON LOWER(cost_per_flow.flow_name) LIKE CONCAT('%', LOWER(descriptions.flow_name), '%')
 ORDER BY
   total_cost_usd DESC


### PR DESCRIPTION
## Description
This PR adds flow description field to the existing `outerbounds_cost_per_flow_v1` view.

The flow descriptions are coming from the `outerbounds_flow_description_v1` BQ table which was created in https://github.com/mozilla/bigquery-etl/pull/6957.


## Related Tickets & Documents
* DENG-5180

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
