### PR TITLE
Set default dest project in stable_and_derived_table_sizes

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/stable_and_derived_table_sizes_v1/query.py
@@ -20,7 +20,7 @@ parser.add_argument(
     help="Project of tables to get sizes for",
 )
 parser.add_argument("--dataset", default=("*_derived", "*_stable"))  # pattern
-parser.add_argument("--destination_project")  # default to --project
+parser.add_argument("--destination_project", help="Project to write results to. Defaults to --project value.")
 parser.add_argument("--destination_dataset", default="monitoring_derived")
 parser.add_argument("--destination_table", default="stable_and_derived_table_sizes_v1")
 
@@ -131,6 +131,10 @@ def save_table_sizes(
 
 def main():
     args = parser.parse_args()
+
+    if args.destination_project is None:
+        args.destination_project = args.project
+
     client = bigquery.Client(args.project)
 
     for datediff in range(2):


### PR DESCRIPTION
## Description

Fix for https://github.com/mozilla/bigquery-etl/pull/7668.  I forgot to set the default destination_project

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
