### PR TITLE
chore(DENG-9033): complete backfills for two snowflake tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_item_schedules_updated_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
     - jpetto@mozilla.com
     - ctroy@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/rejected_corpus_items_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
     - jpetto@mozilla.com
     - ctroy@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

complete backfills for two snowflake tables

- corpus_item_schedules_updated_v1
- rejected_corpus_items_v1

## Related Tickets & Documents
* DENG-9033

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
