### PR TITLE
chore(DENG-9035): fix ETL bugs and backfill third tier snowflake models

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/backfill.yaml
@@ -1,0 +1,12 @@
+2025-06-30:
+  start_date: 2024-09-19
+  end_date: 2025-06-30
+  reason: Backfill table after fixing bug in ETL query and backfilling upstream tables
+  watchers:
+    - jpetto@mozilla.com
+    - ctroy@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dismissed_prospects_v1/query.sql
@@ -25,19 +25,9 @@ FROM
 LEFT JOIN
   `moz-fx-data-shared-prod.snowflake_migration_derived.corpus_items_updated_v1` AS c
   ON c.prospect_id = p.prospect_id
-  {% if is_init() %}
-    AND DATE(c.happened_at) >= '2024-09-19'
-  {% else %}
-    AND DATE(c.happened_at) = @submission_date
-  {% endif %}
 LEFT JOIN
   `moz-fx-data-shared-prod.snowflake_migration_derived.rejected_corpus_items_v1` AS r
   ON r.prospect_id = p.prospect_id
-  {% if is_init() %}
-    AND DATE(r.happened_at) >= '2024-09-19'
-  {% else %}
-    AND DATE(r.happened_at) = @submission_date
-  {% endif %}
 WHERE
   p.prospect_review_status = 'dismissed'
   {% if is_init() %}

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/scheduled_articles_report_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/scheduled_articles_report_v1/backfill.yaml
@@ -1,0 +1,12 @@
+2025-06-30:
+  start_date: 2024-09-19
+  end_date: 2025-06-30
+  reason: Backfill table after fixing bug in ETL query and backfilling upstream tables
+  watchers:
+    - jpetto@mozilla.com
+    - ctroy@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/scheduled_articles_report_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/scheduled_articles_report_v1/query.sql
@@ -10,7 +10,6 @@ WITH approved_ml AS (
     AND curator_created_by = 'ML'
     AND is_syndicated = FALSE
     AND is_collection = FALSE
-    AND DATE(happened_at) >= '2024-09-19'
   GROUP BY
     1,
     2
@@ -38,7 +37,6 @@ removed_ml AS (
     AND curator_created_by = 'ML'
     AND is_syndicated = FALSE
     AND is_collection = FALSE
-    AND DATE(happened_at) >= '2024-09-19'
     AND APPROVED_CORPUS_ITEM_EXTERNAL_ID NOT IN (
       SELECT
         APPROVED_CORPUS_ITEM_EXTERNAL_ID
@@ -46,7 +44,6 @@ removed_ml AS (
         `moz-fx-data-shared-prod.snowflake_migration_derived.corpus_items_updated_v1`
       WHERE
         reviewed_corpus_update_status = 'removed'
-        AND DATE(happened_at) >= '2024-09-19'
     )
   GROUP BY
     1,
@@ -65,13 +62,11 @@ rejected_ml AS (
     `moz-fx-data-shared-prod.snowflake_migration_derived.corpus_items_updated_v1` u
     ON s.APPROVED_CORPUS_ITEM_EXTERNAL_ID = u.APPROVED_CORPUS_ITEM_EXTERNAL_ID
     AND u.reviewed_corpus_update_status = 'removed'
-    AND DATE(u.happened_at) >= '2024-09-19'
   WHERE
     s.scheduled_corpus_status = 'removed'
     AND s.curator_created_by = 'ML'
     AND s.is_syndicated = FALSE
     AND s.is_collection = FALSE
-    AND DATE(s.happened_at) >= '2024-09-19'
   GROUP BY
     1,
     2
@@ -98,7 +93,6 @@ manual_within_tool_ml AS (
       DATE(scheduled_corpus_item_scheduled_at) != DATE(scheduled_corpus_item_created_at)
       AND is_time_sensitive = FALSE
     )
-    AND DATE(happened_at) >= '2024-09-19'
   GROUP BY
     1,
     2
@@ -128,7 +122,6 @@ manual_outside_tool_ml AS (
       DATE(scheduled_corpus_item_scheduled_at) != DATE(scheduled_corpus_item_created_at)
       AND is_time_sensitive = FALSE
     )
-    AND DATE(happened_at) >= '2024-09-19'
   GROUP BY
     1,
     2


### PR DESCRIPTION
## Description

fix ETL bugs and backfill third tier snowflake models

- fixes dismissed_prospects_v1 and scheduled_articles_report_v1

## Related Tickets & Documents
* DENG-9035

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
