### PR TITLE
Revert "feat: add bqetl_backfill_validate pre-commit hook"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,12 +49,3 @@ repos:
     entry: ./bqetl
     args: [format, --check]
     types: [sql]
-- repo: local
-  hooks:
-  - id: bqetl_backfill_validate
-    name: bqetl_backfill_validate
-    language: script
-    entry: ./bqetl
-    args: [backfill, validate, --ignore-missing-metadata]
-    types: [yaml]
-    files: ^.+.backfill.yaml$

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -7,7 +7,6 @@ import sys
 import tempfile
 from collections import defaultdict
 from datetime import date, datetime, timedelta
-from os.path import exists
 from pathlib import Path
 
 import rich_click as click
@@ -248,15 +247,6 @@ def validate(
 ):
     """Validate backfill.yaml files."""
     if qualified_table_name:
-        # checking if path string was passed in instead of "dataset.table_name" format
-        # if yes we convert it to the expected format.
-        # this is to accommodate pre-commit hook
-        qualified_table_name = (
-            ".".join(qualified_table_name.split("/")[-4:-1])
-            if exists(qualified_table_name)
-            else qualified_table_name
-        )
-
         backfills_dict = {
             qualified_table_name: get_entries_from_qualified_table_name(
                 sql_dir, qualified_table_name

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -432,19 +432,6 @@ class TestBackfill:
         )
         assert result.exit_code == 0
 
-    def test_validate_backfill_with_backfill_path(self, mock_date, runner):
-        backfill_file = Path(QUERY_DIR) / BACKFILL_FILE
-        backfill_file.write_text(BACKFILL_YAML_TEMPLATE)
-        assert BACKFILL_FILE in os.listdir(QUERY_DIR)
-
-        result = runner.invoke(
-            validate,
-            [
-                str(backfill_file),
-            ],
-        )
-        assert result.exit_code == 0
-
     def test_validate_backfill_with_billing_project(self, mock_date, runner):
         backfill_file = Path(QUERY_DIR) / BACKFILL_FILE
         backfill_text = (


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#7448

If more than one backfill is modified in a single commit this fails.