### PR TITLE
feat(DENG-8340): migrate stg_scheduled_corpus_items from snowflake

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Stg Scheduled Corpus Items v1
+description: Model scheduled Corpus Item events for the Fx New Tab from raw Snowplow data
+owners:
+  - skamath@mozilla.com
+  - rrando@mozilla.com
+labels:
+  schedule: daily
+  incremental: true
+  owner1: skamath
+  owner2: rrando
+scheduling:
+  dag_name: bqetl_content_ml_daily
+bigquery:
+  time_partitioning:
+    type: day
+    field: happened_at
+    require_partition_filter: true
+    expiration_days: 775
+  clustering:
+    fields:
+      - object_version
+      - approved_corpus_item_external_id
+      - object_update_trigger

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/query.sql
@@ -1,0 +1,93 @@
+WITH scheduled_events AS (
+    -- filter raw events down to just those that are schedule events
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.snowplow_external.events`
+  WHERE
+    event_name = 'object_update'
+    AND unstruct_event_com_pocket_object_update_1.object = 'scheduled_corpus_item'
+    AND app_id NOT LIKE '%-dev'
+    AND app_id LIKE 'pocket-%'
+    -- for all runs after inital, limit scope to entries from the current day
+    {% if not is_init() %}
+      AND DATE(derived_tstamp) = @submission_date
+    {% endif %}
+),
+deduped AS (
+    -- dedupe review events, preferring first event
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY event_id ORDER BY dvce_created_tstamp) AS n
+  FROM
+    scheduled_events
+)
+SELECT
+  event_id,
+  -- object update
+  unstruct_event_com_pocket_object_update_1.object AS object_update_object,
+  unstruct_event_com_pocket_object_update_1.trigger AS object_update_trigger,
+  -- scheduled_corpus_item info
+  contexts_com_pocket_scheduled_corpus_item_1[0].object_version AS object_version,
+  contexts_com_pocket_scheduled_corpus_item_1[
+    0
+  ].scheduled_corpus_item_external_id AS scheduled_corpus_item_external_id,
+  TIMESTAMP_SECONDS(
+    contexts_com_pocket_scheduled_corpus_item_1[0].scheduled_at
+  ) AS scheduled_corpus_item_scheduled_at,
+  contexts_com_pocket_scheduled_corpus_item_1[0].url AS url,
+  contexts_com_pocket_scheduled_corpus_item_1[
+    0
+  ].approved_corpus_item_external_id AS approved_corpus_item_external_id,
+  contexts_com_pocket_scheduled_corpus_item_1[0].scheduled_surface_id AS scheduled_surface_id,
+  contexts_com_pocket_scheduled_corpus_item_1[0].scheduled_surface_name AS scheduled_surface_name,
+  contexts_com_pocket_scheduled_corpus_item_1[
+    0
+  ].scheduled_surface_iana_timezone AS scheduled_surface_iana_timezone,
+  TIMESTAMP_SECONDS(
+    contexts_com_pocket_scheduled_corpus_item_1[0].created_at
+  ) AS scheduled_corpus_item_created_at,
+  contexts_com_pocket_scheduled_corpus_item_1[0].created_by AS curator_created_by,
+  TIMESTAMP_SECONDS(
+    contexts_com_pocket_scheduled_corpus_item_1[0].updated_at
+  ) AS scheduled_corpus_item_updated_at,
+  contexts_com_pocket_scheduled_corpus_item_1[0].updated_by AS curator_updated_by,
+  contexts_com_pocket_scheduled_corpus_item_1[0].generated_by AS schedule_generated_by,
+  contexts_com_pocket_scheduled_corpus_item_1[
+    0
+  ].original_scheduled_corpus_item_external_id AS original_scheduled_corpus_item_external_id,
+  contexts_com_pocket_scheduled_corpus_item_1[0].status AS scheduled_status,
+  ARRAY_TO_STRING(
+    contexts_com_pocket_scheduled_corpus_item_1[0].status_reasons,
+    ","
+  ) AS scheduled_status_reasons,
+  contexts_com_pocket_scheduled_corpus_item_1[
+    0
+  ].status_reason_comment AS scheduled_status_reason_comment,
+  contexts_com_pocket_scheduled_corpus_item_1[0].action_screen AS scheduled_action_ui_page,
+  -- event info
+  derived_tstamp AS happened_at,
+  geo_country,
+  geo_region,
+  geo_region_name,
+  geo_timezone,
+  app_id AS tracker_app_id,
+  useragent,
+  br_lang,
+    -- pass through any relevant contexts/entities
+  TO_JSON(
+    contexts_com_snowplowanalytics_snowplow_ua_parser_context_1
+  ) AS contexts_com_snowplowanalytics_snowplow_ua_parser_context_1,
+  TO_JSON(contexts_nl_basjes_yauaa_context_1) AS contexts_nl_basjes_yauaa_context_1,
+  TO_JSON(
+    contexts_com_iab_snowplow_spiders_and_robots_1
+  ) AS contexts_com_iab_snowplow_spiders_and_robots_1,
+  TO_JSON(contexts_com_pocket_api_user_1) AS contexts_com_pocket_api_user_1,
+  TO_JSON(unstruct_event_com_pocket_object_update_1) AS unstruct_event_com_pocket_object_update_1,
+  TO_BASE64(
+    SHA256(CONCAT(event_id, contexts_com_pocket_scheduled_corpus_item_1[0].object_version))
+  ) AS event_id_object_version_key
+FROM
+  deduped
+WHERE
+  n = 1

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/schema.yaml
@@ -1,18 +1,8 @@
 fields:
   - mode: NULLABLE
     type: STRING
-    name: action_ui_page
-    description: "
-      Indicates where in the Curation Tools UI the action took place Null if the action was
-      performed by a backend ML process"
-  - mode: NULLABLE
-    type: STRING
     name: approved_corpus_item_external_id
     description: "Backend identifier for reviewed_corpus_item's approved_corpus_item_external_id"
-  - mode: NULLABLE
-    type: STRING
-    name: authors
-    description: The list of authors of the reviewed_corpus_item
   - mode: NULLABLE
     type: STRING
     name: br_lang
@@ -35,16 +25,12 @@ fields:
     description: Snowplow's YAUAA user agent parsing enrichment.
   - mode: NULLABLE
     type: STRING
-    name: corpus_review_status
-    description: "The curator's decision on the item's validity for the curated corpus"
-  - mode: NULLABLE
-    type: STRING
     name: curator_created_by
-    description: The curator who created the reviewed_corpus_item
+    description: The curator who created the scheduled_corpus_item
   - mode: NULLABLE
     type: STRING
     name: curator_updated_by
-    description: The curator who updated the reviewed_corpus_item
+    description: The curator who updated the scheduled_corpus_item
   - mode: NULLABLE
     type: STRING
     name: event_id
@@ -77,37 +63,8 @@ fields:
     description: Timestamp making allowance for inaccurate device clock
   - mode: NULLABLE
     type: STRING
-    name: image_url
-    description: The url of the main image of the reviewed corpus item
-  - mode: NULLABLE
-    type: BOOLEAN
-    name: is_collection
-    description: Indicates whether the reviewed_corpus_item is a collection
-  - mode: NULLABLE
-    type: BOOLEAN
-    name: is_syndicated
-    description: Indicates whether the reviewed_corpus_item is a syndicated article
-  - mode: NULLABLE
-    type: BOOLEAN
-    name: is_time_sensitive
-    description: "
-      Indicates whether the reviewed_corpus_item is only relevant for a short period of time
-      (e.g. news)"
-  - mode: NULLABLE
-    type: STRING
-    name: language
-    description: The language of the reviewed_corpus_item
-  - mode: NULLABLE
-    type: STRING
-    name: loaded_from
-    description: "
-      Indicates the source for an approved corpus item PROSPECT: From a prospect feed MANUAL:
-      Manually added by curators ML: Added by an ML generated process BACKFILL: Backfilled from
-      legacy curation process"
-  - mode: NULLABLE
-    type: STRING
     name: object_update_object
-    description: The name of the entity being updated. 'reviewed_corpus_item' for this model.
+    description: The name of the entity being updated. 'scheduled_corpus_item' for this model.
   - mode: NULLABLE
     type: STRING
     name: object_update_trigger
@@ -120,40 +77,69 @@ fields:
       modifications were made."
   - mode: NULLABLE
     type: STRING
-    name: prospect_id
+    name: original_scheduled_corpus_item_external_id
     description: "
-      The identifier for the curation prospect, used to join with the dataset that
-      describes the prospect"
+      A guid that identifies the original schedule on which the curator action (removed or
+      rescheduled) took place"
   - mode: NULLABLE
     type: STRING
-    name: publisher
-    description: The name of the online publication that published this story.
-  - mode: NULLABLE
-    type: STRING
-    name: rejected_corpus_item_external_id
-    description: "Backend identifier for reviewed_corpus_item's rejected corpus item external_id"
-  - mode: NULLABLE
-    type: STRING
-    name: rejection_reasons
+    name: scheduled_action_ui_page
     description: "
-      The list of reasons a curator rejected the item (if the item has a 'rejected'
-      corpus_review_status)"
+      Indicates where in the Curation Tools UI the schedule action took place Null if the
+      action was performed by a backend ML process"
   - mode: NULLABLE
     type: TIMESTAMP
-    name: reviewed_corpus_item_created_at
-    description: timestamp when the reviewed_corpus_item was created
+    name: scheduled_corpus_item_created_at
+    description: timestamp when the scheduled_corpus_item was created
+  - mode: NULLABLE
+    type: STRING
+    name: scheduled_corpus_item_external_id
+    description: scheduled corpus item’s external_id
   - mode: NULLABLE
     type: TIMESTAMP
-    name: reviewed_corpus_item_updated_at
-    description: timestamp when the reviewed_corpus_item was updated
+    name: scheduled_corpus_item_scheduled_at
+    description: timestamp when the scheduled_corpus_item item is scheduled to run
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: scheduled_corpus_item_updated_at
+    description: timestamp when the scheduled_corpus_item was updated
   - mode: NULLABLE
     type: STRING
-    name: title
-    description: The title of the reviewed corpus item
+    name: scheduled_status
+    description: The status of the scheduled_corpus_item, as decided by a curator
   - mode: NULLABLE
     type: STRING
-    name: topic
-    description: The topic of the reviewed_corpus_item
+    name: scheduled_status_reasons
+    description: "
+      The list (array) of reasons why the curator set the current status for the
+      scheduled_corpus_item"
+  - mode: NULLABLE
+    type: STRING
+    name: scheduled_status_reason_comment
+    description: "
+      An optional text field for the curator to provide more information about a change in status"
+  - mode: NULLABLE
+    type: STRING
+    name: scheduled_surface_iana_timezone
+    description: The iana.org timezone of the scheduled surface.
+  - mode: NULLABLE
+    type: STRING
+    name: scheduled_surface_id
+    description: "
+      The curated rec destination where the corpus item is expected to appear (NEW_TAB_EN_INTL,
+      NEW_TAB_EN_US, NEW_TAB_DE_DE, NEW_TAB_EN_GB)"
+  - mode: NULLABLE
+    type: STRING
+    name: scheduled_surface_name
+    description: The name of the scheduled surface
+  - mode: NULLABLE
+    type: STRING
+    name: schedule_generated_by
+    description: "
+      The method by which this schedule was generated. Algorithmically generated by an ML
+      process (ML) or Manually created by curators (MANUAL) Note: Prior to ML generated
+      schedules, all schedules have been created by curators. Therefore, a null value could
+      be attributed with MANUAL"
   - mode: NULLABLE
     type: STRING
     name: tracker_app_id


### PR DESCRIPTION
## Description

migrates the `stg_scheduled_corpus_items` snowflake table. does a bit of optimizing/refactoring of the original DBT model ([GitHub link](https://github.com/Pocket/dbt-snowflake/blob/e7880781e1c31a23e4afccabab008857edba2499/models/staging/curation/curation_base/stg_scheduled_corpus_items.sql), requires Pocket org access).

just like in #7591, as a verification, i ran the model in this PR in BigQuery and the original DBT model in Snowflake against the same date range (`BETWEEN '2025-06-01' AND '2025-06-05'`) and got the exact same number of rows in each warehouse. 🎉 

## Related Tickets & Documents
* DENG-8340

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
