### PR TITLE
[DENG-9043] Allow backfills for moz-confidential tables with addition…

### DIFF
--- a/bigquery_etl/backfill/utils.py
+++ b/bigquery_etl/backfill/utils.py
@@ -28,7 +28,7 @@ BACKFILL_DESTINATION_PROJECT = "moz-fx-data-shared-prod"
 BACKFILL_DESTINATION_DATASET = "backfills_staging_derived"
 
 # currently only supporting backfilling tables with workgroup access: mozilla-confidential.
-VALID_WORKGROUP_MEMBER = ["workgroup:mozilla-confidential"]
+VALID_WORKGROUP_MEMBER = "workgroup:mozilla-confidential"
 
 # Backfills older than this will not run due to staging table expiration
 MAX_BACKFILL_ENTRY_AGE_DAYS = 28
@@ -245,7 +245,7 @@ def _validate_workgroup_members(workgroup_access, metadata_filename):
             elif metadata_filename == DATASET_METADATA_FILE:
                 members = workgroup["members"]
 
-            if members == VALID_WORKGROUP_MEMBER:
+            if VALID_WORKGROUP_MEMBER in members:
                 return True
 
     return False


### PR DESCRIPTION
…al permissions

## Description

So backfill can be done for tables in datasets like https://github.com/mozilla/bigquery-etl/blob/235a7507976b22af532a2555c2946d0f63262e7d/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dataset_metadata.yaml#L9-L14
## Related Tickets & Documents
* DENG-9043

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
