### PR TITLE
fix(imf_exchange_rates): Remove duplicate country from country list

### DIFF
--- a/sql/moz-fx-data-shared-prod/external_derived/imf_exchange_rates_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/imf_exchange_rates_v1/query.py
@@ -16,7 +16,6 @@ country_codes = [
     "CA",
     "CN",
     "CO",
-    "GB",
     "IN",
     "IS",
     "JP",


### PR DESCRIPTION
## Description

The DAG failed today on a non-duplicate check, turned out it was because I accidentally had listed 1 country (GB) 2x in the list of countries to pull data for.

## Related Tickets & Documents
* [Bug 1961364](https://bugzilla.mozilla.org/show_bug.cgi?id=1961364)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
