### PR TITLE
fix: Move `json.from_map_json` UDF into its own `udf.sql` file

### DIFF
--- a/sql/mozfun/json/from_map/udf.sql
+++ b/sql/mozfun/json/from_map/udf.sql
@@ -4,26 +4,6 @@ RETURNS json AS (
   json.from_map_json(TO_JSON(input))
 );
 
-CREATE OR REPLACE FUNCTION json.from_map_json(input JSON)
-RETURNS JSON
-LANGUAGE js
-AS
-  """
-  if (input && input.length) {
-    return input.reduce((acc, {key, value}) => {
-      let parsed;
-      try {
-        parsed = JSON.parse(value);
-      } catch (err) {
-        parsed = value;
-      }
-      acc[key] = parsed;
-      return acc;
-    }, {});
-  }
-  return null;
-""";
-
 -- Tests
 SELECT
   assert.null(json.from_map(NULL)),

--- a/sql/mozfun/json/from_map_json/README.md
+++ b/sql/mozfun/json/from_map_json/README.md
@@ -1,0 +1,1 @@
+Converts a `[{"key": ..., "value": ...}, ...]` serialized map data structure into a JSON object value.

--- a/sql/mozfun/json/from_map_json/metadata.yaml
+++ b/sql/mozfun/json/from_map_json/metadata.yaml
@@ -1,0 +1,3 @@
+friendly_name: To JSON from map JSON
+description: |-
+  Converts a `[{"key": ..., "value": ...}, ...]` serialized map data structure into a JSON object value.

--- a/sql/mozfun/json/from_map_json/udf.sql
+++ b/sql/mozfun/json/from_map_json/udf.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION json.from_map_json(input JSON)
+RETURNS JSON
+LANGUAGE js
+AS
+  """
+  if (input && input.length) {
+    return input.reduce((acc, {key, value}) => {
+      let parsed;
+      try {
+        parsed = JSON.parse(value);
+      } catch (err) {
+        parsed = value;
+      }
+      acc[key] = parsed;
+      return acc;
+    }, {});
+  }
+  return null;
+""";
+
+-- Tests
+SELECT
+  assert.null(json.from_map_json(NULL)),
+  assert.null(json.from_map_json(JSON '[]')),
+  assert.json_equals(
+    JSON '{"foo": {"nested": 1}}',
+    json.from_map_json(JSON '[{"key": "foo", "value": {"nested": 1}}]')
+  ),
+  assert.equals(TRUE, BOOL(json.from_map_json(JSON '[{"key": "foo", "value": "true"}]').foo)),
+  assert.equals(123, INT64(json.from_map_json(JSON '[{"key": "foo", "value": "123"}]').foo))


### PR DESCRIPTION
## Description
`bqetl stage deploy` apparently expects each UDF to be in its own `udf.sql` file, so the `json.from_map_json` UDF being in `sql/mozfun/json/from_map/udf.sql` alongside the `json.from_map` UDF is causing the `deploy-changes-to-stage` CI to fail (e.g. this is currently causing the `deploy-changes-to-stage` CI for #7335 to [fail](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/48129/workflows/3f8f5324-7bb0-4e3e-927a-c1d8ab590a5c/jobs/565897)).

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/7335

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
