### PR TITLE
feat(DENG-9078): Follow up fixes, use fully qualified CTE names

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/baseline_active_users/view.sql
@@ -11,9 +11,9 @@ SELECT
     attribution,
     `distribution`
   ) REPLACE(
-    IFNULL(country, '??') AS country,
+    IFNULL(last_seen.country, '??') AS country,
     IFNULL(city, '??') AS city,
-    COALESCE(REGEXP_EXTRACT(locale, r'^(.+?)-'), locale, NULL) AS locale
+    COALESCE(REGEXP_EXTRACT(last_seen.locale, r'^(.+?)-'), last_seen.locale, NULL) AS locale
   ),
   CASE
     WHEN LOWER(IFNULL(isp, '')) = 'browserstack'
@@ -46,16 +46,16 @@ SELECT
       THEN "legacy"
     ELSE CAST(NULL AS STRING)
   END AS distribution_id_source,
-  normalized_os AS os,
+  last_seen.normalized_os AS os,
   --"os_grouped" is the same as "os", but we are making a choice to include it anyway
   --to make the switch from legacy sources to Glean easier since the column was in the previous view
-  normalized_os AS os_grouped,
+  last_seen.normalized_os AS os_grouped,
   normalized_os_version AS os_version,
   COALESCE(
     `mozfun.norm.glean_windows_version_info`(
-      normalized_os,
-      normalized_os_version,
-      windows_build_number
+      last_seen.normalized_os,
+      last_seen.normalized_os_version,
+      last_seen.windows_build_number
     ),
     normalized_os_version
   ) AS os_version_build,


### PR DESCRIPTION
## Description

This PR fixes the view `moz-fx-data-shared-prod.firefox_desktop.baseline_active_users` to use aliases for columns since some of these columns are now in multiple tables used in the join, when before they were only in one.

This is related to prior PR https://github.com/mozilla/bigquery-etl/pull/7748 where we added 5 new columns to `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_clients_first_seen_v1`.

## Related Tickets & Documents
* [DENG-9078](https://mozilla-hub.atlassian.net/browse/DENG-9078)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9078]: https://mozilla-hub.atlassian.net/browse/DENG-9078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ