### PR TITLE
DENG-7966 Set phabricator-metrics/external workgroup access on phabricator_metrics dataset

### DIFF
--- a/sql/moz-fx-data-shared-prod/phabricator_metrics/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/phabricator_metrics/dataset_metadata.yaml
@@ -12,3 +12,4 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
+  - workgroup:phabricator-metrics/external


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/DENG-7966

Requires https://github.com/mozilla-it/global-platform-admin/pull/2647 for the group to be created.