### PR TITLE
feat: use table metrics for freshness and volume, and use table deployments

### DIFF
--- a/sql/bigconfig.yml
+++ b/sql/bigconfig.yml
@@ -1,5 +1,4 @@
 type: BIGCONFIG_FILE
-
 saved_metric_definitions:
   metrics:
     - saved_metric_id: is_not_null

--- a/sql_generators/usage_reporting/templates/usage_reporting_active_users_aggregates_v1.bigconfig.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_active_users_aggregates_v1.bigconfig.yaml.jinja
@@ -1,25 +1,22 @@
 type: BIGCONFIG_FILE
-
-tag_deployments:
+table_deployments:
   - collection:
       name: {{ bigeye_collection }}
       notification_channels:
         - slack: '{{ bigeye_notification_slack_channel }}'
+
     deployments:
-      - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ app_name }}_derived.{{ table_name }}.submission_date
-        metrics:
-          - saved_metric_id: is_not_null
-      - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ app_name }}_derived.{{ table_name }}.country
-        metrics:
-          - saved_metric_id: is_2_char_len
-      - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ app_name }}_derived.{{ table_name }}.channel
-        metrics:
-          - saved_metric_id: is_valid_channel
-      - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ app_name }}_derived.{{ table_name }}.*
-        metrics:
+      - fq_table_name: {{ project_id }}.{{ project_id }}.{{ app_name }}_derived.{{ table_name }}
+        table_metrics:
           - saved_metric_id: volume
           - saved_metric_id: freshness
+        columns:
+          - column_name: submission_date
+            metrics:
+              - saved_metric_id: is_not_null
+          - column_name: country
+            metrics:
+              - saved_metric_id: is_2_char_len
+          - column_name: channel
+            metrics:
+              - saved_metric_id: is_valid_channel

--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_daily_v1.bigconfig.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_daily_v1.bigconfig.yaml.jinja
@@ -1,23 +1,25 @@
 type: BIGCONFIG_FILE
-
-tag_deployments:
+table_deployments:
   - collection:
       name: {{ bigeye_collection }}
       notification_channels:
         - slack: '{{ bigeye_notification_slack_channel }}'
+
     deployments:
-      - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.submission_date
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.usage_profile_id
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.is_active
-        metrics:
-          - saved_metric_id: is_not_null
-      - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.normalized_country_code
-        metrics:
-          - saved_metric_id: is_2_char_len
-      - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.*
-        metrics:
+      - fq_table_name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}
+        table_metrics:
           - saved_metric_id: volume
           - saved_metric_id: freshness
+        columns:
+          - column_name: submission_date
+            metrics:
+              - saved_metric_id: is_not_null
+          - column_name: usage_profile_id
+            metrics:
+              - saved_metric_id: is_not_null
+          - column_name: is_active
+            metrics:
+              - saved_metric_id: is_not_null
+          - column_name: normalized_country_code
+            metrics:
+              - saved_metric_id: is_2_char_len

--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_first_seen_v1.bigconfig.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_first_seen_v1.bigconfig.yaml.jinja
@@ -1,20 +1,23 @@
 type: BIGCONFIG_FILE
-
-tag_deployments:
+table_deployments:
   - collection:
       name: {{ bigeye_collection }}
       notification_channels:
         - slack: '{{ bigeye_notification_slack_channel }}'
+
     deployments:
-      - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.first_seen_date
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.usage_profile_id
-        metrics:
-          - saved_metric_id: is_not_null
-            rct_overrides:
-              - first_seen_date
-      - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.*
-        metrics:
+      - fq_table_name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}
+        table_metrics:
           - saved_metric_id: volume
           - saved_metric_id: freshness
+        columns:
+          - column_name: first_seen_date
+            metrics:
+              - saved_metric_id: is_not_null
+                rct_overrides:
+                  - first_seen_date
+          - column_name: usage_profile_id
+            metrics:
+              - saved_metric_id: is_not_null
+                rct_overrides:
+                  - first_seen_date

--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_last_seen_v1.bigconfig.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_last_seen_v1.bigconfig.yaml.jinja
@@ -1,21 +1,28 @@
 type: BIGCONFIG_FILE
-
-tag_deployments:
+table_deployments:
   - collection:
       name: {{ bigeye_collection }}
       notification_channels:
         - slack: '{{ bigeye_notification_slack_channel }}'
+
     deployments:
-      - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.submission_date
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.usage_profile_id
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.days_seen_bits
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.days_active_bits
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.days_created_profile_bits
-        metrics:
-          - saved_metric_id: is_not_null
-      - column_selectors:
-        - name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}.*
-        metrics:
+      - fq_table_name: {{ project_id }}.{{ project_id }}.{{ channel_dataset }}_derived.{{ table_name }}
+        table_metrics:
           - saved_metric_id: volume
           - saved_metric_id: freshness
+        columns:
+          - column_name: submission_date
+            metrics:
+              - saved_metric_id: is_not_null
+          - column_name: usage_profile_id
+            metrics:
+              - saved_metric_id: is_not_null
+          - column_name: days_seen_bits
+            metrics:
+              - saved_metric_id: is_not_null
+          - column_name: days_active_bits
+            metrics:
+              - saved_metric_id: is_not_null
+          - column_name: days_created_profile_bits
+            metrics:
+              - saved_metric_id: is_not_null


### PR DESCRIPTION
# feat: use table metrics for freshness and volume, and use table deployments

This is to avoid creating metrics for each column for freshness and volume.