### PR TITLE
bug 1955428 - Use column replacement to place extended attribution and distribution info in client_info with the base info

### DIFF
--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -261,6 +261,12 @@ def write_view_if_not_exists(
                         f"metrics.{metrics_field['name']} AS {metrics_2_types_to_rename[metrics_field['name']]}"
                     ]
 
+            # Extended attribution and distribution information should join the rest in client_info.
+            replacements += [
+                "metrics.object.glean_attribution_ext AS client_info.attribution.ext",
+                "metrics.object.glean_distribution_ext AS client_info.distribution.ext",
+            ]
+
         if datetime_replacements_clause or metrics_2_aliases or metrics_2_exclusions:
             except_clause = ""
             if metrics_2_exclusions:


### PR DESCRIPTION
## Description

Per bug 1955428 (well, per [the design doc](https://docs.google.com/document/d/1TIZhpBeZcJSEnIZJwj0Cj9saL2Tfs0X6oi_4gFU35eM/edit?tab=t.0) beforehand), this takes the specially-named object metrics `glean.attribution.ext` and `glean.distribution.ext` and slides them over into `client_info` next to the rest of `client_info.attribution.*` and `client_info.distribution.*` (see also mozilla/glean#3091, where the `client_info` sections are added to the SDK and mozilla-services/mozilla-pipeline-schemas#841 where the sections and their fields are added to the schema)

## Related Tickets & Documents
* bug 1955428 aka DENG-8191
* https://docs.google.com/document/d/1TIZhpBeZcJSEnIZJwj0Cj9saL2Tfs0X6oi_4gFU35eM/edit?tab=t.0
* mozilla/glean#3091
* mozilla-services/mozilla-pipeline-schemas#841

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
