### PR TITLE
Fix looker_dashboard_load_times_v1 arguments

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/metadata.yaml
@@ -9,7 +9,7 @@ labels:
   owner1: ascholtz
 scheduling:
   dag_name: bqetl_monitoring
-  arguments: ["--date '{{ ds }}'"]
+  arguments: ["--date", "{{ ds }}"]
   date_partition_parameter: null
   secrets:
   - deploy_target: LOOKER_API_CLIENT_ID


### PR DESCRIPTION
## Description
Fixes the failing airflow task: https://workflow.telemetry.mozilla.org/dags/bqetl_monitoring/grid?search=bqetl_monitoring&dag_run_id=scheduled__2025-02-19T02%3A00%3A00%2B00%3A00&task_id=monitoring_derived__looker_dashboard_load_times__v1&tab=logs


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
