### PR TITLE
feat(DENG-8668): Create datasets for new Firefox.com GA4 data

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Firefox.com
+description: |-
+  Data about Firefox.com from Google Analytics 4
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Firefox.com Derived
+description: |-
+  Derived data about Firefox.com from Google Analytics 4
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential


### PR DESCRIPTION
## Description

This PR creates 2 new datasets, intended to store data from the new GA4 property for Firefox.com:
- firefoxdotcom
- firefoxdotcom_derived

## Related Tickets & Documents
* [DENG-8668](https://mozilla-hub.atlassian.net/browse/DENG-8668)


[DENG-8668]: https://mozilla-hub.atlassian.net/browse/DENG-8668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ