### PR TITLE
feat(): Remove status badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/mozilla/bigquery-etl/tree/main.svg?style=svg&circle-token=1df4cefd991043d7d3f13243ea80f38e7aa18341)](https://dl.circleci.com/status-badge/redirect/gh/mozilla/bigquery-etl/tree/main)
 # BigQuery ETL
 
 This repository contains Mozilla Data Team's:


### PR DESCRIPTION
# feat(): Remove status badge from README

Removing status page as now we use multiple workflows and there is a known bug in CircleCI status badge whereby it does not work reliably:

https://circleci.com/docs/status-badges/

"In cases where there are multiple workflows running within a pipeline, the status badge will show the result (red or green) of the latest workflow that has finished running. This is a bug."
