### PR TITLE
Store metrics as struct in SubPlat backend's events_stream

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -341,6 +341,7 @@ generate:
       metrics_as_struct:
       - accounts_frontend
       - accounts_backend
+      - subscription_platform_backend
     events_monitoring:
       skip_apps:
       - ads_backend  # restricted dataset, we don't want to include it aggregate view


### PR DESCRIPTION
## Description

Subscription platform backend telemetry is added in https://github.com/mozilla/probe-scraper/pull/885
This will make their events_stream tables consistent with FxA.
