### PR TITLE
fix: Correct type of `fxa_recovery_phones_v1.uid` columns (bug 1951400)

### DIFF
--- a/sql/moz-fx-data-shared-prod/accounts_db_external/fxa_recovery_phones_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_db_external/fxa_recovery_phones_v1/schema.yaml
@@ -1,6 +1,6 @@
 fields:
 - name: uid
-  type: INTEGER
+  type: STRING
   mode: NULLABLE
   description: Account ID in hexadecimal format.
 - name: phoneNumber

--- a/sql/moz-fx-data-shared-prod/accounts_db_nonprod_external/fxa_recovery_phones_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_db_nonprod_external/fxa_recovery_phones_v1/schema.yaml
@@ -1,6 +1,6 @@
 fields:
 - name: uid
-  type: INTEGER
+  type: STRING
   mode: NULLABLE
   description: Account ID in hexadecimal format.
 - name: phoneNumber


### PR DESCRIPTION
## Description
The `schema.yaml` files for `fxa_recovery_phones_v1` tables added in #7104 had the wrong type for the `uid` columns.  This fixes that.

## Related Tickets & Documents
* [Bug 1951400](https://bugzilla.mozilla.org/show_bug.cgi?id=1951400): Airflow task bqetl_artifact_deployment.publish_new_tables failing for 3/1 - 3/3
* https://github.com/mozilla/bigquery-etl/pull/7104

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
