### PR TITLE
fix(SubPlat): Remove partitioning from ETLs where the whole table is getting overwritten every hour (DENG-3736)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_history_v1/metadata.yaml
@@ -25,13 +25,10 @@ scheduling:
   - ['moz-fx-data-shared-prod', 'subscription_platform_derived', 'recent_subplat_attribution_impressions_v1']
   - ['moz-fx-data-shared-prod', 'subscription_platform_derived', 'stripe_logical_subscriptions_history_v1']
 bigquery:
-  time_partitioning:
-    type: day
-    field: valid_to
-    require_partition_filter: false
-    expiration_days: null
+  time_partitioning: null
   clustering:
     fields:
+    - valid_to
     - valid_from
 references: {}
 require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_history_v1/metadata.yaml
@@ -19,13 +19,10 @@ scheduling:
   # The whole table is overwritten every time, not a specific date partition.
   date_partition_parameter: null
 bigquery:
-  time_partitioning:
-    type: day
-    field: valid_to
-    require_partition_filter: false
-    expiration_days: null
+  time_partitioning: null
   clustering:
     fields:
+    - valid_to
     - valid_from
 references: {}
 require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_history_v1/metadata.yaml
@@ -18,13 +18,10 @@ scheduling:
   # The whole table is overwritten every time, not a specific date partition.
   date_partition_parameter: null
 bigquery:
-  time_partitioning:
-    type: day
-    field: valid_to
-    require_partition_filter: false
-    expiration_days: null
+  time_partitioning: null
   clustering:
     fields:
+    - valid_to
     - valid_from
 references: {}
 require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/metadata.yaml
@@ -22,13 +22,10 @@ scheduling:
   # The whole table is overwritten every time, not a specific date partition.
   date_partition_parameter: null
 bigquery:
-  time_partitioning:
-    type: day
-    field: valid_to
-    require_partition_filter: false
-    expiration_days: null
+  time_partitioning: null
   clustering:
     fields:
+    - valid_to
     - valid_from
 references: {}
 require_column_descriptions: true


### PR DESCRIPTION
## Description
Now that the these ETLs run hourly (#7582), overwriting the entire table hourly will hit BigQuery's limit of 30k table partition modifications per day.

## Related Tickets & Documents
* DENG-3736: Increase frequency for product/subplat data updates
* https://github.com/mozilla/bigquery-etl/pull/7582

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
