### PR TITLE
feat(DENG-8402): Add lifecycle_stage and paid_vs_organic to views

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_engagement_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_engagement_aggregates/view.sql
@@ -2,6 +2,18 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_desktop.desktop_engagement_aggregates`
 AS
 SELECT
-  *
+  *,
+  CASE
+    WHEN first_seen_date = submission_date
+      THEN 'new_profile'
+    WHEN DATE_DIFF(submission_date, first_seen_date, DAY)
+      BETWEEN 1
+      AND 27
+      THEN 'repeat_user'
+    WHEN DATE_DIFF(submission_date, first_seen_date, DAY) >= 28
+      THEN 'existing_user'
+    ELSE 'Unknown'
+  END AS lifecycle_stage,
+  `moz-fx-data-shared-prod.udf.organic_vs_paid_desktop`(attribution_medium) AS paid_vs_organic
 FROM
   `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_engagement_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_retention_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_retention_aggregates/view.sql
@@ -2,6 +2,18 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_desktop.desktop_retention_aggregates`
 AS
 SELECT
-  *
+  *,
+  CASE
+    WHEN first_seen_date = metric_date
+      THEN 'new_profile'
+    WHEN DATE_DIFF(metric_date, first_seen_date, DAY)
+      BETWEEN 1
+      AND 27
+      THEN 'repeat_user'
+    WHEN DATE_DIFF(metric_date, first_seen_date, DAY) >= 28
+      THEN 'existing_user'
+    ELSE 'Unknown'
+  END AS lifecycle_stage,
+  `moz-fx-data-shared-prod.udf.organic_vs_paid_desktop`(attribution_medium) AS paid_vs_organic
 FROM
   `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_retention_aggregates_v1`


### PR DESCRIPTION
## Description
This PR adds 2 columns, `lifecycle_stage` & `paid_vs_organic` to the 2 views:
- `moz-fx-data-shared-prod.firefox_desktop.desktop_retention_aggregates`
- `moz-fx-data-shared-prod.firefox_desktop.desktop_engagement_aggregates`

## Related Tickets & Documents
* [DENG-8402](https://mozilla-hub.atlassian.net/browse/DENG-8402)
* [DENG-8406](https://mozilla-hub.atlassian.net/browse/DENG-8406)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8402]: https://mozilla-hub.atlassian.net/browse/DENG-8402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-8406]: https://mozilla-hub.atlassian.net/browse/DENG-8406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ