### PR TITLE
chore(SubPlat): Initiate backfills to add historical Apple subscription records to SubPlat consolidated reporting tables (DENG-976)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-06-25:
+  start_date: 2021-12-17
+  end_date: 2025-06-15
+  reason: Add records for Apple subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-05-22:
   start_date: 2021-09-09
   end_date: 2025-05-14

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-06-25:
+  start_date: 2021-12-17
+  end_date: 2025-06-15
+  reason: Add records for Apple subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-05-22:
   start_date: 2021-09-09
   end_date: 2025-05-14

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-06-25:
+  start_date: 2021-12-17
+  end_date: 2025-06-15
+  reason: Add records for Apple subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-05-22:
   start_date: 2021-09-09
   end_date: 2025-05-14

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-06-25:
+  start_date: 2021-12-01
+  end_date: 2025-05-01
+  reason: Add records for Apple subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-05-22:
   start_date: 2021-09-01
   end_date: 2025-04-01

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-06-25:
+  start_date: 2021-12-01
+  end_date: 2025-05-01
+  reason: Add records for Apple subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-05-22:
   start_date: 2021-09-01
   end_date: 2025-04-01

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-06-25:
+  start_date: 2021-12-17
+  end_date: 2025-06-15
+  reason: Add records for Apple subscriptions, which are now included in these SubPlat
+    consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
+  watchers:
+  - srose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-05-22:
   start_date: 2021-09-09
   end_date: 2025-05-14


### PR DESCRIPTION
## Description

Initiates backfills of the logical subscription and service subscription tables.

## Related Tickets & Documents
* DENG-976: Apple subscriptions ETL v2

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
