### PR TITLE
feat(DENG-2986): Build rolling_cohorts_v2 & cohort_daily_statistics_v2

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2149,3 +2149,21 @@ bqetl_marketing_analysis:
     - impact/tier_3
   repo: bigquery-etl
   schedule_interval: 0 12 * * *
+
+bqetl_daily_retention:
+  default_args:
+    depends_on_past: false
+    email:
+      - telemetry-alerts@mozilla.com
+      - kwindau@mozilla.com
+    email_on_failure: true
+    email_on_retry: false
+    end_date: null
+    owner: kwindau@mozilla.com
+    retries: 2
+    retry_delay: 30m
+    start_date: '2025-02-11'
+  description: Schedules daily level retention queries
+  schedule_interval: 40 19 * * *
+  tags:
+    - impact/tier_2

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/metadata.yaml
@@ -1,0 +1,27 @@
+friendly_name: Cohort Daily Statistics V2
+description: |-
+  Cohort Daily Statistics consists of one row per cohort date
+  per activity date (up to 180 days after the cohort start date)
+  It's a summary of the cohort's activity in that day.
+
+  Note that the values for client attributes are based on the
+  attributes at the time the cohort started (rather than the
+  values at activity time)
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_daily_retention
+bigquery:
+  time_partitioning:
+    type: day
+    field: activity_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_app_name
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/query.sql
@@ -1,0 +1,134 @@
+WITH submission_date_activity AS (
+  SELECT
+    client_id,
+    submission_date AS activity_date
+  FROM
+    `moz-fx-data-shared-prod.telemetry.active_users`
+  WHERE
+    submission_date = @submission_date
+    AND is_dau IS TRUE
+  GROUP BY
+    client_id,
+    submission_date
+),
+-- Get all the cohorts that are still in range of the current day of activity (180 days)
+cohorts_in_range AS (
+  SELECT
+    client_id,
+    cohort_date,
+    DATE(@submission_date) AS activity_date,
+    activity_segment,
+    app_version,
+    attribution_campaign,
+    attribution_content,
+    attribution_experiment,
+    attribution_medium,
+    attribution_source,
+    attribution_variation,
+    city,
+    country,
+    device_model,
+    distribution_id,
+    is_default_browser,
+    locale,
+    normalized_app_name,
+    normalized_channel,
+    normalized_os,
+    normalized_os_version,
+    os_version_major,
+    os_version_minor,
+    adjust_ad_group,
+    adjust_campaign,
+    adjust_creative,
+    adjust_network,
+    play_store_attribution_campaign,
+    play_store_attribution_medium,
+    play_store_attribution_source,
+    play_store_attribution_content,
+    play_store_attribution_term,
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.rolling_cohorts_v2`
+  WHERE
+    cohort_date
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 180 DAY)
+    AND DATE_SUB(@submission_date, INTERVAL 1 DAY)
+),
+activity_cohort_match AS (
+  SELECT
+    cohorts_in_range.client_id AS cohort_client_id,
+    submission_date_activity.client_id AS active_client_id,
+    cohorts_in_range.* EXCEPT (client_id)
+  FROM
+    cohorts_in_range
+  LEFT JOIN
+    submission_date_activity
+    USING (client_id, activity_date)
+)
+SELECT
+  cohort_date,
+  activity_date,
+  activity_segment,
+  app_version,
+  attribution_campaign,
+  attribution_content,
+  attribution_experiment,
+  attribution_medium,
+  attribution_source,
+  attribution_variation,
+  city,
+  country,
+  device_model,
+  distribution_id,
+  is_default_browser,
+  locale,
+  normalized_app_name,
+  normalized_channel,
+  normalized_os,
+  normalized_os_version,
+  os_version_major,
+  os_version_minor,
+  adjust_ad_group,
+  adjust_campaign,
+  adjust_creative,
+  adjust_network,
+  play_store_attribution_campaign,
+  play_store_attribution_medium,
+  play_store_attribution_source,
+  play_store_attribution_content,
+  play_store_attribution_term,
+  COUNT(cohort_client_id) AS num_clients_in_cohort,
+  COUNT(active_client_id) AS num_clients_active_on_day,
+FROM
+  activity_cohort_match
+GROUP BY
+  cohort_date,
+  activity_date,
+  activity_segment,
+  app_version,
+  attribution_campaign,
+  attribution_content,
+  attribution_experiment,
+  attribution_medium,
+  attribution_source,
+  attribution_variation,
+  city,
+  country,
+  device_model,
+  distribution_id,
+  is_default_browser,
+  locale,
+  normalized_app_name,
+  normalized_channel,
+  normalized_os,
+  normalized_os_version,
+  os_version_major,
+  os_version_minor,
+  adjust_ad_group,
+  adjust_campaign,
+  adjust_creative,
+  adjust_network,
+  play_store_attribution_campaign,
+  play_store_attribution_medium,
+  play_store_attribution_source,
+  play_store_attribution_content,
+  play_store_attribution_term

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/schema.yaml
@@ -1,0 +1,133 @@
+fields:
+- mode: NULLABLE
+  name: cohort_date
+  type: DATE
+  description: Cohort Date
+- mode: NULLABLE
+  name: activity_date
+  type: DATE
+  description: Activity Date
+- mode: NULLABLE
+  name: activity_segment
+  type: STRING
+  description: Activity Segment
+- mode: NULLABLE
+  name: app_version
+  type: STRING
+  description: App Version
+- mode: NULLABLE
+  name: attribution_campaign
+  type: STRING
+  description: Attribution Campaign
+- mode: NULLABLE
+  name: attribution_content
+  type: STRING
+  description: Attribution Content
+- mode: NULLABLE
+  name: attribution_experiment
+  type: STRING
+  description: Attribution Experiment
+- mode: NULLABLE
+  name: attribution_medium
+  type: STRING
+  description: Attribution Medium
+- mode: NULLABLE
+  name: attribution_source
+  type: STRING
+  description: Attribution Source
+- mode: NULLABLE
+  name: attribution_variation
+  type: STRING
+  description: Attribution Variation
+- mode: NULLABLE
+  name: city
+  type: STRING
+  description: City
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: Country
+- mode: NULLABLE
+  name: device_model
+  type: STRING
+  description: Device Model
+- mode: NULLABLE
+  name: distribution_id
+  type: STRING
+  description: Distribution ID
+- mode: NULLABLE
+  name: is_default_browser
+  type: BOOLEAN
+  description: Is Default Browser
+- mode: NULLABLE
+  name: locale
+  type: STRING
+  description: Locale
+- mode: NULLABLE
+  name: normalized_app_name
+  type: STRING
+  description: Normalized App Name
+- mode: NULLABLE
+  name: normalized_channel
+  type: STRING
+  description: Normalized Channel
+- mode: NULLABLE
+  name: normalized_os
+  type: STRING
+  description: Normalized Operating System
+- mode: NULLABLE
+  name: normalized_os_version
+  type: STRING
+  description: Normalized Operating System Version
+- mode: NULLABLE
+  name: os_version_major
+  type: INTEGER
+  description: Operating System Major Version
+- mode: NULLABLE
+  name: os_version_minor
+  type: INTEGER
+  description: Operating System Minor Version
+- name: adjust_ad_group
+  type: STRING
+  mode: NULLABLE
+  description: Adjust Ad Group - Available for Mobile Only
+- name: adjust_campaign
+  type: STRING
+  mode: NULLABLE
+  description: Adjust Campaign - Available for Mobile Only
+- name: adjust_creative
+  type: STRING
+  mode: NULLABLE
+  description: Adjust Creative - Available for Mobile Only
+- name: adjust_network
+  type: STRING
+  mode: NULLABLE
+  description: Adjust Network - Available for Mobile Only
+- name: play_store_attribution_campaign
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Campaign - Available for Mobile Only
+- name: play_store_attribution_medium
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Medium - Available for Mobile Only
+- name: play_store_attribution_source
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Source - Available for Mobile Only
+- name: play_store_attribution_content
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Content - Available for Mobile Only
+- name: play_store_attribution_term
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Term - Available for Mobile Only
+- mode: NULLABLE
+  name: num_clients_in_cohort
+  type: INTEGER
+  description: Number of Clients in Cohort
+- mode: NULLABLE
+  name: num_clients_active_on_day
+  type: INTEGER
+  description: Number of Clients Active on Day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/metadata.yaml
@@ -1,0 +1,30 @@
+friendly_name: Rolling Cohorts
+description: |-
+  Rolling Cohorts consists of one row per client per date (each date
+  representing a new cohort) i.e. all the clients that had their first
+  ping sent that day. This can be left joined with various activity
+  tables to calculate activity metrics for particular cohorts.
+
+  Note that client-attributes such as os versions, is default browser,
+  etc. are based on the values at the time the cohort is created.
+  This might not be the same as when activity happens. For example
+  if a client changes whether Firefox is the default browser.
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: client_level
+scheduling:
+  dag_name: bqetl_daily_retention
+bigquery:
+  time_partitioning:
+    type: day
+    field: cohort_date
+    require_partition_filter: true
+    expiration_days: 775
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_channel
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
@@ -4,7 +4,7 @@ WITH get_default_browser_for_mobile AS (
     SELECT
       submission_date,
       client_id,
-      is_default_browser,
+      COALESCE(is_default_browser, FALSE) AS is_default_browser,
       'Focus iOS' AS normalized_app_name
     FROM
       `moz-fx-data-shared-prod.focus_ios_derived.metrics_clients_last_seen_v1`
@@ -14,7 +14,7 @@ WITH get_default_browser_for_mobile AS (
     SELECT
       a.submission_date,
       a.client_id,
-      a.is_default_browser,
+      COALESCE(a.is_default_browser, FALSE) AS is_default_browser,
       IF(b.isp = 'BrowserStack', CONCAT('Fenix', ' BrowserStack'), 'Fenix') AS normalized_app_name
     FROM
       `moz-fx-data-shared-prod.fenix.metrics_clients_last_seen` a
@@ -29,7 +29,7 @@ WITH get_default_browser_for_mobile AS (
     SELECT
       submission_date,
       client_id,
-      is_default_browser,
+      COALESCE(is_default_browser, FALSE) AS is_default_browser,
       'Firefox iOS' AS normalized_app_name
     FROM
       `moz-fx-data-shared-prod.firefox_ios.metrics_clients_last_seen`
@@ -39,7 +39,7 @@ WITH get_default_browser_for_mobile AS (
     SELECT
       submission_date,
       client_id,
-      is_default_browser,
+      COALESCE(is_default_browser, FALSE) AS is_default_browser,
       'Focus Android Glean' AS normalized_app_name
     FROM
       `moz-fx-data-shared-prod.focus_android.baseline_clients_last_seen`
@@ -49,7 +49,7 @@ WITH get_default_browser_for_mobile AS (
     SELECT
       submission_date,
       client_id,
-      default_browser AS is_default_browser,
+      COALESCE(is_default_browser, FALSE) AS is_default_browser,
       'Focus Android' AS normalized_app_name
     FROM
       `moz-fx-data-shared-prod.telemetry.core_clients_last_seen`
@@ -61,10 +61,10 @@ WITH get_default_browser_for_mobile AS (
     SELECT
       submission_date,
       client_id,
-      is_default_browser,
+      COALESCE(is_default_browser, FALSE) AS is_default_browser,
       'Klar iOS' AS normalized_app_name
     FROM
-      `moz-fx-data-shared-prod.klar_ios.clients_last_seen_joined`
+      `moz-fx-data-shared-prod.klar_ios.metrics_clients_last_seen`
     WHERE
       submission_date = @submission_date
   )

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
@@ -7,19 +7,24 @@ WITH get_default_browser_for_mobile AS (
       is_default_browser,
       'Focus iOS' AS normalized_app_name
     FROM
-      `moz-fx-data-shared-prod.org_mozilla_ios_focus_derived.baseline_clients_last_seen_v1`
+      `moz-fx-data-shared-prod.focus_ios_derived.metrics_clients_last_seen_v1`
     WHERE
       submission_date = @submission_date
     UNION ALL
     SELECT
-      submission_date,
-      client_id,
-      is_default_browser,
-      IF(isp = 'BrowserStack', CONCAT('Fenix', ' BrowserStack'), 'Fenix') AS normalized_app_name
+      a.submission_date,
+      a.client_id,
+      a.is_default_browser,
+      IF(b.isp = 'BrowserStack', CONCAT('Fenix', ' BrowserStack'), 'Fenix') AS normalized_app_name
     FROM
-      `moz-fx-data-shared-prod.fenix.baseline_clients_last_seen`
+      `moz-fx-data-shared-prod.fenix.metrics_clients_last_seen` a
+    JOIN
+      `moz-fx-data-shared-prod.fenix.baseline_clients_last_seen` b
+      ON a.client_id = b.client_id
+      AND a.submission_date = b.submission_date
     WHERE
-      submission_date = @submission_date
+      a.submission_date = @submission_date
+      AND b.submission_date = @submission_date
     UNION ALL
     SELECT
       submission_date,
@@ -27,7 +32,7 @@ WITH get_default_browser_for_mobile AS (
       is_default_browser,
       'Firefox iOS' AS normalized_app_name
     FROM
-      `moz-fx-data-shared-prod.firefox_ios.baseline_clients_last_seen`
+      `moz-fx-data-shared-prod.firefox_ios.metrics_clients_last_seen`
     WHERE
       submission_date = @submission_date
     UNION ALL

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
@@ -15,7 +15,7 @@ WITH get_default_browser_for_mobile AS (
       submission_date,
       client_id,
       is_default_browser,
-      'Fenix' AS normalized_app_name
+      IF(isp = 'BrowserStack', CONCAT('Fenix', ' BrowserStack'), 'Fenix') AS normalized_app_name
     FROM
       `moz-fx-data-shared-prod.fenix.baseline_clients_last_seen`
     WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
@@ -1,0 +1,173 @@
+--Since is_default_browser is not available on active_users, create a CTE with this information for mobile clients
+WITH get_default_browser_for_mobile AS (
+  (
+    SELECT
+      submission_date,
+      client_id,
+      is_default_browser,
+      'Focus iOS' AS normalized_app_name
+    FROM
+      `moz-fx-data-shared-prod.org_mozilla_ios_focus_derived.baseline_clients_last_seen_v1`
+    WHERE
+      submission_date = @submission_date
+    UNION ALL
+    SELECT
+      submission_date,
+      client_id,
+      is_default_browser,
+      'Fenix' AS normalized_app_name
+    FROM
+      `moz-fx-data-shared-prod.fenix.baseline_clients_last_seen`
+    WHERE
+      submission_date = @submission_date
+    UNION ALL
+    SELECT
+      submission_date,
+      client_id,
+      is_default_browser,
+      'Firefox iOS' AS normalized_app_name
+    FROM
+      `moz-fx-data-shared-prod.firefox_ios.baseline_clients_last_seen`
+    WHERE
+      submission_date = @submission_date
+    UNION ALL
+    SELECT
+      submission_date,
+      client_id,
+      is_default_browser,
+      'Focus Android Glean' AS normalized_app_name
+    FROM
+      `moz-fx-data-shared-prod.focus_android.baseline_clients_last_seen`
+    WHERE
+      submission_date = @submission_date
+    UNION ALL
+    SELECT
+      submission_date,
+      client_id,
+      default_browser AS is_default_browser,
+      'Focus Android' AS normalized_app_name
+    FROM
+      `moz-fx-data-shared-prod.telemetry.core_clients_last_seen`
+    WHERE
+      submission_date = @submission_date
+      AND app_name = 'Focus'
+      AND os = 'Android'
+    UNION ALL
+    SELECT
+      submission_date,
+      client_id,
+      is_default_browser,
+      'Klar iOS' AS normalized_app_name
+    FROM
+      `moz-fx-data-shared-prod.klar_ios.clients_last_seen_joined`
+    WHERE
+      submission_date = @submission_date
+  )
+)
+--Desktop
+SELECT
+  au.client_id,
+  au.first_seen_date AS cohort_date,
+  au.activity_segment,
+  au.app_version,
+  cls.attribution.campaign AS attribution_campaign,
+  cls.attribution.content AS attribution_content,
+  cls.attribution.experiment AS attribution_experiment,
+  au.attribution_medium,
+  au.attribution_source,
+  cls.attribution.variation AS attribution_variation,
+  au.city,
+  au.country,
+  ccls.device AS device_model,
+  au.distribution_id,
+  au.is_default_browser,
+  au.locale,
+  au.app_name AS normalized_app_name,
+  au.normalized_channel,
+  au.os AS normalized_os, --old one had it as normalized_os, do I need to add a transform of some kind to normalize?
+  au.normalized_os_version,
+  COALESCE(
+    SAFE_CAST(NULLIF(SPLIT(au.normalized_os_version, ".")[SAFE_OFFSET(0)], "") AS INTEGER),
+    0
+  ) AS os_version_major,
+  COALESCE(
+    SAFE_CAST(NULLIF(SPLIT(au.normalized_os_version, ".")[SAFE_OFFSET(1)], "") AS INTEGER),
+    0
+  ) AS os_version_minor,
+  CAST(NULL AS STRING) AS adjust_ad_group,
+  CAST(NULL AS STRING) AS adjust_campaign,
+  CAST(NULL AS STRING) AS adjust_creative,
+  CAST(NULL AS STRING) AS adjust_network,
+  CAST(NULL AS STRING) AS play_store_attribution_campaign,
+  CAST(NULL AS STRING) AS play_store_attribution_medium,
+  CAST(NULL AS STRING) AS play_store_attribution_source,
+  CAST(NULL AS STRING) AS play_store_attribution_content,
+  CAST(NULL AS STRING) AS play_store_attribution_term,
+FROM
+  `moz-fx-data-shared-prod.telemetry.desktop_active_users` au
+LEFT JOIN
+  `moz-fx-data-shared-prod.telemetry.core_clients_last_seen` ccls
+  ON au.client_id = ccls.client_id
+  AND au.submission_date = ccls.submission_date
+LEFT JOIN
+  `moz-fx-data-shared-prod.telemetry.clients_last_seen` cls
+  ON au.client_id = cls.client_id
+  AND au.submission_date = cls.submission_date
+WHERE
+  au.first_seen_date = @submission_date
+  AND au.submission_date = @submission_date
+UNION ALL
+--Mobile
+SELECT
+  au.client_id,
+  au.first_seen_date AS cohort_date,
+  au.activity_segment,
+  CAST(NULL AS STRING) AS app_version, --FIX
+  CAST(NULL AS string) AS attribution_campaign, --FIX
+  CAST(NULL AS string) AS attribution_content, --FIX
+  CAST(NULL AS string) AS attribution_experiment, --FIX
+  CAST(NULL AS string) AS attribution_medium, --FIX
+  CAST(NULL AS string) AS attribution_source, --FIX
+  CAST(NULL AS string) AS attribution_variation, --FIX
+  au.city,
+  au.country,
+  au.device_model,
+  au.distribution_id,
+  dflt_brwsr.is_default_browser,
+  au.locale,
+  au.app_name AS normalized_app_name, --do I need to do anything to "normalize" ?
+  au.normalized_channel,
+  au.normalized_os,
+  au.normalized_os_version,
+  COALESCE(
+    SAFE_CAST(NULLIF(SPLIT(au.normalized_os_version, ".")[SAFE_OFFSET(0)], "") AS INTEGER),
+    0
+  ) AS os_version_major,
+  COALESCE(
+    SAFE_CAST(NULLIF(SPLIT(au.normalized_os_version, ".")[SAFE_OFFSET(1)], "") AS INTEGER),
+    0
+  ) AS os_version_minor,
+  mnpc.adjust_ad_group,
+  mnpc.adjust_campaign,
+  mnpc.adjust_creative,
+  mnpc.adjust_network,
+  mnpc.play_store_attribution_campaign,
+  mnpc.play_store_attribution_medium,
+  mnpc.play_store_attribution_source,
+  mnpc.play_store_attribution_content,
+  mnpc.play_store_attribution_term,
+FROM
+  `moz-fx-data-shared-prod.telemetry.mobile_active_users` au
+LEFT OUTER JOIN
+--need to check this below still, not correct yet
+  get_default_browser_for_mobile dflt_brwsr
+  ON au.client_id = dflt_brwsr.client_id
+  AND au.submission_date = dflt_brwsr.submission_date
+  AND au.app_name = dflt_brwsr.normalized_app_name --need to check this still
+LEFT JOIN
+  `moz-fx-data-shared-prod.telemetry.mobile_new_profile_clients` mnpc
+  ON au.client_id = mnpc.client_id
+  AND au.submission_date = mnpc.first_seen_date
+WHERE
+  au.first_seen_date = @submission_date
+  AND au.submission_date = @submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
@@ -52,11 +52,9 @@ WITH get_default_browser_for_mobile AS (
       COALESCE(is_default_browser, FALSE) AS is_default_browser,
       'Focus Android' AS normalized_app_name
     FROM
-      `moz-fx-data-shared-prod.telemetry.core_clients_last_seen`
+      `moz-fx-data-shared-prod.focus_android.metrics_clients_last_seen`
     WHERE
       submission_date = @submission_date
-      AND app_name = 'Focus'
-      AND os = 'Android'
     UNION ALL
     SELECT
       submission_date,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
@@ -1,4 +1,8 @@
 --Since is_default_browser is not available on active_users, create a CTE with this information for mobile clients
+--QUESTION: what is the best way to get is_default_browser for Mobile?
+--I was going to use baseline_clients_last_seen like the V1 version but then realized it's always null
+--then I tried to switch to metrics clients last seen but I think I would need to update date logic?
+--This logic is not good yet
 WITH get_default_browser_for_mobile AS (
   (
     SELECT

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/schema.yaml
@@ -1,0 +1,125 @@
+fields:
+- mode: NULLABLE
+  name: client_id
+  type: STRING
+  description: Client ID
+- mode: NULLABLE
+  name: cohort_date
+  type: DATE
+  description: Cohort Date - First Seen Date
+- mode: NULLABLE
+  name: activity_segment
+  type: STRING
+  description: Activity Segment
+- mode: NULLABLE
+  name: app_version
+  type: STRING
+  description: App Version
+- mode: NULLABLE
+  name: attribution_campaign
+  type: STRING
+  description: Attribution Campaign
+- mode: NULLABLE
+  name: attribution_content
+  type: STRING
+  description: Attribution Content
+- mode: NULLABLE
+  name: attribution_experiment
+  type: STRING
+  description: Attribution Experiment
+- mode: NULLABLE
+  name: attribution_medium
+  type: STRING
+  description: Attribution Medium
+- mode: NULLABLE
+  name: attribution_source
+  type: STRING
+  description: Attribution Source
+- mode: NULLABLE
+  name: attribution_variation
+  type: STRING
+  description: Attribution Variation
+- mode: NULLABLE
+  name: city
+  type: STRING
+  description: City
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: Country
+- mode: NULLABLE
+  name: device_model
+  type: STRING
+  description: Device Model
+- mode: NULLABLE
+  name: distribution_id
+  type: STRING
+  description: Distribution ID
+- mode: NULLABLE
+  name: is_default_browser
+  type: BOOLEAN
+  description: Is Default Browser
+- mode: NULLABLE
+  name: locale
+  type: STRING
+  description: Locale
+- mode: NULLABLE
+  name: normalized_app_name
+  type: STRING
+  description: Normalized app Name
+- mode: NULLABLE
+  name: normalized_channel
+  type: STRING
+  description: Normalized Channel
+- mode: NULLABLE
+  name: normalized_os
+  type: STRING
+  description: Normalized Operating System
+- mode: NULLABLE
+  name: normalized_os_version
+  type: STRING
+  description: Normalized Operating System Version
+- mode: NULLABLE
+  name: os_version_major
+  type: INTEGER
+  description: Operating System - Major Version
+- mode: NULLABLE
+  name: os_version_minor
+  type: INTEGER
+  description: Operating System - Minor Version
+- name: adjust_ad_group
+  type: STRING
+  mode: NULLABLE
+  description: Adjust Ad Group - Available for Mobile Only
+- name: adjust_campaign
+  type: STRING
+  mode: NULLABLE
+  description: Adjust Campaign - Available for Mobile Only
+- name: adjust_creative
+  type: STRING
+  mode: NULLABLE
+  description: Adjust Creative - Available for Mobile Only
+- name: adjust_network
+  type: STRING
+  mode: NULLABLE
+  description: Adjust Network - Available for Mobile Only
+- name: play_store_attribution_campaign
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Campaign - Available for Mobile Only
+- name: play_store_attribution_medium
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Medium - Available for Mobile Only
+- name: play_store_attribution_source
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Source - Available for Mobile Only
+- name: play_store_attribution_content
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Content - Available for Mobile Only
+- name: play_store_attribution_term
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Term - Available for Mobile Only


### PR DESCRIPTION
## Description

This PR creates 2 new tables, that are now built off of active_users instead of unified_metrics which is being deprecated.

- moz-fx-data-shared-prod.telemetry_derived.rolling_cohorts_v2
- moz-fx-data-shared-prod.telemetry_derived.cohort_daily_statistics_v2

## Related Tickets & Documents
* [DENG-2986](https://mozilla-hub.atlassian.net/browse/DENG-2986)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-2986]: https://mozilla-hub.atlassian.net/browse/DENG-2986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ