### PR TITLE
feat(DENG-8171): Add 3 new tables to shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -234,6 +234,9 @@ DELETE_TARGETS: DeleteIndex = {
     client_id_target(
         table="telemetry_derived.desktop_retention_clients_v1"
     ): DESKTOP_SRC,
+    client_id_target(
+        table="ltv_derived.firefox_desktop_new_profile_ltv_v1"
+    ): DESKTOP_SRC,
     client_id_target(table="telemetry_stable.block_autoplay_v1"): DESKTOP_SRC,
     client_id_target(table="telemetry_stable.crash_v4"): DESKTOP_SRC,
     client_id_target(table="telemetry_stable.downgrade_v4"): DESKTOP_SRC,
@@ -272,6 +275,14 @@ DELETE_TARGETS: DeleteIndex = {
         DeleteSource(table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID),
     ),
+    DeleteTarget(
+        table="ltv_derived.fenix_new_profile_ltv_v1",
+        field=(CLIENT_ID),
+    ): (DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID),),
+    DeleteTarget(
+        table="ltv_derived.firefox_ios_new_profile_ltv_v1",
+        field=(CLIENT_ID),
+    ): (DeleteSource(table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID),),
     DeleteTarget(
         table="telemetry_derived.fx_accounts_active_daily_clients_v1",
         field=(CLIENT_ID),


### PR DESCRIPTION
## Description

This PR adds 3 new tables to shredder: 
- moz-fx-data-shared-prod.ltv_derived.firefox_desktop_new_profile_ltv_v1
- moz-fx-data-shared-prod.ltv_derived.fenix_new_profile_ltv_v1
- moz-fx-data-shared-prod.ltv_derived.firefox_ios_new_profile_ltv_v1

## Related Tickets & Documents
* [DENG-8171](https://mozilla-hub.atlassian.net/browse/DENG-8171)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8171]: https://mozilla-hub.atlassian.net/browse/DENG-8171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ