### PR TITLE
Add metadata.yml for tasks_v2 + add missing user facing views

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci/task_runs/view.sql
+++ b/sql/moz-fx-data-shared-prod/fxci/task_runs/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.fxci.task_runs`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.fxci_derived.task_runs_v1`

--- a/sql/moz-fx-data-shared-prod/fxci/tasks/view.sql
+++ b/sql/moz-fx-data-shared-prod/fxci/tasks/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.fxci.tasks`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.fxci_derived.tasks_v2`

--- a/sql/moz-fx-data-shared-prod/fxci/worker_metrics/view.sql
+++ b/sql/moz-fx-data-shared-prod/fxci/worker_metrics/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.fxci.worker_metrics`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.fxci_derived.worker_metrics_v1`

--- a/sql/moz-fx-data-shared-prod/fxci_derived/task_runs_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/task_runs_v1/schema.yaml
@@ -1,0 +1,34 @@
+fields:
+  - name: task_id
+    type: STRING
+    mode: REQUIRED
+  - name: run_id
+    type: INTEGER
+    mode: REQUIRED
+  - name: reason_created
+    type: STRING
+    mode: NULLABLE
+  - name: reason_resolved
+    type: STRING
+    mode: NULLABLE
+  - name: resolved
+    type: TIMESTAMP
+    mode: REQUIRED
+  - name: scheduled
+    type: TIMESTAMP
+    mode: REQUIRED
+  - name: started
+    type: TIMESTAMP
+    mode: REQUIRED
+  - name: state
+    type: STRING
+    mode: REQUIRED
+  - name: submission_date
+    type: DATE
+    mode: REQUIRED
+  - name: worker_group
+    type: STRING
+    mode: REQUIRED
+  - name: worker_id
+    type: STRING
+    mode: REQUIRED

--- a/sql/moz-fx-data-shared-prod/fxci_derived/tasks_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/tasks_v1/schema.yaml
@@ -1,0 +1,26 @@
+fields:
+  - name: scheduler_id
+    type: STRING
+    mode: REQUIRED
+  - name: submission_date
+    type: DATE
+    mode: REQUIRED
+  - name: task_group_id
+    type: STRING
+    mode: REQUIRED
+  - name: task_id
+    type: STRING
+    mode: REQUIRED
+  - name: task_queue_id
+    type: STRING
+    mode: REQUIRED
+  - name: tags
+    type: RECORD
+    mode: REPEATED
+    fields:
+      - name: key
+        type: STRING
+        mode: REQUIRED
+      - name: value
+        type: STRING
+        mode: REQUIRED

--- a/sql/moz-fx-data-shared-prod/fxci_derived/tasks_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/tasks_v2/metadata.yaml
@@ -1,0 +1,19 @@
+friendly_name: Firefox-CI Tasks
+description: |-
+  Derived Firefox-CI task data exported from Taskcluster pulse.
+owners:
+- ahalberstadt@mozilla.com
+labels:
+  incremental: true
+  owner1: ahalberstadt
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - task_id
+references: {}

--- a/sql/moz-fx-data-shared-prod/fxci_derived/tasks_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/tasks_v2/schema.yaml
@@ -1,0 +1,44 @@
+fields:
+  - name: scheduler_id
+    type: STRING
+    mode: REQUIRED
+  - name: submission_date
+    type: DATE
+    mode: REQUIRED
+  - name: task_group_id
+    type: STRING
+    mode: REQUIRED
+  - name: task_id
+    type: STRING
+    mode: REQUIRED
+  - name: task_queue_id
+    type: STRING
+    mode: REQUIRED
+  - name: tags
+    type: RECORD
+    mode: REQUIRED
+    fields:
+      - name: created_for_user
+        type: STRING
+        mode: NULLABLE
+      - name: kind
+        type: STRING
+        mode: NULLABLE
+      - name: label
+        type: STRING
+        mode: NULLABLE
+      - name: os
+        type: STRING
+        mode: NULLABLE
+      - name: owned_by
+        type: STRING
+        mode: NULLABLE
+      - name: project
+        type: STRING
+        mode: NULLABLE
+      - name: trust_domain
+        type: STRING
+        mode: NULLABLE
+      - name: worker_implementation
+        type: STRING
+        mode: NULLABLE


### PR DESCRIPTION
## Description

I changed the schema of the tasks table, so a `v2` was necessary. I'll attempt to backfill the data from the old `v1` table later. I also added some missing user facing views for tasks and task_runs.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
