### PR TITLE
[Bug 1958883] Filter out applications in experiment search monitoring that don't have search metrics defined

### DIFF
--- a/sql_generators/experiment_monitoring/templates/experiment_search_aggregates_v1/query.sql
+++ b/sql_generators/experiment_monitoring/templates/experiment_search_aggregates_v1/query.sql
@@ -1,81 +1,98 @@
 -- Generated via ./bqetl generate experiment_monitoring
+
+-- Filter out applications that have all search metrics definitions set to null.
+-- This reduces query complexity.
+{% set filtered_search_metrics = [] %}
+{% for app, metrics in search_metrics.items() %}
+    {% set ns = namespace(non_null_found=false) %}
+    {% for metrics, val in metrics.items() %}
+        {% if val != None %}
+            {% set ns.non_null_found = true %}
+        {% endif %}
+    {% endfor %}
+    {% if ns.non_null_found %}
+        {% set _ = filtered_search_metrics.append((app, metrics)) %}
+    {% endif %}
+{% endfor %}
+
+
 WITH
-{% for app_dataset in applications %}
+{% for app_dataset, metrics in filtered_search_metrics %}
   {% if app_dataset == "telemetry" %}
-  {{ app_dataset }} AS (
-    SELECT
-      submission_timestamp,
-      unnested_experiments.key AS experiment,
-      unnested_experiments.value AS branch,
-      {% for metric_name, metric in search_metrics['telemetry'].items() -%}
-        {% if metric == None %}
-          SUM(0)
-        {% elif metric_name == "search_count" %}
-        SUM(
-          (
-            SELECT
-              SUM(`moz-fx-data-shared-prod`.udf.extract_histogram_sum(value.value))
-            FROM
-              UNNEST(payload.keyed_histograms.search_counts) AS value
-          )
-        )
-        {% else %}
+    {{ app_dataset }} AS (
+      SELECT
+        submission_timestamp,
+        unnested_experiments.key AS experiment,
+        unnested_experiments.value AS branch,
+        {% for metric_name, metric in metrics.items() -%}
+          {% if metric == None %}
+            SUM(0)
+          {% elif metric_name == "search_count" %}
           SUM(
             (
               SELECT
-                SUM(value.value)
+                SUM(`moz-fx-data-shared-prod`.udf.extract_histogram_sum(value.value))
               FROM
-                UNNEST({{ metric }}) AS value
+                UNNEST(payload.keyed_histograms.search_counts) AS value
             )
           )
-        {% endif %}
-        AS {{ metric_name }},
-      {% endfor -%}
-    FROM
-      `moz-fx-data-shared-prod.telemetry_stable.main_v5`
-    LEFT JOIN
-      UNNEST(
-        ARRAY(SELECT AS STRUCT key, value.branch AS value FROM UNNEST(environment.experiments))
-      ) AS unnested_experiments
-    GROUP BY
-      submission_timestamp,
-      experiment,
-      branch
-  ),
+          {% else %}
+            SUM(
+              (
+                SELECT
+                  SUM(value.value)
+                FROM
+                  UNNEST({{ metric }}) AS value
+              )
+            )
+          {% endif %}
+          AS {{ metric_name }},
+        {% endfor -%}
+      FROM
+        `moz-fx-data-shared-prod.telemetry_stable.main_v5`
+      LEFT JOIN
+        UNNEST(
+          ARRAY(SELECT AS STRUCT key, value.branch AS value FROM UNNEST(environment.experiments))
+        ) AS unnested_experiments
+      GROUP BY
+        submission_timestamp,
+        experiment,
+        branch
+    ),
   {% else %}
-  {{ app_dataset }} AS (
-    SELECT
-      submission_timestamp,
-      experiment.key AS experiment,
-      experiment.value.branch AS branch,
-      {% for metric_name, metric in search_metrics[app_dataset].items() %}
-        {% if metric == None %}
-          SUM(0)
-        {% else %}
-          SUM(
-            (
-              SELECT
-                SUM(value.value)
-              FROM
-                UNNEST({{ metric }}) AS value
+    {{ app_dataset }} AS (
+      SELECT
+        submission_timestamp,
+        experiment.key AS experiment,
+        experiment.value.branch AS branch,
+        {% for metric_name, metric in metrics.items() %}
+          {% if metric == None %}
+            SUM(0)
+          {% else %}
+            SUM(
+              (
+                SELECT
+                  SUM(value.value)
+                FROM
+                  UNNEST({{ metric }}) AS value
+              )
             )
-          )
-        {% endif %}
-        AS {{ metric_name }},
-      {% endfor %}
-    FROM
-      `moz-fx-data-shared-prod.{{ app_dataset }}_stable.metrics_v1`
-    LEFT JOIN
-      UNNEST(ping_info.experiments) AS experiment
-    GROUP BY
-      submission_timestamp,
-      experiment,
-      branch
-  ),
+          {% endif %}
+          AS {{ metric_name }},
+        {% endfor %}
+      FROM
+        `moz-fx-data-shared-prod.{{ app_dataset }}_stable.metrics_v1`
+      LEFT JOIN
+        UNNEST(ping_info.experiments) AS experiment
+      GROUP BY
+        submission_timestamp,
+        experiment,
+        branch
+    ),
   {% endif %}
 {% endfor %}
 all_events AS (
-  {% for app_dataset in applications %}
+  {% for app_dataset, metrics in filtered_search_metrics %}
     SELECT
       *
     FROM


### PR DESCRIPTION
Fixes https://workflow.telemetry.mozilla.org/dags/bqetl_experiments_daily/grid?dag_run_id=scheduled__2025-04-04T03%3A00%3A00%2B00%3A00&task_id=telemetry_derived__experiment_search_aggregates__v1

https://bugzilla.mozilla.org/show_bug.cgi?id=1958883

## Description

The  `experiment_search_aggregates_v1` was failing due to metadata complexity being to large. This query removes applications that don't have any search metrics defined. I tested the generated query in BigQuery and it ran successfully. 

The only impact this should have is that instead of showing 0 values for search metrics on the experiment monitoring dashboard for these applications, it will show no data at all. This should be fine.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
