### PR TITLE
Add missing dashboard_page_session field to looker_dashboard_load_times

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/query.py
@@ -39,6 +39,7 @@ def run_query(sdk, date):
             "dashboard_performance.seconds_until_last_data_received",
             "dashboard_performance.seconds_until_last_tile_finished_rendering",
             "dashboard_performance.dash_id",
+            "dashboard_performance.dashboard_page_session",
             "dashboard_performance.first_event_at_date",
         ],
         pivots=None,


### PR DESCRIPTION
## Description

Adds a missing `dashboard_page_session` field to the Looker API query

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
