### PR TITLE
Bug 1967599 - Have Shredder normalize context_ids to deal with brace and non-brace variants.

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -325,7 +325,10 @@ def delete_from_partition(
 
     def create_job(client) -> bigquery.QueryJob:
         def normalized_expr(expr: str) -> str:
-            if expr == "context_id" or expr == "payload.scalars.parent.deletion_request_context_id":
+            if (
+                expr == "context_id"
+                or expr == "payload.scalars.parent.deletion_request_context_id"
+            ):
                 return f"REPLACE(REPLACE({expr}, '{{', ''), '}}', '')"
             return expr
 

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -324,18 +324,23 @@ def delete_from_partition(
         job_config.write_disposition = bigquery.WriteDisposition.WRITE_TRUNCATE
 
     def create_job(client) -> bigquery.QueryJob:
+        def normalized_expr(expr: str) -> str:
+            if expr == "context_id" or expr == "payload.scalars.parent.deletion_request_context_id":
+                return f"REPLACE(REPLACE({expr}, '{{', ''), '}}', '')"
+            return expr
+
         if use_dml:
             field_condition = " OR ".join(
                 f"""
-                {field} IN (
+                {normalized_expr(field)} IN (
                   SELECT
-                    {source.field}
+                    {normalized_expr(source.field)}
                   FROM
                     `{sql_table_id(source)}`
                   WHERE
+                    {" AND ".join((source_condition, *source.conditions))}
+                )
                 """
-                + " AND ".join((source_condition, *source.conditions))
-                + ")"
                 for field, source in zip(target.fields, sources)
             )
 
@@ -362,7 +367,7 @@ def delete_from_partition(
                 LEFT JOIN
                   (
                     SELECT
-                      {source.field} AS _source_{index}
+                      {normalized_expr(source.field)} AS _source_{index}
                     FROM
                       `{sql_table_id(source)}`
                     WHERE
@@ -371,7 +376,7 @@ def delete_from_partition(
                     + (f" AND sample_id = {sample_id}" if sample_id is not None else "")
                     + f"""
                   )
-                  ON {field} = _source_{index}
+                  ON {normalized_expr(field)} = _source_{index}
                 """
                 )
                 for index, (field, source) in enumerate(zip(target.fields, sources))

--- a/tests/shredder/test_delete.py
+++ b/tests/shredder/test_delete.py
@@ -165,3 +165,55 @@ def test_delete_from_table_sampling(mock_list_partitions):
             if sampling_enabled
             else "create_job"
         )
+
+
+@patch("bigquery_etl.shredder.delete.sql_table_id", return_value="dataset.table_v1")
+def test_context_id_brace_normalization(mock_sql_table_id):
+    """
+    Ensure context_id fields are normalized in generated SQL to accept and
+    delete braced and unbraced forms.
+    """
+    mock_table = Mock()
+    mock_table.num_bytes = 1000
+    mock_table.schema = []
+    mock_table.time_partitioning = None
+
+    mock_range = Mock()
+    mock_range.interval = 1
+    mock_range_partitioning = Mock()
+    mock_range_partitioning.range_ = mock_range
+    mock_table.range_partitioning = mock_range_partitioning
+
+    mock_client = Mock()
+    mock_client.get_table.return_value = mock_table
+    mock_client.query.return_value.result.return_value = [
+        {"partition_id": "20240101"},
+    ]
+
+    target = DeleteTarget(table="dataset.table_v1", field="context_id")
+    source = DeleteSource(table="dataset.deletions_v1", field="payload.scalars.parent.deletion_request_context_id")
+
+    task = next(
+        shredder_delete.delete_from_table(
+            client=mock_client,
+            target=target,
+            sources=(source,),
+            dry_run=True,
+            use_dml=True,
+            source_condition="DATE(submission_timestamp) < '2025-05-29'",
+            start_date="2025-05-01",
+            end_date="2025-05-29",
+            max_single_dml_bytes=1,
+            partition_limit=None,
+            sampling_parallelism=10,
+            use_sampling=False,
+            temp_dataset="project.tmp",
+            priority="INTERACTIVE",
+        )
+    )
+
+    task.func.keywords["create_job"](mock_client)
+    sql = mock_client.query.call_args[0][0]
+
+    assert "REPLACE(REPLACE(context_id" in sql
+    assert "REPLACE(REPLACE(payload.scalars.parent.deletion_request_context_id" in sql

--- a/tests/shredder/test_delete.py
+++ b/tests/shredder/test_delete.py
@@ -191,7 +191,10 @@ def test_context_id_brace_normalization(mock_sql_table_id):
     ]
 
     target = DeleteTarget(table="dataset.table_v1", field="context_id")
-    source = DeleteSource(table="dataset.deletions_v1", field="payload.scalars.parent.deletion_request_context_id")
+    source = DeleteSource(
+        table="dataset.deletions_v1",
+        field="payload.scalars.parent.deletion_request_context_id",
+    )
 
     task = next(
         shredder_delete.delete_from_table(


### PR DESCRIPTION
## Description

This PR is meant to fix Bug 1967599, which allows Shredder to accept context_id UUIDs with braces, like `{decafbad-0cd1-0cd2-0cd3-decafbad1000}`, as well as without braces like `decafbad-0cd1-0cd2-0cd3-decafbad1000`.

It should also _delete_ context IDs from the deletion tables with the brace and non-brace variants.

I am notably _very new_ to this repository and project, so please advise if there are better / more correct ways of doing what I'm trying to do here.

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1967599
* https://bugzilla.mozilla.org/show_bug.cgi?id=1967505
* https://github.com/mozilla/application-services/pull/6746

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
