### PR TITLE
DENG-7965 - Add custom temporary support for relay_backend.events in Shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -434,6 +434,14 @@ DELETE_TARGETS: DeleteIndex = {
         table="accounts_frontend_derived.events_stream_v1",
         field=("metrics.string.account_user_id_sha256", CLIENT_ID),
     ): (FXA_SRC, FXA_FRONTEND_GLEAN_SRC),
+    DeleteTarget(
+        table="relay_backend_stable.events_v1",
+        # Temporary workaround for identifier nested in event extras
+        # This triggers custom query override in `delete.py`
+        # We'll be able to remove this once fxa_id is migrated to string metric
+        # See https://mozilla-hub.atlassian.net/browse/DENG-7965 and 7964
+        field="events[*].extra.fxa_id",
+    ): FXA_SRC,
     # legacy mobile
     DeleteTarget(
         table="telemetry_stable.core_v1",

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -273,7 +273,8 @@ def _override_query_with_fxa_id_in_extras(
             """
                 EXISTS (
                   WITH user_ids AS (
-                  SELECT user_id
+                  SELECT 
+                    user_id_unhashed AS user_id
                   FROM
                   `moz-fx-data-shared-prod.firefox_accounts.fxa_delete_events`
                   WHERE """

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -273,7 +273,7 @@ def _override_query_with_fxa_id_in_extras(
             """
                 EXISTS (
                   WITH user_ids AS (
-                  SELECT 
+                  SELECT
                     user_id_unhashed AS user_id
                   FROM
                   `moz-fx-data-shared-prod.firefox_accounts.fxa_delete_events`

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -408,7 +408,7 @@ def delete_from_partition(
                 """
             )
         run_tense = "Would run" if dry_run else "Running"
-        logging.info(f"{run_tense} query: {query}")
+        logging.debug(f"{run_tense} query: {query}")
         return client.query(query, job_config=job_config)
 
     return partial(

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -253,6 +253,44 @@ class Partition:
     is_special: bool = False
 
 
+def _override_query_with_fxa_id_in_extras(
+    field_condition: str,
+    target: DeleteTarget,
+    sources: Iterable[DeleteSource],
+    source_condition: str,
+) -> str:
+    """Override query to handle fxa_id nested in event extras in relay_backend_stable.events_v1."""
+    sources = list(sources)
+    if (
+        target.table == "relay_backend_stable.events_v1"
+        and len(target.fields) == 1
+        and target.fields[0] == "events[*].extra.fxa_id"
+        and len(sources) == 1
+        and sources[0].table == "firefox_accounts.fxa_delete_events"
+        and sources[0].field == "user_id"
+    ):
+        field_condition = (
+            """
+                EXISTS (
+                  WITH user_ids AS (
+                  SELECT user_id
+                  FROM
+                  `moz-fx-data-shared-prod.firefox_accounts.fxa_delete_events`
+                  WHERE """
+            + " AND ".join((source_condition, *sources[0].conditions))
+            + """)
+                  SELECT 1
+                  FROM UNNEST(events) AS e
+                  JOIN UNNEST(e.extra) AS ex
+                  JOIN user_ids u
+                  ON ex.value = u.user_id
+                  WHERE ex.key = 'fxa_id'
+                )
+                """
+        )
+    return field_condition
+
+
 def delete_from_partition(
     dry_run: bool,
     partition: Partition,
@@ -299,6 +337,14 @@ def delete_from_partition(
                 + ")"
                 for field, source in zip(target.fields, sources)
             )
+
+            # Temporary workaround for fxa_id nested in event extras in relay_backend_stable.events_v1
+            # We'll be able to remove this once fxa_id is migrated to string metric
+            # See https://mozilla-hub.atlassian.net/browse/DENG-7965 and 7964
+            field_condition = _override_query_with_fxa_id_in_extras(
+                field_condition, target, sources, source_condition
+            )
+
             query = reformat(
                 f"""
                 DELETE
@@ -361,7 +407,7 @@ def delete_from_partition(
                 """
             )
         run_tense = "Would run" if dry_run else "Running"
-        logging.debug(f"{run_tense} query: {query}")
+        logging.info(f"{run_tense} query: {query}")
         return client.query(query, job_config=job_config)
 
     return partial(


### PR DESCRIPTION
This adds a temporary workaround for Relay table that has `fxa_id` in event extras.
I initially wanted to go with https://mozilla-hub.atlassian.net/browse/DENG-7964 first to move the field to a regular metric, but this might require updates to glean_parser first.
This isn't great, but I haven't found a simpler way. I tried putting an expression to select any `fxa_id` key in `DeleteTarget.field`, but this resulted in correlated subquery which BQ does not support.

I tested this by generating the query locally with `script/shredder_delete --dry_run --start-date=2024-01-01 --end-date=2025-03-02 --only=relay_backend_stable.events_v1` and running it on copied tables.