### PR TITLE
make app_acquisitions and app_installs query.py files match app_conve…

### DIFF
--- a/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/microsoft_derived/app_installs_v1/query.py
@@ -3,6 +3,7 @@
 import csv
 import json
 import os
+import re
 import tempfile
 from argparse import ArgumentParser
 from time import sleep
@@ -57,6 +58,12 @@ def read_json(filename: str) -> dict:
     with open(filename, "r") as f:
         data = json.loads(f.read())
     return data
+
+
+def change_null_to_string(json_string):
+    """Change null values in downloaded json string to string."""
+    none_string = re.sub("null", '"null"', json_string)
+    return none_string
 
 
 def write_dict_to_csv(json_data, filename):
@@ -210,8 +217,10 @@ def main():
         print(f'This is data for {app["app_name"]} - {app["app_id"]} for ', date)
         # Ping the microsoft_store URL and get a response
         json_file = download_microsoft_store_data(date, app["app_id"], bearer_token)
-        query_export = check_json(json_file.text)
-        if query_export is not None:
+        # Nulls need to be changed from a null type to a string type null.
+        json_none_string = change_null_to_string(json_file.text)
+        query_export = eval(json_none_string)
+        if query_export["Value"]:
             # This section writes the tmp json data into a temp CSV file which will then be put into a BigQuery table
             microsoft_store_data = clean_json(query_export, date)
             data.extend(microsoft_store_data)


### PR DESCRIPTION
…rsions query.py

## Description
On occasion, app_conversions job fails, but then re-runs. This might be happening when no data is available. On occasion, app_installs query.py runs, no data is acquired at the time of running, but the job succeds and no data is put into BigQuery.

This PR fixes app_installs and app_acquisitions query.py files to make them match app_conversions' query.py file. This will hopefully match what happens with app_conversions (occasional fails when data is not available and a re-run of the Airflow job to ensure data will be grabbed and put into BigQuery.


## Related Tickets & Documents
* DENG-2631
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
