### PR TITLE
Add play store install referrer response to rolling_cohorts_v2 & cohort weekly statistics

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/query.sql
@@ -43,6 +43,7 @@ cohorts_in_range AS (
     play_store_attribution_source,
     play_store_attribution_content,
     play_store_attribution_term,
+    play_store_attribution_install_referrer_response,
     row_source,
   FROM
     `moz-fx-data-shared-prod.telemetry_derived.rolling_cohorts_v2`
@@ -97,6 +98,7 @@ SELECT
   row_source,
   COUNT(cohort_client_id) AS num_clients_in_cohort,
   COUNT(active_client_id) AS num_clients_active_on_day,
+  play_store_attribution_install_referrer_response
 FROM
   activity_cohort_match
 GROUP BY
@@ -131,4 +133,5 @@ GROUP BY
   play_store_attribution_source,
   play_store_attribution_content,
   play_store_attribution_term,
-  row_source
+  row_source,
+  play_store_attribution_install_referrer_response

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/schema.yaml
@@ -135,3 +135,7 @@ fields:
   name: num_clients_active_on_day
   type: INTEGER
   description: Number of Clients Active on Day
+- name: play_store_attribution_install_referrer_response
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Install Referrer Response

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_statistics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_statistics_v1/query.sql
@@ -26,6 +26,7 @@ WITH clients_first_seen AS (
     play_store_attribution_source,
     play_store_attribution_content,
     play_store_attribution_term,
+    play_store_attribution_install_referrer_response,
     DATE_TRUNC(cohort_date, WEEK) AS cohort_date_week,
     client_id
   FROM
@@ -109,6 +110,7 @@ initial_cohort_counts AS (
     play_store_attribution_source,
     play_store_attribution_content,
     play_store_attribution_term,
+    play_store_attribution_install_referrer_response,
     cohort_date_week,
     COUNT(DISTINCT(client_id)) AS nbr_clients_in_cohort
   FROM
@@ -139,6 +141,7 @@ initial_cohort_counts AS (
     play_store_attribution_source,
     play_store_attribution_content,
     play_store_attribution_term,
+    play_store_attribution_install_referrer_response,
     cohort_date_week
 ),
 unique_week_group_combos AS (
@@ -168,6 +171,7 @@ unique_week_group_combos AS (
     i.play_store_attribution_source,
     i.play_store_attribution_content,
     i.play_store_attribution_term,
+    i.play_store_attribution_install_referrer_response,
     i.cohort_date_week,
     i.nbr_clients_in_cohort,
     w.activity_date_week
@@ -203,6 +207,7 @@ weekly_active_agg AS (
     cfs.play_store_attribution_source,
     cfs.play_store_attribution_content,
     cfs.play_store_attribution_term,
+    cfs.play_store_attribution_install_referrer_response,
     cfs.cohort_date_week,
     wac.activity_date_week,
     COUNT(DISTINCT(wac.client_id)) AS nbr_active_clients
@@ -238,6 +243,7 @@ weekly_active_agg AS (
     cfs.play_store_attribution_source,
     cfs.play_store_attribution_content,
     cfs.play_store_attribution_term,
+    cfs.play_store_attribution_install_referrer_response,
     cfs.cohort_date_week,
     wac.activity_date_week
 )
@@ -267,6 +273,7 @@ SELECT
   uwgc.play_store_attribution_source,
   uwgc.play_store_attribution_content,
   uwgc.play_store_attribution_term,
+  uwgc.play_store_attribution_install_referrer_response,
   uwgc.cohort_date_week,
   uwgc.nbr_clients_in_cohort,
   uwgc.activity_date_week,
@@ -317,6 +324,10 @@ LEFT JOIN
   )
   AND COALESCE(uwgc.play_store_attribution_term, 'NULL') = COALESCE(
     waa.play_store_attribution_term,
+    'NULL'
+  )
+  AND COALESCE(uwgc.play_store_attribution_install_referrer_response, 'NULL') = COALESCE(
+    waa.play_store_attribution_install_referrer_response,
     'NULL'
   )
   AND uwgc.cohort_date_week = waa.cohort_date_week

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_statistics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_statistics_v1/query.sql
@@ -273,12 +273,12 @@ SELECT
   uwgc.play_store_attribution_source,
   uwgc.play_store_attribution_content,
   uwgc.play_store_attribution_term,
-  uwgc.play_store_attribution_install_referrer_response,
   uwgc.cohort_date_week,
   uwgc.nbr_clients_in_cohort,
   uwgc.activity_date_week,
   DATE_DIFF(uwgc.activity_date_week, uwgc.cohort_date_week, WEEK) AS weeks_after_first_seen_week,
-  COALESCE(waa.nbr_active_clients, 0) AS nbr_active_clients
+  COALESCE(waa.nbr_active_clients, 0) AS nbr_active_clients,
+  uwgc.play_store_attribution_install_referrer_response,
 FROM
   unique_week_group_combos uwgc
 LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_statistics_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_statistics_v1/schema.yaml
@@ -119,3 +119,7 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Number of Active Clients
+- name: play_store_attribution_install_referrer_response
+  type: STRING
+  mode: NULLABLE
+  description: Play Store Attribution Install Referrer Response

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/query.sql
@@ -38,6 +38,7 @@ SELECT
   CAST(NULL AS STRING) AS play_store_attribution_content,
   CAST(NULL AS STRING) AS play_store_attribution_term,
   'Desktop' AS row_source,
+  CAST(NULL AS STRING) AS play_store_attribution_install_referrer_response,
 FROM
   `moz-fx-data-shared-prod.telemetry.desktop_active_users` au
 LEFT JOIN
@@ -89,7 +90,8 @@ SELECT
   mnpc.play_store_attribution_source,
   mnpc.play_store_attribution_content,
   mnpc.play_store_attribution_term,
-  'Mobile' AS row_source
+  'Mobile' AS row_source,
+  mnpc.play_store_attribution_install_referrer_response
 FROM
   (
 --in case of multiple rows per client ID / first seen date (rare), pick 1
@@ -131,6 +133,7 @@ LEFT JOIN
       play_store_attribution_source,
       play_store_attribution_content,
       play_store_attribution_term,
+      play_store_attribution_install_referrer_response
     FROM
       `moz-fx-data-shared-prod.telemetry.mobile_new_profile_clients`
     WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/schema.yaml
@@ -130,4 +130,4 @@ fields:
 - name: play_store_attribution_install_referrer_response
   type: STRING
   mode: NULLABLE
-  description: Flag indicating source - i.e. Desktop or Mobile
+  description: Play Store Attribution Install Referrer Response

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/schema.yaml
@@ -127,3 +127,7 @@ fields:
   type: STRING
   mode: NULLABLE
   description: Flag indicating source - i.e. Desktop or Mobile
+- name: play_store_attribution_install_referrer_response
+  type: STRING
+  mode: NULLABLE
+  description: Flag indicating source - i.e. Desktop or Mobile


### PR DESCRIPTION
## Description

This PR adds a new column "play_store_attribution_install_referrer_response" to 3 tables:
- moz-fx-data-shared-prod.telemetry_derived.rolling_cohorts_v2 
- moz-fx-data-shared-prod.telemetry_derived.cohort_weekly_statistics_v1
- moz-fx-data-shared-prod.telemetry_derived.cohort_daily_statistics_v2


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
