### PR TITLE
Cancel expired new_profile_activation_clients_v1 backfill

### DIFF
--- a/bigquery_etl/backfill/parse.py
+++ b/bigquery_etl/backfill/parse.py
@@ -52,6 +52,7 @@ class BackfillStatus(enum.Enum):
 
     INITIATE = "Initiate"
     COMPLETE = "Complete"
+    CANCELLED = "Cancelled"
 
 
 @attr.s(auto_attribs=True)

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_clients_v1/backfill.yaml
@@ -4,7 +4,7 @@
   reason: Backfill to propegate upstream population of install_source field.
   watchers:
   - kik@mozilla.com
-  status: Initiate
+  status: Cancelled
   shredder_mitigation: false
   override_retention_limit: false
 2025-02-03:


### PR DESCRIPTION
## Description

The backfill staging table for https://github.com/mozilla/bigquery-etl/pull/7499 is about to expire so this backfill will need to be redone if it's still needed

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
