### PR TITLE
fix: add bq partitioning metadata

### DIFF
--- a/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_v2/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_v2/metadata.yaml
@@ -8,3 +8,12 @@ scheduling:
 labels:
   table_type: aggregate
   shredder_mitigation: false
+bigquery:
+  time_partitioning:
+    type: day
+    field: window_start
+    require_partition_filter: false
+  clustering:
+    fields:
+    - experiment
+    - branch


### PR DESCRIPTION
## Description

Error from https://github.com/mozilla/bigquery-etl/pull/7534 about not specifying the partition field, which I am assuming is due to the lack of metadata.



**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
