### PR TITLE
feat(): add composite active users to usage reporting generator

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users/view.sql
@@ -27,6 +27,14 @@ SELECT
     ELSE 'Firefox Desktop'
   END AS app_name,
   app_display_version AS app_version,
+  `mozfun.norm.browser_version_info`(app_display_version).major_version AS app_version_major,
+  `mozfun.norm.browser_version_info`(app_display_version).minor_version AS app_version_minor,
+  `mozfun.norm.browser_version_info`(
+    app_display_version
+  ).patch_revision AS app_version_patch_revision,
+  `mozfun.norm.browser_version_info`(
+    app_display_version
+  ).is_major_release AS app_version_is_major_release,
   normalized_channel AS channel,
   COALESCE(last_seen.distribution_id, distribution_mapping.distribution_id) AS distribution_id,
   CASE

--- a/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
@@ -60,5 +60,6 @@ SELECT
     ELSE
       CAST(NULL AS STRING)
   END AS device_type,
+  app_display_version AS app_version,
 FROM
   `{{ project_id }}.{{ dataset }}.baseline_clients_last_seen`

--- a/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
@@ -60,6 +60,10 @@ SELECT
     ELSE
       CAST(NULL AS STRING)
   END AS device_type,
+  EXTRACT(YEAR FROM first_seen_date) AS first_seen_year,
   app_display_version AS app_version,
+  normalized_os AS os,
+  normalized_os_version AS os_version,
+  normalized_channel AS channel,
 FROM
   `{{ project_id }}.{{ dataset }}.baseline_clients_last_seen`

--- a/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/active_users.view.sql
@@ -62,8 +62,14 @@ SELECT
   END AS device_type,
   EXTRACT(YEAR FROM first_seen_date) AS first_seen_year,
   app_display_version AS app_version,
+  `mozfun.norm.browser_version_info`(app_display_version).major_version AS app_version_major,
+  `mozfun.norm.browser_version_info`(app_display_version).minor_version AS app_version_minor,
+  `mozfun.norm.browser_version_info`(app_display_version).patch_revision AS app_version_patch_revision,
+  `mozfun.norm.browser_version_info`(app_display_version).is_major_release AS app_version_is_major_release,
   normalized_os AS os,
   normalized_os_version AS os_version,
+  CAST(`mozfun.norm.truncate_version`(normalized_os_version, "major") AS INTEGER) AS os_version_major,
+  CAST(`mozfun.norm.truncate_version`(normalized_os_version, "minor") AS INTEGER) AS os_version_minor,
   normalized_channel AS channel,
 FROM
   `{{ project_id }}.{{ dataset }}.baseline_clients_last_seen`

--- a/sql_generators/usage_reporting/__init__.py
+++ b/sql_generators/usage_reporting/__init__.py
@@ -30,6 +30,7 @@ ARTIFACT_TEMPLATES = (
 )
 APP_UNION_VIEW_TEMPLATE = "app_union.view.sql.jinja"
 ACTIVE_USERS_VIEW_TEMPLATE = "usage_reporting_active_users.view.sql.jinja"
+COMPOSITE_ACTIVE_USERS_TEMPLATE = "composite_active_users.view.sql.jinja"
 
 
 @click.command()
@@ -218,5 +219,26 @@ def generate(
             full_table_id=f"{target_project}.{app_name}.{active_users_dataset_name}",
             basename="view.sql",
             sql=reformat(rendered_active_users_view),
+            skip_existing=False,
+        )
+
+        composite_active_users_dataset_name = COMPOSITE_ACTIVE_USERS_TEMPLATE.split(
+            "."
+        )[0]
+        composite_active_users_view_template = jinja_env.get_template(
+            COMPOSITE_ACTIVE_USERS_TEMPLATE
+        )
+        rendered_composite_active_users_view = (
+            composite_active_users_view_template.render(
+                **app_template_args,
+                view_name=composite_active_users_dataset_name,
+            )
+        )
+
+        write_sql(
+            output_dir=output_dir,
+            full_table_id=f"{target_project}.{app_name}.{composite_active_users_dataset_name}",
+            basename="view.sql",
+            sql=reformat(rendered_composite_active_users_view),
             skip_existing=False,
         )

--- a/sql_generators/usage_reporting/templates/composite_active_users.view.sql.jinja
+++ b/sql_generators/usage_reporting/templates/composite_active_users.view.sql.jinja
@@ -1,0 +1,71 @@
+CREATE OR REPLACE VIEW
+  `{{ project_id }}.{{ app_name }}.{{ view_name }}`
+AS
+SELECT
+  submission_date,
+  client_id AS usage_profile_id,
+  first_seen_year,
+  channel,
+  app_name,
+  app_version,
+  app_version_major,
+  app_version_minor,
+  app_version_patch_revision,
+  app_version_is_major_release,
+  country,
+  os,
+  os_version,
+  os_version_major,
+  os_version_minor,
+  {% if app_name == "firefox_desktop" %}
+  os_version_build,
+  {% endif %}
+  distribution_id,
+  is_default_browser,
+  activity_segment,
+  is_dau,
+  is_wau,
+  is_mau,
+  is_daily_user,
+  is_weekly_user,
+  is_monthly_user,
+FROM
+  {% if app_name == "firefox_desktop" %}
+  `{{ project_id }}.{{ app_name }}.baseline_active_users`
+  {% else %}
+  `{{ project_id }}.{{ app_name }}.active_users`
+  {% endif %}
+WHERE
+  mozfun.norm.browser_version_info(app_version).major_version < 136
+UNION ALL
+SELECT
+  submission_date,
+  usage_profile_id,
+  first_seen_year,
+  channel,
+  app_name,
+  app_version,
+  app_version_major,
+  app_version_minor,
+  app_version_patch_revision,
+  app_version_is_major_release,
+  country,
+  os,
+  os_version,
+  os_version_major,
+  os_version_minor,
+  {% if app_name == "firefox_desktop" %}
+  os_version_build,
+  {% endif %}
+  is_default_browser,
+  activity_segment,
+  is_dau,
+  is_wau,
+  is_mau,
+  is_daily_user,
+  is_weekly_user,
+  is_monthly_user,
+FROM
+  `{{ project_id }}.{{ app_name }}.usage_reporting_active_users`
+WHERE
+  mozfun.norm.browser_version_info(app_version).major_version >= 136

--- a/sql_generators/usage_reporting/templates/composite_active_users.view.sql.jinja
+++ b/sql_generators/usage_reporting/templates/composite_active_users.view.sql.jinja
@@ -5,6 +5,7 @@ SELECT
   submission_date,
   client_id AS usage_profile_id,
   first_seen_year,
+  first_seen_date,
   channel,
   app_name,
   app_version,
@@ -42,6 +43,7 @@ SELECT
   submission_date,
   usage_profile_id,
   first_seen_year,
+  first_seen_date,
   channel,
   app_name,
   app_version,
@@ -57,6 +59,7 @@ SELECT
   {% if app_name == "firefox_desktop" %}
   os_version_build,
   {% endif %}
+  distribution_id,
   is_default_browser,
   activity_segment,
   is_dau,

--- a/sql_generators/usage_reporting/templates/usage_reporting_active_users.view.sql.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_active_users.view.sql.jinja
@@ -3,7 +3,7 @@ CREATE OR REPLACE VIEW
   `{{ project_id }}.{{ app_name }}.{{ view_name }}`
 AS
 SELECT
-  daily.* EXCEPT(app_channel, normalized_country_code),
+  daily.* EXCEPT(app_channel, normalized_country_code, app_display_version),
   app_channel AS channel,
   IFNULL(normalized_country_code, "??") AS country,
   EXTRACT(YEAR FROM first_seen.first_seen_date) AS first_seen_year,
@@ -34,6 +34,19 @@ SELECT
       THEN "core_user"
     ELSE "other"
   END AS activity_segment,
+  CAST(`mozfun.norm.truncate_version`(os_version, "major") AS INTEGER) AS os_version_major,
+  CAST(`mozfun.norm.truncate_version`(os_version, "minor") AS INTEGER) AS os_version_minor,
+  {% if app_name == "firefox_desktop" %}
+  COALESCE(
+    `mozfun.norm.windows_version_info`(os, os_version, windows_build_number),
+    os_version
+  ) AS os_version_build,
+  {% endif %}
+  app_display_version AS app_version,
+  `mozfun.norm.browser_version_info`(app_display_version).major_version AS app_version_major,
+  `mozfun.norm.browser_version_info`(app_display_version).minor_version AS app_version_minor,
+  `mozfun.norm.browser_version_info`(app_display_version).patch_revision AS app_version_patch_revision,
+  `mozfun.norm.browser_version_info`(app_display_version).is_major_release AS app_version_is_major_release,
   IFNULL(mozfun.bits28.days_since_seen(days_active_bits) = 0, FALSE) AS is_dau,
   IFNULL(mozfun.bits28.days_since_seen(days_active_bits) < 7, FALSE) AS is_wau,
   IFNULL(mozfun.bits28.days_since_seen(days_active_bits) < 28, FALSE) AS is_mau,

--- a/sql_generators/usage_reporting/templates/usage_reporting_active_users.view.sql.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_active_users.view.sql.jinja
@@ -7,6 +7,7 @@ SELECT
   app_channel AS channel,
   IFNULL(normalized_country_code, "??") AS country,
   EXTRACT(YEAR FROM first_seen.first_seen_date) AS first_seen_year,
+  first_seen.first_seen_date,
   {% if app_name in ("fenix", "firefox_desktop") %}
   CASE
     WHEN LOWER(distribution_id) = "mozillaonline"

--- a/sql_generators/usage_reporting/templates/usage_reporting_active_users_aggregates.view.sql.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_active_users_aggregates.view.sql.jinja
@@ -10,5 +10,10 @@ SELECT
     `mozfun.norm.windows_version_info`(os, os_version, windows_build_number),
     os_version
   ) AS os_version_build,
+  `mozfun.norm.browser_version_info`(app_version).major_version AS app_version_major,
+  `mozfun.norm.browser_version_info`(app_version).minor_version AS app_version_minor,
+  `mozfun.norm.browser_version_info`(app_version).patch_revision AS app_version_patch_revision,
+  `mozfun.norm.browser_version_info`(app_version).is_major_release AS app_version_is_major_release,
+  ) AS os_version_build,
 FROM
   `{{ project_id }}.{{ app_name }}.{{ view_name }}_v1`


### PR DESCRIPTION
# feat(): add composite active users to usage reporting generator

Will convert from draft PR once we agree on what the filter should be for the union.

blocked by: https://github.com/mozilla/bigquery-etl/pull/7157