### PR TITLE
DENG-7860: Create baseline_active_users_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.baseline_active_users_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_active_users_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/metadata.yaml
@@ -1,0 +1,24 @@
+friendly_name: Baseline Active Users Aggregates
+description: |-
+  Builds active_users_aggregates using baseline ping data
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  dag: bqetl_analytics_tables
+scheduling:
+  dag_name: bqetl_analytics_tables
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - app_name
+references: {}
+require_column_descriptions: false

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/metadata.yaml
@@ -20,5 +20,7 @@ bigquery:
   clustering:
     fields:
     - app_name
+    - channel
+    - country
 references: {}
 require_column_descriptions: false

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/query.sql
@@ -1,0 +1,119 @@
+WITH clients AS (
+  SELECT
+    client_id,
+    CASE
+      WHEN isp = 'BrowserStack'
+        THEN CONCAT('Firefox Desktop', ' ', isp)
+      WHEN distribution_id = 'MozillaOnline'
+        THEN CONCAT('Firefox Desktop', ' ', distribution_id)
+      ELSE 'Firefox Desktop'
+    END AS app_name,
+    app_display_version AS app_version,
+    normalized_channel AS channel,
+    IFNULL(country, '??') AS country,
+    IFNULL(city, '??') AS city,
+    COALESCE(REGEXP_EXTRACT(locale, r'^(.+?)-'), locale, NULL) AS locale,
+    normalized_os,
+    normalized_os_version,
+    windows_build_number,
+    COALESCE(
+      CAST(NULLIF(SPLIT(normalized_os_version, ".")[SAFE_OFFSET(0)], "") AS INTEGER),
+      0
+    ) AS os_version_major,
+    COALESCE(
+      CAST(NULLIF(SPLIT(normalized_os_version, ".")[SAFE_OFFSET(1)], "") AS INTEGER),
+      0
+    ) AS os_version_minor,
+    submission_date,
+    is_default_browser,
+    distribution_id,
+    CASE
+      WHEN BIT_COUNT(days_desktop_active_bits)
+        BETWEEN 1
+        AND 6
+        THEN 'infrequent_user'
+      WHEN BIT_COUNT(days_desktop_active_bits)
+        BETWEEN 7
+        AND 13
+        THEN 'casual_user'
+      WHEN BIT_COUNT(days_desktop_active_bits)
+        BETWEEN 14
+        AND 20
+        THEN 'regular_user'
+      WHEN BIT_COUNT(days_desktop_active_bits) >= 21
+        THEN 'core_user'
+      ELSE 'other'
+    END AS segment_dau,
+    CASE
+      WHEN BIT_COUNT(days_seen_bits)
+        BETWEEN 1
+        AND 6
+        THEN 'infrequent_user'
+      WHEN BIT_COUNT(days_seen_bits)
+        BETWEEN 7
+        AND 13
+        THEN 'casual_user'
+      WHEN BIT_COUNT(days_seen_bits)
+        BETWEEN 14
+        AND 20
+        THEN 'regular_user'
+      WHEN BIT_COUNT(days_seen_bits) >= 21
+        THEN 'core_user'
+      ELSE 'other'
+    END AS activity_segment,
+    EXTRACT(YEAR FROM first_seen_date) AS first_seen_year,
+    COALESCE(mozfun.bits28.days_since_seen(days_seen_bits) = 0, FALSE) AS is_daily_user,
+    COALESCE(mozfun.bits28.days_since_seen(days_seen_bits) < 7, FALSE) AS is_weekly_user,
+    COALESCE(mozfun.bits28.days_since_seen(days_seen_bits) < 28, FALSE) AS is_monthly_user,
+    COALESCE(mozfun.bits28.days_since_seen(days_desktop_active_bits) = 0, FALSE) AS is_dau,
+    COALESCE(mozfun.bits28.days_since_seen(days_desktop_active_bits) < 7, FALSE) AS is_wau,
+    COALESCE(mozfun.bits28.days_since_seen(days_desktop_active_bits) < 28, FALSE) AS is_mau
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_last_seen`
+  WHERE
+    submission_date = @submission_date
+)
+SELECT
+  submission_date,
+  app_name,
+  app_version,
+  channel,
+  country,
+  city,
+  locale,
+  normalized_os,
+  normalized_os_version,
+  windows_build_number,
+  os_version_major,
+  os_version_minor,
+  is_default_browser,
+  distribution_id,
+  segment_dau,
+  activity_segment,
+  first_seen_year,
+  COUNTIF(is_daily_user) AS daily_users,
+  COUNTIF(is_weekly_user) AS weekly_users,
+  COUNTIF(is_monthly_user) AS monthly_users,
+  COUNTIF(is_dau) AS dau,
+  COUNTIF(is_wau) AS wau,
+  COUNTIF(is_mau) AS mau
+FROM
+  clients
+GROUP BY
+  submission_date,
+  app_name,
+  app_version,
+  channel,
+  country,
+  city,
+  locale,
+  normalized_os,
+  normalized_os_version,
+  windows_build_number,
+  os_version_major,
+  os_version_minor,
+  is_default_browser,
+  distribution_id,
+  segment_dau,
+  activity_segment,
+  first_seen_year

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/query.sql
@@ -43,23 +43,6 @@ WITH clients AS (
       WHEN BIT_COUNT(days_desktop_active_bits) >= 21
         THEN 'core_user'
       ELSE 'other'
-    END AS segment_dau,
-    CASE
-      WHEN BIT_COUNT(days_seen_bits)
-        BETWEEN 1
-        AND 6
-        THEN 'infrequent_user'
-      WHEN BIT_COUNT(days_seen_bits)
-        BETWEEN 7
-        AND 13
-        THEN 'casual_user'
-      WHEN BIT_COUNT(days_seen_bits)
-        BETWEEN 14
-        AND 20
-        THEN 'regular_user'
-      WHEN BIT_COUNT(days_seen_bits) >= 21
-        THEN 'core_user'
-      ELSE 'other'
     END AS activity_segment,
     EXTRACT(YEAR FROM first_seen_date) AS first_seen_year,
     COALESCE(mozfun.bits28.days_since_seen(days_seen_bits) = 0, FALSE) AS is_daily_user,

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/query.sql
@@ -71,7 +71,6 @@ SELECT
   os_version_minor,
   is_default_browser,
   distribution_id,
-  segment_dau,
   activity_segment,
   first_seen_year,
   COUNTIF(is_daily_user) AS daily_users,
@@ -97,6 +96,5 @@ GROUP BY
   os_version_minor,
   is_default_browser,
   distribution_id,
-  segment_dau,
   activity_segment,
   first_seen_year

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/schema.yaml
@@ -55,10 +55,6 @@ fields:
   type: STRING
   mode: NULLABLE
   description: Distribution ID
-- name: segment_dau
-  type: STRING
-  mode: NULLABLE
-  description: Segment DAU
 - name: activity_segment
   type: STRING
   mode: NULLABLE
@@ -70,24 +66,24 @@ fields:
 - name: daily_users
   type: INTEGER
   mode: NULLABLE
-  description: Daily Users
+  description: Number of daily users on the submission_date (based on sending the ping).
 - name: weekly_users
   type: INTEGER
   mode: NULLABLE
-  description: Weekly Users
+  description: Number of weekly users on the submission_date (based on sending the ping).
 - name: monthly_users
   type: INTEGER
   mode: NULLABLE
-  description: Monthly Users
+  description: Number of monthly users on the submission_date (based on sending the ping).
 - name: dau
   type: INTEGER
   mode: NULLABLE
-  description: Daily Active Users
+  description: Number of DAU (Daily Active Users) users on the submission_date (based on activity).
 - name: wau
   type: INTEGER
   mode: NULLABLE
-  description: Weekly Active Users
+  description: Number of WAU (Weekly Active Users) users on the submission_date (based on activity).
 - name: mau
   type: INTEGER
   mode: NULLABLE
-  description: Monthly Active Users
+  description: Number of MAU (Monthly Active Users) users on the submission_date (based on activity).

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/schema.yaml
@@ -2,31 +2,39 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
-  description: Submission Date
+  description: |-
+    Logical date corresponding to the partition (date when our server received the ping)
+    that was processed for generating the metrics.
 - name: app_name
   type: STRING
   mode: NULLABLE
-  description: App Name
+  description: |-
+    App name (Firefox Desktop), if client comes from MozillaOnline distribution
+    then the distribution_id is appended to the app_name. If client comes from BrowserStack (isp)
+    this is appended to the app_name.
 - name: app_version
   type: STRING
   mode: NULLABLE
-  description: App Version
+  description: |-
+    The user visible version string (e.g. "1.0.3"). If the value was not provided through configuration,
+    this metric gets set to Unknown.
 - name: channel
   type: STRING
   mode: NULLABLE
-  description: Channel
+  description: |-
+    The channel the application is being distributed on, example values include: relase, beta, nightly.
 - name: country
   type: STRING
   mode: NULLABLE
-  description: Country
+  description: Country reported by the client.
 - name: city
   type: STRING
   mode: NULLABLE
-  description: City
+  description: City reported by the client.
 - name: locale
   type: STRING
   mode: NULLABLE
-  description: Locale
+  description: Locale reported by the client, which is a combination of language and regional settings.
 - name: normalized_os
   type: STRING
   mode: NULLABLE
@@ -54,15 +62,15 @@ fields:
 - name: distribution_id
   type: STRING
   mode: NULLABLE
-  description: Distribution ID
+  description: The id of the browser distribution made available in installation sources.
 - name: activity_segment
   type: STRING
   mode: NULLABLE
-  description: Activity Segment
+  description: Profile segmentation based on the number of days active in the last 28 days.
 - name: first_seen_year
   type: INTEGER
   mode: NULLABLE
-  description: First Seen Year
+  description: Year extracted from the first_seen_date, that corresponds to the date when the first ping was received.
 - name: daily_users
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/schema.yaml
@@ -1,0 +1,93 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- name: app_name
+  type: STRING
+  mode: NULLABLE
+  description: App Name
+- name: app_version
+  type: STRING
+  mode: NULLABLE
+  description: App Version
+- name: channel
+  type: STRING
+  mode: NULLABLE
+  description: Channel
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Country
+- name: city
+  type: STRING
+  mode: NULLABLE
+  description: City
+- name: locale
+  type: STRING
+  mode: NULLABLE
+  description: Locale
+- name: normalized_os
+  type: STRING
+  mode: NULLABLE
+  description: Normalized Operating System
+- name: normalized_os_version
+  type: STRING
+  mode: NULLABLE
+  description: Normalized Operating System Version
+- name: windows_build_number
+  type: INTEGER
+  mode: NULLABLE
+  description: Windows Build Number
+- name: os_version_major
+  type: INTEGER
+  mode: NULLABLE
+  description: Operating System Major Version
+- name: os_version_minor
+  type: INTEGER
+  mode: NULLABLE
+  description: Operating System Minor Version
+- name: is_default_browser
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Is Default Browser
+- name: distribution_id
+  type: STRING
+  mode: NULLABLE
+  description: Distribution ID
+- name: segment_dau
+  type: STRING
+  mode: NULLABLE
+  description: Segment DAU
+- name: activity_segment
+  type: STRING
+  mode: NULLABLE
+  description: Activity Segment
+- name: first_seen_year
+  type: INTEGER
+  mode: NULLABLE
+  description: First Seen Year
+- name: daily_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Daily Users
+- name: weekly_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Weekly Users
+- name: monthly_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Monthly Users
+- name: dau
+  type: INTEGER
+  mode: NULLABLE
+  description: Daily Active Users
+- name: wau
+  type: INTEGER
+  mode: NULLABLE
+  description: Weekly Active Users
+- name: mau
+  type: INTEGER
+  mode: NULLABLE
+  description: Monthly Active Users


### PR DESCRIPTION
## Description

This PR creates the new table: 
- moz-fx-data-shared-prod.firefox_desktop_derived.baseline_active_users_aggregates_v1
- moz-fx-data-shared-prod.firefox_desktop.baseline_active_users_aggregates

## Related Tickets & Documents
* [DENG-7860](https://mozilla-hub.atlassian.net/browse/DENG-7860)



**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7860]: https://mozilla-hub.atlassian.net/browse/DENG-7860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ