### PR TITLE
Deng 8329 06 add missing columns into firefox desktop baseline active users aggregates backfill complete

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v2/backfill.yaml
@@ -5,5 +5,5 @@
   watchers:
     - kwindau@mozilla.com
     - ago@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false


### PR DESCRIPTION
## Description
Update backfill status to `Complete`. This kicks off a process that moves the data from the staging table to the live table.

## Related Tickets & Documents
https://mozilla-hub.atlassian.net/browse/DENG-8329

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
