### PR TITLE
feat(DENG-8889): increase snowflake migration DAG frequency to hourly

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2295,8 +2295,8 @@ bqetl_content_ml_hourly:
     Hourly extracts for corpus item data to be evaluated for new tab presentation.
   default_args:
     owner: skamath@mozilla.com
-    # manually started in Airflow on 2025-05-26
-    start_date: "2025-05-26"
+    # Converted to an hourly DAG on 2025-06-24
+    start_date: "2025-06-24"
     email: ["skamath@mozilla.com", "rrando@mozilla.com"]
     # if the hourly task fails, retry once after a 10 minute wait
     retries: 1

--- a/dags.yaml
+++ b/dags.yaml
@@ -2289,17 +2289,18 @@ bqetl_monitoring_hourly:
     - impact/tier_1
     - repo/bigquery-etl
 
-bqetl_content_ml_daily:
-  schedule_interval: 0 4 * * *
+bqetl_content_ml_hourly:
+  schedule_interval: 30 * * * *
   description: |
-    Daily extracts for corpus item data to be evaluated for new tab presentation.
+    Hourly extracts for corpus item data to be evaluated for new tab presentation.
   default_args:
     owner: skamath@mozilla.com
     # manually started in Airflow on 2025-05-26
     start_date: "2025-05-26"
     email: ["skamath@mozilla.com", "rrando@mozilla.com"]
-    retries: 2
-    retry_delay: 30m
+    # if the hourly task fails, retry once after a 10 minute wait
+    retries: 1
+    retry_delay: 10m
   tags:
     - impact/tier_2
 

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/metadata.yaml
@@ -4,12 +4,12 @@ owners:
   - skamath@mozilla.com
   - rrando@mozilla.com
 labels:
-  schedule: daily
+  schedule: hourly
   incremental: true
   owner1: skamath
   owner2: rrando
 scheduling:
-  dag_name: bqetl_content_ml_daily
+  dag_name: bqetl_content_ml_hourly
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_updated_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_updated_v1/metadata.yaml
@@ -4,12 +4,12 @@ owners:
   - skamath@mozilla.com
   - rrando@mozilla.com
 labels:
-  schedule: daily
+  schedule: hourly
   incremental: true
   owner1: skamath
   owner2: rrando
 scheduling:
-  dag_name: bqetl_content_ml_daily
+  dag_name: bqetl_content_ml_hourly
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/metadata.yaml
@@ -4,12 +4,12 @@ owners:
   - skamath@mozilla.com
   - rrando@mozilla.com
 labels:
-  schedule: daily
+  schedule: hourly
   incremental: true
   owner1: skamath
   owner2: rrando
 scheduling:
-  dag_name: bqetl_content_ml_daily
+  dag_name: bqetl_content_ml_hourly
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/metadata.yaml
@@ -4,12 +4,12 @@ owners:
   - skamath@mozilla.com
   - rrando@mozilla.com
 labels:
-  schedule: daily
+  schedule: hourly
   incremental: true
   owner1: skamath
   owner2: rrando
 scheduling:
-  dag_name: bqetl_content_ml_daily
+  dag_name: bqetl_content_ml_hourly
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
@@ -4,12 +4,12 @@ owners:
   - skamath@mozilla.com
   - rrando@mozilla.com
 labels:
-  schedule: daily
+  schedule: hourly
   incremental: true
   owner1: skamath
   owner2: rrando
 scheduling:
-  dag_name: bqetl_content_ml_daily
+  dag_name: bqetl_content_ml_hourly
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/metadata.yaml
@@ -4,12 +4,12 @@ owners:
   - skamath@mozilla.com
   - rrando@mozilla.com
 labels:
-  schedule: daily
+  schedule: hourly
   incremental: true
   owner1: skamath
   owner2: rrando
 scheduling:
-  dag_name: bqetl_content_ml_daily
+  dag_name: bqetl_content_ml_hourly
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/scheduled_articles_report_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/scheduled_articles_report_v1/metadata.yaml
@@ -4,12 +4,12 @@ owners:
   - skamath@mozilla.com
   - rrando@mozilla.com
 labels:
-  schedule: daily
+  schedule: hourly
   incremental: false
   owner1: skamath
   owner2: rrando
 scheduling:
-  dag_name: bqetl_content_ml_daily
+  dag_name: bqetl_content_ml_hourly
   date_partition_parameter: null
 bigquery:
   clustering:

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/metadata.yaml
@@ -4,12 +4,12 @@ owners:
   - skamath@mozilla.com
   - rrando@mozilla.com
 labels:
-  schedule: daily
+  schedule: hourly
   incremental: true
   owner1: skamath
   owner2: rrando
 scheduling:
-  dag_name: bqetl_content_ml_daily
+  dag_name: bqetl_content_ml_hourly
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/metadata.yaml
@@ -4,12 +4,12 @@ owners:
   - skamath@mozilla.com
   - rrando@mozilla.com
 labels:
-  schedule: daily
+  schedule: hourly
   incremental: true
   owner1: skamath
   owner2: rrando
 scheduling:
-  dag_name: bqetl_content_ml_daily
+  dag_name: bqetl_content_ml_hourly
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description

increases frequency to every hour for DAG that updates models migrated from snowflake. this matches the frequency that was running in DBT.

## Related Tickets & Documents
* DENG-8889

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
