### PR TITLE
chore: switch to v2 workgroup for DE write access

### DIFF
--- a/bigquery_etl/routine/publish_routines.py
+++ b/bigquery_etl/routine/publish_routines.py
@@ -172,7 +172,7 @@ def publish_routine(
         write_entry = bigquery.AccessEntry(
             "WRITER",
             bigquery.enums.EntityTypes.IAM_MEMBER,
-            "group:team-data-platform@firefox.gcp.mozilla.com",
+            "group:gcp-wg-dataplatform--developers@firefox.gcp.mozilla.com",
         )
         entries = list(dataset.access_entries)
         entries += [read_entry, write_entry]


### PR DESCRIPTION
## Description
The old pre-v1 workgroup was just deleted. https://mozilla-hub.atlassian.net/browse/SVCSE-3363

## Related Tickets & Documents
* SVCSE-3363
