### PR TITLE
feat: add backfill.yaml for usage_reporting_active_users_aggregates fx ios, fenix, desktop, focus android and ios

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,0 +1,8 @@
+2025-03-19:
+  start_date: 2025-03-01
+  end_date: 2025-03-19
+  reason: Initial backfill
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-03-19:
+2025-04-03:
   start_date: 2025-03-01
-  end_date: 2025-03-19
+  end_date: 2025-04-03
   reason: Initial backfill
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,0 +1,8 @@
+2025-03-19:
+  start_date: 2025-03-01
+  end_date: 2025-03-19
+  reason: Initial backfill
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-03-19:
+2025-04-03:
   start_date: 2025-03-01
-  end_date: 2025-03-19
+  end_date: 2025-04-03
   reason: Initial backfill
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,0 +1,8 @@
+2025-03-19:
+  start_date: 2025-03-01
+  end_date: 2025-03-19
+  reason: Initial backfill
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-03-19:
+2025-04-03:
   start_date: 2025-03-01
-  end_date: 2025-03-19
+  end_date: 2025-04-03
   reason: Initial backfill
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,0 +1,8 @@
+2025-03-19:
+  start_date: 2025-03-01
+  end_date: 2025-03-19
+  reason: Initial backfill
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-03-19:
+2025-04-03:
   start_date: 2025-03-01
-  end_date: 2025-03-19
+  end_date: 2025-04-03
   reason: Initial backfill
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/focus_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,0 +1,8 @@
+2025-03-19:
+  start_date: 2025-03-01
+  end_date: 2025-03-19
+  reason: Initial backfill
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/focus_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-03-19:
+2025-04-03:
   start_date: 2025-03-01
-  end_date: 2025-03-19
+  end_date: 2025-04-03
   reason: Initial backfill
   watchers:
   - kik@mozilla.com


### PR DESCRIPTION
# feat: add backfill.yaml for usage_reporting_active_users_aggregates fx ios, fenix, desktop, focus android and ios

depends on: https://github.com/mozilla/bigquery-etl/pull/7146