### PR TITLE
feat(SubPlat): Implement `firestore_stripe_subscriptions_status_v1` ETL (DENG-9071)

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -99,6 +99,7 @@ dry_run:
   - sql/moz-fx-cjms-prod-f3c7/cjms_bigquery/subscriptions_v1/query.sql
   - sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_v1/query.sql
   - sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_changelog_v1/query.sql
+  - sql/moz-fx-data-shared-prod/subscription_platform_derived/firestore_stripe_subscriptions_status_v1/query.sql
   - sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_v1/query.sql
   - sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_changelog_v1/query.sql
   - sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_apple_subscriptions_v1/query.sql

--- a/sql/moz-fx-data-shared-prod/subscription_platform/firestore_stripe_subscriptions_status/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/firestore_stripe_subscriptions_status/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.subscription_platform.firestore_stripe_subscriptions_status`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.subscription_platform_derived.firestore_stripe_subscriptions_status_v1`

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/firestore_stripe_subscriptions_status_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/firestore_stripe_subscriptions_status_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Firestore Stripe subscriptions status
+description: |-
+  Stripe subscriptions' status over time as recorded in Firestore by SubPlat, based on Firestore record changes exported to BigQuery.
+owners:
+- srose@mozilla.com
+labels:
+  incremental: true
+  schedule: hourly
+scheduling:
+  # The partition for a particular date will be rebuilt hourly from 01:30 to 00:30 the next day.
+  dag_name: bqetl_subplat_hourly
+  date_partition_parameter: date
+bigquery:
+  time_partitioning:
+    type: day
+    field: firestore_export_timestamp
+    require_partition_filter: false
+    expiration_days: null
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/firestore_stripe_subscriptions_status_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/firestore_stripe_subscriptions_status_v1/query.sql
@@ -1,0 +1,14 @@
+SELECT
+  document_id AS subscription_id,
+  `timestamp` AS firestore_export_timestamp,
+  operation AS firestore_export_operation,
+  JSON_VALUE(`data`, '$.status') AS subscription_status,
+  JSON_VALUE(old_data, '$.status') AS previous_subscription_status
+FROM
+  `moz-fx-fxa-prod-0712.firestore_export.fxa_auth_prod_stripe_subscriptions_raw_changelog`
+WHERE
+  {% if is_init() %}
+    DATE(`timestamp`) <= DATE(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR))
+  {% else %}
+    DATE(`timestamp`) = @date
+  {% endif %}

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/firestore_stripe_subscriptions_status_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/firestore_stripe_subscriptions_status_v1/schema.yaml
@@ -1,0 +1,28 @@
+fields:
+- name: subscription_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Stripe subscription ID.
+- name: firestore_export_timestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the Firestore export operation occurred.
+- name: firestore_export_operation
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The type of Firestore export operation ("IMPORT", "CREATE", "UPDATE", or "DELETE").
+- name: subscription_status
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Stripe subscription status (if any).
+    This will be null for Firestore delete operations.
+- name: previous_subscription_status
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Previous Stripe subscription status (if any).
+    This will be null for a subscription's initial Firestore export record.


### PR DESCRIPTION
## Description
To allow the status of the Firestore Stripe subscription records to be monitored via Grafana.

This is related to the “[Relay Incomplete Subscriptions](https://mozilla.slack.com/archives/CFBDGQXV5/p1751491690591279)” incident.

## Related Tickets & Documents
* DENG-9071: Surface SubPlat's Firestore Stripe subscription status data in `mozdata` for monitoring

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
