### PR TITLE
Deprecate & unschedule fenix_derived.ltv_state_values_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v1/metadata.yaml
@@ -8,7 +8,7 @@ labels:
   incremental: false
   owner1: frank@mozilla.com
 scheduling:
-  dag_name: bqetl_org_mozilla_firefox_derived
+  #dag_name: bqetl_org_mozilla_firefox_derived
   depends_on_past: false
   date_partition_parameter: null
 bigquery:
@@ -16,3 +16,4 @@ bigquery:
   clustering:
     fields: [country]
 references: {}
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v2/checks.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/ltv_state_values_v2/checks.sql
@@ -9,7 +9,7 @@
 SELECT
   mozfun.assert.equals(1, COUNT(DISTINCT state_function))
 FROM
-  `moz-fx-data-shared-prod.fenix_derived.ltv_state_values_v1`
+  `moz-fx-data-shared-prod.fenix_derived.ltv_state_values_v2`
 GROUP BY
   country;
 
@@ -18,4 +18,4 @@ GROUP BY
 SELECT
   `mozfun.assert.true`(COUNT(DISTINCT country) > 2)
 FROM
-  `moz-fx-data-shared-prod.fenix_derived.ltv_state_values_v1`;
+  `moz-fx-data-shared-prod.fenix_derived.ltv_state_values_v2`;


### PR DESCRIPTION
## Description

* This PR deprecates and un-schedules the build of:`moz-fx-data-shared-prod.fenix_derived.ltv_state_values_v1`
* It also fixes an issue we found, where the checks.sql of the ltv_state_values_v2 table was for some reason referenecing ltv_state_values_v1, so we fixed it to reference ltv_state_values_v2 instead.

## Related Tickets & Documents
* [Bug 1974938](https://bugzilla.mozilla.org/show_bug.cgi?id=1974938)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
