### PR TITLE
feat: create glean-only v2 versions of experiment datasets

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_cumulative_population_estimate_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_cumulative_population_estimate_v2/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: Experiment Enrollment Cumulative Population Estimate
+description: Cumulative number of clients enrolled in experiments (glean only)
+labels:
+  incremental: false
+owners:
+- ascholtz@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_cumulative_population_estimate_v2/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_cumulative_population_estimate_v2/view.sql
@@ -1,0 +1,92 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_cumulative_population_estimate_v2`
+AS
+WITH branches AS (
+  SELECT
+    normandy_slug AS experiment,
+    COALESCE(branch.slug, 'null') AS branch
+  FROM
+    `moz-fx-data-experiments.monitoring.experimenter_experiments_v1`
+  LEFT JOIN
+    UNNEST(branches) AS branch
+  WHERE
+    normandy_slug IS NOT NULL
+),
+branches_per_window AS (
+  -- Each branch should have cumulative values for each window, even if there have been
+  -- no events recorded for a branch during that time window. Then we want to take the
+  -- last available values.
+  SELECT
+    branches.branch,
+    window_start,
+    experiment
+  FROM
+    branches
+  CROSS JOIN
+    (
+      SELECT DISTINCT
+        window_start
+      FROM
+        `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v2`
+    )
+),
+cumulative_populations AS (
+  SELECT
+    window_start,
+    branch,
+    branches_per_window.experiment,
+    SUM(enroll_count) OVER previous_rows_window AS cumulative_enroll_count,
+    SUM(unenroll_count) OVER previous_rows_window AS cumulative_unenroll_count,
+    SUM(graduate_count) OVER previous_rows_window AS cumulative_graduate_count,
+  FROM
+    branches_per_window
+  LEFT JOIN
+    (
+      SELECT
+        * EXCEPT (branch),
+        IF(branch IS NULL, 'null', branch) AS branch
+      FROM
+        `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v2`
+    )
+    USING (window_start, branch, experiment)
+  WINDOW
+    previous_rows_window AS (
+      PARTITION BY
+        branches_per_window.experiment,
+        branch
+      ORDER BY
+        window_start
+      ROWS BETWEEN
+        UNBOUNDED PRECEDING
+        AND CURRENT ROW
+    )
+)
+SELECT
+  `time`,
+  experiment,
+  branch,
+  SUM(cumulative_population) AS value
+FROM
+  (
+    SELECT
+      window_start AS `time`,
+      branch,
+      experiment,
+      MIN(`cumulative_enroll_count`) - MIN(`cumulative_unenroll_count`) - MIN(
+        `cumulative_graduate_count`
+      ) AS cumulative_population
+    FROM
+      cumulative_populations
+    WHERE
+      branch IS NOT NULL
+    GROUP BY
+      1,
+      2,
+      3
+    ORDER BY
+      1
+  )
+GROUP BY
+  1,
+  2,
+  3

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_daily_active_population_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_daily_active_population_v2/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Experiment Enrollment Daily Active Population
+description: |-
+  Daily active clients enrolled in experiments (glean only)
+owners:
+- ascholtz@mozilla.com
+labels:
+  dag: bqetl_experiments_daily
+  owner1: ascholtz
+  table_type: aggregate
+  shredder_mitigation: false
+scheduling:
+  dag_name: bqetl_experiments_daily
+  task_name: experiment_enrollment_daily_active_population_v2
+  date_partition_parameter: null
+bigquery:
+  time_partitioning: null
+  clustering:
+    fields:
+    - experiment
+references: {}

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_daily_active_population_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_daily_active_population_v2/query.sql
@@ -1,0 +1,11 @@
+SELECT
+  CAST(DATE_ADD(submission_date, INTERVAL 1 day) AS timestamp) AS time,
+  experiment_id AS experiment,
+  branch,
+  SUM(active_clients) AS value
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.experiments_daily_active_clients_v2`
+GROUP BY
+  1,
+  2,
+  3

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_daily_active_population_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_daily_active_population_v2/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- name: time
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: experiment
+  type: STRING
+  mode: NULLABLE
+- name: branch
+  type: STRING
+  mode: NULLABLE
+- name: value
+  type: INTEGER
+  mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_other_events_overall_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_other_events_overall_v2/metadata.yaml
@@ -1,0 +1,8 @@
+friendly_name: Experiment Enrollment Other Events Overall
+description: >
+  Number of events other than enroll and unenroll sent by clients
+  enrolled in experiments, clustered by experiment. (glean only)
+labels:
+  incremental: false
+owners:
+- ascholtz@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_other_events_overall_v2/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_other_events_overall_v2/view.sql
@@ -1,0 +1,35 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_other_events_overall_v2`
+AS
+WITH pivot AS (
+  SELECT
+    window_start,
+    experiment,
+    branch,
+    [
+      STRUCT("graduated" AS event, graduate_count AS count),
+      STRUCT("enroll_failed" AS event, enroll_failed_count AS count),
+      STRUCT("unenroll_failed" AS event, unenroll_failed_count AS count),
+      STRUCT("updated" AS event, update_count AS count),
+      STRUCT("update_failed" AS event, update_failed_count AS count),
+      STRUCT("disqualification" AS event, disqualification_count AS count),
+      STRUCT("validation_failed" AS event, validation_failed_count AS count)
+    ] AS events
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v2`
+)
+SELECT
+  window_start AS `time`,
+  experiment,
+  branch,
+  e.event AS event,
+  SUM(e.count) AS value
+FROM
+  pivot
+CROSS JOIN
+  UNNEST(events) AS e
+GROUP BY
+  1,
+  2,
+  3,
+  4

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_overall_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_overall_v2/metadata.yaml
@@ -1,0 +1,8 @@
+friendly_name: Experiment Enrollment Overall
+description: >
+  Overall number of clients enrolled in experiments,
+  clustered by experiment. (glean only)
+labels:
+  incremental: false
+owners:
+- ascholtz@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_overall_v2/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_overall_v2/view.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_overall_v2`
+AS
+SELECT
+  window_start AS `time`,
+  experiment,
+  branch,
+  SUM(`enroll_count`) AS value
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v2`
+GROUP BY
+  1,
+  2,
+  3

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_unenrollment_overall_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_unenrollment_overall_v2/metadata.yaml
@@ -1,0 +1,8 @@
+friendly_name: Experiment Unenrollment Overall
+description: >
+  Overall number of clients that unenrolled from experiments,
+  clustered by experiment. (glean only)
+labels:
+  incremental: false
+owners:
+- ascholtz@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_unenrollment_overall_v2/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/experiment_unenrollment_overall_v2/view.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.telemetry_derived.experiment_unenrollment_overall_v2`
+AS
+SELECT
+  window_start AS `time`,
+  experiment,
+  branch,
+  SUM(`unenroll_count`) AS value
+FROM
+  `moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_aggregates_live_v2`
+GROUP BY
+  1,
+  2,
+  3

--- a/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v2/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v2/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Experiments Daily Active Clients
+description: |
+  A daily number of active clients per experiment, partitioned by day. (glean only)
+owners:
+- ascholtz@mozilla.com
+- mwilliams@mozilla.com
+labels:
+  application: experiments
+  schedule: daily
+  table_type: aggregate
+  shredder_mitigation: false
+scheduling:
+  dag_name: bqetl_experiments_daily
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: null
+  clustering:
+    fields:
+    - experiment_id
+    - branch

--- a/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v2/query.sql
+++ b/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v2/query.sql
@@ -1,0 +1,57 @@
+-- Generated via ./bqetl generate experiment_monitoring
+WITH
+{% for app_dataset in applications %}
+  {% if "_cirrus" in app_dataset %}
+    {{ app_dataset }} AS (
+      SELECT DISTINCT
+        DATE(submission_timestamp) AS submission_date,
+        mozfun.map.get_key(e.extra, "experiment") AS experiment_id,
+        mozfun.map.get_key(e.extra, "branch") AS branch,
+       mozfun.map.get_key(e.extra, "nimbus_user_id") AS client_id
+      FROM
+        `moz-fx-data-shared-prod.{{ app_dataset }}.enrollment` AS enrollment
+      CROSS JOIN
+        UNNEST(events) AS e
+
+
+    )
+  {% else %}
+    {{ app_dataset }} AS (
+      SELECT DISTINCT
+        DATE(submission_timestamp) AS submission_date,
+        e.key AS experiment_id,
+        e.value.branch AS branch,
+        client_info.client_id
+      FROM
+        `moz-fx-data-shared-prod.{{ app_dataset }}.baseline`
+      CROSS JOIN
+        UNNEST(ping_info.experiments) AS e
+    )
+  {% endif %}
+  {% if not loop.last %}
+    ,
+  {% endif %}
+{% endfor %}
+SELECT
+  submission_date,
+  experiment_id,
+  branch,
+  COUNT(*) AS active_clients
+FROM
+  (
+    {% for app_dataset in applications %}
+      SELECT
+        *
+      FROM
+        {{ app_dataset }}
+      {% if not loop.last %}
+        UNION ALL
+      {% endif %}
+    {% endfor %}
+  )
+WHERE
+  submission_date = @submission_date
+GROUP BY
+  submission_date,
+  experiment_id,
+  branch

--- a/sql_generators/experiment_monitoring/templates/templating.yaml
+++ b/sql_generators/experiment_monitoring/templates/templating.yaml
@@ -37,8 +37,6 @@ queries:
   experiment_events_live_v1:
     per_app: true
     start_date: "2025-03-30"
-    skip_applications:
-      - "firefox_desktop"
   experiment_search_events_live_v1:
     per_app: true
     start_date: "2025-03-30"

--- a/sql_generators/experiment_monitoring/templates/templating.yaml
+++ b/sql_generators/experiment_monitoring/templates/templating.yaml
@@ -4,6 +4,11 @@ queries:
     destination_dataset: telemetry_derived
     skip_applications:
       - "firefox_desktop"
+  experiments_daily_active_clients_v2:
+    per_app: false
+    destination_dataset: telemetry_derived
+    skip_applications:
+      - "telemetry"
   experiment_enrollment_aggregates_live_v1:
     per_app: false
     destination_dataset: telemetry_derived


### PR DESCRIPTION
## Description

Creates more (see [previous PR](https://github.com/mozilla/bigquery-etl/pull/7534)) glean-only versions of experiment datasets.

## Related Tickets & Documents
* EXP-4979


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
