### PR TITLE
fix(ech_adoption_rate): fix time_partitioning field

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ech_adoption_rate_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ech_adoption_rate_v1/metadata.yaml
@@ -16,7 +16,7 @@ scheduling:
 bigquery:
   time_partitioning:
     type: day
-    field: 'submission_date'
+    field: submission_date
     require_partition_filter: true
     expiration_days: null
   range_partitioning: null


### PR DESCRIPTION
## Description

There are extra quotes on 'submission_date`, plus the first run of the ETL failed with
```
Partitioning specification must be provided in order to create partitioned table
````

And this will hopefully fix it. 

## Related Tickets & Documents
* DENG-8381

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
