### PR TITLE
bug 1968556: fix(glam) only apply client-side sample metrics logic to metrics_v1 queries

### DIFF
--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -148,7 +148,9 @@ def main():
     distributions, client_sampled_distributions = get_distribution_metrics(schema)
     metrics_sql = get_metrics_sql(distributions)
     client_sampled_metrics_sql = {"labeled": [], "unlabeled": []}
-    if args.product == "firefox_desktop":
+    if args.product == "firefox_desktop" and args.source_table.startswith(
+        "firefox_desktop_stable.metrics_v"
+    ):
         client_sampled_metrics_sql = get_metrics_sql(client_sampled_distributions)
     if not metrics_sql["labeled"] and not metrics_sql["unlabeled"]:
         print(header)

--- a/bigquery_etl/glam/clients_daily_scalar_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_scalar_aggregates.py
@@ -155,7 +155,9 @@ def main():
     unlabeled_metrics = get_unlabeled_metrics_sql(unlabeled_metric_names).strip()
     labeled_metrics = get_labeled_metrics_sql(labeled_metric_names).strip()
     client_sampled_metrics_sql = {"labeled": [], "unlabeled": []}
-    if args.product == "firefox_desktop":
+    if args.product == "firefox_desktop" and args.source_table.startswith(
+        "firefox_desktop_stable.metrics_v"
+    ):
         client_sampled_metrics_sql["unlabeled"] = get_unlabeled_metrics_sql(
             unlabeled_sampled_metric_names
         ).strip()


### PR DESCRIPTION
## Description
Fixes 1968556

Applies [this logic ](https://github.com/mozilla/bigquery-etl/pull/7503) only to the `metrics` table. 

## Related Tickets & Documents
* DENG-8046

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
