### PR TITLE
feat: add a new bqetl_usage_reporting DAG and schedule usage_reporting related queries in it.

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2296,3 +2296,21 @@ bqetl_chrome_extensions_scraper:
   schedule_interval: 40 21 * * 1
   tags:
     - impact/tier_3
+
+bqetl_usage_reporting:
+  default_args:
+    depends_on_past: false
+    email:
+      - kik@mozilla.com
+      - telemetry-alerts@mozilla.com
+    email_on_failure: true
+    email_on_retry: false
+    end_date: null
+    owner: kik@mozilla.com
+    retries: 1
+    retry_delay: 30m
+    start_date: '2025-03-19'
+  description: DAG for updating usage_reporting related datasets.
+  schedule_interval: 0 4 * * *
+  tags:
+    - impact/tier_1

--- a/sql_generators/usage_reporting/templates/usage_reporting_active_users_aggregates_v1.metadata.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_active_users_aggregates_v1.metadata.yaml.jinja
@@ -11,7 +11,7 @@ labels:
   incremental: true
   schedule: daily
 scheduling:
-  dag_name: bqetl_glean_usage
+  dag_name: bqetl_usage_reporting
   task_group: {{ app_name }}
 bigquery:
   time_partitioning:

--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_daily_v1.metadata.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_daily_v1.metadata.yaml.jinja
@@ -11,7 +11,7 @@ labels:
   incremental: true
   schedule: daily
 scheduling:
-  dag_name: bqetl_glean_usage
+  dag_name: bqetl_usage_reporting
   task_group: {{ app_name }}
 bigquery:
   time_partitioning:

--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_first_seen_v1.metadata.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_first_seen_v1.metadata.yaml.jinja
@@ -10,7 +10,7 @@ labels:
   incremental: true
   schedule: daily
 scheduling:
-  dag_name: bqetl_glean_usage
+  dag_name: bqetl_usage_reporting
   task_group: {{ app_name }}
 bigquery:
   time_partitioning:

--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_last_seen_v1.metadata.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_last_seen_v1.metadata.yaml.jinja
@@ -10,7 +10,7 @@ labels:
   incremental: true
   schedule: daily
 scheduling:
-  dag_name: bqetl_glean_usage
+  dag_name: bqetl_usage_reporting
   task_group: {{ app_name }}
 bigquery:
   time_partitioning:


### PR DESCRIPTION
# feat: add a new bqetl_usage_reporting DAG and schedule usage_reporting related queries in it.

For a less cluttered job and avoid mixing with more broader glean related materialization tasks.