### PR TITLE
updating model to bring in historical data for backfilling

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/metadata.yaml
@@ -3,9 +3,12 @@ description: |-
   Interactions on Newtab desktop across all territories and release channels. The addition
   of the Unified API (UAPI) includes mobile data in addition to desktop.
 
-  For any downstream jobs specific to desktop, filter on the os column
+  For any downstream jobs specific to desktop, filter on the surface column
 
   This job runs hourly and is aggregated by day, tile ID, and position.
+
+  Anyone doing backfills on this model should be mindful that the legacy data currently has an
+  expiration of 180 days.
 owners:
   - cbeck@mozilla.com
 labels:


### PR DESCRIPTION
## Description
This PR adds historical data for newtab telemetry collected from the legacy ping going back further than 6 months (current expiration on _stable tables. the further back we go, the more data was flowing through (before clients updated to glean). 

For the ads media mix modeling, we need to be able to go back further than 6 months, so data was imported from Snowflake to Bigquery to accommodate this.

`newtab_interactions_historical_legacy` was copied from Snowflake 
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
[AD-706](https://mozilla-hub.atlassian.net/browse/AD-706)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[AD-706]: https://mozilla-hub.atlassian.net/browse/AD-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ