### PR TITLE
Bug 1968753 - add app inclusion filter to event_flow_monitoring generator

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -355,6 +355,13 @@ generate:
       manual_refresh:  # apps to use manual materialized view refreshes for on-demand billing
       - firefox_desktop
       - firefox_desktop_background_update
+    event_flow_monitoring:
+      include_apps:
+      - accounts_backend
+      - accounts_frontend
+      - focus_android
+      - fenix
+      - firefox_desktop
     bigconfig:
       skip_apps:
       - firefox_echo_show

--- a/sql_generators/glean_usage/event_flow_monitoring.py
+++ b/sql_generators/glean_usage/event_flow_monitoring.py
@@ -4,6 +4,7 @@ import os
 from collections import namedtuple
 from pathlib import Path
 
+from bigquery_etl.config import ConfigLoader
 from sql_generators.glean_usage.common import (
     GleanTable,
     get_table_dir,
@@ -35,8 +36,13 @@ class EventFlowMonitoring(GleanTable):
         """Generate a query across all apps."""
         if not self.across_apps_enabled:
             return
+        
+        # Include only selected apps to avoid too complex query
+        include_apps = ConfigLoader.get(
+            "generate", "glean_usage", "event_flow_monitoring", "include_apps", fallback=[]
+        )
 
-        apps = [app[0] for app in apps]
+        apps = [app[0] for app in apps if app[0]["app_name"] in include_apps]
 
         render_kwargs = dict(
             project_id=project_id,


### PR DESCRIPTION
This query started failing due to too many tables in the union. This quick fix includes only those apps in the query that had some flows in the aggregate in the last month.