### PR TITLE
Mark - backfill for profile_dau_metrics_marketing_geo_testing_v1 (fenix and ios) as Complete

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/profile_dau_metrics_marketing_geo_testing_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/profile_dau_metrics_marketing_geo_testing_v1/backfill.yaml
@@ -5,6 +5,6 @@
   watchers:
   - kik@mozilla.com
   - akommasani@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/profile_dau_metrics_marketing_geo_testing_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/profile_dau_metrics_marketing_geo_testing_v1/backfill.yaml
@@ -5,6 +5,6 @@
   watchers:
   - kik@mozilla.com
   - akommasani@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true


### PR DESCRIPTION
feat: add backfill entries for new_profile_metrics_marketing_geo_testing_v1

depends on: https://github.com/mozilla/bigquery-etl/pull/6970