### PR TITLE
fix: Correct `ExternalTaskMarker.execution_date` values when `depends_on` specifies an `execution_delta`

### DIFF
--- a/bigquery_etl/query_scheduling/dag_collection.py
+++ b/bigquery_etl/query_scheduling/dag_collection.py
@@ -11,6 +11,7 @@ import yaml
 from black import FileMode, format_file_contents
 
 from bigquery_etl.query_scheduling.dag import Dag, InvalidDag, PublicDataJsonDag
+from bigquery_etl.query_scheduling.utils import negate_timedelta_string
 
 
 class DagCollection:
@@ -147,8 +148,14 @@ class DagCollection:
                     for upstream_dependency in (
                         _task.depends_on + _task.upstream_dependencies
                     ):
+                        execution_delta = None
+                        if upstream_dependency.execution_delta:
+                            # Make the execution delta relative to the upstream dependency.
+                            execution_delta = negate_timedelta_string(
+                                upstream_dependency.execution_delta
+                            )
                         downstream_dependencies[upstream_dependency.task_key].append(
-                            _task.to_ref(self)
+                            _task.to_ref(self, execution_delta=execution_delta)
                         )
             self._downstream_dependencies = downstream_dependencies
 

--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -654,12 +654,13 @@ class Task:
 
         return task
 
-    def to_ref(self, dag_collection):
+    def to_ref(self, dag_collection, execution_delta=None):
         """Return the task as `TaskRef`."""
         return TaskRef(
             dag_name=self.dag_name,
             task_id=self.task_name,
             date_partition_offset=self.date_partition_offset,
+            execution_delta=execution_delta,
             schedule_interval=dag_collection.dag_by_name(
                 self.dag_name
             ).schedule_interval,

--- a/bigquery_etl/query_scheduling/utils.py
+++ b/bigquery_etl/query_scheduling/utils.py
@@ -26,6 +26,11 @@ def validate_timedelta_string(s):
         )
 
 
+def negate_timedelta_string(s: str) -> str:
+    """Negate the provided timedelta string."""
+    return s[1:] if s.startswith("-") else ("-" + s)
+
+
 def is_date_string(s):
     """Check whether a string is a valid date string formatted like YYYY-MM-DD."""
     try:


### PR DESCRIPTION
## Description
The existing DAG generation logic isn't taking `execution_delta` settings from `depends_on` metadata into account when generating `ExternalTaskMarker`s, so they have incorrect `execution_date` values in such cases (which I noticed while examining [a `sql.diff` for #7582](https://github.com/mozilla/bigquery-etl/pull/7582#issuecomment-2960439539)).

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/7582

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
