### PR TITLE
feat(DENG-8673): Create firefox.com www_site_downloads_v1

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1361,6 +1361,23 @@ bqetl_google_analytics_derived_ga4:
   tags:
     - impact/tier_2
 
+bqetl_ga4_firefoxdotcom:
+  schedule_interval: 0 14 * * *
+  description: Daily aggregations of data exported from Google Analytics 4
+  default_args:
+    depends_on_past: false
+    owner: kwindau@mozilla.com
+    email:
+      - kwindau@mozilla.com
+      - telemetry-alerts@mozilla.com
+    email_on_failure: true
+    email_on_retry: false
+    start_date: "2025-05-27"
+    retries: 2
+    retry_delay: 30m
+  tags:
+    - impact/tier_2
+
 bqetl_glam_refresh_aggregates:
   default_args:
     depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_downloads/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_downloads/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefoxdotcom.www_site_downloads`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_downloads_v1`

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_downloads_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_downloads_v1/metadata.yaml
@@ -1,0 +1,31 @@
+friendly_name: WWW Site Downloads
+description: |-
+  Data about downloads from firefox.com from GA4
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_ga4_firefoxdotcom
+  depends_on_tables_existing:
+  - task_id: wait_for_firefoxdotcom_events_table
+    table_id: 'moz-fx-data-marketing-prod.analytics_489412379.events_{{ ds_nodash }}'
+    poke_interval: 30m
+    timeout: 10h
+    retries: 1
+    retry_delay: 30m
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - country
+    - device_category
+    - operating_system
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_downloads_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_downloads_v1/query.sql
@@ -1,0 +1,177 @@
+WITH raw_events_data AS (
+  --raw events data gets every event that has an associated/identified Google Analytics session ID
+  SELECT
+    PARSE_DATE('%Y%m%d', event_date) AS `date`,
+    user_pseudo_id || '-' || CAST(e.value.int_value AS string) AS visit_identifier,
+    event_timestamp,
+    device.category AS device_category,
+    device.operating_system AS operating_system,
+    device.language AS `language`,
+    geo.country AS country,
+    traffic_source.name AS traffic_source_name,
+    traffic_source.medium AS traffic_source_medium,
+    traffic_source.source AS traffic_source_source,
+    collected_traffic_source.manual_campaign_id AS manual_campaign_id,
+    collected_traffic_source.manual_term AS manual_term,
+    collected_traffic_source.manual_source AS source,
+    collected_traffic_source.manual_medium AS medium,
+    collected_traffic_source.manual_campaign_name AS campaign,
+    collected_traffic_source.manual_content AS ad_content,
+    device.web_info.browser AS browser,
+    event_name,
+    (
+      SELECT
+        `value`
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'campaign'
+      LIMIT
+        1
+    ).string_value AS campaign_from_event_params,
+    (
+      SELECT
+        `value`
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'product'
+      LIMIT
+        1
+    ).string_value AS product_type,
+    (
+      SELECT
+        `value`
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'platform'
+      LIMIT
+        1
+    ).string_value AS platform_type,
+    (
+      SELECT
+        `value`
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'source'
+      LIMIT
+        1
+    ).string_value AS source_from_event_params,
+  FROM
+    `moz-fx-data-marketing-prod.analytics_489412379.events_*`
+  JOIN
+    UNNEST(event_params) AS e
+  WHERE
+    _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d', @submission_date)
+    AND e.key = 'ga_session_id'
+    AND e.value.int_value IS NOT NULL
+),
+--next, we group by a variety of dimensions and count # of downloads by each dimension
+event_level_data AS (
+  SELECT
+    `date`,
+    visit_identifier,
+    device_category,
+    operating_system,
+    `language`,
+    country,
+    traffic_source_name,
+    traffic_source_medium,
+    traffic_source_source,
+    manual_campaign_id,
+    manual_term,
+    source,
+    medium,
+    campaign,
+    ad_content,
+    browser,
+    campaign_from_event_params,
+    source_from_event_params,
+    --note: the 2 columns are the same because in GA4, there is no logic saying you can only count 1 download per session, unlike GA3
+    COUNTIF(event_name = 'firefox_download') AS download_events
+  FROM
+    raw_events_data stg
+  GROUP BY
+    `date`,
+    visit_identifier,
+    device_category,
+    operating_system,
+    `language`,
+    country,
+    traffic_source_name,
+    traffic_source_medium,
+    traffic_source_source,
+    manual_campaign_id,
+    manual_term,
+    source,
+    medium,
+    campaign,
+    ad_content,
+    browser,
+    campaign_from_event_params,
+    source_from_event_params
+),
+--next, calculate what was the first campaign seen in the session
+first_campaign_from_event_params_in_session AS (
+  SELECT
+    visit_identifier,
+    campaign_from_event_params AS first_campaign_from_event_params_in_session,
+    ROW_NUMBER() OVER (PARTITION BY visit_identifier ORDER BY event_timestamp ASC) AS rnk
+  FROM
+    raw_events_data
+  WHERE
+    campaign_from_event_params IS NOT NULL
+  QUALIFY
+    rnk = 1
+),
+--next, calculate what was the first source seen in the session
+first_source_from_event_params_in_session AS (
+  SELECT
+    visit_identifier,
+    source_from_event_params AS first_source_from_event_params,
+    ROW_NUMBER() OVER (PARTITION BY visit_identifier ORDER BY event_timestamp ASC) AS rnk
+  FROM
+    raw_events_data
+  WHERE
+    source_from_event_params IS NOT NULL
+  QUALIFY
+    rnk = 1
+)
+SELECT
+  a.`date` AS submission_date,
+  a.visit_identifier,
+  a.device_category,
+  a.operating_system,
+  a.`language`,
+  a.country,
+  a.traffic_source_name,
+  a.traffic_source_medium,
+  a.traffic_source_source,
+  a.manual_campaign_id,
+  a.manual_term,
+  a.source,
+  a.medium,
+  a.campaign,
+  a.ad_content,
+  a.browser,
+  a.campaign_from_event_params,
+  b.first_campaign_from_event_params_in_session,
+  a.source_from_event_params,
+  c.first_source_from_event_params AS first_source_from_event_params_in_session,
+  a.download_events,
+  a.download_events AS downloads,
+  IF(
+    NOT `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(a.browser),
+    a.download_events,
+    0
+  ) AS non_fx_downloads
+FROM
+  event_level_data a
+LEFT JOIN
+  first_campaign_from_event_params_in_session b
+  ON a.visit_identifier = b.visit_identifier
+LEFT JOIN
+  first_source_from_event_params_in_session c
+  ON a.visit_identifier = c.visit_identifier

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_downloads_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_downloads_v1/schema.yaml
@@ -1,0 +1,93 @@
+fields:
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+  description: Submission Date
+- name: visit_identifier
+  type: STRING
+  mode: NULLABLE
+  description: Visit Identifier
+- name: device_category
+  type: STRING
+  mode: NULLABLE
+  description: Device Category
+- name: operating_system
+  type: STRING
+  mode: NULLABLE
+  description: Operating System
+- name: language
+  type: STRING
+  mode: NULLABLE
+  description: Language
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Country
+- name: traffic_source_name
+  type: STRING
+  mode: NULLABLE
+  description: Traffic Source Name
+- name: traffic_source_medium
+  type: STRING
+  mode: NULLABLE
+  description: Traffic Source Medium
+- name: traffic_source_source
+  type: STRING
+  mode: NULLABLE
+  description: Traffic Source Source
+- name: manual_campaign_id
+  type: STRING
+  mode: NULLABLE
+  description: Manual Campaign ID
+- name: manual_term
+  type: STRING
+  mode: NULLABLE
+  description: Manual Term
+- name: source
+  type: STRING
+  mode: NULLABLE
+  description: Source
+- name: medium
+  type: STRING
+  mode: NULLABLE
+  description: Medium
+- name: campaign
+  type: STRING
+  mode: NULLABLE
+  description: Campaign
+- name: ad_content
+  type: STRING
+  mode: NULLABLE
+  description: Ad Content
+- name: browser
+  type: STRING
+  mode: NULLABLE
+  description: Browser
+- name: campaign_from_event_params
+  type: STRING
+  mode: NULLABLE
+  description: Campaign from Event Parameters
+- name: first_campaign_from_event_params_in_session
+  type: STRING
+  mode: NULLABLE
+  description: First Campaign from Event Parameters in Session
+- name: source_from_event_params
+  type: STRING
+  mode: NULLABLE
+  description: Source from Event Parameters
+- name: first_source_from_event_params_in_session
+  type: STRING
+  mode: NULLABLE
+  description: First Source from Event Parameters in Session
+- name: download_events
+  type: INTEGER
+  mode: NULLABLE
+  description: Download Events
+- name: downloads
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Downloads
+- name: non_fx_downloads
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Downloads from a Non-Firefox Browser


### PR DESCRIPTION
## Description

This PR also creates the new DAG that we will use to store all of the Firefox.com tasks, `bqetl_ga4_firefoxdotcom`.

This PR creates the new table and view:
- `moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_downloads_v1`
- `moz-fx-data-shared-prod.firefoxdotcom.www_site_downloads`

## Related Tickets & Documents
* [DENG-8673](https://mozilla-hub.atlassian.net/browse/DENG-8673)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8673]: https://mozilla-hub.atlassian.net/browse/DENG-8673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ