### PR TITLE
feat(DENG-7931) Minor tweaks

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -86,7 +86,7 @@ bqetl_mobile_search:
   tags:
     - impact/tier_1
 
-bqetl_google_play_store_developer_reporting_api_data:
+bqetl_google_play_store:
   default_args:
     depends_on_past: false
     email:

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/checks.sql
@@ -1,2 +1,0 @@
-#fail
-{{ is_unique(["submission_date", "google_play_store_app_name", "app_version_code", "startup_type"]) }}

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/metadata.yaml
@@ -13,7 +13,7 @@ labels:
   incremental: true
   owner1: kwindau
 scheduling:
-  dag_name: bqetl_google_play_store_developer_reporting_api_data
+  dag_name: bqetl_google_play_store
   arguments: ["--date", "{{ds}}"]
   secrets:
   - deploy_target: GOOGLE_PLAY_STORE_SRVC_ACCT_INFO

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/checks.sql
@@ -1,2 +1,0 @@
-#fail
-{{ is_unique(["submission_date", "google_play_store_app_name"]) }}

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/metadata.yaml
@@ -13,7 +13,7 @@ labels:
   incremental: true
   owner1: kwindau
 scheduling:
-  dag_name: bqetl_google_play_store_developer_reporting_api_data
+  dag_name: bqetl_google_play_store
   arguments: ["--date", "{{ds}}"]
   secrets:
   - deploy_target: GOOGLE_PLAY_STORE_SRVC_ACCT_INFO


### PR DESCRIPTION
## Description

This PR is a follow up to [PR-7197](https://github.com/mozilla/bigquery-etl/pull/7197)
* It renames the DAG from `bqetl_google_play_store_developer_reporting_api_data` -> `bqetl_google_play_store`
* It also removes the 2 checks.sql files since they always fail when running via a query.py with passed in parameters.

## Related Tickets & Documents
* [DENG-7931](https://mozilla-hub.atlassian.net/browse/DENG-7931)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7931]: https://mozilla-hub.atlassian.net/browse/DENG-7931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ