### PR TITLE
Add poke_interval and timeout option to task sensors

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -91,6 +91,8 @@ class TaskRef:
     schedule_interval: Optional[str] = attr.ib(None)
     date_partition_offset: Optional[int] = attr.ib(None)
     task_group: Optional[str] = attr.ib(None)
+    poke_interval: Optional[str] = attr.ib(None, kw_only=True)
+    timeout: Optional[str] = attr.ib(None, kw_only=True)
 
     @property
     def task_key(self):
@@ -112,6 +114,18 @@ class TaskRef:
         """Validate the schedule_interval format."""
         if value is not None and not is_schedule_interval(value):
             raise ValueError(f"Invalid schedule_interval {value}.")
+
+    @poke_interval.validator
+    def validate_poke_interval(self, attribute, value):
+        """Check that `poke_interval` is a valid timedelta string."""
+        if value is not None:
+            validate_timedelta_string(value)
+
+    @timeout.validator
+    def validate_timeout(self, attribute, value):
+        """Check that `timeout` is a valid timedelta string."""
+        if value is not None:
+            validate_timedelta_string(value)
 
     def get_execution_delta(self, schedule_interval):
         """Determine execution_delta, via schedule_interval if necessary."""

--- a/bigquery_etl/query_scheduling/templates/airflow_dag.j2
+++ b/bigquery_etl/query_scheduling/templates/airflow_dag.j2
@@ -106,7 +106,15 @@ with DAG('{{ name }}', default_args=default_args{%+ if schedule_interval != None
         {% endif -%}
         check_existence=True,
         mode='reschedule',
-        poke_interval=datetime.timedelta(minutes=5),
+        poke_interval=
+        {%- if dependency.poke_interval != None -%}
+        {{ dependency.poke_interval | format_timedelta | format_repr }}
+        {%- else -%}
+        datetime.timedelta(minutes=5)
+        {%- endif -%},
+        {% if dependency.timeout -%}
+        timeout={{ dependency.timeout | format_timedelta | format_repr }},
+        {% endif -%}
         allowed_states=ALLOWED_STATES,
         failed_states=FAILED_STATES,
         pool='DATA_ENG_EXTERNALTASKSENSOR',

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/metadata.yaml
@@ -14,6 +14,8 @@ scheduling:
     # wait for run at 6:00 UTC to get finished state
     # of jobs that start before midnight and end after 2:00
     execution_delta: -4h
+    poke_interval: 10m
+    timeout: 6h
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/metadata.yaml
@@ -13,6 +13,8 @@ scheduling:
     # wait for run at 6:00 UTC to get finished state
     # of jobs that start before midnight and end after 2:00
     execution_delta: -4h
+    poke_interval: 10m
+    timeout: 6h
 bigquery:
   time_partitioning:
     type: day

--- a/tests/query_scheduling/test_task.py
+++ b/tests/query_scheduling/test_task.py
@@ -741,6 +741,8 @@ class TestTask:
                     "dag_name": "external_dag2",
                     "task_id": "external_task2",
                     "execution_delta": "15m",
+                    "poke_interval": "30m",
+                    "timeout": "8h",
                 },
             ],
         }
@@ -756,6 +758,8 @@ class TestTask:
         assert task.depends_on[1].dag_name == "external_dag2"
         assert task.depends_on[1].task_id == "external_task2"
         assert task.depends_on[1].execution_delta == "15m"
+        assert task.depends_on[1].poke_interval == "30m"
+        assert task.depends_on[1].timeout == "8h"
 
     def test_task_trigger_rule(self):
         query_file = (


### PR DESCRIPTION
## Description

For https://github.com/mozilla/private-bigquery-etl/pull/761

execution_delta doesn't support months so we can't exactly line up months with the current dag generation.  As a (hopefully temporary) workaround, we're going to try to set it to always 31 day execution delta and accept some delay for shorter months.  This means poke_interval and timeout need to be increased

## Related Tickets & Documents
* DENG-8776

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
