### PR TITLE
Add 3 new intermediate staging table to shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -269,6 +269,48 @@ DELETE_TARGETS: DeleteIndex = {
     client_id_target(table="telemetry_stable.update_v4"): DESKTOP_SRC,
     client_id_target(table="telemetry_stable.voice_v4"): DESKTOP_SRC,
     DeleteTarget(
+        table="telemetry_derived.cohort_weekly_active_clients_staging_v1",
+        field=(CLIENT_ID,) * 15,
+    ): (
+        DESKTOP_SRC,
+        DeleteSource(table="focus_android.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="klar_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="focus_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="klar_android.deletion_request", field=GLEAN_CLIENT_ID),
+        *FOCUS_ADDITIONAL_DELETIONS,
+        *LEGACY_MOBILE_SOURCES,
+    ),
+    DeleteTarget(
+        table="telemetry_derived.cohort_weekly_active_clients_v1",
+        field=(CLIENT_ID,) * 15,
+    ): (
+        DESKTOP_SRC,
+        DeleteSource(table="focus_android.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="klar_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="focus_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="klar_android.deletion_request", field=GLEAN_CLIENT_ID),
+        *FOCUS_ADDITIONAL_DELETIONS,
+        *LEGACY_MOBILE_SOURCES,
+    ),
+    DeleteTarget(
+        table="telemetry_derived.cohort_weekly_cfs_staging_v1",
+        field=(CLIENT_ID,) * 15,
+    ): (
+        DESKTOP_SRC,
+        DeleteSource(table="focus_android.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="klar_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="focus_ios.deletion_request", field=GLEAN_CLIENT_ID),
+        DeleteSource(table="klar_android.deletion_request", field=GLEAN_CLIENT_ID),
+        *FOCUS_ADDITIONAL_DELETIONS,
+        *LEGACY_MOBILE_SOURCES,
+    ),
+    DeleteTarget(
         table="telemetry_derived.mobile_engagement_clients_v1",
         field=(CLIENT_ID, CLIENT_ID),
     ): (


### PR DESCRIPTION
## Description

This PR adds the 3 new tables from [PR-7441](https://github.com/mozilla/bigquery-etl/pull/7441) to Shredder:
- `moz-fx-data-shared-prod.telemetry_derived.cohort_weekly_active_clients_staging_v1`
- `moz-fx-data-shared-prod.telemetry_derived.cohort_weekly_active_clients_v1`
- `moz-fx-data-shared-prod.telemetry_derived.cohort_weekly_cfs_staging_v1`

Note: All 3 of these tables contain client IDs from legacy desktop and Glean mobile sources.

## Related Tickets & Documents
* [DENG-8561](https://mozilla-hub.atlassian.net/browse/DENG-8561)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8561]: https://mozilla-hub.atlassian.net/browse/DENG-8561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ