### PR TITLE
chore(SubPlat): Complete backfills to add historical Google subscription records to SubPlat consolidated reporting tables (DENG-975)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7333.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description
Completes backfills of the logical subscription and service subscription tables initiated in #7496.

In addition to adding records for Google subscriptions, these backfills also have minor side effects on some existing records for Stripe subscriptions:

- `first_touch_attribution.impression_at` and `last_touch_attribution.impression_at` timestamps have been truncated to milliseconds for 2,978 subscriptions.
	- This appears to be due to `users.created_at` timestamp values from the VPN Guardian database having been truncated to millisecond resolution instead of microsecond resolution.
- `has_refunds` has changed from false to true for 461 subscriptions.
	- This is somewhat to be expected given how Stripe charges can be belatedly refunded, but the `stripe_logical_subscriptions_history_v1` ETL's join for refunds data could be improved with a date condition.
- `has_fraudulent_charges` has changed from false to true for 2 subscriptions.
	- This is somewhat to be expected given how Stripe charges can be belatedly marked as fraudulent, but the `stripe_logical_subscriptions_history_v1` ETL's join for refunds data could be improved with a date condition.
- `payment_provider` has changed from Stripe to PayPal for 4 subscriptions.
	- These were subscriptions started with 100% off coupons, so there were no PayPal transactions for them until they renewed at full price.
	- This could be avoided by basing `payment_provider` on the subscription's `collection_method` rather than looking for invoices with `paypalTransactionId` metadata fields.
- `customer_subscription_number` has increased for 869 subscriptions.
	- This is to be expected with the additional Google subscriptions now intermixed with Stripe subscriptions.

## Related Tickets & Documents
* DENG-975: Google subscriptions ETL v2
* https://github.com/mozilla/bigquery-etl/pull/7496

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
