### PR TITLE
chore(DENG-9033): fix ETL bugs and backfill two snowflake models

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/backfill.yaml
@@ -1,10 +1,11 @@
-2025-06-11:
+2025-06-30:
   start_date: 2024-09-19
-  end_date: 2025-06-10
-  reason: Original model had a bug in the JOIN, resulting in missing rows
+  end_date: 2025-06-29
+  reason: Backfill table after fixing bug in ETL query and backfilling upstream table
   watchers:
     - jpetto@mozilla.com
-  status: Complete
+    - ctroy@mozilla.com
+  status: Initiate
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/query.sql
@@ -59,14 +59,6 @@ FROM
 JOIN
   `moz-fx-data-shared-prod.snowflake_migration_derived.corpus_items_updated_v1` AS a
   ON a.approved_corpus_item_external_id = s.approved_corpus_item_external_id
-  {% if is_init() %}
-    -- 2024-09-19 is the earliest date we have data from snowplow
-    AND DATE(a.happened_at) >= '2024-09-19'
-  {% else %}
-    -- @submission_date is the default name for the query param
-    -- automatically passed in when the job runs
-    AND DATE(a.happened_at) = @submission_date
-  {% endif %}
 WHERE
   object_version = 'new' --only select the new version from each scheduled_corpus_item event
   AND s.object_update_trigger IN (

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/backfill.yaml
@@ -1,0 +1,24 @@
+2025-06-30:
+  start_date: 2024-09-19
+  end_date: 2025-06-29
+  reason: Backfill table after fixing bug in ETL query and backfilling upstream table
+  watchers:
+    - jpetto@mozilla.com
+    - ctroy@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false
+
+2025-06-11:
+  start_date: 2024-09-19
+  end_date: 2025-06-10
+  reason: Original model had a bug in the JOIN, resulting in missing rows
+  watchers:
+    - jpetto@mozilla.com
+  status: Complete
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/query.sql
@@ -31,14 +31,6 @@ FROM
 LEFT JOIN
   `moz-fx-data-shared-prod.snowflake_migration_derived.prospect_item_feed_v1` AS p
   ON p.prospect_id = r.prospect_id
-  {% if is_init() %}
-    -- 2024-09-19 is the earliest date we have data from snowplow
-    AND DATE(p.happened_at) >= '2024-09-19'
-  {% else %}
-    -- @submission_date is the default name for the query param
-    -- automatically passed in when the job runs
-    AND DATE(p.happened_at) = @submission_date
-  {% endif %}
 WHERE
   object_version = 'new' --only select the new version from each reviewed_corpus_item event
   AND r.rejected_corpus_item_external_id IS NOT NULL


### PR DESCRIPTION
## Description

fix ETL bugs and backfill two snowflake models.

- fixes `rejected_corpus_items_v1` and `corpus_item_schedules_updated_v1`

## Related Tickets & Documents
* DENG-9033

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
