### PR TITLE
Add triage notes for bqetl_experimenter_experiments_import

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -710,6 +710,11 @@ bqetl_experimenter_experiments_import:
 
     Imported experiment data is used for experiment monitoring in
     [Grafana](https://grafana.telemetry.mozilla.org/d/XspgvdxZz/experiment-enrollment).
+
+    *Triage notes*
+
+    As long as the most recent DAG run is successful this job can be considered healthy.
+    In such case, past DAG failures can be ignored.
   default_args:
     owner: ascholtz@mozilla.com
     start_date: "2020-10-09"


### PR DESCRIPTION
## Description

Adds triage notes for `bqetl_experimenter_experiments_import` DAG

## Related Tickets & Documents

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
