### PR TITLE
feat: add device_manufacturer_partnerships namespaces

### DIFF
--- a/sql/moz-fx-data-shared-prod/device_manufacturer_partnerships/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/device_manufacturer_partnerships/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Device Manufacturer Partnerships
+description: |-
+  Device manufacturer partnerships tracking.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/device_manufacturer_partnerships_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/device_manufacturer_partnerships_derived/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Device Manufacturer Partnerships
+description: |-
+  Device Manufacturer Partnerships namespace used to materialize Google Sheet connections.
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:accounts-confidential

--- a/sql/moz-fx-data-shared-prod/device_manufacturer_partnerships_external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/device_manufacturer_partnerships_external/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Device Manufacturer Partnerships (External)
+description: |-
+  Device Manufacturer Partnerships (External) namespace used to set up connection to Google Sheets.
+dataset_base_acl: restricted
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:accounts-confidential


### PR DESCRIPTION
feat: add device_manufacturer_partnerships namespaces

- _external - This namespace will act as a location for storing Google Sheet based tables on top of which syndication will be set up to enable downstream usage.
- _derived - will contain materialized tables on top of the Google Sheet tables inside _external for analytics access.
- no postfix - user facing views.
