### PR TITLE
feat(DENG-8914): update mobile_view templates inside active_users_aggregates generators so that focus products use composite dataset

### DIFF
--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -428,10 +428,13 @@ def validate(target):
                     if not validate_public_data(metadata, path):
                         failed = True
 
+                    _, project_id, _ = os.path.dirname(root).split("/")
+
                     if not validate_change_control(
                         file_path=root,
                         metadata=metadata,
                         codeowners_file=CODEOWNERS_FILE,
+                        project_id=project_id,
                     ):
                         failed = True
 

--- a/sql_generators/active_users_aggregates_v3/templates/mobile_view.sql
+++ b/sql_generators/active_users_aggregates_v3/templates/mobile_view.sql
@@ -13,22 +13,6 @@ CREATE OR REPLACE VIEW
       UNION ALL
     {% endif %}
     SELECT
-    -- As per DENG-8914, we want to use composite tables for focus products
-    -- these fields do not exist in the composite view.
-      {% if app_dataset_id in [
-        focus_ios_dataset,
-        focus_android_dataset
-      ] %}
-      activity_segment AS segment,
-      CAST(NULL AS STRING) AS attribution_medium,
-      CAST(NULL AS STRING) AS attribution_source,
-      CAST(NULL AS BOOLEAN) AS attributed,
-      CAST(NULL AS STRING) AS city,
-      CAST(NULL AS STRING) AS locale,
-      CAST(NULL AS STRING) AS adjust_network,
-      CAST(NULL AS STRING) AS install_source,
-      `mozfun.norm.os`(os) AS os_grouped,
-      {% else %}
       segment,
       attribution_medium,
       attribution_source,
@@ -38,7 +22,6 @@ CREATE OR REPLACE VIEW
       adjust_network,
       install_source,
       os_grouped,
-      {% endif %}
       country,
       distribution_id,
       first_seen_year,
@@ -62,13 +45,51 @@ CREATE OR REPLACE VIEW
       app_version_patch_revision,
       app_version_is_major_release,
     FROM
-    -- As per DENG-8914, we want to use composite tables for focus products
-    {% if app_dataset_id in [
-      focus_ios_dataset,
-      focus_android_dataset
-    ] %}
-      `{{ project_id }}.{{ app_dataset_id }}.composite_active_users_aggregates`
-    {% else %}
       `{{ project_id }}.{{ app_dataset_id }}.active_users_aggregates`
+  -- As per DENG-8914, we want to use composite tables for focus products
+  -- these fields do not exist in the composite view.
+  {% if app_dataset_id in [
+    focus_ios_dataset,
+    focus_android_dataset
+  ] %}
+    WHERE
+      submission_date < "2025-03-27"
+    UNION ALL
+    SELECT
+      activity_segment AS segment,
+      CAST(NULL AS STRING) AS attribution_medium,
+      CAST(NULL AS STRING) AS attribution_source,
+      CAST(NULL AS BOOLEAN) AS attributed,
+      CAST(NULL AS STRING) AS city,
+      CAST(NULL AS STRING) AS locale,
+      CAST(NULL AS STRING) AS adjust_network,
+      CAST(NULL AS STRING) AS install_source,
+      `mozfun.norm.os`(os) AS os_grouped,
+      country,
+      distribution_id,
+      first_seen_year,
+      is_default_browser,
+      channel,
+      os,
+      os_version,
+      os_version_major,
+      os_version_minor,
+      submission_date,
+      daily_users,
+      weekly_users,
+      monthly_users,
+      dau,
+      wau,
+      mau,
+      app_name,
+      app_version,
+      app_version_major,
+      app_version_minor,
+      app_version_patch_revision,
+      app_version_is_major_release,
+    FROM
+      `{{ project_id }}.{{ app_dataset_id }}.composite_active_users_aggregates`
+    WHERE
+      submission_date >= "2025-03-27"
     {% endif %}
   {% endfor %}

--- a/sql_generators/active_users_aggregates_v3/templates/mobile_view.sql
+++ b/sql_generators/active_users_aggregates_v3/templates/mobile_view.sql
@@ -46,14 +46,17 @@ CREATE OR REPLACE VIEW
       app_version_is_major_release,
     FROM
       `{{ project_id }}.{{ app_dataset_id }}.active_users_aggregates`
-  -- As per DENG-8914, we want to use composite tables for focus products
-  -- these fields do not exist in the composite view.
+    WHERE
+      -- Hard filter to introduce two day lag to match legacy desktop telemetry KPI delay
+      -- in order to avoid confusion.
+      submission_date < DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
   {% if app_dataset_id in [
     focus_ios_dataset,
     focus_android_dataset
   ] %}
-    WHERE
-      submission_date < "2025-03-27"
+      AND submission_date < "2025-03-27"
+  -- As per DENG-8914, we want to use composite tables for focus products
+  -- these fields do not exist in the composite view.
     UNION ALL
     SELECT
       activity_segment AS segment,
@@ -90,6 +93,9 @@ CREATE OR REPLACE VIEW
     FROM
       `{{ project_id }}.{{ app_dataset_id }}.composite_active_users_aggregates`
     WHERE
-      submission_date >= "2025-03-27"
+      -- Hard filter to introduce two day lag to match legacy desktop telemetry KPI delay
+      -- in order to avoid confusion.
+      submission_date < DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
+      AND submission_date >= "2025-03-27"
     {% endif %}
   {% endfor %}

--- a/sql_generators/active_users_aggregates_v3/templates/mobile_view.sql
+++ b/sql_generators/active_users_aggregates_v3/templates/mobile_view.sql
@@ -13,24 +13,42 @@ CREATE OR REPLACE VIEW
       UNION ALL
     {% endif %}
     SELECT
+    -- As per DENG-8914, we want to use composite tables for focus products
+    -- these fields do not exist in the composite view.
+      {% if app_dataset_id in [
+        focus_ios_dataset,
+        focus_android_dataset
+      ] %}
+      activity_segment AS segment,
+      CAST(NULL AS STRING) AS attribution_medium,
+      CAST(NULL AS STRING) AS attribution_source,
+      CAST(NULL AS BOOLEAN) AS attributed,
+      CAST(NULL AS STRING) AS city,
+      CAST(NULL AS STRING) AS locale,
+      CAST(NULL AS STRING) AS adjust_network,
+      CAST(NULL AS STRING) AS install_source,
+      `mozfun.norm.os`(os) AS os_grouped,
+      {% else %}
       segment,
       attribution_medium,
       attribution_source,
       attributed,
       city,
+      locale,
+      adjust_network,
+      install_source,
+      os_grouped,
+      {% endif %}
       country,
       distribution_id,
       first_seen_year,
       is_default_browser,
-      locale,
       channel,
       os,
       os_version,
       os_version_major,
       os_version_minor,
       submission_date,
-      adjust_network,
-      install_source,
       daily_users,
       weekly_users,
       monthly_users,
@@ -43,7 +61,14 @@ CREATE OR REPLACE VIEW
       app_version_minor,
       app_version_patch_revision,
       app_version_is_major_release,
-      os_grouped,
     FROM
+    -- As per DENG-8914, we want to use composite tables for focus products
+    {% if app_dataset_id in [
+      focus_ios_dataset,
+      focus_android_dataset
+    ] %}
+      `{{ project_id }}.{{ app_dataset_id }}.composite_active_users_aggregates`
+    {% else %}
       `{{ project_id }}.{{ app_dataset_id }}.active_users_aggregates`
+    {% endif %}
   {% endfor %}

--- a/sql_generators/active_users_aggregates_v4/templates/mobile_view.sql
+++ b/sql_generators/active_users_aggregates_v4/templates/mobile_view.sql
@@ -13,22 +13,6 @@ CREATE OR REPLACE VIEW
       UNION ALL
     {% endif %}
     SELECT
-    -- As per DENG-8914, we want to use composite tables for focus products
-    -- these fields do not exist in the composite view.
-      {% if app_dataset_id in [
-        focus_ios_dataset,
-        focus_android_dataset
-      ] %}
-      activity_segment AS segment,
-      CAST(NULL AS STRING) AS attribution_medium,
-      CAST(NULL AS STRING) AS attribution_source,
-      CAST(NULL AS BOOLEAN) AS attributed,
-      CAST(NULL AS STRING) AS city,
-      CAST(NULL AS STRING) AS locale,
-      CAST(NULL AS STRING) AS adjust_network,
-      CAST(NULL AS STRING) AS install_source,
-      `mozfun.norm.os`(os) AS os_grouped,
-      {% else %}
       segment,
       attribution_medium,
       attribution_source,
@@ -38,7 +22,6 @@ CREATE OR REPLACE VIEW
       adjust_network,
       install_source,
       os_grouped,
-      {% endif %}
       country,
       distribution_id,
       first_seen_year,
@@ -62,13 +45,51 @@ CREATE OR REPLACE VIEW
       app_version_patch_revision,
       app_version_is_major_release,
     FROM
-    -- As per DENG-8914, we want to use composite tables for focus products
-    {% if app_dataset_id in [
-      focus_ios_dataset,
-      focus_android_dataset
-    ] %}
-      `{{ project_id }}.{{ app_dataset_id }}.composite_active_users_aggregates`
-    {% else %}
       `{{ project_id }}.{{ app_dataset_id }}.active_users_aggregates`
+  -- As per DENG-8914, we want to use composite tables for focus products
+  -- these fields do not exist in the composite view.
+  {% if app_dataset_id in [
+    focus_ios_dataset,
+    focus_android_dataset
+  ] %}
+    WHERE
+      submission_date < "2025-03-27"
+    UNION ALL
+    SELECT
+      activity_segment AS segment,
+      CAST(NULL AS STRING) AS attribution_medium,
+      CAST(NULL AS STRING) AS attribution_source,
+      CAST(NULL AS BOOLEAN) AS attributed,
+      CAST(NULL AS STRING) AS city,
+      CAST(NULL AS STRING) AS locale,
+      CAST(NULL AS STRING) AS adjust_network,
+      CAST(NULL AS STRING) AS install_source,
+      `mozfun.norm.os`(os) AS os_grouped,
+      country,
+      distribution_id,
+      first_seen_year,
+      is_default_browser,
+      channel,
+      os,
+      os_version,
+      os_version_major,
+      os_version_minor,
+      submission_date,
+      daily_users,
+      weekly_users,
+      monthly_users,
+      dau,
+      wau,
+      mau,
+      app_name,
+      app_version,
+      app_version_major,
+      app_version_minor,
+      app_version_patch_revision,
+      app_version_is_major_release,
+    FROM
+      `{{ project_id }}.{{ app_dataset_id }}.composite_active_users_aggregates`
+    WHERE
+      submission_date >= "2025-03-27"
     {% endif %}
   {% endfor %}

--- a/sql_generators/active_users_aggregates_v4/templates/mobile_view.sql
+++ b/sql_generators/active_users_aggregates_v4/templates/mobile_view.sql
@@ -46,14 +46,17 @@ CREATE OR REPLACE VIEW
       app_version_is_major_release,
     FROM
       `{{ project_id }}.{{ app_dataset_id }}.active_users_aggregates`
-  -- As per DENG-8914, we want to use composite tables for focus products
-  -- these fields do not exist in the composite view.
+    WHERE
+      -- Hard filter to introduce two day lag to match legacy desktop telemetry KPI delay
+      -- in order to avoid confusion.
+      submission_date < DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
   {% if app_dataset_id in [
     focus_ios_dataset,
     focus_android_dataset
   ] %}
-    WHERE
-      submission_date < "2025-03-27"
+      AND submission_date < "2025-03-27"
+  -- As per DENG-8914, we want to use composite tables for focus products
+  -- these fields do not exist in the composite view.
     UNION ALL
     SELECT
       activity_segment AS segment,
@@ -90,6 +93,9 @@ CREATE OR REPLACE VIEW
     FROM
       `{{ project_id }}.{{ app_dataset_id }}.composite_active_users_aggregates`
     WHERE
-      submission_date >= "2025-03-27"
+      -- Hard filter to introduce two day lag to match legacy desktop telemetry KPI delay
+      -- in order to avoid confusion.
+      submission_date < DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
+      AND submission_date >= "2025-03-27"
     {% endif %}
   {% endfor %}

--- a/sql_generators/active_users_aggregates_v4/templates/mobile_view.sql
+++ b/sql_generators/active_users_aggregates_v4/templates/mobile_view.sql
@@ -13,24 +13,42 @@ CREATE OR REPLACE VIEW
       UNION ALL
     {% endif %}
     SELECT
+    -- As per DENG-8914, we want to use composite tables for focus products
+    -- these fields do not exist in the composite view.
+      {% if app_dataset_id in [
+        focus_ios_dataset,
+        focus_android_dataset
+      ] %}
+      activity_segment AS segment,
+      CAST(NULL AS STRING) AS attribution_medium,
+      CAST(NULL AS STRING) AS attribution_source,
+      CAST(NULL AS BOOLEAN) AS attributed,
+      CAST(NULL AS STRING) AS city,
+      CAST(NULL AS STRING) AS locale,
+      CAST(NULL AS STRING) AS adjust_network,
+      CAST(NULL AS STRING) AS install_source,
+      `mozfun.norm.os`(os) AS os_grouped,
+      {% else %}
       segment,
       attribution_medium,
       attribution_source,
       attributed,
       city,
+      locale,
+      adjust_network,
+      install_source,
+      os_grouped,
+      {% endif %}
       country,
       distribution_id,
       first_seen_year,
       is_default_browser,
-      locale,
       channel,
       os,
       os_version,
       os_version_major,
       os_version_minor,
       submission_date,
-      adjust_network,
-      install_source,
       daily_users,
       weekly_users,
       monthly_users,
@@ -43,7 +61,14 @@ CREATE OR REPLACE VIEW
       app_version_minor,
       app_version_patch_revision,
       app_version_is_major_release,
-      os_grouped,
     FROM
+    -- As per DENG-8914, we want to use composite tables for focus products
+    {% if app_dataset_id in [
+      focus_ios_dataset,
+      focus_android_dataset
+    ] %}
+      `{{ project_id }}.{{ app_dataset_id }}.composite_active_users_aggregates`
+    {% else %}
       `{{ project_id }}.{{ app_dataset_id }}.active_users_aggregates`
+    {% endif %}
   {% endfor %}

--- a/sql_generators/usage_reporting/templates/usage_reporting_active_users.view.sql.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_active_users.view.sql.jinja
@@ -12,11 +12,11 @@ SELECT
   {% if app_name in ("fenix", "firefox_desktop") %}
   CASE
     WHEN LOWER(distribution_id) = "mozillaonline"
-      THEN CONCAT("{{ app_name }}", " ", distribution_id)
-    ELSE "{{ app_name }}"
+      THEN CONCAT("{{ friendly_app_name }}", " ", distribution_id)
+    ELSE "{{ friendly_app_name }}"
   END AS app_name,
   {% else %}
-  "{{ app_name }}" AS app_name,
+  "{{ friendly_app_name }}" AS app_name,
   {% endif %}
   -- Activity fields to support metrics built on top of activity
   CASE

--- a/sql_generators/usage_reporting/usage_reporting.py
+++ b/sql_generators/usage_reporting/usage_reporting.py
@@ -162,8 +162,10 @@ def generate_usage_reporting(target_project: str, output_dir: Path):
     }
 
     for app_name, app_channels in generator_apps_info.items():
+        friendly_name = app_name.replace("_", " ").title().replace("Ios", "iOS")
         app_template_args = {
             "app_name": app_name,
+            "friendly_app_name": friendly_name,
             **default_template_args,
         }
 

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix/usage_reporting_active_users/view.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix/usage_reporting_active_users/view.sql
@@ -11,8 +11,8 @@ SELECT
   EXTRACT(YEAR FROM first_seen.first_seen_date) AS first_seen_year,
   CASE
     WHEN LOWER(distribution_id) = "mozillaonline"
-      THEN CONCAT("fenix", " ", distribution_id)
-    ELSE "fenix"
+      THEN CONCAT("Fenix", " ", distribution_id)
+    ELSE "Fenix"
   END AS app_name,
   -- Activity fields to support metrics built on top of activity
   CASE

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop/usage_reporting_active_users/view.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop/usage_reporting_active_users/view.sql
@@ -11,8 +11,8 @@ SELECT
   EXTRACT(YEAR FROM first_seen.first_seen_date) AS first_seen_year,
   CASE
     WHEN LOWER(distribution_id) = "mozillaonline"
-      THEN CONCAT("firefox_desktop", " ", distribution_id)
-    ELSE "firefox_desktop"
+      THEN CONCAT("Firefox Desktop", " ", distribution_id)
+    ELSE "Firefox Desktop"
   END AS app_name,
   -- Activity fields to support metrics built on top of activity
   CASE

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios/usage_reporting_active_users/view.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios/usage_reporting_active_users/view.sql
@@ -9,7 +9,7 @@ SELECT
   daily.normalized_channel AS channel,
   IFNULL(daily.normalized_country_code, "??") AS country,
   EXTRACT(YEAR FROM first_seen.first_seen_date) AS first_seen_year,
-  "firefox_ios" AS app_name,
+  "Firefox iOS" AS app_name,
   -- Activity fields to support metrics built on top of activity
   CASE
     WHEN BIT_COUNT(days_active_bits)


### PR DESCRIPTION
# feat(DENG-8914): update mobile_view templates inside active_users_aggregates generators so that focus products use composite dataset

This is related to changes to focus product telemetry data collection changes. This change should enable us to continue measuring the usage of the focus products.