### PR TITLE
feat(RMST-44): Create derived dataset for CDN requests

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2359,3 +2359,27 @@ bqetl_newtab_historical:
     retry_delay: 5m
   tags:
     - impact/tier_3
+
+bqetl_remotesettings_cdn_requests:
+  catchup: false
+  default_args:
+    depends_on_past: false
+    email:
+    - telemetry-alerts@mozilla.com
+    - mleplatre@mozilla.com
+    email_on_failure: true
+    email_on_retry: true
+    end_date: null
+    max_active_tis_per_dag: null
+    owner: mleplatre@mozilla.com
+    retries: 2
+    retry_delay: 30m
+    start_date: '2025-01-01'
+  description: Remote Settings CDN requests analysis
+  repo: bigquery-etl
+  schedule_interval: 0 4 * * *
+  tags:
+  - impact/tier_3
+  - repo/bigquery-etl
+  - triage/no_triage
+

--- a/sql/moz-fx-data-shared-prod/gke_remote_settings_prod_log_linked/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/gke_remote_settings_prod_log_linked/dataset_metadata.yaml
@@ -1,0 +1,16 @@
+friendly_name: Gke Remote Settings Prod Log Linked
+description: |-
+  Remote Settings requests logs on the GKE load balancer.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+default_table_workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+default_table_expiration_ms: null
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+syndication: {}

--- a/sql/moz-fx-data-shared-prod/gke_remote_settings_prod_log_linked/endpoints_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/gke_remote_settings_prod_log_linked/endpoints_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.gke_remote_settings_prod_log_linked.endpoints_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.gke_remote_settings_prod_log_linked_derived.endpoints_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/gke_remote_settings_prod_log_linked_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/gke_remote_settings_prod_log_linked_derived/dataset_metadata.yaml
@@ -1,0 +1,16 @@
+friendly_name: Gke Remote Settings Prod Log Linked Derived
+description: |-
+  Derived dataset of the Remote Settings requests logs on the GKE load balancer.
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+default_table_workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+default_table_expiration_ms: null
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential
+syndication: {}

--- a/sql/moz-fx-data-shared-prod/gke_remote_settings_prod_log_linked_derived/endpoints_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/gke_remote_settings_prod_log_linked_derived/endpoints_aggregates_v1/metadata.yaml
@@ -1,0 +1,30 @@
+friendly_name: Remote Settings Requests Aggregates by Endpoints
+description: |-
+  The query parses the requests logs on the Remote Settings load balancer and parses the
+  URLs in order to build aggregates by endpoints and collections ids.
+owners:
+- mleplatre@mozilla.com
+- acottner@mozilla.com
+- smarnach@mozilla.com
+- sykim@mozilla.com
+labels:
+  incremental: true
+  owner1: mleplatre
+  dag: bqetl_default
+  owner2: acottner
+  owner3: smarnach
+  owner4: sykim
+scheduling:
+  dag_name: bqetl_remotesettings_cdn_requests
+  task_name: endpoints_aggregates_v1
+bigquery:
+  time_partitioning:
+    type: day
+    field: timestamp
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields: []
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/gke_remote_settings_prod_log_linked_derived/endpoints_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/gke_remote_settings_prod_log_linked_derived/endpoints_aggregates_v1/query.sql
@@ -1,0 +1,119 @@
+WITH attachments_urls AS (
+  SELECT
+    'attachments' AS source,
+    http_request.request_url AS url,
+    http_request.response_size AS size,
+    *
+  FROM
+    `moz-fx-remote-settings-prod.remote_settings_prod_default_log_linked._AllLogs`
+  WHERE
+    http_request.request_url LIKE 'https://firefox-settings-attachments.cdn.mozilla.net%' -- exclude bad URLs
+    AND http_request.status = 200
+),
+api_urls AS (
+  SELECT
+    'api' AS source,
+    http_request.request_url AS url,
+    http_request.response_size AS size,
+    *
+  FROM
+    `moz-fx-remote-settings-prod.gke_remote_settings_prod_log_linked._AllLogs`
+  WHERE
+    http_request.request_url LIKE 'https://firefox.settings.services.mozilla.com%'  -- exclude writers, etc.
+    AND http_request.status = 200
+),
+urls AS (
+  SELECT
+    *
+  FROM
+    attachments_urls
+  UNION ALL
+  SELECT
+    *
+  FROM
+    api_urls
+),
+urls_with_endpoint AS (
+  SELECT
+    CASE
+      WHEN source = 'attachments'
+        AND url LIKE '%/bundles/%'
+        THEN 'bundles'
+      WHEN source = 'attachments'
+        THEN 'attachments'
+      WHEN url LIKE '%/v1/'
+        THEN 'root'
+      WHEN url LIKE '%/records%'
+        THEN 'records'
+      WHEN url LIKE '%/changeset%'
+        AND url LIKE '%collection=%'
+        THEN 'filtered-monitor'
+      WHEN url LIKE '%/changeset%'
+        THEN 'changeset'
+      WHEN url LIKE '%/collections/%'
+        THEN 'collection'
+      ELSE 'other'
+    END AS endpoint,
+    *
+  FROM
+    urls
+  WHERE
+    EXTRACT(DATE FROM timestamp) = @submission_date
+),
+urls_with_types_bid_cid AS (
+  SELECT
+    CASE
+      WHEN endpoint = 'bundles'
+        THEN REGEXP_EXTRACT(url, r'/bundles/([^\\.]+)')
+      WHEN endpoint = 'attachments'
+        THEN REGEXP_EXTRACT(url, r'https://[^/]+/([^/]+)/[^/]+/[^/]+')
+      WHEN endpoint = 'filtered-monitor'
+        THEN REGEXP_EXTRACT(url, r'bucket=([^&]+)')
+      ELSE REGEXP_EXTRACT(url, r'/buckets/([^/]+)/')
+    END AS bid,
+    CASE
+      WHEN endpoint = 'bundles'
+        THEN REGEXP_EXTRACT(url, r'/bundles/([^\\.]+)')
+      WHEN endpoint = 'attachments'
+        THEN REGEXP_EXTRACT(url, r'https://[^/]+/[^/]+/([^/]+)/[^/]+')
+      WHEN endpoint = 'filtered-monitor'
+        THEN REGEXP_EXTRACT(url, r'collection=([^&]+)')
+      ELSE REGEXP_EXTRACT(url, r'/collections/([^/?]+)')
+    END AS cid,
+    *
+  FROM
+    urls_with_endpoint
+),
+total_size_hits_by_cid AS (
+  SELECT
+    MAX(timestamp) AS timestamp,
+    source,
+    endpoint,
+    REPLACE(
+      REPLACE(REPLACE(bid, "-staging", ""), "staging", "blocklists"),
+      "-workspace",
+      ""
+    ) AS bid,
+    COALESCE(SPLIT(cid, '--')[SAFE_OFFSET(1)], cid) AS cid,
+    SUM(size) AS size,
+    COUNT(*) AS hits
+  FROM
+    urls_with_types_bid_cid
+  GROUP BY
+    source,
+    endpoint,
+    bid,
+    cid
+)
+SELECT
+  timestamp,
+  source,
+  endpoint,
+  bid AS bucket_id,
+  cid AS collection_id,
+  hits,
+  size
+FROM
+  total_size_hits_by_cid
+WHERE
+  hits > 2  -- ignore noise (not real clients)


### PR DESCRIPTION
## Description

This PR attempts to create a derived dataset for the CDN requests hits. 

Our CDN requests logs are sampled at 1% and saved into these tables:
- `moz-fx-remote-settings-prod.remote_settings_prod_default_log_linked._AllLogs`
- `moz-fx-remote-settings-prod.gke_remote_settings_prod_log_linked._AllLogs`

We would like to build Looker dashboards and Yardstick panels for this data, and since daily agregates are enough, we want to rely on a derived dataset.

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/RMST-44

## TODO

* [ ] Can we reuse an existing dataset (ie. here `gke_remote_settings_prod_log_linked`)? 
* [ ] Fix the permission error on `query validate`: `User does not have permission to query table moz-fx-remote-settings-prod:gke_remote_settings_prod_log_linked._AllLogs`. 
* [ ] Update the schema (since `./bqetl query schema update` failed too)
* [ ] Adjust date manipulation (is `MAX(timestamp)` enough, what's the good pratice?)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
