### PR TITLE
feat(backfill): Add `ignore_date_partition_offset` backfill option

### DIFF
--- a/bigquery_etl/backfill/parse.py
+++ b/bigquery_etl/backfill/parse.py
@@ -74,6 +74,7 @@ class Backfill:
     shredder_mitigation: Optional[bool] = attr.ib(False)
     override_retention_limit: Optional[bool] = attr.ib(False)
     override_depends_on_past_end_date: Optional[bool] = attr.ib(False)
+    ignore_date_partition_offset: Optional[bool] = attr.ib(False)
     billing_project: Optional[str] = attr.ib(None)
 
     def __str__(self):
@@ -97,6 +98,7 @@ class Backfill:
             shredder_mitigation = {self.shredder_mitigation}
             override_retention_limit = {self.override_retention_limit}
             override_depends_on_past_end_date = {self.override_depends_on_past_end_date}
+            ignore_date_partition_offset = {self.ignore_date_partition_offset}
             billing_project = {self.billing_project}
             """
 
@@ -211,6 +213,9 @@ class Backfill:
                         ),
                         override_depends_on_past_end_date=entry.get(
                             "override_depends_on_past_end_date", False
+                        ),
+                        ignore_date_partition_offset=entry.get(
+                            "ignore_date_partition_offset", False
                         ),
                         billing_project=entry.get("billing_project", None),
                     )

--- a/tests/backfill/test_parse_backfill.py
+++ b/tests/backfill/test_parse_backfill.py
@@ -48,6 +48,7 @@ TEST_BACKFILL_3 = Backfill(
     shredder_mitigation=False,
     override_retention_limit=False,
     override_depends_on_past_end_date=False,
+    ignore_date_partition_offset=False,
     billing_project=DEFAULT_BILLING_PROJECT,
 )
 
@@ -453,6 +454,7 @@ class TestParseBackfill(object):
             "  shredder_mitigation: false\n"
             "  override_retention_limit: false\n"
             "  override_depends_on_past_end_date: false\n"
+            "  ignore_date_partition_offset: false\n"
         )
 
         results = TEST_BACKFILL_1.to_yaml()
@@ -473,6 +475,7 @@ class TestParseBackfill(object):
             shredder_mitigation = False
             override_retention_limit = False
             override_depends_on_past_end_date = False
+            ignore_date_partition_offset = False
             billing_project = None
             """
 
@@ -492,6 +495,7 @@ class TestParseBackfill(object):
             "  shredder_mitigation: false\n"
             "  override_retention_limit: false\n"
             "  override_depends_on_past_end_date: false\n"
+            "  ignore_date_partition_offset: false\n"
         )
 
         TEST_BACKFILL_1.excluded_dates = []


### PR DESCRIPTION
## Description
Managed backfills currently always take an ETL's `date_partition_offset` setting into account, but that has some downsides:
* When specifying the backfill start/end dates you need to account for the offset, which makes it less obvious what table partitions are being backfilled and trickier to get that right.
* Managed backfills don't currently support `date_partition_offset` with monthly partitioned ETLs.

While it is necessary for managed backfills to take the `date_partition_offset` setting into account for some ETLs with custom date parameters, for ETLs simply using the standard date partition parameter it would be better if the backfill start/end dates could map directly to the table partitions (e.g. #7496), so this PR adds an optional `ignore_date_partition_offset` backfill setting to enable that.

## Related Tickets & Documents
* DENG-975: Google subscriptions ETL v2
* https://github.com/mozilla/bigquery-etl/pull/7496

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
