### PR TITLE
fix: Rename dataset glean to glean_telemetry

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry/dataset_metadata.yaml
@@ -1,6 +1,6 @@
-friendly_name: Glean
+friendly_name: Glean Telemetry
 description: |-
-  Contains Glean views for combinations of Glean desktop and mobile apps
+  Contains views of Glean telemetry for desktop and mobile apps
 dataset_base_acl: view
 user_facing: true
 labels: {}


### PR DESCRIPTION
## Description

This is a follow up to [PR-7409](https://github.com/mozilla/bigquery-etl/pull/7409) which caused issues by accidentally using a reserved namespace.  This renames the dataset to `glean_telemetry` instead of `glean`.


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
