### PR TITLE
Bug 1967503 - Add context-id-deletion-request to Shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -119,6 +119,13 @@ IMPRESSION_SRC = DeleteSource(
     table="telemetry_stable.deletion_request_v4",
     field="payload.scalars.parent.deletion_request_impression_id",
 )
+
+CONTEXT_ID_DELETION_SRC = DeleteSource(
+    table="firefox_desktop_stable.context_id_deletion_request_v1",
+    field="metrics.uuid.contextual_services_context_id",
+)
+
+# Legacy context_id deletion sources
 CONTEXTUAL_SERVICES_SRC = DeleteSource(
     table="telemetry_stable.deletion_request_v4",
     field="payload.scalars.parent.deletion_request_context_id",
@@ -127,6 +134,7 @@ QUICK_SUGGEST_SRC = DeleteSource(
     table="firefox_desktop_stable.quick_suggest_deletion_request_v1",
     field=QUICK_SUGGEST_CONTEXT_ID,
 )
+
 FXA_HMAC_SRC = DeleteSource(
     table="firefox_accounts.fxa_delete_events", field="hmac_user_id"
 )
@@ -181,6 +189,7 @@ USER_CHARACTERISTICS_SRC = DeleteSource(
     table="firefox_desktop_stable.deletion_request_v1",
     field=USER_CHARACTERISTICS_ID,
 )
+
 SOURCES = (
     [
         DESKTOP_SRC,
@@ -500,6 +509,7 @@ DELETE_TARGETS: DeleteIndex = {
     user_id_target(
         table="firefox_accounts_derived.fxa_users_services_devices_last_seen_v1"
     ): FXA_SRC,
+    # context_id deletions using legacy context_id deletion source
     context_id_target(
         table="contextual_services_stable.topsites_click_v1"
     ): CONTEXTUAL_SERVICES_SRC,
@@ -516,6 +526,23 @@ DELETE_TARGETS: DeleteIndex = {
         table="firefox_desktop_stable.quick_suggest_v1",
         field=QUICK_SUGGEST_CONTEXT_ID,
     ): QUICK_SUGGEST_SRC,
+    # context_id deletions using the context-id-deletion-request ping
+    context_id_target(
+        table="contextual_services_stable.topsites_click_v1"
+    ): CONTEXT_ID_DELETION_SRC,
+    context_id_target(
+        table="contextual_services_stable.topsites_impression_v1"
+    ): CONTEXT_ID_DELETION_SRC,
+    context_id_target(
+        table="contextual_services_stable.quicksuggest_click_v1"
+    ): CONTEXT_ID_DELETION_SRC,
+    context_id_target(
+        table="contextual_services_stable.quicksuggest_impression_v1"
+    ): CONTEXT_ID_DELETION_SRC,
+    DeleteTarget(
+        table="firefox_desktop_stable.quick_suggest_v1",
+        field=QUICK_SUGGEST_CONTEXT_ID,
+    ): CONTEXT_ID_DELETION_SRC,
     # client association ping
     DeleteTarget(
         table="firefox_desktop_stable.fx_accounts_v1",


### PR DESCRIPTION
## Description

Adds the context-id-deletion-request ping as a source for context_id deletions.

I modelled this patch off of https://github.com/mozilla/bigquery-etl/commit/16a1dc47e1b93028efad97deefb6e42700caffbf, but am unsure how to actually test it. I haven't verified that I got any of this right, beyond the fact that it's valid Python.

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1967503
* https://github.com/mozilla/bigquery-etl/pull/7539

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
