### PR TITLE
Bug 1957476 - Add attr/dist metrics to client_info in stable views

### DIFF
--- a/sql/mozfun/norm/glean_client_info_attribution/README.md
+++ b/sql/mozfun/norm/glean_client_info_attribution/README.md
@@ -1,0 +1,2 @@
+Add application-defined attribution and distribution metrics to client_info struct.
+See https://bugzilla.mozilla.org/show_bug.cgi?id=1930762 and the linked doc for details.

--- a/sql/mozfun/norm/glean_client_info_attribution/metadata.yaml
+++ b/sql/mozfun/norm/glean_client_info_attribution/metadata.yaml
@@ -1,0 +1,4 @@
+friendly_name: Glean Client Info Attribution
+description: |
+  Add application-defined attribution and distribution metrics to client_info struct.
+  See https://bugzilla.mozilla.org/show_bug.cgi?id=1930762 and the linked doc for details.

--- a/sql/mozfun/norm/glean_client_info_attribution/udf.sql
+++ b/sql/mozfun/norm/glean_client_info_attribution/udf.sql
@@ -1,0 +1,56 @@
+CREATE OR REPLACE FUNCTION norm.glean_client_info_attribution(
+  client_info ANY TYPE,
+  attribution_ext JSON,
+  distribution_ext JSON
+) AS (
+  (
+    SELECT AS STRUCT
+      client_info.* REPLACE (
+        (SELECT AS STRUCT client_info.attribution.*, attribution_ext AS ext) AS attribution,
+        (SELECT AS STRUCT client_info.distribution.*, distribution_ext AS ext) AS distribution
+      )
+  )
+);
+
+-- Tests
+SELECT
+  assert.equals(
+    TO_JSON_STRING(
+      STRUCT(
+        'abc' AS client_id,
+        STRUCT("c" AS campaign, JSON '{"prop": "attr"}' AS ext) AS attribution,
+        STRUCT("n" AS name, JSON '{"prop": "dist"}' AS ext) AS distribution
+      )
+    ),
+    TO_JSON_STRING(
+      norm.glean_client_info_attribution(
+        STRUCT(
+          'abc' AS client_id,
+          STRUCT("c" AS campaign) AS attribution,
+          STRUCT("n" AS name) AS distribution
+        ),
+        JSON '{"prop": "attr"}',
+        JSON '{"prop": "dist"}'
+      )
+    )
+  ),
+  assert.equals(
+    TO_JSON_STRING(
+      STRUCT(
+        'abc' AS client_id,
+        STRUCT("c" AS campaign, CAST(NULL AS JSON) AS ext) AS attribution,
+        STRUCT("n" AS name, CAST(NULL AS JSON) AS ext) AS distribution
+      )
+    ),
+    TO_JSON_STRING(
+      norm.glean_client_info_attribution(
+        STRUCT(
+          'abc' AS client_id,
+          STRUCT("c" AS campaign) AS attribution,
+          STRUCT("n" AS name) AS distribution
+        ),
+        CAST(NULL AS JSON),
+        CAST(NULL AS JSON)
+      )
+    )
+  ),


### PR DESCRIPTION
## Description

This changes the stable views to mirror glean attribution and distribution metrics into `client_info` per [this doc](https://docs.google.com/document/d/1TIZhpBeZcJSEnIZJwj0Cj9saL2Tfs0X6oi_4gFU35eM/edit?tab=t.0#heading=h.dc06cblplbtl).

The metrics are `metrics.object.glean_attribution_ext` and `metrics.object.glean_distribution_ext` and they get added to client info as `client_info.attribution.ext` and `client_info.distribution.ext` as JSON fields.  If the metrics don't exist in the schema, the fields are still added as nulls.

@chutten can you confirm the field names and structure is what you expect?

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1957476

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
