### PR TITLE
Remove udf usage from experiment_events_live

### DIFF
--- a/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/materialized_view.sql
+++ b/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/materialized_view.sql
@@ -45,7 +45,7 @@ IF
       events,
       -- Before version 109 (in desktop), clients evaluated schema
       -- before targeting, so validation_errors are invalid
-      IF(mozfun.norm.extract_version(client_info.app_display_version, 'major') >= 109 OR normalized_app_name != 'firefox_desktop', TRUE, FALSE) AS validation_errors_valid
+      CAST(REGEXP_EXTRACT(client_info.app_display_version, r"^([0-9]+).*") AS NUMERIC) >= 109 OR normalized_app_name != 'firefox_desktop' AS validation_errors_valid
     FROM
       `moz-fx-data-shared-prod.{{ dataset }}_live.events_v1`
   ),
@@ -82,7 +82,7 @@ IF
       IF(event_map_value.key = 'branch', event_map_value.value, NULL) AS branch,
       -- Before version 109 (in desktop), clients evaluated schema
       -- before targeting, so validation_errors are invalid
-      IF(mozfun.norm.extract_version(application.version, 'major') >= 109, TRUE, FALSE) AS validation_errors_valid
+      CAST(REGEXP_EXTRACT(application.version, r"^([0-9]+).*") AS NUMERIC) >= 109 AS validation_errors_valid
     FROM
       `moz-fx-data-shared-prod.{{ dataset }}_live.event_v4`
     CROSS JOIN


### PR DESCRIPTION
## Description

This udf usage was added in https://github.com/mozilla/bigquery-etl/pull/6791. Materialized views don't support udfs so deploys are failing with `Materialized views do not support routines`.  Only new materialized views get deployed so it hasn't failed until now.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
