### PR TITLE
fix(SubPlat): Update `active_subscriptions_v1` ETL to account for "Privacy protection plan" bundle (DENG-8391)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/active_subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/active_subscriptions_v1/query.sql
@@ -23,6 +23,7 @@ WITH product_union AS (
   WHERE
     -- in order to avoid double counting, only include bundles via relay
     product_name NOT LIKE "%Relay%"
+    AND product_name != "Privacy protection plan"
 {%- endif %}
 {%- if not loop.last %}
   UNION ALL


### PR DESCRIPTION
## Description
To avoid double-counting bundle subscriptions.

## Related Tickets & Documents
* DENG-8391: Privacy Product Bundle

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
