### PR TITLE
fix(glam): re-adjust client_count for sampling only on scalars

### DIFF
--- a/bigquery_etl/glam/templates/probe_counts_v1.sql
+++ b/bigquery_etl/glam/templates/probe_counts_v1.sql
@@ -106,9 +106,11 @@ WITH probe_counts AS (
     {{ aggregate_grouping }}
 )
 
-{% if channel == "release" %}
+{% if channel == "release" and is_scalar %}
 ,
   -- Fix All OS client counts which were originally calculated taking only 10% of Windows due to sampling.
+  -- This is only relevant for scalars, as histograms are already made right during client normalization.
+  -- See histogram_bucket_counts_v1.sql for details.
   windows_probe_counts AS (
     SELECT
       *

--- a/bigquery_etl/glam/templates/probe_counts_v1.sql
+++ b/bigquery_etl/glam/templates/probe_counts_v1.sql
@@ -109,7 +109,7 @@ WITH probe_counts AS (
 {% if channel == "release" and is_scalar %}
 ,
   -- Fix All OS client counts which were originally calculated taking only 10% of Windows due to sampling.
-  -- This is only relevant for scalars, as histograms are already made right during client normalization.
+ -- This is only relevant for scalars, as histograms are already normalized during client normalization.
   -- See histogram_bucket_counts_v1.sql for details.
   windows_probe_counts AS (
     SELECT


### PR DESCRIPTION
## Description

This PR fixes the release All OS client counts on GLAM. 

## Related Tickets & Documents
* DENG-8486

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
