### PR TITLE
feat(DENG-8136): migrate dismissed_prospects snowflake table

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Dismissed Prospects v1
+description: Model dismissed prospects for the Fx New Tab from prospects_v1, corpus_items_updated_v1, and rejected_corpus_items_v1 tables
+owners:
+  - skamath@mozilla.com
+  - rrando@mozilla.com
+labels:
+  schedule: daily
+  incremental: true
+  owner1: skamath
+  owner2: rrando
+scheduling:
+  dag_name: bqetl_content_ml_daily
+bigquery:
+  time_partitioning:
+    type: day
+    field: happened_at
+    require_partition_filter: true
+    expiration_days: 775
+  clustering:
+    fields:
+      - scheduled_surface_id
+      - reviewed_at
+      - url

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/query.sql
@@ -1,0 +1,49 @@
+SELECT
+  p.authors,
+  p.created_at,
+  p.domain,
+  p.excerpt,
+  p.happened_at,
+  p.image_url,
+  p.is_collection,
+  p.is_syndicated,
+  p.language,
+  p.prospect_id,
+  p.prospect_review_status,
+  p.prospect_source,
+  p.publisher,
+  p.reviewed_at,
+  p.reviewed_by,
+  p.scheduled_surface_id,
+  p.status_reason_comment,
+  p.status_reasons,
+  p.title,
+  p.topic,
+  p.url
+FROM
+  `moz-fx-data-shared-prod.snowflake_migration_derived.prospects_v1` p
+LEFT JOIN
+  `moz-fx-data-shared-prod.snowflake_migration_derived.corpus_items_updated_v1` AS c
+  ON c.prospect_id = p.prospect_id
+  {% if is_init() %}
+    AND DATE(c.happened_at) >= '2024-09-19'
+  {% else %}
+    AND DATE(c.happened_at) = @submission_date
+  {% endif %}
+LEFT JOIN
+  `moz-fx-data-shared-prod.snowflake_migration_derived.rejected_corpus_items_v1` AS r
+  ON r.prospect_id = p.prospect_id
+  {% if is_init() %}
+    AND DATE(r.happened_at) >= '2024-09-19'
+  {% else %}
+    AND DATE(r.happened_at) = @submission_date
+  {% endif %}
+WHERE
+  p.prospect_review_status = 'dismissed'
+  {% if is_init() %}
+    AND DATE(p.happened_at) >= '2024-09-19'
+  {% else %}
+    AND DATE(p.happened_at) = @submission_date
+  {% endif %}
+  AND c.approved_corpus_item_external_id IS NULL
+  AND r.rejected_corpus_item_external_id IS NULL

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/schema.yaml
@@ -1,0 +1,90 @@
+fields:
+  - mode: NULLABLE
+    type: STRING
+    name: authors
+    description: The list of authors of the reviewed_corpus_item
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: created_at
+    description: timestamp when the prospect was first created
+  - mode: NULLABLE
+    type: STRING
+    name: domain
+  - mode: NULLABLE
+    type: STRING
+    name: excerpt
+    description: The excerpt for the reviewed corpus item
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: happened_at
+    description: Timestamp making allowance for inaccurate device clock
+  - mode: NULLABLE
+    type: STRING
+    name: image_url
+    description: The url of the main image of the reviewed corpus item
+  - mode: NULLABLE
+    type: BOOLEAN
+    name: is_collection
+    description: Indicates whether the reviewed_corpus_item is a collection
+  - mode: NULLABLE
+    type: BOOLEAN
+    name: is_syndicated
+    description: Indicates whether the reviewed_corpus_item is a syndicated article
+  - mode: NULLABLE
+    type: STRING
+    name: language
+    description: The language of the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: prospect_id
+    description: Unique identifier for prospects
+  - mode: NULLABLE
+    type: STRING
+    name: prospect_review_status
+    description: The curator's review status for the prospect
+  - mode: NULLABLE
+    type: STRING
+    name: prospect_source
+    description:
+      Source identified by the ML process for the prospect (SYNDICATED, ORGANIC_TIMESPENT,
+      GLOBAL).
+  - mode: NULLABLE
+    type: STRING
+    name: publisher
+    description: The name of the online publication that published this story.
+  - mode: NULLABLE
+    type: TIMESTAMP
+    name: reviewed_at
+    description:
+      timestamp when the prospect was reviewed by the curator. It is also
+      the timestamp that caused this event action
+  - mode: NULLABLE
+    type: STRING
+    name: reviewed_by
+    description: The curator who reviewed the prospect
+  - mode: NULLABLE
+    type: STRING
+    name: scheduled_surface_id
+    description:
+      Recommended destination where the prospect item is expected to appear
+      (NEW_TAB_EN_INTL, NEW_TAB_EN_US, NEW_TAB_DE_DE, NEW_TAB_EN_GB).
+  - mode: NULLABLE
+    type: STRING
+    name: status_reasons
+    description: The list of curator review status reasons
+  - mode: NULLABLE
+    type: STRING
+    name: status_reason_comment
+    description: Curator review status reason comment
+  - mode: NULLABLE
+    type: STRING
+    name: title
+    description: The title of the reviewed corpus item
+  - mode: NULLABLE
+    type: STRING
+    name: topic
+    description: The topic of the reviewed_corpus_item
+  - mode: NULLABLE
+    type: STRING
+    name: url
+    description: The url of the prospects item


### PR DESCRIPTION
## Description

migrate `dismissed_prospects` snowflake table. verified row number parity between snowflake and bigquery for sample data range of `2025-06-01` to `2025-06-11`.

## Related Tickets & Documents
* DENG-8136

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
