### PR TITLE
Add rolling_cohorts_v2 to shredder config

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -199,7 +199,6 @@ DELETE_TARGETS: DeleteIndex = {
     client_id_target(
         table="telemetry_derived.desktop_engagement_clients_v1"
     ): DESKTOP_SRC,
-    client_id_target(table="telemetry_derived.rolling_cohorts_v2"): DESKTOP_SRC,
     client_id_target(table="search_derived.search_clients_last_seen_v1"): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.clients_daily_v6"): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.clients_daily_joined_v1"): DESKTOP_SRC,
@@ -255,6 +254,17 @@ DELETE_TARGETS: DeleteIndex = {
     ): (
         DeleteSource(table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID),
+    ),
+    DeleteTarget(
+        table="telemetry_derived.rolling_cohorts_v2",
+        field=(CLIENT_ID, CLIENT_ID, CLIENT_ID, CLIENT_ID, CLIENT_ID, CLIENT_ID),
+    ): (
+        DESKTOP_SRC,
+        DeleteSource(table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="klar_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="focus_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="klar_android.deletion_request", field=GLEAN_CLIENT_ID),
     ),
     # activity stream
     DeleteTarget(

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -199,6 +199,9 @@ DELETE_TARGETS: DeleteIndex = {
     client_id_target(
         table="telemetry_derived.desktop_engagement_clients_v1"
     ): DESKTOP_SRC,
+        client_id_target(
+        table="telemetry_derived.rolling_cohorts_v2"
+    ): DESKTOP_SRC,
     client_id_target(table="search_derived.search_clients_last_seen_v1"): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.clients_daily_v6"): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.clients_daily_joined_v1"): DESKTOP_SRC,

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -257,9 +257,18 @@ DELETE_TARGETS: DeleteIndex = {
     ),
     DeleteTarget(
         table="telemetry_derived.rolling_cohorts_v2",
-        field=(CLIENT_ID, CLIENT_ID, CLIENT_ID, CLIENT_ID, CLIENT_ID, CLIENT_ID),
+        field=(
+            CLIENT_ID,
+            CLIENT_ID,
+            CLIENT_ID,
+            CLIENT_ID,
+            CLIENT_ID,
+            CLIENT_ID,
+            CLIENT_ID,
+        ),
     ): (
         DESKTOP_SRC,
+        DeleteSource(table="focus_android.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="klar_ios.deletion_request", field=GLEAN_CLIENT_ID),

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -199,9 +199,7 @@ DELETE_TARGETS: DeleteIndex = {
     client_id_target(
         table="telemetry_derived.desktop_engagement_clients_v1"
     ): DESKTOP_SRC,
-        client_id_target(
-        table="telemetry_derived.rolling_cohorts_v2"
-    ): DESKTOP_SRC,
+    client_id_target(table="telemetry_derived.rolling_cohorts_v2"): DESKTOP_SRC,
     client_id_target(table="search_derived.search_clients_last_seen_v1"): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.clients_daily_v6"): DESKTOP_SRC,
     client_id_target(table="telemetry_derived.clients_daily_joined_v1"): DESKTOP_SRC,


### PR DESCRIPTION
## Description

This PR adds the new client level table `moz-fx-data-shared-prod.telemetry_derived.rolling_cohorts_v2` (which contains both desktop and mobile client IDs) to shredder configuration.

## Related Tickets & Documents
* [DENG-2986](https://mozilla-hub.atlassian.net/browse/DENG-2986)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-2986]: https://mozilla-hub.atlassian.net/browse/DENG-2986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ