### PR TITLE
[DENG-8033] Run event_monitoring_aggregates in backfill-3

### DIFF
--- a/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.metadata.yaml
@@ -9,9 +9,9 @@ labels:
   incremental: true 
 scheduling:
   dag_name: bqetl_monitoring
-  # Use backfill-2 project for on-demand query billing
+  # Use backfill-3 project for on-demand query billing
   arguments: [
-    "--billing-project", "moz-fx-data-backfill-2"
+    "--billing-project", "moz-fx-data-backfill-3"
   ]
 bigquery:
   time_partitioning:


### PR DESCRIPTION
## Description

event_monitoring_aggregates runs at the same time as desktop events stream in the backfill-2 project.  The events stream query failed on the first attempt yesterday due to memory so running them on different projects should give each query more resources.

backfill 3 and 4 were changed to on-demand in https://github.com/mozilla-it/global-platform-admin/pull/2672 and I just ran a query in them to verify that it worked.

## Related Tickets & Documents
* DENG-8033

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
