### PR TITLE
feat(DENG-8990): do not require partition filter for snowflake migrated tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/metadata.yaml
@@ -14,7 +14,7 @@ bigquery:
   time_partitioning:
     type: day
     field: happened_at
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: 775
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_updated_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_updated_v1/metadata.yaml
@@ -14,7 +14,7 @@ bigquery:
   time_partitioning:
     type: day
     field: happened_at
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: 775
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/metadata.yaml
@@ -14,7 +14,7 @@ bigquery:
   time_partitioning:
     type: day
     field: happened_at
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: 775
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/metadata.yaml
@@ -14,7 +14,7 @@ bigquery:
   time_partitioning:
     type: day
     field: happened_at
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: 775
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
@@ -14,7 +14,7 @@ bigquery:
   time_partitioning:
     type: day
     field: happened_at
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: 775
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/metadata.yaml
@@ -14,7 +14,7 @@ bigquery:
   time_partitioning:
     type: day
     field: happened_at
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: 775
   clustering:
     # the fields below are guesses and will likely need to be updated based on ML

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/metadata.yaml
@@ -14,7 +14,7 @@ bigquery:
   time_partitioning:
     type: day
     field: happened_at
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: 775
   clustering:
     fields:

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/metadata.yaml
@@ -14,7 +14,7 @@ bigquery:
   time_partitioning:
     type: day
     field: happened_at
-    require_partition_filter: true
+    require_partition_filter: false
     expiration_days: 775
   clustering:
     fields:


### PR DESCRIPTION
## Description

do not require partition filter for snowflake migrated tables.

## Related Tickets & Documents
* DENG-8990

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
