### PR TITLE
chore: add crash_ping_ingest_external dataset

### DIFF
--- a/sql/moz-fx-data-shared-prod/crash_ping_ingest_external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/crash_ping_ingest_external/dataset_metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: Crash Ping Ingest External
+description: |-
+  The data in this dataset is written to from a taskcluster task.
+  See https://mozilla-hub.atlassian.net/browse/DSRE-1900 for more information.
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+- role: roles/bigquery.dataEditor
+  members:
+  - workgroup:dataops-managed/crash-ping-ingest


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DSRE-1900?focusedCommentId=1023642

This is going to be written to from taskcluster via tasks not owned by DE, see the above ticket for details.

Requires https://github.com/mozilla-services/cloudops-infra/pull/6313.

## Related Tickets & Documents
* DSRE-1900
