### PR TITLE
Add public dataset glean_auto_events_derived.apps_auto_events_metadata

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_auto_events_derived/apps_auto_events_metadata_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_auto_events_derived/apps_auto_events_metadata_v1/metadata.yaml
@@ -7,7 +7,7 @@ labels:
   incremental: false
   owner1: efilho
   public_json: true
-  public_sql: false
+  public_sql: true
   review_bugs:
   - '1947481'
 scheduling:


### PR DESCRIPTION
## Description

This fixes a current issue with [bqetl_public_data_json.export_public_data_json_glean_auto_events_derived__apps_auto_events_metadata__v1](https://workflow.telemetry.mozilla.org/dags/bqetl_public_data_json/grid?task_id=export_public_data_json_glean_auto_events_derived__apps_auto_events_metadata__v1&tab=logs&dag_run_id=scheduled__2025-02-17T05%3A00%3A00%2B00%3A00)

```
google.api_core.exceptions.NotFound: 404 GET https://bigquery.googleapis.com/bigquery/v2/projects/mozilla-public-data/datasets/glean_auto_events_derived/tables/apps_auto_events_metadata_v1?prettyPrint=false: Not found: Dataset mozilla-public-data:glean_auto_events_derived
```

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
