### PR TITLE
fix(DENG-8723): Switch glean_telemetry view to use full baseline AUA table instead of slimmed version

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry/active_users_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry/active_users_aggregates/view.sql
@@ -72,4 +72,4 @@ SELECT
   os_grouped,
   mozfun.norm.partnership(distribution_id) AS partnership,
 FROM
-  `moz-fx-data-shared-prod.firefox_desktop.baseline_active_users_aggregates`
+  `moz-fx-data-shared-prod.firefox_desktop.baseline_active_users_aggregates_full`


### PR DESCRIPTION
## Description

This PR is a follow up to [PR-7548](https://github.com/mozilla/bigquery-etl/pull/7548)

## Related Tickets & Documents
* [DENG-8396](https://mozilla-hub.atlassian.net/browse/DENG-8396)
* [DENG-8723](https://mozilla-hub.atlassian.net/browse/DENG-8723)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8396]: https://mozilla-hub.atlassian.net/browse/DENG-8396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-8723]: https://mozilla-hub.atlassian.net/browse/DENG-8723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ