### PR TITLE
DENG-8786 - Add people project to jobs by org table

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
@@ -17,6 +17,7 @@ DEFAULT_PROJECTS = [
     "moz-fx-data-sumo-prod",
     "moz-fx-data-sumo-nonprod",
     "moz-fx-mozsocial-dw-prod",
+    "moz-fx-data-bq-people",
 ]
 
 parser = ArgumentParser(description=__doc__)


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

As we are looking into deprecating some of the tables in the people project ([DENG-8784](https://mozilla-hub.atlassian.net/browse/DENG-8784)), it would be helpful to check usage of such tables.

## Related Tickets & Documents
* DSRE-8786](https://mozilla-hub.atlassian.net/browse/DENG-8786)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8784]: https://mozilla-hub.atlassian.net/browse/DENG-8784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ