### PR TITLE
feat: add bqetl_format pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,11 @@ repos:
     - types-python-dateutil==2.9.0.20241206,
     - types-requests==2.32.0.20241016,
     - types-PyYAML==6.0.12.20241230
+- repo: local
+  hooks:
+  - id: bqetl_format
+    name: bqetl_format
+    language: script
+    entry: ./bqetl
+    args: [format, --check]
+    types: [sql]


### PR DESCRIPTION
# feat: add bqetl_format pre-commit

This would add a local pre-commit hook to run bqetl format --check automatically on each commit on modified sql files. The idea here is to prevent situations in which a developer commit sql code changes to the repository only to find out during the CI run that their SQL needs to be reformatted. This however, is not perfect as currently it results in a Exception stack trace being printed out instead of just filenames of filed that would need to be reformatted. Ideally this would work similarly to something like `black` where pre-commit would detect files would need to be reformatted, actually do the formatting and require us to run the commit cmd again.

No real risk to this change as this just involved executing bqetl format command locally during when attempting to commit staged changes to git. If we find this to not be working well or be annoying we could easily revert this by removing the code introduced in this PR.