### PR TITLE
feat(DENG-7987): Create fxa_accounts_linked_clients_ordered_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/fx_accounts_linked_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_accounts_linked_clients/view.sql
@@ -5,10 +5,6 @@ SELECT
   client_id,
   linked_client_id,
   linkage_first_seen_date,
-  linkage_last_seen_date,
-  client_id_first_seen_date,
-  linked_client_id_first_seen_date,
-  client_id_last_seen_date,
-  linked_client_id_last_seen_date
+  linkage_last_seen_date
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.fx_accounts_linked_clients_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_accounts_linked_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_accounts_linked_clients/view.sql
@@ -2,6 +2,13 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.fx_accounts_linked_clients`
 AS
 SELECT
-  *
+  client_id,
+  linked_client_id,
+  linkage_first_seen_date,
+  linkage_last_seen_date,
+  client_id_first_seen_date,
+  linked_client_id_first_seen_date,
+  client_id_last_seen_date,
+  linked_client_id_last_seen_date
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.fx_accounts_linked_clients_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_accounts_linked_clients_ordered/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_accounts_linked_clients_ordered/view.sql
@@ -1,55 +1,7 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.fx_accounts_linked_clients_ordered`
 AS
-WITH first_seen_date_by_glean_client_id AS (
-  SELECT
-    client_id,
-    MIN(first_seen_date) AS first_seen_date
-  FROM
-    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_first_seen`
-  WHERE
-    submission_date <= CURRENT_DATE
-  GROUP BY
-    client_id
-),
-fxa_linked_plus_fsd AS (
-  SELECT
-    a.client_id,
-    a.linked_client_id,
-    a.linkage_first_seen_date,
-    a.linkage_last_seen_date,
-    b.first_seen_date AS client_id_first_seen_date,
-    c.first_seen_date AS linked_client_id_first_seen_date
-  FROM
-    `moz-fx-data-shared-prod.telemetry_derived.fx_accounts_linked_clients_v1` a
-  LEFT JOIN
-    first_seen_date_by_glean_client_id b
-    ON a.client_id = b.client_id
-  LEFT JOIN
-    first_seen_date_by_glean_client_id c
-    ON a.linked_client_id = c.client_id
-)
---re-order so client ID has a first seen date less than or equal to linked client ID
 SELECT
-  client_id,
-  linked_client_id,
-  linkage_first_seen_date,
-  linkage_last_seen_date,
-  client_id_first_seen_date,
-  linked_client_id_first_seen_date
+  *
 FROM
-  fxa_linked_plus_fsd
-WHERE
-  client_id_first_seen_date <= linked_client_id_first_seen_date
-UNION ALL
-SELECT
-  linked_client_id AS client_id,
-  client_id AS linked_client_id,
-  linkage_first_seen_date,
-  linkage_last_seen_date,
-  linked_client_id_first_seen_date AS client_id_first_seen_date,
-  client_id_first_seen_date AS linked_client_id_first_seen_date
-FROM
-  fxa_linked_plus_fsd
-WHERE
-  client_id_first_seen_date > linked_client_id_first_seen_date
+  `moz-fx-data-shared-prod.telemetry_derived.fx_accounts_linked_clients_ordered_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_accounts_linked_clients_ordered/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_accounts_linked_clients_ordered/view.sql
@@ -2,6 +2,13 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.fx_accounts_linked_clients_ordered`
 AS
 SELECT
-  *
+  client_id,
+  linked_client_id,
+  linkage_first_seen_date,
+  linkage_last_seen_date,
+  client_id_first_seen_date,
+  linked_client_id_first_seen_date,
+  client_id_last_seen_date,
+  linked_client_id_last_seen_date
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.fx_accounts_linked_clients_ordered_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   owner1: kwindau
 scheduling:
   dag_name: bqetl_client_attributes
+  depends_on_past: true
   date_partition_parameter: null
   parameters: ["submission_date:DATE:{{ds}}"]
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/metadata.yaml
@@ -1,0 +1,16 @@
+friendly_name: Firefox Accounts Linked Clients Ordered
+description: |-
+  Table overwrites daily with latest information, orders clients by first seen date
+  Client ID with the smaller first seen date is client ID
+  Client ID with the larger first seen date is linked client ID
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_client_attributes
+  date_partition_parameter: null
+  parameters: ["submission_date:DATE:{{ds}}"]
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/query.sql
@@ -10,16 +10,17 @@ WITH first_seen_date_by_glean_client_id AS (
     client_id
 ),
 last_seen_date_by_glean_client_id AS (
-  SELECT 
+  SELECT
     client_id,
     MAX(submission_date) AS last_seen_date
-  FROM 
-    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_daily`
-  WHERE 
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_last_seen`
+  WHERE
     days_since_seen = 0
     AND submission_date <= @submission_date
-  GROUP BY client_id
-)
+  GROUP BY
+    client_id
+),
 fxa_linked_plus_fsd AS (
   SELECT
     a.client_id,
@@ -38,10 +39,10 @@ fxa_linked_plus_fsd AS (
   LEFT JOIN
     first_seen_date_by_glean_client_id c
     ON a.linked_client_id = c.client_id
-  LEFT JOIN 
-    last_seen_date_by_glean_client_id d 
-    ON a.client_id = d.client_id 
-  LEFT JOIN 
+  LEFT JOIN
+    last_seen_date_by_glean_client_id d
+    ON a.client_id = d.client_id
+  LEFT JOIN
     last_seen_date_by_glean_client_id e
     ON a.linked_client_id = e.client_id
 )

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/query.sql
@@ -1,0 +1,75 @@
+WITH first_seen_date_by_glean_client_id AS (
+  SELECT
+    client_id,
+    MIN(first_seen_date) AS first_seen_date
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_first_seen`
+  WHERE
+    submission_date <= @submission_date
+  GROUP BY
+    client_id
+),
+last_seen_date_by_glean_client_id AS (
+  SELECT 
+    client_id,
+    MAX(submission_date) AS last_seen_date
+  FROM 
+    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_daily`
+  WHERE 
+    days_since_seen = 0
+    AND submission_date <= @submission_date
+  GROUP BY client_id
+)
+fxa_linked_plus_fsd AS (
+  SELECT
+    a.client_id,
+    a.linked_client_id,
+    a.linkage_first_seen_date,
+    a.linkage_last_seen_date,
+    b.first_seen_date AS client_id_first_seen_date,
+    c.first_seen_date AS linked_client_id_first_seen_date,
+    d.last_seen_date AS client_id_last_seen_date,
+    e.last_seen_date AS linked_client_id_last_seen_date
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.fx_accounts_linked_clients_v1` a
+  LEFT JOIN
+    first_seen_date_by_glean_client_id b
+    ON a.client_id = b.client_id
+  LEFT JOIN
+    first_seen_date_by_glean_client_id c
+    ON a.linked_client_id = c.client_id
+  LEFT JOIN 
+    last_seen_date_by_glean_client_id d 
+    ON a.client_id = d.client_id 
+  LEFT JOIN 
+    last_seen_date_by_glean_client_id e
+    ON a.linked_client_id = e.client_id
+)
+--re-order so client ID has a first seen date less than or equal to linked client ID
+SELECT
+  client_id,
+  linked_client_id,
+  linkage_first_seen_date,
+  linkage_last_seen_date,
+  client_id_first_seen_date,
+  linked_client_id_first_seen_date,
+  client_id_last_seen_date,
+  linked_client_id_last_seen_date
+FROM
+  fxa_linked_plus_fsd
+WHERE
+  client_id_first_seen_date <= linked_client_id_first_seen_date
+UNION ALL
+SELECT
+  linked_client_id AS client_id,
+  client_id AS linked_client_id,
+  linkage_first_seen_date,
+  linkage_last_seen_date,
+  linked_client_id_first_seen_date AS client_id_first_seen_date,
+  client_id_first_seen_date AS linked_client_id_first_seen_date,
+  linked_client_id_last_seen_date AS client_id_last_seen_date,
+  client_id_last_seen_date AS linked_client_id_last_seen_date
+FROM
+  fxa_linked_plus_fsd
+WHERE
+  client_id_first_seen_date > linked_client_id_first_seen_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/query.sql
@@ -14,10 +14,9 @@ last_seen_date_by_glean_client_id AS (
     client_id,
     MAX(submission_date) AS last_seen_date
   FROM
-    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_last_seen`
+    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_daily`
   WHERE
-    days_since_seen = 0
-    AND submission_date <= @submission_date
+    submission_date <= @submission_date
   GROUP BY
     client_id
 ),

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/schema.yaml
@@ -1,0 +1,33 @@
+fields:
+- mode: NULLABLE
+  name: client_id
+  type: STRING
+  description: The client ID with the earlier first_seen_date
+- mode: NULLABLE
+  name: linked_client_id
+  type: STRING
+  description: The client ID with the later first_seen_date
+- mode: NULLABLE
+  name: linkage_first_seen_date
+  type: DATE
+  description: Date of when a client ID and linked client ID are first detected to be using the same account ID
+- mode: NULLABLE
+  name: linkage_last_seen_date
+  type: DATE
+  description: Date of when a client ID and linked client ID are last detected to be using the same account ID
+- mode: NULLABLE
+  name: client_id_first_seen_date
+  type: DATE
+  description: The first_seen_date of the client_id
+- mode: NULLABLE
+  name: linked_client_id_first_seen_date
+  type: DATE
+  description: The first_seen_date of the linked_client_id
+- mode: NULLABLE
+  name: client_id_last_seen_date
+  type: DATE
+  description: The last_seen_date of the client_id
+- mode: NULLABLE
+  name: linked_client_id_last_seen_date
+  type: DATE
+  description: The last_seen_date of the linked_client_id


### PR DESCRIPTION
## Description

This PR physicalizes a view that was a bit slow and makes it a table that over-writes daily in full.
It also adds 2 new columns (last seen date for each client ID)

Note - the reason it does a full overwrite is because one of the tables is built on top of a merge statement, so it's not built incrementally.

New table:
- `moz-fx-data-shared-prod.telemetry_derived.fx_accounts_linked_clients_ordered_v1`

Updated view now does a direct pull from the new table:
- `moz-fx-data-shared-prod.telemetry.fx_accounts_linked_clients_ordered`

## Related Tickets & Documents
* [DENG-7987](https://mozilla-hub.atlassian.net/browse/DENG-7987)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7987]: https://mozilla-hub.atlassian.net/browse/DENG-7987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ