### PR TITLE
Fix(bqetl_glean_dictionary): fix tag to make table public on bigquery

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_auto_events_derived/apps_auto_events_metadata_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_auto_events_derived/apps_auto_events_metadata_v1/metadata.yaml
@@ -7,7 +7,7 @@ labels:
   incremental: false
   owner1: efilho
   public_json: true
-  public_sql: true
+  public_bigquery: true
   review_bugs:
   - '1947481'
 scheduling:


### PR DESCRIPTION
## Description

This PR fixes the tag for making `apps_auto_events_metadata` public.


## Related Tickets & Documents
* [Bug 1948422](https://bugzilla.mozilla.org/show_bug.cgi?id=1948422)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
