### PR TITLE
Bug 1968556 - Check if exists before adding sampled metric to glam queries

### DIFF
--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -2,6 +2,7 @@
 
 import argparse
 import sys
+from collections import defaultdict
 from typing import Dict, List
 
 from jinja2 import Environment, PackageLoader
@@ -54,6 +55,7 @@ def get_distribution_metrics(
     # Metrics that are already sampled
     sampled_metric_names = get_sampled_metrics("distributions")
     sampled_metrics = {"timing_distribution": sampled_metric_names}
+    found_sampled_metrics = defaultdict(list)
 
     # Iterate over every element in the schema under the metrics section and
     # collect a list of metric names.
@@ -65,13 +67,12 @@ def get_distribution_metrics(
             if metric_type not in metric_type_set:
                 continue
             for field in metric_field["fields"]:
-                if (
-                    field["name"] not in excluded_metrics
-                    and field["name"] not in sampled_metric_names
-                ):
+                if field["name"] in sampled_metrics.get(metric_type, []):
+                    found_sampled_metrics[metric_type].append(field["name"])
+                elif field["name"] not in excluded_metrics:
                     metrics[metric_type].append(field["name"])
 
-    return metrics, sampled_metrics
+    return metrics, found_sampled_metrics
 
 
 def get_metrics_sql(metrics: Dict[str, List[str]]) -> dict[str, str]:

--- a/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
@@ -39,7 +39,7 @@ unlabeled_metrics AS (
     {{ attributes }}
 ),
 {% if client_sampled_unlabeled_metrics %}
-sampled_unlabelled_metrics AS (
+sampled_unlabeled_metrics AS (
   SELECT
     {{ attributes }},
     ARRAY<STRUCT<metric STRING, metric_type STRING, key STRING, agg_type STRING, value FLOAT64>>[
@@ -55,13 +55,13 @@ sampled_unlabelled_metrics AS (
     {{ attributes }}
 ),
 {% endif %}
-unioned_unlabelled_metrics AS (
+unioned_unlabeled_metrics AS (
   SELECT * FROM
     unlabeled_metrics
   {% if client_sampled_unlabeled_metrics %}
   UNION ALL
   SELECT * FROM
-    sampled_unlabelled_metrics
+    sampled_unlabeled_metrics
   {% endif %}
 ),
 grouped_labeled_metrics AS (
@@ -158,7 +158,7 @@ labeled_metrics AS (
 SELECT
   *
 FROM
-  unioned_unlabelled_metrics
+  unioned_unlabeled_metrics
 UNION ALL
 SELECT
   *


### PR DESCRIPTION
## Description

Fix for #7503. Sampled metrics are currently be added to queries for all the pings but the metrics are only in the metrics ping.  This change makes it so that only metrics that exist are added

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1968556


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
