### PR TITLE
fix: metadata CODEOWNERS metadata validation in CI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,10 @@
 # These datasets are subject to the additional change control procedures
 # described in https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/
 # Active Users
-sql_generators/active_users_aggregates_v3/templates/ @mozilla/kpi_table_reviewers
-sql/**/active_users_aggregates_v3 @mozilla/kpi_table_reviewers
-sql_generators/active_users_aggregates_v4/templates/ @mozilla/kpi_table_reviewers
-sql/**/active_users_aggregates_v4/ @mozilla/kpi_table_reviewers
+/sql_generators/active_users_aggregates_v3/templates/ @mozilla/kpi_table_reviewers
+/sql/**/active_users_aggregates_v3 @mozilla/kpi_table_reviewers
+/sql_generators/active_users_aggregates_v4/templates/ @mozilla/kpi_table_reviewers
+/sql/**/active_users_aggregates_v4 @mozilla/kpi_table_reviewers
 # Search
 /sql/moz-fx-data-shared-prod/search_terms @whd @jasonthomas
 /sql/moz-fx-data-shared-prod/search_terms_derived @whd @jasonthomas

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -78,7 +78,7 @@ def validate_change_control(
         expanded_owners_list = [
             f"{path} {' '.join(entry.split(' ')[1:])}".rstrip()
             for entry in owner_file_content
-            for path in glob.glob(entry.split(" ")[0], recursive=True)
+            for path in glob.glob(entry.split(" ")[0].removeprefix("/"), recursive=True)
         ]
 
         owners_list = []

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -85,7 +85,7 @@ class TestMetadata:
             "labels": {"change_controlled": "true"},
         }
         codeowners = (
-            "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1 test@example.org"
+            "/sql/moz-fx-data-shared-prod/telemetry_derived/query_v1 test@example.org"
         )
         self.check_metadata(
             runner=runner,
@@ -105,7 +105,7 @@ class TestMetadata:
             "labels": {"change_controlled": "true", "foo": "abc"},
         }
         codeowners = (
-            "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1 test2@example.org"
+            "/sql/moz-fx-data-shared-prod/telemetry_derived/query_v1 test2@example.org"
         )
         self.check_metadata(
             runner=runner,
@@ -124,7 +124,7 @@ class TestMetadata:
             ],
             "labels": {"change_controlled": "true", "foo": "abc"},
         }
-        codeowners = "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1 test@example.org test2@example.org test3@example.org"
+        codeowners = "/sql/moz-fx-data-shared-prod/telemetry_derived/query_v1 test@example.org test2@example.org test3@example.org"
         self.check_metadata(
             runner=runner,
             metadata_conf=metadata,
@@ -143,7 +143,7 @@ class TestMetadata:
             "labels": {"change_controlled": "true", "foo": "abc"},
         }
         codeowners = (
-            "sql/**/query_v1 test@example.org test2@example.org test3@example.org"
+            "/sql/**/query_v1 test@example.org test2@example.org test3@example.org"
         )
         self.check_metadata(
             runner=runner,
@@ -163,7 +163,7 @@ class TestMetadata:
             "labels": {"change_controlled": "true", "foo": "abc"},
         }
         codeowners = (
-            "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1 @mozilla/reviewers"
+            "/sql/moz-fx-data-shared-prod/telemetry_derived/query_v1 @mozilla/reviewers"
         )
         self.check_metadata(
             runner=runner,
@@ -186,7 +186,7 @@ class TestMetadata:
             "owners": ["test@example.org", "test2@example.org", "test3@example.org"],
             "labels": {"change_controlled": "true"},
         }
-        codeowners = "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1 test@example.org test2@example.org"
+        codeowners = "/sql/moz-fx-data-shared-prod/telemetry_derived/query_v1 test@example.org test2@example.org"
         self.check_metadata(
             runner=runner,
             metadata_conf=metadata,


### PR DESCRIPTION
# fix: metadata CODEOWNERS metadata validation in CI

This is because in CI when deploying to staging the files get written to directories that do not match those directories defined in the CODEWONERS file. This change aims to add support to validate_change_control function for path with wildcards in CODEOWNERS.

Here's an example error message we get in our CLI currently when trying to edit `active_users_aggregates_v3` generator:

```
The Failed to validate 5 metadata files is because path in CODEOWNERS doesn't match the path of the generated queries in the CI
```

e.g. focus_ios_derived_moz_fx_data_shared_prod_03803ba9d249f6bbca0b1337ddb4c1e2e5afe6e9/active_users_aggregates_v3

This seems to be related to how we handle the query namespace in for our staging testing.
