### PR TITLE
Switch mozilla_org.ga_desktop_conversions to point to latest, deprecate V1

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org/ga_desktop_conversions/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/ga_desktop_conversions/view.sql
@@ -4,4 +4,4 @@ AS
 SELECT
   *
 FROM
-  `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v1`
+  `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v2`

--- a/sql/moz-fx-data-shared-prod/mozilla_org/gclid_conversions/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/gclid_conversions/view.sql
@@ -2,30 +2,6 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.mozilla_org.gclid_conversions`
 AS
 SELECT
-  FORMAT_DATETIME("%F %T", DATETIME(activity_date, TIME(23, 59, 59))) AS activity_date,
-  gclid,
-  -- Names as represented in Google Ads
-  -- https://docs.google.com/spreadsheets/d/1YzhhvbpOlqPLORRJUZ55BIb0H20hwFqQFApR-r0UMfI
-  CASE
-    conversion_name
-    WHEN "did_firefox_first_run"
-      THEN "firefox_first_run"
-    WHEN "did_search"
-      THEN "firefox_first_search"
-    WHEN "did_click_ad"
-      THEN "firefox_first_ad_click"
-    WHEN "did_returned_second_day"
-      THEN "firefox_second_run"
-    ELSE NULL
-  END AS conversion_name,
+  *
 FROM
-  `moz-fx-data-shared-prod`.mozilla_org_derived.gclid_conversions_v1 UNPIVOT(
-    did_conversion FOR conversion_name IN (
-      did_firefox_first_run,
-      did_search,
-      did_click_ad,
-      did_returned_second_day
-    )
-  )
-WHERE
-  did_conversion
+  `moz-fx-data-shared-prod.mozilla_org_derived.gclid_conversions_v3`

--- a/sql/moz-fx-data-shared-prod/mozilla_org/gclid_conversions_v2/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/gclid_conversions_v2/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.mozilla_org.gclid_conversions_v2`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.mozilla_org_derived.gclid_conversions_v2`

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v1/metadata.yaml
@@ -30,4 +30,3 @@ workgroup_access:
   - workgroup:google-managed/external-ads-datafusion
   - workgroup:google-managed/external-ads-dataproc
 deprecated: true
-

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_desktop_conversions_v1/metadata.yaml
@@ -29,3 +29,5 @@ workgroup_access:
   - workgroup:dataops-managed/external-census
   - workgroup:google-managed/external-ads-datafusion
   - workgroup:google-managed/external-ads-dataproc
+deprecated: true
+

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/gclid_conversions_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/gclid_conversions_v2/metadata.yaml
@@ -26,3 +26,4 @@ references: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members: [workgroup:dataops-managed/external-census]
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/gclid_conversions_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/gclid_conversions_v2/metadata.yaml
@@ -26,4 +26,3 @@ references: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members: [workgroup:dataops-managed/external-census]
-deprecated: true


### PR DESCRIPTION
## Description

This PR does 3 things:
1.  It updates the view `moz-fx-data-shared-prod.mozilla_org.ga_desktop_conversions` to point at `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v2`, and deprecates `moz-fx-data-shared-prod.mozilla_org_derived.ga_desktop_conversions_v1`
2. It updates the view `moz-fx-data-shared-prod.mozilla_org.gclid_conversions` to point to the latest table `moz-fx-data-shared-prod.mozilla_org_derived.gclid_conversions_v3`.
3. It deletes the view `moz-fx-data-shared-prod.mozilla_org.gclid_conversions_v2`.

It also deprecates the V1 version of the table.


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
