### PR TITLE
[DENG-8051] Limit concurrency of glam sql generation

### DIFF
--- a/script/glam/generate_glean_sql
+++ b/script/glam/generate_glean_sql
@@ -69,13 +69,15 @@ function write_clients_daily_aggregates {
         select(.type == "TABLE") |
         select(.tableReference.tableId | test("^use_counters.*") | not) |
         "\(.tableReference.tableId)"')
-    # generate all of the schemas in parallel
+    # generate schemas in parallel
     for table in $tables; do
+        # 2 tables at a time to limit concurrent python processes
+        i=$((i % 2))
+        ((i++==0)) && wait
         write_scalars "$product" "$dataset" "$table" "$dst_project" "$sql_dir" &
         write_histograms "$product" "$dataset" "$table" "$dst_project" "$sql_dir" &
     done
 
-    # wait for all of the processes before continuing
     wait
 }
 


### PR DESCRIPTION
## Description

The glam `daily_*` tasks use a lot of memory and occasionally get OOM'd.  I found that it's because the sql generation runs a two python processes per stable table of the target app so fenix spawns 64 processes and each uses a bit of memory.  This changes it to run for 2 tables at a time so max 4 processes.

Memory usage running in a container:
![image](https://github.com/user-attachments/assets/e5068600-a417-4fdf-855f-91e33567bce3)

First bump is with 2 table concurrency (570MB), second is 3 (900MB), and last two are unlimited (3GB and 6.5GB).

## Related Tickets & Documents
* DENG-8051
* https://bugzilla.mozilla.org/show_bug.cgi?id=1957121

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
