### PR TITLE
feat(DENG-9078): Add columns to baseline_clients_first_seen_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/glean_baseline_clients_first_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/glean_baseline_clients_first_seen/view.sql
@@ -16,6 +16,11 @@ SELECT
   JSON_VALUE(attribution_ext.variation) AS attribution_variation,
   distribution_ext,
   legacy_telemetry_client_id,
-  legacy_telemetry_profile_group_id
+  legacy_telemetry_profile_group_id,
+  country,
+  distribution_id,
+  windows_build_number,
+  locale,
+  normalized_os
 FROM
   `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_clients_first_seen_v1`

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
@@ -60,14 +60,12 @@ WITH
           ORDER BY submission_timestamp DESC
           )
       ) AS windows_build_number,
-      --locale
       mozfun.stats.mode_last(
         ARRAY_AGG(
           COALESCE(client_info.locale, metrics.string.glean_baseline_locale) 
           ORDER BY submission_timestamp DESC
           )
       ) AS locale,
-      --locale
       {% endif %}
     FROM
       `{{ baseline_table }}`

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
@@ -66,6 +66,9 @@ WITH
           ORDER BY submission_timestamp DESC
           )
       ) AS locale,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(normalized_os ORDER BY submission_timestamp DESC)
+      ) AS normalized_os,
       {% endif %}
     FROM
       `{{ baseline_table }}`
@@ -158,6 +161,9 @@ _baseline AS (
           ORDER BY submission_timestamp DESC
           )
       ) AS locale,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(normalized_os ORDER BY submission_timestamp DESC)
+      ) AS normalized_os,
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -185,6 +191,7 @@ _current AS (
     distribution_id,
     windows_build_number,
     locale,
+    normalized_os,
     {% endif %}
   FROM
     _baseline
@@ -213,6 +220,7 @@ _previous AS (
     distribution_id,
     windows_build_number,
     locale,
+    normalized_os,
     {% endif %}
   FROM
     `{{ first_seen_table }}` fs
@@ -283,6 +291,9 @@ _current AS (
           ORDER BY submission_timestamp DESC
           )
       ) AS locale,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(normalized_os ORDER BY submission_timestamp DESC)
+      ) AS normalized_os,
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -313,6 +324,7 @@ _previous AS (
     distribution_id,
     windows_build_number,
     locale,
+    normalized_os,
     {% endif %}
   FROM
     `{{ first_seen_table }}`
@@ -356,6 +368,7 @@ SELECT
   distribution_id,
   windows_build_number,
   locale,
+  normalized_os,
   {% endif %}
 FROM _joined
 QUALIFY

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
@@ -54,6 +54,12 @@ WITH
           ORDER BY submission_timestamp DESC
           )
       ) AS distribution_id,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(
+          client_info.windows_build_number  
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS windows_build_number,
       {% endif %}
     FROM
       `{{ baseline_table }}`
@@ -133,7 +139,13 @@ _baseline AS (
           metrics.string.usage_distribution_id 
           ORDER BY submission_timestamp DESC
           )
-      ) AS distribution_id
+      ) AS distribution_id,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(
+          client_info.windows_build_number  
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS windows_build_number,
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -159,6 +171,7 @@ _current AS (
     legacy_telemetry_profile_group_id,
     country,
     distribution_id,
+    windows_build_number,
     {% endif %}
   FROM
     _baseline
@@ -185,6 +198,7 @@ _previous AS (
     legacy_telemetry_profile_group_id,
     country,
     distribution_id,
+    windows_build_number,
     {% endif %}
   FROM
     `{{ first_seen_table }}` fs
@@ -243,6 +257,12 @@ _current AS (
           ORDER BY submission_timestamp DESC
           )
       ) AS distribution_id,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(
+          client_info.windows_build_number  
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS windows_build_number,
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -271,6 +291,7 @@ _previous AS (
     legacy_telemetry_profile_group_id,
     country,
     distribution_id,
+    windows_build_number,
     {% endif %}
   FROM
     `{{ first_seen_table }}`
@@ -312,6 +333,7 @@ SELECT
   legacy_telemetry_profile_group_id,
   country,
   distribution_id,
+  windows_build_number,
   {% endif %}
 FROM _joined
 QUALIFY

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
@@ -41,7 +41,13 @@ WITH
           metrics.uuid.legacy_telemetry_profile_group_id 
           ORDER BY submission_timestamp ASC
           )
-      ) AS legacy_telemetry_profile_group_id
+      ) AS legacy_telemetry_profile_group_id,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(
+          metadata.geo.country 
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS country,
       {% endif %}
     FROM
       `{{ baseline_table }}`
@@ -109,7 +115,13 @@ _baseline AS (
           metrics.uuid.legacy_telemetry_profile_group_id 
           ORDER BY submission_timestamp ASC
           )
-      ) AS legacy_telemetry_profile_group_id
+      ) AS legacy_telemetry_profile_group_id,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(
+          metadata.geo.country 
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS country,
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -132,7 +144,8 @@ _current AS (
     attribution_ext,
     distribution_ext,
     legacy_telemetry_client_id,
-    legacy_telemetry_profile_group_id
+    legacy_telemetry_profile_group_id,
+    country,
     {% endif %}
   FROM
     _baseline
@@ -157,6 +170,7 @@ _previous AS (
     distribution_ext,
     legacy_telemetry_client_id,
     legacy_telemetry_profile_group_id,
+    country,
     {% endif %}
   FROM
     `{{ first_seen_table }}` fs
@@ -202,7 +216,13 @@ _current AS (
         metrics.uuid.legacy_telemetry_profile_group_id 
         ORDER BY submission_timestamp ASC
         )
-    ) AS legacy_telemetry_profile_group_id
+    ) AS legacy_telemetry_profile_group_id,
+    mozfun.stats.mode_last(
+        ARRAY_AGG(
+          metadata.geo.country 
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS country,
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -229,6 +249,7 @@ _previous AS (
     distribution_ext,
     legacy_telemetry_client_id,
     legacy_telemetry_profile_group_id,
+    country,
     {% endif %}
   FROM
     `{{ first_seen_table }}`
@@ -268,6 +289,7 @@ SELECT
   distribution_ext,
   legacy_telemetry_client_id,
   legacy_telemetry_profile_group_id,
+  country,
   {% endif %}
 FROM _joined
 QUALIFY

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
@@ -60,6 +60,14 @@ WITH
           ORDER BY submission_timestamp DESC
           )
       ) AS windows_build_number,
+      --locale
+      mozfun.stats.mode_last(
+        ARRAY_AGG(
+          COALESCE(client_info.locale, metrics.string.glean_baseline_locale) 
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS locale,
+      --locale
       {% endif %}
     FROM
       `{{ baseline_table }}`
@@ -146,6 +154,12 @@ _baseline AS (
           ORDER BY submission_timestamp DESC
           )
       ) AS windows_build_number,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(
+          COALESCE(client_info.locale, metrics.string.glean_baseline_locale) 
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS locale,
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -172,6 +186,7 @@ _current AS (
     country,
     distribution_id,
     windows_build_number,
+    locale,
     {% endif %}
   FROM
     _baseline
@@ -199,6 +214,7 @@ _previous AS (
     country,
     distribution_id,
     windows_build_number,
+    locale,
     {% endif %}
   FROM
     `{{ first_seen_table }}` fs
@@ -263,6 +279,12 @@ _current AS (
           ORDER BY submission_timestamp DESC
           )
       ) AS windows_build_number,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(
+          COALESCE(client_info.locale, metrics.string.glean_baseline_locale) 
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS locale,
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -292,6 +314,7 @@ _previous AS (
     country,
     distribution_id,
     windows_build_number,
+    locale,
     {% endif %}
   FROM
     `{{ first_seen_table }}`
@@ -334,6 +357,7 @@ SELECT
   country,
   distribution_id,
   windows_build_number,
+  locale,
   {% endif %}
 FROM _joined
 QUALIFY

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
@@ -48,6 +48,12 @@ WITH
           ORDER BY submission_timestamp DESC
           )
       ) AS country,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(
+          metrics.string.usage_distribution_id 
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS distribution_id,
       {% endif %}
     FROM
       `{{ baseline_table }}`
@@ -122,6 +128,12 @@ _baseline AS (
           ORDER BY submission_timestamp DESC
           )
       ) AS country,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(
+          metrics.string.usage_distribution_id 
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS distribution_id
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -146,6 +158,7 @@ _current AS (
     legacy_telemetry_client_id,
     legacy_telemetry_profile_group_id,
     country,
+    distribution_id,
     {% endif %}
   FROM
     _baseline
@@ -171,6 +184,7 @@ _previous AS (
     legacy_telemetry_client_id,
     legacy_telemetry_profile_group_id,
     country,
+    distribution_id,
     {% endif %}
   FROM
     `{{ first_seen_table }}` fs
@@ -223,6 +237,12 @@ _current AS (
           ORDER BY submission_timestamp DESC
           )
       ) AS country,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(
+          metrics.string.usage_distribution_id 
+          ORDER BY submission_timestamp DESC
+          )
+      ) AS distribution_id,
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -250,6 +270,7 @@ _previous AS (
     legacy_telemetry_client_id,
     legacy_telemetry_profile_group_id,
     country,
+    distribution_id,
     {% endif %}
   FROM
     `{{ first_seen_table }}`
@@ -290,6 +311,7 @@ SELECT
   legacy_telemetry_client_id,
   legacy_telemetry_profile_group_id,
   country,
+  distribution_id,
   {% endif %}
 FROM _joined
 QUALIFY

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
@@ -75,4 +75,8 @@ fields:
   name: distribution_id
   type: STRING
   description: The distribution ID associated with the install of Firefox.
+- mode: NULLABLE
+  name: windows_build_number
+  type: INTEGER
+  description: The optional Windows build number, reported by Windows (e.g. 22000) and not set for other platforms.
 {% endif %}

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
@@ -67,4 +67,8 @@ fields:
   name: legacy_telemetry_profile_group_id
   type: STRING
   description: A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: First Seen Country
 {% endif %}

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
@@ -71,4 +71,8 @@ fields:
   name: country
   type: STRING
   description: First Seen Country
+- mode: NULLABLE
+  name: distribution_id
+  type: STRING
+  description: The distribution ID associated with the install of Firefox.
 {% endif %}

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
@@ -83,5 +83,9 @@ fields:
   name: locale
   type: STRING
   description: |-
-    The locale of the application during initialization (e.g. "es-ES"). If the locale can't be determined on the system, the value is "und", to indicate "undetermined". 
+    The locale of the application during initialization (e.g. "es-ES"). If the locale can't be determined on the system, the value is "und", to indicate "undetermined".
+- mode: NULLABLE
+  name: normalized_os
+  type: STRING
+  description: Set to "Other" if this message contained an unrecognized OS name 
 {% endif %}

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
@@ -79,4 +79,9 @@ fields:
   name: windows_build_number
   type: INTEGER
   description: The optional Windows build number, reported by Windows (e.g. 22000) and not set for other platforms.
+- mode: NULLABLE
+  name: locale
+  type: STRING
+  description: |-
+    The locale of the application during initialization (e.g. "es-ES"). If the locale can't be determined on the system, the value is "und", to indicate "undetermined". 
 {% endif %}


### PR DESCRIPTION
## Description

This PR adds the following columns to `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_clients_first_seen_v1`
- `country`
- `distribution_id`
- `windows_build_number`
- `locale`
- `normalized_os`

It also adds these new columns to the view: 
- `moz-fx-data-shared-prod.firefox_desktop.glean_baseline_clients_first_seen`

## Related Tickets & Documents
* [DENG-9078](https://mozilla-hub.atlassian.net/browse/DENG-9078)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9078]: https://mozilla-hub.atlassian.net/browse/DENG-9078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ