### PR TITLE
fix(prospects_v1): reduce clustering fileds to max allowed (4)

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
@@ -25,4 +25,3 @@ bigquery:
       - language
       - topic
       - publisher
-      - prospect_review_status


### PR DESCRIPTION
## Description

removes recently added 5th clustering field on `moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1` table (max number of clustering fields is 5).

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
