### PR TITLE
fix: Update `fivetran_costs_derived.incremental_mar_v1` ETL to not use deprecated `connector_id` column (DENG-7910)

### DIFF
--- a/sql/moz-fx-data-shared-prod/fivetran_costs_derived/incremental_mar_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fivetran_costs_derived/incremental_mar_v1/query.sql
@@ -2,7 +2,7 @@ WITH incremental_mar AS (
   SELECT
     measured_date,
     destination_id,
-    connector_id,
+    connection_name,
     table_name,
     free_type,
     incremental_rows
@@ -13,7 +13,7 @@ SELECT
   measured_date,
   DATE_TRUNC(measured_date, month) AS measured_month,
   destination_id,
-  connector_id AS connector,
+  connection_name AS connector,
   table_name,
   CASE
     WHEN LOWER(free_type) = "paid"

--- a/tests/sql/moz-fx-data-shared-prod/fivetran_costs_derived/incremental_mar_v1/test_date_trunc_and_string_manipulation/moz-fx-data-bq-fivetran.fivetran_log.incremental_mar.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fivetran_costs_derived/incremental_mar_v1/test_date_trunc_and_string_manipulation/moz-fx-data-bq-fivetran.fivetran_log.incremental_mar.yaml
@@ -1,49 +1,49 @@
 ---
 - destination_id: destination_1
   measured_date: 2023-01-03
-  connector_id: connector_1
+  connection_name: connector_1
   table_name: table_1
   free_type: PAID
   incremental_rows: 1
 - destination_id: destination_1
   measured_date: 2023-02-05
-  connector_id: connector_2
+  connection_name: connector_2
   table_name: table_2
   free_type: PaID
   incremental_rows: 2
 - destination_id: destination_3
   measured_date: 2023-03-18
-  connector_id: connector_1
+  connection_name: connector_1
   table_name: table_3
   free_type: FREE_SYNCH
   incremental_rows: 333
 - destination_id: destination_1
   measured_date: 2023-04-08
-  connector_id: connector_2
+  connection_name: connector_2
   table_name: table_4
   free_type: SYSTEM
   incremental_rows: 400
 - destination_id: destination_3
   measured_date: 2023-05-17
-  connector_id: connector_1
+  connection_name: connector_1
   table_name: table_5
   free_type: FREE_someThing
   incremental_rows: 51
 - destination_id: destination_3
   measured_date: 2023-06-06
-  connector_id: connector_17
+  connection_name: connector_17
   table_name: table_6
   free_type: something_FREE
   incremental_rows: 66
 - destination_id: destination_3
   measured_date: 2023-07-13
-  connector_id: connector_1
+  connection_name: connector_1
   table_name: table_7
   free_type: something_ELSE
   incremental_rows: 7
 - destination_id: destination_3
   measured_date: 2023-08-12
-  connector_id: connector_1
+  connection_name: connector_1
   table_name: table_8
   free_type: this_IS_free
   incremental_rows: 812


### PR DESCRIPTION
## Description
Fivetran will stop syncing the `incremental_mar.connector_id` column on May 1.

## Related Tickets & Documents
* DENG-7910: Fivetran platform connector updates will be made on 2025-04-15

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
