### PR TITLE
Adding unsubscribes and hard bounces from pocket workspace to suppression list

### DIFF
--- a/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/query.sql
@@ -45,6 +45,24 @@ WITH suppressions AS (
     "Campaign Monitor" AS suppression_source
   FROM
     `moz-fx-data-shared-prod.marketing_suppression_list_external.campaign_monitor_suppression_list_v1`
+  -- braze unsubscribes from Pocket workspace
+  UNION DISTINCT
+  SELECT
+    LOWER(email_address) AS email,
+    TIMESTAMP_SECONDS(time) AS suppressed_timestamp,
+    "clicked header" AS suppression_reason,
+    "Braze Firefox unsubscribe" AS suppression_source
+  FROM
+    `moz-fx-data-shared-prod.braze_external.braze_currents_pocket_unsubscribe_v1`
+  -- braze hard bounces from Pocket workspace
+  UNION DISTINCT
+  SELECT
+    LOWER(email_address) AS email,
+    TIMESTAMP_SECONDS(time) AS suppressed_timestamp,
+    "hard bounce" AS suppression_reason,
+    "Braze Firefox hard bounce" AS suppression_source
+  FROM
+    `moz-fx-data-shared-prod.braze_external.braze_currents_pocket_hard_bounces_v1`
 ),
 final AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/query.sql
@@ -51,7 +51,7 @@ WITH suppressions AS (
     LOWER(email_address) AS email,
     TIMESTAMP_SECONDS(time) AS suppressed_timestamp,
     "clicked header" AS suppression_reason,
-    "Braze Firefox unsubscribe" AS suppression_source
+    "Braze Pocket unsubscribe" AS suppression_source
   FROM
     `moz-fx-data-shared-prod.braze_external.braze_currents_pocket_unsubscribe_v1`
   -- braze hard bounces from Pocket workspace
@@ -60,7 +60,7 @@ WITH suppressions AS (
     LOWER(email_address) AS email,
     TIMESTAMP_SECONDS(time) AS suppressed_timestamp,
     "hard bounce" AS suppression_reason,
-    "Braze Firefox hard bounce" AS suppression_source
+    "Braze Pocket hard bounce" AS suppression_source
   FROM
     `moz-fx-data-shared-prod.braze_external.braze_currents_pocket_hard_bounces_v1`
 ),

--- a/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/expect.yaml
@@ -23,7 +23,7 @@
   suppression_reason: clicked header
   suppression_source: Braze Firefox unsubscribe
 # User 6 braze Firefox hard bounce
-- email: user6@emil.com
+- email: user6@email.com
   suppressed_timestamp: 2022-06-01 00:00:00+00:00
   suppression_reason: hard bounce
   suppression_source: Braze Firefox hard bounce
@@ -32,7 +32,17 @@
   suppressed_timestamp: 2023-07-01 00:00:00+00:00
   suppression_source: Campaign Monitor
 # User 8 braze Mozilla hard bounce
-- email: user8@emil.com
+- email: user8@email.com
   suppressed_timestamp: 2024-08-01 00:00:00+00:00
   suppression_reason: hard bounce
   suppression_source: Braze Mozilla hard bounce
+# User 9 braze Pocket hard bounce
+- email: user9@email.com
+  suppressed_timestamp: 2025-06-16 00:00:00+00:00
+  suppression_reason: hard bounce
+  suppression_source: Braze Pocket hard bounce
+# User 10 braze Pocket unsubscribe
+- email: user10@email.com
+  suppressed_timestamp: 2025-06-16 00:00:00+00:00
+  suppression_reason: clicked header
+  suppression_source: Braze Pocket unsubscribe

--- a/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_firefox_hard_bounces_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_firefox_hard_bounces_v1.yaml
@@ -10,6 +10,6 @@
   time: 1648771200
 # User 5 braze unsubscribe
 # User 6 braze hard bounce
-- email_address: user6@eamil.com
+- email_address: user6@email.com
   time: 1654041600
 # User 7 MoFo

--- a/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_firefox_hard_bounces_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_firefox_hard_bounces_v1.yaml
@@ -10,6 +10,6 @@
   time: 1648771200
 # User 5 braze unsubscribe
 # User 6 braze hard bounce
-- email_address: user6@emil.com
+- email_address: user6@eamil.com
   time: 1654041600
 # User 7 MoFo

--- a/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_mozilla_hard_bounces_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_mozilla_hard_bounces_v1.yaml
@@ -8,5 +8,5 @@
 # User 6 braze Firefox hard bounce
 # User 7 MoFo
 # User 8 braze Mozilla hard bounce
-- email_address: user8@emil.com
+- email_address: user8@email.com
   time: 1722470400

--- a/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_pocket_hard_bounces_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_pocket_hard_bounces_v1.yaml
@@ -1,0 +1,14 @@
+# expect
+---
+# User 1 only on Acoustic
+# User 2 Acoustic and braze unsubscribe
+# User 3 Acoustic and braze unsubscribe and braze firefox hard bounce
+# User 4 Acoustic, braze unsubscribe, braze firefox hard bounce and MoFo
+# User 5 braze firefox unsubscribe
+# User 6 braze Firefox hard bounce
+# User 7 MoFo
+# User 8 braze Mozilla hard bounce
+# User 9 braze Pocket hard bounce
+- email_address: user9@emil.com
+  time: 1750032000
+# User 10 braze Pocket unsubscribes

--- a/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_pocket_hard_bounces_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_pocket_hard_bounces_v1.yaml
@@ -9,6 +9,6 @@
 # User 7 MoFo
 # User 8 braze Mozilla hard bounce
 # User 9 braze Pocket hard bounce
-- email_address: user9@emil.com
+- email_address: user9@email.com
   time: 1750032000
 # User 10 braze Pocket unsubscribes

--- a/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_pocket_unsubscribe_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_pocket_unsubscribe_v1.yaml
@@ -1,0 +1,14 @@
+# expect
+---
+# User 1 only on Acoustic
+# User 2 Acoustic and braze unsubscribe
+# User 3 Acoustic and braze unsubscribe and braze firefox hard bounce
+# User 4 Acoustic, braze unsubscribe, braze firefox hard bounce and MoFo
+# User 5 braze firefox unsubscribe
+# User 6 braze Firefox hard bounce
+# User 7 MoFo
+# User 8 braze Mozilla hard bounce
+# User 9 braze Pocket hard bounce
+# User 10 braze Pocket unsubscribes
+- email_address: user8@emil.com
+  time: 1750032000

--- a/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_pocket_unsubscribe_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_pocket_unsubscribe_v1.yaml
@@ -10,5 +10,5 @@
 # User 8 braze Mozilla hard bounce
 # User 9 braze Pocket hard bounce
 # User 10 braze Pocket unsubscribes
-- email_address: user10@emil.com
+- email_address: user10@email.com
   time: 1750032000

--- a/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_pocket_unsubscribe_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.braze_external.braze_currents_pocket_unsubscribe_v1.yaml
@@ -10,5 +10,5 @@
 # User 8 braze Mozilla hard bounce
 # User 9 braze Pocket hard bounce
 # User 10 braze Pocket unsubscribes
-- email_address: user8@emil.com
+- email_address: user10@emil.com
   time: 1750032000

--- a/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.marketing_suppression_list_external.campaign_monitor_suppression_list_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/marketing_suppression_list_derived/main_suppression_list_v1/test_main_suppression_list/moz-fx-data-shared-prod.marketing_suppression_list_external.campaign_monitor_suppression_list_v1.yaml
@@ -4,7 +4,7 @@
 # User 2 Acoustic and braze unsubscribe
 # User 3 Acoustic and braze unsubscribe and braze hard bounce
 # User 4 Acoustic, braze unsubscribe, braze hard bounce and MoFo
-- email: usEr4@email.com
+- email: user4@email.com
   update_timestamp: 2022-04-01 00:00:00+00:00
   suppression_reason: bounced
 # User 5 braze unsubscribe


### PR DESCRIPTION
## Description
This PR adds unsubscribes and hard bounces from the Pocket workspace in Braze to the suppression list
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-8922

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
