### PR TITLE
DENG-7859 - Complete backfill for Legacy to GLEAN distribution ID mapping table

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_dau_distribution_id_history_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_dau_distribution_id_history_v1/backfill.yaml
@@ -4,6 +4,6 @@
   reason: Backfill Legacy to GLEAN distribution ID mapping for KPI reporting
   watchers:
   - gkatre@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true


### PR DESCRIPTION
## Description

Backfill for Legacy to GLEAN distribution ID mapping table `desktop_dau_distribution_id_history_v1` has been staged in `backfills_staging_derived.firefox_desktop_derived__desktop_dau_distribution_id_history_v1_2025_02_13`

This PR will deploy to the prod table `firefox_desktop_derived.desktop_dau_distribution_id_history_v1`

Did spot checks to verify the presence of the data for the backfill days in the stage table.

## Related Tickets & Documents
* DENG-7859

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
