### PR TITLE
Add is_desktop column to baseline_active_users view.sql

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users/view.sql
@@ -113,7 +113,15 @@ SELECT
   first_seen.attribution.medium AS first_seen_attribution_medium,
   first_seen.attribution.source AS first_seen_attribution_source,
   first_seen.attribution.term AS first_seen_attribution_term,
-  first_seen.distribution.name AS first_seen_distribution_name
+  first_seen.distribution.name AS first_seen_distribution_name,
+  IF(
+    LOWER(IFNULL(isp, '')) <> 'browserstack'
+    AND LOWER(
+      IFNULL(COALESCE(last_seen.distribution_id, distribution_mapping.distribution_id), '')
+    ) <> 'mozillaonline',
+    TRUE,
+    FALSE
+  ) AS is_desktop
 FROM
   `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_last_seen` AS last_seen
 LEFT JOIN


### PR DESCRIPTION
## Description

This PR adds the column "is_desktop" to the view:
- moz-fx-data-shared-prod.firefox_desktop_derived.baseline_active_users


This is needed for some of the upcoming KPI reporting tables.

## Related Tickets & Documents
* [DENG-8026](https://mozilla-hub.atlassian.net/browse/DENG-8026)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8026]: https://mozilla-hub.atlassian.net/browse/DENG-8026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ