### PR TITLE
[DENG-6990] Add manual refresh for firefox_desktop_derived.event_moni…

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2314,3 +2314,24 @@ bqetl_usage_reporting:
   schedule_interval: 0 4 * * *
   tags:
     - impact/tier_1
+
+bqetl_materialized_view_refresh:
+  catchup: false
+  default_args:
+    depends_on_past: false
+    email:
+      - telemetry-alerts@mozilla.com
+      - bewu@mozilla.com
+    email_on_failure: true
+    email_on_retry: true
+    end_date: null
+    owner: bewu@mozilla.com
+    retries: 1
+    retry_delay: 5m
+    start_date: '2025-03-21'
+  description: Manual refreshes of materialized views.  See https://mozilla-hub.atlassian.net/browse/DENG-6990
+  repo: bigquery-etl
+  schedule_interval: 45 * * * *
+  tags:
+    - impact/tier_1
+    - repo/bigquery-etl

--- a/sql/moz-fx-data-backfill-3/firefox_desktop_derived/event_monitoring_live_v1/metadata.yaml
+++ b/sql/moz-fx-data-backfill-3/firefox_desktop_derived/event_monitoring_live_v1/metadata.yaml
@@ -1,0 +1,19 @@
+friendly_name: Event monitoring live refresh
+description: |-
+  Manual refresh for firefox_desktop_derived.event_monitoring_live_v1 to run with on-demand billing.
+  Temporary workaround to reduce costs while a permanent solution is implemented https://mozilla-hub.atlassian.net/browse/DENG-6990
+owners:
+- bewu@mozilla.com
+labels:
+  incremental: true
+  owner1: benwu
+scheduling:
+  dag_name: bqetl_materialized_view_refresh
+  destination_table: null
+  query_file_path: sql/moz-fx-data-backfill-3/firefox_desktop_derived/event_monitoring_live_v1/script.sql
+  arguments:
+  - '--use_legacy_sql=false'
+bigquery:
+  time_partitioning: null
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-backfill-3/firefox_desktop_derived/event_monitoring_live_v1/script.sql
+++ b/sql/moz-fx-data-backfill-3/firefox_desktop_derived/event_monitoring_live_v1/script.sql
@@ -1,0 +1,3 @@
+CALL BQ.REFRESH_MATERIALIZED_VIEW(
+  'moz-fx-data-shared-prod.firefox_desktop_derived.event_monitoring_live_v1'
+);


### PR DESCRIPTION
…toring_live_v1

## Description

I plan on turning off automatic refreshes and using this dag to trigger refreshes for this materialized view from the backfill project so they run with on-demand billing.  This is a temporary solution to reduce costs while something better gets implemented.

## Related Tickets & Documents
* DENG-6990

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
