### PR TITLE
feat(DENG-8339): migrate stg_reviewed_corpus_items from snowflake

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Stg Reviewed Corpus Items v1
+description: Model reviewed Corpus Item events for the Fx New Tab from raw Snowplow data
+owners:
+  - skamath@mozilla.com
+  - rrando@mozilla.com
+labels:
+  schedule: daily
+  incremental: true
+  owner1: skamath
+  owner2: rrando
+scheduling:
+  dag_name: bqetl_content_ml_daily
+bigquery:
+  time_partitioning:
+    type: day
+    field: happened_at
+    require_partition_filter: true
+    expiration_days: 775
+  clustering:
+    fields:
+      - object_version
+      - approved_corpus_item_external_id
+      - object_update_trigger

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/query.sql
@@ -1,0 +1,89 @@
+WITH reviewed_events AS (
+    -- filter raw events down to just those that are review events
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.snowplow_external.events`
+  WHERE
+    event_name = 'object_update'
+    AND unstruct_event_com_pocket_object_update_1.object = 'reviewed_corpus_item'
+    AND app_id NOT LIKE '%-dev'
+    AND app_id LIKE 'pocket-%'
+    -- for all runs after inital, limit scope to entries from the current day
+    {% if not is_init() %}
+      AND DATE(derived_tstamp) = @submission_date
+    {% endif %}
+),
+deduped AS (
+    -- dedupe review events, preferring first event
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY event_id ORDER BY dvce_created_tstamp) AS n
+  FROM
+    reviewed_events
+)
+SELECT
+  event_id,
+  -- object update
+  unstruct_event_com_pocket_object_update_1.object AS object_update_object,
+  unstruct_event_com_pocket_object_update_1.trigger AS object_update_trigger,
+  -- reviewed_corpus_item info
+  contexts_com_pocket_reviewed_corpus_item_1[0].object_version AS object_version,
+  contexts_com_pocket_reviewed_corpus_item_1[
+    0
+  ].approved_corpus_item_external_id AS approved_corpus_item_external_id,
+  contexts_com_pocket_reviewed_corpus_item_1[
+    0
+  ].rejected_corpus_item_external_id AS rejected_corpus_item_external_id,
+  contexts_com_pocket_reviewed_corpus_item_1[0].prospect_id AS prospect_id,
+  contexts_com_pocket_reviewed_corpus_item_1[0].url AS url,
+  contexts_com_pocket_reviewed_corpus_item_1[0].loaded_from AS loaded_from,
+  contexts_com_pocket_reviewed_corpus_item_1[0].corpus_review_status AS corpus_review_status,
+  ARRAY_TO_STRING(
+    contexts_com_pocket_reviewed_corpus_item_1[0].rejection_reasons,
+    ","
+  ) AS rejection_reasons,
+  contexts_com_pocket_reviewed_corpus_item_1[0].action_screen AS action_ui_page,
+  contexts_com_pocket_reviewed_corpus_item_1[0].title AS title,
+  contexts_com_pocket_reviewed_corpus_item_1[0].excerpt AS excerpt,
+  contexts_com_pocket_reviewed_corpus_item_1[0].image_url AS image_url,
+  contexts_com_pocket_reviewed_corpus_item_1[0].language AS language,
+  contexts_com_pocket_reviewed_corpus_item_1[0].topic AS topic,
+  ARRAY_TO_STRING(contexts_com_pocket_reviewed_corpus_item_1[0].authors, ",") AS authors,
+  contexts_com_pocket_reviewed_corpus_item_1[0].publisher AS publisher,
+  contexts_com_pocket_reviewed_corpus_item_1[0].is_collection AS is_collection,
+  contexts_com_pocket_reviewed_corpus_item_1[0].is_syndicated AS is_syndicated,
+  contexts_com_pocket_reviewed_corpus_item_1[0].is_time_sensitive AS is_time_sensitive,
+  TIMESTAMP_SECONDS(
+    contexts_com_pocket_reviewed_corpus_item_1[0].created_at
+  ) AS reviewed_corpus_item_created_at,
+  contexts_com_pocket_reviewed_corpus_item_1[0].created_by AS curator_created_by,
+  TIMESTAMP_SECONDS(
+    contexts_com_pocket_reviewed_corpus_item_1[0].updated_at
+  ) AS reviewed_corpus_item_updated_at,
+  contexts_com_pocket_reviewed_corpus_item_1[0].updated_by AS curator_updated_by,
+  derived_tstamp AS happened_at,
+  geo_country,
+  geo_region,
+  geo_region_name,
+  geo_timezone,
+  app_id AS tracker_app_id,
+  useragent,
+  br_lang,
+  -- pass through any relevant contexts/entities
+  TO_JSON(
+    contexts_com_snowplowanalytics_snowplow_ua_parser_context_1
+  ) AS contexts_com_snowplowanalytics_snowplow_ua_parser_context_1,
+  TO_JSON(contexts_nl_basjes_yauaa_context_1) AS contexts_nl_basjes_yauaa_context_1,
+  TO_JSON(
+    contexts_com_iab_snowplow_spiders_and_robots_1
+  ) AS contexts_com_iab_snowplow_spiders_and_robots_1,
+  TO_JSON(contexts_com_pocket_api_user_1) AS contexts_com_pocket_api_user_1,
+  TO_JSON(unstruct_event_com_pocket_object_update_1) AS unstruct_event_com_pocket_object_update_1,
+  TO_BASE64(
+    SHA256(CONCAT(event_id, contexts_com_pocket_reviewed_corpus_item_1[0].object_version))
+  ) AS event_id_object_version_key
+FROM
+  deduped
+WHERE
+  n = 1

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/schema.yaml
@@ -1,0 +1,172 @@
+fields:
+  - mode: NULLABLE
+    type: STRING
+    name: action_ui_page
+    description: "
+      Indicates where in the Curation Tools UI the action took place Null if the action was
+      performed by a backend ML process"
+  - mode: NULLABLE
+    type: STRING
+    name: approved_corpus_item_external_id
+    description: "Backend identifier for reviewed_corpus_item's approved_corpus_item_external_id"
+  - mode: NULLABLE
+    type: STRING
+    name: authors
+    description: The list of authors of the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: br_lang
+    description: Language the user's browser/device is set to.
+  - mode: NULLABLE
+    type: JSON
+    name: contexts_com_iab_snowplow_spiders_and_robots_1
+    description: The curator who reviewed the prospect
+  - mode: NULLABLE
+    type: JSON
+    name: contexts_com_pocket_api_user_1
+    description: The custom Pocket api_user entity.
+  - mode: NULLABLE
+    type: JSON
+    name: contexts_com_snowplowanalytics_snowplow_ua_parser_context_1
+    description: "Snowplow's in-house user agent parsing enrichment."
+  - mode: NULLABLE
+    type: JSON
+    name: contexts_nl_basjes_yauaa_context_1
+    description: Snowplow's YAUAA user agent parsing enrichment.
+  - mode: NULLABLE
+    type: STRING
+    name: corpus_review_status
+    description: "The curator's decision on the item's validity for the curated corpus"
+  - mode: NULLABLE
+    type: STRING
+    name: curator_created_by
+    description: The curator who created the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: curator_updated_by
+    description: The curator who updated the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: event_id
+    description: A UUID for each event
+  - mode: NULLABLE
+    type: STRING
+    name: event_id_object_version_key
+    description: "
+      Unique key consisting of concatenated event ID & syndicated_article object version,
+      then hashed"
+  - mode: NULLABLE
+    type: STRING
+    name: geo_country
+    description: ISO 3166-1 code for the country the visitor is located in
+  - mode: NULLABLE
+    type: STRING
+    name: geo_region
+    description: ISO-3166-2 code for country region the visitor is in
+  - mode: NULLABLE
+    type: STRING
+    name: geo_region_name
+    description: Visitor region name
+  - mode: NULLABLE
+    type: STRING
+    name: geo_timezone
+    description: Visitor timezone name
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: happened_at
+    description: Timestamp making allowance for inaccurate device clock
+  - mode: NULLABLE
+    type: STRING
+    name: image_url
+    description: The url of the main image of the reviewed corpus item
+  - mode: NULLABLE
+    type: BOOLEAN
+    name: is_collection
+    description: Indicates whether the reviewed_corpus_item is a collection
+  - mode: NULLABLE
+    type: BOOLEAN
+    name: is_syndicated
+    description: Indicates whether the reviewed_corpus_item is a syndicated article
+  - mode: NULLABLE
+    type: BOOLEAN
+    name: is_time_sensitive
+    description: "
+      Indicates whether the reviewed_corpus_item is only relevant for a short period of time
+      (e.g. news)"
+  - mode: NULLABLE
+    type: STRING
+    name: language
+    description: The language of the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: loaded_from
+    description: "
+      Indicates the source for an approved corpus item PROSPECT: From a prospect feed MANUAL:
+      Manually added by curators ML: Added by an ML generated process BACKFILL: Backfilled from
+      legacy curation process"
+  - mode: NULLABLE
+    type: STRING
+    name: object_update_object
+    description: The name of the entity being updated. 'reviewed_corpus_item' for this model.
+  - mode: NULLABLE
+    type: STRING
+    name: object_update_trigger
+    description: The backend action taken that triggers the object update.
+  - mode: NULLABLE
+    type: STRING
+    name: object_version
+    description: "
+      Indication of whether the version of the entity is before or after the
+      modifications were made."
+  - mode: NULLABLE
+    type: STRING
+    name: prospect_id
+    description: "
+      The identifier for the curation prospect, used to join with the dataset that
+      describes the prospect"
+  - mode: NULLABLE
+    type: STRING
+    name: publisher
+    description: The name of the online publication that published this story.
+  - mode: NULLABLE
+    type: STRING
+    name: rejected_corpus_item_external_id
+    description: "Backend identifier for reviewed_corpus_item's rejected corpus item external_id"
+  - mode: NULLABLE
+    type: STRING
+    name: rejection_reasons
+    description: "
+      The list of reasons a curator rejected the item (if the item has a 'rejected'
+      corpus_review_status)"
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: reviewed_corpus_item_created_at
+    description: timestamp when the reviewed_corpus_item was created
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: reviewed_corpus_item_updated_at
+    description: timestamp when the reviewed_corpus_item was updated
+  - mode: NULLABLE
+    type: STRING
+    name: title
+    description: The title of the reviewed corpus item
+  - mode: NULLABLE
+    type: STRING
+    name: topic
+    description: The topic of the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: tracker_app_id
+    description: Snowplow Application ID for the app that emitted this event.
+  - mode: NULLABLE
+    type: JSON
+    name: unstruct_event_com_pocket_object_update_1
+    description: The custom Pocket object update entity.
+  - mode: NULLABLE
+    type: STRING
+    name: url
+    description: The url of the reviewed corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: useragent
+    description: Raw useragent


### PR DESCRIPTION
## Description

migrates the `stg_reviewed_corpus_items` snowflake table. does a bit of optimizing/refactoring of the original DBT model ([GitHub link](https://github.com/Pocket/dbt-snowflake/blob/e7880781e1c31a23e4afccabab008857edba2499/models/staging/curation/curation_base/stg_reviewed_corpus_items.sql#L4), requires Pocket org access), so i'd love a bit of comparison review if possible.

as a verification, i ran the model in this PR in BigQuery and the original DBT model in Snowflake against the same date range (`BETWEEN '2025-06-01' AND '2025-06-05'`) and got the exact same number of rows in each warehouse. 🎉 

## Related Tickets & Documents
* DENG-8339

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
