### PR TITLE
Adjust overactive clients threshold for sponsored_tiles_clients_daily_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/query.sql
@@ -166,7 +166,7 @@ overactive_android_clients AS (
   GROUP BY
     client_id
   HAVING
-    COUNT(*) > 1500000
+    COUNT(*) > 1400000
 ),
 --- ANDROID SPONSORED TILES
 android_events AS (


### PR DESCRIPTION
## Description

Adjusting the overactive clients threshold. This fixed the `Resources exceeded during query execution` and will unblock the Airflow task

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
