### PR TITLE
feat: add beta channels to fenix and firefox_ios usage_reporting configuration

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -397,9 +397,11 @@ generate:
       fenix:
         channels:
         - nightly
+        - beta
       firefox_ios:
         channels:
         - nightly
+        - beta
       firefox_desktop:
         # firefox_desktop is a single app containing multiple channels hence why set to null.
         channels: null


### PR DESCRIPTION
# feat: add beta channels to fenix and firefox_ios usage_reporting configuration