### PR TITLE
[DENG-7602] Add ping counts to schema error and missing columns tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/query.sql
@@ -1,37 +1,68 @@
-SELECT
-  @submission_date AS submission_date,
-  document_namespace,
-  document_type,
-  document_version,
-  TIMESTAMP_TRUNC(submission_timestamp, HOUR) AS hour,
-  job_name,
-  `moz-fx-data-shared-prod.udf.extract_schema_validation_path`(error_message) AS path,
-  COUNT(*) AS error_count,
-  -- aggregating distinct error messages to show sample_error messages
-  -- removing path and exception_class for better readability
-  SUBSTR(
-    STRING_AGG(
-      DISTINCT REPLACE(
-        REPLACE(error_message, "org.everit.json.schema.ValidationException: ", ""),
-        CONCAT(`moz-fx-data-shared-prod.udf.extract_schema_validation_path`(error_message), ": "),
-        ""
+WITH schema_errors AS (
+  SELECT
+    @submission_date AS submission_date,
+    document_namespace,
+    document_type,
+    document_version,
+    TIMESTAMP_TRUNC(submission_timestamp, HOUR) AS hour,
+    job_name,
+    `moz-fx-data-shared-prod.udf.extract_schema_validation_path`(error_message) AS path,
+    COUNT(*) AS error_count,
+    -- aggregating distinct error messages to show sample_error messages
+    -- removing path and exception_class for better readability
+    SUBSTR(
+      STRING_AGG(
+        DISTINCT REPLACE(
+          REPLACE(error_message, "org.everit.json.schema.ValidationException: ", ""),
+          CONCAT(`moz-fx-data-shared-prod.udf.extract_schema_validation_path`(error_message), ": "),
+          ""
+        ),
+        "; "
       ),
-      "; "
-    ),
-    0,
-    300
-  ) AS sample_error_messages,
-  channel,
+      0,
+      300
+    ) AS sample_error_messages,
+    channel,
+    CONCAT(REPLACE(document_namespace, "-", "_"), "_stable") AS dataset_id,
+    -- legacy telemetry doesn't get document_version parsed
+    CONCAT(REPLACE(document_type, "-", "_"), "_v", COALESCE(document_version, "%")) AS table_id,
+  FROM
+    `moz-fx-data-shared-prod.monitoring.payload_bytes_error_all`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND exception_class = "org.everit.json.schema.ValidationException"
+  GROUP BY
+    document_namespace,
+    document_type,
+    document_version,
+    hour,
+    job_name,
+    path,
+    channel
+),
+table_sizes AS (
+  SELECT
+    dataset_id,
+    -- Sum across doc versions for legacy telemetry because versioning is inconsistent
+    IF(
+      dataset_id = "telemetry_stable",
+      REGEXP_REPLACE(table_id, "_v[0-9]+$", "_v%"),
+      table_id
+    ) AS table_id,
+    SUM(row_count) AS row_count,
+  FROM
+    `moz-fx-data-shared-prod.monitoring_derived.stable_and_derived_table_sizes_v1`
+  WHERE
+    submission_date = @submission_date
+  GROUP BY
+    dataset_id,
+    table_id
+)
+SELECT
+  schema_errors.* EXCEPT (dataset_id, table_id),
+  table_sizes.row_count AS valid_ping_count,
 FROM
-  `moz-fx-data-shared-prod.monitoring.payload_bytes_error_all`
-WHERE
-  DATE(submission_timestamp) = @submission_date
-  AND exception_class = 'org.everit.json.schema.ValidationException'
-GROUP BY
-  document_namespace,
-  document_type,
-  document_version,
-  hour,
-  job_name,
-  path,
-  channel
+  schema_errors
+LEFT JOIN
+  table_sizes
+  USING (dataset_id, table_id)

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/schema_error_counts_v2/schema.yaml
@@ -30,3 +30,7 @@ fields:
 - name: channel
   type: STRING
   mode: NULLABLE
+- name: valid_ping_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of rows in the associated stable table

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/structured_missing_columns_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/structured_missing_columns_v1/query.py
@@ -58,6 +58,21 @@ transformed AS (
     document_type,
     document_version,
     path
+),
+row_counts AS (
+  SELECT
+    submission_date,
+    document_namespace,
+    document_type,
+    document_version,
+    COUNT(*) AS total_row_count,
+  FROM
+    extracted
+  GROUP BY
+    submission_date,
+    document_namespace,
+    document_type,
+    document_version
 )
 SELECT
   submission_date,
@@ -65,9 +80,13 @@ SELECT
   document_type,
   document_version,
   path,
-  path_count
+  path_count,
+  total_row_count,
 FROM
   transformed
+INNER JOIN
+  row_counts
+USING (submission_date, document_namespace, document_type, document_version)
 """
 
 

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/structured_missing_columns_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/structured_missing_columns_v1/schema.yaml
@@ -17,3 +17,7 @@ fields:
 - mode: NULLABLE
   name: path_count
   type: INTEGER
+- name: total_row_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of rows in the table

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/query.sql
@@ -67,6 +67,21 @@ transformed AS (
     document_type,
     document_version,
     path
+),
+row_counts AS (
+  SELECT
+    submission_date,
+    document_namespace,
+    document_type,
+    document_version,
+    COUNT(*) AS total_row_count,
+  FROM
+    extracted
+  GROUP BY
+    submission_date,
+    document_namespace,
+    document_type,
+    document_version
 )
 SELECT
   submission_date,
@@ -74,6 +89,10 @@ SELECT
   document_type,
   document_version,
   path,
-  path_count
+  path_count,
+  total_row_count,
 FROM
   transformed
+INNER JOIN
+  row_counts
+  USING (submission_date, document_namespace, document_type, document_version)

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/schema.yaml
@@ -17,3 +17,7 @@ fields:
 - mode: NULLABLE
   name: path_count
   type: INTEGER
+- name: total_row_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of rows in the table


### PR DESCRIPTION
## Description

Adds stable table row counts to the schema error and missing columns tables so they can be used to get affected ping %.

## Related Tickets & Documents
* DENG-7602

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
