### PR TITLE
add files for firefoxdotcom.ga_clients_v1 and view

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/ga_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/ga_clients/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefoxdotcom.ga_clients`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefoxdotcom_derived.ga_clients_v1`

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_clients_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_clients_v1/checks.sql
@@ -1,0 +1,5 @@
+#fail
+{{ is_unique("ga_client_id") }}
+
+#fail
+{{ min_row_count(1000000) }}

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_clients_v1/metadata.yaml
@@ -1,0 +1,18 @@
+friendly_name: GA Clients
+description: |-
+  A table representing GA clients. Grain is one row per client.
+  Key is ga_client_id.
+owners:
+- mhirose@mozilla.com
+- kwindau@mozilla.com
+labels:
+  owner1: mhirose@mozilla.com
+scheduling:
+  depends_on_past: true
+  dag_name: bqetl_ga4_firefoxdotcom
+  date_partition_parameter: null
+  parameters: ["session_date:DATE:{{ds}}"]
+bigquery:
+  clustering:
+    fields: ["first_seen_date"]
+references: {}

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_clients_v1/query.sql
@@ -1,0 +1,81 @@
+WITH historical_clients AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.firefoxdotcom_derived.ga_clients_v1`
+),
+new_clients AS (
+  SELECT
+    ga_client_id,
+    MIN(session_date) AS first_seen_date,
+    MAX(session_date) AS last_seen_date,
+    LOGICAL_OR(had_download_event) AS had_download_event,
+    STRUCT(
+      /* Geos */
+      MIN_BY(country, session_number) AS country,
+      MIN_BY(region, session_number) AS region,
+      MIN_BY(city, session_number) AS city,
+      /* Attribution */
+      MIN_BY(campaign_id, session_number) AS campaign_id,
+      MIN_BY(campaign, session_number) AS campaign,
+      MIN_BY(source, session_number) AS source,
+      MIN_BY(medium, session_number) AS medium,
+      MIN_BY(term, session_number) AS term,
+      MIN_BY(content, session_number) AS content,
+      /* Device */
+      MIN_BY(device_category, session_number) AS device_category,
+      MIN_BY(mobile_device_model, session_number) AS mobile_device_model,
+      MIN_BY(mobile_device_string, session_number) AS mobile_device_string,
+      MIN_BY(os, session_number) AS os,
+      MIN_BY(os_version, session_number) AS os_version,
+      MIN_BY(LANGUAGE, session_number) AS language,
+      MIN_BY(browser, session_number) AS browser,
+      MIN_BY(browser_version, session_number) AS browser_version,
+      /* Session */
+      MIN_BY(ga_session_id, session_number) AS ga_session_id
+    ) AS first_reported,
+  FROM
+    `moz-fx-data-shared-prod.firefoxdotcom_derived.ga_sessions_v1`
+  WHERE
+    ga_client_id IS NOT NULL
+    {% if is_init() %}
+      AND session_date >= "2010-01-01"
+    {% else %}
+      -- Re-process three days, to account for late-arriving data
+      AND session_date
+      BETWEEN DATE_SUB(@session_date, INTERVAL 3 DAY)
+      AND @session_date
+    {% endif %}
+  GROUP BY
+    ga_client_id
+)
+SELECT
+  ga_client_id,
+  -- Least and greatest return NULL if any input is NULL, so we coalesce each value first
+  LEAST(
+    COALESCE(_previous.first_seen_date, _current.first_seen_date),
+    COALESCE(_current.first_seen_date, _previous.first_seen_date)
+  ) AS first_seen_date,
+  GREATEST(
+    COALESCE(_previous.last_seen_date, _current.last_seen_date),
+    COALESCE(_current.last_seen_date, _previous.last_seen_date)
+  ) AS last_seen_date,
+  -- OR treats NULL differently for True/False. If any input is True, it will return True; otherwise it returns NULL.
+  COALESCE(
+    _previous.had_download_event
+    OR _current.had_download_event,
+    FALSE
+  ) AS had_download_event,
+  -- We take the current data for first_reported only if we don't already have first_reported data, or if we're backfilling
+  -- If equal, prefer new data
+  IF(
+    _previous.ga_client_id IS NULL
+    OR _current.first_seen_date <= _previous.first_seen_date,
+    _current.first_reported,
+    _previous.first_reported
+  ) AS first_reported,
+FROM
+  historical_clients AS _previous
+FULL OUTER JOIN
+  new_clients AS _current
+  USING (ga_client_id)

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_clients_v1/schema.yaml
@@ -1,0 +1,96 @@
+fields:
+  - name: ga_client_id
+    mode: NULLABLE
+    type: STRING
+    description: "Uniquely identifiers a GA client, using a cookie on moz.org."
+  - name: first_seen_date
+    mode: NULLABLE
+    type: DATE
+    description: "The first date we saw this GA client."
+  - name: last_seen_date
+    mode: NULLABLE
+    type: DATE
+    description: "The last date we saw this GA client."
+  - name: had_download_event
+    mode: NULLABLE
+    type: BOOLEAN
+    description: "Whether this GA client has ever had a download event."
+  - name: first_reported
+    description: "First instances of fields for a GA client."
+    type: RECORD
+    mode: NULLABLE
+    fields:
+      - name: country
+        type: STRING
+        mode: NULLABLE
+        description: "First reported country for a GA client."
+      - name: region
+        type: STRING
+        mode: NULLABLE
+        description: "First reported region for a GA client."
+      - name: city
+        type: STRING
+        mode: NULLABLE
+        description: "First reported city for a GA client."
+      - name: campaign_id
+        type: STRING
+        mode: NULLABLE
+        description: "First reported campaign ID. Usually associated with AdWords."
+      - name: campaign
+        type: STRING
+        mode: NULLABLE
+        description: "First reported campaign value. Usually set by the utm_campaign URL parameter."
+      - name: source
+        type: STRING
+        mode: NULLABLE
+        description: >
+          First reported source of the traffic. Could be the name of the search engine,
+          the referring hostname, or a value of the utm_source URL parameter.
+      - name: medium
+        type: STRING
+        mode: NULLABLE
+        description: "First reported medium of the traffic source. Could be 'organic', 'cpc', 'referral', or the value of the utm_medium URL parameter."
+      - name: term
+        type: STRING
+        mode: NULLABLE
+        description: "First reported term, or keyword, value. If this was a search results page, this is the keyword entered."
+      - name: content
+        type: STRING
+        mode: NULLABLE
+        description: "First reported ad content of the traffic source. Can be set by the utm_content URL parameter."
+      - name: device_category
+        type: STRING
+        mode: NULLABLE
+        description: "First reported device category value. The type of device (Mobile, Tablet, Desktop)."
+      - name: mobile_device_model
+        type: STRING
+        mode: NULLABLE
+        description: "First reported device model value."
+      - name: mobile_device_string
+        type: STRING
+        mode: NULLABLE
+        description: "First reported mobile device string. The branding, model, and marketing name used to identify the mobile device."
+      - name: os
+        type: STRING
+        mode: NULLABLE
+        description: "First reported operating system of the device (e.g., 'Macintosh' or 'Windows')."
+      - name: os_version
+        type: STRING
+        mode: NULLABLE
+        description: "First reported os_version value."
+      - name: language
+        type: STRING
+        mode: NULLABLE
+        description: "First reported language the device is set to use. Expressed as the IETF language code."
+      - name: browser
+        type: STRING
+        mode: NULLABLE
+        description: "First reported browser used (e.g., 'Chrome' or 'Firefox')."
+      - name: browser_version
+        type: STRING
+        mode: NULLABLE
+        description: "First reported browser_version value."
+      - name: ga_session_id
+        type: STRING
+        mode: NULLABLE
+        description: "First reported GA Session ID. Might be useful to understand client's first sessions, for e.g. marketing campaigns."


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
-->
This PR creates new table and corresponding view for:
`moz-fx-data-shared-prod.firefoxdotcom_derived.ga_clients_v1`
`moz-fx-data-shared-prod.firefoxdotcom.ga_clients`

## Related Tickets & Documents
* DENG-8688
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
