### PR TITLE
fix(bqetl): Fix a bug in `bigquery_etl.pytest_plugin.routine.RoutineFile`

### DIFF
--- a/bigquery_etl/pytest_plugin/routine.py
+++ b/bigquery_etl/pytest_plugin/routine.py
@@ -54,7 +54,7 @@ class RoutineFile(pytest.File):
     def collect(self):
         """Collect."""
         self.add_marker("routine")
-        base_path = self.parent.parent.parent.parent.parent.path
+        base_path = self.path.parent.parent.parent.parent.parent
         path = str(self.path.relative_to(base_path))
         self.routine = parsed_routines()[path]
 


### PR DESCRIPTION
## Description
pytest was failing with `AttributeError: 'NoneType' object has no attribute 'parent'` while trying to collect tests for our user-defined routines.

This issue may have been introduced by #7127.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/7127

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
