### PR TITLE
fix(CI): Update DAG generation so ETL dependencies in the `private-bigquery-etl` repo are detected (DENG-8292)

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -773,7 +773,8 @@ jobs:
             - *restore_venv_cache
             - *build
             - *authenticate
-            - add_ssh_keys:
+            - &add_private_bigquery_etl_ssh_keys
+              add_ssh_keys:
                 # deploy key to private-bigquery-etl
                 fingerprints:
                   - "9d:1e:af:52:78:2c:e8:ec:33:4c:db:cd:5a:ff:70:0a"
@@ -790,7 +791,6 @@ jobs:
                                 git@github.com:mozilla/private-bigquery-etl.git \
                                 ~/private-bigquery-etl
                   rsync --archive ~/private-bigquery-etl/sql/ sql/
-                  rsync --archive ~/private-bigquery-etl/dags.yaml dags.yaml
             - run:
                 name: Generate SQL content
                 no_output_timeout: 30m
@@ -810,7 +810,35 @@ jobs:
                     /tmp/workspace/private-generated-sql/sql/
                   PATH="venv/bin:$PATH" script/bqetl format /tmp/workspace/private-generated-sql/sql/
                   PATH="venv/bin:$PATH" script/bqetl monitoring update /tmp/workspace/private-generated-sql/sql/
-
+            - persist_to_workspace:
+                root: /tmp/workspace
+                paths:
+                  - private-generated-sql
+      - unless:
+          condition: *deploy
+          steps:
+            - *skip
+  private-generate-dags:
+    docker: *docker
+    steps:
+      - when:
+          condition: *deploy
+          steps:
+            - *skip_forked_pr
+            - checkout
+            - *restore_venv_cache
+            - *build
+            - *authenticate
+            - *add_private_bigquery_etl_ssh_keys
+            - run:
+                name: Pull down private-bigquery-etl content
+                command: |
+                  ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+                  git clone --branch main --depth 1 \
+                    git@github.com:mozilla/private-bigquery-etl.git ~/private-bigquery-etl
+            - run:
+                name: Generate DAGs
+                command: |
                   # Change directory to generate DAGs so `sql_file_path` values are relative to the repo root.
                   export PATH="$PWD/venv/bin:$PATH"
                   export PYTHONPATH="$PWD:$PYTHONPATH"
@@ -834,9 +862,7 @@ jobs:
           condition: *deploy
           steps:
             - *attach_generated_sql
-            - add_ssh_keys:
-                fingerprints:
-                  - "9d:1e:af:52:78:2c:e8:ec:33:4c:db:cd:5a:ff:70:0a"
+            - *add_private_bigquery_etl_ssh_keys
             - run:
                 name: Push to private-generated-sql branch
                 # yamllint disable rule:line-length
@@ -1198,9 +1224,15 @@ workflows:
             branches:
               only:
                 - main
+      - private-generate-dags:
+          filters:
+            branches:
+              only:
+                - main
       - push-private-generated-sql:
           requires:
             - private-generate-sql
+            - private-generate-dags
           filters:
             branches:
               only:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -791,6 +791,7 @@ jobs:
                                 git@github.com:mozilla/private-bigquery-etl.git \
                                 ~/private-bigquery-etl
                   rsync --archive ~/private-bigquery-etl/sql/ sql/
+                  rsync --archive ~/private-bigquery-etl/sql_generators/ sql_generators/
             - run:
                 name: Generate SQL content
                 no_output_timeout: 30m
@@ -844,6 +845,10 @@ jobs:
                   export PYTHONPATH="$PWD:$PYTHONPATH"
                   bqetl_script="$PWD/script/bqetl"
                   cd ~/private-bigquery-etl
+
+                  rm -rf sql/
+                  cp -r /tmp/workspace/private-generated-sql/sql sql
+
                   mkdir -p /tmp/workspace/private-generated-sql/dags
                   $bqetl_script dag generate \
                     --output-dir /tmp/workspace/private-generated-sql/dags/
@@ -1225,6 +1230,8 @@ workflows:
               only:
                 - main
       - private-generate-dags:
+          requires:
+            - private-generate-sql
           filters:
             branches:
               only:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -342,13 +342,29 @@ jobs:
             - *restore_venv_cache
             - *build
             - *attach_generated_sql
-            - *copy_generated_sql
             - *authenticate
+            - &add_private_bigquery_etl_ssh_keys
+              add_ssh_keys:
+                # deploy key to private-bigquery-etl
+                fingerprints:
+                  - "9d:1e:af:52:78:2c:e8:ec:33:4c:db:cd:5a:ff:70:0a"
+            - run:
+                name: Pull down private-bigquery-etl content
+                command: |
+                  ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+                  git clone --branch main --depth 1 \
+                    git@github.com:mozilla/private-bigquery-etl.git ~/private-bigquery-etl
             - run:
                 name: Generate DAGs
                 command: |
+                  rm -rf sql/
+                  cp -r /tmp/workspace/private-generated-sql/sql sql
+
+                  cat ~/private-bigquery-etl/dags.yaml | grep -v '^---$' >> dags.yaml
+
                   mkdir -p /tmp/workspace/generated-sql/dags
                   PATH="venv/bin:$PATH" script/bqetl dag generate --output-dir=/tmp/workspace/generated-sql/dags
+                  rm -f /tmp/workspace/generated-sql/dags/private_bqetl_*.py
             # this task is overwriting the content produced by generate-sql;
             # the behaviour here is additive, generated DAGs are just added to
             # the generated-sql output
@@ -766,18 +782,14 @@ jobs:
     resource_class: large
     steps:
       - when:
-          condition: *deploy
+          condition: *validate-sql
           steps:
             - *skip_forked_pr
             - checkout
             - *restore_venv_cache
             - *build
             - *authenticate
-            - &add_private_bigquery_etl_ssh_keys
-              add_ssh_keys:
-                # deploy key to private-bigquery-etl
-                fingerprints:
-                  - "9d:1e:af:52:78:2c:e8:ec:33:4c:db:cd:5a:ff:70:0a"
+            - *add_private_bigquery_etl_ssh_keys
             - run:
                 name: Install rsync
                 command: |
@@ -816,7 +828,7 @@ jobs:
                 paths:
                   - private-generated-sql
       - unless:
-          condition: *deploy
+          condition: *validate-sql
           steps:
             - *skip
   private-generate-dags:
@@ -1191,6 +1203,7 @@ workflows:
       - generate-dags:
           requires:
             - generate-sql
+            - private-generate-sql
       - docs:
           requires:
             - generate-sql
@@ -1224,11 +1237,7 @@ workflows:
       # from the internal repository and pushing generated results back to
       # a branch on that internal repository, which may be initially
       # surprising.
-      - private-generate-sql:
-          filters:
-            branches:
-              only:
-                - main
+      - private-generate-sql
       - private-generate-dags:
           requires:
             - private-generate-sql


### PR DESCRIPTION
## Description
So dependencies from the `private-bigquery-etl` repo don't have to be manually defined via `depends_on` or `external_downstream_tasks` metadata anymore.

This is a counterpart to https://github.com/mozilla/private-bigquery-etl/pull/794.

## Related Tickets & Documents
* DENG-8292: DAG dependencies between bigquery-etl and private-bigquery-etl tables not correctly detected
* https://github.com/mozilla/private-bigquery-etl/pull/794

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
