### PR TITLE
fix(DENG-8738): NULL date checking in WHERE clause skipping necessary rows

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/query.sql
@@ -33,16 +33,6 @@ WITH stg_prospects AS (
   WHERE
     event_name = 'object_update'
     AND unstruct_event_com_pocket_object_update_1.object = 'prospect'
-    AND SAFE_CAST(contexts_com_pocket_prospect_1[0].created_at AS INT64) IS NOT NULL
-    AND SAFE_CAST(contexts_com_pocket_prospect_1[0].created_at AS INT64)
-    BETWEEN 946684800
-    AND UNIX_MILLIS(CURRENT_TIMESTAMP())
-    AND SAFE_CAST(contexts_com_pocket_prospect_1[0].reviewed_at AS INT64) IS NOT NULL
-    -- reviewed_at is in miliseconds (for some reason), so we need to divide
-    AND SAFE_CAST(DIV(contexts_com_pocket_prospect_1[0].reviewed_at, 1000) AS INT64)
-    BETWEEN 946684800
-    AND UNIX_MILLIS(CURRENT_TIMESTAMP())
-  -- This ensures recommended_at is between Jan 1, 2000, and the current time to remain within BQ limits for dates
   QUALIFY
     ROW_NUMBER() OVER (PARTITION BY happened_at ORDER BY happened_at) = 1
 )


### PR DESCRIPTION
## Description

- this removed part of the WHERE clause was causing the model to incorrectly skip rows that have an expected value of NULL in `reviewed_at`.
- the removed code was intended to fix an out of range error when calling TIMESTAMP_SECONDS in the SELECT clause - but this was remedied by dividing the `reviewed_at` value by 1000 (as it was in milliseconds, unlike `created_at` which is in seconds).

## Related Tickets & Documents
* DENG-8738

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
