### PR TITLE
AD-775 Unschedule sponsored_tiles_clients_daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
@@ -10,9 +10,6 @@ owners:
 labels:
   incremental: true
   table_type: client_level
-scheduling:
-  dag_name: bqetl_sponsored_tiles_clients_daily
-  task_name: sponsored_tiles_clients_daily_v1
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description

`sponsored_tiles_clients_daily_v1` has been failing due to out of memory errors. This table looks to be no longer needed -- the only downstream use is one look within an Ads dashboard, and I have confirmed with users of that dashboard that the look in question is no longer looked at.

I think we can probably fully deprecate this table, but I want to investigate a little more before doing that. In the meantime, I think we can safely unschedule it.

## Related Tickets & Documents

[AD-775](https://mozilla-hub.atlassian.net/browse/AD-775)

[AD-775]: https://mozilla-hub.atlassian.net/browse/AD-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ