### PR TITLE
fix: drop acoustic.contact_current_snapshot view definition 

### DIFF
--- a/sql/moz-fx-data-shared-prod/acoustic/contact_current_snapshot/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/acoustic/contact_current_snapshot/metadata.yaml
@@ -1,7 +1,0 @@
-friendly_name: (DEPRECATED) Adjust contact data (current snapshot)
-description: |-
-  Adjust contact data. This specific view accesses the most recent record corresponding to each client.
-  Deprecated as of 2025-04-15.
-
-labels:
-  authorized: false

--- a/sql/moz-fx-data-shared-prod/acoustic/contact_current_snapshot/view.sql
+++ b/sql/moz-fx-data-shared-prod/acoustic/contact_current_snapshot/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.acoustic.contact_current_snapshot`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.acoustic_derived.contact_current_snapshot_v1`


### PR DESCRIPTION
# fix: drop acoustic.contact_current_snapshot view definition 

This is because the underlaying table has been marked as deprecated and causes view deploy to error.
