### PR TITLE
Add nimbus_recorded_targeting_context queries for fenix and firefox ios

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix/nimbus_recorded_targeting_context/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix/nimbus_recorded_targeting_context/view.sql
@@ -5,13 +5,15 @@ SELECT
   m.*
 FROM
   `moz-fx-data-shared-prod.org_mozilla_fenix_derived.recorded_targeting_context_v1` m
-INNER JOIN (
-  SELECT
-    client_id,
-    MAX(submission_date) as latest_date
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_fenix_derived.recorded_targeting_context_v1`
-  GROUP BY client_id
-) ld
-ON
-  m.client_id = ld.client_id AND m.submission_date = ld.latest_date
+INNER JOIN
+  (
+    SELECT
+      client_id,
+      MAX(submission_date) AS latest_date
+    FROM
+      `moz-fx-data-shared-prod.org_mozilla_fenix_derived.recorded_targeting_context_v1`
+    GROUP BY
+      client_id
+  ) ld
+  ON m.client_id = ld.client_id
+  AND m.submission_date = ld.latest_date

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix/nimbus_recorded_targeting_context/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix/nimbus_recorded_targeting_context/view.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_fenix.recorded_targeting_context`
+AS
+SELECT
+  m.*
+FROM
+  `moz-fx-data-shared-prod.org_mozilla_fenix_derived.recorded_targeting_context_v1` m
+INNER JOIN (
+  SELECT
+    client_id,
+    MAX(submission_date) as latest_date
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_fenix_derived.recorded_targeting_context_v1`
+  GROUP BY client_id
+) ld
+ON
+  m.client_id = ld.client_id AND m.submission_date = ld.latest_date

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix/nimbus_recorded_targeting_context/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix/nimbus_recorded_targeting_context/view.sql
@@ -1,17 +1,17 @@
 CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.org_mozilla_fenix.recorded_targeting_context`
+  `moz-fx-data-shared-prod.org_mozilla_fenix.nimbus_recorded_targeting_context`
 AS
 SELECT
   m.*
 FROM
-  `moz-fx-data-shared-prod.org_mozilla_fenix_derived.recorded_targeting_context_v1` m
+  `moz-fx-data-shared-prod.org_mozilla_fenix_derived.nimbus_recorded_targeting_context_v1` m
 INNER JOIN
   (
     SELECT
       client_id,
       MAX(submission_date) AS latest_date
     FROM
-      `moz-fx-data-shared-prod.org_mozilla_fenix_derived.recorded_targeting_context_v1`
+      `moz-fx-data-shared-prod.org_mozilla_fenix_derived.nimbus_recorded_targeting_context_v1`
     GROUP BY
       client_id
   ) ld

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Nimbus Recorded Targeting Context (Fenix)
 description: |-
-  A query to obtain the
+  A query to obtain the previous day's recorded Nimbus targeting context values for each client.
 owners:
 - chumphreys@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
@@ -1,0 +1,15 @@
+friendly_name: Nimbus Recorded Targeting Context (Fenix)
+description: |-
+  A query to obtain the
+owners:
+- chumphreys@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_default
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
@@ -6,10 +6,10 @@ owners:
 labels:
   incremental: true
 scheduling:
-  dag_name: bqetl_default
+  dag_name: bqetl_experiments_daily
 bigquery:
   time_partitioning:
     type: day
     field: submission_date
     require_partition_filter: true
-    expiration_days: null
+    expiration_days: 400

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
@@ -1,0 +1,42 @@
+-- Query for org_mozilla_fenix_derived.recorded_targeting_context_v1
+            -- For more information on writing queries see:
+            -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
+WITH filtered AS (
+    SELECT
+        m.client_info.client_id as client_id,
+        m.submission_timestamp,
+        m.metrics.object.nimbus_system_recorded_nimbus_context as context
+    FROM `moz-fx-data-shared-prod.org_mozilla_fenix.metrics` m
+    WHERE 1=1
+      AND m.metrics.object.nimbus_system_recorded_nimbus_context IS NOT NULL
+      AND DATE(m.submission_timestamp) = @submission_date
+    AND m.normalized_channel = 'release'
+    AND m.app_version_major >= 135
+    )
+SELECT
+    m.client_id,
+    DATE(m.submission_timestamp) as submission_date,
+    CAST(JSON_VALUE(context, '$.androidSdkVersion') as int) as androidSdkVersion,
+    CAST(JSON_VALUE(context, '$.appVersion') as string) as androidSdkVersion,
+    CAST(JSON_VALUE(context, '$.daysSinceInstall') as int) as daysSinceInstall,
+    CAST(JSON_VALUE(context, '$.daysSinceUpdate') as int) as daysSinceUpdate,
+    CAST(JSON_VALUE(context, '$.deviceManufacturer') as string) as deviceManufacturer,
+    CAST(JSON_VALUE(context, '$.deviceModel') as string) as deviceModel,
+    CAST(JSON_VALUE(context, '$.eventQueryValues.daysOpenedInLast28') as int) as eventQuery_daysOpenedInLast28,
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmCampaign') as string) as installReferrerResponseUtmCampaign,
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmContent') as string) as installReferrerResponseUtmContent,
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmMedium') as string) as installReferrerResponseUtmMedium,
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmSource') as string) as installReferrerResponseUtmSource,
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmTerm') as string) as installReferrerResponseUtmTerm,
+    CAST(JSON_VALUE(context, '$.isFirstRun') as boolean) as isFirstRun,
+    CAST(JSON_VALUE(context, '$.language') as string) as language,
+    CAST(JSON_VALUE(context, '$.locale') as string) as locale,
+    CAST(JSON_VALUE(context, '$.region') as string) as region,
+    context
+FROM filtered m
+    INNER JOIN (
+    SELECT client_id, MAX(submission_timestamp) as latest_timestamp
+    FROM filtered
+    GROUP BY client_id
+    ) lt
+ON m.client_id = lt.client_id AND m.submission_timestamp = lt.latest_timestamp

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
@@ -2,41 +2,62 @@
             -- For more information on writing queries see:
             -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
 WITH filtered AS (
-    SELECT
-        m.client_info.client_id as client_id,
-        m.submission_timestamp,
-        m.metrics.object.nimbus_system_recorded_nimbus_context as context
-    FROM `moz-fx-data-shared-prod.org_mozilla_fenix.metrics` m
-    WHERE 1=1
-      AND m.metrics.object.nimbus_system_recorded_nimbus_context IS NOT NULL
-      AND DATE(m.submission_timestamp) = @submission_date
+  SELECT
+    m.client_info.client_id AS client_id,
+    m.submission_timestamp,
+    m.metrics.object.nimbus_system_recorded_nimbus_context AS context
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_fenix.metrics` m
+  WHERE
+    1 = 1
+    AND m.metrics.object.nimbus_system_recorded_nimbus_context IS NOT NULL
+    AND DATE(m.submission_timestamp) = @submission_date
     AND m.normalized_channel = 'release'
     AND m.app_version_major >= 135
-    )
+)
 SELECT
-    m.client_id,
-    DATE(m.submission_timestamp) as submission_date,
-    CAST(JSON_VALUE(context, '$.androidSdkVersion') as int) as androidSdkVersion,
-    CAST(JSON_VALUE(context, '$.appVersion') as string) as androidSdkVersion,
-    CAST(JSON_VALUE(context, '$.daysSinceInstall') as int) as daysSinceInstall,
-    CAST(JSON_VALUE(context, '$.daysSinceUpdate') as int) as daysSinceUpdate,
-    CAST(JSON_VALUE(context, '$.deviceManufacturer') as string) as deviceManufacturer,
-    CAST(JSON_VALUE(context, '$.deviceModel') as string) as deviceModel,
-    CAST(JSON_VALUE(context, '$.eventQueryValues.daysOpenedInLast28') as int) as eventQuery_daysOpenedInLast28,
-    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmCampaign') as string) as installReferrerResponseUtmCampaign,
-    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmContent') as string) as installReferrerResponseUtmContent,
-    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmMedium') as string) as installReferrerResponseUtmMedium,
-    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmSource') as string) as installReferrerResponseUtmSource,
-    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmTerm') as string) as installReferrerResponseUtmTerm,
-    CAST(JSON_VALUE(context, '$.isFirstRun') as boolean) as isFirstRun,
-    CAST(JSON_VALUE(context, '$.language') as string) as language,
-    CAST(JSON_VALUE(context, '$.locale') as string) as locale,
-    CAST(JSON_VALUE(context, '$.region') as string) as region,
-    context
-FROM filtered m
-    INNER JOIN (
-    SELECT client_id, MAX(submission_timestamp) as latest_timestamp
-    FROM filtered
-    GROUP BY client_id
-    ) lt
-ON m.client_id = lt.client_id AND m.submission_timestamp = lt.latest_timestamp
+  m.client_id,
+  DATE(m.submission_timestamp) AS submission_date,
+  CAST(JSON_VALUE(context, '$.androidSdkVersion') AS int) AS androidSdkVersion,
+  CAST(JSON_VALUE(context, '$.appVersion') AS string) AS androidSdkVersion,
+  CAST(JSON_VALUE(context, '$.daysSinceInstall') AS int) AS daysSinceInstall,
+  CAST(JSON_VALUE(context, '$.daysSinceUpdate') AS int) AS daysSinceUpdate,
+  CAST(JSON_VALUE(context, '$.deviceManufacturer') AS string) AS deviceManufacturer,
+  CAST(JSON_VALUE(context, '$.deviceModel') AS string) AS deviceModel,
+  CAST(
+    JSON_VALUE(context, '$.eventQueryValues.daysOpenedInLast28') AS int
+  ) AS eventQuery_daysOpenedInLast28,
+  CAST(
+    JSON_VALUE(context, '$.installReferrerResponseUtmCampaign') AS string
+  ) AS installReferrerResponseUtmCampaign,
+  CAST(
+    JSON_VALUE(context, '$.installReferrerResponseUtmContent') AS string
+  ) AS installReferrerResponseUtmContent,
+  CAST(
+    JSON_VALUE(context, '$.installReferrerResponseUtmMedium') AS string
+  ) AS installReferrerResponseUtmMedium,
+  CAST(
+    JSON_VALUE(context, '$.installReferrerResponseUtmSource') AS string
+  ) AS installReferrerResponseUtmSource,
+  CAST(
+    JSON_VALUE(context, '$.installReferrerResponseUtmTerm') AS string
+  ) AS installReferrerResponseUtmTerm,
+  CAST(JSON_VALUE(context, '$.isFirstRun') AS boolean) AS isFirstRun,
+  CAST(JSON_VALUE(context, '$.language') AS string) AS language,
+  CAST(JSON_VALUE(context, '$.locale') AS string) AS locale,
+  CAST(JSON_VALUE(context, '$.region') AS string) AS region,
+  context
+FROM
+  filtered m
+INNER JOIN
+  (
+    SELECT
+      client_id,
+      MAX(submission_timestamp) AS latest_timestamp
+    FROM
+      filtered
+    GROUP BY
+      client_id
+  ) lt
+  ON m.client_id = lt.client_id
+  AND m.submission_timestamp = lt.latest_timestamp

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/nimbus_recorded_targeting_context/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/nimbus_recorded_targeting_context/view.sql
@@ -5,13 +5,15 @@ SELECT
   m.*
 FROM
   `moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.nimbus_recorded_targeting_context_v1` m
-INNER JOIN (
-  SELECT
-    client_id,
-    MAX(submission_date) as latest_date
-  FROM
-    `moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.nimbus_recorded_targeting_context_v1`
-  GROUP BY client_id
-) ld
-ON
-  m.client_id = ld.client_id AND m.submission_date = ld.latest_date
+INNER JOIN
+  (
+    SELECT
+      client_id,
+      MAX(submission_date) AS latest_date
+    FROM
+      `moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.nimbus_recorded_targeting_context_v1`
+    GROUP BY
+      client_id
+  ) ld
+  ON m.client_id = ld.client_id
+  AND m.submission_date = ld.latest_date

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/nimbus_recorded_targeting_context/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/nimbus_recorded_targeting_context/view.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.org_mozilla_ios_firefox.nimbus_recorded_targeting_context`
+AS
+SELECT
+  m.*
+FROM
+  `moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.nimbus_recorded_targeting_context_v1` m
+INNER JOIN (
+  SELECT
+    client_id,
+    MAX(submission_date) as latest_date
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.nimbus_recorded_targeting_context_v1`
+  GROUP BY client_id
+) ld
+ON
+  m.client_id = ld.client_id AND m.submission_date = ld.latest_date

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
@@ -1,0 +1,15 @@
+friendly_name: Nimbus Recorded Targeting Context (iOS)
+description: |-
+  Please provide a description for the query
+owners:
+- chumphreys@mozilla.com
+labels:
+  incremental: true
+scheduling:
+  dag_name: bqetl_default
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
@@ -6,10 +6,10 @@ owners:
 labels:
   incremental: true
 scheduling:
-  dag_name: bqetl_default
+  dag_name: bqetl_experiments_daily
 bigquery:
   time_partitioning:
     type: day
     field: submission_date
     require_partition_filter: true
-    expiration_days: null
+    expiration_days: 400

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/nimbus_recorded_targeting_context_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Nimbus Recorded Targeting Context (iOS)
 description: |-
-  Please provide a description for the query
+  A query to obtain the previous day's recorded Nimbus targeting context values for each client.
 owners:
 - chumphreys@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/nimbus_recorded_targeting_context_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/nimbus_recorded_targeting_context_v1/query.sql
@@ -1,0 +1,48 @@
+-- Query for org_mozilla_ios_firefox_derived.nimbus_recorded_targeting_context_v1
+            -- For more information on writing queries see:
+            -- https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html
+WITH filtered AS (
+  SELECT
+    m.client_info.client_id AS client_id,
+    m.submission_timestamp,
+    m.metrics.object.nimbus_system_recorded_nimbus_context AS context
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_ios_firefox.metrics` m
+  WHERE
+    1 = 1
+    AND m.metrics.object.nimbus_system_recorded_nimbus_context IS NOT NULL
+    AND DATE(m.submission_timestamp) = @submission_date
+    AND m.normalized_channel = 'release'
+    AND m.app_version_major >= 135
+)
+SELECT
+  m.client_id,
+  DATE(m.submission_timestamp) AS submission_date,
+  CAST(JSON_VALUE(context, '$.appVersion') AS string) AS androidSdkVersion,
+  CAST(JSON_VALUE(context, '$.daysSinceInstall') AS int) AS daysSinceInstall,
+  CAST(JSON_VALUE(context, '$.daysSinceUpdate') AS int) AS daysSinceUpdate,
+  CAST(
+    JSON_VALUE(context, '$.eventQueryValues.daysOpenedInLast28') AS int
+  ) AS eventQuery_daysOpenedInLast28,
+  CAST(JSON_VALUE(context, '$.isDefaultBrowser') AS boolean) AS isDefaultBrowser,
+  CAST(JSON_VALUE(context, '$.isFirstRun') AS boolean) AS isFirstRun,
+  CAST(JSON_VALUE(context, '$.isPhone') AS boolean) AS isPhone,
+  CAST(JSON_VALUE(context, '$.isReviewCheckerEnabled') AS boolean) AS isReviewCheckerEnabled,
+  CAST(JSON_VALUE(context, '$.language') AS string) AS language,
+  CAST(JSON_VALUE(context, '$.locale') AS string) AS locale,
+  CAST(JSON_VALUE(context, '$.region') AS string) AS region,
+  context
+FROM
+  filtered m
+INNER JOIN
+  (
+    SELECT
+      client_id,
+      MAX(submission_timestamp) AS latest_timestamp
+    FROM
+      filtered
+    GROUP BY
+      client_id
+  ) lt
+  ON m.client_id = lt.client_id
+  AND m.submission_timestamp = lt.latest_timestamp


### PR DESCRIPTION
## Description

This PR adds two queries — a query to obtain the previous day's Nimbus recorded targeting contexts for Fenix, and an equivalent one for Firefox iOS.

## Related Tickets & Documents
* [EXP-4608](https://mozilla-hub.atlassian.net/browse/EXP-4608)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[EXP-4608]: https://mozilla-hub.atlassian.net/browse/EXP-4608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ