### PR TITLE
Add version 139 to nimbus events_stream filter

### DIFF
--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -145,7 +145,7 @@ CROSS JOIN
       SELECT event
       FROM UNNEST(events) AS event
       WHERE (
-        app_version_major = 138 AND app_version_minor IN (0, 1)
+        app_version_major IN (138, 139)
         AND (
           (event.category = 'nimbus_events' AND event.name = 'validation_failed')
           OR (event.category = 'normandy' AND event.name = 'validation_failed_nimbus_experiment')


### PR DESCRIPTION
## Description

Firefox 139 release and these events are still very high volume so events stream is failing

## Related Tickets & Documents
* DENG-8432

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
