### PR TITLE
Run fenix events_daily and active_users_rollup_shredder with on-demand

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_rollup_shredder_v1/metadata.yaml
@@ -10,6 +10,9 @@ labels:
   owner2: dberry
 scheduling:
   dag_name: bqetl_shredder_impact_measurement
+  arguments: [
+    "--billing-project=moz-fx-data-backfill-4"
+  ]
 bigquery:
   time_partitioning:
     type: day

--- a/sql_generators/events_daily/templates/event_types_history_v1/metadata.yaml
+++ b/sql_generators/events_daily/templates/event_types_history_v1/metadata.yaml
@@ -6,7 +6,6 @@ description: >
   This table stores all of history, partitioned by
   submission_date.
 owners:
-  - wlachance@mozilla.com
   - akomar@mozilla.com
 labels:
   application: {{ dataset }}

--- a/sql_generators/events_daily/templates/event_types_v1/metadata.yaml
+++ b/sql_generators/events_daily/templates/event_types_v1/metadata.yaml
@@ -3,7 +3,6 @@ friendly_name: {{ name }} Event Types
 description: >
   A materialized view of the most recent day of event_types data
 owners:
-  - wlachance@mozilla.com
   - akomar@mozilla.com
 labels:
   application: {{ dataset }}

--- a/sql_generators/events_daily/templates/events_daily_v1/metadata.yaml
+++ b/sql_generators/events_daily/templates/events_daily_v1/metadata.yaml
@@ -3,7 +3,6 @@ friendly_name: '{{ name }} Events Daily'
 description: >
   Packed event representation with one-row per-client
 owners:
-  - wlachance@mozilla.com
   - akomar@mozilla.com
 labels:
   application: {{ dataset }}
@@ -12,6 +11,11 @@ labels:
   table_type: client_level
 scheduling:
   dag_name: {{ dag_name }}
+  {%- if dataset == "fenix" %}
+  arguments: [
+    "--billing-project=moz-fx-data-backfill-4"
+  ]
+  {%- endif %}
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description

This queries use a lot of slots so running with on-demand is cheaper https://sql.telemetry.mozilla.org/queries/107355

cc @akkomar and @kwindau as owners but there shouldn't be any noticeable changes

Also cleaned up owners in events_daily

## Related Tickets & Documents
* DENG-8859, DENG-8862, and the associated epic

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
