### PR TITLE
[DENG-3656] Support depends on past in managed backfills

### DIFF
--- a/bigquery_etl/backfill/utils.py
+++ b/bigquery_etl/backfill/utils.py
@@ -16,6 +16,7 @@ from bigquery_etl.metadata.parse_metadata import (
     METADATA_FILE,
     DatasetMetadata,
     Metadata,
+    PartitionType,
 )
 from bigquery_etl.util import extract_from_query_path
 
@@ -103,21 +104,66 @@ def get_backfill_backup_table_name(qualified_table_name: str, entry_date: date) 
     return f"{BACKFILL_DESTINATION_PROJECT}.{BACKFILL_DESTINATION_DATASET}.{cloned_table_id}"
 
 
+def validate_table_metadata(sql_dir: str, qualified_table_name: str) -> List[str]:
+    """Run all metadata.yaml validation checks and return list of error strings."""
+    errors = []
+    if not validate_depends_on_past(sql_dir, qualified_table_name):
+        errors.append(
+            f"Tables with depends on past and null partition parameter are not supported: {qualified_table_name}"
+        )
+
+    if not validate_partitioning_type(sql_dir, qualified_table_name):
+        errors.append(
+            f"Unsupported table partitioning type:  {qualified_table_name}, "
+            "only day and month partitioning are supported."
+        )
+
+    if not validate_metadata_workgroups(sql_dir, qualified_table_name):
+        errors.append(
+            "Only mozilla-confidential workgroups are supported. "
+            f"{qualified_table_name} contains workgroup access that is not supported"
+        )
+
+    return errors
+
+
 def validate_depends_on_past(sql_dir, qualified_table_name) -> bool:
     """
-    Check if the table depends on past.
+    Check if the table depends on past and has null date_partition_parameter.
 
-    Managed backfills currently do not support tables that depends on past.
+    Fail if depends_on_past=true and date_partition_parameter=null
     """
     project, dataset, table = qualified_table_name_matching(qualified_table_name)
     table_metadata_path = Path(sql_dir) / project / dataset / table / METADATA_FILE
 
     table_metadata = Metadata.from_file(table_metadata_path)
 
-    if "depends_on_past" in table_metadata.scheduling:
-        return not table_metadata.scheduling[
-            "depends_on_past"
-        ]  # skip if depends_on_past
+    if (
+        "depends_on_past" in table_metadata.scheduling
+        and "date_partition_parameter" in table_metadata.scheduling
+    ):
+        return not (
+            table_metadata.scheduling["depends_on_past"]
+            and table_metadata.scheduling["date_partition_parameter"] is None
+        )
+
+    return True
+
+
+def validate_partitioning_type(sql_dir: str, qualified_table_name: str) -> bool:
+    """
+    Check if the partitioning type is supported.
+    """
+    project, dataset, table = qualified_table_name_matching(qualified_table_name)
+    table_metadata_path = Path(sql_dir) / project / dataset / table / METADATA_FILE
+
+    table_metadata = Metadata.from_file(table_metadata_path)
+
+    if table_metadata.bigquery and table_metadata.bigquery.time_partitioning:
+        return table_metadata.bigquery.time_partitioning.type in [
+            PartitionType.DAY,
+            PartitionType.MONTH,
+        ]
 
     return True
 
@@ -224,10 +270,6 @@ def get_scheduled_backfills(
     backfills_to_process_dict = {}
 
     for qualified_table_name, entries in backfills_dict.items():
-        # do not return backfill if depends on past
-        if not validate_depends_on_past(sql_dir, qualified_table_name):
-            continue
-
         # do not return backfill if not mozilla-confidential
         if not validate_metadata_workgroups(sql_dir, qualified_table_name):
             continue

--- a/bigquery_etl/backfill/utils.py
+++ b/bigquery_etl/backfill/utils.py
@@ -127,9 +127,8 @@ def validate_table_metadata(sql_dir: str, qualified_table_name: str) -> List[str
     return errors
 
 
-def validate_depends_on_past(sql_dir, qualified_table_name) -> bool:
-    """
-    Check if the table depends on past and has null date_partition_parameter.
+def validate_depends_on_past(sql_dir: str, qualified_table_name: str) -> bool:
+    """Check if the table depends on past and has null date_partition_parameter.
 
     Fail if depends_on_past=true and date_partition_parameter=null
     """
@@ -151,9 +150,7 @@ def validate_depends_on_past(sql_dir, qualified_table_name) -> bool:
 
 
 def validate_partitioning_type(sql_dir: str, qualified_table_name: str) -> bool:
-    """
-    Check if the partitioning type is supported.
-    """
+    """Check if the partitioning type is supported."""
     project, dataset, table = qualified_table_name_matching(qualified_table_name)
     table_metadata_path = Path(sql_dir) / project / dataset / table / METADATA_FILE
 

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import rich_click as click
 import yaml
+from dateutil.relativedelta import relativedelta
 from google.cloud import bigquery
 from google.cloud.exceptions import Conflict, NotFound
 
@@ -35,8 +36,7 @@ from ..backfill.utils import (
     get_qualified_table_name_to_entries_map_by_project,
     get_scheduled_backfills,
     qualified_table_name_matching,
-    validate_depends_on_past,
-    validate_metadata_workgroups,
+    validate_table_metadata,
 )
 from ..backfill.validate import (
     validate_duplicate_entry_with_initiate_status,
@@ -51,7 +51,7 @@ from ..cli.utils import (
 )
 from ..config import ConfigLoader
 from ..deploy import FailedDeployException, SkippedDeployException, deploy_table
-from ..metadata.parse_metadata import METADATA_FILE, Metadata
+from ..metadata.parse_metadata import METADATA_FILE, Metadata, PartitionType
 from ..metadata.validate_metadata import SHREDDER_MITIGATION_LABEL
 from ..schema import SCHEMA_FILE, Schema
 
@@ -152,12 +152,8 @@ def create(
 
     A backfill.yaml file will be created if it does not already exist.
     """
-    if not validate_depends_on_past(sql_dir, qualified_table_name):
-        click.echo("Tables that depend on past are currently not supported.")
-        sys.exit(1)
-
-    if not validate_metadata_workgroups(sql_dir, qualified_table_name):
-        click.echo("Only mozilla-confidential workgroups are supported.")
+    if errors := validate_table_metadata(sql_dir, qualified_table_name):
+        click.echo("\n".join(errors))
         sys.exit(1)
 
     existing_backfills = get_entries_from_qualified_table_name(
@@ -235,17 +231,8 @@ def validate(
         )
 
     for table_name in backfills_dict:
-
-        if not validate_depends_on_past(sql_dir, table_name):
-            click.echo(
-                f"Tables that depend on past are currently not supported:  {table_name}"
-            )
-            sys.exit(1)
-
-        if not validate_metadata_workgroups(sql_dir, table_name):
-            click.echo(
-                f"Only mozilla-confidential workgroups are supported.  {table_name} contain workgroup access that is not supported"
-            )
+        if errors := validate_table_metadata(sql_dir, qualified_table_name):
+            click.echo("\n".join(errors))
             sys.exit(1)
 
         try:
@@ -543,6 +530,8 @@ def _initiate_backfill(
         )
         sys.exit(1)
 
+    client = bigquery.Client(project=project)
+
     if entry.shredder_mitigation is True:
         click.echo(
             click.style(
@@ -551,7 +540,7 @@ def _initiate_backfill(
             )
         )
         query_path, _ = generate_query_with_shredder_mitigation(
-            client=bigquery.Client(project=project),
+            client=client,
             project_id=project,
             dataset=dataset,
             destination_table=table,
@@ -571,6 +560,15 @@ def _initiate_backfill(
         custom_query_path = Path(entry.custom_query_path)
 
     override_retention_limit = entry.override_retention_limit
+
+    # copy previous partition if depends_on_past
+    _initialize_previous_partition(
+        client,
+        qualified_table_name,
+        backfill_staging_qualified_table_name,
+        metadata,
+        entry,
+    )
 
     # Backfill table
     # in the long-run we should remove the query backfill command and require a backfill entry for all backfills
@@ -603,6 +601,64 @@ def _initiate_backfill(
         raise ValueError(
             f"Backfill initiate resulted in error for {qualified_table_name}"
         ) from e
+
+
+def _initialize_previous_partition(
+    client: bigquery.Client,
+    table_name: str,
+    staging_table_name: str,
+    metadata: Metadata,
+    backfill_entry: Backfill,
+):
+    """Initialize initial partition for tables with depends_on_past=true.
+
+    For tables with a null date partition parameter, the entire table is copied
+    """
+    if (
+        metadata.scheduling is None
+        or not metadata.scheduling.get("depends_on_past")
+        or metadata.bigquery is None
+        or metadata.bigquery.time_partitioning is None
+    ):
+        return
+
+    match metadata.bigquery.time_partitioning.type:
+        case PartitionType.DAY:
+            previous_partition_date = backfill_entry.start_date - timedelta(days=1)
+        case PartitionType.MONTH:
+            previous_partition_date = backfill_entry.start_date - relativedelta(
+                months=1
+            )
+        case _:
+            raise ValueError(
+                "Unsupported partitioning type for backfills: "
+                f"{metadata.bigquery.time_partitioning.type}"
+            )
+
+    partition_param, offset = "submission_date", 0
+    if metadata.scheduling:
+        partition_param = metadata.scheduling.get(
+            "date_partition_parameter", partition_param
+        )
+        offset = metadata.scheduling.get("date_partition_offset", offset)
+
+    previous_partition_id = get_backfill_partition(
+        previous_partition_date,
+        partition_param,
+        offset,
+        metadata.bigquery.time_partitioning.type,
+    )
+
+    if previous_partition_id is None:
+        raise ValueError(
+            f"Unable to get initial partition id for depends_on_past table: {table_name}"
+        )
+
+    _copy_table(
+        source_table=f"{table_name}${previous_partition_id}",
+        destination_table=f"{staging_table_name}${previous_partition_id}",
+        client=client,
+    )
 
 
 @backfill.command(

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/backfill.yaml
@@ -1,0 +1,10 @@
+2025-02-20:
+  start_date: 2025-02-10
+  end_date: 2025-02-20
+  reason: Test for depends_on_past backfill support
+  watchers:
+  - bewu@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false

--- a/tests/backfill/test_dir_depends_on_past/backfill.yaml
+++ b/tests/backfill/test_dir_depends_on_past/backfill.yaml
@@ -1,0 +1,9 @@
+2023-05-03:
+  start_date: 2021-01-03
+  end_date: 2021-05-03
+  excluded_dates:
+  - 2021-02-03
+  reason: no_reason
+  watchers:
+  - test@example.org
+  status: Initiate

--- a/tests/backfill/test_dir_depends_on_past/metadata.yaml
+++ b/tests/backfill/test_dir_depends_on_past/metadata.yaml
@@ -1,0 +1,9 @@
+friendly_name: Metadata file for backfill validation testing
+description: |-
+  Metadata file for backfill validation testing
+owners:
+- nobody@mozilla.com
+scheduling:
+  depends_on_past: true
+labels:
+  owner1: nobody@mozilla.com

--- a/tests/backfill/test_parse_backfill.py
+++ b/tests/backfill/test_parse_backfill.py
@@ -44,10 +44,11 @@ TEST_BACKFILL_3 = Backfill(
     DEFAULT_REASON,
     [DEFAULT_WATCHER],
     DEFAULT_STATUS,
-    "custom_query.sql",
-    False,
-    False,
-    DEFAULT_BILLING_PROJECT,
+    custom_query_path="custom_query.sql",
+    shredder_mitigation=False,
+    override_retention_limit=False,
+    override_depends_on_past_end_date=False,
+    billing_project=DEFAULT_BILLING_PROJECT,
 )
 
 
@@ -93,10 +94,10 @@ class TestParseBackfill(object):
                 TEST_BACKFILL_1.reason,
                 TEST_BACKFILL_1.watchers,
                 TEST_BACKFILL_1.status,
-                None,
-                None,
-                False,
-                invalid_billing_project,
+                custom_query_path=None,
+                shredder_mitigation=None,
+                override_retention_limit=False,
+                billing_project=invalid_billing_project,
             )
 
         assert "Invalid billing project" in str(e.value)
@@ -451,6 +452,7 @@ class TestParseBackfill(object):
             "  status: Initiate\n"
             "  shredder_mitigation: false\n"
             "  override_retention_limit: false\n"
+            "  override_depends_on_past_end_date: false\n"
         )
 
         results = TEST_BACKFILL_1.to_yaml()
@@ -470,6 +472,8 @@ class TestParseBackfill(object):
             custom_query_path = None
             shredder_mitigation = False
             override_retention_limit = False
+            override_depends_on_past_end_date = False
+            billing_project = None
             """
 
         assert actual_backfill_str == expected_backfill_str
@@ -487,6 +491,7 @@ class TestParseBackfill(object):
             "  status: Initiate\n"
             "  shredder_mitigation: false\n"
             "  override_retention_limit: false\n"
+            "  override_depends_on_past_end_date: false\n"
         )
 
         TEST_BACKFILL_1.excluded_dates = []

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -28,13 +28,13 @@ from bigquery_etl.backfill.utils import (
     validate_metadata_workgroups,
 )
 from bigquery_etl.cli.backfill import (
+    _initialize_previous_partition,
     complete,
     create,
     info,
     initiate,
     scheduled,
     validate,
-    _initialize_previous_partition,
 )
 from bigquery_etl.cli.stage import QUERY_FILE
 from bigquery_etl.deploy import FailedDeployException


### PR DESCRIPTION
## Description

Adds managed backfill support for `depends_on_past=True` tables by copying the previous partition (month or day) to the staging table.  This allows backfilling of `clients_last_seen` type tables.  A check was added to look for backfill end dates in the past to attempt to make users think about data continuity issues but it doesn't cover everything.

Tables with null date_partition_parameter like `clients_first_seen` still aren't supported because there isn't a "previous" partition.  A lot of these can be recreated in a single query (e.g. `is_init`) so I don't know if they need managed backfill support but that can be added later if needed.

Also added a backfill for core_clients_last_seen since it's a small table to test the airflow run with.  The backfill won't be set to completed so it won't modify prod.

## Related Tickets & Documents
* DENG-3656

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
