### PR TITLE
Fix join in android_onboarding funnel

### DIFF
--- a/sql_generators/funnels/configs/android_onboarding.toml
+++ b/sql_generators/funnels/configs/android_onboarding.toml
@@ -197,7 +197,7 @@ from_expression = """
   USING(client_id)
   LEFT JOIN
     (SELECT * FROM fenix.events_unnested eu WHERE DATE(submission_timestamp) = @submission_date) AS eu
-  USING(client_id)
+  ON ac.client_id = eu.client_info.client_id
   LEFT JOIN
     (SELECT client_info.client_id,
     ANY_VALUE(`mozfun.map.get_key`(event_extra, 'sequence_id')) AS funnel_id


### PR DESCRIPTION
## Description

Fixes change from https://github.com/mozilla/bigquery-etl/pull/7069.  [Query is failing](https://workflow.telemetry.mozilla.org/dags/bqetl_generated_funnels/grid?dag_run_id=scheduled__2025-02-27T05%3A00%3A00%2B00%3A00&task_id=fenix_derived__android_onboarding__v1&tab=logs) with `Column client_id in USING clause not found on right side of join at [45:12]`.  This query is in the dry run skip list because it takes a long time to dry run so it wasn't caught

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
