### PR TITLE
DENG-7838 - firefox_desktop_derived.baseline_clients_daily_v1 complete

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_clients_daily_v1/backfill.yaml
@@ -4,6 +4,6 @@
   reason: DAU computations based on baseline ping [DENG-7838]
   watchers:
   - gkatre@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true


### PR DESCRIPTION
## Description

Complete and move to prod: backfill of firefox_desktop_derived.baseline_clients_daily_v1 from 2021-12-01 to 2025-02-03

I have done spot checks on the backfill staging table `moz-fx-data-shared-prod.backfills_staging_derived.firefox_desktop_derived__baseline_clients_daily_v1_2025_02_05` and the prod table `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_clients_daily_v1`. The generated backfill table seems good to move to prod for those dates.

## Related Tickets & Documents
* DENG-7838

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
