### PR TITLE
Normalize looker dashboard perf metrics

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/looker_dashboard_load_times/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/looker_dashboard_load_times/view.sql
@@ -2,6 +2,33 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.monitoring.looker_dashboard_load_times`
 AS
 SELECT
-  *
+  total_runtime,
+  seconds_until_controller_initialized,
+  seconds_until_dom_content_loaded,
+  seconds_until_metadata_loaded,
+  seconds_until_dashboard_run_start,
+  -- seconds_until_dashboard_run_start represents the time the tab was opened,
+  -- so it needs to be used as offset to get the number of seconds
+  seconds_until_first_data_received - seconds_until_dashboard_run_start AS seconds_until_first_data_received,
+  -- tile rendering times should be set to 0, if data is loaded from cache
+  -- if the rendering time is lower than the run start, then it indicates it's loaded from cache
+  IF(
+    seconds_until_first_tile_finished_rendering > seconds_until_dashboard_run_start,
+    seconds_until_first_tile_finished_rendering - seconds_until_dashboard_run_start,
+    0
+  ) AS seconds_until_first_tile_finished_rendering,
+  seconds_until_last_data_received - seconds_until_dashboard_run_start AS seconds_until_last_data_received,
+  IF(
+    seconds_until_last_tile_finished_rendering > seconds_until_dashboard_run_start,
+    seconds_until_last_tile_finished_rendering - seconds_until_dashboard_run_start,
+    0
+  ) AS seconds_until_last_tile_finished_rendering,
+  dash_id,
+  dashboard_page_session,
+  submission_date,
+  refresh_interval,
+  -- some of these numbers might not make sense for auto-refreshed dashboards, so providing this as filter option
+  refresh_interval IS NOT NULL AS is_auto_refreshed,
+  dashboard_run_session
 FROM
   `moz-fx-data-shared-prod.monitoring_derived.looker_dashboard_load_times_v1`

--- a/sql/moz-fx-data-shared-prod/monitoring/looker_dashboard_load_times/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/looker_dashboard_load_times/view.sql
@@ -17,7 +17,11 @@ SELECT
     seconds_until_first_tile_finished_rendering - seconds_until_dashboard_run_start,
     0
   ) AS seconds_until_first_tile_finished_rendering,
-  seconds_until_last_data_received - seconds_until_dashboard_run_start AS seconds_until_last_data_received,
+  IF(
+    seconds_until_last_data_received > seconds_until_dashboard_run_start,
+    seconds_until_last_data_received - seconds_until_dashboard_run_start,
+    0
+  ) AS seconds_until_last_data_received,
   IF(
     seconds_until_last_tile_finished_rendering > seconds_until_dashboard_run_start,
     seconds_until_last_tile_finished_rendering - seconds_until_dashboard_run_start,

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/query.py
@@ -41,6 +41,9 @@ def run_query(sdk, date):
             "dashboard_performance.dash_id",
             "dashboard_performance.dashboard_page_session",
             "dashboard_performance.first_event_at_date",
+            "dashboard.refresh_interval",
+            "dashboard_performance.dashboard_run_session",
+            ""
         ],
         pivots=None,
         fill_fields=None,
@@ -92,6 +95,8 @@ def import_performance_data_for_date(sdk, destination_table, date):
         bigquery.SchemaField("dash_id", "STRING"),
         bigquery.SchemaField("dashboard_page_session", "STRING"),
         bigquery.SchemaField("submission_date", "DATE"),
+        bigquery.SchemaField("refresh_interval", "STRING"),
+        bigquery.SchemaField("dashboard_run_session", "STRING"),
     )
     job_config.write_disposition = bigquery.job.WriteDisposition.WRITE_TRUNCATE
     job_config.time_partitioning = bigquery.TimePartitioning(

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/query.py
@@ -43,7 +43,6 @@ def run_query(sdk, date):
             "dashboard_performance.first_event_at_date",
             "dashboard.refresh_interval",
             "dashboard_performance.dashboard_run_session",
-            ""
         ],
         pivots=None,
         fill_fields=None,

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/looker_dashboard_load_times_v1/schema.yaml
@@ -56,3 +56,12 @@ fields:
   name: submission_date
   type: DATE
   description: The first occurrence of a particular dashboard being run
+- mode: NULLABLE
+  name: refresh_interval
+  type: STRING
+  description: Indicates that the dashboard is refreshed automatically
+- mode: NULLABLE
+  name: dashboard_run_session
+  type: STRING
+  description: A unique string identifier assigned to a particular dashboard each
+    time a dashboard is run


### PR DESCRIPTION
We had another session with Looker support and they explained how the recorded dashboard performance times need to be normalized/subtracted/offset. This PR implements these changes in the view and pulls in some more fields into the source table.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
