### PR TITLE
feat(DENG-8134): migrate rejected_corpus_items snowflake table

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
@@ -25,3 +25,4 @@ bigquery:
       - language
       - topic
       - publisher
+      - prospect_review_status

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Rejected Corpus Items v1
+description: Model corpus item rejected events for the Fx New Tab from stg_reviewed_corpus_items_v1 and prospect_item_feed_v1 tables
+owners:
+  - skamath@mozilla.com
+  - rrando@mozilla.com
+labels:
+  schedule: daily
+  incremental: true
+  owner1: skamath
+  owner2: rrando
+scheduling:
+  dag_name: bqetl_content_ml_daily
+bigquery:
+  time_partitioning:
+    type: day
+    field: happened_at
+    require_partition_filter: true
+    expiration_days: 775
+  clustering:
+    # the fields below are guesses and will likely need to be updated based on ML
+    # access patterns
+    fields:
+      - scheduled_surface_id

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/query.sql
@@ -1,0 +1,53 @@
+SELECT
+  r.authors,
+  r.corpus_review_status,
+  r.curator_created_by,
+  r.curator_updated_by,
+  r.excerpt,
+  r.happened_at,
+  r.image_url,
+  r.is_collection,
+  r.is_syndicated,
+  r.is_time_sensitive,
+  r.language,
+  r.loaded_from,
+  p.predicted_topic,
+  p.expires_at AS prospect_expires_at,
+  p.flow AS prospect_flow,
+  r.prospect_id,
+  p.prospect_source,
+  r.publisher,
+  r.rejected_corpus_item_external_id,
+  r.action_ui_page AS rejection_action_ui_page,
+  r.rejection_reasons,
+  r.reviewed_corpus_item_created_at,
+  r.reviewed_corpus_item_updated_at,
+  p.scheduled_surface_id,
+  r.title,
+  r.topic,
+  r.url,
+FROM
+  `moz-fx-data-shared-prod.snowflake_migration_derived.stg_reviewed_corpus_items_v1` AS r
+LEFT JOIN
+  `moz-fx-data-shared-prod.snowflake_migration_derived.prospect_item_feed_v1` AS p
+  ON p.prospect_id = r.prospect_id
+WHERE
+  object_version = 'new' --only select the new version from each reviewed_corpus_item event
+  AND r.rejected_corpus_item_external_id IS NOT NULL
+  {% if is_init() %}
+    -- 2024-09-19 is the earliest date we have data from snowplow
+    AND DATE(r.happened_at) >= '2024-09-19'
+    AND DATE(p.happened_at) >= '2024-09-19'
+  {% else %}
+    -- @submission_date is the default name for the query param
+    -- automatically passed in when the job runs
+    AND DATE(r.happened_at) = @submission_date
+    AND DATE(p.happened_at) = @submission_date
+  {% endif %}
+QUALIFY
+  ROW_NUMBER() OVER (
+    PARTITION BY
+      r.rejected_corpus_item_external_id
+    ORDER BY
+      r.happened_at DESC
+  ) = 1

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/schema.yaml
@@ -1,0 +1,121 @@
+fields:
+  - mode: NULLABLE
+    type: STRING
+    name: authors
+    description: The list of authors of the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: corpus_review_status
+    description: "
+      The curator's decision on the item’s validity for the curated corpus (values are
+      'recommendation', 'corpus')."
+  - mode: NULLABLE
+    type: STRING
+    name: curator_created_by
+    description: The curator who created the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: curator_updated_by
+    description: The curator who updated the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: excerpt
+    description: The excerpt for the reviewed corpus item
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: happened_at
+    description: Timestamp making allowance for inaccurate device clock
+  - mode: NULLABLE
+    type: STRING
+    name: image_url
+    description: The url of the main image of the reviewed corpus item
+  - mode: NULLABLE
+    type: BOOLEAN
+    name: is_collection
+    description: Indicates whether the reviewed_corpus_item is a collection
+  - mode: NULLABLE
+    type: BOOLEAN
+    name: is_syndicated
+    description: Indicates whether the reviewed_corpus_item is a syndicated article
+  - mode: NULLABLE
+    type: BOOLEAN
+    name: is_time_sensitive
+    description: "
+      Indicates whether the reviewed_corpus_item is only relevant for a short period of time
+      (e.g. news)"
+  - mode: NULLABLE
+    type: STRING
+    name: language
+    description: The language of the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: loaded_from
+    description: "
+      Indicates the source for an approved corpus item PROSPECT: From a prospect feed MANUAL:
+      Manually added by curators"
+  - mode: NULLABLE
+    type: STRING
+    name: predicted_topic
+    description: Topic categorization based on content predictions (examples TECHNOLOGY, TRAVEL, SPORTS, BUSINESS, EDUCATION)
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: prospect_expires_at
+    description: The date at which this candidate set is no longer "fresh".
+  - mode: NULLABLE
+    type: STRING
+    name: prospect_flow
+    description: Name of the metaflow script generating this candidate set from dl-meatflow-jobs.
+  - mode: NULLABLE
+    type: STRING
+    name: prospect_id
+    description: The id of the item as a prospect (potential corporeal candidate)
+  - mode: NULLABLE
+    type: STRING
+    name: prospect_source
+    description: Source identified by the ML process for the prospect (SYNDICATED, ORGANIC_TIMESPENT, GLOBAL).
+  - mode: NULLABLE
+    type: STRING
+    name: publisher
+    description: The name of the online publication that published this story.
+  - mode: NULLABLE
+    type: STRING
+    name: rejected_corpus_item_external_id
+    description: Backend identifier for reviewed_corpus_item’s rejected corpus item external_id
+  - mode: NULLABLE
+    type: STRING
+    name: rejection_action_ui_page
+    description: "
+      Indicates where in the Curation Tools UI the action took place Null if the action was performed
+      by a backend ML process"
+  - mode: NULLABLE
+    type: STRING
+    name: rejection_reasons
+    description: "
+      The list of reasons a curator rejected the item (if the item has a “rejected”
+      corpus_review_status)"
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: reviewed_corpus_item_created_at
+    description: timestamp when the reviewed_corpus_item was created
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: reviewed_corpus_item_updated_at
+    description: timestamp when the reviewed_corpus_item was updated
+  - mode: NULLABLE
+    type: STRING
+    name: scheduled_surface_id
+    description: "
+      The curated rec destination where the corpus item is expected to appear (NEW_TAB_EN_INTL,
+      NEW_TAB_EN_US, NEW_TAB_DE_DE, NEW_TAB_EN_GB)."
+  - mode: NULLABLE
+    type: STRING
+    name: title
+    description: The title of the reviewed corpus item
+  - mode: NULLABLE
+    type: STRING
+    name: topic
+    description: The topic of the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: url
+    description: The url of the reviewed corpus_item


### PR DESCRIPTION
- add a new cluster field on the prospects_v1 table

## Description

migrate the `rejected_corpus_items` snowflake table.

## Related Tickets & Documents
* DENG-8134

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
