### PR TITLE
feat(DENG-8408): replicate ML RSS ingestion data to prod-shared project

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2302,3 +2302,16 @@ bqetl_monitoring_hourly:
   tags:
     - impact/tier_1
     - repo/bigquery-etl
+
+bqetl_mozsoc_ml_prod_replication:
+  schedule_interval: daily
+  description: |
+    Replicates data from moz-fx-mozsoc-ml-prod BigQuery project for Looker access
+  default_args:
+    owner: rrando@mozilla.com
+    start_date: "2025-05-05" #TODO: Change to merge date
+    email: ["rrando@mozilla.com"]
+    retries: 2
+    retry_delay: 30m
+  tags:
+    - impact/tier_2

--- a/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/dataset_metadata.yaml
@@ -1,0 +1,9 @@
+friendly_name: ML Content Ingestion Replication
+description: |-
+  https://mozilla-hub.atlassian.net/browse/DENG-8408
+user_facing: false
+labels: {}
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/rss_feed_items/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/rss_feed_items/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: RSS Feed Items
+description: RSS items ingested by ML
+owners:
+  - rrando@mozilla.com
+labels:
+  schedule: daily
+  incremental: false
+  owner1: rrando
+scheduling:
+  dag_name: bqetl_content_ml_rss_parsing

--- a/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/rss_feed_items/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/rss_feed_items/query.sql
@@ -1,0 +1,4 @@
+SELECT
+  *
+FROM
+  `moz-fx-mozsoc-ml-prod.prod_rss_news.rss_feed_items`

--- a/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/rss_feed_items/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/rss_feed_items/schema.yaml
@@ -1,0 +1,61 @@
+fields:
+  - mode: NULLABLE
+    type: STRING
+    name: language
+  - mode: NULLABLE
+    type: STRING
+    name: id
+  - mode: NULLABLE
+    type: STRING
+    name: keywords
+  - mode: NULLABLE
+    type: STRING
+    name: origin_url
+  - mode: NULLABLE
+    type: STRING
+    name: origin_title
+  - mode: NULLABLE
+    type: STRING
+    name: content_cleaned
+  - mode: NULLABLE
+    type: STRING
+    name: title
+  - mode: NULLABLE
+    type: STRING
+    name: author
+  - mode: NULLABLE
+    type: STRING
+    name: summary
+  - mode: NULLABLE
+    type: FLOAT
+    name: engagement
+  - mode: NULLABLE
+    type: STRING
+    name: published_date
+  - mode: NULLABLE
+    type: BOOLEAN
+    name: unread
+  - mode: NULLABLE
+    type: STRING
+    name: crawled_date
+  - mode: NULLABLE
+    type: STRING
+    name: canonical_url
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: published_at
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: crawled_at
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: loaded_at
+  - mode: NULLABLE
+    type: INTEGER
+    name: load_count
+  - mode: NULLABLE
+    type: STRING
+    name: category
+  - mode: NULLABLE
+    type: STRING
+    name: surface

--- a/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/zyte_cache/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/zyte_cache/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Zyte Cache
+description: Metadata cache from Zyte article parsing
+owners:
+  - rrando@mozilla.com
+labels:
+  schedule: daily
+  incremental: false
+  owner1: rrando
+scheduling:
+  dag_name: bqetl_content_ml_rss_parsing

--- a/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/zyte_cache/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/zyte_cache/query.sql
@@ -1,0 +1,4 @@
+SELECT
+  *
+FROM
+  `moz-fx-mozsoc-ml-prod.prod_articles.zyte_cache`

--- a/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/zyte_cache/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozsoc_ml_prod/zyte_cache/schema.yaml
@@ -1,0 +1,43 @@
+fields:
+  - mode: NULLABLE
+    type: STRING
+    name: canonical_url
+  - mode: NULLABLE
+    type: STRING
+    name: zyte_headline
+  - mode: NULLABLE
+    type: STRING
+    name: zyte_description
+  - mode: NULLABLE
+    type: STRING
+    name: zyte_authors
+  - mode: NULLABLE
+    type: STRING
+    name: zyte_mainImage
+  - mode: NULLABLE
+    type: STRING
+    name: zyte_articleBody
+  - mode: NULLABLE
+    type: STRING
+    name: zyte_datePublished
+  - mode: NULLABLE
+    type: STRING
+    name: zyte_datePublishedRaw
+  - mode: NULLABLE
+    type: STRING
+    name: zyte_dateModified
+  - mode: NULLABLE
+    type: STRING
+    name: zyte_canonicalUrl
+  - mode: NULLABLE
+    type: DATETIME
+    name: zyte_cached_at
+  - mode: NULLABLE
+    type: STRING
+    name: zyte_breadcrumbs
+  - mode: NULLABLE
+    type: STRING
+    name: zyte_inLanguage
+  - mode: NULLABLE
+    type: STRING
+    name: canonical_url


### PR DESCRIPTION
## Description

This PR adds an ETL job to replicate data from the `moz-fx-mozsoc-ml-prod` BigQuery project into the `moz-fx-data-shared-prod` BigQuery project in order to create Looker reports.

The intention is to replicate the table contents once per day.

## Related Tickets & Documents
* [DENG-8408](https://mozilla-hub.atlassian.net/browse/DENG-8408)
* [DENG-8127](https://mozilla-hub.atlassian.net/browse/DENG-8127)
* [DENG-8085](https://mozilla-hub.atlassian.net/browse/DENG-8085)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8408]: https://mozilla-hub.atlassian.net/browse/DENG-8408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-8127]: https://mozilla-hub.atlassian.net/browse/DENG-8127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-8085]: https://mozilla-hub.atlassian.net/browse/DENG-8085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ