### PR TITLE
[DENG-8101] Grant webcompat/dashboard-service viewer access to fenix …

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix/broken_site_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/broken_site_report/metadata.yaml
@@ -1,0 +1,6 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:webcompat/dashboard-service

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix/broken_site_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix/broken_site_report/metadata.yaml
@@ -1,0 +1,6 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:webcompat/dashboard-service

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_nightly/broken_site_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_nightly/broken_site_report/metadata.yaml
@@ -1,0 +1,6 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:webcompat/dashboard-service

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fennec_aurora/broken_site_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fennec_aurora/broken_site_report/metadata.yaml
@@ -1,0 +1,6 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:webcompat/dashboard-service

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox/broken_site_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox/broken_site_report/metadata.yaml
@@ -1,0 +1,6 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:webcompat/dashboard-service

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta/broken_site_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta/broken_site_report/metadata.yaml
@@ -1,0 +1,6 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:webcompat/dashboard-service


### PR DESCRIPTION
…broken_site_report views

## Description

Similar to https://github.com/mozilla/bigquery-etl/pull/5322, this grants the workgroup access to all the broken_site_report views using authorized views because the workgroup doesn't have access to the ping tables

Also made changes to stable_views generator so the description is still added when a partial metadata.yaml exists.

## Related Tickets & Documents
* DENG-8101

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
