### PR TITLE
DENG-8048 Add default access to ads_derived dataset to ads WG

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/dataset_metadata.yaml
@@ -8,3 +8,6 @@ workgroup_access:
   - role: roles/bigquery.dataEditor
     members:
       - workgroup:ads/data-developers
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:ads

--- a/sql/moz-fx-data-shared-prod/ads_derived/nt_visits_to_sessions_conversion_factors_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/nt_visits_to_sessions_conversion_factors_daily_v1/metadata.yaml
@@ -26,3 +26,4 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:mozilla-confidential
+deprecated: true


### PR DESCRIPTION
## Description

Complements [https://github.com/mozilla/private-bigquery-etl/pull/736] -- the `ads_derived` dataset is almost entirely defined in `private-bigquery-etl`, but one table is defined here.

I believe this table is no longer in use, so my plan is to initiate the [deprecation process](https://docs.google.com/document/d/1ek-XNCKpxMK47mjc_RU-RNvUwHNOhNlbQHig8MZh6fk/edit) for this table and then remove this folder from `bigquery-etl` entirely, but that's going to take a little longer to do, and I'd like to get this permission change in first.

## Related Tickets & Documents
* DENG-8048

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
