### PR TITLE
feat(SubPlat): Update SubPlat ETLs to use new attribution metadata from SubPlat 3

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/all_subscriptions_v1/query.sql
@@ -252,6 +252,19 @@ all_subscriptions AS (
   FROM
     google_iap_subscriptions
 ),
+subscriptions_attribution AS (
+  SELECT
+    subscription_id,
+    attribution
+  FROM
+    `moz-fx-data-shared-prod.mozilla_vpn_derived.all_subscriptions_attribution_v1`
+  UNION ALL
+  SELECT
+    subscription_id,
+    attribution
+  FROM
+    `moz-fx-data-shared-prod.mozilla_vpn_derived.stripe_subscriptions_attribution_v1`
+),
 subscription_last_touch_attributions AS (
   -- Select the latest attribution before the subscription originally started.
   SELECT
@@ -266,7 +279,7 @@ subscription_last_touch_attributions AS (
   FROM
     all_subscriptions AS subscriptions
   JOIN
-    `moz-fx-data-shared-prod.mozilla_vpn_derived.all_subscriptions_attribution_v1` AS subscriptions_attribution
+    subscriptions_attribution
     ON subscriptions.subscription_id = subscriptions_attribution.subscription_id
     AND COALESCE(
       subscriptions.original_subscription_start_date,

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/stripe_subscriptions_attribution_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/stripe_subscriptions_attribution_v1/metadata.yaml
@@ -1,0 +1,17 @@
+friendly_name: Mozilla VPN Stripe subscriptions attribution
+description: >
+  Last-touch attribution for Mozilla VPN Stripe subscriptions based on subscription metadata stored by SubPlat 3.
+owners:
+  - srose@mozilla.com
+labels:
+  application: mozilla_vpn
+  schedule: daily
+  incremental: true
+scheduling:
+  dag_name: bqetl_subplat
+  date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    type: day
+    field: date
+    require_partition_filter: false

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/stripe_subscriptions_attribution_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/stripe_subscriptions_attribution_v1/query.sql
@@ -1,0 +1,57 @@
+WITH stripe_subscriptions_history AS (
+  SELECT
+    *,
+    CONCAT(
+      subscription_id,
+      COALESCE(
+        CONCAT(
+          "-",
+          NULLIF(ROW_NUMBER() OVER (PARTITION BY subscription_id ORDER BY valid_from), 1)
+        ),
+        ""
+      )
+    ) AS subscription_sequence_id
+  FROM
+    `moz-fx-data-shared-prod`.subscription_platform_derived.stripe_subscriptions_history_v1
+  WHERE
+    -- Only include the current history records and the last history records for previous plans.
+    (valid_to IS NULL OR plan_ended_at IS NOT NULL)
+    AND status NOT IN ("incomplete", "incomplete_expired")
+),
+stripe_subscriptions AS (
+  SELECT
+    subscription_sequence_id AS subscription_id,
+    IF(
+      (trial_end > TIMESTAMP(CURRENT_DATE) OR ended_at <= trial_end),
+      trial_start,
+      COALESCE(plan_started_at, subscription_start_date)
+    ) AS effective_start_date,
+    attribution
+  FROM
+    stripe_subscriptions_history
+  WHERE
+    "guardian_vpn_1" IN UNNEST(stripe_subscriptions_history.product_capabilities)
+    OR "guardian_vpn_1" IN UNNEST(stripe_subscriptions_history.plan_capabilities)
+)
+SELECT
+  subscription_id,
+  DATE(effective_start_date) AS `date`,
+  STRUCT(
+    effective_start_date AS `timestamp`,
+    attribution.entrypoint_experiment,
+    attribution.entrypoint_variation,
+    attribution.utm_campaign,
+    attribution.utm_content,
+    attribution.utm_medium,
+    attribution.utm_source,
+    attribution.utm_term
+  ) AS attribution
+FROM
+  stripe_subscriptions
+WHERE
+  attribution IS NOT NULL
+  {% if is_init() %}
+    AND DATE(effective_start_date) < CURRENT_DATE()
+  {% else %}
+    AND DATE(effective_start_date) = @date
+  {% endif %}

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/stripe_subscriptions_attribution_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/stripe_subscriptions_attribution_v1/schema.yaml
@@ -1,0 +1,35 @@
+fields:
+- name: subscription_id
+  type: STRING
+  mode: NULLABLE
+- name: date
+  type: DATE
+  mode: NULLABLE
+- name: attribution
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: timestamp
+    type: TIMESTAMP
+    mode: NULLABLE
+  - name: entrypoint_experiment
+    type: STRING
+    mode: NULLABLE
+  - name: entrypoint_variation
+    type: STRING
+    mode: NULLABLE
+  - name: utm_campaign
+    type: STRING
+    mode: NULLABLE
+  - name: utm_content
+    type: STRING
+    mode: NULLABLE
+  - name: utm_medium
+    type: STRING
+    mode: NULLABLE
+  - name: utm_source
+    type: STRING
+    mode: NULLABLE
+  - name: utm_term
+    type: STRING
+    mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_history_v1/query.sql
@@ -23,9 +23,21 @@ countries AS (
 ),
 subscription_attributions AS (
   SELECT
-    *
+    subscription_id,
+    IF(
+      attribution_v2.subscription_id IS NOT NULL,
+      NULL,
+      attribution_v1.first_touch_attribution
+    ) AS first_touch_attribution,
+    COALESCE(
+      attribution_v2.last_touch_attribution,
+      attribution_v1.last_touch_attribution
+    ) AS last_touch_attribution
   FROM
-    `moz-fx-data-shared-prod.subscription_platform_derived.stripe_logical_subscriptions_attribution_v1`
+    `moz-fx-data-shared-prod.subscription_platform_derived.stripe_logical_subscriptions_attribution_v1` AS attribution_v1
+  FULL JOIN
+    `moz-fx-data-shared-prod.subscription_platform_derived.stripe_logical_subscriptions_attribution_v2` AS attribution_v2
+    USING (subscription_id)
 )
 SELECT
   history.id,

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscriptions_history_v1/query.sql
@@ -64,9 +64,21 @@ subscriptions_history_periods AS (
 ),
 subscription_attributions AS (
   SELECT
-    *
+    subscription_id,
+    IF(
+      attribution_v2.subscription_id IS NOT NULL,
+      NULL,
+      attribution_v1.first_touch_attribution
+    ) AS first_touch_attribution,
+    COALESCE(
+      attribution_v2.last_touch_attribution,
+      attribution_v1.last_touch_attribution
+    ) AS last_touch_attribution
   FROM
-    `moz-fx-data-shared-prod.subscription_platform_derived.stripe_service_subscriptions_attribution_v1`
+    `moz-fx-data-shared-prod.subscription_platform_derived.stripe_service_subscriptions_attribution_v1` AS attribution_v1
+  FULL JOIN
+    `moz-fx-data-shared-prod.subscription_platform_derived.stripe_service_subscriptions_attribution_v2` AS attribution_v2
+    USING (subscription_id)
 ),
 subscriptions_history AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/checks.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/checks.sql
@@ -1,0 +1,2 @@
+#fail
+{{ is_unique(["subscription_id"]) }}

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Stripe logical subscriptions attribution
+description: |-
+  Attribution for Stripe logical subscriptions based on Stripe subscription metadata stored by SubPlat 3.
+owners:
+- srose@mozilla.com
+labels:
+  incremental: true
+  schedule: hourly
+scheduling:
+  # The partition for a particular date will be rebuilt hourly from 01:30 to 00:30 the next day.
+  dag_name: bqetl_subplat_hourly
+  date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    type: day
+    field: subscription_started_at
+    require_partition_filter: false
+    expiration_days: null
+  clustering: null
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/query.sql
@@ -1,0 +1,45 @@
+WITH subscription_starts AS (
+  SELECT
+    subscription.id AS subscription_id,
+    subscription.started_at,
+    provider_subscriptions_history_id AS stripe_subscriptions_history_id
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.stripe_logical_subscriptions_history_v1`
+  WHERE
+    {% if is_init() %}
+      DATE(subscription.started_at) <= DATE(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR))
+    {% else %}
+      DATE(subscription.started_at) = @date
+    {% endif %}
+  QUALIFY
+    1 = ROW_NUMBER() OVER (PARTITION BY subscription.id ORDER BY valid_from, valid_to)
+)
+SELECT
+  subscription_starts.subscription_id,
+  subscription_starts.started_at AS subscription_started_at,
+  STRUCT(
+    subscription_starts.started_at AS impression_at,
+    history.subscription.metadata.session_entrypoint AS entrypoint,
+    history.subscription.metadata.session_entrypoint_experiment AS entrypoint_experiment,
+    history.subscription.metadata.session_entrypoint_variation AS entrypoint_variation,
+    history.subscription.metadata.utm_campaign,
+    history.subscription.metadata.utm_content,
+    history.subscription.metadata.utm_medium,
+    history.subscription.metadata.utm_source,
+    history.subscription.metadata.utm_term
+  ) AS last_touch_attribution
+FROM
+  subscription_starts
+JOIN
+  `moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_history_v2` AS history
+  ON subscription_starts.stripe_subscriptions_history_id = history.id
+WHERE
+  history.subscription.metadata.session_flow_id IS NOT NULL
+  OR history.subscription.metadata.session_entrypoint IS NOT NULL
+  OR history.subscription.metadata.session_entrypoint_experiment IS NOT NULL
+  OR history.subscription.metadata.session_entrypoint_variation IS NOT NULL
+  OR history.subscription.metadata.utm_campaign IS NOT NULL
+  OR history.subscription.metadata.utm_content IS NOT NULL
+  OR history.subscription.metadata.utm_medium IS NOT NULL
+  OR history.subscription.metadata.utm_source IS NOT NULL
+  OR history.subscription.metadata.utm_term IS NOT NULL

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/schema.yaml
@@ -1,0 +1,62 @@
+fields:
+- name: subscription_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Logical subscription ID.
+- name: subscription_started_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the subscription started.
+- name: last_touch_attribution
+  type: RECORD
+  mode: NULLABLE
+  description: |-
+    Last-touch attribution for the subscription (if any).
+  fields:
+  - name: impression_at
+    type: TIMESTAMP
+    mode: NULLABLE
+    description: |-
+      When the last-touch attribution impression occurred.
+  - name: entrypoint
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint.
+  - name: entrypoint_experiment
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint experiment.
+  - name: entrypoint_variation
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint experiment variation.
+  - name: utm_campaign
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM campaign.
+  - name: utm_content
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM content.
+  - name: utm_medium
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM medium.
+  - name: utm_source
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM source.
+  - name: utm_term
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM term.

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/checks.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/checks.sql
@@ -1,0 +1,2 @@
+#fail
+{{ is_unique(["subscription_id"]) }}

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Stripe service subscriptions attribution
+description: |-
+  Attribution for Stripe service subscriptions based on Stripe subscription metadata stored by SubPlat 3.
+owners:
+- srose@mozilla.com
+labels:
+  incremental: true
+  schedule: hourly
+scheduling:
+  # The partition for a particular date will be rebuilt hourly from 01:30 to 00:30 the next day.
+  dag_name: bqetl_subplat_hourly
+  date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    type: day
+    field: subscription_started_at
+    require_partition_filter: false
+    expiration_days: null
+  clustering: null
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/query.sql
@@ -1,0 +1,63 @@
+WITH subscription_starts AS (
+  SELECT
+    CONCAT(
+      subscription.provider,
+      '-',
+      subscription.provider_subscription_id,
+      '-',
+      service.id,
+      '-',
+      FORMAT_TIMESTAMP('%FT%H:%M:%E6S', valid_from)
+    ) AS subscription_id,
+    valid_from AS started_at,
+    provider_subscriptions_history_id AS stripe_subscriptions_history_id
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.logical_subscriptions_history_v1`
+  CROSS JOIN
+    UNNEST(subscription.services) AS service
+  WHERE
+    subscription.provider = 'Stripe'
+  QUALIFY
+    valid_from IS DISTINCT FROM LAG(valid_to) OVER (
+      PARTITION BY
+        subscription.id,
+        service.id
+      ORDER BY
+        valid_from,
+        valid_to
+    )
+    {% if is_init() %}
+      AND DATE(valid_from) <= DATE(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR))
+    {% else %}
+      AND DATE(valid_from) = @date
+    {% endif %}
+)
+SELECT
+  subscription_starts.subscription_id,
+  subscription_starts.started_at AS subscription_started_at,
+  STRUCT(
+    subscription_starts.started_at AS impression_at,
+    history.subscription.metadata.session_entrypoint AS entrypoint,
+    history.subscription.metadata.session_entrypoint_experiment AS entrypoint_experiment,
+    history.subscription.metadata.session_entrypoint_variation AS entrypoint_variation,
+    history.subscription.metadata.utm_campaign,
+    history.subscription.metadata.utm_content,
+    history.subscription.metadata.utm_medium,
+    history.subscription.metadata.utm_source,
+    history.subscription.metadata.utm_term
+  ) AS last_touch_attribution
+FROM
+  subscription_starts
+JOIN
+  `moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_history_v2` AS history
+  ON subscription_starts.stripe_subscriptions_history_id = history.id
+WHERE
+  history.subscription.metadata.session_flow_id IS NOT NULL
+  OR history.subscription.metadata.session_entrypoint IS NOT NULL
+  OR history.subscription.metadata.session_entrypoint_experiment IS NOT NULL
+  OR history.subscription.metadata.session_entrypoint_variation IS NOT NULL
+  OR history.subscription.metadata.utm_campaign IS NOT NULL
+  OR history.subscription.metadata.utm_content IS NOT NULL
+  OR history.subscription.metadata.utm_medium IS NOT NULL
+  OR history.subscription.metadata.utm_source IS NOT NULL
+  OR history.subscription.metadata.utm_term IS NOT NULL

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/schema.yaml
@@ -1,0 +1,62 @@
+fields:
+- name: subscription_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Service subscription ID.
+- name: subscription_started_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the service subscription started.
+- name: last_touch_attribution
+  type: RECORD
+  mode: NULLABLE
+  description: |-
+    Last-touch attribution for the service subscription (if any).
+  fields:
+  - name: impression_at
+    type: TIMESTAMP
+    mode: NULLABLE
+    description: |-
+      When the last-touch attribution impression occurred.
+  - name: entrypoint
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint.
+  - name: entrypoint_experiment
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint experiment.
+  - name: entrypoint_variation
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint experiment variation.
+  - name: utm_campaign
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM campaign.
+  - name: utm_content
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM content.
+  - name: utm_medium
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM medium.
+  - name: utm_source
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM source.
+  - name: utm_term
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM term.

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v1/schema.yaml
@@ -116,3 +116,34 @@ fields:
 - mode: NULLABLE
   name: promotion_discounts_amount
   type: INTEGER
+- name: attribution
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: flow_id
+    type: STRING
+    mode: NULLABLE
+  - name: entrypoint
+    type: STRING
+    mode: NULLABLE
+  - name: entrypoint_experiment
+    type: STRING
+    mode: NULLABLE
+  - name: entrypoint_variation
+    type: STRING
+    mode: NULLABLE
+  - name: utm_campaign
+    type: STRING
+    mode: NULLABLE
+  - name: utm_content
+    type: STRING
+    mode: NULLABLE
+  - name: utm_medium
+    type: STRING
+    mode: NULLABLE
+  - name: utm_source
+    type: STRING
+    mode: NULLABLE
+  - name: utm_term
+    type: STRING
+    mode: NULLABLE


### PR DESCRIPTION
## Description
SubPlat 3 is setting some additional Stripe subscription metadata fields as workarounds to help us preserve the accuracy of the subscription products reporting in the face of the changes to how SubPlat works.

## Related Tickets & Documents
* DENG-8885: Update SubPlat ETLs to use Stripe subscription attribution metadata

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
