### PR TITLE
chore(GLAM): Extract _new from fog hist and scalar aggregates

### DIFF
--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -227,11 +227,25 @@ def main():
             **dict(app_id_channel=(f"'{channel_prefixes[args.prefix]}'")),
         ),
         init(
+            "clients_scalar_aggregates_new_v1",
+            **models.clients_scalar_aggregates_new(
+                destination_table=(
+                    f"glam_etl.{args.prefix}__clients_scalar_aggregates_new_v1"
+                ),
+            ),
+        ),
+        table(
+            "clients_scalar_aggregates_new_v1",
+            **models.clients_scalar_aggregates_new(
+                destination_table=(
+                    f"glam_etl.{args.prefix}__clients_scalar_aggregates_new_v1"
+                ),
+                **config[args.prefix],
+            ),
+        ),
+        init(
             "clients_scalar_aggregates_v1",
             **models.clients_scalar_aggregates(
-                source_table=(
-                    f"glam_etl.{args.prefix}__view_clients_daily_scalar_aggregates_v1"
-                ),
                 destination_table=(
                     f"glam_etl.{args.prefix}__clients_scalar_aggregates_v1"
                 ),
@@ -240,13 +254,20 @@ def main():
         table(
             "clients_scalar_aggregates_v1",
             **models.clients_scalar_aggregates(
-                source_table=(
-                    f"glam_etl.{args.prefix}__view_clients_daily_scalar_aggregates_v1"
-                ),
                 destination_table=(
                     f"glam_etl.{args.prefix}__clients_scalar_aggregates_v1"
                 ),
                 **config[args.prefix],
+            ),
+        ),
+        init(
+            "clients_histogram_aggregates_new_v1",
+            **models.clients_histogram_aggregates_new(parameterize=True),
+        ),
+        table(
+            "clients_histogram_aggregates_new_v1",
+            **models.clients_histogram_aggregates_new(
+                parameterize=True, **config[args.prefix]
             ),
         ),
         init(

--- a/bigquery_etl/glam/models.py
+++ b/bigquery_etl/glam/models.py
@@ -3,6 +3,41 @@
 from .utils import compute_datacube_groupings, get_custom_distribution_metadata
 
 
+def clients_scalar_aggregates_new(**kwargs):
+    """Variables for clients scalar aggregation."""
+    attributes_list = [
+        "client_id",
+        "ping_type",
+        "os",
+        "app_version",
+        "app_build_id",
+        "channel",
+    ]
+    attributes_type_list = ["STRING", "STRING", "STRING", "INT64", "STRING", "STRING"]
+    user_data_attributes_list = ["metric", "metric_type", "key"]
+    return dict(
+        attributes=",".join(attributes_list),
+        attributes_list=attributes_list,
+        attributes_type=",".join(
+            f"{name} {dtype}"
+            for name, dtype in zip(attributes_list, attributes_type_list)
+        ),
+        user_data_attributes=",".join(user_data_attributes_list),
+        user_data_type="""
+            ARRAY<
+                STRUCT<
+                metric STRING,
+                metric_type STRING,
+                key STRING,
+                agg_type STRING,
+                value FLOAT64
+                >
+            >
+        """,
+        **kwargs,
+    )
+
+
 def clients_scalar_aggregates(**kwargs):
     """Variables for clients scalar aggregation."""
     attributes_list = [
@@ -33,6 +68,30 @@ def clients_scalar_aggregates(**kwargs):
                 value FLOAT64
                 >
             >
+        """,
+        **kwargs,
+    )
+
+
+def clients_histogram_aggregates_new(**kwargs):
+    """Variables for histogram aggregates new."""
+    attributes_list = [
+        "sample_id",
+        "client_id",
+        "ping_type",
+        "os",
+        "app_version",
+        "app_build_id",
+        "channel",
+    ]
+    return dict(
+        attributes_list=attributes_list,
+        attributes=",".join(attributes_list),
+        metric_attributes="""
+            metric,
+            metric_type,
+            key,
+            agg_type
         """,
         **kwargs,
     )

--- a/bigquery_etl/glam/templates/clients_histogram_aggregates_new_v1.init.sql
+++ b/bigquery_etl/glam/templates/clients_histogram_aggregates_new_v1.init.sql
@@ -1,0 +1,26 @@
+{{ header }}
+CREATE TABLE IF NOT EXISTS
+  `{{ project }}.glam_etl.{{ prefix }}__clients_histogram_aggregates_new_v1`(
+    sample_id INT64,
+    client_id STRING,
+    ping_type STRING,
+    os STRING,
+    app_version INT64,
+    app_build_id STRING,
+    channel STRING,
+    histogram_aggregates ARRAY<
+      STRUCT<
+        metric STRING,
+        metric_type STRING,
+        key STRING,
+        agg_type STRING,
+        value ARRAY<STRUCT<key STRING, value INT64>>
+      >
+    >
+  )
+PARTITION BY
+  RANGE_BUCKET(sample_id, GENERATE_ARRAY(0, 100, 1))
+CLUSTER BY
+  app_version,
+  channel,
+  client_id

--- a/bigquery_etl/glam/templates/clients_histogram_aggregates_new_v1.sql
+++ b/bigquery_etl/glam/templates/clients_histogram_aggregates_new_v1.sql
@@ -1,0 +1,69 @@
+{% set aggregate_filter_clause %}
+{% if filter_version %}
+  LEFT JOIN
+    glam_etl.{{ prefix }}__latest_versions_v1
+    USING (channel)
+{% endif %}
+WHERE
+      -- allow for builds to be slighly ahead of the current submission date, to
+      -- account for a reasonable amount of clock skew
+  {{ build_date_udf }}(app_build_id) < DATE_ADD(@submission_date, INTERVAL 3 day)
+      -- only keep builds from the last year
+  AND {{ build_date_udf }}(app_build_id) > DATE_SUB(@submission_date, INTERVAL 365 day)
+  {% if filter_version %}
+    AND app_version
+    BETWEEN (latest_version - {{ num_versions_to_keep }} +1)
+    AND latest_version
+  {% endif %}
+  {% endset %}
+WITH extracted_daily AS (
+  SELECT
+    * EXCEPT (app_version, histogram_aggregates),
+    CAST(app_version AS INT64) AS app_version,
+    unnested_histogram_aggregates AS histogram_aggregates
+  FROM
+    glam_etl.{{ prefix }}__view_clients_daily_histogram_aggregates_v1,
+    UNNEST(histogram_aggregates) unnested_histogram_aggregates
+  WHERE
+    {% if parameterize %}
+      submission_date = @submission_date
+    {% else %}
+      submission_date = DATE_SUB(current_date, INTERVAL 2 day)
+    {% endif %}
+    AND value IS NOT NULL
+    AND ARRAY_LENGTH(value) > 0
+),
+filtered_daily AS (
+  SELECT
+    {{ attributes }},
+    histogram_aggregates.*
+  FROM
+    extracted_daily {{ aggregate_filter_clause }}
+),
+-- re-aggregate based on the latest version
+aggregated_daily AS (
+  SELECT
+    {{ attributes }},
+    {{ metric_attributes }},
+    mozfun.map.sum(ARRAY_CONCAT_AGG(mozfun.glam.histogram_filter_high_values(value))) AS value
+  FROM
+    filtered_daily
+  GROUP BY
+    {{ attributes }},
+    {{ metric_attributes }}
+)
+SELECT
+  {{ attributes }},
+  ARRAY_AGG(
+    STRUCT<
+      metric STRING,
+      metric_type STRING,
+      key STRING,
+      agg_type STRING,
+      aggregates ARRAY<STRUCT<key STRING, value INT64>>
+    >({{ metric_attributes }}, value)
+  ) AS histogram_aggregates
+FROM
+  aggregated_daily
+GROUP BY
+  {{ attributes }}

--- a/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
@@ -1,97 +1,45 @@
-{{ header }}
-{% include "clients_histogram_aggregates_v1.udf.sql" %}
-
+{{ header }} {% include "clients_histogram_aggregates_v1.udf.sql" %}
 {% set aggregate_filter_clause %}
-  {% if filter_version %}
+{% if filter_version %}
   LEFT JOIN
-      glam_etl.{{ prefix }}__latest_versions_v1
-      USING (channel)
-  {% endif %}
-  WHERE
+    glam_etl.{{ prefix }} __latest_versions_v1
+    USING (channel)
+{% endif %}
+WHERE
       -- allow for builds to be slighly ahead of the current submission date, to
       -- account for a reasonable amount of clock skew
-      {{ build_date_udf }}(app_build_id) < DATE_ADD(@submission_date, INTERVAL 3 day)
+  {{ build_date_udf }}(app_build_id) < DATE_ADD(@submission_date, INTERVAL 3 day)
       -- only keep builds from the last year
-      AND {{ build_date_udf }}(app_build_id) > DATE_SUB(@submission_date, INTERVAL 365 day)
-      {% if filter_version %}
-      AND app_version BETWEEN (latest_version - {{ num_versions_to_keep }} + 1) AND latest_version
-      {% endif %}
-{% endset %}
-
+  AND {{ build_date_udf }}(app_build_id) > DATE_SUB(@submission_date, INTERVAL 365 day)
+  {% if filter_version %}
+    AND app_version
+    BETWEEN (latest_version - {{ num_versions_to_keep }} +1)
+    AND latest_version
+  {% endif %}
+  {% endset %}
 WITH extracted_accumulated AS (
   SELECT
     *
   FROM
-    glam_etl.{{ prefix }}__clients_histogram_aggregates_v1
-  {% if parameterize %}
-  WHERE
-    sample_id >= @min_sample_id
-    AND sample_id <= @max_sample_id
-  {% endif %}
+    glam_etl.{{ prefix }} __clients_histogram_aggregates_v1
+    {% if parameterize %}
+      WHERE
+        sample_id >= @min_sample_id
+        AND sample_id <= @max_sample_id
+    {% endif %}
 ),
 filtered_accumulated AS (
   SELECT
     {{ attributes }},
     histogram_aggregates
   FROM
-    extracted_accumulated
-  {{ aggregate_filter_clause }}
+    extracted_accumulated {{ aggregate_filter_clause }}
 ),
--- unnest the daily data
-extracted_daily AS (
-  SELECT
-    * EXCEPT (app_version, histogram_aggregates),
-    CAST(app_version AS INT64) AS app_version,
-    unnested_histogram_aggregates as histogram_aggregates
-  FROM
-    glam_etl.{{ prefix }}__view_clients_daily_histogram_aggregates_v1,
-    UNNEST(histogram_aggregates) unnested_histogram_aggregates
-  WHERE
-    {% if parameterize %}
-      submission_date = @submission_date
-    {% else %}
-      submission_date = DATE_SUB(current_date, interval 2 day)
-    {% endif %}
-    AND value IS NOT NULL
-    AND ARRAY_LENGTH(value) > 0
-),
-filtered_daily AS (
-  SELECT
-    {{ attributes }},
-    histogram_aggregates.*
-  FROM
-    extracted_daily
-  {{ aggregate_filter_clause }}
-),
--- re-aggregate based on the latest version
-aggregated_daily AS (
-  SELECT
-    {{ attributes }},
-    {{ metric_attributes }},
-    mozfun.map.sum(ARRAY_CONCAT_AGG(mozfun.glam.histogram_filter_high_values(value))) AS value
-  FROM
-    filtered_daily
-  GROUP BY
-    {{ attributes }},
-    {{ metric_attributes }}
-),
--- note: this seems costly, if it's just going to be unnested again
 transformed_daily AS (
   SELECT
-    {{ attributes }},
-    ARRAY_AGG(
-      STRUCT<
-        metric STRING,
-        metric_type STRING,
-        key STRING,
-        agg_type STRING,
-        aggregates ARRAY<STRUCT<key STRING, value INT64>>
-      >({{ metric_attributes }}, value)
-    ) AS histogram_aggregates
+    *
   FROM
-    aggregated_daily
-  GROUP BY
-    {{ attributes }}
+    glam_etl.{{ prefix }} __clients_histogram_aggregates_new_v1
 )
 SELECT
   {% for attribute in attributes_list %}

--- a/bigquery_etl/glam/templates/clients_scalar_aggregates_new_v1.init.sql
+++ b/bigquery_etl/glam/templates/clients_scalar_aggregates_new_v1.init.sql
@@ -1,0 +1,12 @@
+{{ header }}
+CREATE TABLE IF NOT EXISTS
+  `{{ project }}.{{ destination_table }}`(
+    {{ attributes_type }},
+    scalar_aggregates {{ user_data_type }}
+  )
+PARTITION BY
+  RANGE_BUCKET(app_version, GENERATE_ARRAY(0, 200, 1))
+CLUSTER BY
+  app_version,
+  channel,
+  client_id

--- a/bigquery_etl/glam/templates/clients_scalar_aggregates_new_v1.sql
+++ b/bigquery_etl/glam/templates/clients_scalar_aggregates_new_v1.sql
@@ -1,0 +1,88 @@
+{% set aggregate_filter_clause %}
+{% if filter_version %}
+  LEFT JOIN
+    glam_etl.{{ prefix }}__latest_versions_v1
+    USING (channel)
+{% endif %}
+WHERE
+      -- allow for builds to be slighly ahead of the current submission date, to
+      -- account for a reasonable amount of clock skew
+  {{ build_date_udf }}(app_build_id) < DATE_ADD(@submission_date, INTERVAL 3 day)
+      -- only keep builds from the last year
+  AND {{ build_date_udf }}(app_build_id) > DATE_SUB(@submission_date, INTERVAL 365 day)
+  {% if filter_version %}
+    AND app_version
+    BETWEEN (latest_version - {{ num_versions_to_keep }} +1)
+    AND latest_version
+  {% endif %}
+  {% endset %}
+WITH filtered_date_channel AS (
+  SELECT
+    *
+  FROM
+    glam_etl.{{prefix}}__clients_scalar_aggregates_new_v1
+  WHERE
+    submission_date = @submission_date
+),
+filtered_aggregates AS (
+  SELECT
+    submission_date,
+    {{ attributes }},
+    {{ user_data_attributes }},
+    agg_type,
+    value
+  FROM
+    filtered_date_channel
+  CROSS JOIN
+    UNNEST(scalar_aggregates)
+  WHERE
+    value IS NOT NULL
+),
+version_filtered_new AS (
+  SELECT
+    submission_date,
+    {% for attribute in attributes_list %}
+      scalar_aggs.{{ attribute }},
+    {% endfor %}
+    {{ user_data_attributes }},
+    agg_type,
+    value
+  FROM
+    filtered_aggregates AS scalar_aggs {{ aggregate_filter_clause }}
+),
+scalar_aggregates_new AS (
+  SELECT
+    {{ attributes }},
+    {{ user_data_attributes }},
+    agg_type,
+    --format:off
+    CASE agg_type
+      WHEN 'max' THEN max(value)
+      WHEN 'min' THEN min(value)
+      WHEN 'count' THEN sum(value)
+      WHEN 'sum' THEN sum(value)
+      WHEN 'false' THEN sum(value)
+      WHEN 'true' THEN sum(value)
+    END AS value
+    --format:on
+  FROM
+    version_filtered_new
+  WHERE
+    -- avoid overflows from very large numbers that are typically anomalies
+    -- Negative values are incorrect and should not happen but were observed,
+    -- probably due to some bit flips.
+    value
+    BETWEEN 0
+    AND POW(2, 40)
+  GROUP BY
+    {{ attributes }},
+    {{ user_data_attributes }},
+    agg_type
+)
+SELECT
+  {{ attributes }},
+  ARRAY_AGG(({{ user_data_attributes }}, agg_type, value)) AS scalar_aggregates
+FROM
+  scalar_aggregates_new
+GROUP BY
+  {{ attributes }}

--- a/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_scalar_aggregates_v1.sql
@@ -18,77 +18,11 @@
       {% endif %}
 {% endset %}
 
-WITH filtered_date_channel AS (
+WITH filtered_new AS (
   SELECT
     *
   FROM
-    {{ source_table }}
-  WHERE
-    submission_date = @submission_date
-),
-filtered_aggregates AS (
-  SELECT
-    submission_date,
-    {{ attributes }},
-    {{ user_data_attributes }},
-    agg_type,
-    value
-  FROM
-    filtered_date_channel
-  CROSS JOIN
-    UNNEST(scalar_aggregates)
-  WHERE
-    value IS NOT NULL
-),
-version_filtered_new AS (
-  SELECT
-    submission_date,
-    {% for attribute in attributes_list %}
-      scalar_aggs.{{ attribute }},
-    {% endfor %}
-    {{ user_data_attributes }},
-    agg_type,
-    value
-  FROM
-    filtered_aggregates AS scalar_aggs
-  {{ aggregate_filter_clause }}
-),
-scalar_aggregates_new AS (
-  SELECT
-    {{ attributes }},
-    {{ user_data_attributes }},
-    agg_type,
-    --format:off
-    CASE agg_type
-      WHEN 'max' THEN max(value)
-      WHEN 'min' THEN min(value)
-      WHEN 'count' THEN sum(value)
-      WHEN 'sum' THEN sum(value)
-      WHEN 'false' THEN sum(value)
-      WHEN 'true' THEN sum(value)
-    END AS value
-    --format:on
-  FROM
-    version_filtered_new
-  WHERE
-    -- avoid overflows from very large numbers that are typically anomalies
-    -- Negative values are incorrect and should not happen but were observed,
-    -- probably due to some bit flips.
-    value BETWEEN 0 AND POW(2, 40)
-  GROUP BY
-    {{ attributes }},
-    {{ user_data_attributes }},
-    agg_type
-),
-filtered_new AS (
-  SELECT
-    {{ attributes }},
-    ARRAY_AGG(({{ user_data_attributes }}, agg_type, value)) AS scalar_aggregates
-  FROM
-    scalar_aggregates_new
-  GROUP BY
-    {{ attributes }}
-
+    glam_etl.{{prefix}}__clients_scalar_aggregates_new_v1
 ),
 filtered_old AS (
   SELECT


### PR DESCRIPTION
## Description

This PR creates `clients_scalar_aggregates_new_v1` and `clients_histogram_aggregates_new_v1` for the `glam_fog` and `glam_fenix` DAGs. The two tasks are extracted from `clients_scalar_aggregates_v1` and `clients_histogram_aggregates_v1` respectively. The intention behind this is to reduce resource contention on both DAGs. so if this refactor isn't enough I will add processing by samples on top of it.

## Related Tickets & Documents
* DENG-8798


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
