### PR TITLE
Add logic to enforce column descriptions on new tables

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -238,7 +238,7 @@ def create(ctx, name, sql_dir, project_id, owner, dag, no_schedule):
             time_partitioning=PartitionMetadata(field="", type=PartitionType.DAY),
             clustering=ClusteringMetadata(fields=[]),
         ),
-        enforce_col_desc=True,
+        require_column_descriptions=True,
     )
     metadata.write(metadata_file)
 

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -238,6 +238,7 @@ def create(ctx, name, sql_dir, project_id, owner, dag, no_schedule):
             time_partitioning=PartitionMetadata(field="", type=PartitionType.DAY),
             clustering=ClusteringMetadata(fields=[]),
         ),
+        enforce_col_desc=True,
     )
     metadata.write(metadata_file)
 

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -184,6 +184,7 @@ class Metadata:
     deprecated: bool = attr.ib(False)
     deletion_date: Optional[date] = attr.ib(None)
     monitoring: Optional[MonitoringMetadata] = attr.ib(None)
+    enforce_col_desc: bool = attr.ib(False)
 
     @owners.validator
     def validate_owners(self, attribute, value):
@@ -261,6 +262,7 @@ class Metadata:
         deprecated = False
         deletion_date = None
         monitoring = None
+        enforce_col_desc = False
 
         with open(metadata_file, "r") as yaml_stream:
             try:
@@ -343,6 +345,9 @@ class Metadata:
                         # column needs to be set explicitly
                         monitoring.partition_column_set = True
 
+                if "enforce_col_desc" in metadata:
+                    enforce_col_desc = metadata["enforce_col_desc"]
+
                 return cls(
                     friendly_name,
                     description,
@@ -357,6 +362,7 @@ class Metadata:
                     deprecated,
                     deletion_date,
                     monitoring,
+                    enforce_col_desc,
                 )
             except yaml.YAMLError as e:
                 raise e

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -184,7 +184,7 @@ class Metadata:
     deprecated: bool = attr.ib(False)
     deletion_date: Optional[date] = attr.ib(None)
     monitoring: Optional[MonitoringMetadata] = attr.ib(None)
-    enforce_col_desc: bool = attr.ib(False)
+    require_column_descriptions: bool = attr.ib(False)
 
     @owners.validator
     def validate_owners(self, attribute, value):
@@ -262,7 +262,7 @@ class Metadata:
         deprecated = False
         deletion_date = None
         monitoring = None
-        enforce_col_desc = False
+        require_column_descriptions = False
 
         with open(metadata_file, "r") as yaml_stream:
             try:
@@ -345,8 +345,10 @@ class Metadata:
                         # column needs to be set explicitly
                         monitoring.partition_column_set = True
 
-                if "enforce_col_desc" in metadata:
-                    enforce_col_desc = metadata["enforce_col_desc"]
+                if "require_column_descriptions" in metadata:
+                    require_column_descriptions = metadata[
+                        "require_column_descriptions"
+                    ]
 
                 return cls(
                     friendly_name,
@@ -362,7 +364,7 @@ class Metadata:
                     deprecated,
                     deletion_date,
                     monitoring,
-                    enforce_col_desc,
+                    require_column_descriptions,
                 )
             except yaml.YAMLError as e:
                 raise e

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -207,7 +207,7 @@ def validate_shredder_mitigation(query_dir, metadata):
 def validate_col_desc_enforced(query_dir, metadata):
     """Check schemas with enforce_col_desc = True comply with requirements."""
     # If column descriptions need to be enforced:
-    if metadata.enforce_col_desc is True:
+    if metadata.require_column_descriptions:
 
         schema_file = Path(query_dir) / SCHEMA_FILE
         if not schema_file.exists():

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -204,6 +204,35 @@ def validate_shredder_mitigation(query_dir, metadata):
     return True
 
 
+def validate_col_desc_enforced(query_dir, metadata):
+    """Check schemas with enforce_col_desc = True comply with requirements."""
+    # If column descriptions need to be enforced:
+    if metadata.enforce_col_desc is True:
+
+        schema_file = Path(query_dir) / SCHEMA_FILE
+        if not schema_file.exists():
+            click.echo(
+                click.style(
+                    f"Table {query_dir} does not have schema.yaml required for column descriptions.",
+                    fg="yellow",
+                )
+            )
+            return False
+        schema = Schema.from_schema_file(schema_file).to_bigquery_schema()
+
+        for field in schema:
+            # Validate that the query columns have descriptions.
+            if not field.description:
+                click.echo(
+                    f"Column description validation failed, {field.name} does not have "
+                    f"a description in the schema."
+                )
+                return False
+        return True
+    else:
+        return True
+
+
 def validate_deprecation(metadata, path):
     """Check that deprecated is True when deletion date exists."""
     if metadata.deletion_date and not metadata.deprecated:
@@ -329,6 +358,9 @@ def validate(target):
                     if not validate_retention_policy_based_on_table_type(
                         metadata, path
                     ):
+                        failed = True
+
+                    if not validate_col_desc_enforced(root, metadata):
                         failed = True
 
                     # todo more validation

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -205,8 +205,7 @@ def validate_shredder_mitigation(query_dir, metadata):
 
 
 def validate_col_desc_enforced(query_dir, metadata):
-    """Check schemas with enforce_col_desc = True comply with requirements."""
-    # If column descriptions need to be enforced:
+    """Check schemas with require_column_descriptions = True comply with requirements."""
     if metadata.require_column_descriptions:
 
         schema_file = Path(query_dir) / SCHEMA_FILE
@@ -229,8 +228,7 @@ def validate_col_desc_enforced(query_dir, metadata):
                 )
                 return False
         return True
-    else:
-        return True
+    return True
 
 
 def validate_deprecation(metadata, path):

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -224,8 +224,8 @@ def validate_col_desc_enforced(query_dir, metadata):
             # Validate that the query columns have descriptions.
             if not field.description:
                 click.echo(
-                    f"Column description validation failed, {field.name} does not have "
-                    f"a description in the schema."
+                    f"Column description validation failed for {query_dir}, "
+                    f"{field.name} does not have a description in the schema."
                 )
                 return False
         return True

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -687,11 +687,7 @@ class TestMetadata:
             assert result is None
             assert captured.out == ""
 
-    @patch("google.cloud.bigquery.Client")
-    @patch("google.cloud.bigquery.Table")
-    def test_validate_col_desc_enforced(
-        self, mock_bigquery_table, mock_bigquery_client, runner
-    ):
+    def test_validate_col_desc_enforced(self, runner):
         """Test that validation fails when metadata says enforce column descriptions but a column desc is missing"""
         metadata = {"friendly_name": "Test", "require_column_descriptions": True}
         schema = {
@@ -705,7 +701,6 @@ class TestMetadata:
                 {"mode": "REQUIRED", "name": "column_3", "type": "STRING"},
             ]
         }
-        mock_bigquery_client().get_table.return_value = mock_bigquery_table()
 
         with runner.isolated_filesystem():
             query_path = Path(self.test_path) / "query.sql"
@@ -724,11 +719,7 @@ class TestMetadata:
             result = validate_col_desc_enforced(self.test_path, metadata_from_file)
             assert result is False
 
-    @patch("google.cloud.bigquery.Client")
-    @patch("google.cloud.bigquery.Table")
-    def test_validate_col_desc_passes_when_not_enforced(
-        self, mock_bigquery_table, mock_bigquery_client, runner
-    ):
+    def test_validate_col_desc_passes_when_not_enforced(self, runner):
         """Test that validation passes when metadata says enforce column descriptions is False and a col desc is missing"""
         metadata = {"friendly_name": "Test", "require_column_descriptions": False}
         schema = {
@@ -742,7 +733,6 @@ class TestMetadata:
                 {"mode": "REQUIRED", "name": "column_3", "type": "STRING"},
             ]
         }
-        mock_bigquery_client().get_table.return_value = mock_bigquery_table()
 
         with runner.isolated_filesystem():
             query_path = Path(self.test_path) / "query.sql"
@@ -761,11 +751,7 @@ class TestMetadata:
             result = validate_col_desc_enforced(self.test_path, metadata_from_file)
             assert result is True
 
-    @patch("google.cloud.bigquery.Client")
-    @patch("google.cloud.bigquery.Table")
-    def test_validate_col_desc_passes_with_all_col_desc_and_enforcement(
-        self, mock_bigquery_table, mock_bigquery_client, runner
-    ):
+    def test_validate_col_desc_passes_with_all_col_desc_and_enforcement(self, runner):
         """Test that validation passes when metadata says enforce column descriptions is True and all cols have a desc"""
         metadata = {"friendly_name": "Test", "require_column_descriptions": True}
         schema = {
@@ -784,7 +770,6 @@ class TestMetadata:
                 },
             ]
         }
-        mock_bigquery_client().get_table.return_value = mock_bigquery_table()
 
         with runner.isolated_filesystem():
             query_path = Path(self.test_path) / "query.sql"

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -687,8 +687,6 @@ class TestMetadata:
             assert result is None
             assert captured.out == ""
 
-    @patch("google.cloud.bigquery.Client")
-    @patch("google.cloud.bigquery.Table")
     def test_validate_col_desc_enforced(
         self, mock_bigquery_table, mock_bigquery_client, runner
     ):
@@ -724,8 +722,6 @@ class TestMetadata:
             result = validate_col_desc_enforced(self.test_path, metadata_from_file)
             assert result is False
 
-    @patch("google.cloud.bigquery.Client")
-    @patch("google.cloud.bigquery.Table")
     def test_validate_col_desc_passes_when_not_enforced(
         self, mock_bigquery_table, mock_bigquery_client, runner
     ):
@@ -761,8 +757,6 @@ class TestMetadata:
             result = validate_col_desc_enforced(self.test_path, metadata_from_file)
             assert result is True
 
-    @patch("google.cloud.bigquery.Client")
-    @patch("google.cloud.bigquery.Table")
     def test_validate_col_desc_passes_with_all_col_desc_and_enforcement(
         self, mock_bigquery_table, mock_bigquery_client, runner
     ):

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -788,7 +788,7 @@ class TestMetadata:
             result = validate_col_desc_enforced(self.test_path, metadata_from_file)
             assert result is True
 
-    def test_nested_validate_col_desc(self, runner):
+    def test_nested_validate_col_desc1(self, runner):
         """Test that validation fails when metadata says enforce column descriptions is True and no desc on nested"""
         metadata = {"friendly_name": "Test", "require_column_descriptions": True}
 
@@ -835,7 +835,7 @@ class TestMetadata:
             result = validate_col_desc_enforced(self.test_path, metadata_from_file)
             assert result is False
 
-    def test_nested_validate_col_desc(self, runner):
+    def test_nested_validate_col_desc2(self, runner):
         """Test that validation fails when metadata says enforce column descriptions is True and no desc on nested"""
         metadata = {"friendly_name": "Test", "require_column_descriptions": True}
 

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -834,3 +834,55 @@ class TestMetadata:
 
             result = validate_col_desc_enforced(self.test_path, metadata_from_file)
             assert result is False
+
+    def test_nested_validate_col_desc(self, runner):
+        """Test that validation fails when metadata says enforce column descriptions is True and no desc on nested"""
+        metadata = {"friendly_name": "Test", "require_column_descriptions": True}
+
+        schema = {
+            "fields": [
+                {
+                    "mode": "REQUIRED",
+                    "name": "profile_id",
+                    "type": "STRING",
+                    "description": "description 1",
+                },
+                {
+                    "mode": "REQUIRED",
+                    "name": "column_3",
+                    "type": "STRING",
+                    "description": "description 2",
+                },
+                {
+                    "mode": "REQUIRED",
+                    "name": "metadata",
+                    "type": "RECORD",
+                    "description": "description 2",
+                    "fields": [
+                        {
+                            "mode": "REQUIRED",
+                            "name": "column_3",
+                            "type": "STRING",
+                            "description": "nested desc",
+                        }
+                    ],
+                },
+            ]
+        }
+
+        with runner.isolated_filesystem():
+            query_path = Path(self.test_path) / "query.sql"
+            metadata_path = Path(self.test_path) / "metadata.yaml"
+            schema_path = Path(self.test_path) / "schema.yaml"
+            os.makedirs(self.test_path, exist_ok=True)
+
+            with open(query_path, "w") as f:
+                f.write("SELECT column_1 FROM test_table group by column_1")
+            with open(metadata_path, "w") as f:
+                f.write(yaml.safe_dump(metadata))
+            with open(schema_path, "w") as f:
+                f.write(yaml.safe_dump(schema))
+            metadata_from_file = Metadata.from_file(metadata_path)
+
+            result = validate_col_desc_enforced(self.test_path, metadata_from_file)
+            assert result is True

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -836,7 +836,7 @@ class TestMetadata:
             assert result is False
 
     def test_nested_validate_col_desc2(self, runner):
-        """Test that validation fails when metadata says enforce column descriptions is True and no desc on nested"""
+        """Test that validation passes when metadata says enforce column descriptions is True and there are desc"""
         metadata = {"friendly_name": "Test", "require_column_descriptions": True}
 
         schema = {

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -15,8 +15,8 @@ from bigquery_etl.metadata.parse_metadata import Metadata
 from bigquery_etl.metadata.validate_metadata import (
     validate,
     validate_change_control,
-    validate_shredder_mitigation,
     validate_col_desc_enforced,
+    validate_shredder_mitigation,
 )
 
 TEST_DIR = Path(__file__).parent.parent

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -687,11 +687,13 @@ class TestMetadata:
             assert result is None
             assert captured.out == ""
 
+    @patch("google.cloud.bigquery.Client")
+    @patch("google.cloud.bigquery.Table")
     def test_validate_col_desc_enforced(
         self, mock_bigquery_table, mock_bigquery_client, runner
     ):
         """Test that validation fails when metadata says enforce column descriptions but a column desc is missing"""
-        metadata = {"friendly_name": "Test", "enforce_col_desc": True}
+        metadata = {"friendly_name": "Test", "require_column_descriptions": True}
         schema = {
             "fields": [
                 {
@@ -722,11 +724,13 @@ class TestMetadata:
             result = validate_col_desc_enforced(self.test_path, metadata_from_file)
             assert result is False
 
+    @patch("google.cloud.bigquery.Client")
+    @patch("google.cloud.bigquery.Table")
     def test_validate_col_desc_passes_when_not_enforced(
         self, mock_bigquery_table, mock_bigquery_client, runner
     ):
         """Test that validation passes when metadata says enforce column descriptions is False and a col desc is missing"""
-        metadata = {"friendly_name": "Test", "enforce_col_desc": False}
+        metadata = {"friendly_name": "Test", "require_column_descriptions": False}
         schema = {
             "fields": [
                 {
@@ -757,11 +761,13 @@ class TestMetadata:
             result = validate_col_desc_enforced(self.test_path, metadata_from_file)
             assert result is True
 
+    @patch("google.cloud.bigquery.Client")
+    @patch("google.cloud.bigquery.Table")
     def test_validate_col_desc_passes_with_all_col_desc_and_enforcement(
         self, mock_bigquery_table, mock_bigquery_client, runner
     ):
         """Test that validation passes when metadata says enforce column descriptions is True and all cols have a desc"""
-        metadata = {"friendly_name": "Test", "enforce_col_desc": True}
+        metadata = {"friendly_name": "Test", "require_column_descriptions": True}
         schema = {
             "fields": [
                 {


### PR DESCRIPTION
## Description
- This PR adds a check to ensure new tables have column descriptions enforced (this check can be turned off if needed).

- When someone runs `./bqetl query create` it will now add a new key to the metadata.yaml file called: `require_column_descriptions=True`

- If this is left as True, when the metadata validation step runs, it will check to ensure column descriptions are on all tables where this is set to True.  If you set to False, it will not run this check.

- Note: In tables where this is not specified, the default value for require_column_descriptions is False

## Related Tickets & Documents
* [DENG-7908](https://mozilla-hub.atlassian.net/browse/DENG-7908)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7908]: https://mozilla-hub.atlassian.net/browse/DENG-7908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ