### PR TITLE
Change nullable columns in fxci.task_runs

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci_derived/task_runs_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/task_runs_v1/schema.yaml
@@ -19,7 +19,7 @@ fields:
     mode: REQUIRED
   - name: started
     type: TIMESTAMP
-    mode: REQUIRED
+    mode: NULLABLE
   - name: state
     type: STRING
     mode: REQUIRED
@@ -28,7 +28,7 @@ fields:
     mode: REQUIRED
   - name: worker_group
     type: STRING
-    mode: REQUIRED
+    mode: NULLABLE
   - name: worker_id
     type: STRING
-    mode: REQUIRED
+    mode: NULLABLE


### PR DESCRIPTION
## Description

Follow-up to https://github.com/mozilla/bigquery-etl/pull/7094.  These fields are already set to nullable in the table and changing to required isn't supported so this is [failing table deploys](https://workflow.telemetry.mozilla.org/dags/bqetl_artifact_deployment/grid?dag_run_id=manual__2025-02-28T18%3A24%3A04.991678%2B00%3A00&task_id=publish_new_tables&tab=logs).  Error is `Provided Schema does not match Table moz-fx-data-shared-prod:fxci_derived.task_runs_v1. Field started has changed mode from NULLABLE to REQUIRED`

@ahal is it ok to keep these as nullable?  Otherwise we would need to recreate the table

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
