### PR TITLE
feat: ensure partition field is specific for bigeye metrics set on retention and new_profiles

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.bigconfig.yml
@@ -12,10 +12,14 @@ tag_deployments:
         - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.is_mobile
         metrics:
           - saved_metric_id: is_not_null
+            rct_overrides:
+              - first_seen_date
       - column_selectors:
         - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.normalized_channel
         metrics:
           - saved_metric_id: is_99_percent_valid_normalized_channel
+            rct_overrides:
+              - first_seen_date
       - column_selectors:
         - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.*
         metrics:

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.bigconfig.yml
@@ -12,10 +12,24 @@ tag_deployments:
         - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.is_mobile
         metrics:
           - saved_metric_id: is_not_null
+            lookback:
+              lookback_window:
+                interval_type: DAYS
+                interval_value: 28
+              lookback_type: DATA_TIME
+            rct_overrides:
+              - metric_date
       - column_selectors:
         - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.normalized_channel
         metrics:
           - saved_metric_id: is_99_percent_valid_normalized_channel
+            lookback:
+              lookback_window:
+                interval_type: DAYS
+                interval_value: 28
+              lookback_type: DATA_TIME
+            rct_overrides:
+              - metric_date
       - column_selectors:
         - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.*
         metrics:


### PR DESCRIPTION
# feat: ensure partition field is specific for bigeye metrics set on retention and new_profiles

This is to avoid a full table scan on each metric run.