### PR TITLE
Increase history from 180 days to last 768 days

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_statistics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_statistics_v1/query.sql
@@ -33,9 +33,9 @@ WITH clients_first_seen AS (
     `moz-fx-data-shared-prod.telemetry_derived.rolling_cohorts_v2`
   WHERE
     cohort_date >= DATE_TRUNC(
-      DATE_SUB(@submission_date, INTERVAL 180 day),
+      DATE_SUB(@submission_date, INTERVAL 768 day),
       WEEK
-    ) --start of week for date 180 days ago
+    ) --start of week for date 768 days ago
     AND cohort_date <= DATE_SUB(
       DATE_TRUNC(@submission_date, WEEK),
       INTERVAL 1 DAY
@@ -59,9 +59,9 @@ weekly_active_clients AS (
     `moz-fx-data-shared-prod.telemetry.active_users`
   WHERE
     submission_date >= DATE_TRUNC(
-      DATE_SUB(@submission_date, INTERVAL 180 day),
+      DATE_SUB(@submission_date, INTERVAL 768 day),
       WEEK
-    ) --start of week for date 180 days ago
+    ) --start of week for date 768 days ago
     AND submission_date <= DATE_SUB(
       DATE_TRUNC(@submission_date, WEEK),
       INTERVAL 1 DAY
@@ -75,9 +75,9 @@ unique_weeks AS (
     `mozdata.external.calendar`
   WHERE
     submission_date >= DATE_TRUNC(
-      DATE_SUB(@submission_date, INTERVAL 180 day),
+      DATE_SUB(@submission_date, INTERVAL 768 day),
       WEEK
-    ) --start of week 180 days ago
+    ) --start of week 768 days ago
     AND submission_date <= DATE_SUB(
       DATE_TRUNC(@submission_date, WEEK),
       INTERVAL 1 DAY


### PR DESCRIPTION
## Description

The table `moz-fx-data-shared-prod.telemetry_derived.cohort_weekly_statistics_v1` has logic to pull all cohorts starting in last 180 days, but extending this to be a larger time range (now all cohorts starting in last 775 days). Note, using 768 here because the logic gets the start of the week so this ensures the start will be within the 775 day range.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
