### PR TITLE
Bug 1958887 - Remove view authorization for fenix.broken_site_report

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix/broken_site_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix/broken_site_report/metadata.yaml
@@ -1,5 +1,3 @@
-labels:
-  authorized: true
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:


### PR DESCRIPTION
## Description

Permission issues while deploying this view started on 2025-04-04 that seem to be related to this being an authorized view.  View deploys started working again a couple hours ago but I don't know why the issue started and stopped.  Removing the authorization should remove this point of failure.  The views this references are authorized so this one shouldn't need to be authorized

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1958887

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
