### PR TITLE
revert changes to delay, so can add delay to airflow job instead

### DIFF
--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_acquisitions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_acquisitions_v1/query.py
@@ -5,7 +5,6 @@ import json
 import os
 import tempfile
 from argparse import ArgumentParser
-from datetime import datetime, timedelta
 from time import sleep
 
 import requests
@@ -215,9 +214,7 @@ def main():
     dataset = args.dataset
     table_name = "app_acquisitions_v1"
 
-    args_date = args.date
-    # Data for Microsoft isn't always available on the next day. Use a 3 day delay.
-    date = datetime.strptime(args_date, "%Y-%m-%d").date() - timedelta(days=3)
+    date = args.date
     client_id = MS_CLIENT_ID
     client_secret = MS_CLIENT_SECRET
     app_list = MS_APP_LIST

--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_conversions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_conversions_v1/query.py
@@ -6,7 +6,6 @@ import os
 import re
 import tempfile
 from argparse import ArgumentParser
-from datetime import datetime, timedelta
 from time import sleep
 
 import requests
@@ -191,9 +190,7 @@ def main():
     dataset = args.dataset
     table_name = "app_conversions_v1"
 
-    args_date = args.date
-    # Data for Microsoft isn't always available on the next day. Use a 3 day delay.
-    date = datetime.strptime(args_date, "%Y-%m-%d").date() - timedelta(days=3)
+    date = args.date
     client_id = MS_CLIENT_ID
     client_secret = MS_CLIENT_SECRET
     app_list = MS_APP_LIST
@@ -210,7 +207,7 @@ def main():
 
     # Cycle through the apps to get the relevant data
     for app in ms_app_list:
-        print(f'This is data for {app["app_name"]} - {app["app_id"]} ')
+        print(f'This is data for {app["app_name"]} - {app["app_id"]} for ', date)
         # Ping the microsoft_store URL and get a response
         json_file = download_microsoft_store_data(date, app["app_id"], bearer_token)
         # For some reason, the date returned from https://manage.devcenter.microsoft.com/v1.0/my/analytics/appchannelconversions? returns the date as null.
@@ -223,7 +220,7 @@ def main():
             microsoft_store_data = clean_json(query_export, date)
             data.extend(microsoft_store_data)
         else:
-            print("no data for today")
+            print("no data for ", date)
         sleep(5)
     upload_to_bigquery(data, project, dataset, table_name, date)
 

--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/query.py
@@ -5,7 +5,6 @@ import json
 import os
 import tempfile
 from argparse import ArgumentParser
-from datetime import datetime, timedelta
 from time import sleep
 
 import requests
@@ -192,8 +191,7 @@ def main():
     dataset = args.dataset
     table_name = "app_installs_v1"
 
-    args_date = args.date
-    date = datetime.strptime(args_date, "%Y-%m-%d").date() - timedelta(days=3)
+    date = args.date
     client_id = MS_CLIENT_ID
     client_secret = MS_CLIENT_SECRET
     app_list = MS_APP_LIST
@@ -210,7 +208,7 @@ def main():
 
     # Cycle through the apps to get the relevant data
     for app in ms_app_list:
-        print(f'This is data for {app["app_name"]} - {app["app_id"]} ')
+        print(f'This is data for {app["app_name"]} - {app["app_id"]} for ', date)
         # Ping the microsoft_store URL and get a response
         json_file = download_microsoft_store_data(date, app["app_id"], bearer_token)
         query_export = check_json(json_file.text)
@@ -219,7 +217,7 @@ def main():
             microsoft_store_data = clean_json(query_export, date)
             data.extend(microsoft_store_data)
         else:
-            print("no data for today")
+            print("no data for ", date)
         sleep(5)
     upload_to_bigquery(data, project, dataset, table_name, date)
 


### PR DESCRIPTION
## Description
This PR removes the timedelta and adds more descriptive comments to understand what date's data is being downloaded
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-XXXX
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
