### PR TITLE
chore(SubPlat): Unschedule Hubs subscriptions ETLs

### DIFF
--- a/sql/moz-fx-data-shared-prod/hubs_derived/active_subscription_ids_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/hubs_derived/active_subscription_ids_v1/metadata.yaml
@@ -7,7 +7,8 @@ labels:
   application: hubs
   schedule: daily
 scheduling:
-  dag_name: bqetl_subplat
+  # Mozilla ended support for Hubs on 2024-05-31.
+  #dag_name: bqetl_subplat
   # While this ETL doesn't depend on its own previous runs, other ETLs are built
   # on the assumption that this is built sequentially day-by-day with no gaps.
   depends_on_past: true

--- a/sql/moz-fx-data-shared-prod/hubs_derived/active_subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/hubs_derived/active_subscriptions_v1/metadata.yaml
@@ -7,7 +7,8 @@ labels:
   application: hubs
   schedule: daily
 scheduling:
-  dag_name: bqetl_subplat
+  # Mozilla ended support for Hubs on 2024-05-31.
+  #dag_name: bqetl_subplat
   # delay aggregates by 7 days, to ensure data is complete
   date_partition_offset: -7
   date_partition_parameter: date

--- a/sql/moz-fx-data-shared-prod/hubs_derived/subscription_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/hubs_derived/subscription_events_v1/metadata.yaml
@@ -7,7 +7,8 @@ labels:
   application: hubs
   schedule: daily
 scheduling:
-  dag_name: bqetl_subplat
+  # Mozilla ended support for Hubs on 2024-05-31.
+  #dag_name: bqetl_subplat
   # Delay aggregates by 8 days, to ensure data is complete. Upstream tables are
   # delayed 7 days, and this needs an additional day of delay for cancel events.
   date_partition_offset: -8

--- a/sql/moz-fx-data-shared-prod/hubs_derived/subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/hubs_derived/subscriptions_v1/metadata.yaml
@@ -7,7 +7,8 @@ labels:
   application: hubs
   schedule: daily
 scheduling:
-  dag_name: bqetl_subplat
+  # Mozilla ended support for Hubs on 2024-05-31.
+  #dag_name: bqetl_subplat
   # destination is the whole table, not a single partition,
   # so don't use date_partition_parameter
   date_partition_parameter: null


### PR DESCRIPTION
## Description
Mozilla ended support for Hubs on 2024-05-31.

## Related Tickets & Documents
N/A

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
