### PR TITLE
chore(DENG-8567): make remote settings syndicate dataset user-facing

### DIFF
--- a/sql/moz-fx-data-shared-prod/remote_settings_logs_aggregates/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/remote_settings_logs_aggregates/dataset_metadata.yaml
@@ -1,10 +1,10 @@
-friendly_name: remote_settings_logs_aggregates_syndicate
+friendly_name: remote_settings_logs_aggregates
 description: |
   This dataset contains Remote Settings CDN requests logs aggregates per endpoints
   and collections. It is derived from the load balancer logs using a BigQuery Transfer
   job that runs every day.
 dataset_base_acl: syndicate
-user_facing: false
+user_facing: true
 labels: {}
 syndication:
   stage:


### PR DESCRIPTION
We don't expect to need to create any derived tables from this so for simplicity we can make the whole dataset user facing (like https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/mdn_rumba/dataset_metadata.yaml#L4).

This will require operator input at deployment.