### PR TITLE
chore(SubPlat): Initiate backfills to add historical Google subscription records to SubPlat consolidated reporting tables (DENG-975)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -1,3 +1,15 @@
+2025-05-22:
+  start_date: 2021-09-09
+  end_date: 2025-05-14
+  reason: Add records for Google subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+
 2024-11-13:
   start_date: 2019-10-10
   end_date: 2024-11-12

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2025-05-22:
+  start_date: 2021-09-09
+  end_date: 2025-05-14
+  reason: Add records for Google subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -1,3 +1,15 @@
+2025-05-22:
+  start_date: 2021-09-09
+  end_date: 2025-05-14
+  reason: Add records for Google subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+
 2024-11-13:
   start_date: 2019-10-10
   end_date: 2024-11-12

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
@@ -1,3 +1,15 @@
+2025-05-22:
+  start_date: 2021-09-01
+  end_date: 2025-04-01
+  reason: Add records for Google subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+
 2024-11-13:
   start_date: 2019-10-01
   end_date: 2024-10-01

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2025-05-22:
+  start_date: 2021-09-01
+  end_date: 2025-04-01
+  reason: Add records for Google subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2025-05-22:
+  start_date: 2021-09-09
+  end_date: 2025-05-14
+  reason: Add records for Google subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description
Initiates backfills of the logical subscription and service subscription tables.

## Related Tickets & Documents
* DENG-975: Google subscriptions ETL v2

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
