### PR TITLE
Bug 1958887 - Remove view authorization for fenix.broken_site_report

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix/broken_site_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/broken_site_report/metadata.yaml
@@ -1,5 +1,3 @@
-labels:
-  authorized: true
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix/broken_site_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix/broken_site_report/metadata.yaml
@@ -1,3 +1,5 @@
+labels:
+  authorized: true
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:


### PR DESCRIPTION
## Description

I changed the wrong view in https://github.com/mozilla/bigquery-etl/pull/7285

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1958887

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
