### PR TITLE
Add legacy sources to rolling_cohorts_v2 delete sources - shredder mitigation

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -257,20 +257,7 @@ DELETE_TARGETS: DeleteIndex = {
     ),
     DeleteTarget(
         table="telemetry_derived.rolling_cohorts_v2",
-        field=(
-            CLIENT_ID,
-            CLIENT_ID,
-            CLIENT_ID,
-            CLIENT_ID,
-            CLIENT_ID,
-            CLIENT_ID,
-            CLIENT_ID,
-            CLIENT_ID,
-            CLIENT_ID,
-            CLIENT_ID,
-            CLIENT_ID,
-            CLIENT_ID,
-        ),
+        field=(CLIENT_ID,) * 12,
     ): (
         DESKTOP_SRC,
         DeleteSource(table="focus_android.deletion_request", field=GLEAN_CLIENT_ID),
@@ -279,26 +266,7 @@ DELETE_TARGETS: DeleteIndex = {
         DeleteSource(table="klar_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="focus_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="klar_android.deletion_request", field=GLEAN_CLIENT_ID),
-        DeleteSource(
-            table="org_mozilla_ios_fennec_stable.deletion_request_v1",
-            field="metrics.uuid.legacy_ids_client_id",
-        ),
-        DeleteSource(
-            table="org_mozilla_ios_firefox_stable.deletion_request_v1",
-            field="metrics.uuid.legacy_ids_client_id",
-        ),
-        DeleteSource(
-            table="org_mozilla_ios_firefoxbeta_stable.deletion_request_v1",
-            field="metrics.uuid.legacy_ids_client_id",
-        ),
-        DeleteSource(
-            table="org_mozilla_tv_firefox_stable.deletion_request_v1",
-            field="metrics.uuid.legacy_ids_client_id",
-        ),
-        DeleteSource(
-            table="mozilla_lockbox_stable.deletion_request_v1",
-            field="metrics.uuid.legacy_ids_client_id",
-        ),
+        *LEGACY_MOBILE_SOURCES,
     ),
     # activity stream
     DeleteTarget(

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -265,6 +265,11 @@ DELETE_TARGETS: DeleteIndex = {
             CLIENT_ID,
             CLIENT_ID,
             CLIENT_ID,
+            CLIENT_ID,
+            CLIENT_ID,
+            CLIENT_ID,
+            CLIENT_ID,
+            CLIENT_ID,
         ),
     ): (
         DESKTOP_SRC,
@@ -274,6 +279,26 @@ DELETE_TARGETS: DeleteIndex = {
         DeleteSource(table="klar_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="focus_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="klar_android.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(
+            table="org_mozilla_ios_fennec_stable.deletion_request_v1",
+            field="metrics.uuid.legacy_ids_client_id",
+        ),
+        DeleteSource(
+            table="org_mozilla_ios_firefox_stable.deletion_request_v1",
+            field="metrics.uuid.legacy_ids_client_id",
+        ),
+        DeleteSource(
+            table="org_mozilla_ios_firefoxbeta_stable.deletion_request_v1",
+            field="metrics.uuid.legacy_ids_client_id",
+        ),
+        DeleteSource(
+            table="org_mozilla_tv_firefox_stable.deletion_request_v1",
+            field="metrics.uuid.legacy_ids_client_id",
+        ),
+        DeleteSource(
+            table="mozilla_lockbox_stable.deletion_request_v1",
+            field="metrics.uuid.legacy_ids_client_id",
+        ),
     ),
     # activity stream
     DeleteTarget(


### PR DESCRIPTION
This PR updates the shredder mitigation set up for telemetry_derived.rolling_cohorts_v2 to include legacy sources