### PR TITLE
Reduce overactive clients threshold in `events_daily_v1` ETLs

### DIFF
--- a/sql_generators/events_daily/templates/events_daily_v1/query.sql
+++ b/sql_generators/events_daily/templates/events_daily_v1/query.sql
@@ -50,7 +50,7 @@ WITH sample AS (
     )
     AND client_id IS NOT NULL
     -- filter out overactive clients: they distort the data and can cause the job to fail: https://bugzilla.mozilla.org/show_bug.cgi?id=1730190
-    AND client_event_count < 200000
+    AND client_event_count < 150000
 ),
 joined AS (
   SELECT


### PR DESCRIPTION
This should fix `bqetl_fenix_event_rollup .fenix_derived__events_daily__v1` failing today.