### PR TITLE
add where clause to nimbus recorded targeting context views

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix/nimbus_recorded_targeting_context/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix/nimbus_recorded_targeting_context/view.sql
@@ -12,8 +12,12 @@ INNER JOIN
       MAX(submission_date) AS latest_date
     FROM
       `moz-fx-data-shared-prod.org_mozilla_fenix_derived.nimbus_recorded_targeting_context_v1`
+    WHERE
+      submission_date > '2025-01-01'
     GROUP BY
       client_id
   ) ld
   ON m.client_id = ld.client_id
   AND m.submission_date = ld.latest_date
+WHERE
+  submission_date > '2025-01-01'

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/nimbus_recorded_targeting_context/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox/nimbus_recorded_targeting_context/view.sql
@@ -12,8 +12,12 @@ INNER JOIN
       MAX(submission_date) AS latest_date
     FROM
       `moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.nimbus_recorded_targeting_context_v1`
+    WHERE
+      submission_date > '2025-01-01'
     GROUP BY
       client_id
   ) ld
   ON m.client_id = ld.client_id
   AND m.submission_date = ld.latest_date
+WHERE
+  submission_date > '2025-01-01'


### PR DESCRIPTION
## Description

This PR updates the nimbus recorded targeting context views to have a where clause so they can be queried.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
