### PR TITLE
feat(DENG-7860):  Create baseline_active_users_aggregates_v1

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2204,3 +2204,21 @@ bqetl_glean_dictionary:
   tags:
     - impact/tier_3
     - repo/bigquery-etl
+
+bqetl_baseline_active_user_aggregates:
+  default_args:
+    depends_on_past: false
+    email:
+      - kwindau@mozilla.com
+    email_on_failure: true
+    email_on_retry: false
+    owner: kwindau@mozilla.com
+    retries: 2
+    retry_delay: 30m
+    start_date: '2025-02-18'
+  description: Builds telemetry_derived.baseline_active_user_aggregates_v1
+  repo: bigquery-etl
+  schedule_interval: 40 4 * * *
+  tags:
+    - impact/tier_2
+    - repo/bigquery-etl

--- a/sql/moz-fx-data-shared-prod/telemetry/baseline_active_users_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/baseline_active_users_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.baseline_active_users_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.baseline_active_users_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/baseline_active_users_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/baseline_active_users_aggregates_v1/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Baseline Active Users Aggregates
+description: |-
+  Builds active_users_aggregates using baseline ping data
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_baseline_active_user_aggregates
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - app_name
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/baseline_active_users_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/baseline_active_users_aggregates_v1/query.sql
@@ -1,0 +1,123 @@
+WITH clients AS (
+  SELECT
+    client_id,
+    CASE
+      WHEN isp = 'BrowserStack'
+        THEN CONCAT('Firefox Desktop', ' ', isp)
+      WHEN distribution_id = 'MozillaOnline'
+        THEN CONCAT('Firefox Desktop', ' ', distribution_id)
+      ELSE 'Firefox Desktop'
+    END AS app_name,
+    app_display_version AS app_version,
+    normalized_channel AS channel,
+    IFNULL(country, '??') AS country,
+    IFNULL(city, '??') AS city,
+    COALESCE(REGEXP_EXTRACT(locale, r'^(.+?)-'), locale, NULL) AS locale,
+    normalized_os AS os,
+    COALESCE(
+      `mozfun.norm.windows_version_info`(
+        normalized_os,
+        normalized_os_version,
+        windows_build_number
+      ),
+      normalized_os_version
+    ) AS os_version_build,
+    COALESCE(
+      CAST(NULLIF(SPLIT(normalized_os_version, ".")[SAFE_OFFSET(0)], "") AS INTEGER),
+      0
+    ) AS os_version_major,
+    COALESCE(
+      CAST(NULLIF(SPLIT(normalized_os_version, ".")[SAFE_OFFSET(1)], "") AS INTEGER),
+      0
+    ) AS os_version_minor,
+    submission_date,
+    is_default_browser,
+    distribution_id,
+    CASE
+      WHEN BIT_COUNT(days_desktop_active_bits)
+        BETWEEN 1
+        AND 6
+        THEN 'infrequent_user'
+      WHEN BIT_COUNT(days_desktop_active_bits)
+        BETWEEN 7
+        AND 13
+        THEN 'casual_user'
+      WHEN BIT_COUNT(days_desktop_active_bits)
+        BETWEEN 14
+        AND 20
+        THEN 'regular_user'
+      WHEN BIT_COUNT(days_desktop_active_bits) >= 21
+        THEN 'core_user'
+      ELSE 'other'
+    END AS segment_dau,
+    CASE
+      WHEN BIT_COUNT(days_seen_bits)
+        BETWEEN 1
+        AND 6
+        THEN 'infrequent_user'
+      WHEN BIT_COUNT(days_seen_bits)
+        BETWEEN 7
+        AND 13
+        THEN 'casual_user'
+      WHEN BIT_COUNT(days_seen_bits)
+        BETWEEN 14
+        AND 20
+        THEN 'regular_user'
+      WHEN BIT_COUNT(days_seen_bits) >= 21
+        THEN 'core_user'
+      ELSE 'other'
+    END AS activity_segment,
+    EXTRACT(YEAR FROM first_seen_date) AS first_seen_year,
+    COALESCE(mozfun.bits28.days_since_seen(days_seen_bits) = 0, FALSE) AS is_daily_user,
+    COALESCE(mozfun.bits28.days_since_seen(days_seen_bits) < 7, FALSE) AS is_weekly_user,
+    COALESCE(mozfun.bits28.days_since_seen(days_seen_bits) < 28, FALSE) AS is_monthly_user,
+    COALESCE(mozfun.bits28.days_since_seen(days_desktop_active_bits) = 0, FALSE) AS is_dau,
+    COALESCE(mozfun.bits28.days_since_seen(days_desktop_active_bits) < 7, FALSE) AS is_wau,
+    COALESCE(mozfun.bits28.days_since_seen(days_desktop_active_bits) < 28, FALSE) AS is_mau
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_last_seen`
+  WHERE
+    submission_date = @submission_date
+)
+SELECT
+  submission_date,
+  app_name,
+  app_version,
+  channel,
+  country,
+  city,
+  locale,
+  os,
+  os_version_build,
+  os_version_major,
+  os_version_minor,
+  is_default_browser,
+  distribution_id,
+  segment_dau,
+  activity_segment,
+  first_seen_year,
+  COUNTIF(is_daily_user) AS daily_users,
+  COUNTIF(is_weekly_user) AS weekly_users,
+  COUNTIF(is_monthly_user) AS monthly_users,
+  COUNTIF(is_dau) AS dau,
+  COUNTIF(is_wau) AS wau,
+  COUNTIF(is_mau) AS mau
+FROM
+  clients
+GROUP BY
+  submission_date,
+  app_name,
+  app_version,
+  channel,
+  country,
+  city,
+  locale,
+  os,
+  os_version_build,
+  os_version_major,
+  os_version_minor,
+  is_default_browser,
+  distribution_id,
+  segment_dau,
+  activity_segment,
+  first_seen_year

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/baseline_active_users_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/baseline_active_users_aggregates_v1/schema.yaml
@@ -1,5 +1,5 @@
 fields:
-- mode: NULLABLE
+- mode: REQUIRED
   name: submission_date
   type: DATE
   description: Submission Date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/baseline_active_users_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/baseline_active_users_aggregates_v1/schema.yaml
@@ -1,0 +1,89 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: app_name
+  type: STRING
+  mode: NULLABLE
+  description: App Name
+- name: app_version
+  type: STRING
+  mode: NULLABLE
+  description: App Version
+- name: channel
+  type: STRING
+  mode: NULLABLE
+  description: Channel
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Country
+- name: city
+  type: STRING
+  mode: NULLABLE
+  description: City
+- name: locale
+  type: STRING
+  mode: NULLABLE
+  description: Locale
+- name: os
+  type: STRING
+  mode: NULLABLE
+  description: Operating System
+- name: os_version_build
+  type: STRING
+  mode: NULLABLE
+  description: Operating System Version Build
+- name: os_version_major
+  type: INTEGER
+  mode: NULLABLE
+  description: Operating System - Major Version
+- name: os_version_minor
+  type: INTEGER
+  mode: NULLABLE
+  description: Operating System - Minor Version
+- name: is_default_browser
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Is Default Browser
+- name: distribution_id
+  type: STRING
+  mode: NULLABLE
+  description: Distribution ID
+- name: segment_dau
+  type: STRING
+  mode: NULLABLE
+  description: Segment DAU
+- name: activity_segment
+  type: STRING
+  mode: NULLABLE
+  description: Activity Segment
+- name: first_seen_year
+  type: INTEGER
+  mode: NULLABLE
+  description: First Seen Year
+- name: daily_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Daily Users
+- name: weekly_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Weekly Users
+- name: monthly_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Monthly Users
+- name: dau
+  type: INTEGER
+  mode: NULLABLE
+  description: DAU - Daily Active Users
+- name: wau
+  type: INTEGER
+  mode: NULLABLE
+  description: WAU - Weekly Active Users
+- name: mau
+  type: INTEGER
+  mode: NULLABLE
+  description: MAU - Monthly Active Users

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/baseline_active_users_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/baseline_active_users_aggregates_v1/schema.yaml
@@ -1,5 +1,5 @@
 fields:
-- mode: REQUIRED
+- mode: NULLABLE
   name: submission_date
   type: DATE
   description: Submission Date


### PR DESCRIPTION
## Description

This PR creates the new table:
- moz-fx-data-shared-prod.telemetry_derived.baseline_active_users_aggregates_v1

And associated view: 
- moz-fx-data-shared-prod.telemetry.baseline_active_users_aggregates

## Related Tickets & Documents
* [DENG-7860](https://mozilla-hub.atlassian.net/browse/DENG-7860)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7860]: https://mozilla-hub.atlassian.net/browse/DENG-7860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ