### PR TITLE
fix(SubPlat): Remove schema update option from `recent_fxa_gcp_*_events` ETLs (DENG-3736)

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/recent_fxa_gcp_stderr_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/recent_fxa_gcp_stderr_events_v1/metadata.yaml
@@ -12,8 +12,6 @@ scheduling:
   dag_name: bqetl_subplat_hourly
   # The whole table is overwritten every time, not a specific date partition.
   date_partition_parameter: null
-  arguments:
-  - --schema_update_option=ALLOW_FIELD_ADDITION
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/recent_fxa_gcp_stdout_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/recent_fxa_gcp_stdout_events_v1/metadata.yaml
@@ -12,8 +12,6 @@ scheduling:
   dag_name: bqetl_subplat_hourly
   # The whole table is overwritten every time, not a specific date partition.
   date_partition_parameter: null
-  arguments:
-  - --schema_update_option=ALLOW_FIELD_ADDITION
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description
I just added these hourly ETLs in #7582, but BigQuery doesn't like the `ALLOW_FIELD_ADDITION` schema update option being specified when overwriting the entire table, so the ETLs are failing.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/7582
* DENG-3736: Increase frequency for product/subplat data updates

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
