### PR TITLE
Pull country from metrics in quick_suggest ping

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
@@ -14,7 +14,14 @@ combined AS (
     metrics.uuid.quick_suggest_context_id AS context_id,
     DATE(submission_timestamp) AS submission_date,
     'desktop' AS form_factor,
-    normalized_country_code AS country,
+    -- As of Firefox 140, the quick_suggest ping is sent via OHTTP and now
+    -- receives geo information from the client rather than from Glean ingestion's
+    -- IP geolocation. We no longer send subdivision, only country.
+    IF(
+      SAFE_CAST(metadata.user_agent.version AS INT64) < 140,
+      normalized_country_code,
+      metrics.string.country,
+    ) AS country,
     LOWER(metrics.string.quick_suggest_advertiser) AS advertiser,
     SPLIT(metadata.user_agent.os, ' ')[SAFE_OFFSET(0)] AS normalized_os,
     client_info.app_channel AS release_channel,

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/query.sql
@@ -20,8 +20,19 @@ combined AS (
       "impression"
     ) AS event_type,
     'desktop' AS form_factor,
-    normalized_country_code AS country,
-    metadata.geo.subdivision1 AS subdivision1,
+    -- As of Firefox 140, the quick_suggest ping is sent via OHTTP and now
+    -- receives geo information from the client rather than from Glean ingestion's
+    -- IP geolocation. We no longer send subdivision, only country.
+    IF(
+      SAFE_CAST(metadata.user_agent.version AS INT64) < 140,
+      normalized_country_code,
+      metrics.string.country,
+    ) AS country,
+    IF(
+      SAFE_CAST(metadata.user_agent.version AS INT64) < 140,
+      metadata.geo.subdivision1,
+      CAST(NULL AS STRING)
+    ) AS subdivision1,
     metrics.string.quick_suggest_advertiser AS advertiser,
     client_info.app_channel AS release_channel,
     metrics.quantity.quick_suggest_position AS position,

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_suggest_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_suggest_v2/query.sql
@@ -18,8 +18,19 @@ ping_data AS (
       "click",
       "impression"
     ) AS interaction_type,
-    metadata.geo.country AS country_code,
-    metadata.geo.subdivision1 AS region_code,
+    -- As of Firefox 140, the quick_suggest ping is sent via OHTTP and now
+    -- receives geo information from the client rather than from Glean ingestion's
+    -- IP geolocation. We no longer send subdivision, only country.
+    IF(
+      SAFE_CAST(metadata.user_agent.version AS INT64) < 140,
+      metadata.geo.country,
+      metrics.string.country,
+    ) AS country_code,
+    IF(
+      SAFE_CAST(metadata.user_agent.version AS INT64) < 140,
+      metadata.geo.subdivision1,
+      CAST(NULL AS STRING)
+    ) AS region_code,
     metadata.user_agent.os AS os_family,
     metadata.user_agent.version AS product_version,
   FROM

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/query.sql
@@ -45,8 +45,16 @@ WITH impressions AS (
     sample_id,
     metrics.boolean.quick_suggest_is_clicked AS is_clicked,
     client_info.locale AS locale,
-    metadata.geo.country,
-    metadata.geo.subdivision1 AS region,
+    IF(
+      SAFE_CAST(metadata.user_agent.version AS INT64) < 140,
+      metadata.geo.country,
+      metrics.string.country,
+    ) AS country,
+    IF(
+      SAFE_CAST(metadata.user_agent.version AS INT64) < 140,
+      metadata.geo.subdivision1,
+      CAST(NULL AS STRING)
+    ) AS region,
     normalized_os,
     normalized_os_version,
     normalized_channel,


### PR DESCRIPTION
## Description

This PR changes tables that are directly downstream of the `quick_suggest` tables to pull `country` from `metrics` rather than from `metadata`, in accordance with a change to the ping in Firefox 140.

I still need to update the tests, so I'm leaving this as a draft for now.

## Related Tickets & Documents
* [AD-869](https://mozilla-hub.atlassian.net/browse/AD-869)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
