### PR TITLE
Bug 1957735 - Add search-with table to shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -107,6 +107,7 @@ FXA_USER_ID = "jsonPayload.fields.user_id"
 SYNC_IDS = ("SUBSTR(payload.device_id, 0, 32)", "payload.uid")
 CONTEXT_ID = "context_id"
 QUICK_SUGGEST_CONTEXT_ID = "metrics.uuid.quick_suggest_context_id"
+SEARCH_WITH_CONTEXT_ID = "metrics.uuid.search_with_context_id"
 USER_CHARACTERISTICS_ID = "metrics.uuid.characteristics_client_identifier"
 
 DESKTOP_SRC = DeleteSource(
@@ -541,6 +542,10 @@ DELETE_TARGETS: DeleteIndex = {
     DeleteTarget(
         table="firefox_desktop_stable.quick_suggest_v1",
         field=(QUICK_SUGGEST_CONTEXT_ID, QUICK_SUGGEST_CONTEXT_ID),
+    ): (CONTEXT_ID_DELETION_SRC, QUICK_SUGGEST_SRC),
+    DeleteTarget(
+        table="firefox_desktop_stable.search_with_v1",
+        field=(SEARCH_WITH_CONTEXT_ID, SEARCH_WITH_CONTEXT_ID),
     ): (CONTEXT_ID_DELETION_SRC, QUICK_SUGGEST_SRC),
     # client association ping
     DeleteTarget(

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -545,8 +545,8 @@ DELETE_TARGETS: DeleteIndex = {
     ): (CONTEXT_ID_DELETION_SRC, QUICK_SUGGEST_SRC),
     DeleteTarget(
         table="firefox_desktop_stable.search_with_v1",
-        field=(SEARCH_WITH_CONTEXT_ID, SEARCH_WITH_CONTEXT_ID),
-    ): (CONTEXT_ID_DELETION_SRC, QUICK_SUGGEST_SRC),
+        field=(SEARCH_WITH_CONTEXT_ID, SEARCH_WITH_CONTEXT_ID, SEARCH_WITH_CONTEXT_ID),
+    ): (CONTEXT_ID_DELETION_SRC, QUICK_SUGGEST_SRC, DESKTOP_GLEAN_SRC),
     # client association ping
     DeleteTarget(
         table="firefox_desktop_stable.fx_accounts_v1",


### PR DESCRIPTION
## Description

Supersedes https://github.com/mozilla/bigquery-etl/pull/7329 - I'm filing a new PR because that one is forked and now has conflicts.
Generated query:
```
DELETE
  `moz-fx-data-shared-prod.firefox_desktop_stable.search_with_v1`
WHERE
  (
    metrics.uuid.search_with_context_id IN (
      SELECT
        metrics.uuid.contextual_services_context_id
      FROM
        `moz-fx-data-shared-prod.firefox_desktop_stable.context_id_deletion_request_v1`
      WHERE
        DATE(submission_timestamp) >= '2025-01-01'
        AND DATE(submission_timestamp) < '2025-03-02'
    )
    OR metrics.uuid.search_with_context_id IN (
      SELECT
        metrics.uuid.quick_suggest_context_id
      FROM
        `moz-fx-data-shared-prod.firefox_desktop_stable.quick_suggest_deletion_request_v1`
      WHERE
        DATE(submission_timestamp) >= '2025-01-01'
        AND DATE(submission_timestamp) < '2025-03-02'
    )
  )
  AND (CAST(submission_timestamp AS DATE) < '2025-03-02')
```

## Related Tickets & Documents
https://bugzilla.mozilla.org/show_bug.cgi?id=1957735
