### PR TITLE
feat(DENG-7931): Add # distinct users to slow_startup_events_by_startup_type_and_version

### DIFF
--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
@@ -150,6 +150,7 @@ def main():
             version_code = None
             startup_type = None
             distinct_users = None
+            slow_startup_pct = None
 
             for dimension in row["dimensions"]:
                 if dimension["dimension"] == "startType":

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
@@ -160,9 +160,7 @@ def main():
 
             for metric in row["metrics"]:
                 if metric["metric"] == "slowStartRate":
-                    slow_startup_pct = row["metrics"][0]["decimalValue"][
-                        "value"
-                    ]  ## FIX
+                    slow_startup_pct = metric["decimalValue"]["value"]
                 if metric["metric"] == "distinctUsers":
                     distinct_users = metric["decimalValue"]["value"]
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
@@ -152,7 +152,6 @@ def main():
             distinct_users = None
 
             for dimension in row["dimensions"]:
-
                 if dimension["dimension"] == "startType":
                     startup_type = dimension["stringValue"]
                 if dimension["dimension"] == "versionCode":

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/schema.yaml
@@ -19,3 +19,7 @@ fields:
   type: NUMERIC
   mode: NULLABLE
   description: The percent of unique users with a slow start event during the app start
+- name: nbr_distinct_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Distinct Users


### PR DESCRIPTION
## Description

This PR adds a new column, `nbr_distinct_users` to the table:
- moz-fx-data-shared-prod.google_play_store_derived.slow_startup_events_by_startup_type_and_version_v1

## Related Tickets & Documents
* [DENG-7931](https://mozilla-hub.atlassian.net/browse/DENG-7931)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-7931]: https://mozilla-hub.atlassian.net/browse/DENG-7931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ