### PR TITLE
[DENG-7933] Ignore labels in column_exists_in_schema check

### DIFF
--- a/sql/moz-fx-data-shared-prod/udf/remove_label_from_metric_path/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/udf/remove_label_from_metric_path/metadata.yaml
@@ -1,0 +1,5 @@
+---
+friendly_name: Remove label from metric path
+description: >
+  Removes the label name from the column path of a Glean labeled metric.
+  e.g. metric.labeled_counter.name.label -> metric.labeled_counter.name

--- a/sql/moz-fx-data-shared-prod/udf/remove_label_from_metric_path/udf.sql
+++ b/sql/moz-fx-data-shared-prod/udf/remove_label_from_metric_path/udf.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE FUNCTION udf.remove_label_from_metric_path(column_path STRING)
+RETURNS STRING AS (
+  IF(
+    STARTS_WITH(column_path, 'metrics.labeled_'),
+    -- labeled metric path looks like metrics.labeled_counter.metric_name.label
+    (
+      SELECT
+        ARRAY_TO_STRING(ARRAY_AGG(s ORDER BY offset), '.')
+      FROM
+        UNNEST(SPLIT(column_path, '.')) AS s
+        WITH OFFSET
+      WHERE
+        offset < 3
+    ),
+    column_path
+  )
+);
+
+-- Tests
+SELECT
+  mozfun.assert.equals(
+    "metrics.labeled_counter.abc",
+    udf.remove_label_from_metric_path("metrics.labeled_counter.abc.true")
+  ),
+  mozfun.assert.equals(
+    "metrics.labeled_boolean.tb_ui_configuration_pane_visibility",
+    udf.remove_label_from_metric_path(
+      "metrics.labeled_boolean.tb_ui_configuration_pane_visibility.folder_pane"
+    )
+  ),
+  mozfun.assert.equals(
+    "metrics.custom_distribution.update_pref_service_errors_notify.values",
+    udf.remove_label_from_metric_path(
+      "metrics.custom_distribution.update_pref_service_errors_notify.values"
+    )
+  ),


### PR DESCRIPTION
## Description

This bug showed up in https://bugzilla.mozilla.org/show_bug.cgi?id=1949480 where the column name of a labeled metric looks like `metrics.labeled_counter.update.can_use_bits_notify.CanUseBits` where `CanUseBits` is one of the labels and the actual column name would be `metrics.labeled_counter.update_can_use_bits_notify` which is a struct with key and value fields.  The view currently looks for a column named `CanUseBits` so `column_exists_in_schema` will be false even if `update_can_use_bits_notify` is in the schema.

Another way to do this is to remove the labels from the paths in `monitoring_derived.structured_missing_columns_v1` but I'm not sure if there's value in having the label there.

Also I'm not sure what the proposed "labeled labeled counters" will look like and if this will work for those

## Related Tickets & Documents
* DENG-7933

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
