### PR TITLE
DENG-7788: Don't require a partition filter

### DIFF
--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/metadata.yaml
@@ -13,7 +13,7 @@ bigquery:
   time_partitioning:
     type: day
     field: submission_date
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: null
   range_partitioning: null
 references: {}

--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
@@ -267,7 +267,6 @@ def main():
     client = bigquery.Client(TARGET_PROJECT)
 
     # If data already ran for this date, delete out
-    # Delete any data already in table for same year so we don't end up with duplicates
     delete_query = f"""DELETE FROM `moz-fx-data-shared-prod.external_derived.chrome_extensions_v1`
   WHERE submission_date = '{logical_dag_date_string}'"""
     del_job = client.query(delete_query)


### PR DESCRIPTION
## Description

This PR removes the partition filter requirement for queries since this only runs weekly (so won't always have data for every day) and since it's a very small table.

## Related Tickets & Documents
* [DENG-7788](https://mozilla-hub.atlassian.net/browse/DENG-7788)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
