### PR TITLE
Remove bqetl_sponsored_tiles_clients_daily DAG

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -901,25 +901,6 @@ bqetl_domain_meta:
     - triage/no_triage
     - repo/bigquery-etl
 
-bqetl_sponsored_tiles_clients_daily:
-  default_args:
-    depends_on_past: false
-    email:
-      - telemetry-alerts@mozilla.com
-      - skahmann@mozilla.com
-    email_on_failure: true
-    email_on_retry: true
-    end_date: null
-    owner: skahmann@mozilla.com
-    retries: 2
-    retry_delay: 30m
-    start_date: '2022-09-13'
-  description: daily run of sponsored tiles related fields
-  schedule_interval: 0 4 * * *
-  tags:
-    - impact/tier_3
-    - repo/bigquery-etl
-
 bqetl_mobile_activation:
   default_args:
     depends_on_past: false


### PR DESCRIPTION
## Description

Removes the `bqetl_sponsored_tiles_clients_daily` DAG. This only ran the `bqetl_sponsored_tiles_clients_daily_v1` table, which has been rescheduled.

## Related Tickets & Documents

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
