### PR TITLE
[DENG-7602] Add row counts to stable_and_derived_table_sizes

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/metadata.yaml
@@ -9,8 +9,8 @@ labels:
   incremental: true
 scheduling:
   dag_name: bqetl_monitoring
-  # Delay by 1 day to allow all derived tables to get populated for the date.
-  arguments: ["--date", "{{ macros.ds_add(ds, -1) }}"]
+  # Each run will process ds and ds-1 to get derived tables that may take more time to populate.
+  arguments: ["--date", "{{ ds }}"]
   referenced_tables:
     - ['moz-fx-data-shared-prod', '*_stable', '*']
     - ['moz-fx-data-shared-prod', 'telemetry_stable', 'main_v5']

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/query.py
@@ -1,75 +1,114 @@
 #!/usr/bin/env python3
 
 """Determine stable and derived table size partitions by performing dry runs."""
-
+import datetime
 from argparse import ArgumentParser
 from fnmatch import fnmatchcase
-from functools import partial
+from functools import partial, cache
 from multiprocessing.pool import ThreadPool
+from typing import Any, Dict, List, Optional, Tuple
 
-from google.cloud import bigquery
+from google.cloud import bigquery, exceptions
 
 parser = ArgumentParser(description=__doc__)
-parser.add_argument("--date", required=True)  # expect string with format yyyy-mm-dd
-parser.add_argument("--project", default="moz-fx-data-shared-prod")
+parser.add_argument(
+    "--date", required=True, type=datetime.date.fromisoformat, help="Date in yyyy-mm-dd"
+)
+parser.add_argument(
+    "--project",
+    default="moz-fx-data-shared-prod",
+    help="Project of tables to get sizes for",
+)
 parser.add_argument("--dataset", default=("*_derived", "*_stable"))  # pattern
+parser.add_argument("--destination_project")  # default to --project
 parser.add_argument("--destination_dataset", default="monitoring_derived")
 parser.add_argument("--destination_table", default="stable_and_derived_table_sizes_v1")
 
 
-def get_tables(client, project, dataset):
+def get_tables(
+    client: bigquery.Client, dataset: str
+) -> List[Tuple[str, str]]:
     """Returns list of all available tables."""
-    sql = f"SELECT dataset_id, table_id FROM `{project}.{dataset}.__TABLES__`"
-
-    try:
-        result = client.query(sql).result()
-        return [(row.dataset_id, row.table_id) for row in result]
-    except Exception as e:
-        print(f"Error querying dataset {dataset}: {e}")
-
-    return []
+    return [(table.dataset_id, table.table_id) for table in client.list_tables(dataset)]
 
 
-def get_partition_size_json(client, date, table):
+@cache
+def get_partition_columns_for_dataset(
+    client: bigquery.Client, dataset_id: str
+) -> Dict[str, str]:
+    sql = f"""
+    SELECT table_schema, table_name, column_name
+    FROM {dataset_id}.INFORMATION_SCHEMA.COLUMNS
+    WHERE is_partitioning_column = 'YES'
+    """
+
+    results = {
+        f"{result.table_schema}.{result.table_name}": result.column_name
+        for result in client.query_and_wait(sql)
+    }
+
+    return results
+
+
+def get_partition_size_json(
+    client: bigquery.Client, date: datetime.date, table: Tuple[str, str]
+) -> Optional[Dict[str, Any]]:
     """Returns the size of a specific date parition of the specified table."""
-    job_config = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)
-    job_config_columns_info = bigquery.QueryJobConfig(
-        dry_run=False, use_query_cache=False
-    )
     dataset_id = table[0]
     table_id = table[1]
 
-    partition_column_sql = f"""
-                            SELECT column_name
-                            FROM {dataset_id}.INFORMATION_SCHEMA.COLUMNS
-                            WHERE table_name = '{table_id}' and is_partitioning_column = 'YES'
-                        """
-    partition_column_name_result = client.query(
-        partition_column_sql, job_config=job_config_columns_info
+    partitioning_column = get_partition_columns_for_dataset(client, dataset_id).get(
+        f"{dataset_id}.{table_id}"
     )
 
-    partition_column_name = [row[0] for row in partition_column_name_result.result()]
+    if partitioning_column in ("submission_date", "submission_timestamp"):
+        try:
+            table_info = client.get_table(
+                f"{dataset_id}.{table_id}${date.strftime('%Y%m%d')}"
+            )
+            byte_size = table_info.num_bytes
+            row_count = table_info.num_rows
+        except exceptions.BadRequest as e:  # non-daily partitions will cause error
+            print(f"Error getting partition {dataset_id}.{table_id}: {e}")
 
-    if len(partition_column_name) > 0 and partition_column_name[0] in (
-        "submission_date",
-        "submission_timestamp",
-    ):
-        sql = f"""
+            # dry run partition if we can't get the daily partition
+            try:
+                sql = f"""
                 SELECT * FROM `{dataset_id}.{table_id}`
-                WHERE DATE({partition_column_name[0]}) = '{date}'
-            """
-        job = client.query(sql, job_config=job_config)
-        size = job.total_bytes_processed if job.total_bytes_processed is not None else 0
+                WHERE DATE({partitioning_column}) = '{date}'
+                """
+                job = client.query(
+                    sql, job_config=bigquery.QueryJobConfig(dry_run=True)
+                )
+                byte_size = (
+                    job.total_bytes_processed
+                    if job.total_bytes_processed is not None
+                    else 0
+                )
+                row_count = None
+            except exceptions.Forbidden as e2:
+                err_msg = e2.message.split("\n")[0]
+                print(f"Error running query {dataset_id}.{table_id}: {err_msg}")
+                return
+
         return {
-            "submission_date": date,
+            "submission_date": date.isoformat(),
             "dataset_id": dataset_id,
             "table_id": table_id,
-            "byte_size": size,
+            "byte_size": byte_size,
+            "row_count": row_count,
         }
 
 
-def save_table_sizes(client, table_sizes, date, destination_dataset, destination_table):
-    """Writes paritions sizes for tables for a specific day to BigQuery."""
+def save_table_sizes(
+    client: bigquery.Client,
+    table_sizes: List[Dict[str, Any]],
+    date: datetime.date,
+    destination_project: str,
+    destination_dataset: str,
+    destination_table: str,
+):
+    """Writes partitions sizes for tables for a specific day to BigQuery."""
 
     job_config = bigquery.LoadJobConfig()
     job_config.schema = (
@@ -77,13 +116,15 @@ def save_table_sizes(client, table_sizes, date, destination_dataset, destination
         bigquery.SchemaField("dataset_id", "STRING"),
         bigquery.SchemaField("table_id", "STRING"),
         bigquery.SchemaField("byte_size", "INT64"),
+        bigquery.SchemaField("row_count", "INT64"),
     )
-    job_config.write_disposition = bigquery.job.WriteDisposition.WRITE_TRUNCATE
+    job_config.write_disposition = bigquery.WriteDisposition.WRITE_TRUNCATE
+    job_config.schema_update_options = bigquery.SchemaUpdateOption.ALLOW_FIELD_ADDITION
 
-    partition_date = date.replace("-", "")
+    partition_date = date.strftime("%Y%m%d")
     client.load_table_from_json(
         table_sizes,
-        f"{destination_dataset}.{destination_table}${partition_date}",
+        f"{destination_project}.{destination_dataset}.{destination_table}${partition_date}",
         job_config=job_config,
     ).result()
 
@@ -91,38 +132,43 @@ def save_table_sizes(client, table_sizes, date, destination_dataset, destination
 def main():
     args = parser.parse_args()
     client = bigquery.Client(args.project)
-    stable_derived_partition_sizes = []
 
-    for arg_dataset in args.dataset:
-        stable_datasets = [
-            dataset.dataset_id
-            for dataset in list(client.list_datasets())
-            if fnmatchcase(dataset.dataset_id, arg_dataset)
-            and not fnmatchcase(dataset.dataset_id, "monitoring_derived")
-        ]
-        with ThreadPool(20) as p:
-            stable_tables = p.map(
-                partial(get_tables, client, args.project),
-                stable_datasets,
-                chunksize=1,
-            )
-            stable_tables = [table for tables in stable_tables for table in tables]
+    for datediff in range(2):
+        stable_derived_partition_sizes = []
+        current_date = args.date - datetime.timedelta(days=datediff)
+        print(f"Getting {current_date}")
 
-            partition_sizes = p.map(
-                partial(get_partition_size_json, client, args.date),
-                stable_tables,
-                chunksize=1,
-            )
-            partition_sizes = filter(lambda x: x is not None, partition_sizes)
-            stable_derived_partition_sizes.extend(partition_sizes)
+        for arg_dataset in args.dataset:
+            datasets = [
+                dataset.dataset_id
+                for dataset in list(client.list_datasets())
+                if fnmatchcase(dataset.dataset_id, arg_dataset)
+                and dataset.dataset_id not in ("monitoring_derived", "backfills_staging_derived")
+            ]
+            with ThreadPool(20) as p:
+                tables = p.map(
+                    partial(get_tables, client),
+                    datasets,
+                    chunksize=1,
+                )
+                tables = [table for tables in tables for table in tables]
 
-    save_table_sizes(
-        client,
-        stable_derived_partition_sizes,
-        args.date,
-        args.destination_dataset,
-        args.destination_table,
-    )
+                partition_sizes = p.map(
+                    partial(get_partition_size_json, client, current_date),
+                    tables,
+                    chunksize=1,
+                )
+                partition_sizes = filter(lambda x: x is not None, partition_sizes)
+                stable_derived_partition_sizes.extend(partition_sizes)
+
+        save_table_sizes(
+            client,
+            stable_derived_partition_sizes,
+            current_date,
+            args.destination_project,
+            args.destination_dataset,
+            args.destination_table,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Adds row counts for each table as the first step for DENG-7602. A few other changes were made:
- now using client methods to list tables and get sizes of tables to avoid permission issues if user doesn't have data read access on the table/dataset
- removed the one day delay on the run date and made it process the last two days on each run to get the stable table sizes quicker
 

## Related Tickets & Documents
* DENG-7602

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
