### PR TITLE
fix(snowflake models): fix join filtering bug causing missing data

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/query.sql
@@ -31,18 +31,24 @@ FROM
 LEFT JOIN
   `moz-fx-data-shared-prod.snowflake_migration_derived.prospect_item_feed_v1` AS p
   ON p.prospect_id = r.prospect_id
+  {% if is_init() %}
+    -- 2024-09-19 is the earliest date we have data from snowplow
+    AND DATE(p.happened_at) >= '2024-09-19'
+  {% else %}
+    -- @submission_date is the default name for the query param
+    -- automatically passed in when the job runs
+    AND DATE(p.happened_at) = @submission_date
+  {% endif %}
 WHERE
   object_version = 'new' --only select the new version from each reviewed_corpus_item event
   AND r.rejected_corpus_item_external_id IS NOT NULL
   {% if is_init() %}
     -- 2024-09-19 is the earliest date we have data from snowplow
     AND DATE(r.happened_at) >= '2024-09-19'
-    AND DATE(p.happened_at) >= '2024-09-19'
   {% else %}
     -- @submission_date is the default name for the query param
     -- automatically passed in when the job runs
     AND DATE(r.happened_at) = @submission_date
-    AND DATE(p.happened_at) = @submission_date
   {% endif %}
 QUALIFY
   ROW_NUMBER() OVER (


### PR DESCRIPTION
## Description

fixes bugs in the joins on these two models. doing the date filtering in the `WHERE` clause was causing the `LEFT JOIN` to act like an `INNER JOIN`, resulting in missing rows. the following models are fixed here:

- corpus_items_updated_v1
- rejected_corpus_items_v1

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
