### PR TITLE
fix: Increase table sensor timeout defaults to 24 hours

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -134,7 +134,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         {% if table_sensor_task.timeout != None -%}
         timeout={{ table_sensor_task.timeout | format_timedelta | format_repr }},
         {% else -%}
-        timeout=datetime.timedelta(hours=8),
+        timeout=datetime.timedelta(hours=24),
         {% endif -%}
         {% if table_sensor_task.retries != None -%}
         retries={{ table_sensor_task.retries }},
@@ -165,7 +165,7 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         {% if table_partition_sensor_task.timeout != None -%}
         timeout={{ table_partition_sensor_task.timeout | format_timedelta | format_repr }},
         {% else -%}
-        timeout=datetime.timedelta(hours=8),
+        timeout=datetime.timedelta(hours=24),
         {% endif -%}
         {% if table_partition_sensor_task.retries != None -%}
         retries={{ table_partition_sensor_task.retries }},


### PR DESCRIPTION
## Description
When I added support for table sensors in #5039 I chose 8 hours as the default timeout so that when combined with the common DAG-level defaults of 2 retries it would result in the sensor waiting for ~24 hours total before giving up and failing entirely.  However, it turns out I was wrong about sensors retrying when they hit their timeout, as that behavior was [changed way back in Airflow 2.2.0](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#if-a-sensor-times-out-it-will-not-retry) so that sensors don't retry when they hit their timeout.

So to get the original intended behavior of table sensors waiting for up to 24 hours by default this PR is increasing the table sensors' default timeout to 24 hours.

## Related Tickets & Documents
* [Bug 1950175](https://bugzilla.mozilla.org/show_bug.cgi?id=1950175): Airflow tasks in bqetl_google_search_console failing since 2025-02-22

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
