### PR TITLE
feat: mark attribution_clients backfill complete

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/backfill.yaml
@@ -4,5 +4,5 @@
   reason: normalized_channel added, backfill to populate this field historically
   watchers:
   - kik@mozilla.com
-  status: Initiate
+  status: Complete
   override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/attribution_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/attribution_clients_v1/backfill.yaml
@@ -4,5 +4,5 @@
   reason: normalized_channel added, backfill to populate this field historically
   watchers:
   - kik@mozilla.com
-  status: Initiate
+  status: Complete
   override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/attribution_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/attribution_clients_v1/backfill.yaml
@@ -4,5 +4,5 @@
   reason: normalized_channel added, backfill to populate this field historically
   watchers:
   - kik@mozilla.com
-  status: Initiate
+  status: Complete
   override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/focus_ios_derived/attribution_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_ios_derived/attribution_clients_v1/backfill.yaml
@@ -4,5 +4,5 @@
   reason: normalized_channel added, backfill to populate this field historically
   watchers:
   - kik@mozilla.com
-  status: Initiate
+  status: Complete
   override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/klar_android_derived/attribution_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/klar_android_derived/attribution_clients_v1/backfill.yaml
@@ -4,5 +4,5 @@
   reason: normalized_channel added, backfill to populate this field historically
   watchers:
   - kik@mozilla.com
-  status: Initiate
+  status: Complete
   override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/klar_ios_derived/attribution_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/klar_ios_derived/attribution_clients_v1/backfill.yaml
@@ -4,5 +4,5 @@
   reason: normalized_channel added, backfill to populate this field historically
   watchers:
   - kik@mozilla.com
-  status: Initiate
+  status: Complete
   override_retention_limit: false

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.metadata.yaml
@@ -5,7 +5,7 @@ description: |-
   Table grain: client_id, normalized_channel
 
   Notes:
-  - 2025-05-14: `normalized_channel` field added (backfilled up until 2023-04-08)
+  - 2025-05-14: `normalized_channel` field added (backfilled up until 2023-04-08, prior to this the value will always be `null`)
 
 owners:
   - mozilla/kpi_table_reviewers


### PR DESCRIPTION
# feat: mark attribution_clients backfill complete

Also including a note in the schema and description that normalized_channel is null prior to the backfill start date
