### PR TITLE
DENG-7245: Remove TAAR references

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/dataset_metadata.yaml
@@ -8,6 +8,5 @@ labels: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
-  - workgroup:dataops-managed/taar
   - workgroup:mozilla-confidential
   - workgroup:dataops-managed/external-fides

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
@@ -21,10 +21,6 @@ scheduling:
   priority: 85
   start_date: '2019-04-15'
   depends_on_past: true
-  external_downstream_tasks:
-  - task_id: wait_for_clients_last_seen
-    dag_name: taar_daily
-    execution_delta: 2h
 bigquery:
   time_partitioning:
     type: day
@@ -43,8 +39,4 @@ schema:
     - telemetry_derived
     - clients_daily_v6
     exclude: null
-workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:dataops-managed/taar
 references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
@@ -28,10 +28,6 @@ scheduling:
   email:
   - kwindau@mozilla.com
   depends_on_past: true
-  external_downstream_tasks:
-  - task_id: wait_for_clients_last_seen
-    dag_name: taar_daily
-    execution_delta: 2h
 bigquery:
   time_partitioning:
     type: day
@@ -50,8 +46,4 @@ schema:
     - telemetry_derived
     - clients_daily_v6
     exclude: null
-workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:dataops-managed/taar
 references: {}

--- a/tests/data/test_sql/moz-fx-data-test-project/test/non_incremental_query_v1/metadata.yaml
+++ b/tests/data/test_sql/moz-fx-data-test-project/test/non_incremental_query_v1/metadata.yaml
@@ -18,5 +18,5 @@ scheduling:
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
-      - workgroup:dataops-managed/taar
+      - workgroup:dataops-managed/external-fides
 deprecated: true

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -121,7 +121,8 @@ class TestParseMetadata(object):
         assert metadata.workgroup_access is not None
         assert metadata.workgroup_access[0].role == "roles/bigquery.dataViewer"
         assert (
-            metadata.workgroup_access[0].members[0] == "workgroup:dataops-managed/taar"
+            metadata.workgroup_access[0].members[0]
+            == "workgroup:dataops-managed/external-fides"
         )
 
     def test_of_query_file_no_metadata(self):


### PR DESCRIPTION
## Description
This is a follow up to https://github.com/mozilla/telemetry-airflow/pull/2169 where all TAAR DAGs were removed. There were some references to these DAGs and related workgroup left in this repo.

Blocks https://github.com/mozilla-services/cloudops-infra/pull/6356

## Related Tickets & Documents
https://mozilla-hub.atlassian.net/browse/DENG-7245