### PR TITLE
AD-850 Fix dependencies on newtab_interactions_hourly_v1

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2347,7 +2347,7 @@ bqetl_ech_adoption_rate:
     - repo/bigquery-etl
 
 bqetl_newtab_historical:
-  schedule_interval: 0 2 * * *
+  schedule_interval: once
   description: |
     Load Newtab historical data from GCS into BigQuery
   default_args:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/metadata.yaml
@@ -32,8 +32,10 @@ scheduling:
     # explicit query file path is necessary because the destination table
     # includes a partition identifier that is not in the path
     sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/query.sql
+  referenced_tables: []
   depends_on:
-    - ["moz-fx-data-shared-prod", "ads_derived", "interaction_aggregates_hourly_v1"]
+    - task_id: ads_derived__interaction_aggregates_hourly__v1
+      dag_name: private_bqetl_ads_hourly
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/metadata.yaml
@@ -32,6 +32,8 @@ scheduling:
     # explicit query file path is necessary because the destination table
     # includes a partition identifier that is not in the path
     sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/query.sql
+  depends_on:
+    - ["moz-fx-data-shared-prod", "ads_derived", "interaction_aggregates_hourly_v1"]
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description

`telemetry_derived.newtab_interactions_hourly_v1` (a table that runs daily) is currently not running because it is waiting on `telemetry_derived.newtab_interactions_historical_legacy_v1`, which runs daily. Additionally, it's missing a dependency that should be there. There are two changes here:

* Stop running `telemetry_derived.newtab_interactions_historical_legacy_v1` altogether. It only needs to run on an ad hoc basis
* Make the depencies for `newtab_interactions_hourly_v1` in the metadata to:
  * Remove the automatically generated depenency on `newtab_interactions_historical_legacy_v1` by setting `referenced_tables` to `[]`
  * Manually add a dependency on `ads_derived.interaction_aggregates_hourly_v1`

## Related Tickets & Documents
* [AD-850](https://mozilla-hub.atlassian.net/browse/AD-850)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[AD-850]: https://mozilla-hub.atlassian.net/browse/AD-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ