### PR TITLE
[DENG-8350] read access on socorro_crash for crash-ping-ingest

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/socorro_crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/socorro_crash/metadata.yaml
@@ -13,3 +13,5 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:ci-and-quality-tools/taskcluster
+      # https://mozilla-hub.atlassian.net/browse/DENG-8350
+      - workgroup:dataops-managed/crash-ping-ingest

--- a/sql/moz-fx-data-shared-prod/telemetry/socorro_crash_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/socorro_crash_v2/metadata.yaml
@@ -13,3 +13,5 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:ci-and-quality-tools/taskcluster
+      # https://mozilla-hub.atlassian.net/browse/DENG-8350
+      - workgroup:dataops-managed/crash-ping-ingest


### PR DESCRIPTION
## Description

Gives read access to socorro_crash for crash-ping-ingest, similar to #7267.

## Related Tickets & Documents
* DENG-8350


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
