### PR TITLE
fix: pass the params as multiple types (string and column name) into the composite_key check to work correctly with Bigeye query generation

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.bigconfig.yml
@@ -22,8 +22,12 @@ tag_deployments:
             parameters:
               - key: col_1
                 column_name: client_id
+              - key: col_1_string
+                string_value: client_id
               - key: col_2
                 column_name: normalized_channel
+              - key: col_2_string
+                string_value: normalized_channel
               - key: table
                 string_value: {{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
             rct_overrides:


### PR DESCRIPTION
# fix: pass the params as multiple types (string and column name) into the composite_key check to work correctly with Bigeye query generation

This as per Bigeye's recommendation