### PR TITLE
chore: switch to data-developers subgroups for DE write access

### DIFF
--- a/sql/moz-fx-data-shared-prod/acoustic_external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/acoustic_external/dataset_metadata.yaml
@@ -11,4 +11,4 @@ workgroup_access:
   - workgroup:braze
 - role: roles/bigquery.dataEditor
   members:
-  - workgroup:braze/writers
+  - workgroup:braze/data-developers

--- a/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
@@ -7,4 +7,4 @@ labels: {}
 workgroup_access:
   - role: roles/bigquery.dataEditor
     members:
-      - workgroup:ads/writers
+      - workgroup:ads/data-developers

--- a/sql/moz-fx-data-shared-prod/braze_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/dataset_metadata.yaml
@@ -11,4 +11,4 @@ workgroup_access:
       - workgroup:braze
   - role: roles/bigquery.dataEditor
     members:
-      - workgroup:braze/writers
+      - workgroup:braze/data-developers

--- a/sql/moz-fx-data-shared-prod/braze_external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_external/dataset_metadata.yaml
@@ -23,4 +23,4 @@ workgroup_access:
       - workgroup:braze/ingestion-firefox
   - role: roles/bigquery.dataEditor
     members:
-      - workgroup:braze/writers
+      - workgroup:braze/data-developers

--- a/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/dataset_metadata.yaml
@@ -11,4 +11,4 @@ workgroup_access:
       - workgroup:braze/ingestion-mozilla-dev
   - role: roles/bigquery.dataEditor
     members:
-      - workgroup:braze/writers
+      - workgroup:braze/data-developers

--- a/sql/moz-fx-data-shared-prod/marketing_suppression_list_external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/marketing_suppression_list_external/dataset_metadata.yaml
@@ -11,4 +11,4 @@ workgroup_access:
       - workgroup:braze/ingestion-mozilla-dev
   - role: roles/bigquery.dataEditor
     members:
-      - workgroup:braze/writers
+      - workgroup:braze/data-developers


### PR DESCRIPTION
## Description

Write-up coming in https://mozilla-hub.atlassian.net/browse/DSRE-1925 once PRs are all filed
This has timing dependencies so should not be merged directly

## Related Tickets & Documents
* DSRE-1925

