### PR TITLE
fix(glam): DENG-8037 - Fix amount of versions to process to 3 instead of 4

### DIFF
--- a/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
@@ -14,7 +14,7 @@
       -- only keep builds from the last year
       AND {{ build_date_udf }}(app_build_id) > DATE_SUB(@submission_date, INTERVAL 365 day)
       {% if filter_version %}
-      AND app_version BETWEEN (latest_version - {{ num_versions_to_keep }}) AND latest_version
+      AND app_version BETWEEN (latest_version - {{ num_versions_to_keep }} + 1) AND latest_version
       {% endif %}
 {% endset %}
 

--- a/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
@@ -14,7 +14,7 @@
       -- only keep builds from the last year
       AND {{ build_date_udf }}(app_build_id) > DATE_SUB(@submission_date, INTERVAL 365 day)
       {% if filter_version %}
-      AND app_version BETWEEN (latest_version - {{ num_versions_to_keep }}) AND latest_version
+      AND app_version BETWEEN (latest_version - {{ num_versions_to_keep }} + 1) AND latest_version
       {% endif %}
 {% endset %}
 


### PR DESCRIPTION
## Description

This PR fixes the amount of versions the GLAM ETL for Glean keeps to 3 instead of 4.


## Related Tickets & Documents
* DENG-8037


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
