### PR TITLE
[DENG-7209] Add channel to firefox-installer schema errors

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/backfill.yaml
@@ -1,0 +1,9 @@
+2025-02-11:
+  start_date: 2024-11-01
+  end_date: 2025-02-10
+  reason: Added channel to to non-telemetry errors https://mozilla-hub.atlassian.net/browse/DENG-7209
+  watchers:
+  - bewu@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/metadata.yaml
@@ -2,12 +2,12 @@ friendly_name: Schema Error Counts
 description: |
   Counts the number of schema errors in the error stream per hour.
 owners:
-- amiyaguchi@mozilla.com
+- bewu@mozilla.com
 labels:
   schedule: daily
   incremental: true
   dag: bqetl_monitoring
-  owner1: amiyaguchi
+  owner1: bewu
 scheduling:
   dag_name: bqetl_monitoring
 bigquery:


### PR DESCRIPTION
## Description

Adding channel for firefox installer errors since those are high volume as well.  Also doing a backfill of 100 days so the health check dashboard graphs are consistent

## Related Tickets & Documents
* DENG-7209

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
