### PR TITLE
fix: Mark `bqetl` as not compatible with Python 3.12 or later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ authors = [
 ]
 description = "Tooling for building derived datasets in BigQuery"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11, <3.12"
 dynamic = ["dependencies"]
-version = "2025.1.1"
+version = "2025.2.1"
 
 [project.urls]
 Homepage = "https://github.com/mozilla/bigquery-etl"


### PR DESCRIPTION
## Description
`bqetl` isn't currently compatible with Python 3.12 or 3.13, so this PR updates `pyproject.toml` to indicate that.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/issues/5711

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
