### PR TITLE
feat(DENG-7788): Create external_derived.chrome_extensions_v1

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2258,6 +2258,6 @@ bqetl_chrome_extensions_scraper:
     retry_delay: 30m
     start_date: '2025-03-20'
   description: Pulls info about Chrome extensions from the Chrome webstore
-  schedule_interval: 40 21 * * *
+  schedule_interval: 40 21 * * 1
   tags:
     - impact/tier_3

--- a/dags.yaml
+++ b/dags.yaml
@@ -2256,7 +2256,7 @@ bqetl_chrome_extensions_scraper:
     owner: kwindau@mozilla.com
     retries: 2
     retry_delay: 30m
-    start_date: '2025-03-20'
+    start_date: '2025-03-01'
   description: Pulls info about Chrome extensions from the Chrome webstore
   schedule_interval: 40 21 * * 1
   tags:

--- a/dags.yaml
+++ b/dags.yaml
@@ -2244,3 +2244,20 @@ bqetl_un_population:
   schedule_interval: 0 13 15 2 *
   tags:
     - impact/tier_3
+
+bqetl_chrome_extensions_scraper:
+  default_args:
+    depends_on_past: false
+    email:
+      - kwindau@mozilla.com
+    email_on_failure: true
+    email_on_retry: false
+    end_date: null
+    owner: kwindau@mozilla.com
+    retries: 2
+    retry_delay: 30m
+    start_date: '2025-03-20'
+  description: Pulls info about Chrome extensions from the Chrome webstore
+  schedule_interval: 40 21 * * *
+  tags:
+    - impact/tier_3

--- a/sql/moz-fx-data-shared-prod/external/chrome_extensions/view.sql
+++ b/sql/moz-fx-data-shared-prod/external/chrome_extensions/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.external.chrome_extensions`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.external_derived.chrome_extensions_v1`

--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kwindau
 scheduling:
   dag_name: bqetl_chrome_extensions_scraper
+  arguments: ["--date", "{{ds}}"]
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/metadata.yaml
@@ -1,0 +1,19 @@
+friendly_name: Chrome Extensions
+description: |-
+  Data about extensions offered by Google Chrome
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_chrome_extensions_scraper
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
@@ -205,9 +205,6 @@ def main():
 
     # Loop through the links found on the main page of the Chrome Webstore
     for idx, current_link in enumerate(unique_links_on_chrome_webstore_page):
-        # Print the link # and the link URL
-        print("PROCESSING TOP LEVEL idx: ", str(idx))
-        print("PROCESSING TOP LEVEL LINK: ", str(current_link))
 
         # Check if the link is a "detail page" or a "non detail page"
         is_detail_page = check_if_detail_or_non_detail_page(current_link)
@@ -238,13 +235,6 @@ def main():
             # Loop through each link on this page
             for link_on_page in unique_links_on_non_detail_page:
 
-                # Print the link we are about to process
-                print(
-                    "Processing Secondary Link: ",
-                    link_on_page,
-                    " found on main page link: ",
-                    current_link,
-                )
 
                 # Check if it's a detail page link or not
                 is_detail_page = check_if_detail_or_non_detail_page(link_on_page)

--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
@@ -1,25 +1,27 @@
-#Load libraries
+# Load libraries
 import pandas as pd
-import numpy as np
 from datetime import datetime
 import requests
 from bs4 import BeautifulSoup
 import re
-import os
+from argparse import ArgumentParser
 from google.cloud import bigquery
+from urllib.parse import urljoin
 
-#Main website for Chrome Webstore
+# Main website for Chrome Webstore
 CHROME_WEBSTORE_URL = "https://chromewebstore.google.com"
 
-#Links to ignore from the Chrome Webstore page
-LIST_OF_LINKS_TO_IGNORE = ["https://chromewebstore.google.com/user/installed",
-                    "https://chrome.google.com/webstore/devconsole/",
-                    "https://www.google.com/intl/en/about/products",
-                    "https://support.google.com/chrome_webstore/answer/1047776?hl=en-US",
-                    "https://myaccount.google.com/privacypolicy?hl=en-US",
-                    "https://support.google.com/chrome_webstore?hl=en-US",
-                    "https://ssl.gstatic.com/chrome/webstore/intl/en-US/gallery_tos.html",
-                    "./"]
+# Links to ignore from the Chrome Webstore page
+LIST_OF_LINKS_TO_IGNORE = [
+    "https://chromewebstore.google.com/user/installed",
+    "https://chrome.google.com/webstore/devconsole/",
+    "https://www.google.com/intl/en/about/products",
+    "https://support.google.com/chrome_webstore/answer/1047776?hl=en-US",
+    "https://myaccount.google.com/privacypolicy?hl=en-US",
+    "https://support.google.com/chrome_webstore?hl=en-US",
+    "https://ssl.gstatic.com/chrome/webstore/intl/en-US/gallery_tos.html",
+    "./",
+]
 
 
 TARGET_PROJECT = "moz-fx-data-shared-prod"
@@ -28,74 +30,87 @@ GCS_BUCKET = "gs://moz-fx-data-prod-external-data/"
 RESULTS_FPATH = "CHROME_EXTENSIONS/chrome_extensions_%s.csv"
 TIMEOUT_IN_SECONDS = 10
 
+
 # Function to get all unique links found on a given webpage
-def get_unique_links_from_webpage(url, timeout_seconds, links_to_ignore):
-    """ Input: Webpage, timeout seconds (integer)
-      Output: List of unique links on that page"""
+def get_unique_links_from_webpage(
+    url, base_url, timeout_seconds, links_to_ignore, links_to_not_process
+):
+    """Input: Webpage, timeout seconds (integer), links to ignore, links already processed
+    Output: List of unique, absolute links on that page"""
 
     response = requests.get(url, timeout=timeout_seconds)
     soup = BeautifulSoup(response.text, "html.parser")
 
-    links = [a['href'] for a in soup.find_all('a', href=True)]
+    links = [urljoin(base_url, a["href"]) for a in soup.find_all("a", href=True)]
     unique_links = []
     for link in links:
-        if link not in unique_links and link not in links_to_ignore:
-            if link.startswith("./"):
-                link_without_period_at_front = re.sub(r"^\.", "", link)
-                link = url + link_without_period_at_front
+        if (
+            link not in unique_links
+            and link not in links_to_ignore
+            and link not in links_to_not_process
+        ):
             unique_links.append(link)
     return unique_links
 
 
 # Function to get the soup returned from a given page
 def get_soup_from_webpage(webpage_url, timeout_seconds):
-    """ Input: Webpage URL, timeout
-        Output: BeautifulSoup class"""
-    response=requests.get(webpage_url, timeout=timeout_seconds)
+    """Input: Webpage URL, timeout
+    Output: BeautifulSoup class"""
+    response = requests.get(webpage_url, timeout=timeout_seconds)
     soup_from_webpage = BeautifulSoup(response.text, "html.parser")
     return soup_from_webpage
 
+
 # Function to get all paragraphs from a soup
 def get_paragraphs_from_soup(webpage_soup):
-    """ Input: Webpage Soup
-        Output: List of paragraphs found in the soup"""
-    paragraphs = [p.text for p in webpage_soup.find_all('p')]
+    """Input: Webpage Soup
+    Output: List of paragraphs found in the soup"""
+    paragraphs = [p.text for p in webpage_soup.find_all("p")]
     return paragraphs
 
+
 def get_h1_headers_from_soup(webpage_soup):
-    """ Input: Webpage Soup
-        Output: List of H1 Elements Found"""
-    headers = [h1.text for h1 in webpage_soup.find_all('h1')]
+    """Input: Webpage Soup
+    Output: List of H1 Elements Found"""
+    headers = [h1.text for h1 in webpage_soup.find_all("h1")]
     return headers
+
 
 def get_h2_headers_from_soup(webpage_soup):
-    """ Input: Webpage Soup
-        Output: List of H2 Elements Found
+    """Input: Webpage Soup
+    Output: List of H2 Elements Found
     """
-    headers = [h2.text for h2 in webpage_soup.find_all('h2')]
+    headers = [h2.text for h2 in webpage_soup.find_all("h2")]
     return headers
 
+
 def get_divs_from_soup(webpage_soup):
-    """ Input: Webpage Soup
-        Output: List of H2 Elements Found
+    """Input: Webpage Soup
+    Output: List of H2 Elements Found
     """
-    divs = [div.text for div in webpage_soup.find_all('div')]
+    divs = [div.text for div in webpage_soup.find_all("div")]
     return divs
 
+
 def initialize_results_df():
-    """ Returns a dataframe with 0 rows with the desired format"""
-    results_df = pd.DataFrame(columns=['submission_date',
-                                      'url',
-                                      'chrome_extension_name',
-                                      'star_rating',
-                                      'number_of_ratings',
-                                      'number_of_users'])
+    """Returns a dataframe with 0 rows with the desired format"""
+    results_df = pd.DataFrame(
+        columns=[
+            "submission_date",
+            "url",
+            "chrome_extension_name",
+            "star_rating",
+            "number_of_ratings",
+            "number_of_users",
+        ]
+    )
     return results_df
 
 
 def check_if_detail_or_non_detail_page(url):
-    """ Input: A URL (string)
-        Output: Boolean, indicating if the URL contains /detail/ in it"""
+    """Input: A URL (string)
+    Output: Boolean, indicating if the URL contains /detail/ in it"""
     detail_page = False
     if "/detail/" in url:
         detail_page = True
@@ -103,150 +118,193 @@ def check_if_detail_or_non_detail_page(url):
 
 
 def pull_data_from_detail_page(url, timeout_limit, current_date):
-    """ Input: URL, timeout limit (integer), and current date"""
-    ##Initialize as empty strings
-    number_of_ratings = 'NOT FOUND'
-    chrome_extension_name = 'NOT FOUND'
-    star_rating = 'NOT FOUND'
-    number_of_users = 'NOT FOUND'
+    """Input: URL, timeout limit (integer), and current date"""
+    # Initialize as empty strings
+    number_of_ratings = "NOT FOUND"
+    chrome_extension_name = "NOT FOUND"
+    star_rating = "NOT FOUND"
+    number_of_users = "NOT FOUND"
 
-    #Get the soup from the current link
-    current_link_soup = get_soup_from_webpage(webpage_url=url,
-                                              timeout_seconds=timeout_limit)
-    
-    #Get paragraphs & headers from the current link
+    # Get the soup from the current link
+    current_link_soup = get_soup_from_webpage(
+        webpage_url=url, timeout_seconds=timeout_limit
+    )
+
+    # Get paragraphs & headers from the current link
     paragraphs_from_current_link_soup = get_paragraphs_from_soup(current_link_soup)
     headers_from_current_link_soup = get_h1_headers_from_soup(current_link_soup)
     h2_headers_from_current_link_soup = get_h2_headers_from_soup(current_link_soup)
     divs_from_current_link_soup = get_divs_from_soup(current_link_soup)
 
-    #Get the number of ratings
+    # Get the number of ratings
     for paragraph in paragraphs_from_current_link_soup:
-        #Check if this has the ratings information
-        if paragraph.endswith('ratings'):
-            #Get portion before the space
+        # Check if this has the ratings information
+        if paragraph.endswith("ratings"):
+            # Get portion before the space
             number_of_ratings = paragraph.split(" ")[0]
 
-    #Get the extension name
+    # Get the extension name
     for header in headers_from_current_link_soup:
         chrome_extension_name = header
 
-    #Get the star rating
+    # Get the star rating
     for h2_header in h2_headers_from_current_link_soup:
-        if 'out of 5' in h2_header:
+        if "out of 5" in h2_header:
             pattern = r"^.*?out of 5"
             match = re.search(pattern, h2_header)
             if match:
-              star_rating = match.group(0).split(" ")[0]
+                star_rating = match.group(0).split(" ")[0]
 
-    #Get the number of users
+    # Get the number of users
     for div in divs_from_current_link_soup:
-        if ' users' in div:
+        if " users" in div:
             pattern = r"(\d{1,3}(?:,\d{3})*|\d+) (?=users)"
-            match = re.search(pattern, div)   
+            match = re.search(pattern, div)
             if match:
-              number_of_users = match.group(0).split(" ")[0].replace(",", "")
+                number_of_users = match.group(0).split(" ")[0].replace(",", "")
 
-    #Put the results into a dataframe
-    curr_link_results_df = pd.DataFrame({'submission_date':[current_date],
-                                        'url': [url],
-                                        'chrome_extension_name':[chrome_extension_name],
-                                        'star_rating':[star_rating],
-                                        'number_of_ratings':[number_of_ratings],
-                                        'number_of_users':[number_of_users]})
-    
+    # Put the results into a dataframe
+    curr_link_results_df = pd.DataFrame(
+        {
+            "submission_date": [current_date],
+            "url": [url],
+            "chrome_extension_name": [chrome_extension_name],
+            "star_rating": [star_rating],
+            "number_of_ratings": [number_of_ratings],
+            "number_of_users": [number_of_users],
+        }
+    )
+
     return curr_link_results_df
 
-def main():
-    #Get today's date
-    curr_date = datetime.today().strftime('%Y-%m-%d')
 
-    #First, get a list of all the unique links from the Chrome webstore page
-    #Excluding those on the list of links to ignore list
-    unique_links_on_chrome_webstore_page = get_unique_links_from_webpage(url=CHROME_WEBSTORE_URL,
-                                                                       timeout_seconds=TIMEOUT_IN_SECONDS,
-                                                                       links_to_ignore=LIST_OF_LINKS_TO_IGNORE)
-    #Initialize a dataframe to store extension level results
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--date", required=True)
+    args = parser.parse_args()
+
+    # Get DAG logical date
+    logical_dag_date = datetime.strptime(args.date, "%Y-%m-%d").date()
+    logical_dag_date_string = logical_dag_date.strftime("%Y-%m-%d")
+
+    # Initialize a list of the non-detail page links that have already been processed
+    links_already_processed = []
+
+    # First, get a list of all the unique links from the Chrome webstore page
+    # Excluding those on the list of links to ignore list
+    unique_links_on_chrome_webstore_page = get_unique_links_from_webpage(
+        url=CHROME_WEBSTORE_URL,
+        base_url=CHROME_WEBSTORE_URL,
+        timeout_seconds=TIMEOUT_IN_SECONDS,
+        links_to_ignore=LIST_OF_LINKS_TO_IGNORE,
+        links_to_not_process=links_already_processed,
+    )
+
+    # Initialize a dataframe to store extension level results
     results_df = initialize_results_df()
 
-    #Next, loop through the links found on the main page of the Chrome Webstore
+    # Loop through the links found on the main page of the Chrome Webstore
     for idx, current_link in enumerate(unique_links_on_chrome_webstore_page):
-        #Print the link # and the link URL
-        print('idx: ', str(idx))
-        print('current_link: ', str(current_link))
+        # Print the link # and the link URL
+        print("PROCESSING TOP LEVEL idx: ", str(idx))
+        print("PROCESSING TOP LEVEL LINK: ", str(current_link))
 
-        #Check if the link is a "detail page" or a "non detail page"
-        #Note - info about extensions are only found on detail pages
+        # Check if the link is a "detail page" or a "non detail page"
         is_detail_page = check_if_detail_or_non_detail_page(current_link)
-        print('is_detail_page: ', str(is_detail_page))
 
-        #If the link is a detail page
+        # If the link is a detail page
         if is_detail_page:
-          #Get the data from that page
-          detail_page_results_df = pull_data_from_detail_page(url=current_link, 
-                                                              timeout_limit=TIMEOUT_IN_SECONDS, 
-                                                              current_date=curr_date)
-          
-          #Append the data scraped to results_df
-          results_df = pd.concat([results_df, detail_page_results_df])
-            
-        #If this is not a detail page
+            # Get the data from that page
+            detail_page_results_df = pull_data_from_detail_page(
+                url=current_link,
+                timeout_limit=TIMEOUT_IN_SECONDS,
+                current_date=logical_dag_date_string,
+            )
+
+            # Append the data scraped to results_df
+            results_df = pd.concat([results_df, detail_page_results_df])
+
+        # If this link is not a detail page
         else:
-          #Get the links on this page
-          unique_links_on_non_detail_page = get_unique_links_from_webpage(url=current_link,
-                                                                          timeout_seconds=TIMEOUT_IN_SECONDS,
-                                                                          links_to_ignore=LIST_OF_LINKS_TO_IGNORE)
-          ### TO DO - FIX BELOW 
-          # #Loop through each link on this page
-          # for link_on_non_detail_page in unique_links_on_non_detail_page:
-          #     print(link_on_non_detail_page)
-          #     #Check if it's a detail page link or not
-          #     is_detail_page = check_if_detail_or_non_detail_page(link_on_non_detail_page)
-          #     print('is_detail_page: ',str(is_detail_page))
+            # Get the links on this page
+            unique_links_on_non_detail_page = get_unique_links_from_webpage(
+                url=current_link,
+                base_url=CHROME_WEBSTORE_URL,
+                timeout_seconds=TIMEOUT_IN_SECONDS,
+                links_to_ignore=LIST_OF_LINKS_TO_IGNORE,
+                links_to_not_process=links_already_processed,
+            )
 
-          #     #If it's a detail page, record results
-          #     if is_detail_page:
-          #       #Get the data from that page
-          #       detail_page_results_df = pull_data_from_detail_page()
-          #       #Append the data scraped to results_df
-          #       results_df = pd.concat([results_df, detail_page_results_df])
-          #     else:
-          #         print('not checking, 2nd layer deep')
+            # Loop through each link on this page
+            for link_on_page in unique_links_on_non_detail_page:
 
-          
-          
-    print('FINAL RESULTS DATAFRAME')
-    print(results_df)        
+                # Print the link we are about to process
+                print(
+                    "Processing Secondary Link: ",
+                    link_on_page,
+                    " found on main page link: ",
+                    current_link,
+                )
 
+                # Check if it's a detail page link or not
+                is_detail_page = check_if_detail_or_non_detail_page(link_on_page)
 
+                # If it's a detail page, record results
+                if is_detail_page:
+                    # Get the data from that page
+                    detail_page_results_df = pull_data_from_detail_page(
+                        url=link_on_page,
+                        timeout_limit=TIMEOUT_IN_SECONDS,
+                        current_date=logical_dag_date_string,
+                    )
+                    # Append the data scraped to results_df
+                    results_df = pd.concat([results_df, detail_page_results_df])
 
-    
-      
-    # #Write data to CSV in GCS
-    # final_results_fpath = GCS_BUCKET + RESULTS_FPATH % (curr_date)
+                # If it's another page with more links, ignore for now - we are only scraping 1 layer deep
+                # Add the link on the already processed list
+                links_already_processed.append(link_on_page)
 
+        # Add the top level link to already processed
+        links_already_processed.append(current_link)
 
-    # #Write data to BQ table
-    # # Open a connection to BQ
-    # client = bigquery.Client(TARGET_PROJECT)
+    # Write data to CSV in GCS
+    final_results_fpath = GCS_BUCKET + RESULTS_FPATH % (logical_dag_date_string)
+    results_df.to_csv(final_results_fpath, index=False)
+    print("Results written to: ", str(final_results_fpath))
 
-    # # Load data from GCS to BQ table - appending to what is already there
-    # load_csv_to_gcp_job = client.load_table_from_uri(
-    #     fpath,
-    #     TARGET_TABLE,
-    #     job_config=bigquery.LoadJobConfig(
-    #         create_disposition="CREATE_NEVER",
-    #         write_disposition="WRITE_APPEND",
-    #         schema=[
-    #             {"name": "location_id", "type": "INTEGER", "mode": "NULLABLE"},
-    #         ],
-    #         skip_leading_rows=1,
-    #         source_format=bigquery.SourceFormat.CSV,
-    #     ),
-    # )
+    # Write data to BQ table
+    # Open a connection to BQ
+    client = bigquery.Client(TARGET_PROJECT)
 
-    # load_csv_to_gcp_job.result()
-   
+    # If data already ran for this date, delete out
+    # Delete any data already in table for same year so we don't end up with duplicates
+    delete_query = f"""DELETE FROM `moz-fx-data-shared-prod.external_derived.chrome_extensions_v1`
+  WHERE submission_date = '{logical_dag_date_string}'"""
+    del_job = client.query(delete_query)
+    del_job.result()
+
+    # Load data from GCS to BQ table - appending to what is already there
+    load_csv_to_gcp_job = client.load_table_from_uri(
+        final_results_fpath,
+        TARGET_TABLE,
+        job_config=bigquery.LoadJobConfig(
+            create_disposition="CREATE_NEVER",
+            write_disposition="WRITE_APPEND",
+            schema=[
+                {"name": "submission_date", "type": "DATE", "mode": "NULLABLE"},
+                {"name": "url", "type": "STRING", "mode": "NULLABLE"},
+                {"name": "chrome_extension_name", "type": "STRING", "mode": "NULLABLE"},
+                {"name": "star_rating", "type": "NUMERIC", "mode": "NULLABLE"},
+                {"name": "number_of_ratings", "type": "STRING", "mode": "NULLABLE"},
+                {"name": "number_of_users", "type": "STRING", "mode": "NULLABLE"},
+            ],
+            skip_leading_rows=1,
+            source_format=bigquery.SourceFormat.CSV,
+        ),
+    )
+
+    load_csv_to_gcp_job.result()
+
 
 if __name__ == "__main__":
     main()

--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
@@ -1,0 +1,252 @@
+#Load libraries
+import pandas as pd
+import numpy as np
+from datetime import datetime
+import requests
+from bs4 import BeautifulSoup
+import re
+import os
+from google.cloud import bigquery
+
+#Main website for Chrome Webstore
+CHROME_WEBSTORE_URL = "https://chromewebstore.google.com"
+
+#Links to ignore from the Chrome Webstore page
+LIST_OF_LINKS_TO_IGNORE = ["https://chromewebstore.google.com/user/installed",
+                    "https://chrome.google.com/webstore/devconsole/",
+                    "https://www.google.com/intl/en/about/products",
+                    "https://support.google.com/chrome_webstore/answer/1047776?hl=en-US",
+                    "https://myaccount.google.com/privacypolicy?hl=en-US",
+                    "https://support.google.com/chrome_webstore?hl=en-US",
+                    "https://ssl.gstatic.com/chrome/webstore/intl/en-US/gallery_tos.html",
+                    "./"]
+
+
+TARGET_PROJECT = "moz-fx-data-shared-prod"
+TARGET_TABLE = "moz-fx-data-shared-prod.external_derived.chrome_extensions_v1"
+GCS_BUCKET = "gs://moz-fx-data-prod-external-data/"
+RESULTS_FPATH = "CHROME_EXTENSIONS/chrome_extensions_%s.csv"
+TIMEOUT_IN_SECONDS = 10
+
+# Function to get all unique links found on a given webpage
+def get_unique_links_from_webpage(url, timeout_seconds, links_to_ignore):
+    """ Input: Webpage, timeout seconds (integer)
+      Output: List of unique links on that page"""
+
+    response = requests.get(url, timeout=timeout_seconds)
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    links = [a['href'] for a in soup.find_all('a', href=True)]
+    unique_links = []
+    for link in links:
+        if link not in unique_links and link not in links_to_ignore:
+            if link.startswith("./"):
+                link_without_period_at_front = re.sub(r"^\.", "", link)
+                link = url + link_without_period_at_front
+            unique_links.append(link)
+    return unique_links
+
+
+# Function to get the soup returned from a given page
+def get_soup_from_webpage(webpage_url, timeout_seconds):
+    """ Input: Webpage URL, timeout
+        Output: BeautifulSoup class"""
+    response=requests.get(webpage_url, timeout=timeout_seconds)
+    soup_from_webpage = BeautifulSoup(response.text, "html.parser")
+    return soup_from_webpage
+
+# Function to get all paragraphs from a soup
+def get_paragraphs_from_soup(webpage_soup):
+    """ Input: Webpage Soup
+        Output: List of paragraphs found in the soup"""
+    paragraphs = [p.text for p in webpage_soup.find_all('p')]
+    return paragraphs
+
+def get_h1_headers_from_soup(webpage_soup):
+    """ Input: Webpage Soup
+        Output: List of H1 Elements Found"""
+    headers = [h1.text for h1 in webpage_soup.find_all('h1')]
+    return headers
+
+def get_h2_headers_from_soup(webpage_soup):
+    """ Input: Webpage Soup
+        Output: List of H2 Elements Found
+    """
+    headers = [h2.text for h2 in webpage_soup.find_all('h2')]
+    return headers
+
+def get_divs_from_soup(webpage_soup):
+    """ Input: Webpage Soup
+        Output: List of H2 Elements Found
+    """
+    divs = [div.text for div in webpage_soup.find_all('div')]
+    return divs
+
+def initialize_results_df():
+    """ Returns a dataframe with 0 rows with the desired format"""
+    results_df = pd.DataFrame(columns=['submission_date',
+                                      'url',
+                                      'chrome_extension_name',
+                                      'star_rating',
+                                      'number_of_ratings',
+                                      'number_of_users'])
+    return results_df
+
+
+def check_if_detail_or_non_detail_page(url):
+    """ Input: A URL (string)
+        Output: Boolean, indicating if the URL contains /detail/ in it"""
+    detail_page = False
+    if "/detail/" in url:
+        detail_page = True
+    return detail_page
+
+
+def pull_data_from_detail_page(url, timeout_limit, current_date):
+    """ Input: URL, timeout limit (integer), and current date"""
+    ##Initialize as empty strings
+    number_of_ratings = 'NOT FOUND'
+    chrome_extension_name = 'NOT FOUND'
+    star_rating = 'NOT FOUND'
+    number_of_users = 'NOT FOUND'
+
+    #Get the soup from the current link
+    current_link_soup = get_soup_from_webpage(webpage_url=url,
+                                              timeout_seconds=timeout_limit)
+    
+    #Get paragraphs & headers from the current link
+    paragraphs_from_current_link_soup = get_paragraphs_from_soup(current_link_soup)
+    headers_from_current_link_soup = get_h1_headers_from_soup(current_link_soup)
+    h2_headers_from_current_link_soup = get_h2_headers_from_soup(current_link_soup)
+    divs_from_current_link_soup = get_divs_from_soup(current_link_soup)
+
+    #Get the number of ratings
+    for paragraph in paragraphs_from_current_link_soup:
+        #Check if this has the ratings information
+        if paragraph.endswith('ratings'):
+            #Get portion before the space
+            number_of_ratings = paragraph.split(" ")[0]
+
+    #Get the extension name
+    for header in headers_from_current_link_soup:
+        chrome_extension_name = header
+
+    #Get the star rating
+    for h2_header in h2_headers_from_current_link_soup:
+        if 'out of 5' in h2_header:
+            pattern = r"^.*?out of 5"
+            match = re.search(pattern, h2_header)
+            if match:
+              star_rating = match.group(0).split(" ")[0]
+
+    #Get the number of users
+    for div in divs_from_current_link_soup:
+        if ' users' in div:
+            pattern = r"(\d{1,3}(?:,\d{3})*|\d+) (?=users)"
+            match = re.search(pattern, div)   
+            if match:
+              number_of_users = match.group(0).split(" ")[0].replace(",", "")
+
+    #Put the results into a dataframe
+    curr_link_results_df = pd.DataFrame({'submission_date':[current_date],
+                                        'url': [url],
+                                        'chrome_extension_name':[chrome_extension_name],
+                                        'star_rating':[star_rating],
+                                        'number_of_ratings':[number_of_ratings],
+                                        'number_of_users':[number_of_users]})
+    
+    return curr_link_results_df
+
+def main():
+    #Get today's date
+    curr_date = datetime.today().strftime('%Y-%m-%d')
+
+    #First, get a list of all the unique links from the Chrome webstore page
+    #Excluding those on the list of links to ignore list
+    unique_links_on_chrome_webstore_page = get_unique_links_from_webpage(url=CHROME_WEBSTORE_URL,
+                                                                       timeout_seconds=TIMEOUT_IN_SECONDS,
+                                                                       links_to_ignore=LIST_OF_LINKS_TO_IGNORE)
+    #Initialize a dataframe to store extension level results
+    results_df = initialize_results_df()
+
+    #Next, loop through the links found on the main page of the Chrome Webstore
+    for idx, current_link in enumerate(unique_links_on_chrome_webstore_page):
+        #Print the link # and the link URL
+        print('idx: ', str(idx))
+        print('current_link: ', str(current_link))
+
+        #Check if the link is a "detail page" or a "non detail page"
+        #Note - info about extensions are only found on detail pages
+        is_detail_page = check_if_detail_or_non_detail_page(current_link)
+        print('is_detail_page: ', str(is_detail_page))
+
+        #If the link is a detail page
+        if is_detail_page:
+          #Get the data from that page
+          detail_page_results_df = pull_data_from_detail_page(url=current_link, 
+                                                              timeout_limit=TIMEOUT_IN_SECONDS, 
+                                                              current_date=curr_date)
+          
+          #Append the data scraped to results_df
+          results_df = pd.concat([results_df, detail_page_results_df])
+            
+        #If this is not a detail page
+        else:
+          #Get the links on this page
+          unique_links_on_non_detail_page = get_unique_links_from_webpage(url=current_link,
+                                                                          timeout_seconds=TIMEOUT_IN_SECONDS,
+                                                                          links_to_ignore=LIST_OF_LINKS_TO_IGNORE)
+          ### TO DO - FIX BELOW 
+          # #Loop through each link on this page
+          # for link_on_non_detail_page in unique_links_on_non_detail_page:
+          #     print(link_on_non_detail_page)
+          #     #Check if it's a detail page link or not
+          #     is_detail_page = check_if_detail_or_non_detail_page(link_on_non_detail_page)
+          #     print('is_detail_page: ',str(is_detail_page))
+
+          #     #If it's a detail page, record results
+          #     if is_detail_page:
+          #       #Get the data from that page
+          #       detail_page_results_df = pull_data_from_detail_page()
+          #       #Append the data scraped to results_df
+          #       results_df = pd.concat([results_df, detail_page_results_df])
+          #     else:
+          #         print('not checking, 2nd layer deep')
+
+          
+          
+    print('FINAL RESULTS DATAFRAME')
+    print(results_df)        
+
+
+
+    
+      
+    # #Write data to CSV in GCS
+    # final_results_fpath = GCS_BUCKET + RESULTS_FPATH % (curr_date)
+
+
+    # #Write data to BQ table
+    # # Open a connection to BQ
+    # client = bigquery.Client(TARGET_PROJECT)
+
+    # # Load data from GCS to BQ table - appending to what is already there
+    # load_csv_to_gcp_job = client.load_table_from_uri(
+    #     fpath,
+    #     TARGET_TABLE,
+    #     job_config=bigquery.LoadJobConfig(
+    #         create_disposition="CREATE_NEVER",
+    #         write_disposition="WRITE_APPEND",
+    #         schema=[
+    #             {"name": "location_id", "type": "INTEGER", "mode": "NULLABLE"},
+    #         ],
+    #         skip_leading_rows=1,
+    #         source_format=bigquery.SourceFormat.CSV,
+    #     ),
+    # )
+
+    # load_csv_to_gcp_job.result()
+   
+
+if __name__ == "__main__":
+    main()

--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/schema.yaml
@@ -1,0 +1,25 @@
+fields:
+- name: submission_date
+  mode: NULLABLE
+  type: DATE
+  description: Submission Date
+- name: url
+  mode: NULLABLE
+  type: STRING
+  description: Chrome Extension URL
+- name: chrome_extension_name
+  mode: NULLABLE
+  type: STRING
+  description: Chrome Extension Name
+- name: star_rating
+  mode: NULLABLE
+  type: NUMERIC
+  description: Star Rating
+- name: number_of_ratings
+  mode: NULLABLE
+  type: STRING
+  description: Number of Ratings
+- name: number_of_users
+  mode: NULLABLE
+  type: STRING
+  description: Number of Users


### PR DESCRIPTION
## Description
This PR pulls Chrome extension data from the Chrome webstore and loads into the following table and corresponding view:
- moz-fx-data-shared-prod.external_derived.chrome_extensions_v1
- moz-fx-data-shared-prod.external.chrome_extensions

It also creates a new DAG `bqetl_chrome_extensions_scraper` that only runs weekly since this data doesn't change very often.

## Related Tickets & Documents
* [DENG-7788](https://mozilla-hub.atlassian.net/browse/DENG-7788)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7788]: https://mozilla-hub.atlassian.net/browse/DENG-7788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ