### PR TITLE
change type of entity_id from INTEGER to STRING

### DIFF
--- a/sql/moz-fx-data-shared-prod/addon_moderations_derived/cinder_decisions_raw_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/addon_moderations_derived/cinder_decisions_raw_v1/schema.yaml
@@ -22,7 +22,7 @@ fields:
 
 - mode: NULLABLE
   name: entity_id
-  type: INTEGER
+  type: STRING
   description: Entity ID
 
 - mode: NULLABLE


### PR DESCRIPTION
## Description
This PR changes the TYPE of the entity_id from INTEGER to STRING. Since this is an ID, it should be a string and immutable. I caught this error when I was working on the DSA report due in February, noticed the type when I was reviewing the data that was available.
<!--
Please do not leave this blank
This PR changes the TYPE of the entity_id from INTEGER to STRING. Since this is an ID, it should be a string and immutable
-->

## Related Tickets & Documents
* DENG-8156
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
