### PR TITLE
Skip generating event monitoring for sync pings

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -353,7 +353,7 @@ generate:
       - topsites-impression # access denied
       - serp-categorization # access denied
       - background-update # table doesn't exist
-      - sync # got removed
+      - sync # Bug 1972434
       events_tables: # overwrite event tables
         pine: # Probe info returns pings that don't have tables, only use events_v1
         - events_v1


### PR DESCRIPTION
## Description

https://bugzilla.mozilla.org/show_bug.cgi?id=1972434

It looks like this will be fixed once https://phabricator.services.mozilla.com/D253877 lands. The `sync` ping is currently being migrated to Glean: https://bugzilla.mozilla.org/show_bug.cgi?id=1963812
It seems there are already some metrics that have been assigned to use this ping, such as `fxa.closetab_received` (based on https://probeinfo.telemetry.mozilla.org/glean/firefox-desktop/metrics). When generating the events monitoring queries, these metrics are used to determine the stable tables to pull in events from. But the ping has not been configured as such yet, which should however get fixed after the PR that chutten filed lands.

We should ignore generating SQL for this ping for now, until it properly landed