### PR TITLE
feat(DENG-8048): replicate ML RSS ingestion data to prod-shared project

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozsoc_ml_prod_articles_zyte_cache/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozsoc_ml_prod_articles_zyte_cache/dataset_metadata.yaml
@@ -1,0 +1,16 @@
+friendly_name: Content ML Team - Zyte Cache
+description: Metadata cache from Zyte article parsing
+dataset_base_acl: syndicate
+user_facing: true
+labels: {}
+syndication:
+  prod:
+    syndicated_project: "moz-fx-mozsoc-ml-prod"
+    syndicated_dataset: "prod_articles"
+  syndicated_tables:
+    - zyte_cache
+  administer_views: false
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/mozsoc_ml_prod_rss_news/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozsoc_ml_prod_rss_news/dataset_metadata.yaml
@@ -1,0 +1,16 @@
+friendly_name: Content ML Team - RSS Feed Items
+description: RSS items ingested by ML
+dataset_base_acl: syndicate
+user_facing: true
+labels: {}
+syndication:
+  prod:
+    syndicated_project: "moz-fx-mozsoc-ml-prod"
+    syndicated_dataset: "prod_rss_news"
+  syndicated_tables:
+    - rss_feed_items
+  administer_views: false
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential


### PR DESCRIPTION
## Description

This PR adds syndication for two datasets/tables in the `moz-fx-mozsoc-ml-prod` BigQuery project into the `moz-fx-data-shared-prod` BigQuery project in order to make the data available to Looker reports.

The intention is to have a full copy of the referenced tables residing in the `moz-fx-data-shared-prod` BigQuery project.

## Related Tickets & Documents
* [DENG-8408](https://mozilla-hub.atlassian.net/browse/DENG-8408)
* [DENG-8127](https://mozilla-hub.atlassian.net/browse/DENG-8127)
* [DENG-8085](https://mozilla-hub.atlassian.net/browse/DENG-8085)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

[DENG-8408]: https://mozilla-hub.atlassian.net/browse/DENG-8408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-8127]: https://mozilla-hub.atlassian.net/browse/DENG-8127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-8085]: https://mozilla-hub.atlassian.net/browse/DENG-8085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ