### PR TITLE
chore(org_mozilla_broken_site_report): Drop the JSON-building from the views.

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
@@ -11,59 +11,7 @@ SELECT
   client_info.app_display_version AS app_version,
   normalized_channel AS app_channel,
   normalized_os AS os,
-  TO_JSON_STRING(
-    STRUCT(
-      STRUCT(
-        STRUCT(
-          metrics.text2.broken_site_report_browser_info_app_default_useragent_string AS default_useragent_string,
-          metrics.boolean.broken_site_report_browser_info_app_fission_enabled AS fission_enabled,
-          metrics.string_list.broken_site_report_browser_info_app_default_locales AS app_default_locales
-        ) AS app,
-        STRUCT(
-          metrics.text2.broken_site_report_browser_info_graphics_devices_json AS devices_json,
-          metrics.text2.broken_site_report_browser_info_graphics_drivers_json AS drivers_json,
-          metrics.text2.broken_site_report_browser_info_graphics_features_json AS features_json,
-          metrics.text2.broken_site_report_browser_info_graphics_monitors_json AS monitors_json,
-          metrics.boolean.broken_site_report_browser_info_graphics_has_touch_screen AS has_touch_screen,
-          metrics.string.broken_site_report_browser_info_graphics_device_pixel_ratio AS device_pixel_ratio
-        ) AS graphics,
-        STRUCT(
-          metrics.boolean.broken_site_report_browser_info_prefs_software_webrender AS software_webrender,
-          metrics.boolean.broken_site_report_browser_info_prefs_global_privacy_control_enabled AS global_privacy_control_enabled,
-          metrics.boolean.broken_site_report_browser_info_prefs_installtrigger_enabled AS installtrigger_enabled,
-          metrics.boolean.broken_site_report_browser_info_prefs_forced_accelerated_layers AS forced_accelerated_layers,
-          metrics.boolean.broken_site_report_browser_info_prefs_opaque_response_blocking AS opaque_response_blocking,
-          metrics.boolean.broken_site_report_browser_info_prefs_resist_fingerprinting_enabled AS resist_fingerprinting_enabled,
-          metrics.quantity.broken_site_report_browser_info_prefs_cookie_behavior AS cookie_behavior
-        ) AS prefs,
-        STRUCT(
-          metrics.boolean.broken_site_report_browser_info_system_is_tablet AS is_tablet,
-          metrics.quantity.broken_site_report_browser_info_system_memory AS memory
-        ) AS system,
-        STRUCT(
-          metrics.string_list.broken_site_report_browser_info_security_antispyware AS antispyware,
-          metrics.string_list.broken_site_report_browser_info_security_antivirus AS antivirus,
-          metrics.string_list.broken_site_report_browser_info_security_firewall AS firewall
-        ) AS security
-      ) AS browser_info,
-      STRUCT(
-        metrics.text2.broken_site_report_tab_info_useragent_string AS useragent_string,
-        metrics.string_list.broken_site_report_tab_info_languages AS languages,
-        STRUCT(
-          metrics.boolean.broken_site_report_tab_info_frameworks_mobify AS mobify,
-          metrics.boolean.broken_site_report_tab_info_frameworks_fastclick AS fastclick,
-          metrics.boolean.broken_site_report_tab_info_frameworks_marfeel AS marfeel
-        ) AS frameworks,
-        STRUCT(
-          metrics.boolean.broken_site_report_tab_info_antitracking_has_mixed_display_content_blocked AS has_mixed_display_content_blocked,
-          metrics.boolean.broken_site_report_tab_info_antitracking_is_private_browsing AS is_private_browsing,
-          metrics.boolean.broken_site_report_tab_info_antitracking_has_mixed_active_content_blocked AS has_mixed_active_content_blocked,
-          metrics.boolean.broken_site_report_tab_info_antitracking_has_tracking_content_blocked AS has_tracking_content_blocked,
-          metrics.string.broken_site_report_tab_info_antitracking_block_list AS block_list
-        ) AS antitracking
-      ) AS tab_info
-    )
-  ) AS details
+  metrics as details
 FROM
   (
     SELECT

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
@@ -4,8 +4,8 @@ AS
 SELECT
   document_id AS uuid,
   CAST(submission_timestamp AS DATETIME) AS reported_at,
-  metrics.text2.broken_site_report_description AS comments,
-  metrics.url2.broken_site_report_url AS url,
+  metrics.text.broken_site_report_description AS comments,
+  metrics.url.broken_site_report_url AS url,
   metrics.string.broken_site_report_breakage_category AS breakage_category,
   app_name,
   client_info.app_display_version AS app_version,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
@@ -11,7 +11,7 @@ SELECT
   client_info.app_display_version AS app_version,
   normalized_channel AS app_channel,
   normalized_os AS os,
-  metrics as details
+  metrics AS details
 FROM
   (
     SELECT

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
@@ -23,8 +23,8 @@ WITH live_reports AS (
 SELECT
   document_id AS uuid,
   CAST(submission_timestamp AS DATETIME) AS reported_at,
-  metrics.text2.broken_site_report_description AS comments,
-  metrics.url2.broken_site_report_url AS url,
+  metrics.text.broken_site_report_description AS comments,
+  metrics.url.broken_site_report_url AS url,
   metrics.string.broken_site_report_breakage_category AS breakage_category,
   app_name,
   client_info.app_display_version AS app_version,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
@@ -30,7 +30,7 @@ SELECT
   client_info.app_display_version AS app_version,
   normalized_channel AS app_channel,
   normalized_os AS os,
-  metrics as details
+  metrics AS details
 FROM
   live_reports
 WHERE

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
@@ -30,59 +30,7 @@ SELECT
   client_info.app_display_version AS app_version,
   normalized_channel AS app_channel,
   normalized_os AS os,
-  TO_JSON_STRING(
-    STRUCT(
-      STRUCT(
-        STRUCT(
-          metrics.text2.broken_site_report_browser_info_app_default_useragent_string AS default_useragent_string,
-          metrics.boolean.broken_site_report_browser_info_app_fission_enabled AS fission_enabled,
-          metrics.string_list.broken_site_report_browser_info_app_default_locales AS app_default_locales
-        ) AS app,
-        STRUCT(
-          metrics.text2.broken_site_report_browser_info_graphics_devices_json AS devices_json,
-          metrics.text2.broken_site_report_browser_info_graphics_drivers_json AS drivers_json,
-          metrics.text2.broken_site_report_browser_info_graphics_features_json AS features_json,
-          metrics.text2.broken_site_report_browser_info_graphics_monitors_json AS monitors_json,
-          metrics.boolean.broken_site_report_browser_info_graphics_has_touch_screen AS has_touch_screen,
-          metrics.string.broken_site_report_browser_info_graphics_device_pixel_ratio AS device_pixel_ratio
-        ) AS graphics,
-        STRUCT(
-          metrics.boolean.broken_site_report_browser_info_prefs_software_webrender AS software_webrender,
-          metrics.boolean.broken_site_report_browser_info_prefs_global_privacy_control_enabled AS global_privacy_control_enabled,
-          metrics.boolean.broken_site_report_browser_info_prefs_installtrigger_enabled AS installtrigger_enabled,
-          metrics.boolean.broken_site_report_browser_info_prefs_forced_accelerated_layers AS forced_accelerated_layers,
-          metrics.boolean.broken_site_report_browser_info_prefs_opaque_response_blocking AS opaque_response_blocking,
-          metrics.boolean.broken_site_report_browser_info_prefs_resist_fingerprinting_enabled AS resist_fingerprinting_enabled,
-          metrics.quantity.broken_site_report_browser_info_prefs_cookie_behavior AS cookie_behavior
-        ) AS prefs,
-        STRUCT(
-          metrics.boolean.broken_site_report_browser_info_system_is_tablet AS is_tablet,
-          metrics.quantity.broken_site_report_browser_info_system_memory AS memory
-        ) AS system,
-        STRUCT(
-          metrics.string_list.broken_site_report_browser_info_security_antispyware AS antispyware,
-          metrics.string_list.broken_site_report_browser_info_security_antivirus AS antivirus,
-          metrics.string_list.broken_site_report_browser_info_security_firewall AS firewall
-        ) AS security
-      ) AS browser_info,
-      STRUCT(
-        metrics.text2.broken_site_report_tab_info_useragent_string AS useragent_string,
-        metrics.string_list.broken_site_report_tab_info_languages AS languages,
-        STRUCT(
-          metrics.boolean.broken_site_report_tab_info_frameworks_mobify AS mobify,
-          metrics.boolean.broken_site_report_tab_info_frameworks_fastclick AS fastclick,
-          metrics.boolean.broken_site_report_tab_info_frameworks_marfeel AS marfeel
-        ) AS frameworks,
-        STRUCT(
-          metrics.boolean.broken_site_report_tab_info_antitracking_has_mixed_display_content_blocked AS has_mixed_display_content_blocked,
-          metrics.boolean.broken_site_report_tab_info_antitracking_is_private_browsing AS is_private_browsing,
-          metrics.boolean.broken_site_report_tab_info_antitracking_has_mixed_active_content_blocked AS has_mixed_active_content_blocked,
-          metrics.boolean.broken_site_report_tab_info_antitracking_has_tracking_content_blocked AS has_tracking_content_blocked,
-          metrics.string.broken_site_report_tab_info_antitracking_block_list AS block_list
-        ) AS antitracking
-      ) AS tab_info
-    )
-  ) AS details
+  metrics as details
 FROM
   live_reports
 WHERE

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
@@ -23,8 +23,8 @@ WITH live_reports AS (
 SELECT
   document_id AS uuid,
   CAST(submission_timestamp AS DATETIME) AS reported_at,
-  metrics.text.broken_site_report_description AS comments,
-  metrics.url.broken_site_report_url AS url,
+  metrics.text2.broken_site_report_description AS comments,
+  metrics.url2.broken_site_report_url AS url,
   metrics.string.broken_site_report_breakage_category AS breakage_category,
   app_name,
   client_info.app_display_version AS app_version,


### PR DESCRIPTION
## Description

We originally did that to keep compatibility with another data format that we planned to import. We never imported that data, and we're actually destructing the JSON again on the receiver side, so this isn't super useful.

Exposing all metrics as the new `details` "column" (i.e. record) will allow us to consume all data on our end, but we don't have to maintain that large block of boilerplate code.

This will break existing consumers of the details values - that's fine, as far as we know, we're in full control over everything.

r? @scholtzan

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
n/a

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
