### PR TITLE
AD-931 Fix legacy telemetry removal of fraudulent activity in newtab_interactions_hourly

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_interactions_hourly_v1/query.sql
@@ -37,7 +37,7 @@ legacy_impression_data AS (
 -- this CTE allows us to filter out >2 clicks from a given client on the same tile within 1 second
 legacy_flattened_impression_data AS (
   SELECT
-    submission_timestamp,
+    TIMESTAMP_TRUNC(submission_timestamp, SECOND) AS submission_second,
     impression_id AS client_id, -- client_id renamed to impression_id in GCP
     flattened_tiles.id AS tile_id,
     --the 3x1 layout has a bug where we need to use the position of each element in the tiles array instead of the actual pos field
@@ -60,14 +60,14 @@ legacy_flattened_impression_data AS (
     UNNEST(legacy_impression_data.tiles) AS flattened_tiles
     WITH OFFSET AS alt_pos
   GROUP BY
-    submission_timestamp,
+    submission_second,
     client_id,
     tile_id,
     position
 ),
 legacy_summary AS (
   SELECT
-    DATE(submission_timestamp) AS submission_date,
+    DATE(submission_second) AS submission_date,
     CAST(NULL AS STRING) AS recommendation_id,
     tile_id,
     position,


### PR DESCRIPTION
## Description

This PR fixes an issue in `newtab_interactions_hourly` where legacy (ActivityStream) telemetry is not correctly handling overactive clients. This adjusts the code to work as described in the comment: For any client activity where a client clicks the same tile > 2 times in a second, all the activity for that [client, tile, second] is discarded.

## Related Tickets & Documents
* AD-931

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
