### PR TITLE
 [DENG-8843] Retain dataEditor workgroup_access and map metadataViewer permissions on deprecated tables

### DIFF
--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -93,7 +93,16 @@ def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None
         if table_metadata.deprecated:
             # set workgroup: [] if table has been tagged as deprecated
             # this overwrites existing workgroups
-            table_metadata.workgroup_access = []
+            if table_metadata.workgroup_access is not None:
+                table_metadata.workgroup_access = [
+                    table_workgroup_access
+                    for table_workgroup_access in table_metadata.workgroup_access
+                    if table_workgroup_access.role in retained_dataset_roles
+                ]
+
+            else:
+                table_metadata.workgroup_access = []
+
             table_metadata_updated = True
             dataset_metadata.workgroup_access = [
                 workgroup

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -218,7 +218,7 @@ class TestMetadata:
                 str(tmpdirname)
                 + "/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/"
             ]
-            r = runner.invoke(update, name, "--sql_dir=" + str(tmpdirname) + "/sql")
+            runner.invoke(update, name, "--sql_dir=" + str(tmpdirname) + "/sql")
             with open(
                 tmpdirname
                 + "/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml",
@@ -244,7 +244,11 @@ class TestMetadata:
             {
                 "members": ["workgroup:mozilla-test"],
                 "role": "roles/bigquery.dataEditor",
-            }
+            },
+            {
+                "members": ["workgroup:mozilla-confidential"],
+                "role": "roles/bigquery.metadataViewer",
+            },
         ]
         assert dataset_metadata["default_table_workgroup_access"] == [
             {

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -218,7 +218,7 @@ class TestMetadata:
                 str(tmpdirname)
                 + "/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/"
             ]
-            runner.invoke(update, name, "--sql_dir=" + str(tmpdirname) + "/sql")
+            r = runner.invoke(update, name, "--sql_dir=" + str(tmpdirname) + "/sql")
             with open(
                 tmpdirname
                 + "/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml",
@@ -233,7 +233,12 @@ class TestMetadata:
             ) as stream:
                 dataset_metadata = yaml.safe_load(stream)
 
-        assert metadata["workgroup_access"] == []
+        assert metadata["workgroup_access"] == [
+            {
+                "members": ["workgroup:mozilla-foo"],
+                "role": "roles/bigquery.dataEditor",
+            }
+        ]
         assert metadata["deprecated"]
         assert dataset_metadata["workgroup_access"] == [
             {

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
@@ -7,3 +7,10 @@ deprecated: true
 monitoring:
   enabled: true
 deletion_date: 2024-03-02
+workgroup_access:
+- role: roles/bigquery.metadataViewer
+  members:
+  - workgroup:mozilla-foo
+- role: roles/bigquery.dataEditor
+  members:
+  - workgroup:mozilla-foo

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
@@ -8,9 +8,9 @@ monitoring:
   enabled: true
 deletion_date: 2024-03-02
 workgroup_access:
-- role: roles/bigquery.metadataViewer
-  members:
-  - workgroup:mozilla-foo
-- role: roles/bigquery.dataEditor
-  members:
-  - workgroup:mozilla-foo
+  - role: roles/bigquery.metadataViewer
+    members:
+    - workgroup:mozilla-foo
+  - role: roles/bigquery.dataEditor
+    members:
+    - workgroup:mozilla-foo

--- a/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/metadata.yaml
@@ -10,7 +10,7 @@ deletion_date: 2024-03-02
 workgroup_access:
   - role: roles/bigquery.metadataViewer
     members:
-    - workgroup:mozilla-foo
+      - workgroup:mozilla-foo
   - role: roles/bigquery.dataEditor
     members:
-    - workgroup:mozilla-foo
+      - workgroup:mozilla-foo


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DENG-8843

This updates the metadata generation logic for `workgroup_access`. This will only remove `roles/bigquery.dataViewer` access on table metadata while keeping `roles/bigquery.dataEditor` intact.
This will also translate `roles/bigquery.dataViewer` to dataset-level `roles/bigquery.metadataViewer` if there is a deprecated table in the dataset.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
