### PR TITLE
fix(DENG-2986) Minor tweaks to new rolling_cohorts_v2 and cohort_daily_statistics_v2 tables

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -160,6 +160,17 @@ LEGACY_MOBILE_SOURCES = tuple(
         "mozilla_lockbox",
     )
 )
+FOCUS_ADDITIONAL_DELETIONS = tuple(
+    DeleteSource(
+        table=f"{product}_derived.additional_deletion_requests_v1",
+        field="client_id",
+    )
+    for product in (
+        "org_mozilla_focus",
+        "org_mozilla_focus_beta",
+        "org_mozilla_focus_nightly",
+    )
+)
 USER_CHARACTERISTICS_SRC = DeleteSource(
     table="firefox_desktop_stable.deletion_request_v1",
     field=USER_CHARACTERISTICS_ID,
@@ -257,7 +268,7 @@ DELETE_TARGETS: DeleteIndex = {
     ),
     DeleteTarget(
         table="telemetry_derived.rolling_cohorts_v2",
-        field=(CLIENT_ID,) * 12,
+        field=(CLIENT_ID,) * 15,
     ): (
         DESKTOP_SRC,
         DeleteSource(table="focus_android.deletion_request", field=GLEAN_CLIENT_ID),
@@ -266,6 +277,7 @@ DELETE_TARGETS: DeleteIndex = {
         DeleteSource(table="klar_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="focus_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="klar_android.deletion_request", field=GLEAN_CLIENT_ID),
+        *FOCUS_ADDITIONAL_DELETIONS,
         *LEGACY_MOBILE_SOURCES,
     ),
     # activity stream

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/metadata.yaml
@@ -1,8 +1,7 @@
 friendly_name: Cohort Daily Statistics V2
 description: |-
-  Cohort Daily Statistics consists of one row per cohort date
-  per activity date (up to 180 days after the cohort start date)
-  It's a summary of the cohort's activity in that day.
+  Cohort Daily Statistics tracks retention for a cohort with 
+  the same first seen date and same set of attributes over the next 180 days
 
   Note that the values for client attributes are based on the
   attributes at the time the cohort started (rather than the

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Cohort Daily Statistics V2
 description: |-
-  Cohort Daily Statistics tracks retention for a cohort with 
+  Cohort Daily Statistics tracks retention for a cohort with
   the same first seen date and same set of attributes over the next 180 days
 
   Note that the values for client attributes are based on the

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/query.sql
@@ -43,6 +43,7 @@ cohorts_in_range AS (
     play_store_attribution_source,
     play_store_attribution_content,
     play_store_attribution_term,
+    row_source,
   FROM
     `moz-fx-data-shared-prod.telemetry_derived.rolling_cohorts_v2`
   WHERE
@@ -93,6 +94,7 @@ SELECT
   play_store_attribution_source,
   play_store_attribution_content,
   play_store_attribution_term,
+  row_source,
   COUNT(cohort_client_id) AS num_clients_in_cohort,
   COUNT(active_client_id) AS num_clients_active_on_day,
 FROM
@@ -128,4 +130,5 @@ GROUP BY
   play_store_attribution_medium,
   play_store_attribution_source,
   play_store_attribution_content,
-  play_store_attribution_term
+  play_store_attribution_term,
+  row_source

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/schema.yaml
@@ -123,6 +123,10 @@ fields:
   type: STRING
   mode: NULLABLE
   description: Play Store Attribution Term - Available for Mobile Only
+- name: row_source
+  type: STRING
+  mode: NULLABLE
+  description: Row Source - Indicates if Desktop or Mobile
 - mode: NULLABLE
   name: num_clients_in_cohort
   type: INTEGER

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/checks.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/checks.sql
@@ -1,0 +1,2 @@
+#fail
+{{ is_unique(["client_id", "row_source"], "cohort_date = @submission_date")}}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Rolling Cohorts
 description: |-
-  Rolling Cohorts consists of one row per client per date (each date
+  Rolling Cohorts consists of one row per client & row_source per date (each date
   representing a new cohort) i.e. all the clients that had their first
   ping sent that day. This can be left joined with various activity
   tables to calculate activity metrics for particular cohorts.

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
@@ -18,7 +18,7 @@ SELECT
   au.locale,
   au.app_name AS normalized_app_name,
   au.normalized_channel,
-  au.os AS normalized_os, --old one had it as normalized_os, do I need to add a transform of some kind to normalize?
+  au.os AS normalized_os,
   au.normalized_os_version,
   COALESCE(
     SAFE_CAST(NULLIF(SPLIT(au.normalized_os_version, ".")[SAFE_OFFSET(0)], "") AS INTEGER),

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
@@ -37,6 +37,7 @@ SELECT
   CAST(NULL AS STRING) AS play_store_attribution_source,
   CAST(NULL AS STRING) AS play_store_attribution_content,
   CAST(NULL AS STRING) AS play_store_attribution_term,
+  'Desktop' AS row_source,
 FROM
   `moz-fx-data-shared-prod.telemetry.desktop_active_users` au
 LEFT JOIN
@@ -88,12 +89,53 @@ SELECT
   mnpc.play_store_attribution_source,
   mnpc.play_store_attribution_content,
   mnpc.play_store_attribution_term,
+  'Mobile' AS row_source
 FROM
-  `moz-fx-data-shared-prod.telemetry.mobile_active_users` au
+  (
+--in case of multiple rows per client ID / first seen date (rare), pick 1
+    SELECT
+      client_id,
+      submission_date,
+      first_seen_date,
+      activity_segment,
+      app_display_version,
+      city,
+      country,
+      device_model,
+      distribution_id,
+      locale,
+      app_name,
+      normalized_channel,
+      normalized_os,
+      normalized_os_version
+    FROM
+      `moz-fx-data-shared-prod.telemetry.mobile_active_users`
+    WHERE
+      first_seen_date = @submission_date
+      AND submission_date = @submission_date
+    QUALIFY
+      ROW_NUMBER() OVER (PARTITION BY client_id) = 1
+  ) au
 LEFT JOIN
-  `moz-fx-data-shared-prod.telemetry.mobile_new_profile_clients` mnpc
+  (
+--in case of multiple rows per client ID /first seen date (rare), pick 1
+    SELECT
+      first_seen_date,
+      client_id,
+      adjust_ad_group,
+      adjust_campaign,
+      adjust_creative,
+      adjust_network,
+      play_store_attribution_campaign,
+      play_store_attribution_medium,
+      play_store_attribution_source,
+      play_store_attribution_content,
+      play_store_attribution_term,
+    FROM
+      `moz-fx-data-shared-prod.telemetry.mobile_new_profile_clients`
+    WHERE
+      first_seen_date = @submission_date
+    QUALIFY
+      ROW_NUMBER() OVER (PARTITION BY client_id) = 1
+  ) mnpc
   ON au.client_id = mnpc.client_id
-  AND au.submission_date = mnpc.first_seen_date
-WHERE
-  au.first_seen_date = @submission_date
-  AND au.submission_date = @submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/schema.yaml
@@ -123,3 +123,7 @@ fields:
   type: STRING
   mode: NULLABLE
   description: Play Store Attribution Term - Available for Mobile Only
+- name: row_source
+  type: STRING
+  mode: NULLABLE
+  description: Flag indicating source - i.e. Desktop or Mobile


### PR DESCRIPTION
## Description

This PR does some primary key handling for the rare cases where a client ID is used across multiple channels and/or multiple apps on the same first seen date. It also adds 1 new column to both tables called "row_source" (this is a flag for desktop vs mobile at a high level).
It also adds a data check to ensure that it's 1 row per cohort date, client ID, and row source in rolling_cohorts_v2.

This also updates the shredder mitigation config for rolling_cohorts_v2 to add the Focus additional deletion sources.

## Related Tickets & Documents
* [DENG-2986](https://mozilla-hub.atlassian.net/browse/DENG-2986)
* [Bug 1947555](https://bugzilla.mozilla.org/show_bug.cgi?id=1947555)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-2986]: https://mozilla-hub.atlassian.net/browse/DENG-2986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ