### PR TITLE
DENG-8646 Align FOG min-clients-per-build-id with Legacy

### DIFF
--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -190,7 +190,7 @@ def main():
             "filter_version": True,
             "num_versions_to_keep": 3,
             "total_users": 10,
-            "minimum_client_count": 100,
+            "minimum_client_count": 375,
         },
         "firefox_desktop_glam_beta": {
             "build_date_udf": "mozfun.glam.build_hour_to_datetime",


### PR DESCRIPTION
## Description

The [Legacy aggregates](https://github.com/mozilla/bigquery-etl/blob/aab08a6c1e9633e04acb549687ec2cd32fdc5494/sql/moz-fx-data-shared-prod/telemetry_derived/clients_histogram_bucket_counts_v1/query.sql#L39C1-L39C76) filter nightly builds with fewer than 375 clients in them. Let's have the same threshold (admittedly for all builds within an hour, which on desktop is [essentially always just one buildid anyway](https://hg-edge.mozilla.org/mozilla-central/firefoxreleases)) for FOG's aggregates.

## Related Tickets & Documents
* DENG-8646

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
