### PR TITLE
removing placement filter to bring in tiles

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/query.sql
@@ -203,7 +203,6 @@ uapi_summary AS (
     {% else %}
       DATE(submission_hour) = @submission_date
     {% endif %}
-    AND placement IN ('newtab_spocs', 'newtab_rectangle', 'newtab_billboard', 'newtab_leaderboard')
   GROUP BY
     submission_date,
     ad_id,


### PR DESCRIPTION
## Description
This PR removes a filter on placement so that we can bring in all placements to filter on downstream and accommodate the mmm data feed
<!--
Please do not leave this blank

-->

## Related Tickets & Documents
[AD-706](https://mozilla-hub.atlassian.net/browse/AD-706)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[AD-706]: https://mozilla-hub.atlassian.net/browse/AD-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ