### PR TITLE
Add UDF to new_profile_activation_clients view for Fenix

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.view.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.view.sql
@@ -9,6 +9,11 @@ SELECT
   {% else %}
     "Organic" AS paid_vs_organic,
   {% endif %}
+  {% if dataset == 'fenix' %}
+  `moz-fx-data-shared-prod.udf.organic_vs_paid_mobile_gclid_attribution`(play_store_attribution_install_referrer_response) AS paid_vs_organic_via_gclid_attribution,
+  {% else %}
+  CAST(NULL AS STRING) AS paid_vs_organic_via_gclid_attribution,
+  {% endif %}
   -- Checking if the client was seen more than once in the first 2 - 7 days
   -- and if they had more than 0 searches within the time window (3 days).
   IF(num_days_seen_day_2_7 > 1 AND search_count > 0, TRUE, FALSE) AS is_activated,


### PR DESCRIPTION
## Description

This PR adds a column `paid_vs_organic_via_gclid_attribution` to the view:
* `moz-fx-data-shared-prod.fenix.new_profile_activation_clients`
## Related Tickets & Documents
* [DENG-8720](https://mozilla-hub.atlassian.net/browse/DENG-8720)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8720]: https://mozilla-hub.atlassian.net/browse/DENG-8720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ