### PR TITLE
feat(DENG-8338): migrate prospect_item_feed table from snowflake

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2280,8 +2280,9 @@ bqetl_content_ml_daily:
     Daily extracts for corpus item data to be evaluated for new tab presentation.
   default_args:
     owner: skamath@mozilla.com
-    start_date: "2025-05-05" #TODO: Change to merge date
-    email: ["skamath@mozilla.com", "mlcooper@mozilla.com"]
+    # manually started in Airflow on 2025-05-27
+    start_date: "2025-05-27"
+    email: ["skamath@mozilla.com", "rrando@mozilla.com"]
     retries: 2
     retry_delay: 30m
   tags:

--- a/dags.yaml
+++ b/dags.yaml
@@ -2280,8 +2280,8 @@ bqetl_content_ml_daily:
     Daily extracts for corpus item data to be evaluated for new tab presentation.
   default_args:
     owner: skamath@mozilla.com
-    # manually started in Airflow on 2025-05-27
-    start_date: "2025-05-27"
+    # manually started in Airflow on 2025-05-26
+    start_date: "2025-05-26"
     email: ["skamath@mozilla.com", "rrando@mozilla.com"]
     retries: 2
     retry_delay: 30m

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/metadata.yaml
@@ -1,0 +1,27 @@
+friendly_name: Prospect Item Feed v1
+description: Model prospect created events for the Fx New Tab from prospects_v1 table
+owners:
+  - skamath@mozilla.com
+  - rrando@mozilla.com
+labels:
+  schedule: daily
+  incremental: true
+  owner1: skamath
+  owner2: rrando
+scheduling:
+  dag_name: bqetl_content_ml_daily
+  # be specific about which tables this depends on so the DAG can execute
+  # jobs in the proper order
+  referenced_tables:
+    - ["moz-fx-data-shared-prod", "snowflake_migration_derived", "prospects_v1"]
+bigquery:
+  time_partitioning:
+    type: day
+    field: happened_at
+    require_partition_filter: true
+    expiration_days: 775
+  clustering:
+    fields:
+      - prospect_id
+      - prospect_source
+      - scheduled_surface_id

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/metadata.yaml
@@ -10,10 +10,6 @@ labels:
   owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_daily
-  # be specific about which tables this depends on so the DAG can execute
-  # jobs in the proper order
-  referenced_tables:
-    - ["moz-fx-data-shared-prod", "snowflake_migration_derived", "prospects_v1"]
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/query.sql
@@ -2,7 +2,7 @@ SELECT
   JSON_VALUE(run_details.candidate_set_id) AS candidate_set_id,
   -- line below is copied over from original DBT model
   'prospect' AS candidate_set_type, -- the hardcoding is for backward compatiblility with the legacy item feed from candidate set generation
-  LAX_INT64(run_details.expires_at) AS expires_at,
+  TIMESTAMP_SECONDS(LAX_INT64(run_details.expires_at)) AS expires_at,
   JSON_VALUE(run_details.flow) AS flow,
   happened_at,
   topic AS predicted_topic,

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/query.sql
@@ -1,0 +1,29 @@
+SELECT
+  JSON_VALUE(run_details.candidate_set_id) AS candidate_set_id,
+  -- line below is copied over from original DBT model
+  'prospect' AS candidate_set_type, -- the hardcoding is for backward compatiblility with the legacy item feed from candidate set generation
+  LAX_INT64(run_details.expires_at) AS expires_at,
+  JSON_VALUE(run_details.flow) AS flow,
+  happened_at,
+  topic AS predicted_topic,
+  prospect_id,
+  prospect_source,
+  LAX_INT64(features.rank) AS rank,
+  JSON_VALUE(run_details.run_id) AS run_id,
+  scheduled_surface_id,
+  schema_version,
+  happened_at AS snowflake_loaded_at
+FROM
+  `moz-fx-data-shared-prod.snowflake_migration_derived.prospects_v1`
+WHERE
+  object_update_trigger = 'prospect_created'
+  {% if is_init() %}
+    -- 2024-09-19 is the earliest date we have data from snowplow
+    AND DATE(happened_at) >= '2024-09-19'
+  {% else %}
+    -- @submission_date is the default name for the query param
+    -- automatically passed in when the job runs
+    AND DATE(happened_at) = @submission_date
+  {% endif %}
+QUALIFY
+  ROW_NUMBER() OVER (PARTITION BY prospect_id ORDER BY happened_at DESC) = 1;

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/schema.yaml
@@ -1,0 +1,57 @@
+fields:
+  - mode: NULLABLE
+    type: STRING
+    name: candidate_set_id
+    description: A string identifier for the candidate set to which this run pertains.
+  - mode: NULLABLE
+    type: STRING
+    name: candidate_set_type
+    description: Indicates if candidate set consists of either prospects for curation or candidates for recommendation slates
+  - mode: NULLABLE
+    type: INTEGER
+    name: expires_at
+    description: The date at which this candidate set is no longer "fresh".
+  - mode: NULLABLE
+    type: STRING
+    name: flow
+    description: Name of the metaflow script generating this candidate set from dl-meatflow-jobs.
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: happened_at
+    description: This is an alias for happened_at (timestamp for the prospect creation signal)
+  - mode: NULLABLE
+    type: STRING
+    name: predicted_topic
+    description: Topic categorization based on content predictions (examples TECHNOLOGY, TRAVEL, SPORTS, BUSINESS, EDUCATION)
+  - mode: NULLABLE
+    type: STRING
+    name: prospect_id
+    description: The id of the item as a prospect (potential corporeal candidate)
+  - mode: NULLABLE
+    type: STRING
+    name: prospect_source
+    description: Source identified by the ML process for the prospect (SYNDICATED, ORGANIC_TIMESPENT, GLOBAL).
+  - mode: NULLABLE
+    type: INTEGER
+    name: rank
+    description: Rank of prospects within a candidate set (based on prospect_source and scheduled_surface_id).
+  - mode: NULLABLE
+    type: STRING
+    name: run_id
+    description:
+      A string identifier for the unique run of the given candidate set.
+      Will be constant across items that were part of the same candidate set & run.
+  - mode: NULLABLE
+    type: STRING
+    name: scheduled_surface_id
+    description: The curated rec destination where the corpus item is expected to appear (NEW_TAB_EN_INTL, NEW_TAB_EN_US, NEW_TAB_DE_DE, NEW_TAB_EN_GB).
+  - mode: NULLABLE
+    type: STRING
+    name: schema_version
+    description: Allows for future updates to the schema for this event.
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: snowflake_loaded_at
+    description:
+      This is an alias for happened_at (timestamp for the prospect creation signal)
+      Note - The "snowflake_loaded_at" name is being retained for backward compatibility

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/schema.yaml
@@ -8,7 +8,7 @@ fields:
     name: candidate_set_type
     description: Indicates if candidate set consists of either prospects for curation or candidates for recommendation slates
   - mode: NULLABLE
-    type: INTEGER
+    type: TIMESTAMP
     name: expires_at
     description: The date at which this candidate set is no longer "fresh".
   - mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
@@ -2,12 +2,12 @@ friendly_name: Prospects v1
 description: Model prospective article options for the Fx New Tab from raw Snowplow data
 owners:
   - skamath@mozilla.com
-  - mlcooper@mozilla.com
+  - rrando@mozilla.com
 labels:
   schedule: daily
   incremental: true
   owner1: skamath
-  owner2: mlcooper
+  owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_daily
   # destination is the whole table, not a single partition,
@@ -16,7 +16,6 @@ scheduling:
 bigquery:
   time_partitioning:
     type: day
-  # TODO: confirm
     field: happened_at
     require_partition_filter: true
     expiration_days: 775


### PR DESCRIPTION
## Description

migrate prospect_item_feed table from snowflake.

this job is intended to execute after the `prospects_v1` [source table](https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml) is updated.

## Related Tickets & Documents
* DENG-8338

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
