### PR TITLE
fix(org_mozilla_broken_site_report): Add all channel-specific datasets to the live view.

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
@@ -19,6 +19,42 @@ WITH live_reports AS (
     `moz-fx-data-shared-prod.org_mozilla_fenix_live.broken_site_report_v1`
   WHERE
     DATE(submission_timestamp) > "2025-01-01"
+  UNION ALL
+  SELECT
+    *,
+    "Fenix" AS app_name,
+    ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp ASC) AS rn
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_fenix_nightly_live.broken_site_report_v1`
+  WHERE
+    DATE(submission_timestamp) > "2025-01-01"
+  UNION ALL
+  SELECT
+    *,
+    "Fenix" AS app_name,
+    ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp ASC) AS rn
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_fennec_aurora_live.broken_site_report_v1`
+  WHERE
+    DATE(submission_timestamp) > "2025-01-01"
+  UNION ALL
+  SELECT
+    *,
+    "Fenix" AS app_name,
+    ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp ASC) AS rn
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_firefox_beta_live.broken_site_report_v1`
+  WHERE
+    DATE(submission_timestamp) > "2025-01-01"
+  UNION ALL
+  SELECT
+    *,
+    "Fenix" AS app_name,
+    ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp ASC) AS rn
+  FROM
+    `moz-fx-data-shared-prod.org_mozilla_firefox_live.broken_site_report_v1`
+  WHERE
+    DATE(submission_timestamp) > "2025-01-01"
 )
 SELECT
   document_id AS uuid,


### PR DESCRIPTION
## Description

Previously, the view only selected from `org_mozilla_fenix_live.broken_site_report_v1`, which I think is only the Nightly channel? For the non-live data, we have the `moz-fx-data-shared-prod.fenix.broken_site_report` view, which is an aggregate of multiple other datasets. Specifically, that view queries from

- `moz-fx-data-shared-prod.org_mozilla_fenix_nightly.broken_site_report`
- `moz-fx-data-shared-prod.org_mozilla_fenix.broken_site_report`
- `moz-fx-data-shared-prod.org_mozilla_fennec_aurora.broken_site_report`
- `moz-fx-data-shared-prod.org_mozilla_firefox_beta.broken_site_report`
- `moz-fx-data-shared-prod.org_mozilla_firefox.broken_site_report`

since all those datasets have a `_live` variant with a `broken_site_report_v1` table, I expanded this view to also include those. I'm not sure where the `moz-fx-data-shared-prod.fenix.broken_site_report` view even comes from, but if there's a way to similarly auto-generate a `_live` version without having to maintain this view manually, that'd not be horrible, either.

r? @scholtzan 

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**