### PR TITLE
chore(Fides): Grant Fides DSAR access

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/dataset_metadata.yaml
@@ -8,3 +8,4 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
+  - workgroup:dataops-managed/external-fides

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/dataset_metadata.yaml
@@ -9,3 +9,4 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
+  - workgroup:dataops-managed/external-fides


### PR DESCRIPTION
## Description

This PR grants the Fides service account data viewer access to the following 2 datasets:
- search_derived
- telemetry_derived

The purpose of this is for testing running DSARs using Fides.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
