### PR TITLE
feat(DENG-8439): Update UDF

### DIFF
--- a/sql/mozfun/norm/glean_windows_version_info/udf.sql
+++ b/sql/mozfun/norm/glean_windows_version_info/udf.sql
@@ -40,7 +40,7 @@ RETURNS STRING AS (
     WHEN os = 'Windows'
       AND os_version = '10.0'
       AND windows_build_number IS NULL
-      THEN 'Windows 10/11 (build unknown)'
+      THEN 'build unknown - likely Windows 10 or 11'
     ELSE NULL
   END
 );
@@ -59,6 +59,6 @@ SELECT
   assert.equals('Windows 10', norm.glean_windows_version_info('Windows', '10.0', 19043)),
   assert.equals('Windows 11', norm.glean_windows_version_info('Windows', '10.0', 22623)),
   assert.equals(
-    'Windows 10/11 (build unknown)',
+    'build unknown - likely Windows 10 or 11',
     norm.glean_windows_version_info('Windows', '10.0', NULL)
   );


### PR DESCRIPTION
## Description
This PR updates the UDF for Glean Windows Version to change the output when the windows build # is null and it's Windows 10 or 11.

## Related Tickets & Documents
* [DENG-8439](https://mozilla-hub.atlassian.net/browse/DENG-8439)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8439]: https://mozilla-hub.atlassian.net/browse/DENG-8439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ