### PR TITLE
DENG-8424 - Allow read access to crash tables by workgroup:remote-settings/gke

### DIFF
--- a/sql/moz-fx-data-shared-prod/crash_ping_ingest_external/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/crash_ping_ingest_external/dataset_metadata.yaml
@@ -14,3 +14,5 @@ workgroup_access:
 - role: roles/bigquery.dataEditor
   members:
   - workgroup:dataops-managed/crash-ping-ingest
+  # https://mozilla-hub.atlassian.net/browse/DENG-8424
+  - workgroup:remote-settings/gke

--- a/sql/moz-fx-data-shared-prod/fenix/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/crash/metadata.yaml
@@ -3,3 +3,5 @@ workgroup_access:
   members:
   # https://mozilla-hub.atlassian.net/browse/DENG-8189
   - workgroup:dataops-managed/crash-ping-ingest
+  # https://mozilla-hub.atlassian.net/browse/DENG-8424
+  - workgroup:remote-settings/gke

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_crashes/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_crashes/metadata.yaml
@@ -9,3 +9,5 @@ workgroup_access:
   members:
   # https://mozilla-hub.atlassian.net/browse/DENG-8189
   - workgroup:dataops-managed/crash-ping-ingest
+  # https://mozilla-hub.atlassian.net/browse/DENG-8424
+  - workgroup:remote-settings/gke

--- a/sql/moz-fx-data-shared-prod/telemetry/socorro_crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/socorro_crash/metadata.yaml
@@ -15,3 +15,5 @@ workgroup_access:
       - workgroup:ci-and-quality-tools/taskcluster
       # https://mozilla-hub.atlassian.net/browse/DENG-8350
       - workgroup:dataops-managed/crash-ping-ingest
+      # https://mozilla-hub.atlassian.net/browse/DENG-8424
+      - workgroup:remote-settings/gke


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/DENG-8424