### PR TITLE
[Bug 1960649] Limit number of events that are aggregated in event_flow_monitoring_aggregates

### DIFF
--- a/sql_generators/glean_usage/templates/event_flow_monitoring_aggregates_v1.script.sql
+++ b/sql_generators/glean_usage/templates/event_flow_monitoring_aggregates_v1.script.sql
@@ -132,7 +132,7 @@ CREATE TEMP TABLE
       flow_id,
       normalized_app_name,
       channel,
-      ARRAY_AGG(event ORDER BY event.source.timestamp) AS events,
+      ARRAY_AGG(event ORDER BY event.source.timestamp LIMIT 10000) AS events,
       -- create a flow hash that concats all the events that are part of the flow
       -- <event_category>.<event_name> -> <event_category>.<event_name> -> ...
       ARRAY_TO_STRING(
@@ -141,6 +141,7 @@ CREATE TEMP TABLE
             CONCAT(IF(event.source.category IS NOT NULL, CONCAT(event.source.category, "."), ""), event.source.name)
             ORDER BY
               event.source.timestamp
+            LIMIT 10000
           ),
           [
             ARRAY_REVERSE(
@@ -148,6 +149,7 @@ CREATE TEMP TABLE
                 CONCAT(IF(event.target.category IS NOT NULL, CONCAT(event.target.category, "."), ""), event.target.name)
                 ORDER BY
                   event.source.timestamp
+                LIMIT 10000
               )
             )[SAFE_OFFSET(0)]
           ]


### PR DESCRIPTION


## Description
https://bugzilla.mozilla.org/show_bug.cgi?id=1960649

Airflow was failing due to some clients sending to many events that exceeded the limit of what `ARRAY_AGG` can do (10k+ events). This adds a limit to how many events are being aggregated

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
