### PR TITLE
feat(DENG-7982): Add new table fx_accounts_linked_clients_ordered_v1 to shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -279,6 +279,10 @@ DELETE_TARGETS: DeleteIndex = {
         field=(CLIENT_ID, "linked_client_id"),
     ): (DESKTOP_GLEAN_SRC, DESKTOP_GLEAN_SRC),
     DeleteTarget(
+        table="telemetry_derived.fx_accounts_linked_clients_ordered_v1",
+        field=(CLIENT_ID, "linked_client_id"),
+    ): (DESKTOP_GLEAN_SRC, DESKTOP_GLEAN_SRC),
+    DeleteTarget(
         table="telemetry_derived.rolling_cohorts_v2",
         field=(CLIENT_ID,) * 15,
     ): (

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_ordered_v1/metadata.yaml
@@ -6,8 +6,8 @@ description: |-
 owners:
 - kwindau@mozilla.com
 labels:
-  incremental: true
   owner1: kwindau
+  table_type: client_level
 scheduling:
   dag_name: bqetl_client_attributes
   depends_on_past: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_linked_clients_v1/metadata.yaml
@@ -4,7 +4,6 @@ description: |-
 owners:
 - kwindau@mozilla.com
 labels:
-  incremental: true
   owner1: kwindau
   depends_on_past: true
   table_type: client_level


### PR DESCRIPTION
## Description

This PR adds a new table to shredder
- `moz-fx-data-shared-prod.telemetry_derived.fx_accounts_linked_clients_ordered_v1`

It also updates labels on 2 tables:
* It removes the incremental labels on both `fx_accounts_linked_clients_v1` and `fx_accounts_linked_clients_ordered_v1`
* It adds table_type: client_level label to `fx_accounts_linked_clients_ordered_v1`

(I already redeployed the tables with the updated labels, this is just making the files match)


## Related Tickets & Documents
* [DENG-7982](https://mozilla-hub.atlassian.net/browse/DENG-7982)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7982]: https://mozilla-hub.atlassian.net/browse/DENG-7982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ