### PR TITLE
feat(DENG-7984): add focus_android and focus_ios to usage_reporting generator configuration

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -412,9 +412,13 @@ generate:
       focus_android:
         channels:
         - release
+        - beta
+        - nightly
       focus_ios:
         channels:
         - release
+        - beta
+        - nightly
 
 
 retention_exclusion_list:

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -417,8 +417,6 @@ generate:
       focus_ios:
         channels:
         - release
-        - beta
-        - nightly
 
 
 retention_exclusion_list:

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -409,6 +409,12 @@ generate:
       firefox_desktop:
         # firefox_desktop is a single app containing multiple channels hence why set to null.
         channels: null
+      focus_android:
+        channels:
+        - release
+      focus_ios:
+        channels:
+        - release
 
 
 retention_exclusion_list:


### PR DESCRIPTION
# feat(DENG-7984): add focus_android and focus_ios to usage_reporting generator configuration

Adding focus_android and focus_ios to the usage_reporting generator.