### PR TITLE
feat(DENG-8438): Update OS UDFs in baseline_active_users view

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users/view.sql
@@ -47,36 +47,23 @@ SELECT
     ELSE CAST(NULL AS STRING)
   END AS distribution_id_source,
   normalized_os AS os,
+  --"os_grouped" is the same as "os", but we are making a choice to include it anyway
+  --to make the switch from legacy sources to Glean easier since the column was in the previous view
+  normalized_os AS os_grouped,
   normalized_os_version AS os_version,
   COALESCE(
-    `mozfun.norm.windows_version_info`(normalized_os, normalized_os_version, windows_build_number),
+    `mozfun.norm.glean_windows_version_info`(
+      normalized_os,
+      normalized_os_version,
+      windows_build_number
+    ),
     normalized_os_version
   ) AS os_version_build,
   CAST(
-    `mozfun.norm.extract_version`(
-      COALESCE(
-        `mozfun.norm.windows_version_info`(
-          normalized_os,
-          normalized_os_version,
-          windows_build_number
-        ),
-        normalized_os_version
-      ),
-      "major"
-    ) AS INTEGER
+    `mozfun.norm.extract_version`(normalized_os_version, "major") AS INTEGER
   ) AS os_version_major,
   CAST(
-    `mozfun.norm.extract_version`(
-      COALESCE(
-        `mozfun.norm.windows_version_info`(
-          normalized_os,
-          normalized_os_version,
-          windows_build_number
-        ),
-        normalized_os_version
-      ),
-      "minor"
-    ) AS INTEGER
+    `mozfun.norm.extract_version`(normalized_os_version, "minor") AS INTEGER
   ) AS os_version_minor,
   CASE
     WHEN BIT_COUNT(days_desktop_active_bits)


### PR DESCRIPTION
## Description

This PR updates the OS UDF functions used in the view:
- `moz-fx-data-shared-prod.firefox_desktop.baseline_active_users`

There are 3 changes:
1. It simplifies the logic for OS version major and OS version minor.  
2. It also fixes the logic for os_build to use the new "glean_windows_version_info" UDF.
3. It adds a new column to help keep consistency with the old AUA table to make swapping Looker dashboards easier.

## Related Tickets & Documents
* [DENG-8439](https://mozilla-hub.atlassian.net/browse/DENG-8439)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8439]: https://mozilla-hub.atlassian.net/browse/DENG-8439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ