### PR TITLE
Deng 8329 06 add missing columns into firefox desktop baseline active users aggregates view

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users_aggregates/view.sql
@@ -30,4 +30,4 @@ SELECT
   `mozfun.norm.browser_version_info`(app_version).patch_revision AS app_version_patch_revision,
   `mozfun.norm.browser_version_info`(app_version).is_major_release AS app_version_is_major_release,
 FROM
-  `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_active_users_aggregates_v1`
+  `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_active_users_aggregates_v2`


### PR DESCRIPTION
## Description
Replaces the v1 table with the v2 table created in https://github.com/mozilla/bigquery-etl/pull/7397

## Related Tickets & Documents
https://mozilla-hub.atlassian.net/browse/DENG-8329

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
