### PR TITLE
feat: handle cases when SQL syntaxt is invalid and add invalid to the final report

### DIFF
--- a/bigquery_etl/format_sql/format.py
+++ b/bigquery_etl/format_sql/format.py
@@ -113,5 +113,5 @@ def format(paths, check=False, parallelism=8):
             )
             + "."
         )
-        if (check and reformatted) or (check and invalid):
+        if check and (reformatted or invalid):
             sys.exit(1)

--- a/bigquery_etl/format_sql/format.py
+++ b/bigquery_etl/format_sql/format.py
@@ -7,6 +7,7 @@ import sys
 from functools import partial
 from multiprocessing.pool import Pool
 from pathlib import Path
+from typing import Tuple
 
 from sqlglot.errors import ParseError
 
@@ -35,7 +36,15 @@ def skip_qualifying_references():
     ]
 
 
-def _format_path(check, path):
+def _format_path(check: bool, path: str) -> Tuple[int, int]:
+    """
+    Format SQL file or if `check` flag set validate it is correct format.
+
+    :param check:   Flag which indicates whether we should only check if query needs reformatted.
+    :param path:    String path of the SQL file to perform the operations on.
+    :return:        a tuple with two elements. Element one represents if formamtting was applied,
+                    element two if the query's format is invalid.
+    """
     query = Path(path).read_text()
 
     try:

--- a/tests/cli/test_cli_format.py
+++ b/tests/cli/test_cli_format.py
@@ -29,7 +29,10 @@ class TestFormat:
                 f.write("SELECT 1 FROM test")
             with open("test/bar.sql", "w") as f:
                 f.write("SELECT 1 FROM test")
+            with open("test/baz.sql", "w") as f:
+                f.write("SELECT 1 FROM test WHERE 1 AND AND")
 
             result = runner.invoke(sql_format, ["test"])
-            assert "2 files reformatted." in result.output
+            assert "2 files reformatted" in result.output
+            assert "1 file invalid" in result.output
             assert result.exit_code == 0


### PR DESCRIPTION
# feat: handle cases when SQL syntaxt is invalid and add invalid to the final report

Currently, if SQL is found to be invalid we end up with an exception being raised when running bqetl format command and an exception stack trace being printed.

This change is meant to handle these cases more gracefully.