### PR TITLE
Add dataset for Looker dashboard performance

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,6 +18,7 @@ google-cloud-storage==3.0.0
 Jinja2==3.1.5
 jsonschema==4.23.0
 PyJWT==2.10.1
+looker-sdk==25.2.0
 markdown-include==0.8.1
 mdx_truly_sane_lists==1.3
 mkdocs==1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,6 +118,7 @@ attrs==25.1.0 \
     #   cattrs
     #   glom
     #   jsonschema
+    #   looker-sdk
     #   mozilla-metric-config-parser
     #   pytest-mypy
     #   referencing
@@ -197,6 +198,7 @@ cattrs==24.1.2 \
     --hash=sha256:8028cfe1ff5382df59dd36474a86e02d817b06eaf8af84555441bac915d2ef85
     # via
     #   -r requirements.in
+    #   looker-sdk
     #   mozilla-metric-config-parser
 certifi==2024.7.4 \
     --hash=sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b \
@@ -796,6 +798,10 @@ keyring==24.3.1 \
     --hash=sha256:c3327b6ffafc0e8befbdb597cacdb4928ffe5c1212f7645f186e6d9957a898db \
     --hash=sha256:df38a4d7419a6a60fea5cef1e45a948a3e8430dd12ad88b0f423c5c143906218
     # via bigeye-sdk
+looker-sdk==25.2.0 \
+    --hash=sha256:08fa5a181ac12c192f52f3637c751f09165935713eeb21c52b7a62b61fc8abca \
+    --hash=sha256:a71bf1ce23ca5edb282d6d214d83995573a22882c2ca4c63e5f5fdf67f6b04e9
+    # via -r requirements.in
 lz4==4.3.3 \
     --hash=sha256:01fe674ef2889dbb9899d8a67361e0c4a2c833af5aeb37dd505727cf5d2a131e \
     --hash=sha256:054b4631a355606e99a42396f5db4d22046a3397ffc3269a348ec41eaebd69d2 \
@@ -1933,6 +1939,7 @@ requests==2.32.3 \
     #   google-api-core
     #   google-cloud-bigquery
     #   google-cloud-storage
+    #   looker-sdk
     #   mkdocs-material
     #   mozilla-metric-config-parser
     #   mozilla-schema-generator
@@ -2260,6 +2267,7 @@ typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
     # via
+    #   looker-sdk
     #   mypy
     #   polyfactory
     #   pydantic

--- a/sql/moz-fx-data-shared-prod/monitoring/looker_dashboard_load_times/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/looker_dashboard_load_times/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.monitoring.looker_dashboard_load_times`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.monitoring_derived.looker_dashboard_load_times_v1`

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Looker Dashboard Load Times
+description: |-
+  Looker dashboard load times imported from Looker.
+owners:
+- ascholtz@mozilla.com
+labels:
+  incremental: true
+  dag: bqetl_monitoring
+  owner1: ascholtz
+scheduling:
+  dag_name: bqetl_monitoring
+  arguments: ["--date '{{ ds }}'"]
+  date_partition_parameter: null
+  secrets:
+  - deploy_target: LOOKER_API_CLIENT_ID
+    key: probe_scraper_secret__looker_api_client_id_prod
+  - deploy_target: LOOKER_API_CLIENT_SECRET
+    key: probe_scraper_secret__looker_api_client_secret_prod
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/query.py
@@ -1,0 +1,130 @@
+import os
+
+import click
+import looker_sdk
+
+from looker_sdk import methods40 as methods
+from looker_sdk import models40 as models
+from looker_sdk import error
+import json
+from google.cloud import bigquery
+
+
+def setup_sdk(client_id, client_secret, instance) -> methods.Looker40SDK:
+    os.environ["LOOKERSDK_BASE_URL"] = instance
+    os.environ["LOOKERSDK_API_VERSION"] = "4.0"
+    os.environ["LOOKERSDK_VERIFY_SSL"] = "true"
+    os.environ["LOOKERSDK_TIMEOUT"] = "9000"
+    os.environ["LOOKERSDK_CLIENT_ID"] = client_id
+    os.environ["LOOKERSDK_CLIENT_SECRET"] = client_secret
+
+    return looker_sdk.init40()
+
+
+def run_query(sdk, date):
+    """Runs the specified query with the specified filters."""
+    lookml_date = f"date({date.year}, {date.month}, {date.day})"
+
+    request = models.WriteQuery(
+        model="system__activity",
+        view="dashboard_performance",
+        fields=[
+            "dashboard_history_stats.total_runtime",
+            "dashboard_page_event_stats.seconds_until_controller_initialized",
+            "dashboard_page_event_stats.seconds_until_dom_content_loaded",
+            "dashboard_page_event_stats.seconds_until_metadata_loaded",
+            "dashboard_performance.seconds_until_dashboard_run_start",
+            "dashboard_performance.seconds_until_first_data_received",
+            "dashboard_performance.seconds_until_first_tile_finished_rendering",
+            "dashboard_performance.seconds_until_last_data_received",
+            "dashboard_performance.seconds_until_last_tile_finished_rendering",
+            "dashboard_performance.dash_id",
+            "dashboard_performance.first_event_at_date",
+        ],
+        pivots=None,
+        fill_fields=None,
+        filters={"dashboard.is_legacy": "No", "dashboard.moved_to_trash": "No"},
+        sorts=["dashboard_history_stats.total_runtime"],
+        limit=5000,
+        column_limit=50,
+        total=None,
+        row_total=None,
+        subtotals=None,
+        dynamic_fields=None,
+        query_timezone=None,
+        filter_expression="${dashboard_performance.first_event_at_date} = "
+        + lookml_date,
+    )
+    try:
+        json_ = sdk.run_inline_query("json", request, cache=False)
+    except error.SDKError:
+        raise Exception("Error running query")
+    else:
+        json_resp = json.loads(json_)
+    return json_resp
+
+
+def import_performance_data_for_date(sdk, destination_table, date):
+    result = run_query(sdk, date)
+    # field identifiers are formatted like dashboard_performance.<name>, only the latter part is relevant
+    result = [{key.split(".")[1]: value for key, value in r.items()} for r in result]
+    result = [
+        {
+            "submission_date" if key == "first_event_at_date" else key: value
+            for key, value in r.items()
+        }
+        for r in result
+    ]
+
+    client = bigquery.Client()
+    job_config = bigquery.LoadJobConfig()
+    job_config.schema = (
+        bigquery.SchemaField("total_runtime", "FLOAT64"),
+        bigquery.SchemaField("seconds_until_controller_initialized", "FLOAT64"),
+        bigquery.SchemaField("seconds_until_dom_content_loaded", "FLOAT64"),
+        bigquery.SchemaField("seconds_until_metadata_loaded", "FLOAT64"),
+        bigquery.SchemaField("seconds_until_dashboard_run_start", "FLOAT64"),
+        bigquery.SchemaField("seconds_until_first_data_received", "FLOAT64"),
+        bigquery.SchemaField("seconds_until_first_tile_finished_rendering", "FLOAT64"),
+        bigquery.SchemaField("seconds_until_last_data_received", "FLOAT64"),
+        bigquery.SchemaField("seconds_until_last_tile_finished_rendering", "FLOAT64"),
+        bigquery.SchemaField("dash_id", "STRING"),
+        bigquery.SchemaField("dashboard_page_session", "STRING"),
+        bigquery.SchemaField("submission_date", "DATE"),
+    )
+    job_config.write_disposition = bigquery.job.WriteDisposition.WRITE_TRUNCATE
+    job_config.time_partitioning = bigquery.TimePartitioning(
+        type_=bigquery.TimePartitioningType.DAY,
+        field="submission_date",
+    )
+
+    partition_date = date.strftime("%Y%m%d")
+    client.load_table_from_json(
+        result,
+        f"{destination_table}${partition_date}",
+        job_config=job_config,
+    ).result()
+
+
+@click.command()
+@click.option("--client_id", envvar="LOOKER_API_CLIENT_ID", required=True)
+@click.option("--client_secret", envvar="LOOKER_API_CLIENT_SECRET", required=True)
+@click.option("--instance_uri", default="https://mozilla.cloud.looker.com", required=True)
+@click.option(
+    "--destination_table",
+    "--destination-table",
+    required=True,
+    default="moz-fx-data-shared-prod.monitoring_derived.looker_dashboard_load_times_v1",
+)
+@click.option("--date", required=True, type=click.DateTime(formats=["%Y-%m-%d"]))
+def main(
+    client_id: str, client_secret: str, instance_uri: str, destination_table, date
+):
+    sdk = setup_sdk(client_id, client_secret, instance_uri)
+
+    click.echo(f"Importing Looker dashboard performance data for {date}")
+    import_performance_data_for_date(sdk, destination_table, date)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/schema.yaml
@@ -1,0 +1,58 @@
+fields:
+- mode: NULLABLE
+  name: total_runtime
+  type: FLOAT
+  description: Total dashboard run time in seconds
+- mode: NULLABLE
+  name: seconds_until_controller_initialized
+  type: FLOAT
+  description: The number of seconds that passed before the last query results were
+    returned to the dashboard
+- mode: NULLABLE
+  name: seconds_until_dom_content_loaded
+  type: FLOAT
+  description: The number of seconds that passed before the document object model
+    (DOM) was loaded on the dashboard page
+- mode: NULLABLE
+  name: seconds_until_metadata_loaded
+  type: FLOAT
+  description: The number of seconds that passed before metadata was loaded on the
+    dashboard page
+- mode: NULLABLE
+  name: seconds_until_dashboard_run_start
+  type: FLOAT
+  description: The number of seconds that passed before the dashboard loaded and the
+    'Run' button was clicked
+- mode: NULLABLE
+  name: seconds_until_first_data_received
+  type: FLOAT
+  description: The number of seconds that passed before the first query results were
+    returned to the dashboard
+- mode: NULLABLE
+  name: seconds_until_first_tile_finished_rendering
+  type: FLOAT
+  description: The number of seconds that passed before the first dashboard tile was
+    displayed with query results
+- mode: NULLABLE
+  name: seconds_until_last_data_received
+  type: FLOAT
+  description: The number of seconds that passed before the last query results were
+    returned to the dashboard
+- mode: NULLABLE
+  name: seconds_until_last_tile_finished_rendering
+  type: FLOAT
+  description: The number of seconds that passed before the last dashboard tile was
+    displayed with query results
+- mode: NULLABLE
+  name: dash_id
+  type: STRING
+  description: Dashboard ID
+- mode: NULLABLE
+  name: dashboard_page_session
+  type: STRING
+  description: A unique string identifier assigned to a particular dashboard each
+    time a dashboard page is loaded
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: The first occurrence of a particular dashboard being run


### PR DESCRIPTION
## Description

This adds a new dataset for pulling in Looker dashboard performance data from the Looker activity explores via the Looker API. This data is used to analyse different percentiles of dashboard performances.

Doing the same analysis within Looker is not possible due to it not being able to aggregate different percentiles and due to running into the 5000 rows limit 

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
