### PR TITLE
feat(DENG-2407): relax FxA events sql checks

### DIFF
--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_daily_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/users_services_daily_v1/checks.sql
@@ -48,6 +48,7 @@ check_results AS (
         OR (event_name LIKE 'access_token_%' AND events_new.count_new - events_old.count_old > 50)
       )
     )
+    AND events_new.count_new < events_old.count_old -- we no longer need old events, it's safe to ignore if they're not instrumented
 )
 SELECT
   IF(
@@ -121,6 +122,7 @@ check_results AS (
         events_old.count_old
       ) > 0.15 -- low-volume events can have higher relative discrepancies
     )
+    AND events_new.count_new < events_old.count_old -- we no longer need old events, it's safe to ignore if they're not instrumented
 )
 SELECT
   IF(


### PR DESCRIPTION
This will fix intermittent check failures.
Now when `accounts_events` explores are hidden and no key/new dashboards use them it's enough if these checks validate that all new events are implemented in `events` ping. We can ignore cases when new event is not implemented in legacy `accounts_events` ping.