### PR TITLE
[DENG-8237]: update patched function

### DIFF
--- a/tests/sql_generators/usage_reporting/test_usage_reporting.py
+++ b/tests/sql_generators/usage_reporting/test_usage_reporting.py
@@ -161,7 +161,7 @@ PROBE_SCRAPER_APP_INFO_MOCK_VALUE = {
 
 
 # TODO: update the test_get_specific_apps_app_info_from_probe_scraper tests to use paremetisation.
-@patch("sql_generators.usage_reporting.usage_reporting.get_app_info")
+@patch("sql_generators.glean_usage.common.get_app_info")
 def test_get_specific_apps_app_info_from_probe_scraper_empty(mock_get_app_info):
     mock_get_app_info.return_value = PROBE_SCRAPER_APP_INFO_MOCK_VALUE
 
@@ -175,7 +175,7 @@ def test_get_specific_apps_app_info_from_probe_scraper_empty(mock_get_app_info):
 
 
 # TODO: we should mock the response from probe scraper API in this test.
-@patch("sql_generators.usage_reporting.usage_reporting.get_app_info")
+@patch("sql_generators.glean_usage.common.get_app_info")
 def test_get_specific_apps_app_info_from_probe_scraper(mock_get_app_info):
     mock_get_app_info.return_value = PROBE_SCRAPER_APP_INFO_MOCK_VALUE
 
@@ -271,7 +271,7 @@ def test_get_specific_apps_app_info_from_probe_scraper(mock_get_app_info):
     assert expected == actual
 
 
-@patch("sql_generators.usage_reporting.usage_reporting.get_app_info")
+@patch("sql_generators.glean_usage.common.get_app_info")
 def test_get_specific_apps_app_info_from_probe_scraper_filtered(mock_get_app_info):
     mock_get_app_info.return_value = PROBE_SCRAPER_APP_INFO_MOCK_VALUE
 


### PR DESCRIPTION
## Description
[Fix unit test failures](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/47686/workflows/fcdcd99f-793f-4757-8e61-f70289c5995c/jobs/559084) for the Usage Reporting module by updating the patched method `get_app_info`.

Running `pytest tests/sql_generators/usage_reporting/test_usage_reporting.py --disable-warnings --verbose` shows the tests now pass
<img width="1653" alt="Screenshot 2025-04-07 at 4 01 17 PM" src="https://github.com/user-attachments/assets/9ef44ce7-35aa-4efd-8472-cf4fdc668c70" />


## Related Tickets & Documents
[JIRA](https://mozilla-hub.atlassian.net/browse/DENG-8237)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
