### PR TITLE
Adjust delay to get data sooner for team using it 1 day sooner

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -95,8 +95,8 @@ bqetl_google_play_store:
     email_on_retry: false
     end_date: null
     owner: kwindau@mozilla.com
-    retries: 2
-    retry_delay: 30m
+    retries: 4
+    retry_delay: 360m
     start_date: '2025-03-18'
   description: Schedules daily level google play store export data
   schedule_interval: 10 18 * * *

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
@@ -94,7 +94,7 @@ def main():
     print("logical_dag_date_string: ", logical_dag_date_string)
 
     # Get 2 days prior - we always will pull data for the previous day
-    data_pull_date = logical_dag_date - timedelta(days=2)
+    data_pull_date = logical_dag_date - timedelta(days=1)
     data_pull_date_string = data_pull_date.strftime("%Y-%m-%d")
     print("data_pull_date")
     print(data_pull_date)

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/query.py
@@ -94,7 +94,7 @@ def main():
     print("logical_dag_date_string: ", logical_dag_date_string)
 
     # Get 2 days prior - we always will pull data for the previous day
-    data_pull_date = logical_dag_date - timedelta(days=2)
+    data_pull_date = logical_dag_date - timedelta(days=1)
     data_pull_date_string = data_pull_date.strftime("%Y-%m-%d")
     print("data_pull_date")
     print(data_pull_date)

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_version_and_device_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_version_and_device_v1/query.py
@@ -100,7 +100,7 @@ def main():
     print("logical_dag_date_string: ", logical_dag_date_string)
 
     # Get 2 days prior - we always will pull data for the previous day
-    data_pull_date = logical_dag_date - timedelta(days=2)
+    data_pull_date = logical_dag_date - timedelta(days=1)
     data_pull_date_string = data_pull_date.strftime("%Y-%m-%d")
     print("data_pull_date")
     print(data_pull_date)


### PR DESCRIPTION
## Description

This PR updates the delay for 3 jobs loading data from the Google Play Store, to run with a 2 day delay instead of a 3 day delay from the execution time of the DAG.

## Related Tickets & Documents
* [DENG-7931](https://mozilla-hub.atlassian.net/browse/DENG-7931)


[DENG-7931]: https://mozilla-hub.atlassian.net/browse/DENG-7931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ