### PR TITLE
Removing unwanted section filer

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/query.sql
@@ -66,8 +66,6 @@ SELECT
   COUNTIF(event_name = 'dismiss') AS dismiss_count
 FROM
   flattened_events
-WHERE
-  section IS NOT NULL
 GROUP BY
   submission_date,
   app_version,


### PR DESCRIPTION
## Description

This fix relates to https://github.com/mozilla/bigquery-etl/pull/7257
The filter `section IS NOT NULL` is not needed was accidentally applied. The `section` attribute is a very recent addition to the `newtab` ping and does not apply to older FF versions


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
