### PR TITLE
feat(DENG-8090): Add category column to chrome_extensions_v1

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2293,7 +2293,7 @@ bqetl_chrome_extensions_scraper:
     retry_delay: 30m
     start_date: '2025-03-01'
   description: Pulls info about Chrome extensions from the Chrome webstore
-  schedule_interval: 40 21 * * 1
+  schedule_interval: 40 21 * * *
   tags:
     - impact/tier_3
 

--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
@@ -156,9 +156,6 @@ def check_if_detail_or_non_detail_page(url):
 
 def pull_data_from_detail_page(url, timeout_limit, current_date):
     """Input: URL, timeout limit (integer), and current date"""
-    # TEMP FOR TESTING
-    print("Current URL: ", url)
-    # TEMP FOR TESTING
 
     # Initialize as empty strings
     number_of_ratings = None

--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/query.py
@@ -95,13 +95,30 @@ def get_divs_from_soup(webpage_soup):
 
 def get_website_url_from_soup(webpage_soup):
     """Input: Webpage Soup
-    Output: Website URL (str) if found, otherwise return None """
+    Output: Website URL (str) if found, otherwise return None"""
     website_url = None
     website_links = webpage_soup.find_all("a")
     for website_link in website_links:
         if website_link.has_attr("href") and "Website" in website_link.text:
             website_url = website_link["href"]
     return website_url
+
+
+def get_category_from_soup(webpage_soup):
+    """Input: Webpage Soup
+    Output: Category of the extension if found, otherwise return None"""
+    category = None
+    website_links = webpage_soup.find_all("a")
+    for link_nbr, website_link in enumerate(website_links):
+        if (
+            website_link.has_attr("href")
+            and "Extension" in website_link.text
+            and link_nbr + 1 < len(website_links)
+        ):
+            # Get the next link text
+            category = website_links[link_nbr + 1].text.strip()
+
+    return category
 
 
 def initialize_results_df():
@@ -122,6 +139,7 @@ def initialize_results_df():
             "developer_website",
             "developer_phone",
             "extension_updated_date",
+            "category",
         ]
     )
     return results_df
@@ -138,6 +156,9 @@ def check_if_detail_or_non_detail_page(url):
 
 def pull_data_from_detail_page(url, timeout_limit, current_date):
     """Input: URL, timeout limit (integer), and current date"""
+    # TEMP FOR TESTING
+    print("Current URL: ", url)
+    # TEMP FOR TESTING
 
     # Initialize as empty strings
     number_of_ratings = None
@@ -250,6 +271,8 @@ def pull_data_from_detail_page(url, timeout_limit, current_date):
                     else:
                         developer_email = developer_email_and_phone
 
+    category = get_category_from_soup(current_link_soup)
+
     # Put the results into a dataframe
     curr_link_results_df = pd.DataFrame(
         {
@@ -267,6 +290,7 @@ def pull_data_from_detail_page(url, timeout_limit, current_date):
             "developer_website": [developer_website],
             "developer_phone": [developer_phone],
             "extension_updated_date": [extension_updated_date],
+            "category": [category],
         }
     )
 
@@ -392,6 +416,11 @@ def main():
                 {"name": "developer_phone", "type": "STRING", "mode": "NULLABLE"},
                 {
                     "name": "extension_updated_date",
+                    "type": "STRING",
+                    "mode": "NULLABLE",
+                },
+                {
+                    "name": "category",
                     "type": "STRING",
                     "mode": "NULLABLE",
                 },

--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_extensions_v1/schema.yaml
@@ -55,3 +55,7 @@ fields:
   mode: NULLABLE
   type: STRING
   description: Extension Updated Date
+- name: category
+  mode: NULLABLE
+  type: STRING
+  description: Extension Category


### PR DESCRIPTION
## Description

This PR adds the new column `category` to the table:
- moz-fx-data-shared-prod.external_derived.chrome_extensions_v1

It also changes the DAG from running weekly to daily

## Related Tickets & Documents
* [DENG-8090](https://mozilla-hub.atlassian.net/browse/DENG-8090)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8090]: https://mozilla-hub.atlassian.net/browse/DENG-8090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ