### PR TITLE
feat(DENG-8425): Add 2 columns to baseline_clients_first_seen_v1

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
@@ -200,32 +200,12 @@ _previous AS (
   --Switch to using separate if statements instead of 1
   --because dry run is struggling to validate the final struct
   SELECT
-    IF(_previous.client_id IS NULL 
-    OR _previous.first_seen_date >= _current.first_seen_date,
-       _current.submission_date, _previous.submission_date) AS submission_date,
-    IF(_previous.client_id IS NULL 
-    OR _previous.first_seen_date >= _current.first_seen_date,
-       _current.first_seen_date, _previous.first_seen_date) AS first_seen_date,
-    IF(_previous.client_id IS NULL 
-    OR _previous.first_seen_date >= _current.first_seen_date,
-       _current.sample_id, _previous.sample_id) AS sample_id,
-    IF(_previous.client_id IS NULL 
-    OR _previous.first_seen_date >= _current.first_seen_date,
-       _current.client_id, _previous.client_id) AS client_id,
-    IF(_previous.client_id IS NULL 
-    OR _previous.first_seen_date >= _current.first_seen_date,
-       _current.attribution, _previous.attribution) AS attribution,
-    IF(_previous.client_id IS NULL 
-    OR _previous.first_seen_date >= _current.first_seen_date,
-       _current.distribution, _previous.distribution) AS `distribution`,
-    {% if app_name == "firefox_desktop" %}
-    IF(_previous.client_id IS NULL 
-    OR _previous.first_seen_date >= _current.first_seen_date,
-       _current.attribution_ext, _previous.attribution_ext) AS attribution_ext,
-    IF(_previous.client_id IS NULL 
-    OR _previous.first_seen_date >= _current.first_seen_date,
-       _current.distribution_ext, _previous.distribution_ext) AS distribution_ext
-    {% endif %}
+    IF(
+      _previous.client_id IS NULL
+      OR _previous.first_seen_date >= _current.first_seen_date,
+      _current,
+      _previous
+    ).*
   FROM
     _current
   FULL JOIN

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
@@ -43,3 +43,14 @@ fields:
     name: name
     type: STRING
     description: The distribution name (e.g. 'MozillaOnline').
+
+{% if app_name == "firefox_desktop" %}
+- mode: NULLABLE
+  name: attribution_ext
+  type: JSON
+  description: Extended Attribution Information
+- mode: NULLABLE
+  name: distribution_ext
+  type: JSON
+  description: Extended Distribution Information
+{% endif %}


### PR DESCRIPTION
## Description
* This PR adds 2 new columns, `attribution_ext` & `distribution_ext`, to the SQL generator template for `baseline_clients_first_seen_v1` - but only for the app firefox_desktop (it does not add the columns to other apps since there is no data yet for other apps)


## Related Tickets & Documents
* [DENG-8425](https://mozilla-hub.atlassian.net/browse/DENG-8425)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8425]: https://mozilla-hub.atlassian.net/browse/DENG-8425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ