### PR TITLE
[DENG-7798] Disallow null date_partition_parameter in backfills for partitioned tables

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -761,6 +761,13 @@ def backfill(
         if metadata.bigquery and metadata.bigquery.time_partitioning:
             partitioning_type = metadata.bigquery.time_partitioning.type
 
+        # null date_partition_parameter explicitly set to null will
+        # cause each backfill query to overwrite the entire table
+        if partitioning_type is not None and date_partition_parameter is None:
+            raise ValueError(
+                f"Cannot backfill partitioned table with date_partition_parameter set to null: {query_file.parent}"
+            )
+
         date_range = BackfillDateRange(
             start_date.date(),
             end_date.date(),

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_usage_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_usage_v1/backfill.yaml
@@ -1,9 +1,0 @@
-2025-02-17:
-  start_date: 2025-01-01
-  end_date: 2025-01-01
-  reason: test
-  watchers:
-  - bewu@mozilla.com
-  status: Initiate
-  shredder_mitigation: false
-  override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_usage_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_usage_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2025-02-17:
+  start_date: 2025-01-01
+  end_date: 2025-01-01
+  reason: test
+  watchers:
+  - bewu@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -241,7 +241,7 @@ class TestBackfill:
 
         assert result.exit_code == 1
         assert (
-            "Tables that depend on past are currently not supported." in result.output
+            "Tables that depend on past are currently not supported" in result.output
         )
 
     def test_create_backfill_with_invalid_watcher(self, runner):

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -240,9 +240,7 @@ class TestBackfill:
         )
 
         assert result.exit_code == 1
-        assert (
-            "Tables that depend on past are currently not supported" in result.output
-        )
+        assert "Tables that depend on past are currently not supported" in result.output
 
     def test_create_backfill_with_invalid_watcher(self, runner):
         invalid_watcher = "test.org"


### PR DESCRIPTION
## Description

When `date_partition_parameter` is set to null on a partitioned table (unset is fine) and `date_partition_offset` isn't set, each backfill query will overwrite the entire destination table instead of a single partition.  I'm unsure if there are valid reasons for this combination of params but I found a lot of cases while looking at DENG-7799

## Related Tickets & Documents
* DENG-7798
* DENG-7799


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
