### PR TITLE
Deprecate and unschedule CJMS ETLs (DENG-8515)

### DIFF
--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/flows_v1/metadata.yaml
@@ -1,13 +1,15 @@
 friendly_name: Non-Prod FxA flows by date
-description: >
+description: |-
   Non-Prod FxA flow_id, first seen timestamp, and last seen user id by date
+
+  Deprecated since 2025-05-09.
 owners:
   - srose@mozilla.com
 labels:
   application: cjms
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  #dag_name: bqetl_cjms_nonprod
   query_project: moz-fx-data-shared-prod
   # delay aggregates by 2 hours, to ensure data is complete
   date_partition_parameter: null
@@ -30,3 +32,5 @@ bigquery:
     type: day
     field: submission_date
     require_partition_filter: false
+deprecated: true
+deletion_date: 2025-08-09

--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/refunds_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/refunds_v1/metadata.yaml
@@ -1,13 +1,18 @@
 friendly_name: Stripe refunds on CJ subscriptions
-description: Stripe refunds on CJ subscriptions
+description: |-
+  Stripe refunds on CJ subscriptions
+
+  Deprecated since 2025-05-09.
 owners:
   - srose@mozilla.com
 labels:
   application: cjms
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  #dag_name: bqetl_cjms_nonprod
   query_project: moz-fx-data-shared-prod
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null
+deprecated: true
+deletion_date: 2025-08-09

--- a/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-nonprod-9a36/cjms_bigquery/subscriptions_v1/metadata.yaml
@@ -1,13 +1,18 @@
 friendly_name: Stripe subscriptions attributed to CJ flows
-description: Stripe subscriptions attributed to CJ flows
+description: |-
+  Stripe subscriptions attributed to CJ flows
+
+  Deprecated since 2025-05-09.
 owners:
   - srose@mozilla.com
 labels:
   application: cjms
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  #dag_name: bqetl_cjms_nonprod
   query_project: moz-fx-data-shared-prod
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null
+deprecated: true
+deletion_date: 2025-08-09

--- a/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/flows_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/flows_v1/metadata.yaml
@@ -1,16 +1,20 @@
 friendly_name: FxA flows by date
-description: >
+description: |-
   FxA flow_id, first seen timestamp, and last seen user id by date
+
+  Deprecated since 2025-05-09.
 owners:
   - srose@mozilla.com
 labels:
   application: cjms
-  schedule: hourly
+  schedule: daily
 scheduling:
-  dag_name: bqetl_subplat
+  #dag_name: bqetl_subplat
   query_project: moz-fx-data-shared-prod
 bigquery:
   time_partitioning:
     type: day
     field: submission_date
     require_partition_filter: false
+deprecated: true
+deletion_date: 2025-08-09

--- a/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/refunds_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/refunds_v1/metadata.yaml
@@ -1,13 +1,18 @@
 friendly_name: Stripe refunds on CJ subscriptions
-description: Stripe refunds on CJ subscriptions
+description: |-
+  Stripe refunds on CJ subscriptions
+
+  Deprecated since 2025-05-09.
 owners:
   - srose@mozilla.com
 labels:
   application: cjms
-  schedule: hourly
+  schedule: daily
 scheduling:
-  dag_name: bqetl_subplat
+  #dag_name: bqetl_subplat
   query_project: moz-fx-data-shared-prod
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null
+deprecated: true
+deletion_date: 2025-08-09

--- a/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/subscriptions_v1/metadata.yaml
@@ -1,13 +1,18 @@
 friendly_name: Stripe subscriptions attributed to CJ flows
-description: Stripe subscriptions attributed to CJ flows
+description: |-
+  Stripe subscriptions attributed to CJ flows
+
+  Deprecated since 2025-05-09.
 owners:
   - srose@mozilla.com
 labels:
   application: cjms
-  schedule: hourly
+  schedule: daily
 scheduling:
-  dag_name: bqetl_subplat
+  #dag_name: bqetl_subplat
   query_project: moz-fx-data-shared-prod
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null
+deprecated: true
+deletion_date: 2025-08-09

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_card_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_card_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_charge_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_charge_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_coupon_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_coupon_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_customer_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_customer_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_discount_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_discount_v1/metadata.yaml
@@ -7,7 +7,7 @@ labels:
   incremental: false
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # The whole table is overwritten every time, not a specific date partition.
   date_partition_parameter: null
   depends_on_fivetran:

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_invoice_discount_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_invoice_discount_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_invoice_discount_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_invoice_discount_v2/metadata.yaml
@@ -7,7 +7,7 @@ labels:
   incremental: false
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # The whole table is overwritten every time, not a specific date partition.
   date_partition_parameter: null
 bigquery:

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_invoice_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_invoice_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_plan_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_plan_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_product_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_product_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_promotion_code_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_promotion_code_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_refund_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_refund_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_subscription_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_subscription_history_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/stripe_external/nonprod_subscription_item_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/nonprod_subscription_item_v1/metadata.yaml
@@ -5,7 +5,7 @@ owners:
 labels:
   schedule: hourly
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_history_v1/metadata.yaml
@@ -7,7 +7,7 @@ labels:
   schedule: hourly
   incremental: false
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_v1/metadata.yaml
@@ -7,7 +7,7 @@ labels:
   schedule: hourly
   incremental: false
 scheduling:
-  dag_name: bqetl_cjms_nonprod
+  dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null


### PR DESCRIPTION
## Description
Some non-prod CJMS ETLs started failing today with a CJMS database connection permission error, and the CJMS infrastructure is going to be decommissioned ([OPST-2169](https://mozilla-hub.atlassian.net/browse/OPST-2169)), so this PR deprecates and unschedules all CJMS ETLs (I'll follow up to delete the CJMS ETLs and tables in August).

This also moves the Stripe non-prod ETLs to the `bqetl_sublat` DAG since they no longer need to run hourly to feed the hourly non-prod CJMS ETLs.

## Related Tickets & Documents
* DENG-8515: Unschedule CJMS ETLs
* [OPST-2169](https://mozilla-hub.atlassian.net/browse/OPST-2169): delete cjms (GCPv1) infra

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
