### PR TITLE
fix(DENG-7787): Clean up comments, change last updated date logic

### DIFF
--- a/sql/moz-fx-data-shared-prod/external_derived/population_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/population_v1/query.py
@@ -25,6 +25,25 @@ LOC_IDS_OF_INTEREST = [
     826,  # UK
     250,  # FR
     840,  # US
+    36,  # Australia
+    56,  # Belgium
+    68,  # Bolivia
+    76,  # Brazil
+    84,  # Belize
+    156,  # China
+    170,  # Colombia
+    188,  # Costa Rica
+    208,  # Denmark
+    304,  # Greenland
+    300,  # Greece
+    352,  # Iceland
+    360,  # Indonesia
+    404,  # Kenya
+    528,  # Netherlands
+    566,  # Nigeria
+    578,  # Norway
+    688,  # Serbia
+    702,  # Singapore
 ]
 TARGET_PROJECT = "moz-fx-data-shared-prod"
 TARGET_TABLE = "moz-fx-data-shared-prod.external_derived.population_v1"

--- a/sql/moz-fx-data-shared-prod/external_derived/population_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/population_v1/query.py
@@ -35,8 +35,8 @@ bearer_token = os.getenv("UN_POPULATION_BEARER_TOKEN")
 
 
 def fetch_data(url, hdr, pyld, timeout_limit):
-    """Inputs: URL, Header, Payload, Timeout Limit
-    Output: Shows errors if errors arise during the fetch"""
+    """Inputs: URL, Header, Payload, Timeout Limit (seconds)
+    Output: Raises an error if an issue arises during the fetch"""
     try:
         response = requests.get(url, headers=hdr, data=pyld, timeout=timeout_limit)
         response.raise_for_status()  # Raises an HTTPError for 4xx and 5xx status codes
@@ -68,12 +68,13 @@ def pull_population_data(year_to_pull_data_for, location_id, indicator_id):
 
     # Initialize the dataframe with the first set of results
     results_df = pd.DataFrame(results["data"])
+    # Code is currently only built to handle 1 page of results, so error out if there is more than 1
     if results["nextPage"] is not None:
         raise Exception(
             "More than 1 page of results provided; code only built to handle 1 page"
         )
 
-    # Rename the columns to the new, cleaner names
+    # Rename the columns to match the columns in schema.yaml
     results_df = results_df.rename(
         columns={
             "locationId": "location_id",
@@ -107,14 +108,15 @@ def pull_population_data(year_to_pull_data_for, location_id, indicator_id):
 
 
 def main():
-    """Call the API, save data to GCS, load to BQ staging, delete & load to BQ gold"""
+    """Call the API, save data to GCS, delete any data already in table for same year, then load to BQ table"""
     parser = ArgumentParser(description=__doc__)
     parser.add_argument("--date", required=True)
     args = parser.parse_args()
     logical_dag_date = datetime.strptime(args.date, "%Y-%m-%d").date()
     logical_date_date_string = logical_dag_date.strftime("%Y-%m-%d")
 
-    # Calculate year of interest from curr date
+    # Calculate year of interest from the DAG run date
+    # DAG runs 1x a year, so this gets the year from the DAG logical date
     year_of_interest = logical_dag_date.strftime("%Y")
     print(f"Pulling data for year: {year_of_interest}")
 
@@ -158,13 +160,13 @@ def main():
     )
 
     # For each location
-    for LOC_ID in LOC_IDS_OF_INTEREST:
-        # Get the population data
+    for loc_id in LOC_IDS_OF_INTEREST:
+        # Get the population data as a dataframe
         population_data = pull_population_data(
-            year_of_interest, LOC_ID, INDICATOR_ID_OF_INTEREST
+            year_of_interest, loc_id, INDICATOR_ID_OF_INTEREST
         )
 
-        # append to final results dataframe
+        # Append the new data to the full_results_df
         full_results_df = pd.concat([full_results_df, population_data])
 
     # Enforce data types

--- a/sql/moz-fx-data-shared-prod/external_derived/population_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/population_v1/query.py
@@ -33,7 +33,6 @@ GCS_BUCKET = "gs://moz-fx-data-prod-external-data/"
 # Pull bearer token from Google Secret Manager
 bearer_token = os.getenv("UN_POPULATION_BEARER_TOKEN")
 
-
 def fetch_data(url, hdr, pyld, timeout_limit):
     """Inputs: URL, Header, Payload, Timeout Limit (seconds)
     Output: Raises an error if an issue arises during the fetch"""
@@ -113,11 +112,16 @@ def main():
     parser.add_argument("--date", required=True)
     args = parser.parse_args()
     logical_dag_date = datetime.strptime(args.date, "%Y-%m-%d").date()
-    logical_date_date_string = logical_dag_date.strftime("%Y-%m-%d")
+    logical_dag_date_string = logical_dag_date.strftime("%Y-%m-%d")
+
+    # Calculate current date
+    today = datetime.today()
+    curr_date = today.strftime("%Y-%m-%d")
 
     # Calculate year of interest from the DAG run date
     # DAG runs 1x a year, so this gets the year from the DAG logical date
     year_of_interest = logical_dag_date.strftime("%Y")
+    year_of_interest = str(int(year_of_interest) + 1)
     print(f"Pulling data for year: {year_of_interest}")
 
     # Initialize an empty data frame which we will append all results to
@@ -192,12 +196,12 @@ def main():
     full_results_df["age_end"] = full_results_df["age_end"].astype(int)
 
     # Add last updated date
-    full_results_df["last_updated"] = logical_date_date_string
+    full_results_df["last_updated"] = curr_date
 
     # Calculate GCS filepath to write to and then write CSV to that filepath
     fpath = (
         GCS_BUCKET
-        + f"UN_Population_Data/pop_data_year_{year_of_interest}_as_of_{logical_date_date_string}.csv"
+        + f"UN_Population_Data/pop_data_year_{year_of_interest}_as_of_{logical_dag_date_string}.csv"
     )
     full_results_df.to_csv(fpath, index=False)
 

--- a/sql/moz-fx-data-shared-prod/external_derived/population_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/population_v1/query.py
@@ -210,7 +210,7 @@ def main():
     del_job = client.query(delete_query)
     del_job.result()
 
-    # Load data from GCS to BQ table
+    # Load data from GCS to BQ table - appending to what is already there
     load_csv_to_gcp_job = client.load_table_from_uri(
         fpath,
         TARGET_TABLE,


### PR DESCRIPTION
## Description

This PR:
- cleans up the comments
- changes the column "last updated" in the table to be the date that the DAG actually ran on, not the logical dag date (which is 1 year prior). 
- It also makes sure the year it pulls data for is the next year, not the year of the logical dag date (for example, when it runs for the logical dag date of 2024-02-15, it will now pull data for 2025, not 2024, which is the desired behavior)
- Adds more countries to the list of countries we pull population data for

## Related Tickets & Documents
* [DENG-7787](https://mozilla-hub.atlassian.net/browse/DENG-7787)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7787]: https://mozilla-hub.atlassian.net/browse/DENG-7787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ