### PR TITLE
Add slack username details to backfill watchers doc

### DIFF
--- a/bigquery_etl/backfill/parse.py
+++ b/bigquery_etl/backfill/parse.py
@@ -68,6 +68,8 @@ class Backfill:
     end_date: date = attr.ib()
     excluded_dates: List[date] = attr.ib()
     reason: str = attr.ib()
+    # watchers are expected to be emails with the name matching
+    # the username listed at https://mozilla.slack.com/account/settings#username
     watchers: List[str] = attr.ib()
     status: BackfillStatus = attr.ib()
     custom_query_path: Optional[str] = attr.ib(None)

--- a/docs/cookbooks/creating_a_derived_dataset.md
+++ b/docs/cookbooks/creating_a_derived_dataset.md
@@ -280,6 +280,9 @@ For our example:
 
 2. Fill out the missing details:
   - Watchers: Mozilla Emails for users that should be notified via Slack about backfill progress.
+    - Note that the email name should match the username listed here: https://mozilla.slack.com/account/settings#username.
+      If it doesn't, put the username with `@mozilla.com` instead (an email won't be sent there).
+      e.g. if your username is `abcdef`, set the watcher to `abcdef@mozilla.com`
   - Reason: Why are you backfilling this table?
 
 3. Open a Pull Request with the backfill entry, see [this example](https://github.com/mozilla/bigquery-etl/pull/5369). Once merged, you should receive a notification in around an hour that processing has started. Your backfill data will be temporarily placed in a staging location.


### PR DESCRIPTION
## Description

Adding some details on how the slack username lookup works for managed backfills.  This is somewhat unclear so I want to document this somewhere.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
