### PR TITLE
[DENG-8480] Use CODEOWNERS for dependabot reviewer tagging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-    reviewers:
-      - mozilla/data-platform-infra-wg

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,3 +21,6 @@
 /sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_tiles_v2 @mozilla/request_payload_reviewers
 /sql/moz-fx-data-shared-prod/contextual_services_derived/suggest_revenue_levers_daily_v1 @mozilla/revenue_forecasting_data_reviewers
 /sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1 @mozilla/dataops
+# Dependency updates
+requirements.txt @mozilla/data-platform-infra-wg
+requirements.in @mozilla/data-platform-infra-wg


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DENG-8480

Dependabot reviewers configuration is being removed, and instead they are recommending to rely on CODEOWNERS files to assign reviewers

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
