### PR TITLE
Move static_combos to end of glam histogram buckets query

### DIFF
--- a/bigquery_etl/glam/templates/histogram_bucket_counts_v1.sql
+++ b/bigquery_etl/glam/templates/histogram_bucket_counts_v1.sql
@@ -17,7 +17,7 @@ build_ids AS (
     app_build_id,
     channel,
   FROM
-    all_combos
+    sampled_source
   GROUP BY
     1,
     2
@@ -41,9 +41,9 @@ histograms_cte AS (
           mozfun.glam.histogram_normalized_sum_with_original(value, 1.0) AS aggregates,
         {% endif %}
       FROM unnest(histogram_aggregates)
-    )AS histogram_aggregates
+    ) AS histogram_aggregates
   FROM
-    all_combos
+    sampled_source
 ),
 unnested AS (
   SELECT
@@ -103,15 +103,56 @@ records as (
     SELECT
         {{ attributes }},
         {{ metric_attributes }},
-        STRUCT<key STRING, value FLOAT64>(CAST(bucket AS STRING), 1.0 * SUM(value)) AS record,
-        STRUCT<key STRING, value FLOAT64>(CAST(bucket AS STRING), 1.0 * SUM(non_norm_value)) AS non_norm_record
+        CAST(bucket AS STRING) AS bucket,
+        1.0 * SUM(value) AS normalized_value,
+        1.0 * SUM(non_norm_value) AS non_norm_value,
     FROM
         unnested
     GROUP BY
         {{ attributes }},
         {{ metric_attributes }},
         bucket
+),
+with_combos AS (
+  SELECT
+    records.* REPLACE (
+      COALESCE(combo.ping_type, records.ping_type) AS ping_type,
+      COALESCE(combo.os, records.os) AS os,
+      COALESCE(combo.app_build_id, records.app_build_id) AS app_build_id
+    )
+  FROM
+    records
+  CROSS JOIN
+    static_combos AS combo
+),
+aggregated_combos AS (
+  SELECT
+    ping_type,
+    os,
+    app_version,
+    app_build_id,
+    channel,
+    metric,
+    metric_type,
+    key,
+    agg_type,
+    STRUCT<key STRING, value FLOAT64>(bucket, SUM(normalized_value)) AS record,
+    STRUCT<key STRING, value FLOAT64>(bucket, SUM(non_norm_value)) AS non_norm_record,
+  FROM
+    with_combos
+  GROUP BY
+      ping_type,
+      os,
+      app_version,
+      app_build_id,
+      channel,
+      metric,
+      metric_type,
+      key,
+      agg_type,
+      bucket
 )
+
 SELECT
     * EXCEPT(metric_type, histogram_type),
     -- Suffix `custom_distribution` with bucketing type
@@ -121,7 +162,7 @@ SELECT
       metric_type
     ) as metric_type
 FROM
-    records
+    aggregated_combos
 LEFT OUTER JOIN
     distribution_metadata
     USING (metric_type, metric)


### PR DESCRIPTION
## Description

This moves the static combos cross join to after the aggregation step so the things that get cross joined are the aggregated buckets instead of the entire histograms.

[Comparing the results](https://sql.telemetry.mozilla.org/queries/106039/source), most buckets are the same so I feel confident that the math works but there are some buckets where they don't match which might be from clients not being included from either side.  I'm still trying to figure out how that's happening.

Query improvements are suspiciously good (release sample id 0 goes from 4400 slot hours to 78) so I'm still kind of skeptical:

old or new query | channel | sample id | job id | bytes processed | run time | slot hours | shuffled | spilled to disk
-- | -- | -- | -- | -- | -- | -- | -- | --
old | release | 0 | moz-fx-glam-prod:US.bqjob_r5880726ab8601cf4_000001952de08e1b_1 | 1.22 TB | 4 hr 21 min | 4425 😮 | 138.35 TB | 45.08 TB
new | release | 0 | moz-fx-data-backfill-2:US.bquxjob_a81b5b0_1955e54a7e8 | 964.33 GB | 2 min 43 sec | 78 | 3.71 TB | 0 B
old | nightly | 0-2 | moz-fx-glam-prod:US.bqjob_r6284d1008ab499b5_0000019559fb1d85_1 | 15.4 GB | 5 min 19 sec | 18 | 1.95 TB | 0
new | nightly | 0-2 | moz-fx-data-backfill-2:US.7d393b61-1f99-4330-9e5d-25975bb169dd | 15.4 GB | 39 sec | 2 | 210.61 GB | 0
old | nightly | 3-5 | moz-fx-glam-prod:US.bqjob_r703d58924517d025_000001955a02c236_1 | 15.25 GB | 6 min 55 sec | 17 | 1.94 TB | 685.45 GB
new | nightly | 3-5 | moz-fx-data-backfill-2:US.2e35aded-5136-4925-8404-971493999671 | 15.25 GB | 36 sec | 2 | 167.75 GB | 0
old | nightly | 6-9 | moz-fx-glam-prod:US.bqjob_r701772c8e3ac0ed1_000001955a0b1b6d_1 | 19.89 GB | 7 min 44 sec | 21 | 2.42 TB | 875.52 GB
new | nightly | 6-9 | moz-fx-data-backfill-2:US.1421d088-ce6f-4548-9945-258adf8ffe2c | 19.89 GB | 38 sec | 2 | 212.32 GB | 0
old | nightly | 10-49 | moz-fx-glam-prod:US.bqjob_r1b1e43d095935c73_000001955a13f6c4_1 | 201.42 GB | 1 hr 4 min | 335 | 27.24 TB | 11.25 TB
new | nightly | 10-49 | moz-fx-data-backfill-2:US.3bbbdea5-48ff-4b95-9adb-4df1d580a77a | 201.42 GB | 1 min 15 sec | 28 | 2.04 TB | 0
old | nightly | 50-99 | moz-fx-glam-prod:US.bqjob_r4ba7f429b74c160c_000001955a50feb1_1 | 254.64 GB | 56 min 17 sec | 434 | 35.76 TB | 12.78 TB
new | nightly | 50-99 | moz-fx-data-backfill-2:US.69d38d5f-5e9b-4cea-8a6b-b67eda249e21 | 254.64 GB | 1 min 50 sec | 39 | 3.57 TB | 0
new | nightly | 0-99 | moz-fx-data-backfill-2:US.bquxjob_1a32be13_1955e753d54 | 506.57 GB | 3 min 34 sec | 84 | 6.9 TB | 2.7 TB


<!-- notionvc: b1b2bb41-25b0-4d30-ac40-9a9b57bc9005 -->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
