### PR TITLE
feat(DENG-8069): Add normalized columns

### DIFF
--- a/sql/moz-fx-data-shared-prod/external/chrome_extensions/view.sql
+++ b/sql/moz-fx-data-shared-prod/external/chrome_extensions/view.sql
@@ -2,6 +2,29 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.external.chrome_extensions`
 AS
 SELECT
-  *
+  submission_date,
+  `url`,
+  chrome_extension_name,
+  star_rating AS star_rating_raw,
+  SAFE_CAST(star_rating AS numeric) AS star_rating_numeric,
+  number_of_ratings AS number_of_ratings_raw,
+  CASE
+    WHEN REGEXP_CONTAINS(LOWER(number_of_ratings), r'^\d+(\.\d+)?k$')
+      THEN CAST(REGEXP_EXTRACT(LOWER(number_of_ratings), r'^(\d+(\.\d+)?)') AS FLOAT64) * 1000
+    WHEN REGEXP_CONTAINS(number_of_ratings, r'^\d+$')
+      THEN CAST(number_of_ratings AS INT64)
+    ELSE NULL
+  END AS number_of_ratings_numeric,
+  number_of_users AS number_of_users_raw,
+  SAFE_CAST(number_of_users AS INT64) AS number_of_users_numeric,
+  extension_version,
+  extension_size,
+  extension_languages,
+  developer_desc,
+  developer_email,
+  developer_website,
+  developer_phone,
+  extension_updated_date,
+  category
 FROM
   `moz-fx-data-shared-prod.external_derived.chrome_extensions_v1`

--- a/sql/moz-fx-data-shared-prod/external/chrome_extensions/view.sql
+++ b/sql/moz-fx-data-shared-prod/external/chrome_extensions/view.sql
@@ -10,7 +10,7 @@ SELECT
   number_of_ratings AS number_of_ratings_raw,
   CASE
     WHEN REGEXP_CONTAINS(LOWER(number_of_ratings), r'^\d+(\.\d+)?k$')
-      THEN CAST(REGEXP_EXTRACT(LOWER(number_of_ratings), r'^(\d+(\.\d+)?)') AS FLOAT64) * 1000
+      THEN CAST(REGEXP_EXTRACT(LOWER(number_of_ratings), r'^(\d+(?:\.\d+)?)') AS FLOAT64) * 1000
     WHEN REGEXP_CONTAINS(number_of_ratings, r'^\d+$')
       THEN CAST(number_of_ratings AS INT64)
     ELSE NULL


### PR DESCRIPTION
## Description

This PR adds 3 new columns to the view `mozdata.external.chrome_extensions` that help normalize the scraped strings into an expected format.  The 3 new columns are: 
- star_rating_numeric
- number_of_ratings_numeric
- number_of_users_numeric

## Related Tickets & Documents
* [DENG-8069](https://mozilla-hub.atlassian.net/browse/DENG-8069)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8069]: https://mozilla-hub.atlassian.net/browse/DENG-8069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ