### PR TITLE
Use fixed column order in baseline_clients_last_seen

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.query.sql
@@ -44,7 +44,38 @@ WITH _current AS (
     CAST(browser_engagement_uri_count > 0 AS INT64) &
     CAST(browser_engagement_active_ticks > 0 AS INT64) AS days_desktop_active_bits,
     {% endif %}
-    * EXCEPT(submission_date)
+    client_id,
+    sample_id,
+    first_run_date,
+    durations,
+    days_seen_session_start_bits,
+    days_seen_session_end_bits,
+    normalized_channel,
+    normalized_os,
+    normalized_os_version,
+    android_sdk_version,
+    locale,
+    city,
+    country,
+    isp,
+    app_build,
+    app_channel,
+    app_display_version,
+    architecture,
+    device_manufacturer,
+    device_model,
+    telemetry_sdk_build,
+    first_seen_date,
+    is_new_profile,
+    distribution_id,
+    geo_subdivision,
+    profile_group_id,
+    install_source,
+    windows_build_number,
+    browser_engagement_uri_count,
+    browser_engagement_active_ticks,
+    legacy_telemetry_client_id,
+    is_default_browser,
   FROM
     `{{ daily_table }}`
   WHERE
@@ -54,21 +85,46 @@ WITH _current AS (
   --
 _previous AS (
   SELECT
+    -- All columns except submission_date ( * (EXCEPT(submission_date)) )
+    -- listed out to ensure order is identical to output of _current
     days_seen_bits,
     days_active_bits,
     {% if app_name == "firefox_desktop" %}
     days_desktop_active_bits,
     {% endif %}
     days_created_profile_bits,
-    * EXCEPT (
-        submission_date,
-        days_seen_bits,
-        days_active_bits,
-        {% if app_name == "firefox_desktop" %}
-        days_desktop_active_bits,
-        {% endif %}
-        days_created_profile_bits
-      ),
+    client_id,
+    sample_id,
+    first_run_date,
+    durations,
+    days_seen_session_start_bits,
+    days_seen_session_end_bits,
+    normalized_channel,
+    normalized_os,
+    normalized_os_version,
+    android_sdk_version,
+    locale,
+    city,
+    country,
+    isp,
+    app_build,
+    app_channel,
+    app_display_version,
+    architecture,
+    device_manufacturer,
+    device_model,
+    telemetry_sdk_build,
+    first_seen_date,
+    is_new_profile,
+    distribution_id,
+    geo_subdivision,
+    profile_group_id,
+    install_source,
+    windows_build_number,
+    browser_engagement_uri_count,
+    browser_engagement_active_ticks,
+    legacy_telemetry_client_id,
+    is_default_browser,
   FROM
     `{{ last_seen_table }}`
   WHERE


### PR DESCRIPTION
## Description

The difference in column order is causing the focus queries to fail when dry running in https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/46413/workflows/1a25c214-59e6-42f7-8e30-834ec5d10098/jobs/542162

```
[{'code': 400, 'errors': [{'message': 'No matching signature for function IF\n  Argument types: BOOL, STRUCT<days_seen_bits INT64, days_active_bits INT64, days_created_profile_bits INT64, ...>, STRUCT<days_seen_bits INT64, days_active_bits INT64, days_created_profile_bits INT64, ...>\n  Signature: IF(BOOL, T1, T1)...
```

The line is `IF(_current.client_id IS NOT NULL, _current, _previous).*`.  Apparently column order matters for this so I'm adding all the columns to both CTEs in the same order

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
