### PR TITLE
feat: create glean-only versions of experiment enrollment aggregate tables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,4 @@ repos:
     entry: ./bqetl
     args: [format, --check]
     types: [sql]
+    exclude: sql_generators/.+\.sql$

--- a/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_live_v2/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_live_v2/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Experiment Enrollment Aggregates Live
+description: >
+  View for live experiment enrollment events. (glean only)
+labels:
+  incremental: false

--- a/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_live_v2/view.sql
+++ b/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_live_v2/view.sql
@@ -1,0 +1,46 @@
+-- Generated via ./bqetl generate experiment_monitoring
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v2` AS
+  {% for app_dataset in applications %}
+    SELECT
+      type,
+      experiment,
+      branch,
+      window_start,
+      window_end,
+      enroll_count,
+      unenroll_count,
+      graduate_count,
+      update_count,
+      enroll_failed_count,
+      unenroll_failed_count,
+      update_failed_count,
+      disqualification_count,
+      exposure_count,
+      validation_failed_count
+    FROM
+      `moz-fx-data-shared-prod.{{ app_dataset }}_derived.experiment_events_live_v1`
+    WHERE
+      window_start > TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
+    UNION ALL
+  {% endfor %}
+SELECT
+  type,
+  experiment,
+  branch,
+  window_start,
+  window_end,
+  enroll_count,
+  unenroll_count,
+  graduate_count,
+  update_count,
+  enroll_failed_count,
+  unenroll_failed_count,
+  update_failed_count,
+  disqualification_count,
+  exposure_count,
+  validation_failed_count
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_v2`
+WHERE
+  window_start <= TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))

--- a/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_v2/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_v2/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Experiment Enrollment Aggregates
+description: Experiment enrollment aggregates, partitioned by day. (glean-only)
+owners:
+- ascholtz@mozilla.com
+- mwilliams@mozilla.com
+scheduling:
+  dag_name: bqetl_experiments_daily
+labels:
+  table_type: aggregate
+  shredder_mitigation: false

--- a/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_v2/query.sql
+++ b/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_v2/query.sql
@@ -1,0 +1,80 @@
+-- Generated via ./bqetl generate experiment_monitoring
+WITH
+{% for app_dataset in applications %}
+  {% if "_cirrus" in app_dataset %}
+  {{ app_dataset }} AS (
+    SELECT
+      submission_timestamp AS `timestamp`,
+      event.category AS `type`,
+      mozfun.map.get_key(event.extra, 'experiment') AS experiment,
+      mozfun.map.get_key(event.extra, 'branch') AS branch,
+      event.name AS event_method,
+      TRUE as validation_errors_valid
+    FROM
+      `moz-fx-data-shared-prod.{{ app_dataset }}.enrollment`,
+      UNNEST(events) AS event
+    WHERE
+      event.category = 'cirrus_events' AND
+      DATE(submission_timestamp) = @submission_date
+  ),
+  {% else %}
+  {{ app_dataset }} AS (
+    SELECT
+      submission_timestamp AS `timestamp`,
+      event_category AS `type`,
+      JSON_VALUE(event_extra, '$.experiment') AS experiment,
+      JSON_VALUE(event_extra, '$.branch') AS branch,
+      event_name AS event_method,
+      -- Before version 109 (in desktop), clients evaluated schema
+      -- before targeting, so validation_errors are invalid
+      IF(mozfun.norm.extract_version(client_info.app_display_version, 'major') >= 109 OR normalized_app_name != 'firefox_desktop', TRUE, FALSE) AS validation_errors_valid
+    FROM
+      `moz-fx-data-shared-prod.{{ app_dataset }}.events_stream`
+    WHERE
+      event.category = 'nimbus_events' AND
+      DATE(submission_timestamp) = @submission_date
+  ),
+  {% endif %}
+{% endfor %}
+all_events AS (
+  {% for app_dataset in applications %}
+    SELECT
+      *
+    FROM
+      {{ app_dataset }}
+    {% if not loop.last %}
+      UNION ALL
+    {% endif %}
+  {% endfor %}
+)
+SELECT
+  `type`,
+  experiment,
+  branch,
+  TIMESTAMP_ADD(
+    TIMESTAMP_TRUNC(`timestamp`, HOUR),
+    -- Aggregates event counts over 5-minute intervals
+    INTERVAL(DIV(EXTRACT(MINUTE FROM `timestamp`), 5) * 5) MINUTE
+  ) AS window_start,
+  TIMESTAMP_ADD(
+    TIMESTAMP_TRUNC(`timestamp`, HOUR),
+    INTERVAL((DIV(EXTRACT(MINUTE FROM `timestamp`), 5) + 1) * 5) MINUTE
+  ) AS window_end,
+  COUNTIF(event_method = 'enroll' OR event_method = 'enrollment') AS enroll_count,
+  COUNTIF(event_method = 'unenroll' OR event_method = 'unenrollment') AS unenroll_count,
+  COUNTIF(event_method = 'graduate') AS graduate_count,
+  COUNTIF(event_method = 'update') AS update_count,
+  COUNTIF(event_method = 'enrollFailed') AS enroll_failed_count,
+  COUNTIF(event_method = 'unenrollFailed') AS unenroll_failed_count,
+  COUNTIF(event_method = 'updateFailed') AS update_failed_count,
+  COUNTIF(event_method = 'disqualification') AS disqualification_count,
+  COUNTIF(event_method = 'expose' OR event_method = 'exposure') AS exposure_count,
+  COUNTIF(event_method = 'validationFailed' AND validation_errors_valid) AS validation_failed_count,
+FROM
+  all_events
+GROUP BY
+  `type`,
+  experiment,
+  branch,
+  window_start,
+  window_end

--- a/sql_generators/experiment_monitoring/templates/templating.yaml
+++ b/sql_generators/experiment_monitoring/templates/templating.yaml
@@ -2,15 +2,33 @@ queries:
   experiments_daily_active_clients_v1:
     per_app: false
     destination_dataset: telemetry_derived
+    skip_applications:
+      - "firefox_desktop"
   experiment_enrollment_aggregates_live_v1:
     per_app: false
     destination_dataset: telemetry_derived
+    skip_applications:
+      - "firefox_desktop"
+  experiment_enrollment_aggregates_live_v2:
+    per_app: false
+    destination_dataset: telemetry_derived
+    skip_applications:
+      - "telemetry"
   experiment_search_aggregates_v1:
     per_app: false
     destination_dataset: telemetry_derived
+    skip_applications:
+      - "firefox_desktop"
   experiment_enrollment_aggregates_v1:
     per_app: false
     destination_dataset: telemetry_derived
+    skip_applications:
+      - "firefox_desktop"
+  experiment_enrollment_aggregates_v2:
+    per_app: false
+    destination_dataset: telemetry_derived
+    skip_applications:
+      - "telemetry"
   experiment_events_live_v1:
     per_app: true
     start_date: "2025-03-30"
@@ -40,6 +58,10 @@ search_metrics:
     ad_clicks_count: payload.processes.parent.keyed_scalars.browser_search_adclicks_urlbar
     search_with_ads_count: payload.processes.parent.keyed_scalars.browser_search_withads_urlbar
     search_count: payload.keyed_histograms.search_counts
+  firefox_desktop:
+    ad_clicks_count: metrics.labeled_counter.browser_search_ad_clicks
+    search_with_ads_count: metrics.labeled_counter.browser_search_with_ads
+    search_count: metrics.labeled_counter.metrics_search_count
   org_mozilla_ios_firefox:
     ad_clicks_count: null
     search_with_ads_count: null
@@ -104,6 +126,7 @@ applications:
   - org_mozilla_ios_firefoxbeta
   - org_mozilla_ios_fennec
   - telemetry
+  - firefox_desktop
   - org_mozilla_klar
   - org_mozilla_focus
   - org_mozilla_focus_nightly


### PR DESCRIPTION
## Description

This adds `v2` versions of enrollment aggregations that exclude legacy and include glean for desktop. Also explicitly excludes legacy from the `v1` versions.

This also updates the pre-commit format hook to exclude `sql_generators`.

## Related Tickets & Documents
* EXP-4979

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
