### PR TITLE
feat(DENG-8567): create a dataset syndicate for Remote Settings CDN logs aggregates

### DIFF
--- a/sql/moz-fx-data-shared-prod/remote_settings_logs_agggregates_syndicate/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/remote_settings_logs_agggregates_syndicate/dataset_metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: remote_settings_logs_aggregates_syndicate
+description: |
+  This dataset contains Remote Settings CDN requests logs aggregates per endpoints
+  and collections. It is derived from the load balancer logs using a BigQuery Transfer
+  job that runs every day.
+dataset_base_acl: syndicate
+user_facing: false
+labels: {}
+syndication:
+  stage:
+    syndicated_project: "moz-fx-remote-settings-prod"
+    syndicated_dataset: "prod_logs_aggregates_dataset "
+  prod:
+    syndicated_project: "moz-fx-remote-settings-nonprod"
+    syndicated_dataset: "nonprod_logs_aggregates_dataset "
+  administer_views: false
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential


### PR DESCRIPTION
## Description

This PR creates a dataset syndicate for Remote Settings CDN logs aggregates so that we can leverage the data in Looker.

The prod dataset only contains one table, whereas the nonprod dataset contains a table for DEV and anoother one for STAGE

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/DENG-8567
* https://mozilla-hub.atlassian.net/browse/RMST-44

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
