### PR TITLE
Create new table telemetry_derived.active_users_rollup_shredder_v1

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1898,6 +1898,7 @@ bqetl_shredder_impact_measurement:
   tags:
     - impact/tier_2
 
+
 bqetl_addons_moderations:
   default_args:
     depends_on_past: false

--- a/dags.yaml
+++ b/dags.yaml
@@ -1885,6 +1885,19 @@ bqetl_monitoring_weekly:
   tags:
     - impact/tier_3
 
+bqetl_shredder_impact_measurement:
+  schedule_interval: 40 12 * * 7
+  description: |
+    This DAG populates a table that measures the impact of shredder that only runs weekly
+  default_args:
+    owner: kwindau@mozilla.com
+    email: ["kwindau@mozilla.com"]
+    start_date: "2025-05-01"
+    retries: 2
+    retry_delay: 30m
+  tags:
+    - impact/tier_2
+
 bqetl_addons_moderations:
   default_args:
     depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/telemetry/active_users_rollup_shredder/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/active_users_rollup_shredder/view.sql
@@ -2,6 +2,18 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.active_users_rollup_shredder`
 AS
 SELECT
-  *
+  submission_date,
+  app_name,
+  logical_dag_date,
+  dag_run_date,
+  dau,
+  wau,
+  mau,
+  daily_users,
+  weekly_users,
+  monthly_users,
+  desktop,
+  mobile,
+  unique_client_ids
 FROM
   `moz-fx-data-shared-prod.telemetry_derived.active_users_rollup_shredder_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry/active_users_rollup_shredder/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/active_users_rollup_shredder/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry.active_users_rollup_shredder`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.active_users_rollup_shredder_v1`

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Active Users Rollup Shredder
 description: |-
-  Runs weekly to record the number of clients in telemetry.active_users
+  Records the number of clients in telemetry.active_users over time
   to better understand the impact of shredder over time.
 owners:
 - kwindau@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/metadata.yaml
@@ -13,7 +13,7 @@ scheduling:
 bigquery:
   time_partitioning:
     type: day
-    field: submission_date
+    field: logical_dag_date
     require_partition_filter: false
     expiration_days: null
   range_partitioning: null

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/metadata.yaml
@@ -1,0 +1,24 @@
+friendly_name: Active Users Rollup Shredder
+description: |-
+  Runs weekly to record the number of clients in telemetry.active_users
+  to better understand the impact of shredder over time.
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  owner2: dberry
+scheduling:
+  dag_name: bqetl_shredder_impact_measurement
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - app_name
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/query.sql
@@ -2,7 +2,7 @@ SELECT
   submission_date,
   app_name,
   @submission_date AS logical_dag_date,
-  CURRENT_DATE() AS run_date,
+  CURRENT_DATE() AS dag_run_date,
   SUM(CAST(is_dau AS int)) AS dau,
   SUM(CAST(is_wau AS int)) AS wau,
   SUM(CAST(is_mau AS int)) AS mau,
@@ -20,4 +20,4 @@ GROUP BY
   submission_date,
   app_name,
   logical_dag_date,
-  run_date
+  dag_run_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/query.sql
@@ -1,0 +1,23 @@
+SELECT
+  submission_date,
+  app_name,
+  @submission_date AS logical_dag_date,
+  CURRENT_DATE() AS run_date,
+  SUM(CAST(is_dau AS int)) AS dau,
+  SUM(CAST(is_wau AS int)) AS wau,
+  SUM(CAST(is_mau AS int)) AS mau,
+  SUM(CAST(is_daily_user AS int)) AS daily_users,
+  SUM(CAST(is_weekly_user AS int)) AS weekly_users,
+  SUM(CAST(is_monthly_user AS int)) AS monthly_users,
+  SUM(CAST(is_desktop AS int)) AS desktop,
+  SUM(CAST(is_mobile AS int)) AS mobile,
+  COUNT(DISTINCT(client_id)) AS unique_client_ids
+FROM
+  `moz-fx-data-shared-prod.telemetry.active_users`
+WHERE
+  submission_date >= '2023-01-01'
+GROUP BY
+  submission_date,
+  app_name,
+  logical_dag_date,
+  run_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/query.sql
@@ -11,7 +11,8 @@ SELECT
   SUM(CAST(is_monthly_user AS int)) AS monthly_users,
   SUM(CAST(is_desktop AS int)) AS desktop,
   SUM(CAST(is_mobile AS int)) AS mobile,
-  COUNT(DISTINCT(client_id)) AS unique_client_ids
+  COUNT(DISTINCT(client_id)) AS unique_client_ids,
+  COUNT(1) AS row_count
 FROM
   `moz-fx-data-shared-prod.telemetry.active_users`
 WHERE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/schema.yaml
@@ -1,0 +1,53 @@
+fields:
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+  description: Submission date recorded from telemetry.active_users
+- name: app_name
+  type: STRING
+  mode: NULLABLE
+  description: App name recorded from telemetry.active_users
+- name: logical_dag_date
+  type: DATE
+  mode: NULLABLE
+  description: Logical DAG Run Date - does not indicate the actual execution date of the RUN
+- name: run_date
+  type: DATE
+  mode: NULLABLE
+  description: Execution date
+- name: dau
+  type: INTEGER
+  mode: NULLABLE
+  description: DAU (daily active users) recorded from telemetry.active_users
+- name: wau
+  type: INTEGER
+  mode: NULLABLE
+  description: WAU (weekly active users) recorded from telemetry.active_users
+- name: mau
+  type: INTEGER
+  mode: NULLABLE
+  description: MAU (monthly active users) recorded from telemetry.active_users
+- name: daily_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Daily Users recorded from telemetry.active_users
+- name: weekly_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Weekly Users recorded from telemetry.active_users
+- name: monthly_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Monthly users recorded from telemetry.active_users
+- name: desktop
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of clients qualifying towards the desktop KPI as is_desktop from telemetry.active_users
+- name: mobile
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of clients qualifying towards the mobile KPI as is_mobile from telemetry.active_users
+- name: unique_client_ids
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique client IDs from telemetry.active_users

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/schema.yaml
@@ -10,7 +10,7 @@ fields:
 - name: logical_dag_date
   type: DATE
   mode: NULLABLE
-  description: Logical DAG Run Date; does not indicate the actual execution date of the RUN
+  description: Logical DAG Run Date; does not indicate the actual execution date of the DAG
 - name: dag_run_date
   type: DATE
   mode: NULLABLE
@@ -18,36 +18,40 @@ fields:
 - name: dau
   type: INTEGER
   mode: NULLABLE
-  description: DAU (daily active users) recorded from telemetry.active_users
+  description: DAU (daily active users) recorded from telemetry.active_users for this app name & submission date as of run date
 - name: wau
   type: INTEGER
   mode: NULLABLE
-  description: WAU (weekly active users) recorded from telemetry.active_users
+  description: WAU (weekly active users) recorded from telemetry.active_users for this app name & submission date as of run date
 - name: mau
   type: INTEGER
   mode: NULLABLE
-  description: MAU (monthly active users) recorded from telemetry.active_users
+  description: MAU (monthly active users) recorded from telemetry.active_users for this app name & submission date as of run date
 - name: daily_users
   type: INTEGER
   mode: NULLABLE
-  description: Daily Users recorded from telemetry.active_users
+  description: Daily Users recorded from telemetry.active_users for this app name & submission date as of run date
 - name: weekly_users
   type: INTEGER
   mode: NULLABLE
-  description: Weekly Users recorded from telemetry.active_users
+  description: Weekly Users recorded from telemetry.active_users for this app name & submission date as of run date
 - name: monthly_users
   type: INTEGER
   mode: NULLABLE
-  description: Monthly users recorded from telemetry.active_users
+  description: Monthly users recorded from telemetry.active_users for this app name & submission date as of run date
 - name: desktop
   type: INTEGER
   mode: NULLABLE
-  description: Number of clients qualifying towards the desktop KPI as is_desktop from telemetry.active_users
+  description: Number of clients qualifying towards the desktop KPI as is_desktop from telemetry.active_users for this app name & submission date as of run date
 - name: mobile
   type: INTEGER
   mode: NULLABLE
-  description: Number of clients qualifying towards the mobile KPI as is_mobile from telemetry.active_users
+  description: Number of clients qualifying towards the mobile KPI as is_mobile from telemetry.active_users for this app name & submission date as of run date
 - name: unique_client_ids
   type: INTEGER
   mode: NULLABLE
-  description: Count of unique client IDs from telemetry.active_users
+  description: Count of unique client IDs from telemetry.active_users for this app name and submission date as of run date
+- name: row_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Row count from telemetry.active_users for this app name & submission date as of run date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/schema.yaml
@@ -10,11 +10,11 @@ fields:
 - name: logical_dag_date
   type: DATE
   mode: NULLABLE
-  description: Logical DAG Run Date - does not indicate the actual execution date of the RUN
-- name: run_date
+  description: Logical DAG Run Date; does not indicate the actual execution date of the RUN
+- name: dag_run_date
   type: DATE
   mode: NULLABLE
-  description: Execution date
+  description: Execution date of the DAG
 - name: dau
   type: INTEGER
   mode: NULLABLE


### PR DESCRIPTION
## Description

This PR creates a new table and view whose purpose is to record the impact of Shredder over time.
- `moz-fx-data-shared-prod.telemetry_derived.active_users_rollup_shredder_v1`
- `moz-fx-data-shared-prod.telemetry.active_users_rollup_shredder_v1`

It also creates a new DAG to populate this table weekly, scheduled to run on Sundays:
- `bqetl_shredder_impact_measurement`


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
