### PR TITLE
fix(DENG-8434): Remove join condition until tables are backfilled so …

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_clients.view.sql
@@ -5,7 +5,7 @@ AS
 SELECT
   client_id,
   active_users.submission_date AS first_seen_date,
-  normalized_channel,
+  active_users.normalized_channel,
   app_name,
   app_display_version AS app_version,
   country,

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_clients.view.sql
@@ -27,7 +27,7 @@ FROM
   `{{ project_id }}.{{ dataset }}.active_users` AS active_users
 LEFT JOIN
   `{{ project_id }}.{{ dataset }}.attribution_clients` AS attribution
-  USING(client_id, normalized_channel)
+  USING(client_id) --temporarily removing normalized_channel until backfill finishes
 WHERE
   active_users.submission_date < CURRENT_DATE
   AND is_new_profile


### PR DESCRIPTION
## Description

This PR updates the logic for the SQL generated `new_profile_clients` views.  

We are removing the join on normalized_channel that was added via [PR-7395](https://github.com/mozilla/bigquery-etl/pull/7395) until the backfill of the upstream attribution_clients table is complete, because right now, the new column in the join condition is always null, basically making the join never really work.

Related tickets:
[DENG-8577](https://mozilla-hub.atlassian.net/browse/DENG-8577)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8577]: https://mozilla-hub.atlassian.net/browse/DENG-8577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ