### PR TITLE
chore(SubPlat): Complete backfills to add historical Apple subscription records to SubPlat consolidated reporting tables (DENG-976)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
@@ -5,7 +5,7 @@
     consolidated reporting ETLs as of https://github.com/mozilla/bigquery-etl/pull/7679.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description
Completes backfills of the logical subscription and service subscription tables initiated in #7690.

In addition to adding records for Apple subscriptions, these backfills also have minor side effects on some existing records:

- `first_touch_attribution.impression_at` and `last_touch_attribution.impression_at` timestamps have been truncated to milliseconds for 156 subscriptions.
- `has_refunds` has changed from false to true for 58 subscriptions.
- `has_fraudulent_charges` has changed from false to true for 1 subscription.
- `payment_provider` has changed from Stripe to PayPal for 1 subscription.
- `customer_subscription_number` has increased for 710 subscriptions.

These are very similar to the side effects of the backfill that added records for Google subscriptions (#7549), and the reasons are the same.

## Related Tickets & Documents
* DENG-976: Apple subscriptions ETL v2
* https://github.com/mozilla/bigquery-etl/pull/7690

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
