### PR TITLE
Move channel logic from schema_error_counts to payload_bytes_error_all

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/payload_bytes_error_all/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/payload_bytes_error_all/view.sql
@@ -5,18 +5,26 @@ AS
 -- most users.
 SELECT
   'structured' AS pipeline_family,
+  COALESCE(
+    -- glean pings
+    JSON_VALUE(`moz-fx-data-shared-prod.udf_js.gunzip`(payload), '$.client_info.app_channel'),
+    -- firefox-installer
+    JSON_VALUE(`moz-fx-data-shared-prod.udf_js.gunzip`(payload), '$.update_channel')
+  ) AS channel,
   * EXCEPT (payload)
 FROM
   `moz-fx-data-shared-prod.payload_bytes_error.structured`
 UNION ALL
 SELECT
   'stub_installer' AS pipeline_family,
+  SPLIT(uri, "/")[SAFE_OFFSET(3)] AS channel,
   * EXCEPT (payload)
 FROM
   `moz-fx-data-shared-prod.payload_bytes_error.stub_installer`
 UNION ALL
 SELECT
   'telemetry' AS pipeline_family,
+  `moz-fx-data-shared-prod.udf.parse_desktop_telemetry_uri`(uri).app_update_channel AS channel,
   * EXCEPT (payload)
 FROM
   `moz-fx-data-shared-prod.payload_bytes_error.telemetry`

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/query.sql
@@ -1,110 +1,37 @@
-WITH payload_bytes_error_all AS (
-  -- Direct access to payload_bytes_error is restricted to airflow
-  -- Use the tables in the errors dataset for testing
-  -- e.g. moz-fx-data-shared-prod.errors.structured_firefox_desktop__metrics_v1
-  SELECT
-    'structured' AS pipeline_family,
-    *
-  FROM
-    `moz-fx-data-shared-prod.payload_bytes_error.structured`
-  UNION ALL
-  SELECT
-    'stub_installer' AS pipeline_family,
-    * REPLACE (NULL AS payload)
-  FROM
-    `moz-fx-data-shared-prod.payload_bytes_error.stub_installer`
-  UNION ALL
-  SELECT
-    'telemetry' AS pipeline_family,
-    * REPLACE (NULL AS payload)
-  FROM
-    `moz-fx-data-shared-prod.payload_bytes_error.telemetry`
-),
-extracted AS (
-  SELECT
-    TIMESTAMP_TRUNC(submission_timestamp, HOUR) AS hour,
-    job_name,
-    document_namespace,
-    document_type,
-    document_version,
-    error_message,
-    uri,
-    pipeline_family,
-    payload,
-  FROM
-    payload_bytes_error_all
-  WHERE
-    DATE(submission_timestamp) = @submission_date
-    AND exception_class IN (
-      'org.everit.json.schema.ValidationException',
-      'com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException'  -- stub_installer error
-    )
-),
-count_errors AS (
-  SELECT
-    document_namespace,
-    document_type,
-    document_version,
-    hour,
-    job_name,
-    `moz-fx-data-shared-prod.udf.extract_schema_validation_path`(error_message) AS path,
-    CASE
-      pipeline_family
-      WHEN 'structured'
-        THEN COALESCE(
-            -- glean pings
-            JSON_VALUE(
-              `moz-fx-data-shared-prod.udf_js.gunzip`(payload),
-              '$.client_info.app_channel'
-            ),
-            -- firefox-installer
-            JSON_VALUE(`moz-fx-data-shared-prod.udf_js.gunzip`(payload), '$.update_channel')
-          )
-      WHEN 'stub_installer'
-        THEN SPLIT(uri, "/")[SAFE_OFFSET(3)]
-      ELSE `moz-fx-data-shared-prod.udf.parse_desktop_telemetry_uri`(uri).app_update_channel
-    END AS channel,
-    COUNT(*) AS error_count,
-    -- aggregating distinct error messages to show sample_error messages
-    -- removing path and exception_class for better readability
-    SUBSTR(
-      STRING_AGG(
-        DISTINCT
-        CASE
-          pipeline_family
-          WHEN 'stub_installer'
-            THEN REPLACE(
-                error_message,
-                "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException: ",
-                ""
-              )
-          ELSE REPLACE(
-              REPLACE(error_message, "org.everit.json.schema.ValidationException: ", ""),
-              CONCAT(
-                `moz-fx-data-shared-prod.udf.extract_schema_validation_path`(error_message),
-                ": "
-              ),
-              ""
-            )
-        END,
-        "; "
-      ),
-      0,
-      300
-    ) AS sample_error_messages,
-  FROM
-    extracted
-  GROUP BY
-    document_namespace,
-    document_type,
-    document_version,
-    hour,
-    job_name,
-    path,
-    channel
-)
 SELECT
   @submission_date AS submission_date,
-  *
+  document_namespace,
+  document_type,
+  document_version,
+  TIMESTAMP_TRUNC(submission_timestamp, HOUR) AS hour,
+  job_name,
+  `moz-fx-data-shared-prod.udf.extract_schema_validation_path`(error_message) AS path,
+  COUNT(*) AS error_count,
+  -- aggregating distinct error messages to show sample_error messages
+  -- removing path and exception_class for better readability
+  SUBSTR(
+    STRING_AGG(
+      DISTINCT REPLACE(
+        REPLACE(error_message, "org.everit.json.schema.ValidationException: ", ""),
+        CONCAT(`moz-fx-data-shared-prod.udf.extract_schema_validation_path`(error_message), ": "),
+        ""
+      ),
+      "; "
+    ),
+    0,
+    300
+  ) AS sample_error_messages,
+  channel,
 FROM
-  count_errors
+  `moz-fx-data-shared-prod.monitoring.payload_bytes_error_all`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND exception_class = 'org.everit.json.schema.ValidationException'
+GROUP BY
+  document_namespace,
+  document_type,
+  document_version,
+  hour,
+  job_name,
+  path,
+  channel


### PR DESCRIPTION
## Description

This moves the channel parsing for errors from the schema errors query to the `payload_bytes_error_all` authorized view which lets us get channel info for all errors and not just schema errors.  

This also removes stub installer parse errors from the schema errors table (added in https://github.com/mozilla/bigquery-etl/pull/7015) because I found that it's confusing to have different exception classes in the graphs and stub installer errors show up in their own graph in the dashboard anyway.

Needed to grant the circleci account access to the gcs bucket with the JS libs: https://github.com/mozilla-services/cloudops-infra/pull/6343  I manually did it for now

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
