### PR TITLE
feat(DENG-8888): Add windows_version to desktop_engagement_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/query.sql
@@ -14,6 +14,7 @@ SELECT
   normalized_channel,
   normalized_os,
   normalized_os_version,
+  windows_version,
   country,
   is_desktop,
   COUNTIF(is_dau) AS dau,
@@ -39,5 +40,6 @@ GROUP BY
   normalized_channel,
   normalized_os,
   normalized_os_version,
+  windows_version,
   country,
   is_desktop

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_engagement_aggregates_v1/schema.yaml
@@ -60,6 +60,10 @@ fields:
   type: STRING
   description: Normalized Operating System Version
 - mode: NULLABLE
+  name: windows_version
+  type: STRING
+  description: Windows Version
+- mode: NULLABLE
   name: country
   type: STRING
   description: Country


### PR DESCRIPTION
## Description

This PR adds the new column `windows_version` to the table and corresponding view:
- `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_engagement_aggregates_v1`
- `moz-fx-data-shared-prod.firefox_desktop.desktop_engagement_aggregates`

## Related Tickets & Documents
* [DENG-8888](https://mozilla-hub.atlassian.net/browse/DENG-8888)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8888]: https://mozilla-hub.atlassian.net/browse/DENG-8888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ