### PR TITLE
fix: Disable monitoring for this backfill dataset

### DIFF
--- a/sql/moz-fx-data-shared-prod/backfills_staging_derived/baseline_clients_last_seen_v1_20211130/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/backfills_staging_derived/baseline_clients_last_seen_v1_20211130/metadata.yaml
@@ -26,7 +26,7 @@ bigquery:
       - normalized_channel
       - sample_id
 monitoring:
-  enabled: true
+  enabled: false
 schema:
   derived_from:
     - table: ['moz-fx-data-shared-prod', 'firefox_desktop_derived', 'baseline_clients_daily_v1']


### PR DESCRIPTION
fix: Disable monitoring for this backfill dataset

This is causing Bigeye monitor deployment job to fail as this table no longer appears to exist.
