### PR TITLE
feat: add bqetl_backfill_validate pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,6 @@ repos:
     name: bqetl_backfill_validate
     language: script
     entry: ./bqetl
-    args: [backfill, validate]
+    args: [backfill, validate, --ignore-missing-metadata]
     types: [yaml]
     files: ^.+.backfill.yaml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,4 +57,4 @@ repos:
     entry: ./bqetl
     args: [backfill, validate-multiple, --ignore-missing-metadata]
     types: [yaml]
-    files: ^.+.backfill.yaml$
+    files: ^.+/backfill\.yaml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
     entry: ./bqetl
     args: [format, --check]
     types: [sql]
+    exclude: sql_generators/.+\.sql$
 - repo: local
   hooks:
   - id: bqetl_backfill_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,6 @@ repos:
     name: bqetl_backfill_validate
     language: script
     entry: ./bqetl
-    args: [backfill, validate, --ignore-missing-metadata]
+    args: [backfill, validate-multiple, --ignore-missing-metadata]
     types: [yaml]
     files: ^.+.backfill.yaml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,4 +49,12 @@ repos:
     entry: ./bqetl
     args: [format, --check]
     types: [sql]
-    exclude: sql_generators/.+\.sql$
+- repo: local
+  hooks:
+  - id: bqetl_backfill_validate
+    name: bqetl_backfill_validate
+    language: script
+    entry: ./bqetl
+    args: [backfill, validate]
+    types: [yaml]
+    files: ^.+.backfill.yaml$

--- a/bigquery_etl/backfill/validate.py
+++ b/bigquery_etl/backfill/validate.py
@@ -136,3 +136,7 @@ def validate_entries(backfills: List[Backfill], backfill_file: Path) -> None:
         validate_depends_on_past_end_date(backfill_entry, backfill_file)
         validate_old_entry_date(backfill_entry)
     validate_entries_are_sorted(backfills)
+
+
+class BackfillConfigurationError(Exception):
+    """Backfill configuration error."""

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -234,24 +234,27 @@ def create(
     ./bqetl backfill validate
     """
 )
-@click.argument("asset_name", required=False)
+@click.argument("qualified_table_name", required=False)
 @sql_dir_option
 @project_id_option()
 @ignore_missing_metadata_option
 @click.pass_context
 def validate(
     ctx,
-    asset_name,
+    qualified_table_name,
     sql_dir,
     project_id,
     ignore_missing_metadata,
 ):
     """Validate backfill.yaml files."""
-    if asset_name:
-        # checking if path instead of "dataset.table_name" format was passed
+    if qualified_table_name:
+        # checking if path string was passed in instead of "dataset.table_name" format
         # if yes we convert it to the expected format.
+        # this is to accommodate pre-commit hook
         qualified_table_name = (
-            ".".join(asset_name.split("/")[-4:-1]) if exists(asset_name) else asset_name
+            ".".join(qualified_table_name.split("/")[-4:-1])
+            if exists(qualified_table_name)
+            else qualified_table_name
         )
 
         backfills_dict = {

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 from collections import defaultdict
 from datetime import date, datetime, timedelta
+from os.path import exists
 from pathlib import Path
 
 import rich_click as click
@@ -233,20 +234,26 @@ def create(
     ./bqetl backfill validate
     """
 )
-@click.argument("qualified_table_name", required=False)
+@click.argument("asset_name", required=False)
 @sql_dir_option
 @project_id_option()
 @ignore_missing_metadata_option
 @click.pass_context
 def validate(
     ctx,
-    qualified_table_name,
+    asset_name,
     sql_dir,
     project_id,
     ignore_missing_metadata,
 ):
     """Validate backfill.yaml files."""
-    if qualified_table_name:
+    if asset_name:
+        # checking if path instead of "dataset.table_name" format was passed
+        # if yes we convert it to the expected format.
+        qualified_table_name = (
+            ".".join(asset_name.split("/")[-4:-1]) if exists(asset_name) else asset_name
+        )
+
         backfills_dict = {
             qualified_table_name: get_entries_from_qualified_table_name(
                 sql_dir, qualified_table_name

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -350,10 +350,10 @@ def validate_multiple(
         try:
             validate_errors = ctx.invoke(validate, **cmd_args)
             click.echo(validate_errors)
-        except (KeyError, FileNotFoundError) as error:
+        except (KeyError, FileNotFoundError, ValueError) as error:
             errors.append(error)
             error_message = f"{str(error.with_traceback)} -> {str(error)}"
-            click.echo(f"Validation for {backfill_file} FAILED with: {error_message}.")
+            click.echo(f"Validation for {backfill_file} FAILED with: {error_message}")
 
     if sum([len(errors), len(validate_errors or list())]) > 0:
         sys.exit(1)

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -432,6 +432,19 @@ class TestBackfill:
         )
         assert result.exit_code == 0
 
+    def test_validate_backfill_with_backfill_path(self, mock_date, runner):
+        backfill_file = Path(QUERY_DIR) / BACKFILL_FILE
+        backfill_file.write_text(BACKFILL_YAML_TEMPLATE)
+        assert BACKFILL_FILE in os.listdir(QUERY_DIR)
+
+        result = runner.invoke(
+            validate,
+            [
+                str(backfill_file),
+            ],
+        )
+        assert result.exit_code == 0
+
     def test_validate_backfill_with_billing_project(self, mock_date, runner):
         backfill_file = Path(QUERY_DIR) / BACKFILL_FILE
         backfill_text = (

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -36,6 +36,7 @@ from bigquery_etl.cli.backfill import (
     initiate,
     scheduled,
     validate,
+    validate_multiple,
 )
 from bigquery_etl.cli.stage import QUERY_FILE
 from bigquery_etl.deploy import FailedDeployException
@@ -432,18 +433,45 @@ class TestBackfill:
         )
         assert result.exit_code == 0
 
-    def test_validate_backfill_with_backfill_path(self, mock_date, runner):
+    def test_validate_multiple_backfill_one_path(self, mock_date, runner):
         backfill_file = Path(QUERY_DIR) / BACKFILL_FILE
         backfill_file.write_text(BACKFILL_YAML_TEMPLATE)
         assert BACKFILL_FILE in os.listdir(QUERY_DIR)
 
         result = runner.invoke(
-            validate,
+            validate_multiple,
             [
                 str(backfill_file),
             ],
         )
         assert result.exit_code == 0
+
+    def test_validate_multiple_backfill_multi_path(
+        self, mock_date, setup_second_query, runner
+    ):
+        backfill_file_1 = Path(QUERY_DIR) / BACKFILL_FILE
+        backfill_file_1.write_text(BACKFILL_YAML_TEMPLATE)
+        assert BACKFILL_FILE in os.listdir(QUERY_DIR)
+
+        backfill_file_2 = Path(QUERY_DIR_2) / BACKFILL_FILE
+        backfill_file_2.write_text(BACKFILL_YAML_TEMPLATE)
+        assert BACKFILL_FILE in os.listdir(QUERY_DIR_2)
+
+        result = runner.invoke(
+            validate_multiple,
+            [
+                str(backfill_file_1),
+                str(backfill_file_2),
+            ],
+        )
+        # print(dir(result))
+        # print(result.exc_info)
+        # print(result.runner)
+        # print(result.exit_code)
+        print(result.stdout)
+        print(result.output)
+        # print(result.exception)
+        # assert result.exit_code == 0
 
     def test_validate_backfill_with_billing_project(self, mock_date, runner):
         backfill_file = Path(QUERY_DIR) / BACKFILL_FILE

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -464,14 +464,7 @@ class TestBackfill:
                 str(backfill_file_2),
             ],
         )
-        # print(dir(result))
-        # print(result.exc_info)
-        # print(result.runner)
-        # print(result.exit_code)
-        print(result.stdout)
-        print(result.output)
-        # print(result.exception)
-        # assert result.exit_code == 0
+        assert result.exit_code == 0
 
     def test_validate_backfill_with_billing_project(self, mock_date, runner):
         backfill_file = Path(QUERY_DIR) / BACKFILL_FILE


### PR DESCRIPTION
`validate_multiple` command added to support multiple backfill file paths being passed into bqetl for backfill config validation. Example usage:

```shell
/bqetl backfill validate-multiple \
        sql/moz-fx-data-shared-prod/org_mozilla_fenix_nightly_derived/baseline_clients_daily_v1/backfill.yaml \
        sql/moz-fx-data-shared-prod/org_mozilla_firefox_derived/baseline_clients_daily_v1/backfill.yaml
```

This will run validation for all files passed in and exist with status code 1 if any errors are found by the upstream `validate` command.