### PR TITLE
Add windows_version to firefox_desktop.baseline_clients_daily view

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_daily.view.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily.view.sql
@@ -5,5 +5,12 @@ CREATE OR REPLACE VIEW
 AS
 SELECT
   *
+ {% if app_name == "firefox_desktop" %}
+, mozfun.norm.glean_windows_version_info(
+    normalized_os,
+    normalized_os_version,
+    windows_build_number
+  ) AS windows_version
+ {% endif %}
 FROM
   `{{ project_id }}.{{ daily_table }}`


### PR DESCRIPTION
## Description

This PR adds a new column, "windows_version", to the view:
- moz-fx-data-shared-prod.firefox_desktop.baseline_clients_daily

## Related Tickets & Documents
* [DENG-8847](https://mozilla-hub.atlassian.net/browse/DENG-8847)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
