### PR TITLE
Add initialization SQL for newtab_interactions_hourly_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/query.sql
@@ -194,9 +194,9 @@ uapi_summary AS (
     `moz-fx-data-shared-prod.ads_derived.interaction_aggregates_hourly_v1`
   WHERE
     {% if is_init() %}
-      submission_timestamp >= '2025-01-01'
+      submission_hour >= '2025-01-01'
     {% else %}
-      DATE(submission_timestamp) = @submission_date
+      DATE(submission_hour) = @submission_date
     {% endif %}
     AND placement IN ('newtab_spocs', 'newtab_rectangle', 'newtab_billboard', 'newtab_leaderboard')
   GROUP BY

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/query.sql
@@ -6,7 +6,11 @@ legacy_deduplicated_pings AS (
   FROM
     `moz-fx-data-shared-prod.activity_stream_live.impression_stats_v1`
   WHERE
-    DATE(submission_timestamp) = @submission_date
+    {% if is_init() %}
+      submission_timestamp >= '2025-01-01'
+    {% else %}
+      DATE(submission_timestamp) = @submission_date
+    {% endif %}
   QUALIFY
     ROW_NUMBER() OVER (
       PARTITION BY
@@ -97,7 +101,11 @@ glean_deduplicated_pings AS (
   FROM
     `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
   WHERE
-    DATE(submission_timestamp) = @submission_date
+    {% if is_init() %}
+      submission_timestamp >= '2025-01-01'
+    {% else %}
+      DATE(submission_timestamp) = @submission_date
+    {% endif %}
   QUALIFY
     ROW_NUMBER() OVER (
       PARTITION BY
@@ -115,7 +123,12 @@ glean_flattened_pocket_events AS (
     mozfun.map.get_key(events.extra, 'recommendation_id') AS recommendation_id,
     mozfun.map.get_key(events.extra, 'tile_id') AS tile_id,
     mozfun.map.get_key(events.extra, 'position') AS position,
-    COUNT(1) OVER (PARTITION BY document_id, events.name) AS user_event_count
+    COUNT(1) OVER (
+      PARTITION BY
+        client_info.client_id,
+        DATE(submission_timestamp),
+        events.name
+    ) AS user_event_count
   FROM
     glean_deduplicated_pings,
     UNNEST(events) AS events
@@ -147,7 +160,7 @@ glean_summary AS (
     glean_flattened_pocket_events
   WHERE
     -- exclude suspicious activity
-    NOT (user_event_count > 50)
+    NOT (user_event_count > 50 AND event_name = 'click')
   GROUP BY
     submission_date,
     recommendation_id,
@@ -180,8 +193,11 @@ uapi_summary AS (
   FROM
     `moz-fx-data-shared-prod.ads_derived.interaction_aggregates_hourly_v1`
   WHERE
-    DATE(submission_hour) = @submission_date
-    AND form_factor = 'desktop'
+    {% if is_init() %}
+      submission_timestamp >= '2025-01-01'
+    {% else %}
+      DATE(submission_timestamp) = @submission_date
+    {% endif %}
     AND placement IN ('newtab_spocs', 'newtab_rectangle', 'newtab_billboard', 'newtab_leaderboard')
   GROUP BY
     submission_date,


### PR DESCRIPTION
## Description

Adds initialization SQL for `newtab_interactions_hourly_v1`. Because managed backfills aren't currently fully supported for hourly tables, this is the easiest way to initially backfill this table.

## Related Tickets & Documents
* [AD-681](https://mozilla-hub.atlassian.net/browse/AD-681)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[AD-681]: https://mozilla-hub.atlassian.net/browse/AD-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ