### PR TITLE
fix(bug-1946076): handle the case of is_default_browser existing in both baseline and metrics now

### DIFF
--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -22,7 +22,8 @@ SELECT
   baseline.sample_id,
   baseline.submission_date,
   baseline.normalized_channel,
-  * EXCEPT(submission_date, normalized_channel, client_id, sample_id),
+  * EXCEPT(submission_date, normalized_channel, client_id, sample_id, is_default_browser),
+  COALESCE(baseline.is_default_browser, metrics.is_default_browser) AS is_default_browser,
 FROM
   baseline
 LEFT JOIN metrics

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -23,7 +23,7 @@ SELECT
   baseline.submission_date,
   baseline.normalized_channel,
   * EXCEPT(submission_date, normalized_channel, client_id, sample_id, is_default_browser),
-  COALESCE(baseline.is_default_browser, metrics.is_default_browser) AS is_default_browser,
+  baseline.is_default_browser,
 FROM
   baseline
 LEFT JOIN metrics


### PR DESCRIPTION
# fix(bug-1946076): handle the case of is_default_browser existing in both baseline and metrics now