### PR TITLE
Bug 1960934 - Limit materialized_view_refresh task concurrency

### DIFF
--- a/bigquery_etl/query_scheduling/dag.py
+++ b/bigquery_etl/query_scheduling/dag.py
@@ -69,6 +69,7 @@ class DagDefaultArgs:
     email_on_failure: bool = attr.ib(True)
     email_on_retry: bool = attr.ib(True)
     retries: int = attr.ib(2)
+    max_active_tis_per_dag: Optional[int] = attr.ib(None)
 
     @owner.validator
     def validate_owner(self, attribute, value):

--- a/dags.yaml
+++ b/dags.yaml
@@ -2308,11 +2308,18 @@ bqetl_materialized_view_refresh:
     email_on_failure: true
     email_on_retry: true
     end_date: null
+    # prevent concurrent refreshes of the same view
+    max_active_tis_per_dag: 1
     owner: bewu@mozilla.com
     retries: 1
     retry_delay: 5m
     start_date: '2025-03-21'
-  description: Manual refreshes of materialized views.  See https://mozilla-hub.atlassian.net/browse/DENG-6990
+  description: |
+    Manual refreshes of materialized views.  See https://mozilla-hub.atlassian.net/browse/DENG-6990
+
+    *Triage notes*
+
+    Transient errors may occur.  The DAG is fine long as the latest run worked.
   repo: bigquery-etl
   schedule_interval: 45 * * * *
   tags:

--- a/tests/data/dags/python_script_test_dag
+++ b/tests/data/dags/python_script_test_dag
@@ -34,6 +34,7 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
+    "max_active_tis_per_dag": None,
 }
 
 tags = ["repo/bigquery-etl"]

--- a/tests/data/dags/simple_test_dag
+++ b/tests/data/dags/simple_test_dag
@@ -36,6 +36,7 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
+    "max_active_tis_per_dag": None,
 }
 
 tags = ["repo/bigquery-etl"]

--- a/tests/data/dags/test_dag_duplicate_dependencies
+++ b/tests/data/dags/test_dag_duplicate_dependencies
@@ -35,6 +35,7 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
+    "max_active_tis_per_dag": None,
 }
 
 tags = ["repo/bigquery-etl"]

--- a/tests/data/dags/test_dag_external_check_dependency
+++ b/tests/data/dags/test_dag_external_check_dependency
@@ -34,6 +34,7 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
+    "max_active_tis_per_dag": None,
 }
 
 tags = ["repo/bigquery-etl"]

--- a/tests/data/dags/test_dag_external_dependency
+++ b/tests/data/dags/test_dag_external_dependency
@@ -34,6 +34,7 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
+    "max_active_tis_per_dag": None,
 }
 
 tags = ["repo/bigquery-etl"]

--- a/tests/data/dags/test_dag_with_bigquery_table_sensors
+++ b/tests/data/dags/test_dag_with_bigquery_table_sensors
@@ -38,6 +38,7 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
+    "max_active_tis_per_dag": None,
 }
 
 tags = ["repo/bigquery-etl"]

--- a/tests/data/dags/test_dag_with_check_dependencies
+++ b/tests/data/dags/test_dag_with_check_dependencies
@@ -34,6 +34,7 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
+    "max_active_tis_per_dag": None,
 }
 
 tags = ["repo/bigquery-etl"]

--- a/tests/data/dags/test_dag_with_check_table_dependencies
+++ b/tests/data/dags/test_dag_with_check_table_dependencies
@@ -34,6 +34,7 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
+    "max_active_tis_per_dag": None,
 }
 
 tags = ["repo/bigquery-etl"]

--- a/tests/data/dags/test_dag_with_dependencies
+++ b/tests/data/dags/test_dag_with_dependencies
@@ -34,6 +34,7 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
+    "max_active_tis_per_dag": None,
 }
 
 tags = ["repo/bigquery-etl"]

--- a/tests/data/dags/test_dag_with_secrets
+++ b/tests/data/dags/test_dag_with_secrets
@@ -48,6 +48,7 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
+    "max_active_tis_per_dag": None,
 }
 
 tags = ["repo/bigquery-etl"]

--- a/tests/data/dags/test_public_data_json_dag
+++ b/tests/data/dags/test_public_data_json_dag
@@ -32,6 +32,7 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
+    "max_active_tis_per_dag": None,
 }
 
 tags = ["repo/bigquery-etl"]


### PR DESCRIPTION
## Description

Task runs sometime overlap due to DENG-8332 which can cause failures.  This changes the dag to run at most one instance of each task.

This also adds `"max_active_tis_per_dag": None` to the default args of every existing dag. `None` is the default value so I think that should be fine 

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1960934
* DENG-8332

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
