### PR TITLE
[DENG-8594] Update workgroup access for telemetry.firefox_crashes

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/firefox_crashes/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/firefox_crashes/metadata.yaml
@@ -1,0 +1,13 @@
+friendly_name: Firefox Crashes
+description: |-
+  Combined crashes for Firefox desktop, Fenix, Focus Android, and Klar.
+  Deduped by minidump hash.
+owners:
+- benwu@mozilla.com
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-8189
+  - workgroup:dataops-managed/crash-ping-ingest
+  # https://mozilla-hub.atlassian.net/browse/DENG-8424
+  - workgroup:remote-settings/gke


### PR DESCRIPTION
## Description

These workgroups aren't in moz-confidential so they can't query the views in `telemetry` by default

## Related Tickets & Documents
* DENG-8594

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
