### PR TITLE
fix(DENG-8986): update DAG & ETL owners for snowflake migrated tables

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2294,10 +2294,10 @@ bqetl_content_ml_hourly:
   description: |
     Hourly extracts for corpus item data to be evaluated for new tab presentation.
   default_args:
-    owner: skamath@mozilla.com
+    owner: jpetto@mozilla.com
     # Converted to an hourly DAG on 2025-06-24
     start_date: "2025-06-24"
-    email: ["skamath@mozilla.com", "rrando@mozilla.com"]
+    email: ["jpetto@mozilla.com", "rrando@mozilla.com"]
     # if the hourly task fails, retry once after a 10 minute wait
     retries: 1
     retry_delay: 10m

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/approved_corpus_items/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/approved_corpus_items/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: Approved Corpus Items
 description: View of approved corpus items in the corpus_items_updated_v1 table
 owners:
-  - skamath@mozilla.com
+  - jpetto@mozilla.com
   - rrando@mozilla.com

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/metadata.yaml
@@ -1,12 +1,12 @@
 friendly_name: Corpus Item Schedules Updated v1
 description: Model corpus item schedule updated events for the Fx New Tab from stg_scheduled_corpus_items_v1 and corpus_items_updated_v1 tables
 owners:
-  - skamath@mozilla.com
+  - jpetto@mozilla.com
   - rrando@mozilla.com
 labels:
   schedule: hourly
   incremental: true
-  owner1: skamath
+  owner1: jpetto
   owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_hourly

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_updated_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_updated_v1/metadata.yaml
@@ -1,12 +1,12 @@
 friendly_name: Corpus Items Updated v1
 description: Model corpus item updated events for the Fx New Tab from stg_reviewed_corpus_items_v1 and prospect_item_feed_v1 tables
 owners:
-  - skamath@mozilla.com
+  - jpetto@mozilla.com
   - rrando@mozilla.com
 labels:
   schedule: hourly
   incremental: true
-  owner1: skamath
+  owner1: jpetto
   owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_hourly

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/curator_actions/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/curator_actions/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: Curator Actions
 description: View of curator actions on ML provided prospects and corpus items.
 owners:
-  - rrando@mozilla.com
   - jpetto@mozilla.com
+  - rrando@mozilla.com

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/metadata.yaml
@@ -1,12 +1,12 @@
 friendly_name: Dismissed Prospects v1
 description: Model dismissed prospects for the Fx New Tab from prospects_v1, corpus_items_updated_v1, and rejected_corpus_items_v1 tables
 owners:
-  - skamath@mozilla.com
+  - jpetto@mozilla.com
   - rrando@mozilla.com
 labels:
   schedule: hourly
   incremental: true
-  owner1: skamath
+  owner1: jpetto
   owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_hourly

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospect_item_feed_v1/metadata.yaml
@@ -1,12 +1,12 @@
 friendly_name: Prospect Item Feed v1
 description: Model prospect created events for the Fx New Tab from prospects_v1 table
 owners:
-  - skamath@mozilla.com
+  - jpetto@mozilla.com
   - rrando@mozilla.com
 labels:
   schedule: hourly
   incremental: true
-  owner1: skamath
+  owner1: jpetto
   owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_hourly

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/prospects_v1/metadata.yaml
@@ -1,12 +1,12 @@
 friendly_name: Prospects v1
 description: Model prospective article options for the Fx New Tab from raw Snowplow data
 owners:
-  - skamath@mozilla.com
+  - jpetto@mozilla.com
   - rrando@mozilla.com
 labels:
   schedule: hourly
   incremental: true
-  owner1: skamath
+  owner1: jpetto
   owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_hourly

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/metadata.yaml
@@ -1,12 +1,12 @@
 friendly_name: Rejected Corpus Items v1
 description: Model corpus item rejected events for the Fx New Tab from stg_reviewed_corpus_items_v1 and prospect_item_feed_v1 tables
 owners:
-  - skamath@mozilla.com
+  - jpetto@mozilla.com
   - rrando@mozilla.com
 labels:
   schedule: hourly
   incremental: true
-  owner1: skamath
+  owner1: jpetto
   owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_hourly

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/scheduled_articles_report_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/scheduled_articles_report_v1/metadata.yaml
@@ -1,12 +1,12 @@
 friendly_name: Scheduled Articles Report v1
 description: Model article approval, rejected, and removal rates per day per surface
 owners:
-  - skamath@mozilla.com
+  - jpetto@mozilla.com
   - rrando@mozilla.com
 labels:
   schedule: hourly
   incremental: false
-  owner1: skamath
+  owner1: jpetto
   owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_hourly

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/scheduled_corpus_items/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/scheduled_corpus_items/metadata.yaml
@@ -1,5 +1,5 @@
 friendly_name: Scheduled Corpus Items
 description: View of scheduled corpus items in the corpus_item_schedules_updated_v1 table
 owners:
-  - skamath@mozilla.com
+  - jpetto@mozilla.com
   - rrando@mozilla.com

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_reviewed_corpus_items_v1/metadata.yaml
@@ -1,12 +1,12 @@
 friendly_name: Stg Reviewed Corpus Items v1
 description: Model reviewed Corpus Item events for the Fx New Tab from raw Snowplow data
 owners:
-  - skamath@mozilla.com
+  - jpetto@mozilla.com
   - rrando@mozilla.com
 labels:
   schedule: hourly
   incremental: true
-  owner1: skamath
+  owner1: jpetto
   owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_hourly

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/stg_scheduled_corpus_items_v1/metadata.yaml
@@ -1,12 +1,12 @@
 friendly_name: Stg Scheduled Corpus Items v1
 description: Model scheduled Corpus Item events for the Fx New Tab from raw Snowplow data
 owners:
-  - skamath@mozilla.com
+  - jpetto@mozilla.com
   - rrando@mozilla.com
 labels:
   schedule: hourly
   incremental: true
-  owner1: skamath
+  owner1: jpetto
   owner2: rrando
 scheduling:
   dag_name: bqetl_content_ml_hourly


### PR DESCRIPTION
## Description

update DAG & ETL owners for snowflake migrated tables

## Related Tickets & Documents
* DENG-8986

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
