### PR TITLE
feat: add windows_build_number to usage_reporting_clients_daily template

### DIFF
--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_daily_v1.query.sql.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_daily_v1.query.sql.jinja
@@ -28,6 +28,7 @@ WITH usage_reporting_base AS (
     {% if app_name == "firefox_desktop" %}
     COALESCE(metrics.counter.browser_engagement_uri_count, 0) AS browser_engagement_uri_count,
     COALESCE(metrics.counter.browser_engagement_active_ticks, 0) AS browser_engagement_active_ticks,
+    metrics.quantity.usage_windows_build_number AS windows_build_number,
     {% else %}
     COALESCE(metrics.timespan.usage_duration.value, 0) AS duration,
     {% endif %}
@@ -54,6 +55,7 @@ SELECT
   -- is_active definition is different between desktop and mobile products.
   {% if app_name == "firefox_desktop" %}
   COALESCE(LOGICAL_OR(is_active), SUM(browser_engagement_uri_count) > 0 AND SUM(browser_engagement_active_ticks) > 0, FALSE) AS is_active,
+  udf.mode_last(ARRAY_AGG(windows_build_number IGNORE NULLS ORDER BY submission_timestamp ASC)) AS windows_build_number,
   {% else %}
   COALESCE(LOGICAL_OR(is_active), SUM(IF(duration BETWEEN 0 AND 100000, duration, 0)) > 0, FALSE) AS is_active,
   {% endif %}

--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_daily_v1.schema.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_daily_v1.schema.yaml.jinja
@@ -81,3 +81,10 @@ fields:
   type: BOOLEAN
   description: |
     A flag field indicating whether the specific client was active.
+{% if app_name == "firefox_desktop" -%}
+- mode: NULLABLE
+  name: windows_build_number
+  type: INTEGER
+  description: |
+    The optional Windows build number, reported by Windows (e.g. 22000) and not set for other platforms.
+{%- endif -%}


### PR DESCRIPTION
# feat: add windows_build_number to usage_reporting_clients_daily template

This field is needed to accurately determine os version on Windows.