### PR TITLE
chore: backfill tos_rollout_enrollments tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/tos_rollout_enrollments_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/tos_rollout_enrollments_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2025-02-25:
+  start_date: 2025-02-16
+  end_date: 2025-02-23
+  reason: Need data in table to start building ToS dashboards.
+  watchers:
+  - dberry@mozilla.com
+  - mwilliams@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/tos_rollout_enrollments_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/tos_rollout_enrollments_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2025-02-25:
+  start_date: 2025-02-16
+  end_date: 2025-02-23
+  reason: Need data in table to start building ToS dashboards.
+  watchers:
+  - dberry@mozilla.com
+  - mwilliams@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/tos_rollout_enrollments_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/tos_rollout_enrollments_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2025-02-25:
+  start_date: 2025-02-16
+  end_date: 2025-02-23
+  reason: Need data in table to start building ToS dashboards.
+  watchers:
+  - dberry@mozilla.com
+  - mwilliams@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

Requested by @danielkberry in order to start building dashboards for ToS monitoring. DAG has been running for a few days, but only data so far is from manual testing so the tables are mostly empty.

## Related Tickets & Documents

N/A

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
