### PR TITLE
fix(SubPlat): Enable `ignore_date_partition_offset` option for backfills added in #7496 (DENG-975)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -9,6 +9,7 @@
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
 
 2024-11-13:
   start_date: 2019-10-10

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
@@ -9,3 +9,4 @@
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -9,6 +9,7 @@
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
 
 2024-11-13:
   start_date: 2019-10-10

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
@@ -9,6 +9,7 @@
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
 
 2024-11-13:
   start_date: 2019-10-01

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
@@ -9,3 +9,4 @@
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
@@ -9,3 +9,4 @@
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true


### PR DESCRIPTION
## Description
When I added these backfills in #7496 I didn't realize that managed backfills took an ETL's `date_partition_offset` setting into account, and that it would prevent the backfills of the monthly-partitioned ETLs from working.

I have since added an `ignore_date_partition_offset` backfill option (#7510), and this PR enables the `ignore_date_partition_offset` for these backfills.

## Related Tickets & Documents
* DENG-975: Google subscriptions ETL v2
* https://github.com/mozilla/bigquery-etl/pull/7496
* https://github.com/mozilla/bigquery-etl/pull/7510

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
