### PR TITLE
[DENG-9047] Add option to slice events_stream by sample_id

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -347,6 +347,9 @@ generate:
       - accounts_frontend
       - accounts_backend
       - subscription_platform_backend
+      slice_by_sample_id:
+      - firefox_desktop
+      - firefox_desktop_background_update
     events_monitoring:
       skip_apps:
       - ads_backend  # restricted dataset, we don't want to include it aggregate view

--- a/sql_generators/glean_usage/events_stream.py
+++ b/sql_generators/glean_usage/events_stream.py
@@ -49,6 +49,16 @@ class EventsStreamTable(GleanTable):
             "generate", "glean_usage", "events_stream", "metrics_as_struct", fallback=[]
         )
 
+        slice_by_sample_id = app_id in ConfigLoader.get(
+            "generate",
+            "glean_usage",
+            "events_stream",
+            "slice_by_sample_id",
+            fallback=[],
+        )
+        if slice_by_sample_id:
+            self.python_query = True
+
         # Separate apps with legacy telemetry client ID vs those that don't have it
         if app_id == "firefox_desktop":
             has_legacy_telemetry_client_id = True
@@ -68,6 +78,7 @@ class EventsStreamTable(GleanTable):
             "has_legacy_telemetry_client_id": has_legacy_telemetry_client_id,
             "metrics_as_struct": metrics_as_struct,
             "has_metrics": ping_has_metrics(app_id, unversioned_table_name),
+            "slice_by_sample_id": slice_by_sample_id,
         }
 
         super().generate_per_app_id(

--- a/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
@@ -21,7 +21,17 @@ scheduling:
     {%- if metrics_as_struct %}
     "--schema_update_option", "ALLOW_FIELD_ADDITION",
     {%- endif %}
+    {%- if slice_by_sample_id %}
+    # slice_by_sample_id will run as a python script
+    "--slices", "10",
+    "--submission-date", {% raw %}"{{ ds }}"{% endraw %},
+    "--destination-table", "{{ project_id }}.{{ derived_dataset }}.{{ target_table }}",
+    {%- endif %}
   ]
+  {%- if slice_by_sample_id %}
+  referenced_tables:
+    - [ "{{ project_id }}", "{{ app_name }}", "events" ]
+  {%- endif %}
 bigquery:
   time_partitioning:
     type: day

--- a/sql_generators/glean_usage/templates/events_stream_v1.query.py
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import click
+from google.cloud import bigquery
+
+from bigquery_etl.util.common import TempDatasetReference
+
+query = (Path(__file__).parent / "query_supplemental.sql").read_text()
+
+
+@click.command()
+@click.option(
+    "--submission-date",
+    required=True,
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+)
+@click.option(
+    "--billing-project",
+    default=None,
+    help="Project to use to run queries",
+)
+@click.option(
+    "--destination-table",
+    required=True,
+    type=bigquery.TableReference.from_string,
+    help="Table to write final results to, formatted as PROJECT_ID.DATASET_ID.TABLE_ID",
+)
+@click.option(
+    "--temp-dataset",
+    default="moz-fx-data-shared-prod.tmp",
+    type=TempDatasetReference.from_string,
+    help="Dataset where intermediate query results will be temporarily stored, "
+    "formatted as PROJECT_ID.DATASET_ID",
+)
+@click.option(
+    "--slices",
+    type=int,
+    default=1,
+    help="Number of queries to split events stream query into, based on sample id",
+)
+def main(submission_date, billing_project, destination_table, temp_dataset, slices):
+    client = bigquery.Client(project=billing_project)
+
+    sample_id_interval_size = 100 // slices
+
+    destination_table = client.get_table(destination_table)
+
+    temp_tables = []
+
+    for min_sample_id in range(0, 100, sample_id_interval_size):
+        max_sample_id = min_sample_id + (sample_id_interval_size - 1)
+
+        # create temp table
+        temp_table = bigquery.Table(temp_dataset.temp_table())
+        temp_table.schema = destination_table.schema
+        temp_table.time_partitioning = destination_table.time_partitioning
+        temp_table.clustering_fields = destination_table.clustering_fields
+        temp_table.expires = datetime.utcnow() + timedelta(days=1)
+        temp_table = client.create_table(temp_table)
+
+        job = client.query(
+            query=query,
+            job_config=bigquery.QueryJobConfig(
+                destination=temp_table,
+                write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+                query_parameters=[
+                    bigquery.ScalarQueryParameter(
+                        "min_sample_id", "INT64", min_sample_id
+                    ),
+                    bigquery.ScalarQueryParameter(
+                        "max_sample_id", "INT64", max_sample_id
+                    ),
+                    bigquery.ScalarQueryParameter(
+                        "submission_date", "DATE", submission_date.date()
+                    ),
+                ],
+            ),
+        )
+        print(
+            f"Writing sample id {min_sample_id} to {max_sample_id} to {temp_table}: {job.path}"
+        )
+        job.result()
+        temp_tables.append(job.destination)
+
+    print(f"Copying to {destination_table}")
+    client.copy_table(
+        sources=temp_tables,
+        destination=f"{destination_table}${submission_date.strftime('%Y%m%d')}",
+        job_config=bigquery.CopyJobConfig(
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -113,13 +113,10 @@ WITH base AS (
   FROM
     `{{ events_view }}`
   WHERE
-    {% raw %}
-    {% if is_init() %}
-      DATE(submission_timestamp) >= '2023-11-01'
-    {% else %}
-      DATE(submission_timestamp) = @submission_date
+    DATE(submission_timestamp) = @submission_date
+    {% if slice_by_sample_id %}
+      AND sample_id BETWEEN @min_sample_id AND @max_sample_id
     {% endif %}
-    {% endraw %}
 )
 --
 SELECT


### PR DESCRIPTION
## Description

Turns some events stream queries into python scripts to run them by sample id slices similar to copy deduplicate.  This also adds query.py support to glean usage to make this work.

## Related Tickets & Documents
* DENG-9047
* https://bugzilla.mozilla.org/show_bug.cgi?id=1974286

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
