### PR TITLE
Revert "chore(deps): bump bigeye-sdk from 0.5.1 to 0.5.2"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 attrs==25.3.0
 authlib==1.5.2
 beautifulsoup4==4.13.4
-bigeye-sdk==0.5.2
+bigeye-sdk==0.5.1
 black==25.1.0
 cattrs==24.1.3
 click==8.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,9 +144,9 @@ beautifulsoup4==4.13.4 \
 betterproto[compiler]==1.2.5 \
     --hash=sha256:74a3ab34646054f674d236d1229ba8182dc2eae86feb249b8590ef496ce9803d
     # via bigeye-sdk
-bigeye-sdk==0.5.2 \
-    --hash=sha256:8949418dc842c1659dd7782616d8829eb10a8fdbbc2432c537a2f356dad1e446 \
-    --hash=sha256:9c1cb29ee805df7ebf7314588e8b07694436e000cd0daf2b5a28a68a955184c7
+bigeye-sdk==0.5.1 \
+    --hash=sha256:103c92a7117e48066aeac105ccf3596292d7ec973c92fbbdde77126ec3e0e0e0 \
+    --hash=sha256:6827c3a48278b5486c7429cff04c553874577c4f3c322f74d000fe91b9dd37c3
     # via -r requirements.in
 black==25.1.0 \
     --hash=sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171 \


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#7485