### PR TITLE
backfill two snowflake models in their entirety:

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_updated_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_updated_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2025-06-11:
+  start_date: 2024-09-19
+  end_date: 2025-06-10
+  reason: Original model had a bug in the JOIN, resulting in missing rows
+  watchers:
+    - jpetto@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2025-06-11:
+  start_date: 2024-09-19
+  end_date: 2025-06-10
+  reason: Original model had a bug in the JOIN, resulting in missing rows
+  watchers:
+    - jpetto@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false


### PR DESCRIPTION
 ## Description

backfill two migrated snowflake models in their entirety (due to a bug in the original sql):

- corpus_items_updated_v1
- rejected_corpus_items_v1

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
