### PR TITLE
feat: do not include normalized_channel bigeye metric for baseline tables for ios nightly dataset

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.bigconfig.yml
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.bigconfig.yml
@@ -19,10 +19,13 @@ tag_deployments:
           - name: {{ project_id }}.{{ project_id }}.{{ derived_dataset }}.{{ target_table }}.durations
         metrics:
           - saved_metric_id: is_99_percent_not_null
+      {#- Excluding ios nightly channel as normalized_channel contains mostly null values causing the metric to fail. -#}
+      {% if not (app_name == "firefox_ios" and derived_dataset == "org_mozilla_ios_fennec_derived") %}
       - column_selectors:
         - name: {{ project_id }}.{{ project_id }}.{{ derived_dataset }}.{{ target_table }}.normalized_channel
         metrics:
           - saved_metric_id: is_99_percent_valid_normalized_channel
+      {% endif %}
       - column_selectors:
         - name: {{ project_id }}.{{ project_id }}.{{ derived_dataset }}.{{ target_table }}.*
         metrics:

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.bigconfig.yml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.bigconfig.yml
@@ -15,15 +15,18 @@ tag_deployments:
         - name: {{ project_id }}.{{ project_id }}.{{ derived_dataset }}.{{ target_table }}.days_active_bits
         - name: {{ project_id }}.{{ project_id }}.{{ derived_dataset }}.{{ target_table }}.days_created_profile_bits
         metrics:
-          - saved_metric_id: is_99_percent_not_null
+          - saved_metric_id: is_not_null
       - column_selectors:
         - name: {{ project_id }}.{{ project_id }}.{{ derived_dataset }}.{{ target_table }}.first_seen_date
         metrics:
           - saved_metric_id: is_99_percent_not_null
+      {#- Excluding ios nightly channel as normalized_channel contains mostly null values causing the metric to fail. -#}
+      {% if not (app_name == "firefox_ios" and derived_dataset == "org_mozilla_ios_fennec_derived") %}
       - column_selectors:
         - name: {{ project_id }}.{{ project_id }}.{{ derived_dataset }}.{{ target_table }}.normalized_channel
         metrics:
           - saved_metric_id: is_99_percent_valid_normalized_channel
+      {% endif %}
       # For now being commented out due to a bug in the predefined metric (wrong regex being used) resulting in 0 matches.
       # Will uncomment once the underlaying issue has been fixed.
       # - column_selectors:


### PR DESCRIPTION
# feat: do not include normalized_channel bigeye metric for baseline tables for ios nightly dataset

This is because this specific column contains mostly only null values for this particular channel causing it to constantly fail.