### PR TITLE
[DENG-8037] Change glean glam to keep latest 3 versions

### DIFF
--- a/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
@@ -14,7 +14,7 @@
       -- only keep builds from the last year
       AND {{ build_date_udf }}(app_build_id) > DATE_SUB(@submission_date, INTERVAL 365 day)
       {% if filter_version %}
-      AND app_version BETWEEN (latest_version - {{ num_versions_to_keep }}) AND latest_version
+      AND app_version BETWEEN (latest_version - {{ num_versions_to_keep }} + 1) AND latest_version
       {% endif %}
 {% endset %}
 

--- a/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
@@ -14,7 +14,7 @@
       -- only keep builds from the last year
       AND {{ build_date_udf }}(app_build_id) > DATE_SUB(@submission_date, INTERVAL 365 day)
       {% if filter_version %}
-      AND app_version BETWEEN (latest_version - {{ num_versions_to_keep }}) AND latest_version
+      AND app_version BETWEEN (latest_version - {{ num_versions_to_keep }} + 1) AND latest_version
       {% endif %}
 {% endset %}
 


### PR DESCRIPTION
## Description

https://github.com/mozilla/bigquery-etl/pull/5868 changed this condition from `app_version > (latest_version - {{ num_versions_to_keep }})` to `app_version BETWEEN (latest_version - {{ num_versions_to_keep }})` which means we're currently keeping the last 4 versions instead of 3.

Since the older versions will have more data, keeping the 4th version will increase the table size by about 40-65% depending on how deep we are into the current release cycle.  Version 133 is currently 36.4% of the rows in `firefox_desktop_glam_release__clients_histogram_aggregates_v1` and 32.9% of `firefox_desktop_glam_release__clients_scalar_aggregates_v1` so this should result in good cost reductions

## Related Tickets & Documents
* DENG-8037

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
