### PR TITLE
feat(DENG-8415): Add attribution to baseline_clients_last_seen_v1

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.query.sql
@@ -16,7 +16,7 @@ SELECT
   -- to the daily table we can add those columns in the same order to the end
   -- of this schema, which may be necessary for the daily join query between
   -- the two tables to validate.
-  * EXCEPT(isp, attribution, `distribution`),
+  * EXCEPT(isp),
 FROM
   `{{ daily_table }}`
 WHERE
@@ -48,9 +48,7 @@ WITH _current AS (
     isp,
     * EXCEPT(
         submission_date, 
-        isp, 
-        attribution, 
-        `distribution`
+        isp
       )
   FROM
     `{{ daily_table }}`

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
@@ -87,3 +87,35 @@ fields:
 - mode: NULLABLE
   name: is_default_browser
   type: BOOLEAN
+- mode: NULLABLE
+  name: attribution
+  type: RECORD
+  fields:
+  - mode: NULLABLE
+    name: campaign
+    type: STRING
+    description: The attribution campaign (e.g. 'mozilla-org').
+  - mode: NULLABLE
+    name: content
+    type: STRING
+    description: The attribution content (e.g. 'firefoxview').
+  - mode: NULLABLE
+    name: medium
+    type: STRING
+    description: The attribution medium (e.g. 'organic' for a search engine).
+  - mode: NULLABLE
+    name: source
+    type: STRING
+    description: The attribution source (e.g. 'google-play').
+  - mode: NULLABLE
+    name: term
+    type: STRING
+    description: The attribution term (e.g. 'browser with developer tools for android').
+- mode: NULLABLE
+  name: distribution
+  type: RECORD
+  fields:
+  - mode: NULLABLE
+    name: name
+    type: STRING
+    description: The distribution name (e.g. 'MozillaOnline').


### PR DESCRIPTION
## Description

* This PR adds the new columns `attribution` and `distribution` to the SQL generator template for `baseline_clients_last_seen_v1`
* This PR is a follow up PR to fix issues caused by [PR-7376](https://github.com/mozilla/bigquery-etl/pull/7376) which accidentally allowed these new columns to flow into the downstream table `baseline_clients_last_seen_v1` before the code was updated to handle them

## Related Tickets & Documents
* [DENG-8415](https://mozilla-hub.atlassian.net/browse/DENG-8415)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8415]: https://mozilla-hub.atlassian.net/browse/DENG-8415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ