### PR TITLE
fix(DENG-7900): Adjust linkage_last_seen_date logic

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_v1/script.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_v1/script.sql
@@ -8,7 +8,10 @@ MERGE INTO
         COALESCE(old.linkage_first_seen_date, n.submission_date),
         n.submission_date
       ) AS linkage_first_seen_date,
-      GREATEST(old.linkage_last_seen_date, n.submission_date) AS linkage_last_seen_date
+      GREATEST(
+        COALESCE(old.linkage_last_seen_date, n.submission_date),
+        n.submission_date
+      ) AS linkage_last_seen_date
     FROM
       (
         SELECT


### PR DESCRIPTION
## Description

This PR fixes the logic used in the merge statement for the linkage_last_seen_date column.  The old logic wasn't working correctly for new rows (it would insert a null for linkage last seen date for a newly added client ID / linked client ID, instead of the desired date).

## Related Tickets & Documents
* [DENG-7900](https://mozilla-hub.atlassian.net/browse/DENG-7900)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7900]: https://mozilla-hub.atlassian.net/browse/DENG-7900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ