### PR TITLE
fix: remove the additional custom import logic from usage_reporting and patch correct object in unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = {file = ["requirements.in"]}
 [tool.setuptools_scm]
 
 [tool.setuptools.packages.find]
-include = ["bigquery_etl", "bigquery_etl.*"]
+include = ["bigquery_etl", "bigquery_etl.*", "sql_generators", "sql_generators.*"]
 
 [project.scripts]
 bqetl = "bigquery_etl.cli:cli"

--- a/sql_generators/usage_reporting/usage_reporting.py
+++ b/sql_generators/usage_reporting/usage_reporting.py
@@ -8,6 +8,7 @@ from jinja2 import Environment, FileSystemLoader
 from bigquery_etl.config import ConfigLoader
 from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.util.common import write_sql
+from sql_generators.glean_usage.common import get_app_info
 
 GENERATOR_ROOT = Path(path.dirname(__file__))
 
@@ -64,8 +65,6 @@ def get_specific_apps_app_info_from_probe_scraper(usage_reporting_apps):
     The app info returned includes app_name, and bq namespaces containing data \
     for specific app channels.
     """
-    from sql_generators.glean_usage.common import get_app_info
-
     probe_scraper_app_info = get_app_info()
 
     app_info_filtered: dict = dict()
@@ -350,17 +349,5 @@ if __name__ == "__main__":
     parser.add_argument("--project", default="moz-fx-data-shared-prod")
     parser.add_argument("--output_dir", default="sql")
     args = parser.parse_args()
-
-    # Something is wrong with how modules are managed, we need to do this when calling the module directly.
-    # Otherwise, the cli module does this.
-    import importlib.util
-    import sys
-
-    sql_generators_dir = "sql_generators"
-    spec = importlib.util.spec_from_file_location(
-        sql_generators_dir, (f"{sql_generators_dir}/__init__.py")
-    )
-    module = importlib.util.module_from_spec(spec)  # type: ignore
-    sys.modules["sql_generators"] = module
 
     generate_usage_reporting(args.project, args.output_dir)

--- a/tests/sql_generators/usage_reporting/test_usage_reporting.py
+++ b/tests/sql_generators/usage_reporting/test_usage_reporting.py
@@ -161,7 +161,7 @@ PROBE_SCRAPER_APP_INFO_MOCK_VALUE = {
 
 
 # TODO: update the test_get_specific_apps_app_info_from_probe_scraper tests to use paremetisation.
-@patch("sql_generators.glean_usage.common.get_app_info")
+@patch("sql_generators.usage_reporting.usage_reporting.get_app_info")
 def test_get_specific_apps_app_info_from_probe_scraper_empty(mock_get_app_info):
     mock_get_app_info.return_value = PROBE_SCRAPER_APP_INFO_MOCK_VALUE
 
@@ -175,7 +175,7 @@ def test_get_specific_apps_app_info_from_probe_scraper_empty(mock_get_app_info):
 
 
 # TODO: we should mock the response from probe scraper API in this test.
-@patch("sql_generators.glean_usage.common.get_app_info")
+@patch("sql_generators.usage_reporting.usage_reporting.get_app_info")
 def test_get_specific_apps_app_info_from_probe_scraper(mock_get_app_info):
     mock_get_app_info.return_value = PROBE_SCRAPER_APP_INFO_MOCK_VALUE
 
@@ -271,7 +271,7 @@ def test_get_specific_apps_app_info_from_probe_scraper(mock_get_app_info):
     assert expected == actual
 
 
-@patch("sql_generators.glean_usage.common.get_app_info")
+@patch("sql_generators.usage_reporting.usage_reporting.get_app_info")
 def test_get_specific_apps_app_info_from_probe_scraper_filtered(mock_get_app_info):
     mock_get_app_info.return_value = PROBE_SCRAPER_APP_INFO_MOCK_VALUE
 

--- a/tests/sql_generators/usage_reporting/test_usage_reporting.py
+++ b/tests/sql_generators/usage_reporting/test_usage_reporting.py
@@ -281,7 +281,6 @@ def test_get_specific_apps_app_info_from_probe_scraper_filtered(mock_get_app_inf
         "firefox_desktop": {"channels": None},
     }
     actual = get_specific_apps_app_info_from_probe_scraper(input)
-    assert mock_get_app_info.called
 
     expected = {
         "firefox_desktop": {
@@ -300,4 +299,5 @@ def test_get_specific_apps_app_info_from_probe_scraper_filtered(mock_get_app_inf
         },
     }
 
+    assert mock_get_app_info.called
     assert expected == actual


### PR DESCRIPTION
# fix: remove the additional custom import logic from usage_reporting and patch correct object in unit tests

Thanks @ogzillla for your input to simplify the import logic.

To verify these changes locally:

```shell
# 1. update pip
venv/bin/python -m pip install --upgrade pip

# 2. Re-install bigquery-etl package
venv/bin/python -m pip install -e .

# 3. Run unit tests
venv/bin/python -m pytest -W ignore::DeprecationWarning tests/sql_generators/usage_reporting/test_usage_reporting.py
```

Both generation via the ./bqetl generate command and when calling the module directly.

![Uploading image.png…]()
