### PR TITLE
feat(DENG-8869): Add column to desktop_retention_clients

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_clients_v1/metadata.yaml
@@ -18,6 +18,7 @@ bigquery:
   range_partitioning: null
   clustering:
     fields:
+    - sample_id
     - country
     - normalized_os
 references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_clients_v1/schema.yaml
@@ -133,3 +133,7 @@ fields:
   name: retained_week_4_new_profile
   type: BOOLEAN
   description: Retained Week 4 New Profile
+- mode: NULLABLE
+  name: legacy_telemetry_client_id
+  type: STRING
+  description: Legacy Telemetry Client Identifier


### PR DESCRIPTION
## Description

This PR adds the new column `legacy_telemetry_client_id` to the table and corresponding view:
- `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_retention_clients_v1`
- `moz-fx-data-shared-prod.firefox_desktop.desktop_retention_clients`

## Related Tickets & Documents
* [DENG-8869](https://mozilla-hub.atlassian.net/browse/DENG-8869)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8869]: https://mozilla-hub.atlassian.net/browse/DENG-8869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ