### PR TITLE
feat: add backfill entry for firefox_desktop_derived.baseline_active_users_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/backfill.yaml
@@ -1,3 +1,12 @@
+2025-02-26:
+  start_date: 2023-01-13
+  end_date: 2025-02-26
+  reason: Re-run backfill to consider legacy distribution_id values.
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+
 2025-02-25:
   start_date: 2023-01-12
   end_date: 2025-02-25


### PR DESCRIPTION
# feat: add backfill entry for firefox_desktop_derived.baseline_active_users_aggregates_v1

depends on: https://github.com/mozilla/bigquery-etl/pull/7099