### PR TITLE
fix(DENG-8404): Add logic to not include client IDs with new-ish deletion requests

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_clients_v1/query.sql
@@ -47,7 +47,7 @@ LEFT JOIN
     FROM
       `moz-fx-data-shared-prod.firefox_desktop_stable.deletion_request_v1`
     WHERE
-      DATE(submission_timestamp) <= current_date
+      DATE(submission_timestamp) >= DATE_SUB(@submission_date, INTERVAL 17 WEEK)
   ) AS deletion_requests
   ON cls.client_id = deletion_requests.client_id
 WHERE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_clients_v1/query.sql
@@ -40,5 +40,16 @@ LEFT JOIN
   `moz-fx-data-shared-prod.firefox_desktop.baseline_active_users` aud
   ON cls.client_id = aud.client_id
   AND cls.submission_date = aud.submission_date
+LEFT JOIN
+  (
+    SELECT DISTINCT
+      client_info.client_id AS client_id
+    FROM
+      `moz-fx-data-shared-prod.firefox_desktop_stable.deletion_request_v1`
+    WHERE
+      DATE(submission_timestamp) <= current_date
+  ) AS deletion_requests
+  ON cls.client_id = deletion_requests.client_id
 WHERE
   cls.submission_date = @submission_date
+  AND deletion_requests.client_id IS NULL


### PR DESCRIPTION
## Description

* This table `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_engagement_clients` is a new table, and since being built, we've noticed that it tends to have a small number of clients with 2 or more rows (each with different first seen dates) which causes the uniqueness check to fail daily.  These clients with duplicates are ones who have submitted deletion requests, and were previously shredded from the first seen table, but then show up with a new first seen date.  This PR should help prevent issues by preventing clients who have submitted deletion requests from being included in the table.

Related PRs:
* [DENG-8404](https://mozilla-hub.atlassian.net/browse/DENG-8404)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8404]: https://mozilla-hub.atlassian.net/browse/DENG-8404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ