### PR TITLE
add files for firefox_whatsnew_summary table and view

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/firefox_whatsnew_summary/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/firefox_whatsnew_summary/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefoxdotcom.firefox_whatsnew_summary`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefoxdotcom_derived.firefox_whatsnew_summary_v1`

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/firefox_whatsnew_summary_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/firefox_whatsnew_summary_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Firefox Whatsnew Summary V1
+description: |-
+  This table aggregates the traffic to Firefox "what's new" pages using Google Analytics 4 data
+owners:
+- mhirose@mozilla.com
+labels:
+  incremental: true
+  owner1: mhirose@mozilla.com
+scheduling:
+  dag_name: bqetl_ga4_firefoxdotcom
+bigquery:
+  time_partitioning:
+    type: day
+    field: date
+    require_partition_filter: false
+    expiration_days: null
+  clustering:
+    fields:
+    - country
+    - version
+references: {}

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/firefox_whatsnew_summary_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/firefox_whatsnew_summary_v1/query.sql
@@ -1,0 +1,42 @@
+WITH wnp_visits AS (
+  SELECT
+    date,
+    visit_identifier,
+    TRIM(page_path_level1, '/') AS locale,
+    page_level_2 AS version,
+    mozfun.norm.browser_version_info(page_level_2) AS version_info,
+    country,
+    CAST(bounces AS boolean) AS is_bounce
+  FROM
+    `moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_hits_v1`
+  WHERE
+    date = @submission_date
+    AND hit_type = 'PAGE'
+    -- Match page paths like "/{locale}/firefox/{version}/whatsnew/..."
+    -- Version regular expression is adapted from https://github.com/mozilla/bedrock/blob/main/bedrock/releasenotes/__init__.py
+    AND page_level_1 = 'firefox'
+    AND REGEXP_CONTAINS(page_level_2, r'^\d{1,3}(\.\d{1,3}){1,3}((a|b(eta)?)\d*)?(pre\d*)?(esr)?$')
+    AND page_level_3 = 'whatsnew'
+)
+SELECT
+  date,
+  country,
+  locale,
+  version,
+  version_info.major_version,
+  version_info.minor_version,
+  version_info.patch_revision,
+  version_info.is_major_release,
+  COUNT(DISTINCT visit_identifier) AS visits,
+  COUNT(DISTINCT CASE WHEN is_bounce = TRUE THEN visit_identifier END) AS bounces
+FROM
+  wnp_visits
+GROUP BY
+  date,
+  country,
+  locale,
+  version,
+  version_info.major_version,
+  version_info.minor_version,
+  version_info.patch_revision,
+  version_info.is_major_release

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/firefox_whatsnew_summary_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/firefox_whatsnew_summary_v1/schema.yaml
@@ -1,0 +1,41 @@
+fields:
+- mode: NULLABLE
+  name: date
+  type: DATE
+  description: Date of the visit
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: Country - The country from which events were reported, based on IP address
+- mode: NULLABLE
+  name: locale
+  type: STRING
+  description: Locale - Sourced from page path level 1 (e.g. en-US, zh-CN, etc)
+- mode: NULLABLE
+  name: version
+  type: STRING
+  description: Version - Sourced from page level 2, e.g. /{locale}/firefox/{version}/whatsnew/...
+- mode: NULLABLE
+  name: major_version
+  type: NUMERIC
+  description: Major Version - The major release version number
+- mode: NULLABLE
+  name: minor_version
+  type: NUMERIC
+  description: Minor Version - The minor release version number
+- mode: NULLABLE
+  name: patch_revision
+  type: NUMERIC
+  description: Patch Revision - The patch revision version number
+- mode: NULLABLE
+  name: is_major_release
+  type: BOOLEAN
+  description: Is Major Release - Indicates if this is a new major release (i.e. minor version is 0)
+- mode: NULLABLE
+  name: visits
+  type: INT64
+  description: Visits - The number of unique visits, where a unique visit is the user_pseudo_id plus session ID
+- mode: NULLABLE
+  name: bounces
+  type: INT64
+  description: Bounces - The number of unique visits where the session was considered a bounce


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
-->
This PR creates the new table and corresponding view for:
`moz-fx-data-shared-prod.firefoxdotcom_derived.firefox_whatsnew_summmary_v1`
`moz-fx-data-shared-prod.firefoxdotcom.firefox_whatsnew_summary`

## Related Tickets & Documents
* DENG-8687
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
