### PR TITLE
Use deep copy when merging schemas

### DIFF
--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -7,6 +7,7 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Iterable, List, Optional
 
 import attr
+import ujson
 import yaml
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
@@ -265,7 +266,10 @@ class Schema:
             else:
                 if update and add_missing_fields:
                     # node does not exist in schema, add to schema
-                    columns.append(node.copy())
+                    if node["type"] == "RECORD":  # deep copy record fields
+                        columns.append(ujson.loads(ujson.dumps(node)))
+                    else:
+                        columns.append(node.copy())
                     print(f"Field {node_name} added to {prefix}")
                 else:
                     if not ignore_missing_fields:


### PR DESCRIPTION
## Description

I found this bug while looking at the desktop_crashes generator: https://github.com/mozilla/bigquery-etl/blob/730e33d3d43854f6bee38d38aacf0412927982d9/sql_generators/desktop_crashes/__init__.py#L44-L51

Multiple source schemas are merged into a target schema but since it uses a shallow copy, the  dict references in the target are the same as the ones in the sources so the source schemas get updated unexpectedly.

Deep copying the desktop metrics dict takes ~6.5 ms so performance shouldn't performance shouldn't matter.

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1920544

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
