### PR TITLE
Log dryrun run time in bqetl dryrun

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -481,7 +481,7 @@ class DryRun:
             # We want the dryrun service to only have read permissions, so
             # we expect CREATE VIEW and CREATE TABLE to throw specific
             # exceptions.
-            print(f"{self.sqlfile!s:59} OK, DDL/DML skipped")
+            print(f"{self.sqlfile!s:59} OK but DDL/DML skipped")
         elif self.get_error() == Errors.DATE_FILTER_NEEDED and self.strip_dml:
             # With strip_dml flag, some queries require a partition filter
             # (submission_date, submission_timestamp, etc.) to run


### PR DESCRIPTION
## Description

`fog_decision_support_percentiles_v1` is still timing out after increasing the limit in DENG-7843 but it succeeded once in https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/45776/workflows/c424911e-96ef-4ecc-8b3c-2a3459b2723c/jobs/533134

It would be useful to log how long it takes to dry run so we can see changes over time when a query suddenly starts consistently failing like in this case.

## Related Tickets & Documents
* DENG-7843

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
