### PR TITLE
fix(GLAM): Histogram probe_counts collapse on range_min and max

### DIFF
--- a/bigquery_etl/glam/templates/probe_counts_v1.sql
+++ b/bigquery_etl/glam/templates/probe_counts_v1.sql
@@ -84,14 +84,14 @@ WITH probe_counts AS (
       mozfun.glam.histogram_fill_buckets_dirichlet(
         mozfun.map.sum(ARRAY_AGG(record)),
         mozfun.glam.histogram_buckets_cast_string_array(
-          udf_get_buckets(metric_type, range_min, range_max, bucket_count)
+          udf_get_buckets(metric_type, MIN(range_min), MAX(range_max), bucket_count)
         ),
         CAST(ROUND(SUM(record.value)) AS INT64)
       ) AS aggregates,
       mozfun.glam.histogram_fill_buckets(
         mozfun.map.sum(ARRAY_AGG(non_norm_record)),
         mozfun.glam.histogram_buckets_cast_string_array(
-          udf_get_buckets(metric_type, range_min, range_max, bucket_count)
+          udf_get_buckets(metric_type, MIN(range_min), MAX(range_max), bucket_count)
         )
       ) AS non_norm_aggregates
     {% endif %}
@@ -99,8 +99,10 @@ WITH probe_counts AS (
     {{ source_table }}
   GROUP BY
     {{ attributes }},
-    range_min,
-    range_max,
+    {% if is_scalar %}
+      range_min,
+      range_max,
+    {% endif %}
     bucket_count,
     {{ aggregate_attributes }},
     {{ aggregate_grouping }}


### PR DESCRIPTION
## Description

Although this is a small fix, the root cause is a bit complex. Please read the ticket for a thorough explanation.
In summary, `bucket_counts` is a TaskGroup that processes data in `sample_id` ranges, which potentially causes different `range_max`  values to be attributed to the same metric across different chunks due to stripping of 0-buckets from telemetry. The downstream task, `probe_counts`, needs to collapse on `range_min` and `range_max` so all chunks  with these different ranges can be aggregated together.

## Related Tickets & Documents
* DENG-8946

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
