### PR TITLE
fix(DENG-8907): improve performance of ETL for prospects_v1 snowflake…

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
@@ -10,9 +10,6 @@ labels:
   owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_daily
-  # destination is the whole table, not a single partition,
-  # so don't use date_partition_parameter
-  date_partition_parameter: null
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/query.sql
@@ -37,7 +37,7 @@ WITH stg_prospects AS (
       AND DATE(derived_tstamp) = @submission_date
     {% endif %}
   QUALIFY
-    ROW_NUMBER() OVER (PARTITION BY happened_at ORDER BY happened_at) = 1
+    ROW_NUMBER() OVER (PARTITION BY event_id ORDER BY dvce_created_tstamp) = 1
 )
 SELECT
   p.prospect_id,

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/query.sql
@@ -33,6 +33,9 @@ WITH stg_prospects AS (
   WHERE
     event_name = 'object_update'
     AND unstruct_event_com_pocket_object_update_1.object = 'prospect'
+    {% if not is_init() %}
+      AND DATE(derived_tstamp) = @submission_date
+    {% endif %}
   QUALIFY
     ROW_NUMBER() OVER (PARTITION BY happened_at ORDER BY happened_at) = 1
 )


### PR DESCRIPTION
## Description

improve performance of ETL for prospects_v1 snowflake table.

- adds date filtering on base query so as to not rebuild the entire table on every run

## Related Tickets & Documents
* DENG-8907

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
