### PR TITLE
[DENG-8214] Add additional projects and fields to jobs_by_organization

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
@@ -12,6 +12,11 @@ DEFAULT_PROJECTS = [
     "moz-fx-data-shared-prod",
     "moz-fx-data-marketing-prod",
     "moz-fx-data-bq-data-science",
+    "moz-fx-glam-prod",
+    "moz-fx-glam-nonprod",
+    "moz-fx-data-sumo-prod",
+    "moz-fx-data-sumo-nonprod",
+    "moz-fx-mozsocial-dw-prod",
 ]
 
 parser = ArgumentParser(description=__doc__)
@@ -53,7 +58,8 @@ def create_query(job_date: date, project: str):
           query_info.resource_warning as query_info_resource_warning,
           query_info.query_hashes.normalized_literals as query_info_query_hashes_normalized_literals,
           transferred_bytes,
-          DATE(creation_time) as creation_date
+          DATE(creation_time) as creation_date,
+          materialized_view_statistics,
         FROM
           `{project}.region-us.INFORMATION_SCHEMA.JOBS_BY_ORGANIZATION`
         WHERE

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/schema.yaml
@@ -180,3 +180,40 @@ fields:
   name: creation_date
   type: DATE
   description: Date of the creation_time
+
+- mode: NULLABLE
+  name: materialized_view_statistics
+  type: RECORD
+  description: Statistics of materialized views considered in a query job.
+  fields:
+  - mode: REPEATED
+    name: materialized_view
+    type: RECORD
+    description: A materialized view considered for a query job.
+    fields:
+    - mode: NULLABLE
+      name: table_reference
+      type: RECORD
+      description: The candidate materialized view.
+      fields:
+      - mode: NULLABLE
+        name: project_id
+        type: STRING
+      - mode: NULLABLE
+        name: dataset_id
+        type: STRING
+      - mode: NULLABLE
+        name: table_id
+        type: STRING
+    - mode: NULLABLE
+      name: chosen
+      type: BOOLEAN
+      description: Whether the materialized view is chosen for the query.
+    - mode: NULLABLE
+      name: estimated_bytes_saved
+      type: INTEGER
+      description: If present, specifies a best-effort estimation of the bytes saved by using the materialized view rather than its base tables.
+    - mode: NULLABLE
+      name: rejected_reason
+      type: STRING
+      description: If present, specifies the reason why the materialized view was not chosen for the query.


### PR DESCRIPTION
## Description

This adds more projects and materialized view stats to the jobs_by_organization derived table.  These projects are the most expensive one that are currently missing ([comparison with billing data](https://sql.telemetry.mozilla.org/queries/106900/source)) so including them should gives us a more complete view of bigquery spend with this table.

For change control, the projects being added are:
- moz-fx-glam-prod
- moz-fx-glam-nonprod
- moz-fx-data-sumo-prod
- moz-fx-data-sumo-nonprod
- moz-fx-mozsocial-dw-prod

## Related Tickets & Documents
* DENG-8214

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
