### PR TITLE
fix(glam): DENG-7666 improve fog_release_bucket_counts

### DIFF
--- a/bigquery_etl/glam/models.py
+++ b/bigquery_etl/glam/models.py
@@ -115,6 +115,7 @@ def histogram_bucket_counts(**kwargs):
     return dict(
         attributes_list=attributes_list,
         attributes=",".join(attributes_list),
+        fixed_attributes=",".join(fixed_attributes),
         cubed_attributes=cubed_attributes,
         attribute_combinations=compute_datacube_groupings(cubed_attributes),
         metric_attributes_list=metric_attributes_list,

--- a/bigquery_etl/glam/templates/histogram_bucket_counts_v1.sql
+++ b/bigquery_etl/glam/templates/histogram_bucket_counts_v1.sql
@@ -25,7 +25,7 @@ build_ids AS (
       COUNT(DISTINCT client_id) > {{ minimum_client_count }}
     {% endif %}
 ),
-data_with_enough_wau AS (
+data_with_enough_clients AS (
   SELECT
     *
   FROM
@@ -80,7 +80,7 @@ histograms_cte AS (
     {% for combination in combinations %}
       {{
         histograms_cte_select(
-          "data_with_enough_wau",
+          "data_with_enough_clients",
           fixed_attributes,
           metric_attributes,
           channel == "release",


### PR DESCRIPTION
## Description

fixes [1944388](https://bugzilla.mozilla.org/show_bug.cgi?id=1944388)
This PR ports https://github.com/mozilla/bigquery-etl/pull/4218 to `glam_fog`. It improves histogram_bucket_counts step for release.

## Related Tickets & Documents
* DENG-7666
* [bug 1944388](https://bugzilla.mozilla.org/show_bug.cgi?id=1944388)

Tested with a single percent sample (sample_id = 99, release) and it went from:
![Screenshot 2025-03-04 at 2 19 18 PM](https://github.com/user-attachments/assets/6d616dd5-bc12-4eeb-a905-72cef95b77c5)

to

![Screenshot 2025-03-04 at 2 20 20 PM](https://github.com/user-attachments/assets/e9af41fe-8559-4809-af81-fd1fcaf75259)


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
