### PR TITLE
feat(DENG-8401): Create desktop_retention_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_retention_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_retention_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.desktop_retention_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_retention_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_aggregates_v1/metadata.yaml
@@ -1,0 +1,28 @@
+friendly_name: Desktop Retention Aggregates
+description: |-
+  Calculates user retention by app, channel, country, and more.
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_desktop_retention_model
+  date_partition_parameter: metric_date
+  date_partition_offset: -27
+  parameters:
+  - submission_date:DATE:{{ds}}
+bigquery:
+  time_partitioning:
+    type: day
+    field: metric_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - country
+    - normalized_os
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_aggregates_v1/query.sql
@@ -1,0 +1,48 @@
+SELECT
+  metric_date,
+  first_seen_date,
+  normalized_channel,
+  country,
+  app_version,
+  locale,
+  attribution_campaign,
+  attribution_content,
+  attribution_dlsource,
+  attribution_medium,
+  attribution_ua,
+  attribution_experiment,
+  attribution_variation,
+  distribution_id,
+  normalized_os,
+  normalized_os_version,
+  is_desktop,
+  COUNTIF(ping_sent_metric_date) AS ping_sent_metric_date,
+  COUNTIF(ping_sent_week_4) AS ping_sent_week_4,
+  COUNTIF(active_metric_date) AS active_metric_date,
+  COUNTIF(retained_week_4) AS retained_week_4,
+  COUNTIF(retained_week_4_new_profile) AS retained_week_4_new_profiles,
+  COUNTIF(new_profile_metric_date) AS new_profiles_metric_date,
+  COUNTIF(repeat_profile) AS repeat_profiles,
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_retention_clients_v1`
+WHERE
+  metric_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
+  AND submission_date = @submission_date
+GROUP BY
+  metric_date,
+  first_seen_date,
+  normalized_channel,
+  country,
+  app_version,
+  locale,
+  attribution_campaign,
+  attribution_content,
+  attribution_dlsource,
+  attribution_medium,
+  attribution_ua,
+  attribution_experiment,
+  attribution_variation,
+  distribution_id,
+  normalized_os,
+  normalized_os_version,
+  is_desktop

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_aggregates_v1/schema.yaml
@@ -1,0 +1,97 @@
+fields:
+- mode: NULLABLE
+  name: metric_date
+  type: DATE
+  description: Metric Date
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+  description: First Seen Date
+- mode: NULLABLE
+  name: normalized_channel
+  type: STRING
+  description: Normalized Channel
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: Country
+- mode: NULLABLE
+  name: app_version
+  type: STRING
+  description: App Version
+- mode: NULLABLE
+  name: locale
+  type: STRING
+  description: Locale
+- mode: NULLABLE
+  name: attribution_campaign
+  type: STRING
+  description: Attribution Campaign
+- mode: NULLABLE
+  name: attribution_content
+  type: STRING
+  description: Attribution Content
+- mode: NULLABLE
+  name: attribution_dlsource
+  type: STRING
+  description: Attribution DL Source
+- mode: NULLABLE
+  name: attribution_medium
+  type: STRING
+  description: Attribution Medium
+- mode: NULLABLE
+  name: attribution_ua
+  type: STRING
+  description: Attribution UA
+- mode: NULLABLE
+  name: attribution_experiment
+  type: STRING
+  description: Attribution Experiment
+- mode: NULLABLE
+  name: attribution_variation
+  type: STRING
+  description: Attribution Variation
+- mode: NULLABLE
+  name: distribution_id
+  type: STRING
+  description: Distribution ID
+- mode: NULLABLE
+  name: normalized_os
+  type: STRING
+  description: Normalized OS
+- mode: NULLABLE
+  name: normalized_os_version
+  type: STRING
+  description: Normalized OS Version
+- mode: NULLABLE
+  name: is_desktop
+  type: BOOLEAN
+  description: Indicates if the client is included in the desktop KPI
+- mode: NULLABLE
+  name: ping_sent_metric_date
+  type: INT64
+  description: Count of Pings Sent on Metric Date
+- mode: NULLABLE
+  name: ping_sent_week_4
+  type: INT64
+  description: Count of Pings Sent on Week 4
+- mode: NULLABLE
+  name: active_metric_date
+  type: INT64
+  description: Count of Clients Active on Metric Date
+- mode: NULLABLE
+  name: retained_week_4
+  type: INT64
+  description: Count of Clients Retained on Week 4
+- mode: NULLABLE
+  name: retained_week_4_new_profiles
+  type: INT64
+  description: Count of New Profiles Retained on Week 4
+- mode: NULLABLE
+  name: new_profiles_metric_date
+  type: INT64
+  description: Count of New Profiles on Metric Date
+- mode: NULLABLE
+  name: repeat_profiles
+  type: INT64
+  description: Count of Repeat Profiles


### PR DESCRIPTION
## Description

This PR creates the following new table and associated view:
- `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_retention_aggregates_v1`
- `moz-fx-data-shared-prod.firefox_desktop.desktop_retention_aggregates`

## Related Tickets & Documents
* [DENG-8401](https://mozilla-hub.atlassian.net/browse/DENG-8401)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8401]: https://mozilla-hub.atlassian.net/browse/DENG-8401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ