### PR TITLE
feat(monitoring): Add `query_dialect` column to `jobs_by_organization_v1` ETL

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
@@ -60,6 +60,7 @@ def create_query(job_date: date, project: str):
           transferred_bytes,
           DATE(creation_time) as creation_date,
           materialized_view_statistics,
+          query_dialect,
         FROM
           `{project}.region-us.INFORMATION_SCHEMA.JOBS_BY_ORGANIZATION`
         WHERE

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/schema.yaml
@@ -217,3 +217,8 @@ fields:
       name: rejected_reason
       type: STRING
       description: If present, specifies the reason why the materialized view was not chosen for the query.
+
+- mode: NULLABLE
+  name: query_dialect
+  type: STRING
+  description: The query dialect used for the job.


### PR DESCRIPTION
## Description
BigQuery has added a new `query_dialect` column to the [`JOBS_BY_ORGANIZATION` view](https://cloud.google.com/bigquery/docs/information-schema-jobs-by-organization), which this PR passes through to the `jobs_by_organization_v1` ETL.

## Related Tickets & Documents
* [OPST-2485](https://mozilla-hub.atlassian.net/browse/OPST-2485): Set organization default for BQ SQL dialect to standard SQL

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[OPST-2485]: https://mozilla-hub.atlassian.net/browse/OPST-2485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ