### PR TITLE
feat(glam): Add support to client-sampled metrics

### DIFF
--- a/bigquery_etl/glam/client_side_sampled_metrics.py
+++ b/bigquery_etl/glam/client_side_sampled_metrics.py
@@ -1,0 +1,29 @@
+"""Client-side sampled metrics.
+
+This module defines client-side sampled metrics and provides a function
+to retrieve metrics by type.
+"""
+
+cs_sampled_metrics = {
+    "distributions": [
+        "glam_experiment_async_sheet_load",
+        "glam_experiment_http_content_html5parser_ondatafinished_to_onstop_delay",
+        "glam_experiment_largest_contentful_paint",
+        "glam_experiment_protect_time",
+        "glam_experiment_sub_complete_load_net",
+        "glam_experiment_time",
+    ],
+    "counters": [
+        "glam_experiment_active_ticks",
+        "glam_experiment_panel_shown",
+        "glam_experiment_os_socket_limit_reached",
+        "glam_experiment_used",
+        "glam_experiment_cpu_time_bogus_values",
+        "glam_experiment_total_cpu_time_ms",
+    ],
+}
+
+
+def get(metric_type: str) -> list:
+    """Get client-side sampled metrics by type."""
+    return cs_sampled_metrics[metric_type]

--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -9,6 +9,7 @@ from jinja2 import Environment, PackageLoader
 from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.util.probe_filters import get_etl_excluded_probes_quickfix
 
+from .client_side_sampled_metrics import get as get_sampled_metrics
 from .utils import get_schema, ping_type_from_table
 
 ATTRIBUTES = ",".join(
@@ -32,7 +33,9 @@ def render_main(**kwargs):
     return reformat(main_sql.render(**kwargs))
 
 
-def get_distribution_metrics(schema: Dict) -> Dict[str, List[str]]:
+def get_distribution_metrics(
+    schema: Dict,
+) -> tuple[Dict[str, List[str]], Dict[str, List[str]]]:
     """Find all distribution-like metrics in a Glean table.
 
     Metric types are defined in the Glean documentation found here:
@@ -48,6 +51,10 @@ def get_distribution_metrics(schema: Dict) -> Dict[str, List[str]]:
     metrics: Dict[str, List[str]] = {metric_type: [] for metric_type in metric_type_set}
     excluded_metrics = get_etl_excluded_probes_quickfix("fenix")
 
+    # Metrics that are already sampled
+    sampled_metric_names = get_sampled_metrics("distributions")
+    sampled_metrics = {"timing_distribution": sampled_metric_names}
+
     # Iterate over every element in the schema under the metrics section and
     # collect a list of metric names.
     for root_field in schema:
@@ -58,9 +65,13 @@ def get_distribution_metrics(schema: Dict) -> Dict[str, List[str]]:
             if metric_type not in metric_type_set:
                 continue
             for field in metric_field["fields"]:
-                if field["name"] not in excluded_metrics:
+                if (
+                    field["name"] not in excluded_metrics
+                    and field["name"] not in sampled_metric_names
+                ):
                     metrics[metric_type].append(field["name"])
-    return metrics
+
+    return metrics, sampled_metrics
 
 
 def get_metrics_sql(metrics: Dict[str, List[str]]) -> dict[str, str]:
@@ -134,9 +145,12 @@ def main():
     )
 
     schema = get_schema(args.source_table)
-    distributions = get_distribution_metrics(schema)
+    distributions, client_sampled_distributions = get_distribution_metrics(schema)
     metrics_sql = get_metrics_sql(distributions)
-    if not metrics_sql["labeled"] or not metrics_sql["unlabeled"]:
+    client_sampled_metrics_sql = {"labeled": [], "unlabeled": []}
+    if args.product == "firefox_desktop":
+        client_sampled_metrics_sql = get_metrics_sql(client_sampled_distributions)
+    if not metrics_sql["labeled"] and not metrics_sql["unlabeled"]:
         print(header)
         print("-- Empty query: no probes found!")
         sys.exit(1)
@@ -149,6 +163,11 @@ def main():
             histograms=metrics_sql["unlabeled"],
             labeled_histograms=metrics_sql["labeled"],
             ping_type=ping_type_from_table(args.source_table),
+            client_sampled_histograms=client_sampled_metrics_sql["unlabeled"],
+            client_sampled_labeled_histograms=client_sampled_metrics_sql["labeled"],
+            client_sampled_channel="release",
+            client_sampled_os="Windows",
+            client_sampled_max_sample_id=100,
         )
     )
 


### PR DESCRIPTION
## Description

This PR adapts the GLAM ETL to not further sample a static list of metrics that are already getting sampled on the client-side via server knobs. More in the ticket below.

## Related Tickets & Documents
* DENG-8046

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
