### PR TITLE
Deng 8498 new profiles aggregates

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1682,6 +1682,27 @@ bqetl_firefox_desktop_ad_click_history:
     - repo/bigquery-etl
     - impact/tier_2
 
+bqetl_firefox_desktop_new_profiles_aggregates:
+  default_args:
+    depends_on_past: false
+    email:
+      - lmcfall@mozilla.com
+      - telemetry-alerts@mozilla.com
+    email_on_failure: true
+    email_on_retry: false
+    end_date: null
+    owner: lmcfall@mozilla.com
+    retries: 2
+    retry_delay: 30m
+    start_date: '2024-07-16'
+  description: |
+    TODO
+  repo: bigquery-etl
+  schedule_interval: 0 16 * * *
+  tags:
+    - repo/bigquery-etl
+    - impact/tier_2
+
 bqetl_merino_newtab_extract_to_gcs:
   default_args:
     depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/new_profiles_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/new_profiles_aggregates/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.new_profiles_aggregates`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.new_profiles_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/new_profiles_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/new_profiles_aggregates_v1/metadata.yaml
@@ -1,0 +1,19 @@
+friendly_name: New Profiles Aggregates
+description: |-
+  Please provide a description for the query
+owners:
+- lmcfall@mozilla.com
+labels:
+  incremental: true
+  owner1: lmcfall
+scheduling:
+  dag_name: bqetl_default
+bigquery:
+  time_partitioning:
+    type: day
+    field: first_seen_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/new_profiles_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/new_profiles_aggregates_v1/query.sql
@@ -1,0 +1,87 @@
+WITH clients_first_seen AS (
+  SELECT
+    client_id,
+    first_seen_date,
+    is_desktop,
+    attribution.medium AS attribution_medium,
+    attribution.source AS attribution_source,
+    attribution.campaign AS attribution_campaign,
+    attribution.content AS attribution_content,
+    attribution_dlsource,
+    attribution_ua,
+    (attribution.medium IS NOT NULL OR attribution.source IS NOT NULL) AS attributed,
+    `moz-fx-data-shared-prod.udf.organic_vs_paid_desktop`(attribution.medium) AS paid_vs_organic,
+    city,
+    country,
+    distribution_id,
+    normalized_channel AS channel,
+    normalized_os,
+    normalized_os_version,
+    locale,
+    app_display_version,
+    windows_version,
+    windows_build_number
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_first_seen` cfs
+  WHERE
+    cfs.submission_date = @submission_date
+),
+active_users AS (
+  SELECT
+    client_id,
+    is_dau,
+    submission_date
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.baseline_active_users` au
+  WHERE
+    au.submission_date = @submission_date
+)
+SELECT
+  cfs.first_seen_date,
+  cfs.is_desktop,
+  cfs.attribution_medium,
+  cfs.attribution_source,
+  cfs.attribution_campaign,
+  cfs.attribution_content,
+  cfs.attribution_dlsource,
+  cfs.attribution_ua,
+  cfs.attributed,
+  cfs.paid_vs_organic,
+  cfs.city,
+  cfs.country,
+  cfs.distribution_id,
+  cfs.channel,
+  cfs.normalized_os,
+  cfs.normalized_os_version,
+  cfs.locale,
+  cfs.windows_version,
+  cfs.windows_build_number,
+  COALESCE(au.is_dau, FALSE) AS is_dau,
+  COUNT(cfs.client_id) AS new_profiles
+FROM
+  clients_first_seen cfs
+LEFT JOIN
+  active_users au
+  ON cfs.client_id = au.client_id
+  AND cfs.first_seen_date = au.submission_date
+GROUP BY
+  cfs.first_seen_date,
+  cfs.is_desktop,
+  cfs.attribution_medium,
+  cfs.attribution_source,
+  cfs.attribution_campaign,
+  cfs.attribution_content,
+  cfs.attribution_dlsource,
+  cfs.attribution_ua,
+  cfs.attributed,
+  cfs.paid_vs_organic,
+  cfs.city,
+  cfs.country,
+  cfs.distribution_id,
+  cfs.channel,
+  cfs.normalized_os,
+  cfs.normalized_os_version,
+  cfs.locale,
+  cfs.windows_version,
+  cfs.windows_build_number,
+  au.is_dau

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/new_profiles_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/new_profiles_aggregates_v1/schema.yaml
@@ -1,0 +1,4 @@
+fields:
+- description: Date when clients were first seen.
+  name: first_seen_date
+  type: DATE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/new_profiles_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/new_profiles_aggregates_v1/schema.yaml
@@ -2,3 +2,84 @@ fields:
 - description: Date when clients were first seen.
   name: first_seen_date
   type: DATE
+  mode: NULLABLE
+- description: Indicates if the client is included in the desktop KPI.
+  name: is_desktop
+  type: BOOLEAN
+  mode: NULLABLE
+- description: Category of the source, such as 'organic' for a search engine.
+  name: attribution_medium
+  type: STRING
+  mode: NULLABLE
+- description: Referring partner domain, when install happens via a known partner.
+  name: attribution_source
+  type: STRING
+  mode: NULLABLE
+- description: Identifier of the particular campaign that led to the download of the product.
+  name: attribution_campaign
+  type: STRING
+  mode: NULLABLE
+- description: Identifier to indicate the particular link within a campaign.
+  name: attribution_content
+  type: STRING
+  mode: NULLABLE
+- description: Identifier that indicates where installations of Firefox originated.
+  name: attribution_dlsource
+  type: STRING
+  mode: NULLABLE
+- description: Client's user agent, which corresponds to the web browser used to download the Firefox installer.
+  name: attribution_ua
+  type: STRING
+  mode: NULLABLE
+- description: True if attribution_medium is not null AND attribution_source is not null.
+  name: attributed
+  type: BOOLEAN
+  mode: NULLABLE
+- description: Is desktop client attribution organic or paid
+  name: paid_vs_organic
+  type: STRING
+  mode: NULLABLE
+- description: City retrieved as a result of a geographic lookup based on the client's IP address.
+  name: city
+  type: STRING
+  mode: NULLABLE
+- description: The ISO 3166-1 alpha-2 country code.
+  name: country
+  type: STRING
+  mode: NULLABLE
+- description: The value of the `distribution.id` preference that identifies the Firefox distribution.
+  name: distribution_id
+  type: STRING
+  mode: NULLABLE
+- description: The Firefox channel, set to Other for unrecognized channel names.
+  name: channel
+  type: STRING
+  mode: NULLABLE
+- description: The OS name, set to Other for unrecognized OS names.
+  name: normalized_os
+  type: STRING
+  mode: NULLABLE
+- description: The OS version.
+  name: normalized_os_version
+  type: STRING
+  mode: NULLABLE
+- description: The best locale that the application should be localized to.
+  name: locale
+  type: STRING
+  mode: NULLABLE
+- description: Combo of os, os_version, windows_build_number, NULL if not windows.
+  name: windows_version
+  type: STRING
+  mode: NULLABLE
+- description: Windows build number.
+  name: windows_build_number
+  type: INTEGER
+  mode: NULLABLE
+- description: Is the client active or not on the date.
+  name: is_dau
+  type: BOOLEAN
+  mode: NULLABLE
+- description: Count of clients that are new on this date.
+  name: new_profiles
+  type: INTEGER
+  mode: NULLABLE


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR adds the new tables `firefox_desktop_derived.new_profiles_aggregates_v1` & `firefox_desktop.new_profiles_aggregates`

## Related Tickets & Documents
* [DENG-8498](https://mozilla-hub.atlassian.net/browse/DENG-8498)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
