### PR TITLE
Revert "Skip generating event monitoring for sync pings"

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -353,7 +353,6 @@ generate:
       - topsites-impression # access denied
       - serp-categorization # access denied
       - background-update # table doesn't exist
-      - sync # Bug 1972434
       events_tables: # overwrite event tables
         pine: # Probe info returns pings that don't have tables, only use events_v1
         - events_v1


### PR DESCRIPTION
Reverts mozilla/bigquery-etl#7659

The `moz-fx-data-shared-prod.firefox_desktop_stable.sync_v1` table does now exists, so we no longer need to skip it in the generation.