### PR TITLE
Update triage instructions for bqetl_public_data_json DAG

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -313,6 +313,9 @@ bqetl_public_data_json:
 
     Depends on the results of several upstream DAGs, the latest of which
     runs at 04:00 UTC.
+
+    As long as the most recent DAG run is successful this job can be considered healthy.
+    In such case, past DAG failures can be ignored.
   default_args:
     owner: ascholtz@mozilla.com
     start_date: "2020-04-14"


### PR DESCRIPTION
## Description

Adds an Airflow triage note to `bqetl_public_data_json` DAG

## Related Tickets & Documents

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
