### PR TITLE
feat: Disable monitoring (Bigeye metrics) for focus_ios, klar_ios, focus_android, and klar_android (telemetry changes).

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -372,6 +372,10 @@ generate:
       - moso_mastodon_backend
       - mozphab
       - mozregression
+      - focus_android
+      - klar_android
+      - focus_ios
+      - klar_ios
       skip_app_metrics:
       - thunderbird_desktop
     bqetl_checks:


### PR DESCRIPTION
# feat: Disable monitoring (Bigeye metrics) for focus_ios, klar_ios, focus_android, and klar_android (telemetry changes).

