### PR TITLE
[DENG-8189] Give read access for crash pings to crash-ping-ingest

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/crash/metadata.yaml
@@ -1,0 +1,5 @@
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-8189
+  - workgroup:dataops-managed/crash-ping-ingest

--- a/sql/moz-fx-data-shared-prod/firefox_crashreporter/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_crashreporter/crash/metadata.yaml
@@ -1,0 +1,7 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-8189
+  - workgroup:dataops-managed/crash-ping-ingest

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/crash/metadata.yaml
@@ -1,0 +1,7 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-8189
+  - workgroup:dataops-managed/crash-ping-ingest

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_crashes/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_crashes/metadata.yaml
@@ -4,3 +4,8 @@ description: |-
   Union of multiple Firefox desktop crash ping sources.
 owners:
 - bewu@mozilla.cam
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-8189
+  - workgroup:dataops-managed/crash-ping-ingest

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix/crash/metadata.yaml
@@ -1,0 +1,7 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-8189
+  - workgroup:dataops-managed/crash-ping-ingest

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_nightly/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_nightly/crash/metadata.yaml
@@ -1,0 +1,7 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-8189
+  - workgroup:dataops-managed/crash-ping-ingest

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fennec_aurora/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fennec_aurora/crash/metadata.yaml
@@ -1,0 +1,7 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-8189
+  - workgroup:dataops-managed/crash-ping-ingest

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox/crash/metadata.yaml
@@ -1,0 +1,7 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-8189
+  - workgroup:dataops-managed/crash-ping-ingest

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta/crash/metadata.yaml
@@ -1,0 +1,7 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-8189
+  - workgroup:dataops-managed/crash-ping-ingest

--- a/sql_generators/desktop_crashes/__init__.py
+++ b/sql_generators/desktop_crashes/__init__.py
@@ -9,8 +9,8 @@ from bigquery_etl.schema import Schema
 from bigquery_etl.util.common import write_sql
 
 CRASH_TABLES = [
-    ("moz-fx-data-shared-prod", "firefox_desktop_stable", "crash_v1"),
-    ("moz-fx-data-shared-prod", "firefox_crashreporter_stable", "crash_v1"),
+    ("moz-fx-data-shared-prod", "firefox_desktop", "crash"),
+    ("moz-fx-data-shared-prod", "firefox_crashreporter", "crash"),
 ]
 
 


### PR DESCRIPTION
## Description

Similar to https://github.com/mozilla/bigquery-etl/pull/7234, this gives read access to the crash ping stable tables.  The stable views are authorized so that the stable table permissions don't need to be changed.

## Related Tickets & Documents
* DENG-8189

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
