### PR TITLE
chore(glam): update fog minimum_client_count according to current WAU

### DIFF
--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -204,7 +204,7 @@ def main():
             "filter_version": True,
             "num_versions_to_keep": 3,
             "total_users": 100,
-            "minimum_client_count": 100000,
+            "minimum_client_count": 450000,
         },
     }
 

--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -190,14 +190,14 @@ def main():
             "filter_version": True,
             "num_versions_to_keep": 3,
             "total_users": 10,
-            "minimum_client_count": 100,
+            "minimum_client_count": 300,
         },
         "firefox_desktop_glam_beta": {
             "build_date_udf": "mozfun.glam.build_hour_to_datetime",
             "filter_version": True,
             "num_versions_to_keep": 3,
             "total_users": 100,
-            "minimum_client_count": 1000,
+            "minimum_client_count": 1500,
         },
         "firefox_desktop_glam_release": {
             "build_date_udf": "mozfun.glam.build_hour_to_datetime",


### PR DESCRIPTION
## Description

GLAM aggregations have a minimum client count threshold that is 0.5% of WAU. So, based on current values of [Firefox Desktop DAU/WAU/MAU by release channel](https://mozilla.cloud.looker.com/dashboards/1845?Submission%20Date=after%2060%20weeks%20ago&Browser%20Name=Firefox%20Desktop), I'm updating the threshold values.

## Related Tickets & Documents
* DENG-8646

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
