### PR TITLE
feat(DENG-8495): Create new glean dataset

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Glean
+description: |-
+  Contains Glean views for combinations of Glean desktop and mobile apps
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+syndication: {}


### PR DESCRIPTION
## Description

- For the OKR project, creating a new dataset called "glean" that will house the new active_users_aggregates view that combines Glean desktop and Glean mobile app information.
- Traditionally, telemetry was intended to be used for "legacy" data, so want to create a separate place that can house new Glean based views.

## Related Tickets & Documents
* [DENG-8495](https://mozilla-hub.atlassian.net/browse/DENG-8495)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8495]: https://mozilla-hub.atlassian.net/browse/DENG-8495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ