### PR TITLE
feat(): include bigconfig table deployments when setting default metrics

### DIFF
--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -376,11 +376,9 @@ def _update_bigconfig(
             "saved_metric_id": (
                 metric.saved_metric_id.upper().removesuffix("_FAIL")
                 if metric.saved_metric_id
-                else metric.saved_metric_id
+                else None
             ),
-            "metric_name": (
-                metric.metric_name.upper() if metric.metric_name else metric.metric_name
-            ),
+            "metric_name": (metric.metric_name.upper() if metric.metric_name else None),
         }
         for collection in bigconfig.tag_deployments
         for deployment in collection.deployments
@@ -397,12 +395,10 @@ def _update_bigconfig(
             "saved_metric_id": (
                 table_metric.saved_metric_id.upper().removesuffix("_FAIL")
                 if table_metric.saved_metric_id
-                else table_metric.saved_metric_id
+                else None
             ),
             "metric_name": (
-                table_metric.metric_name.upper()
-                if table_metric.metric_name
-                else table_metric.metric_name
+                table_metric.metric_name.upper() if table_metric.metric_name else None
             ),
         }
         for collection in bigconfig.table_deployments
@@ -410,15 +406,15 @@ def _update_bigconfig(
         for table_metric in deployment.table_metrics
     ]
 
-    for metric in tag_deployment_metrics + table_deployment_metrics:
-        default_metric = (
-            metric.get("predefined_metric")
-            or metric.get("saved_metric_id")
-            or metric.get("metric_name")
+    for deployment_metric in tag_deployment_metrics + table_deployment_metrics:
+        config_metric = (
+            deployment_metric["predefined_metric"]
+            or deployment_metric["saved_metric_id"]
+            or deployment_metric["metric_name"]
         )
 
-        if default_metric in default_metrics:
-            default_metrics.remove(default_metric)
+        if config_metric in default_metrics:
+            default_metrics.remove(config_metric)
 
     if len(default_metrics) > 0:
         deployments = [

--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -366,24 +366,59 @@ def _update_bigconfig(
     default_metrics,
 ):
     """Update the BigConfig file to monitor a view."""
-    for collection in bigconfig.tag_deployments:
-        for deployment in collection.deployments:
-            for metric in deployment.metrics:
-                if (
-                    metric.metric_type is not None
-                    and metric.metric_type.predefined_metric in default_metrics
-                ):
-                    default_metrics.remove(metric.metric_type.predefined_metric)
-                elif (
-                    metric.saved_metric_id is not None
-                    and (metric_id := metric.saved_metric_id.upper()) in default_metrics
-                ):
-                    default_metrics.remove(metric_id)
+    tag_deployment_metrics = [
+        {
+            "predefined_metric": (
+                metric.metric_type.predefined_metric.upper()
+                if metric.metric_type
+                else None
+            ),
+            "saved_metric_id": (
+                metric.saved_metric_id.upper().removesuffix("_FAIL")
+                if metric.saved_metric_id
+                else metric.saved_metric_id
+            ),
+            "metric_name": (
+                metric.metric_name.upper() if metric.metric_name else metric.metric_name
+            ),
+        }
+        for collection in bigconfig.tag_deployments
+        for deployment in collection.deployments
+        for metric in deployment.metrics
+    ]
 
-        if metadata.monitoring.collection and collection.collection is None:
-            collection.collection = SimpleCollection(
-                name=metadata.monitoring.collection
-            )
+    table_deployment_metrics = [
+        {
+            "predefined_metric": (
+                table_metric.metric_type.predefined_metric.upper()
+                if table_metric.metric_type
+                else None
+            ),
+            "saved_metric_id": (
+                table_metric.saved_metric_id.upper().removesuffix("_FAIL")
+                if table_metric.saved_metric_id
+                else table_metric.saved_metric_id
+            ),
+            "metric_name": (
+                table_metric.metric_name.upper()
+                if table_metric.metric_name
+                else table_metric.metric_name
+            ),
+        }
+        for collection in bigconfig.table_deployments
+        for deployment in collection.deployments
+        for table_metric in deployment.table_metrics
+    ]
+
+    for metric in tag_deployment_metrics + table_deployment_metrics:
+        default_metric = (
+            metric.get("predefined_metric")
+            or metric.get("saved_metric_id")
+            or metric.get("metric_name")
+        )
+
+        if default_metric in default_metrics:
+            default_metrics.remove(default_metric)
 
     if len(default_metrics) > 0:
         deployments = [

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/releases_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/releases_v1/bigconfig.yml
@@ -11,7 +11,7 @@ tag_deployments:
     - metric_type:
         type: PREDEFINED
         predefined_metric: FRESHNESS
-      metric_name: FRESHNESS [warn]
+      metric_name: FRESHNESS
       metric_schedule:
         named_schedule:
           name: Default Schedule - 13:00 UTC


### PR DESCRIPTION
# feat(): include Bigconfig table deployments when setting default metrics

Previously only metrics defined under the `tag_deployments` would be considered when determining if any of the default metrics should be added to the configuration. This change ensures that metrics defined under `table_deployments` are also considered.