### PR TITLE
Deng 8677 create downloads with attribution

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/downloads_with_attribution/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/downloads_with_attribution/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefoxdotcom.downloads_with_attribution`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefoxdotcom_derived.downloads_with_attribution_v1`

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/downloads_with_attribution_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/downloads_with_attribution_v1/checks.sql
@@ -1,0 +1,13 @@
+#fail
+ASSERT(
+  (
+    SELECT
+      COUNT(*)
+    FROM
+      `{{project_id}}.{{dataset_id}}.{{table_name}}`
+    WHERE
+      download_date = @download_date
+  ) > 50000
+)
+AS
+  'ETL Data Check Failed: Table {{project_id}}.{{dataset_id}}.{{table_name}} contains less than 50,000 rows for date: {{ download_date }}.'

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/downloads_with_attribution_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/downloads_with_attribution_v1/metadata.yaml
@@ -1,0 +1,62 @@
+friendly_name: Downloads With Attribution
+description: |-
+  A daily joining of Firefox download tokens with Google Analytics attribution data.
+  Due to delays in GA session reporting this table has a total 3 day lag. This is due to a combination of delayed data
+  from GA, end of day processing in ETL and the need to check GA sessions a day later for the download attribution.
+  e.g Data for 2025-06-05 will not be available until 2025-06-08
+
+  1. Each row in this table is a unique dltoken.
+
+  2. A single GA session can have multiple dltokens (a session resulted in multiple downloads).
+
+  3. The two datasets are first joined using the GA client_id and a custom download_session_id (v2 implementatin).
+
+  4. If either the stub_visit_id or stub_download_session_id is NULL, '', '(not set)', or 'something',
+    the join_result_v2 column is:
+    * DOWNLOAD_CLIENT_OR_SESSION_ID_NULL
+    * DOWNLOAD_CLIENT_OR_SESSION_ID_EMPTY
+    * DOWNLOAD_CLIENT_OR_SESSION_ID_VALUE_NOT_SET
+    * DOWNLOAD_CLIENT_OR_SESSION_ID_VALUE_SOMETHING
+    * All GA derived values are null
+    * The join_result_v1 is null
+
+  5. The join_result_v2 column is CLIENT_ID_SESSION_ID_MATCH for a successful join and join_result_v1 is null since the
+      v1 logic was not applied.
+
+  6. Occasionally GA sessions do not include a download_session_id only the client_id but the download data has both
+      theclient_id and the download_session_id.  Because of the missing GA field the join does not match resulting in
+      ~7000 dltoken rows with join_result_v2 = MISSING_GA_CLIENT_OR_SESSION_ID.  When this result is detected, the join
+      is performed again for only those dltokens using the client_id only (V1 implementation).  This may result in a
+      few hundred MISSING_GA_CLIENT occurring along with GA_UNRESOLVABLE due to multiple GA sessions for the selected
+      time range.
+
+  7.  In all cases where v1 logic has been applied, the join_result_v2 is set to MISSING_GA_CLIENT_OR_SESSION_ID
+
+  8.  If the v1 logic is applied, the join_result_v1 column will be CLIENT_ID_ONLY_MATCH for a successful join.
+
+  9. A GA session which does not have a dltoken with a corresponding stub_visit_id/clientId match is excluded from this
+      dataset.
+
+  10. If a dltoken occurs in the raw stub attribution table more than once:
+    * count_dltoken_duplicates will be >= 1.
+    * A value of 0 means there are no duplicates (expected state).
+    * A value of 1 means there was 1 other row with the dltoken value, etc.
+owners:
+- mhirose@mozilla.com
+labels:
+  incremental: true
+  schedule: daily
+  owner1: mhirose
+scheduling:
+  dag_name: bqetl_ga4_firefoxdotcom
+  task_name: firefoxdotcom_derived__downloads_with_attribution__v1
+  date_partition_parameter: download_date
+  date_partition_offset: -1
+bigquery:
+  time_partitioning:
+    type: day
+    field: download_date
+    require_partition_filter: false
+    expiration_days: null
+  clustering: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/downloads_with_attribution_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/downloads_with_attribution_v1/query.sql
@@ -57,7 +57,7 @@ WITH all_hits AS (
       NULL
     ) AS download_session_id
   FROM
-    `moz-fx-data-marketing-prod.analytics_489412379.events_*` AS ga
+    `moz-fx-data-marketing-prod.analytics_489412379.ga_sessions_*` AS ga
   CROSS JOIN
     UNNEST(hits) AS hit
   WHERE
@@ -114,7 +114,7 @@ ga_session_dimensions AS (
     mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(device.language)) AS `language`,
     IFNULL(mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(totals.timeOnSite)), 0) AS time_on_site
   FROM
-    `moz-fx-data-marketing-prod.analytics_489412379.events_*` AS ga
+    `moz-fx-data-marketing-prod.analytics_489412379.ga_sessions_*`
   WHERE
     _TABLE_SUFFIX
     BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(@download_date, INTERVAL 2 DAY))

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/downloads_with_attribution_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/downloads_with_attribution_v1/query.sql
@@ -1,0 +1,399 @@
+CREATE TEMP FUNCTION normalize_browser(browser STRING) AS (
+  CASE
+    WHEN `moz-fx-data-shared-prod.udf.ga_is_mozilla_browser`(browser)
+      THEN 'Firefox'
+    WHEN browser IN ('Internet Explorer')
+      THEN 'MSIE'
+    WHEN browser IN ('Edge')
+      THEN 'Edge'
+    WHEN browser IN ('Chrome')
+      THEN 'Chrome'
+    WHEN browser IN ('Safari')
+      THEN 'Safari'
+    WHEN browser IN ('(not set)')
+      THEN NULL
+    WHEN browser IS NULL
+      THEN NULL
+    ELSE 'Other'
+  END
+);
+
+CREATE TEMP FUNCTION normalize_ga_os(os STRING, nrows INTEGER) AS (
+  CASE
+    WHEN nrows > 1
+      THEN NULL
+    WHEN os IS NULL
+      THEN NULL
+    WHEN os LIKE 'Macintosh%'
+      THEN 'Mac'  -- these values are coming from GA.
+    ELSE mozfun.norm.os(os)
+  END
+);
+
+-- Unnest all the hits for all  sessions, one row per hit.
+-- Different hit.type values (EVENT | PAGE)
+-- and hit.eventInfo.eventAction('Firefox Download'| 'Stub Session ID') are
+-- extracted in the following CTEs
+-- Those extracted fields are joined to the GA session level data, one session per day.
+WITH all_hits AS (
+  SELECT
+    clientId AS client_id,
+    visitId AS visit_id,
+    hit.appInfo.landingScreenName AS landing_page,
+    hit.page.pagePath AS pagepath,
+    IF(
+      hit.type = 'EVENT'
+      AND hit.eventInfo.eventAction = 'Firefox Download'
+      AND hit.eventInfo.eventCategory IS NOT NULL
+      AND hit.eventInfo.eventLabel LIKE 'Firefox for Desktop%',
+      TRUE,
+      FALSE
+    ) AS has_ga_download_event,
+    hit.type AS hit_type,
+    IF(
+      hit.type = 'EVENT'
+      AND hit.eventInfo.eventAction = 'Stub Session ID',
+      hit.eventInfo.eventLabel,
+      NULL
+    ) AS download_session_id
+  FROM
+    `moz-fx-data-marketing-prod.analytics_489412379.events_*` AS ga
+  CROSS JOIN
+    UNNEST(hits) AS hit
+  WHERE
+    _TABLE_SUFFIX
+    BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(@download_date, INTERVAL 2 DAY))
+    AND FORMAT_DATE('%Y%m%d', DATE_ADD(@download_date, INTERVAL 1 DAY))
+),
+page_hits AS (
+  SELECT
+    client_id,
+    visit_id,
+    COUNT(pagePath) AS pageviews,
+    COUNT(DISTINCT pagePath) AS unique_pageviews,
+  FROM
+    all_hits
+  WHERE
+    hit_type = 'PAGE'
+  GROUP BY
+    client_id,
+    visit_id
+),
+event_hits AS (
+  SELECT
+    client_id,
+    visit_id,
+    -- This will extract one download_session_id value arbitrarily; an initial attempt to 'fix' the behaviour resulted
+    -- in a 'Resources exceeded during query execution error'.  Since it is rare to have more than one
+    -- download_session_id per GA session implementation will be left as is.
+    mozfun.stats.mode_last(ARRAY_AGG(download_session_id)) AS download_session_id,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(landing_page)) AS landing_page,
+    LOGICAL_OR(has_ga_download_event) AS has_ga_download_event
+  FROM
+    all_hits
+  WHERE
+    hit_type = 'EVENT'
+  GROUP BY
+    client_id,
+    visit_id
+    -- download_session_id  cannot group by download_session_id here since not every hit will have download_session_id
+),
+ga_session_dimensions AS (
+  SELECT
+    clientId AS client_id,
+    visitId AS visit_id,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(geoNetwork.country)) AS country,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(trafficSource.adContent)) AS ad_content,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(trafficSource.campaign)) AS campaign,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(trafficSource.medium)) AS medium,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(trafficSource.source)) AS source,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(device.deviceCategory)) AS device_category,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(device.operatingSystem)) AS os,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(device.browser)) AS browser,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(device.browserVersion)) AS browser_version,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(device.language)) AS `language`,
+    IFNULL(mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(totals.timeOnSite)), 0) AS time_on_site
+  FROM
+    `moz-fx-data-marketing-prod.analytics_489412379.events_*` AS ga
+  WHERE
+    _TABLE_SUFFIX
+    BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(@download_date, INTERVAL 2 DAY))
+    AND FORMAT_DATE('%Y%m%d', DATE_ADD(@download_date, INTERVAL 1 DAY))
+  GROUP BY
+    client_id,
+    visit_id
+),
+ga_sessions_with_hits_fields AS (
+  SELECT
+    * EXCEPT (pageviews, unique_pageviews),
+    IFNULL(pageviews, 0) AS pageviews,
+    IFNULL(unique_pageviews, 0) AS unique_pageviews,
+  FROM
+    ga_session_dimensions ga
+  LEFT JOIN
+    page_hits p
+    USING (client_id, visit_id)
+  JOIN
+    event_hits
+    USING (client_id, visit_id)
+),
+-- Extract all the download rows, de-duping and tracking number of duplicates per download token.
+stub_downloads AS (
+  SELECT
+    s.jsonPayload.fields.visit_id AS stub_visit_id,
+    jsonPayload.fields.session_id AS stub_download_session_id,
+    s.jsonPayload.fields.dltoken AS dltoken,
+    (COUNT(*) - 1) AS count_dltoken_duplicates,
+    DATE(@download_date) AS download_date
+  FROM
+    `moz-fx-stubattribut-prod-32a5.stubattribution_prod.stdout` s
+  WHERE
+    DATE(s.timestamp) = @download_date
+    AND s.jsonPayload.fields.log_type = 'download_started'
+  GROUP BY
+    stub_visit_id,
+    stub_download_session_id,
+    dltoken
+),
+multiple_downloads_in_session AS (
+  SELECT
+    stub_visit_id,
+    stub_download_session_id,
+    IF(COUNT(*) > 1, TRUE, FALSE) AS additional_download_occurred
+  FROM
+    stub_downloads
+  GROUP BY
+    stub_visit_id,
+    stub_download_session_id
+),
+stub_downloads_with_download_tracking AS (
+  SELECT
+    s1.stub_visit_id,
+    s1.stub_download_session_id,
+    dltoken,
+    count_dltoken_duplicates,
+    additional_download_occurred,
+    download_date
+  FROM
+    stub_downloads s1
+  JOIN
+    multiple_downloads_in_session s2
+    ON (
+      s1.stub_visit_id = s2.stub_visit_id
+      AND IFNULL(s1.stub_download_session_id, "null") = IFNULL(s2.stub_download_session_id, "null")
+    )
+),
+-- This will drop all the ga_sessions w/o a DLtoken but keep DLtoken without a GA session.
+-- This will also result in multiple rows as the ga.client_id is not unique for the day
+-- since this visit_id is missing from the stub.
+-- The join must use client_id/stub_visit_id and download_session_id/stub_download_session_id
+downloads_with_ga_session AS (
+  SELECT
+    gs.client_id AS client_id,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(country)) AS country,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(ad_content)) AS ad_content,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(campaign)) AS campaign,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(medium)) AS medium,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(source)) AS source,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(device_category)) AS device_category,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(os)) AS os,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(browser)) AS browser,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(browser_version)) AS browser_version,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(`language`)) AS `language`,
+    s.stub_visit_id AS stub_visit_id,
+    s.stub_download_session_id AS stub_download_session_id,
+    s.dltoken AS dltoken,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(landing_page)) AS landing_page,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(pageviews)) AS pageviews,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(unique_pageviews)) AS unique_pageviews,
+    LOGICAL_OR(has_ga_download_event) AS has_ga_download_event,
+    mozfun.stats.mode_last_retain_nulls(
+      ARRAY_AGG(count_dltoken_duplicates)
+    ) AS count_dltoken_duplicates,
+    LOGICAL_OR(additional_download_occurred) AS additional_download_occurred,
+    COUNT(*) AS nrows,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(s.download_date)) AS download_date,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(time_on_site)) AS time_on_site
+  FROM
+    ga_sessions_with_hits_fields gs
+  RIGHT JOIN
+    stub_downloads_with_download_tracking s
+    ON (gs.client_id = s.stub_visit_id AND gs.download_session_id = s.stub_download_session_id)
+  GROUP BY
+    gs.client_id,
+    dltoken,
+    stub_visit_id,
+    stub_download_session_id
+),
+-- This table is the result of joining the stub downlaod data with the GA rows
+-- using the client_id and the custom session_download_id
+v2_table AS (
+  SELECT
+    dltoken,
+    download_date,
+    IF(nrows <= 1, time_on_site, NULL) AS time_on_site,
+    IF(nrows <= 1, ad_content, NULL) AS ad_content,
+    IF(nrows <= 1, campaign, NULL) AS campaign,
+    IF(nrows <= 1, medium, NULL) AS medium,
+    IF(nrows <= 1, source, NULL) AS source,
+    IF(nrows <= 1, landing_page, NULL) AS landing_page,
+    IF(nrows <= 1, country, NULL) AS country,
+    IF(nrows <= 1, cn.code, NULL) AS normalized_country_code,
+    IF(nrows <= 1, device_category, NULL) AS device_category,
+    IF(nrows <= 1, os, NULL) AS os,
+    normalize_ga_os(os, nrows) AS normalized_os,
+    IF(nrows <= 1, browser, NULL) AS browser,
+    IF(nrows <= 1, normalize_browser(browser), NULL) AS normalized_browser,
+    IF(nrows <= 1, browser_version, NULL) AS browser_version,
+ -- only setting browser major version since that is the only value used in
+ -- moz-fx-data-shared-prod.firefox_installer.install
+    IF(
+      nrows <= 1,
+      CAST(mozfun.norm.extract_version(browser_version, 'major') AS INTEGER),
+      NULL
+    ) AS browser_major_version,
+    IF(nrows <= 1, `language`, NULL) AS `language`,
+    IF(nrows <= 1, pageviews, NULL) AS pageviews,
+    IF(nrows <= 1, unique_pageviews, NULL) AS unique_pageviews,
+    IF(nrows <= 1, has_ga_download_event, NULL) AS has_ga_download_event,
+    count_dltoken_duplicates,
+    additional_download_occurred,
+    CASE
+      WHEN stub_visit_id IS NULL
+        OR stub_download_session_id IS NULL
+        THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_NULL'
+      WHEN stub_visit_id = ''
+        OR stub_download_session_id = ''
+        THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_EMPTY'
+      WHEN stub_visit_id = '(not set)'
+        OR stub_download_session_id = '(not set)'
+        THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_VALUE_NOT_SET'
+      WHEN stub_visit_id = 'something'
+        OR stub_download_session_id = 'something'
+        THEN 'DOWNLOAD_CLIENT_OR_SESSION_ID_VALUE_SOMETHING'
+      WHEN client_id IS NULL
+        THEN 'MISSING_GA_CLIENT_OR_SESSION_ID'
+      WHEN nrows > 1
+        THEN 'GA_UNRESOLVABLE'
+      ELSE 'CLIENT_ID_SESSION_ID_MATCH'
+    END AS join_result_v2
+  FROM
+    downloads_with_ga_session
+  LEFT JOIN
+    `moz-fx-data-shared-prod.static.country_names_v1` AS cn
+    ON cn.name = country
+),
+-- Some of the joins for v2_table as not successful due to the GA data not including
+-- the download_session_id.  The downloads which are unable to match to a GA session
+-- are set to exception='MISSING_GA_CLIENT_OR_SESSION_ID'
+-- Those dltokens are re-processed using the V1 logic (loin using only the client_id)
+extract_dltoken_missing_ga_client AS (
+  SELECT
+    s.stub_visit_id,
+    v2.dltoken,
+    v2.count_dltoken_duplicates,
+    v2.additional_download_occurred,
+    v2.download_date
+  FROM
+    v2_table v2
+  JOIN
+    stub_downloads_with_download_tracking s
+    ON (s.dltoken = v2.dltoken)
+  WHERE
+    join_result_v2 = 'MISSING_GA_CLIENT_OR_SESSION_ID'
+),
+v1_downloads_with_ga_session AS (
+  SELECT
+    gs.client_id,
+    dltoken,
+    stub_visit_id,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(country)) AS country,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(ad_content)) AS ad_content,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(campaign)) AS campaign,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(medium)) AS medium,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(source)) AS source,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(device_category)) AS device_category,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(os)) AS os,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(browser)) AS browser,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(browser_version)) AS browser_version,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(`language`)) AS `language`,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(landing_page)) AS landing_page,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(pageviews)) AS pageviews,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(unique_pageviews)) AS unique_pageviews,
+    LOGICAL_OR(has_ga_download_event) AS has_ga_download_event,
+    mozfun.stats.mode_last_retain_nulls(
+      ARRAY_AGG(count_dltoken_duplicates)
+    ) AS count_dltoken_duplicates,
+    LOGICAL_OR(additional_download_occurred) AS additional_download_occurred,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(s.download_date)) AS download_date,
+    mozfun.stats.mode_last_retain_nulls(ARRAY_AGG(time_on_site)) AS time_on_site,
+    COUNT(*) AS nrows
+  FROM
+    ga_sessions_with_hits_fields gs
+  RIGHT JOIN
+    extract_dltoken_missing_ga_client s
+    ON gs.client_id = s.stub_visit_id
+  GROUP BY
+    gs.client_id,
+    stub_visit_id,
+    dltoken
+),
+v1_table AS (
+  SELECT
+    dltoken,
+    download_date,
+    IF(nrows <= 1, time_on_site, NULL) AS time_on_site,
+    IF(nrows <= 1, ad_content, NULL) AS ad_content,
+    IF(nrows <= 1, campaign, NULL) AS campaign,
+    IF(nrows <= 1, medium, NULL) AS medium,
+    IF(nrows <= 1, source, NULL) AS source,
+    IF(nrows <= 1, landing_page, NULL) AS landing_page,
+    IF(nrows <= 1, country, NULL) AS country,
+    IF(nrows <= 1, cn.code, NULL) AS normalized_country_code,
+    IF(nrows <= 1, device_category, NULL) AS device_category,
+    IF(nrows <= 1, os, NULL) AS os,
+    normalize_ga_os(os, nrows) AS normalized_os,
+    IF(nrows <= 1, browser, NULL) AS browser,
+    IF(nrows <= 1, normalize_browser(browser), NULL) AS normalized_browser,
+    IF(nrows <= 1, browser_version, NULL) AS browser_version,
+ -- only setting browser major version since that is the only value used in
+ -- moz-fx-data-shared-prod.firefox_installer.install
+    IF(
+      nrows <= 1,
+      CAST(mozfun.norm.extract_version(browser_version, 'major') AS INTEGER),
+      NULL
+    ) AS browser_major_version,
+    IF(nrows <= 1, `language`, NULL) AS `language`,
+    IF(nrows <= 1, pageviews, NULL) AS pageviews,
+    IF(nrows <= 1, unique_pageviews, NULL) AS unique_pageviews,
+    IF(nrows <= 1, has_ga_download_event, NULL) AS has_ga_download_event,
+    count_dltoken_duplicates,
+    additional_download_occurred,
+    CASE
+      WHEN client_id IS NULL
+        THEN 'MISSING_GA_CLIENT'
+      WHEN nrows > 1
+        THEN 'GA_UNRESOLVABLE'
+      ELSE 'CLIENT_ID_ONLY_MATCH'
+    END AS join_result_v1
+  FROM
+    v1_downloads_with_ga_session
+  LEFT JOIN
+    `moz-fx-data-shared-prod.static.country_names_v1` AS cn
+    ON cn.name = country
+)
+SELECT
+  * EXCEPT (join_result_v1),
+  'MISSING_GA_CLIENT_OR_SESSION_ID' AS join_result_v2,
+  join_result_v1 AS join_result_v1
+FROM
+  v1_table
+UNION ALL
+SELECT
+  * EXCEPT (join_result_v2),
+  join_result_v2 AS join_result_v2,
+  NULL AS join_result_v1
+FROM
+  v2_table
+WHERE
+  join_result_v2 != 'MISSING_GA_CLIENT_OR_SESSION_ID'

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/downloads_with_attribution_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/downloads_with_attribution_v1/schema.yaml
@@ -1,0 +1,152 @@
+fields:
+- description: Unique token generated for the Firefox download. Value should never
+    be NULL.
+  mode: NULLABLE
+  name: dltoken
+  type: STRING
+- description: Total time of the GA session expressed in seconds.
+  mode: NULLABLE
+  name: time_on_site
+  type: INTEGER
+- description: A description of the advertising or promotional copy.  Value will be
+    null if the Firefox download has no corresponding Google Analytics session.
+  mode: NULLABLE
+  name: ad_content
+  type: STRING
+- description: The name of a marketing campaign.  Value will be null if the Firefox
+    download has no corresponding Google Analytics session.
+  mode: NULLABLE
+  name: campaign
+  type: STRING
+- description: The type of referrals (e.g. referral, organic, email). Value will be
+    null if the Firefox download has no corresponding Google Analytics session.
+  mode: NULLABLE
+  name: medium
+  type: STRING
+- description: The source of referrals (e.g.  bing).  Value will be null if the Firefox
+    download has no corresponding Google Analytics session.
+  mode: NULLABLE
+  name: source
+  type: STRING
+- description: Landing page for the Google Analytics session corresponding to the
+    Firefox download. Value will be null if the Firefox download has no corresponding
+    Google Analytics session.
+  mode: NULLABLE
+  name: landing_page
+  type: STRING
+- description: Full country name.  Value will be null if the Firefox download has
+    no corresponding Google Analytics session.
+  mode: NULLABLE
+  name: country
+  type: STRING
+- description: 2-char country code.  Value will be null if the Firefox download has
+    no corresponding Google Analytics session.
+  mode: NULLABLE
+  name: normalized_country_code
+  type: STRING
+- description: e.g. desktop, tablet, mobile.  Value will be null if the Firefox download
+    has no corresponding Google Analytics session.
+  mode: NULLABLE
+  name: device_category
+  type: STRING
+- description: OS used during download. Value will be null if the Firefox download
+    has no corresponding Google Analytics session.
+  mode: NULLABLE
+  name: os
+  type: STRING
+- description: OS values grouped into (Windows, Android, Mac, Linux, iOS and Other).
+    Value will be null if the Firefox download has no corresponding Google Analytics
+    session.
+  mode: NULLABLE
+  name: normalized_os
+  type: STRING
+- description: Browser used to download Firefox (e.g. Chrome, Edge).  Value will be
+    null if the Firefox download has no corresponding Google Analytics session.
+  mode: NULLABLE
+  name: browser
+  type: STRING
+- description: Browser values grouped into (Firefox, MSIE, Edge, Chrome, Safari, Other,
+    NULL).  Value will be null if the Firefox download has no corresponding Google
+    Analytics session.
+  mode: NULLABLE
+  name: normalized_browser
+  type: STRING
+- description: Complete version label of browser used to download Firefox (note this
+    is NOT the version of Firefox which was downloaded).  Value will be null if the
+    Firefox download has no corresponding Google Analytics session.
+  mode: NULLABLE
+  name: browser_version
+  type: STRING
+- description: Major version of the browser used to download Firefox.  This is numeric
+    to facilitate querying.  \ne.g where browser='Edge' and browser_major_version
+    >= 11.  This is NOT the version of Firefox which was downloaded. Value will be
+    null if the Firefox download has no corresponding Google Analytics session.
+  mode: NULLABLE
+  name: browser_major_version
+  type: INTEGER
+- description: Device language, may be 2 char language code (en) or 4 char locale
+    (en-gb). Value will be null if the Firefox download has no corresponding Google
+    Analytics session.
+  mode: NULLABLE
+  name: language
+  type: STRING
+- description: Total count of pages hit for the Google Analytics session associated
+    with the Firefox download.  Value will be null if the Firefox download has no
+    corresponding Google Analytics session.
+  mode: NULLABLE
+  name: pageviews
+  type: INTEGER
+- description: Total count of unique pages hit for the Google Analytics session associated
+    with the Firefox download.  Value will be null if the Firefox download has no
+    corresponding Google Analytics session.
+  mode: NULLABLE
+  name: unique_pageviews
+  type: INTEGER
+- description: If has_ga_download_event = True then a corresponding Google Analytics
+    'Download Event' has been found.  If has_ga_download_event = False, while there
+    may be a corresponding Google Analytics session for the Firefox download, no ''Download
+    Event'' was captured for that session.
+  mode: NULLABLE
+  name: has_ga_download_event
+  type: BOOLEAN
+- description: This field is intended for diagnostics.The dltoken should be unique
+    however occasionally duplicates may be present in the raw data.  It has been confirmed
+    that duplicate dltokens are true duplicates in that all the other column values
+    for the record are also duplicated.  This table does not contain duplicate dltokens
+    however count_dltoken_duplicates will indicate if duplicate dltokens existed in
+    the raw data. count_dltoken_duplicates = 0 indicates that there was no duplicate
+    dltoken in the raw data.count_dltoken_duplicates = 1 indicates that there was
+    1 other row with the same dltoken.
+  mode: NULLABLE
+  name: count_dltoken_duplicates
+  type: INTEGER
+- description: This column represents if there was at least one other download completed
+    during the same session as this download.
+  mode: NULLABLE
+  name: additional_download_occurred
+  type: BOOLEAN
+- description: Indicates the result of the JOIN between the stub attr data and the GA session associated with the
+    Firefox download using client_id and download_session_id.  Values are limited to
+    1.CLIENT_ID_SESSION_ID_MATCH - Normal state, GA session matches the download. 2. GA_UNRESOLVABLE - More than one GA
+    session matches the Firefox download. 3. DOWNLOAD_SESSION_ID_NULL - The stub_download_session_id
+    is null. 4. DOWNLOAD_CLIENT_OR_SESSION_ID_EMPTY - The stub attr record did not contain either a client or
+    stub_download_session_id. 5. DOWNLOAD_CLIENT_OR_SESSION_ID_VALUE_NOT_SET -  The stub attr record contained GA
+    session identifier or stub_download_session_id with value (not set). 6. DOWNLOAD_CLIENT_OR_SESSION_ID_VALUE_SOMETHING
+    - The raw download record contained GA session identifier or stub_download_session_id with value something.
+    7. MISSING_GA_CLIENT_OR_SESSION_ID - The stub attr record contained a valid GA session identifier and
+    stub_download_session_id however there was no corresponding GA session found.
+  mode: NULLABLE
+  name: join_result_v2
+  type: STRING
+- description: Indicates the result of the JOIN between the stub attr data and the GA session associated
+    with the Firefox download action using only the client_id. Values are limited to 1.CLIENT_ID_ONLY_MATCH -
+    Normal state, unique GA session matches the download. 2. GA_UNRESOLVABLE - Indicates that more than one GA session
+    matches the Firefox download. 3. MISSING_GA_CLIENT - The stub attr record contained a valid GA session identifier
+    however there was no corresponding GA session found.
+  mode: NULLABLE
+  name: join_result_v1
+  type: STRING
+- description: The date of download, sourced from download logs.
+  mode: NULLABLE
+  name: download_date
+  type: DATE


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR creates the new table and corresponding view:
`moz-fx-data-shared-prod.firefoxdotcom_derived.downloads_with_attribution_v1`
`moz-fx-data-shared-prod.firefoxdotcom.downloads_with_attribution`
-->

## Related Tickets & Documents
* DENG-8677


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
