### PR TITLE
feat: Add authorized views for Zoom data synced by Fivetran (DENG-6964)

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -160,6 +160,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/monitoring_derived/table_partition_expirations_v1/query.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/query.sql
   - sql/moz-fx-data-shared-prod/jira_service_desk/**/*.sql
+  - sql/moz-fx-data-shared-prod/zoom/**/*.sql
   # No matching signature for function IF
   - sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_last_seen/query.sql
   # Duplicate UDF

--- a/sql/moz-fx-data-shared-prod/zoom/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/zoom/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Zoom
+description: |-
+  Data about Mozilla's Zoom meetings and participants.
+dataset_base_acl: view_restricted
+user_facing: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:zoom/data-developers
+  - workgroup:zoom/data-viewers

--- a/sql/moz-fx-data-shared-prod/zoom/meeting_participants/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/zoom/meeting_participants/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Zoom meeting participants
+description: |-
+  Mozilla's Zoom meeting participants as synced by Fivetran starting in January 2025.
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/zoom/meeting_participants/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/zoom/meeting_participants/schema.yaml
@@ -1,0 +1,81 @@
+fields:
+- name: meeting_id
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    The meeting's ID (also known as the meeting number) in integer format.
+- name: participant_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Participant ID.
+    This is a unique ID assigned to the participant joining a meeting and is valid for that meeting only.
+- name: participant_user_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The participant's universally unique ID (UUID).
+    * If the participant joins the meeting by logging into Zoom, this is their user ID.
+    * If the participant joins the meeting without logging into Zoom, this is an empty string.
+- name: bo_mtg_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The breakout room ID.
+    Each breakout room is assigned a unique ID.
+- name: customer_key
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The participant's SDK identifier.
+    This value can be alphanumeric, up to a maximum length of 35 characters.
+- name: duration
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Participant duration, in seconds, calculated by subtracting the `leave_time` from the `join_time` for the `user_id`.
+    If the participant leaves and rejoins the same meeting, they are assigned a different `user_id` and Zoom displays their new duration in a separate object.
+    Because of this, the duration may not reflect the total time the user was in the meeting.
+- name: failover
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Indicates if failover happened during the meeting.
+- name: join_time
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    Participant join time in UTC.
+- name: leave_time
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    Participant leave time in UTC.
+- name: name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Participant display name.
+- name: registrant_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Unique identifier of the registrant.
+- name: status
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The participant's status.
+    * `in_meeting` - In a meeting.
+    * `in_waiting_room` - In a waiting room.
+- name: user_email
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Participant email.
+    If the participant is not part of the host's account, this is an empty string, with some exceptions.
+- name: is_deleted
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the meeting participant record is deleted.

--- a/sql/moz-fx-data-shared-prod/zoom/meeting_participants/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/zoom/meeting_participants/schema.yaml
@@ -14,9 +14,8 @@ fields:
   type: STRING
   mode: NULLABLE
   description: |-
-    The participant's universally unique ID (UUID).
-    * If the participant joins the meeting by logging into Zoom, this is their user ID.
-    * If the participant joins the meeting without logging into Zoom, this is an empty string.
+    The participant's user ID.
+    If the participant joins the meeting without logging into Zoom, this is an empty string.
 - name: bo_mtg_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/zoom/meeting_participants/view.sql
+++ b/sql/moz-fx-data-shared-prod/zoom/meeting_participants/view.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.zoom.meeting_participants`
+AS
+SELECT
+  meeting_id,
+  user_id AS participant_id,
+  participant_user_id,
+  bo_mtg_id,
+  customer_key,
+  duration,
+  failover,
+  join_time,
+  leave_time,
+  name,
+  registrant_id,
+  status,
+  user_email,
+  _fivetran_deleted AS is_deleted,
+FROM
+  `moz-fx-data-bq-fivetran.zoom.meeting_participant`

--- a/sql/moz-fx-data-shared-prod/zoom/meeting_reports/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/zoom/meeting_reports/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Zoom meeting reports
+description: |-
+  Mozilla's Zoom meeting reports as synced by Fivetran starting in January 2025.
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/zoom/meeting_reports/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/zoom/meeting_reports/schema.yaml
@@ -41,7 +41,7 @@ fields:
   description: |-
     The sum of meeting minutes from all meeting participants in the meeting.
 - name: type
-  type: STRING
+  type: INTEGER
   mode: NULLABLE
   description: |-
     Meeting type.

--- a/sql/moz-fx-data-shared-prod/zoom/meeting_reports/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/zoom/meeting_reports/schema.yaml
@@ -1,0 +1,68 @@
+fields:
+- name: uuid
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The meeting's universally unique identifier (UUID).
+    Each meeting instance generates a meeting UUID.
+- name: meeting_id
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    The meeting's ID (also known as the meeting number) in integer format.
+- name: dept
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The host's department.
+- name: duration
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    The meeting's duration in minutes.
+- name: end_time
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    The meeting's end date and time in UTC.
+- name: participants_count
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    The number of meeting participants.
+- name: start_time
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    The meeting's start date and time in UTC.
+- name: total_minutes
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    The sum of meeting minutes from all meeting participants in the meeting.
+- name: type
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Meeting type.
+    * `1` - Instant meeting.
+    * `2` - Scheduled meeting.
+    * `3` - Recurring meeting with no fixed time.
+    * `4` - Meeting created via PMI (Personal Meeting ID).
+    * `7` - Personal Audio Conference (PAC).
+    * `8` - Recurring meeting with fixed time.
+- name: user_email
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The host's email address.
+- name: user_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The host's display name.
+- name: is_deleted
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the meeting report is deleted.

--- a/sql/moz-fx-data-shared-prod/zoom/meeting_reports/view.sql
+++ b/sql/moz-fx-data-shared-prod/zoom/meeting_reports/view.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.zoom.meeting_reports`
+AS
+SELECT
+  uuid,
+  meeting_id,
+  dept,
+  duration,
+  end_time,
+  participants_count,
+  start_time,
+  total_minutes,
+  type,
+  user_email,
+  user_name,
+  _fivetran_deleted AS is_deleted,
+FROM
+  `moz-fx-data-bq-fivetran.zoom.meeting_report`

--- a/sql/moz-fx-data-shared-prod/zoom/meeting_reports/view.sql
+++ b/sql/moz-fx-data-shared-prod/zoom/meeting_reports/view.sql
@@ -10,7 +10,7 @@ SELECT
   participants_count,
   start_time,
   total_minutes,
-  type,
+  SAFE_CAST(type AS INTEGER) AS type,
   user_email,
   user_name,
   _fivetran_deleted AS is_deleted,

--- a/sql/moz-fx-data-shared-prod/zoom/meetings/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/zoom/meetings/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Zoom meetings
+description: |-
+  Mozilla's Zoom meetings as synced by Fivetran starting in January 2025.
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/zoom/meetings/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/zoom/meetings/schema.yaml
@@ -1,0 +1,53 @@
+fields:
+- name: uuid
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Unique meeting ID.
+    Each meeting instance will generate its own meeting UUID.
+- name: id
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Meeting ID (also known as the meeting number) in integer format.
+- name: host_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    ID of the user who is set as the meeting's host.
+- name: created_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    Time of creation in UTC.
+- name: duration
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Meeting duration in minutes.
+- name: start_time
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    Meeting start time in UTC.
+- name: timezone
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Timezone the meeting was scheduled in.
+- name: type
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Meeting type.
+    * `1` - Instant meeting.
+    * `2` - Scheduled meeting.
+    * `3` - Recurring meeting with no fixed time.
+    * `4` - Meeting created via PMI (Personal Meeting ID).
+    * `7` - Personal Audio Conference (PAC).
+    * `8` - Recurring meeting with fixed time.
+- name: is_deleted
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the meeting is deleted.

--- a/sql/moz-fx-data-shared-prod/zoom/meetings/view.sql
+++ b/sql/moz-fx-data-shared-prod/zoom/meetings/view.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.zoom.meetings`
+AS
+SELECT
+  uuid,
+  id,
+  host_id,
+  created_at,
+  duration,
+  start_time,
+  timezone,
+  type,
+  _fivetran_deleted AS is_deleted,
+FROM
+  `moz-fx-data-bq-fivetran.zoom.meeting`

--- a/sql/moz-fx-data-shared-prod/zoom/users/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/zoom/users/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Zoom users
+description: |-
+  Mozilla's Zoom users as synced by Fivetran starting in January 2025.
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/zoom/users/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/zoom/users/schema.yaml
@@ -1,0 +1,94 @@
+fields:
+- name: id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The user's ID.
+    The API does not return this value for users with the `pending` status.
+- name: created_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    The date and time when this user was created in UTC.
+- name: dept
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The user's department.
+- name: email
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The user's email address.
+- name: first_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The user's first name.
+- name: language
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The user's default language for the Zoom Web Portal.
+- name: last_client_version
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The last client version that user used to log in.
+- name: last_login_time
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    The user's last login time in UTC.
+    This field has a three-day buffer period.
+    For example, if user first logged in on 2020-01-01 then logged out and logged in on 2020-01-02, this value will still reflect the login time of 2020-01-01.
+    However, if the user logs in on 2020-01-04, the value of this field will reflect the corresponding login time since it exceeds the three-day buffer period.
+- name: last_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The user's last name.
+- name: pmi
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    The user's personal meeting ID.
+- name: role_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The ID of the user's assigned role.
+- name: status
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The user's status.
+    * `active` - An active user.
+    * `inactive` - A deactivated user.
+    * `pending` - A pending user.
+- name: timezone
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The user's timezone.
+- name: type
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    The user's assigned plan type.
+    * `1` - Basic.
+    * `2` - Licensed.
+    * `4` - Unassigned without Meetings Basic.
+    * `99` - None (this can only be set with `ssoCreate`).
+- name: verified
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Whether the user's email address for the Zoom account is verified.
+    * `1` - A verified user email.
+    * `0` - The user's email is not verified.
+- name: is_deleted
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the user is deleted.

--- a/sql/moz-fx-data-shared-prod/zoom/users/view.sql
+++ b/sql/moz-fx-data-shared-prod/zoom/users/view.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.zoom.users`
+AS
+SELECT
+  id,
+  created_at,
+  dept,
+  email,
+  first_name,
+  languages AS `language`,
+  last_client_version,
+  last_login_time,
+  last_name,
+  pmi,
+  role_id,
+  status,
+  timezone,
+  type,
+  verified,
+  _fivetran_deleted AS is_deleted,
+FROM
+  `moz-fx-data-bq-fivetran.zoom.users`


### PR DESCRIPTION
## Description
Adds authorized views for Zoom data synced by Fivetran.

## Related Tickets & Documents
* DENG-6964: Integrate Zoom into BigQuery/Looker using FiveTran (API)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**