### PR TITLE
DENG-2986 - Update cohort_daily_statistics view

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/cohort_daily_statistics/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/cohort_daily_statistics/view.sql
@@ -28,3 +28,6 @@ SELECT
   num_clients_active_on_day
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.cohort_daily_statistics_v2`
+WHERE
+  normalized_app_name NOT LIKE '%BrowserStack'
+  AND normalized_app_name NOT LIKE '%MozillaOnline'


### PR DESCRIPTION
## Description
This PR updates the view telemetry.cohort_daily_statistics to exclude app names ending in BrowserStack or MozillaOnline (since those will always have is_dau = False, not useful in this view)

## Related Tickets & Documents
* [DENG-2986](https://mozilla-hub.atlassian.net/browse/DENG-2986)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-2986]: https://mozilla-hub.atlassian.net/browse/DENG-2986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ