### PR TITLE
fix: new_profile_activations query validation error (schema / query mismatch)

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.query.sql
@@ -17,7 +17,6 @@ SELECT
   submission_date,
   first_seen_date,
   normalized_channel,
-  normalized_channel AS channel,
   app_name,
   app_version,
   country,


### PR DESCRIPTION
# fix: new_profile_activations query validation error (schema / query mismatch)