### PR TITLE
fix: revert the friendly name change for fenix and create a new field instead of joining with the search dataset

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/__init__.py
+++ b/sql_generators/mobile_kpi_support_metrics/__init__.py
@@ -204,6 +204,7 @@ class Product:
     """Encapsulation of what we expect a 'Product' to look like in this generator."""
 
     friendly_name: str
+    search_join_key: str
     is_mobile_kpi: bool = False
     attribution_groups: list[AttributionFieldGroup] = field(
         default_factory=list[AttributionFields.empty]  # type: ignore[valid-type]
@@ -245,7 +246,8 @@ class MobileProducts(Enum):
     """Enumeration with browser names and equivalent dataset names."""
 
     fenix = Product(
-        friendly_name="Firefox Android",
+        friendly_name="Fenix",
+        search_join_key="Firefox Android",
         is_mobile_kpi=True,
         attribution_groups=[
             AttributionFields.play_store,
@@ -257,13 +259,16 @@ class MobileProducts(Enum):
     )
     focus_android = Product(
         friendly_name="Focus Android",
+        search_join_key="Focus Android",
         is_mobile_kpi=True,
     )
     klar_android = Product(
         friendly_name="Klar Android",
+        search_join_key="Klar Android",
     )
     firefox_ios = Product(
         friendly_name="Firefox iOS",
+        search_join_key="Firefox iOS",
         is_mobile_kpi=True,
         attribution_groups=[
             AttributionFields.is_suspicious_device_client,
@@ -272,10 +277,12 @@ class MobileProducts(Enum):
     )
     focus_ios = Product(
         friendly_name="Focus iOS",
+        search_join_key="Focus iOS",
         is_mobile_kpi=True,
     )
     klar_ios = Product(
         friendly_name="Klar iOS",
+        search_join_key="Klar iOS",
     )
 
 

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.query.sql
@@ -48,7 +48,7 @@ client_search AS (
     `{{ project_id }}.search.mobile_search_clients_daily`
   WHERE
     submission_date BETWEEN DATE_SUB(@submission_date, INTERVAL 3 DAY) AND @submission_date
-    AND normalized_app_name_os = "{{ friendly_name }}"
+    AND normalized_app_name_os = "{{ search_join_key }}"
   GROUP BY
     client_id
 )


### PR DESCRIPTION
# fix: revert the friendly name change for fenix and create a new field instead of joining with the search dataset

reverting change introduced in this commit: https://github.com/mozilla/bigquery-etl/pull/6948/commits/7d0851f33adfebb26f59a8a8ecf390345946c85c

Also, adding `search_join_key` property to allow joining with search dataset.