### PR TITLE
[DENG-6990] Fix/optimize event monitoring live and aggregates

### DIFF
--- a/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
@@ -1,121 +1,95 @@
 -- Generated via ./bqetl generate glean_usage
+WITH
 {% for app in apps %}
 {% set outer_loop = loop -%}
 {% for dataset in app -%}
 {% if dataset['bq_dataset_family'] not in ["telemetry"]
    and dataset['bq_dataset_family'] in event_tables_per_dataset %}
-  {% if not outer_loop.first -%}
+  {% for events_table in event_tables_per_dataset[dataset['bq_dataset_family']] -%}
+    base_{{ dataset['bq_dataset_family'] }}_{{ events_table }} AS (
+      SELECT
+        submission_timestamp,
+        event.category AS event_category,
+        event.name AS event_name,
+        event_extra.key AS event_extra_key,
+        normalized_country_code AS country,
+        "{{ dataset['canonical_app_name'] }}" AS normalized_app_name,
+        client_info.app_channel AS channel,
+        client_info.app_display_version AS version,
+        -- experiments[ARRAY_LENGTH(experiments)] will be set to '*'
+        COALESCE(ping_info.experiments[SAFE_OFFSET(experiment_index)].key, '*') AS experiment,
+        COALESCE(ping_info.experiments[SAFE_OFFSET(experiment_index)].value.branch, '*') AS experiment_branch,
+      FROM
+        `{{ project_id }}.{{ dataset['bq_dataset_family'] }}_stable.{{ events_table }}`
+      CROSS JOIN
+        UNNEST(events) AS event
+      CROSS JOIN
+        -- Iterator for accessing experiments.
+        -- Add one more for aggregating events across all experiments
+        UNNEST(GENERATE_ARRAY(0, ARRAY_LENGTH(ping_info.experiments))) AS experiment_index
+      LEFT JOIN
+        UNNEST(event.extra) AS event_extra
+    ),
+  {% endfor %}
+  {{ dataset['bq_dataset_family'] }}_aggregated AS (
+    SELECT
+      @submission_date AS submission_date,
+      TIMESTAMP_ADD(
+        TIMESTAMP_TRUNC(submission_timestamp, HOUR),
+          -- Aggregates event counts over 60-minute intervals
+        INTERVAL(DIV(EXTRACT(MINUTE FROM submission_timestamp), 60) * 60) MINUTE
+      ) AS window_start,
+      TIMESTAMP_ADD(
+        TIMESTAMP_TRUNC(submission_timestamp, HOUR),
+        INTERVAL((DIV(EXTRACT(MINUTE FROM submission_timestamp), 60) + 1) * 60) MINUTE
+      ) AS window_end,
+      * EXCEPT (submission_timestamp),
+      COUNT(*) AS total_events,
+    FROM
+      (
+        {% for events_table in event_tables_per_dataset[dataset['bq_dataset_family']] -%}
+          SELECT
+            *
+          FROM
+            base_{{ dataset['bq_dataset_family'] }}_{{ events_table }}
+          {{ "UNION ALL" if not loop.last }}
+        {% endfor -%}
+      )
+    WHERE
+      DATE(submission_timestamp) = @submission_date
+    GROUP BY
+      submission_date,
+      window_start,
+      window_end,
+      event_category,
+      event_name,
+      event_extra_key,
+      country,
+      normalized_app_name,
+      channel,
+      version,
+      experiment,
+      experiment_branch
+  )
+  {% if not outer_loop.last -%}
+  ,
+  {% endif -%}
+{% endif %}
+{% endfor %}
+{% endfor %}
+
+{% for app in apps %}
+{% set outer_loop = loop -%}
+{% for dataset in app -%}
+{% if dataset['bq_dataset_family'] not in ["telemetry"]
+   and dataset['bq_dataset_family'] in event_tables_per_dataset %}
+  SELECT
+    *
+  FROM
+    {{ dataset['bq_dataset_family'] }}_aggregated
+  {% if not outer_loop.last -%}
   UNION ALL
   {% endif -%}
-  SELECT
-    @submission_date AS submission_date,
-    TIMESTAMP_ADD(
-      TIMESTAMP_TRUNC(submission_timestamp, HOUR),
-    -- Aggregates event counts over 60-minute intervals
-      INTERVAL(
-        DIV(
-          EXTRACT(MINUTE FROM submission_timestamp),
-          60
-        ) * 60
-      ) MINUTE
-    ) AS window_start,
-    TIMESTAMP_ADD(
-      TIMESTAMP_TRUNC(submission_timestamp, HOUR),
-      INTERVAL(
-        (
-          DIV(
-            EXTRACT(MINUTE FROM submission_timestamp),
-            60
-          ) + 1
-        ) * 60
-      ) MINUTE
-    ) AS window_end,
-    event.category AS event_category,
-    event.name AS event_name,
-    event_extra.key AS event_extra_key,
-    normalized_country_code AS country,
-    "{{ dataset['canonical_app_name'] }}" AS normalized_app_name,
-    channel,
-    version,
-    -- Access experiment information.
-    -- Additional iteration is necessary to aggregate total event count across experiments
-    -- which is denoted with "*".
-    -- Some clients are enrolled in multiple experiments, so simply summing up the totals
-    -- across all the experiments would double count events.
-    CASE
-      experiment_index
-    WHEN
-      ARRAY_LENGTH(ping_info.experiments)
-    THEN
-      "*"
-    ELSE
-      ping_info.experiments[SAFE_OFFSET(experiment_index)].key
-    END AS experiment,
-    CASE
-      experiment_index
-    WHEN
-      ARRAY_LENGTH(ping_info.experiments)
-    THEN
-      "*"
-    ELSE
-      ping_info.experiments[SAFE_OFFSET(experiment_index)].value.branch
-    END AS experiment_branch,
-    COUNT(*) AS total_events
-  FROM (
-    {% for events_table in event_tables_per_dataset[dataset['bq_dataset_family']] -%}
-    SELECT
-      submission_timestamp,
-      events,
-      normalized_country_code,
-      client_info.app_channel AS channel,
-      client_info.app_display_version AS version,
-      STRUCT (
-        ping_info.end_time,
-        ARRAY(
-          SELECT AS STRUCT
-            key,
-            STRUCT(
-              value.branch,
-              STRUCT(
-                value.extra.type,
-                value.extra.enrollment_id
-              ) AS extra
-            ) AS value
-          FROM
-            UNNEST(ping_info.experiments)
-        ) AS experiments,
-        ping_info.ping_type,
-        ping_info.seq,
-        ping_info.start_time,
-        ping_info.reason
-      ) AS ping_info,
-    FROM
-      `{{ project_id }}.{{ dataset['bq_dataset_family'] }}_stable.{{ events_table }}`
-    {{ "UNION ALL" if not loop.last }}
-    {% endfor -%}
-  )
-  CROSS JOIN
-    UNNEST(events) AS event,
-    -- Iterator for accessing experiments.
-    -- Add one more for aggregating events across all experiments
-    UNNEST(GENERATE_ARRAY(0, ARRAY_LENGTH(ping_info.experiments))) AS experiment_index
-  LEFT JOIN
-    UNNEST(event.extra) AS event_extra
-  WHERE
-    DATE(submission_timestamp) = @submission_date
-  GROUP BY
-    submission_date,
-    window_start,
-    window_end,
-    event_category,
-    event_name,
-    event_extra_key,
-    country,
-    normalized_app_name,
-    channel,
-    version,
-    experiment,
-    experiment_branch
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
@@ -5,101 +5,59 @@ IF
   CLUSTER BY channel, event_category, event_name
   OPTIONS
     (enable_refresh = TRUE, refresh_interval_minutes = 60) AS
+    WITH
+    {% for events_table in events_tables -%}
+      base_{{ events_table }} AS (
+        SELECT
+          submission_timestamp,
+          event.category AS event_category,
+          event.name AS event_name,
+          event_extra.key AS event_extra_key,
+          normalized_country_code AS country,
+          '{{ app_name }}' AS normalized_app_name,
+          client_info.app_channel AS channel,
+          client_info.app_display_version AS version,
+          -- experiments[ARRAY_LENGTH(experiments)] will be set to '*'
+          COALESCE(ping_info.experiments[SAFE_OFFSET(experiment_index)].key, '*') AS experiment,
+          COALESCE(ping_info.experiments[SAFE_OFFSET(experiment_index)].value.branch, '*') AS experiment_branch,
+        FROM
+          `{{ project_id }}.{{ dataset }}_live.{{ events_table }}`
+        CROSS JOIN
+          UNNEST(events) AS event
+        CROSS JOIN
+          -- Iterator for accessing experiments.
+          -- Add one more for aggregating events across all experiments
+          UNNEST(GENERATE_ARRAY(0, ARRAY_LENGTH(ping_info.experiments))) AS experiment_index
+        LEFT JOIN
+          UNNEST(event.extra) AS event_extra
+      ){{ "," if not loop.last }}
+    {% endfor -%},
+    combined AS (
+    {% for events_table in events_tables -%}
+      SELECT
+        *
+      FROM
+        base_{{ events_table }}
+      {{ "UNION ALL" if not loop.last }}
+    {% endfor -%}
+    )
+
     SELECT
       -- used for partitioning, only allows TIMESTAMP columns
       TIMESTAMP_TRUNC(submission_timestamp, DAY) AS submission_date,
       TIMESTAMP_ADD(
-        TIMESTAMP_TRUNC(submission_timestamp, HOUR),
+      TIMESTAMP_TRUNC(submission_timestamp, HOUR),
         -- Aggregates event counts over 60-minute intervals
-        INTERVAL(
-          DIV(
-            EXTRACT(MINUTE FROM submission_timestamp),
-            60
-          ) * 60
-        ) MINUTE
+        INTERVAL(DIV(EXTRACT(MINUTE FROM submission_timestamp), 60) * 60) MINUTE
       ) AS window_start,
       TIMESTAMP_ADD(
         TIMESTAMP_TRUNC(submission_timestamp, HOUR),
-        INTERVAL(
-          (
-            DIV(
-              EXTRACT(MINUTE FROM submission_timestamp),
-              60
-            ) + 1
-          ) * 60
-        ) MINUTE
+        INTERVAL((DIV(EXTRACT(MINUTE FROM submission_timestamp), 60) + 1) * 60) MINUTE
       ) AS window_end,
-      event.category AS event_category,
-      event.name AS event_name,
-      event_extra.key AS event_extra_key,
-      normalized_country_code AS country,
-      '{{ app_name }}' AS normalized_app_name,
-      channel,
-      version,
-      -- Access experiment information.
-      -- Additional iteration is necessary to aggregate total event count across experiments
-      -- which is denoted with "*".
-      -- Some clients are enrolled in multiple experiments, so simply summing up the totals
-      -- across all the experiments would double count events.
-      CASE
-        experiment_index
-      WHEN
-        ARRAY_LENGTH(ping_info.experiments)
-      THEN
-        "*"
-      ELSE
-        ping_info.experiments[SAFE_OFFSET(experiment_index)].key
-      END AS experiment,
-      CASE
-        experiment_index
-      WHEN
-        ARRAY_LENGTH(ping_info.experiments)
-      THEN
-        "*"
-      ELSE
-        ping_info.experiments[SAFE_OFFSET(experiment_index)].value.branch
-      END AS experiment_branch,
-      COUNT(*) AS total_events
-    FROM (
-      {% for events_table in events_tables -%}
-      SELECT
-        submission_timestamp,
-        events,
-        normalized_country_code,
-        client_info.app_channel AS channel,
-        client_info.app_display_version AS version,
-        STRUCT(
-          ping_info.end_time,
-          ARRAY(
-            SELECT AS STRUCT
-              key,
-              STRUCT(
-                value.branch,
-                STRUCT(
-                  value.extra.type,
-                  value.extra.enrollment_id
-                ) AS extra
-              ) AS value
-            FROM
-              UNNEST(ping_info.experiments)
-          ) AS experiments,
-          ping_info.ping_type,
-          ping_info.seq,
-          ping_info.start_time,
-          ping_info.reason
-        ) AS ping_info,
-      FROM
-      `{{ project_id }}.{{ dataset }}_live.{{ events_table }}`
-      {{ "UNION ALL" if not loop.last }}
-      {% endfor -%}
-    )
-    CROSS JOIN
-      UNNEST(events) AS event,
-      -- Iterator for accessing experiments.
-      -- Add one more for aggregating events across all experiments
-      UNNEST(GENERATE_ARRAY(0, ARRAY_LENGTH(ping_info.experiments))) AS experiment_index
-    LEFT JOIN
-      UNNEST(event.extra) AS event_extra
+      * EXCEPT (submission_timestamp),
+      COUNT(*) AS total_events,
+    FROM
+      combined
     WHERE
       DATE(submission_timestamp) >= "{{ current_date }}"
     GROUP BY


### PR DESCRIPTION
## Description

The [current event_monitoring_live definition](https://github.com/mozilla/bigquery-etl/blob/generated-sql/sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/event_monitoring_live_v1/materialized_view.sql) doesn't work because materialized views don't support array and struct constructors (added to the view in #6887).  This restructures the query so events from each ping are unnested before unioning them to avoid the initial problem.  The same thing is done to `event_monitoring_aggregates` for consistency and because I found this uses 15% less slot time.

I tested equivalence by full joining the outputs of the before and after which looks fine.  `Mozilla VPN` is the normalized name of multiple apps so it messes up the join a bit but it seems correct.

## Related Tickets & Documents
* DENG-6990

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
