### PR TITLE
feat(SubPlat): Save new Stripe subscription metadata fields (DENG-4218, DENG-8885)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/schema.yaml
@@ -604,6 +604,60 @@ fields:
       mode: NULLABLE
       description: ID of the previous plan the customer was subscribed to via this
         subscription (if any).
+    - name: currency
+      type: STRING
+      mode: NULLABLE
+      description: ISO 4217 code for the actual plan currency, possibly in lowercase.
+        This may differ from `subscription.items[0].plan.currency` if multi-currency prices are being used.
+    - name: amount
+      type: INTEGER
+      mode: NULLABLE
+      description: The actual plan amount in whole cents to be charged.
+        This may differ from `subscription.items[0].plan.amount` if multi-currency prices are being used.
+    - name: session_flow_id
+      type: STRING
+      mode: NULLABLE
+      description: ID of the subscription flow which resulted in the creation of the subscription.
+    - name: session_entrypoint
+      type: STRING
+      mode: NULLABLE
+      description: The `entrypoint` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: session_entrypoint_experiment
+      type: STRING
+      mode: NULLABLE
+      description: The `entrypoint_experiment` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: session_entrypoint_variation
+      type: STRING
+      mode: NULLABLE
+      description: The `entrypoint_variation` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: utm_campaign
+      type: STRING
+      mode: NULLABLE
+      description: The `utm_campaign` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: utm_content
+      type: STRING
+      mode: NULLABLE
+      description: The `utm_content` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: utm_medium
+      type: STRING
+      mode: NULLABLE
+      description: The `utm_medium` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: utm_source
+      type: STRING
+      mode: NULLABLE
+      description: The `utm_source` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: utm_term
+      type: STRING
+      mode: NULLABLE
+      description: The `utm_term` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
   - name: pending_setup_intent_id
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/query.sql
@@ -68,7 +68,18 @@ CREATE TEMP FUNCTION synthesize_subscription(
             NULL
           ) AS cancelled_for_customer_at,
           IF(plan_start > subscription.start_date, plan_start, NULL) AS plan_change_date,
-          previous_plan_id
+          previous_plan_id,
+          CAST(NULL AS STRING) AS currency,
+          CAST(NULL AS INT64) AS amount,
+          CAST(NULL AS STRING) AS session_flow_id,
+          CAST(NULL AS STRING) AS session_entrypoint,
+          CAST(NULL AS STRING) AS session_entrypoint_experiment,
+          CAST(NULL AS STRING) AS session_entrypoint_variation,
+          CAST(NULL AS STRING) AS utm_campaign,
+          CAST(NULL AS STRING) AS utm_content,
+          CAST(NULL AS STRING) AS utm_medium,
+          CAST(NULL AS STRING) AS utm_source,
+          CAST(NULL AS STRING) AS utm_term
         ) AS metadata,
         CASE
           WHEN subscription.status IN ('incomplete', 'incomplete_expired')
@@ -105,7 +116,22 @@ WITH original_changelog AS (
             TIMESTAMP_SECONDS(
               CAST(JSON_VALUE(subscription.metadata.plan_change_date) AS INT64)
             ) AS plan_change_date,
-            JSON_VALUE(subscription.metadata.previous_plan_id) AS previous_plan_id
+            JSON_VALUE(subscription.metadata.previous_plan_id) AS previous_plan_id,
+            JSON_VALUE(subscription.metadata.currency) AS currency,
+            CAST(JSON_VALUE(subscription.metadata.amount) AS INT64) AS amount,
+            JSON_VALUE(subscription.metadata.session_flow_id) AS session_flow_id,
+            JSON_VALUE(subscription.metadata.session_entrypoint) AS session_entrypoint,
+            JSON_VALUE(
+              subscription.metadata.session_entrypoint_experiment
+            ) AS session_entrypoint_experiment,
+            JSON_VALUE(
+              subscription.metadata.session_entrypoint_variation
+            ) AS session_entrypoint_variation,
+            JSON_VALUE(subscription.metadata.utm_campaign) AS utm_campaign,
+            JSON_VALUE(subscription.metadata.utm_content) AS utm_content,
+            JSON_VALUE(subscription.metadata.utm_medium) AS utm_medium,
+            JSON_VALUE(subscription.metadata.utm_source) AS utm_source,
+            JSON_VALUE(subscription.metadata.utm_term) AS utm_term
           ) AS metadata
         )
     ) AS subscription,

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/schema.yaml
@@ -415,6 +415,60 @@ fields:
       mode: NULLABLE
       description: ID of the previous plan the customer was subscribed to via this
         subscription (if any).
+    - name: currency
+      type: STRING
+      mode: NULLABLE
+      description: ISO 4217 code for the actual plan currency, possibly in lowercase.
+        This may differ from `subscription.items[0].plan.currency` if multi-currency prices are being used.
+    - name: amount
+      type: INTEGER
+      mode: NULLABLE
+      description: The actual plan amount in whole cents to be charged.
+        This may differ from `subscription.items[0].plan.amount` if multi-currency prices are being used.
+    - name: session_flow_id
+      type: STRING
+      mode: NULLABLE
+      description: ID of the subscription flow which resulted in the creation of the subscription.
+    - name: session_entrypoint
+      type: STRING
+      mode: NULLABLE
+      description: The `entrypoint` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: session_entrypoint_experiment
+      type: STRING
+      mode: NULLABLE
+      description: The `entrypoint_experiment` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: session_entrypoint_variation
+      type: STRING
+      mode: NULLABLE
+      description: The `entrypoint_variation` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: utm_campaign
+      type: STRING
+      mode: NULLABLE
+      description: The `utm_campaign` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: utm_content
+      type: STRING
+      mode: NULLABLE
+      description: The `utm_content` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: utm_medium
+      type: STRING
+      mode: NULLABLE
+      description: The `utm_medium` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: utm_source
+      type: STRING
+      mode: NULLABLE
+      description: The `utm_source` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
+    - name: utm_term
+      type: STRING
+      mode: NULLABLE
+      description: The `utm_term` attribution parameter from the subscription flow
+        which resulted in the creation of the subscription.
   - name: pending_setup_intent_id
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_v2/schema.yaml
@@ -563,6 +563,60 @@ fields:
     mode: NULLABLE
     description: ID of the previous plan the customer was subscribed to via this subscription
       (if any).
+  - name: currency
+    type: STRING
+    mode: NULLABLE
+    description: ISO 4217 code for the actual plan currency, possibly in lowercase.
+      This may differ from `subscription.items[0].plan.currency` if multi-currency prices are being used.
+  - name: amount
+    type: INTEGER
+    mode: NULLABLE
+    description: The actual plan amount in whole cents to be charged.
+      This may differ from `subscription.items[0].plan.amount` if multi-currency prices are being used.
+  - name: session_flow_id
+    type: STRING
+    mode: NULLABLE
+    description: ID of the subscription flow which resulted in the creation of the subscription.
+  - name: session_entrypoint
+    type: STRING
+    mode: NULLABLE
+    description: The `entrypoint` attribution parameter from the subscription flow
+      which resulted in the creation of the subscription.
+  - name: session_entrypoint_experiment
+    type: STRING
+    mode: NULLABLE
+    description: The `entrypoint_experiment` attribution parameter from the subscription flow
+      which resulted in the creation of the subscription.
+  - name: session_entrypoint_variation
+    type: STRING
+    mode: NULLABLE
+    description: The `entrypoint_variation` attribution parameter from the subscription flow
+      which resulted in the creation of the subscription.
+  - name: utm_campaign
+    type: STRING
+    mode: NULLABLE
+    description: The `utm_campaign` attribution parameter from the subscription flow
+      which resulted in the creation of the subscription.
+  - name: utm_content
+    type: STRING
+    mode: NULLABLE
+    description: The `utm_content` attribution parameter from the subscription flow
+      which resulted in the creation of the subscription.
+  - name: utm_medium
+    type: STRING
+    mode: NULLABLE
+    description: The `utm_medium` attribution parameter from the subscription flow
+      which resulted in the creation of the subscription.
+  - name: utm_source
+    type: STRING
+    mode: NULLABLE
+    description: The `utm_source` attribution parameter from the subscription flow
+      which resulted in the creation of the subscription.
+  - name: utm_term
+    type: STRING
+    mode: NULLABLE
+    description: The `utm_term` attribution parameter from the subscription flow
+      which resulted in the creation of the subscription.
 - name: pending_setup_intent_id
   type: STRING
   mode: NULLABLE


### PR DESCRIPTION
## Description
SubPlat 3 is setting some additional Stripe subscription metadata fields as workarounds to help us preserve the accuracy of the subscription products reporting in the face of the changes to how SubPlat works.

This PR updates the incremental `stripe_subscriptions_revised_changelog_v1` ETL to save the new metadata fields going forward so we can use them in future updates to the SubPlat ETLs' logic.

## Related Tickets & Documents
* DENG-4218: Update SubPlat ETL to support Stripe multi-currency plans
* DENG-8885: Update SubPlat ETLs to use Stripe subscription attribution metadata

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
