### PR TITLE
fix: Support using `date_partition_offset` with monthly partitioned ETLs

### DIFF
--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -231,11 +231,21 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
     {% elif task.is_dq_check -%}
        {{ task.task_name }} = bigquery_dq_check(
             task_id='{{ task.task_name }}',
-            {#+ TODO when Airflow is updated to 2.2+ use ds_nodash instead of ds_format -#}
-            source_table={%+ if task.date_partition_offset -%}'{{ task.destination_table }}${% raw %}{{{% endraw %} macros.ds_format(macros.ds_add(ds, {{ task.date_partition_offset }}), "%Y-%m-%d", "%Y%m%d") {% raw %}}}{% endraw %}'
-                            {%+ elif task.destination_table -%}'{{ task.destination_table }}'
-                            {%+ else -%}None
-                            {%+ endif -%},
+            {%+ if task.date_partition_offset -%}
+            source_table='{{ task.destination_table }}$
+                {%- raw %}{{ {% endraw -%}
+                macros.ds_format(macros.ds_add(ds, {{ task.date_partition_offset }}), "%Y-%m-%d",
+                    {%- if task.table_partition_type == "year" %} "%Y"
+                    {%- elif task.table_partition_type == "month" %} "%Y%m"
+                    {%- else %} "%Y%m%d"
+                    {%- endif -%}
+                )
+                {%- raw %} }}{% endraw %}',
+            {%+ elif task.destination_table -%}
+            source_table='{{ task.destination_table }}',
+            {%+ else -%}
+            source_table=None,
+            {%+ endif -%}
             {%+ if task.query_project -%}
             dataset_id='{{ task.project }}:{{ task.dataset }}',
             project_id='{{ task.query_project }}',
@@ -315,11 +325,21 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
             #### WARNING: This task has been scheduled in the default DAG. It can be moved to a more suitable DAG using `bqetl query schedule`.
             {% endif %}
             task_id='{{ task.task_name }}',
-            {#+ TODO when Airflow is updated to 2.2+ use ds_nodash instead of ds_format -#}
-            destination_table={%+ if task.date_partition_offset -%}'{{ task.destination_table }}${% raw %}{{{% endraw %} macros.ds_format(macros.ds_add(ds, {{ task.date_partition_offset }}), "%Y-%m-%d", "%Y%m%d") {% raw %}}}{% endraw %}'
-                            {%+ elif task.destination_table -%}'{{ task.destination_table }}'
-                            {%+ else -%}None
-                            {%+ endif -%},
+            {%+ if task.date_partition_offset -%}
+            destination_table='{{ task.destination_table }}$
+                {%- raw %}{{ {% endraw -%}
+                macros.ds_format(macros.ds_add(ds, {{ task.date_partition_offset }}), "%Y-%m-%d",
+                    {%- if task.table_partition_type == "year" %} "%Y"
+                    {%- elif task.table_partition_type == "month" %} "%Y%m"
+                    {%- else %} "%Y%m%d"
+                    {%- endif -%}
+                )
+                {%- raw %} }}{% endraw %}',
+            {%+ elif task.destination_table -%}
+            destination_table='{{ task.destination_table }}',
+            {%+ else -%}
+            destination_table=None,
+            {%+ endif -%}
             {%+ if task.query_project -%}
             dataset_id='{{ task.project }}:{{ task.dataset }}',
             project_id='{{ task.query_project }}',


### PR DESCRIPTION
## Description
The existing DAG generation logic assumes ETLs using `date_partition_offset` are partitioned by date, which is causing two monthly partitioned SubPlat ETLs to fail ([bug 1968341](https://bugzilla.mozilla.org/show_bug.cgi?id=1968341), [bug 1968342](https://bugzilla.mozilla.org/show_bug.cgi?id=1968342)) after I set `date_partition_offset` for them (#7471).

## Related Tickets & Documents
* DENG-975: Google subscriptions ETL v2
* https://github.com/mozilla/bigquery-etl/pull/7471
* [Bug 1968341](https://bugzilla.mozilla.org/show_bug.cgi?id=1968341): Airflow task bqetl_subplat.subscription_platform_derived__monthly_active_logical_subscriptions__v1 failed for exec_date 2025-05-22
* [Bug 1968342](https://bugzilla.mozilla.org/show_bug.cgi?id=1968342): Airflow task bqetl_subplat.subscription_platform_derived__monthly_active_service_subscriptions__v1 failed for exec_date 2025-05-22

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
