### PR TITLE
Set service-desk workgroup access on jira service desk datasets (DENG-7814)

### DIFF
--- a/sql/moz-fx-data-shared-prod/jira_service_desk/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/dataset_metadata.yaml
@@ -4,7 +4,13 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
+default_table_workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:service-desk/data-viewers
+  - workgroup:service-desk/data-developers
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
-  - workgroup:mozilla-confidential
+  - workgroup:service-desk/data-viewers
+  - workgroup:service-desk/data-developers

--- a/sql/moz-fx-data-shared-prod/jira_service_desk/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk/dataset_metadata.yaml
@@ -1,14 +1,9 @@
 friendly_name: Jira Service Desk
 description: |-
   Views on the Jira Service Desk data pulled from Fivetran.
-dataset_base_acl: view
+dataset_base_acl: view_restricted
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:service-desk/data-viewers
-  - workgroup:service-desk/data-developers
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/jira_service_desk_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk_derived/dataset_metadata.yaml
@@ -4,7 +4,13 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
+default_table_workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:service-desk/data-viewers
+  - workgroup:service-desk/data-developers
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
-  - workgroup:mozilla-confidential
+  - workgroup:service-desk/data-viewers
+  - workgroup:service-desk/data-developers

--- a/sql/moz-fx-data-shared-prod/jira_service_desk_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk_derived/dataset_metadata.yaml
@@ -1,14 +1,9 @@
 friendly_name: Jira Service Desk Derived
 description: |-
   Jira Service Desk data pulled from Fivetran.
-dataset_base_acl: derived
+dataset_base_acl: derived_restricted
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:service-desk/data-viewers
-  - workgroup:service-desk/data-developers
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/jira_service_desk_syndicate/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk_syndicate/dataset_metadata.yaml
@@ -22,11 +22,6 @@ syndication:
     - request
     - request_type
   administer_views: true
-default_table_workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:service-desk/data-viewers
-      - workgroup:service-desk/data-developers
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:

--- a/sql/moz-fx-data-shared-prod/jira_service_desk_syndicate/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk_syndicate/dataset_metadata.yaml
@@ -22,7 +22,13 @@ syndication:
     - request
     - request_type
   administer_views: true
+default_table_workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:service-desk/data-viewers
+      - workgroup:service-desk/data-developers
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
-      - workgroup:mozilla-confidential
+      - workgroup:service-desk/data-viewers
+      - workgroup:service-desk/data-developers


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DENG-7814

This restricts access to the Jira Service Desk datasets to the `service-desk` workgroup.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
