### PR TITLE
[DENG-8432] Filter out nimbus_events.validation_failed and normandy.validation_failed_nimbus_experiment for firefox_desktop_background_update

### DIFF
--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -144,15 +144,15 @@ CROSS JOIN
     ARRAY(
       SELECT event
       FROM UNNEST(events) AS event
-      WHERE NOT (
+      WHERE (
         app_version_major = 138 AND app_version_minor IN (0, 1)
         AND (
           (event.category = 'nimbus_events' AND event.name = 'validation_failed')
           OR (event.category = 'normandy' AND event.name = 'validation_failed_nimbus_experiment')
         )
-      )
+      ) IS NOT TRUE
     )
-  )
+  ) AS event
   {% else %}
   UNNEST(events) AS event
   {% endif %}

--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -135,7 +135,25 @@ SELECT
 FROM
   base
 CROSS JOIN
+  -- See https://mozilla-hub.atlassian.net/browse/DENG-8432
+  -- Filtering out nimbus and normandy events that are emitted due to 'invalid-feature'.
+  -- The number of these events is too large to be processed, invalid-feature has also
+  -- been removed in more recent versions.
+  {% if app_name == "firefox_desktop_background_update" %}
+  ARRAY(
+    SELECT event
+    FROM UNNEST(events) AS event
+    WHERE NOT (
+      app_version_major = 138 AND app_version_minor IN (0, 1)
+      AND (
+        (event.category = 'nimbus_events' AND event.name = 'validation_failed')
+        OR (event.category = 'normandy' AND event.name = 'validation_failed_nimbus_experiment')
+      )
+    )
+  )
+  {% else %}
   UNNEST(events) AS event
+  {% endif %}
   {% if app_name == "firefox_desktop" %}
     -- See https://mozilla-hub.atlassian.net/browse/DENG-7513
     WHERE

--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -135,19 +135,21 @@ SELECT
 FROM
   base
 CROSS JOIN
+  {% if app_name == "firefox_desktop_background_update" %}
   -- See https://mozilla-hub.atlassian.net/browse/DENG-8432
   -- Filtering out nimbus and normandy events that are emitted due to 'invalid-feature'.
   -- The number of these events is too large to be processed, invalid-feature has also
   -- been removed in more recent versions.
-  {% if app_name == "firefox_desktop_background_update" %}
-  ARRAY(
-    SELECT event
-    FROM UNNEST(events) AS event
-    WHERE NOT (
-      app_version_major = 138 AND app_version_minor IN (0, 1)
-      AND (
-        (event.category = 'nimbus_events' AND event.name = 'validation_failed')
-        OR (event.category = 'normandy' AND event.name = 'validation_failed_nimbus_experiment')
+  UNNEST(
+    ARRAY(
+      SELECT event
+      FROM UNNEST(events) AS event
+      WHERE NOT (
+        app_version_major = 138 AND app_version_minor IN (0, 1)
+        AND (
+          (event.category = 'nimbus_events' AND event.name = 'validation_failed')
+          OR (event.category = 'normandy' AND event.name = 'validation_failed_nimbus_experiment')
+        )
       )
     )
   )


### PR DESCRIPTION
## Description

See https://mozilla-hub.atlassian.net/browse/DENG-8432

We saw an increase in `nimbus_events.validation_failed` and `normandy.validation_failed_nimbus_experiment` events that could no longer be processed for `firefox_desktop_background_update.events_stream`. This issue has since been fixed on the FF client (https://phabricator.services.mozilla.com/D247864), but we'll need to filter out these events in the meantime to unblock `firefox_desktop_background_update.events_stream`

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
