### PR TITLE
DENG-7838 - Backfill baseline_clients_daily for desktop from 2021-12-01

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_clients_daily_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2025-02-05:
+  start_date: 2021-12-01
+  end_date: 2025-02-03
+  reason: DAU computations based on baseline ping [DENG-7838]
+  watchers:
+  - gkatre@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true


### PR DESCRIPTION
## Description

Backfill firefox_desktop_derived. baseline_clients_daily_v1 from 2021-12-01

## Related Tickets & Documents
* DENG-7838

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
