### PR TITLE
feat(DENG-8439): Create Glean UDF for parsing Windows OS version

### DIFF
--- a/sql/mozfun/norm/glean_windows_version_info/README.md
+++ b/sql/mozfun/norm/glean_windows_version_info/README.md
@@ -1,0 +1,1 @@
+To be used with Glean datasets, helps normalize Windows version information.

--- a/sql/mozfun/norm/glean_windows_version_info/metadata.yaml
+++ b/sql/mozfun/norm/glean_windows_version_info/metadata.yaml
@@ -1,0 +1,9 @@
+---
+friendly_name: Normalize Glean Windows OS Version
+description: |
+  Given an unnormalized set of Windows identifiers, return a friendly version
+  of the operating system name.
+
+  Requires os, os_version and windows_build_number.
+
+  E.G. from windows_build_number >= 22000 return Windows 11

--- a/sql/mozfun/norm/glean_windows_version_info/udf.sql
+++ b/sql/mozfun/norm/glean_windows_version_info/udf.sql
@@ -1,0 +1,64 @@
+CREATE OR REPLACE FUNCTION norm.glean_windows_version_info(
+  os STRING,
+  os_version STRING,
+  windows_build_number INT64
+)
+RETURNS STRING AS (
+  CASE
+    WHEN os = 'Windows'
+      AND os_version = '4.0'
+      THEN 'Windows NT 4.0'
+    WHEN os = 'Windows'
+      AND os_version = '4.1'
+      THEN 'Windows 98'
+    WHEN os = 'Windows'
+      AND os_version = '5.0'
+      THEN 'Windows 2000'
+    WHEN os = 'Windows'
+      AND os_version IN ('5.1', '5.2')
+      THEN 'Windows XP'
+    WHEN os = 'Windows'
+      AND os_version = '6.0'
+      THEN 'Windows Vista'
+    WHEN os = 'Windows'
+      AND os_version = '6.1'
+      THEN 'Windows 7'
+    WHEN os = 'Windows'
+      AND os_version = '6.2'
+      THEN 'Windows 8'
+    WHEN os = 'Windows'
+      AND os_version = '6.3'
+      THEN 'Windows 8.1'
+    WHEN os = 'Windows'
+      AND os_version = '10.0'
+      AND windows_build_number < 22000
+      THEN 'Windows 10'
+    WHEN os = 'Windows'
+      AND os_version = '10.0'
+      AND windows_build_number >= 22000
+      THEN 'Windows 11'
+    WHEN os = 'Windows'
+      AND os_version = '10.0'
+      AND windows_build_number IS NULL
+      THEN 'Windows 10/11 (build unknown)'
+    ELSE NULL
+  END
+);
+
+-- Tests
+SELECT
+  assert.equals('Windows NT 4.0', norm.glean_windows_version_info('Windows', '4.0', NULL)),
+  assert.equals('Windows 98', norm.glean_windows_version_info('Windows', '4.1', NULL)),
+  assert.equals('Windows 2000', norm.glean_windows_version_info('Windows', '5.0', NULL)),
+  assert.equals('Windows XP', norm.glean_windows_version_info('Windows', '5.1', NULL)),
+  assert.equals('Windows XP', norm.glean_windows_version_info('Windows', '5.2', NULL)),
+  assert.equals('Windows Vista', norm.glean_windows_version_info('Windows', '6.0', NULL)),
+  assert.equals('Windows 7', norm.glean_windows_version_info('Windows', '6.1', 7601)),
+  assert.equals('Windows 8', norm.glean_windows_version_info('Windows', '6.2', 7602)),
+  assert.equals('Windows 8.1', norm.glean_windows_version_info('Windows', '6.3', NULL)),
+  assert.equals('Windows 10', norm.glean_windows_version_info('Windows', '10.0', 19043)),
+  assert.equals('Windows 11', norm.glean_windows_version_info('Windows', '10.0', 22623)),
+  assert.equals(
+    'Windows 10/11 (build unknown)',
+    norm.glean_windows_version_info('Windows', '10.0', NULL)
+  );


### PR DESCRIPTION
## Description
This PR creates a new UDF, `norm.glean_windows_version_info`, and creates tests of the UDF.

This UDF helps parse Windows version information but for Glean inputs which are slightly different than what the Legacy inputs were (particularly for the "os" column).

## Related Tickets & Documents
* [DENG-8439](https://mozilla-hub.atlassian.net/browse/DENG-8439)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8439]: https://mozilla-hub.atlassian.net/browse/DENG-8439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ