### PR TITLE
chore(DENG-9032): complete backfill of corpus_items_updated_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_updated_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_updated_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
     - jpetto@mozilla.com
     - ctroy@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

complete backfill of `corpus_items_updated_v1`.

## Related Tickets & Documents
* DENG-9032

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
