### PR TITLE
DENG-8977 - Allow read access to inner views/tables by workgroup:remote-settings/gke

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_crashreporter/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_crashreporter/crash/metadata.yaml
@@ -5,3 +5,5 @@ workgroup_access:
   members:
   # https://mozilla-hub.atlassian.net/browse/DENG-8189
   - workgroup:dataops-managed/crash-ping-ingest
+  # https://mozilla-hub.atlassian.net/browse/DENG-8977
+  - workgroup:remote-settings/gke

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/crash/metadata.yaml
@@ -5,3 +5,5 @@ workgroup_access:
   members:
   # https://mozilla-hub.atlassian.net/browse/DENG-8189
   - workgroup:dataops-managed/crash-ping-ingest
+  # https://mozilla-hub.atlassian.net/browse/DENG-8977
+  - workgroup:remote-settings/gke

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix/crash/metadata.yaml
@@ -5,3 +5,5 @@ workgroup_access:
   members:
   # https://mozilla-hub.atlassian.net/browse/DENG-8189
   - workgroup:dataops-managed/crash-ping-ingest
+  # https://mozilla-hub.atlassian.net/browse/DENG-8977
+  - workgroup:remote-settings/gke

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_nightly/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_nightly/crash/metadata.yaml
@@ -5,3 +5,5 @@ workgroup_access:
   members:
   # https://mozilla-hub.atlassian.net/browse/DENG-8189
   - workgroup:dataops-managed/crash-ping-ingest
+  # https://mozilla-hub.atlassian.net/browse/DENG-8977
+  - workgroup:remote-settings/gke

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fennec_aurora/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fennec_aurora/crash/metadata.yaml
@@ -5,3 +5,5 @@ workgroup_access:
   members:
   # https://mozilla-hub.atlassian.net/browse/DENG-8189
   - workgroup:dataops-managed/crash-ping-ingest
+  # https://mozilla-hub.atlassian.net/browse/DENG-8977
+  - workgroup:remote-settings/gke

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox/crash/metadata.yaml
@@ -5,3 +5,5 @@ workgroup_access:
   members:
   # https://mozilla-hub.atlassian.net/browse/DENG-8189
   - workgroup:dataops-managed/crash-ping-ingest
+  # https://mozilla-hub.atlassian.net/browse/DENG-8977
+  - workgroup:remote-settings/gke

--- a/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta/crash/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_firefox_beta/crash/metadata.yaml
@@ -5,3 +5,5 @@ workgroup_access:
   members:
   # https://mozilla-hub.atlassian.net/browse/DENG-8189
   - workgroup:dataops-managed/crash-ping-ingest
+  # https://mozilla-hub.atlassian.net/browse/DENG-8977
+  - workgroup:remote-settings/gke

--- a/sql/moz-fx-data-shared-prod/telemetry/socorro_crash_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/socorro_crash_v2/metadata.yaml
@@ -15,3 +15,5 @@ workgroup_access:
       - workgroup:ci-and-quality-tools/taskcluster
       # https://mozilla-hub.atlassian.net/browse/DENG-8350
       - workgroup:dataops-managed/crash-ping-ingest
+      # https://mozilla-hub.atlassian.net/browse/DENG-8977
+      - workgroup:remote-settings/gke


### PR DESCRIPTION
## Description

This PR adds dataViewer access for `workgroup:remote-settings/gke` on all tables/views that `workgroup:dataops-managed/crash-ping-ingest` has (as of this writing), as these match the inner tables/views used by the views which were added in DENG-8424 (#7474).


## Related Tickets & Documents

* DENG-8977

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
