### PR TITLE
Add lifecycle_stage to OKR client level views

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_engagement_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_engagement_clients/view.sql
@@ -2,6 +2,17 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_desktop.desktop_engagement_clients`
 AS
 SELECT
-  *
+  *,
+  CASE
+    WHEN first_seen_date = submission_date
+      THEN 'new_profile'
+    WHEN DATE_DIFF(submission_date, first_seen_date, DAY)
+      BETWEEN 1
+      AND 27
+      THEN 'repeat_user'
+    WHEN DATE_DIFF(submission_date, first_seen_date, DAY) >= 28
+      THEN 'existing_user'
+    ELSE 'Unknown'
+  END AS lifecycle_stage
 FROM
   `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_engagement_clients_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_retention_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/desktop_retention_clients/view.sql
@@ -2,6 +2,17 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_desktop.desktop_retention_clients`
 AS
 SELECT
-  *
+  *,
+  CASE
+    WHEN first_seen_date = metric_date
+      THEN 'new_profile'
+    WHEN DATE_DIFF(metric_date, first_seen_date, DAY)
+      BETWEEN 1
+      AND 27
+      THEN 'repeat_user'
+    WHEN DATE_DIFF(metric_date, first_seen_date, DAY) >= 28
+      THEN 'existing_user'
+    ELSE 'Unknown'
+  END AS lifecycle_stage
 FROM
   `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_retention_clients_v1`


### PR DESCRIPTION
## Description

This PR adds the new column `lifecycle_stage` to the 2 views:
- `moz-fx-data-shared-prod.firefox_desktop.desktop_retention_clients`
- `moz-fx-data-shared-prod.firefox_desktop.desktop_engagement_clients`


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
