### PR TITLE
fix(code):Change base_jira_url to the jira PROD url

### DIFF
--- a/sql/moz-fx-data-shared-prod/jira_service_desk_derived/user_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/jira_service_desk_derived/user_v1/query.py
@@ -137,7 +137,7 @@ def main():
     parser.add_argument(
         "--base-url",
         dest="base_jira_url",
-        default="https://mozilla-hub-sandbox-721.atlassian.net",
+        default="https://mozilla-hub.atlassian.net",
         required=False
     )
 


### PR DESCRIPTION
## Description
Change the jira URL to point to PROD

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
[DENG-6141](https://mozilla-hub.atlassian.net/browse/DENG-6141)
 
 


[ASP-6006]: https://mozilla-hub.atlassian.net/browse/ASP-6006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DENG-6141]: https://mozilla-hub.atlassian.net/browse/DENG-6141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ