### PR TITLE
Update checks.sql

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_clients_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_clients_v1/checks.sql
@@ -1,5 +1,2 @@
 #fail
 {{ is_unique("ga_client_id") }}
-
-#fail
-#{{ min_row_count(1000000) }} #Removing temporarily until traffic is on


### PR DESCRIPTION
## Description

This PR removes the minimum rows count check on `moz-fx-data-shared-prod.firefoxdotcom_derived.ga_clients_v1` since the production traffic isn't going here yet so we don't have very many rows yet, so it'll keep alerting until we turn on prod traffic.  We'll re-enable this QA check once it goes live.

## Related Tickets & Documents
* [DENG-8688](https://mozilla-hub.atlassian.net/browse/DENG-8688)
**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8688]: https://mozilla-hub.atlassian.net/browse/DENG-8688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ