### PR TITLE
Fix 1961168

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
@@ -19,7 +19,7 @@ SELECT
   m.client_id,
   DATE(m.submission_timestamp) AS submission_date,
   CAST(JSON_VALUE(context, '$.androidSdkVersion') AS int) AS androidSdkVersion,
-  CAST(JSON_VALUE(context, '$.appVersion') AS string) AS androidSdkVersion,
+  CAST(JSON_VALUE(context, '$.appVersion') AS string) AS appVersion,
   CAST(JSON_VALUE(context, '$.daysSinceInstall') AS int) AS daysSinceInstall,
   CAST(JSON_VALUE(context, '$.daysSinceUpdate') AS int) AS daysSinceUpdate,
   CAST(JSON_VALUE(context, '$.deviceManufacturer') AS string) AS deviceManufacturer,


### PR DESCRIPTION
## Description

This PR fixes an issue in which the nimbus_recorded_targeting_context_v1 query selected two pieces of data with the same column name.

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1961168 

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
