### PR TITLE
move the timedelta to main so data goes into the proper partition

### DIFF
--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_conversions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_conversions_v1/query.py
@@ -98,9 +98,8 @@ def microsoft_authorization(tenant_id, client_id, client_secret, resource_url):
 def download_microsoft_store_data(date, application_id, bearer_token):
     """Download data from Microsoft - application_id, bearer_token are called here."""
     # Need to delay the running of the job to ensure data is present.
-    input_date = datetime.strptime(date, "%Y-%m-%d").date()
-    start_date = input_date - timedelta(days=3)
-    end_date = input_date - timedelta(days=3)
+    start_date = date
+    end_date = date
     token = bearer_token
     app_id = application_id
     # getting overview metrics for different kpis / Deliverables
@@ -192,7 +191,9 @@ def main():
     dataset = args.dataset
     table_name = "app_conversions_v1"
 
-    date = args.date
+    args_date = args.date
+    # Data for Microsoft isn't always available on the next day. Use a 3 day delay.
+    date = datetime.strptime(args_date, "%Y-%m-%d").date() - timedelta(days=3)
     client_id = MS_CLIENT_ID
     client_secret = MS_CLIENT_SECRET
     app_list = MS_APP_LIST

--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/query.py
@@ -87,9 +87,8 @@ def microsoft_authorization(tenant_id, client_id, client_secret, resource_url):
 def download_microsoft_store_data(date, application_id, bearer_token):
     """Download data from Microsoft - application_id, bearer_token are called here."""
     # Need to delay the running of the job to ensure data is present.
-    input_date = datetime.strptime(date, "%Y-%m-%d").date()
-    start_date = input_date - timedelta(days=3)
-    end_date = input_date - timedelta(days=3)
+    start_date = date
+    end_date = date
     token = bearer_token
     app_id = application_id
     groupBy = [
@@ -193,7 +192,8 @@ def main():
     dataset = args.dataset
     table_name = "app_installs_v1"
 
-    date = args.date
+    args_date = args.date
+    date = datetime.strptime(args_date, "%Y-%m-%d").date() - timedelta(days=3)
     client_id = MS_CLIENT_ID
     client_secret = MS_CLIENT_SECRET
     app_list = MS_APP_LIST


### PR DESCRIPTION
## Description
This PR fixes the error of data being put into the wrong partition. Originally, the timedelta was put into the section where the script would download the data from Microsoft store. Since there is a 3 day delay, the date for the data did not match the partition date.

Move the timedelta out of the download function and into main. This will ensure that the data goes into the right partition

Added comments to explain why the delay is used

Added the date to the output message to make the date of the data clearer
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-XXXX
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
