### PR TITLE
feat(DENG-8870 + DENG-8887): Add 2 columns to desktop_engagement_clients

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_clients_v1/metadata.yaml
@@ -18,6 +18,7 @@ bigquery:
   range_partitioning: null
   clustering:
     fields:
+    - sample_id
     - country
     - normalized_os
 references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_clients_v1/query.sql
@@ -29,7 +29,16 @@ SELECT
   aud.is_desktop,
   aud.is_dau,
   aud.is_wau,
-  aud.is_mau
+  aud.is_mau,
+  COALESCE(
+    cls.legacy_telemetry_client_id,
+    cfs.legacy_telemetry_client_id
+  ) AS legacy_telemetry_client_id,
+  mozfun.norm.glean_windows_version_info(
+    cls.normalized_os,
+    cls.normalized_os_version,
+    cls.windows_build_number
+  ) AS windows_version
 FROM
   `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_last_seen` cls
 LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_clients_v1/schema.yaml
@@ -99,3 +99,11 @@ fields:
   type: BOOLEAN
   mode: NULLABLE
   description: Flag indicating client qualifies as a "Monthly Active User" on this submission date
+- name: legacy_telemetry_client_id
+  type: STRING
+  mode: NULLABLE
+  description: Legacy Telemetry Client Identifier
+- name: windows_version
+  type: STRING
+  mode: NULLABLE
+  description: Windows Version


### PR DESCRIPTION
## Description

This PR adds 2 new columns, `legacy_telemetry_client_id` & `windows_version` to:
- `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_engagement_clients_v1`
- `moz-fx-data-shared-prod.firefox_desktop.desktop_engagement_clients`

This also adds clustering first by Glean sample_id.

## Related Tickets & Documents
* [DENG-8870](https://mozilla-hub.atlassian.net/browse/DENG-8870)
* [DENG-8887](https://mozilla-hub.atlassian.net/browse/DENG-8887)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8870]: https://mozilla-hub.atlassian.net/browse/DENG-8870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-8887]: https://mozilla-hub.atlassian.net/browse/DENG-8887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ