### PR TITLE
DENG-7982 - add 2 new tables to shredder config

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -271,6 +271,14 @@ DELETE_TARGETS: DeleteIndex = {
         field=(CLIENT_ID),
     ): (DESKTOP_GLEAN_SRC),
     DeleteTarget(
+        table="telemetry_derived.fx_accounts_linked_clients_staging_v1",
+        field=(CLIENT_ID),
+    ): (DESKTOP_GLEAN_SRC),
+    DeleteTarget(
+        table="telemetry_derived.fx_accounts_linked_clients_v1",
+        field=(CLIENT_ID),
+    ): (DESKTOP_GLEAN_SRC),
+    DeleteTarget(
         table="telemetry_derived.rolling_cohorts_v2",
         field=(CLIENT_ID,) * 15,
     ): (

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -272,12 +272,12 @@ DELETE_TARGETS: DeleteIndex = {
     ): (DESKTOP_GLEAN_SRC),
     DeleteTarget(
         table="telemetry_derived.fx_accounts_linked_clients_staging_v1",
-        field=(CLIENT_ID),
-    ): (DESKTOP_GLEAN_SRC),
+        field=(CLIENT_ID, "linked_client_id"),
+    ): (DESKTOP_GLEAN_SRC, DESKTOP_GLEAN_SRC),
     DeleteTarget(
         table="telemetry_derived.fx_accounts_linked_clients_v1",
-        field=(CLIENT_ID),
-    ): (DESKTOP_GLEAN_SRC),
+        field=(CLIENT_ID, "linked_client_id"),
+    ): (DESKTOP_GLEAN_SRC, DESKTOP_GLEAN_SRC),
     DeleteTarget(
         table="telemetry_derived.rolling_cohorts_v2",
         field=(CLIENT_ID,) * 15,


### PR DESCRIPTION
## Description

This PR adds 2 new tables to Shredder:
- moz-fx-data-shared-prod.telemetry_derived.fx_accounts_linked_clients_staging_v1
- moz-fx-data-shared-prod.telemetry_derived.fx_accounts_linked_clients_v1

## Related Tickets & Documents
* [DENG-7982](https://mozilla-hub.atlassian.net/browse/DENG-7982)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7982]: https://mozilla-hub.atlassian.net/browse/DENG-7982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ