### PR TITLE
feat(DENG-8405): Create desktop_engagement_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_engagement_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_engagement_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.desktop_engagement_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_engagement_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/metadata.yaml
@@ -1,0 +1,24 @@
+friendly_name: Desktop Engagement Aggregates
+description: |-
+  Contains aggregated DAU, WAU, and MAU by different attributes for engagement ratio calculation.
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_desktop_engagement_model
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - country
+    - normalized_os
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/query.sql
@@ -1,0 +1,43 @@
+SELECT
+  submission_date,
+  first_seen_date,
+  distribution_id,
+  locale,
+  app_version,
+  attribution_campaign,
+  attribution_content,
+  attribution_dlsource,
+  attribution_medium,
+  attribution_ua,
+  attribution_experiment,
+  attribution_variation,
+  normalized_channel,
+  normalized_os,
+  normalized_os_version,
+  country,
+  is_desktop,
+  COUNTIF(is_dau) AS dau,
+  COUNTIF(is_wau) AS wau,
+  COUNTIF(is_mau) AS mau
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_engagement_clients_v1`
+WHERE
+  submission_date = @submission_date
+GROUP BY
+  submission_date,
+  first_seen_date,
+  distribution_id,
+  locale,
+  app_version,
+  attribution_campaign,
+  attribution_content,
+  attribution_dlsource,
+  attribution_medium,
+  attribution_ua,
+  attribution_experiment,
+  attribution_variation,
+  normalized_channel,
+  normalized_os,
+  normalized_os_version,
+  country,
+  is_desktop

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/schema.yaml
@@ -1,0 +1,81 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+  description: First Seen Date - Date when the server first received any of the 3 ping types from this client
+- mode: NULLABLE
+  name: distribution_id
+  type: STRING
+  description: Distribution ID - Identifies the Firefox distribution
+- mode: NULLABLE
+  name: locale
+  type: STRING
+  description: Locale
+- mode: NULLABLE
+  name: app_version
+  type: STRING
+  description: App Version
+- mode: NULLABLE
+  name: attribution_campaign
+  type: STRING
+  description: Attribution Campaign (from clients first seen)
+- mode: NULLABLE
+  name: attribution_content
+  type: STRING
+  description: Attribution Content (from clients first seen)
+- mode: NULLABLE
+  name: attribution_dlsource
+  type: STRING
+  description: Attribution Download Source (from clients first seen)
+- mode: NULLABLE
+  name: attribution_medium
+  type: STRING
+  description: Attribution Medium (from clients first seen)
+- mode: NULLABLE
+  name: attribution_ua
+  type: STRING
+  description: Attribution UA (from clients first seen)
+- mode: NULLABLE
+  name: attribution_experiment
+  type: STRING
+  description: Attribution Experiment (from clients first seen)
+- mode: NULLABLE
+  name: attribution_variation
+  type: STRING
+  description: Attribution Variation (from clients last seen since unavailable in clients first seen)
+- mode: NULLABLE
+  name: normalized_channel
+  type: STRING
+  description: Normalized Channel - The Firefox channel, set to Other for unrecognized channel names
+- mode: NULLABLE
+  name: normalized_os
+  type: STRING
+  description: Normalized Operating System
+- mode: NULLABLE
+  name: normalized_os_version
+  type: STRING
+  description: Normalized Operating System Version
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: Country
+- mode: NULLABLE
+  name: is_desktop
+  type: BOOLEAN
+  description: Indicates if the client is included in the desktop KPI
+- mode: NULLABLE
+  name: dau
+  type: INT64
+  description: DAU - Daily Active User
+- mode: NULLABLE
+  name: wau
+  type: INT64
+  description: WAU - Weekly Active User
+- mode: NULLABLE
+  name: mau
+  type: INT64
+  description: MAU - Monthly Active User

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/schema.yaml
@@ -6,7 +6,7 @@ fields:
 - mode: NULLABLE
   name: first_seen_date
   type: DATE
-  description: First Seen Date - Date when the server first received any of the 3 ping types from this client
+  description: First Seen Date
 - mode: NULLABLE
   name: distribution_id
   type: STRING
@@ -22,31 +22,31 @@ fields:
 - mode: NULLABLE
   name: attribution_campaign
   type: STRING
-  description: Attribution Campaign (from clients first seen)
+  description: Attribution Campaign
 - mode: NULLABLE
   name: attribution_content
   type: STRING
-  description: Attribution Content (from clients first seen)
+  description: Attribution Content
 - mode: NULLABLE
   name: attribution_dlsource
   type: STRING
-  description: Attribution Download Source (from clients first seen)
+  description: Attribution Download Source
 - mode: NULLABLE
   name: attribution_medium
   type: STRING
-  description: Attribution Medium (from clients first seen)
+  description: Attribution Medium
 - mode: NULLABLE
   name: attribution_ua
   type: STRING
-  description: Attribution UA (from clients first seen)
+  description: Attribution User Agent
 - mode: NULLABLE
   name: attribution_experiment
   type: STRING
-  description: Attribution Experiment (from clients first seen)
+  description: Attribution Experiment
 - mode: NULLABLE
   name: attribution_variation
   type: STRING
-  description: Attribution Variation (from clients last seen since unavailable in clients first seen)
+  description: Attribution Variation
 - mode: NULLABLE
   name: normalized_channel
   type: STRING

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/schema.yaml
@@ -70,12 +70,12 @@ fields:
 - mode: NULLABLE
   name: dau
   type: INT64
-  description: DAU - Daily Active User
+  description: Number of daily active users
 - mode: NULLABLE
   name: wau
   type: INT64
-  description: WAU - Weekly Active User
+  description: Number of weekly active users
 - mode: NULLABLE
   name: mau
   type: INT64
-  description: MAU - Monthly Active User
+  description: Number of monthly active users


### PR DESCRIPTION
## Description

This PR creates the following new table and associated view:
- `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_engagement_aggregates_v1`
- `moz-fx-data-shared-prod.firefox_desktop.desktop_engagement_aggregates`

## Related Tickets & Documents
* [DENG-8405](https://mozilla-hub.atlassian.net/browse/DENG-8405)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8405]: https://mozilla-hub.atlassian.net/browse/DENG-8405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ