### PR TITLE
Add main branch commits to generated-sql commit messages

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -698,6 +698,7 @@ jobs:
                   cp -r /tmp/workspace/generated-sql/dags dags
                   git add .
                   git commit -m "Auto-push due to change on main branch [ci skip]" \
+                    -m "Created from ${CIRCLE_SHA1}" \
                     && git tag c-${CIRCLE_SHA1:0:9} \
                     && git push \
                     && git push origin c-${CIRCLE_SHA1:0:9} \
@@ -806,6 +807,9 @@ jobs:
                   bqetl_script="$PWD/script/bqetl"
                   cd ~/private-bigquery-etl
 
+                  # persist commit hash used for generation
+                  git rev-parse HEAD >> PRIVATE_BIGQUERY_ETL_SHA
+
                   $bqetl_script generate all --target-project moz-fx-data-shared-prod
                   $bqetl_script dependency record --skip-existing sql/
                   $bqetl_script metadata update sql/
@@ -819,6 +823,7 @@ jobs:
                 root: /tmp/workspace
                 paths:
                   - private-generated-sql
+                  - PRIVATE_BIGQUERY_ETL_SHA
       - unless:
           condition: *validate-sql
           steps:
@@ -847,7 +852,11 @@ jobs:
                   rm -rf dags/
                   cp -r /tmp/workspace/private-generated-sql/dags dags
                   git add .
+
+                  private_bqetl_sha=$(cat /tmp/workspace/PRIVATE_BIGQUERY_ETL_SHA)
+
                   git commit -m "Auto-push due to change on main branch [ci skip]" \
+                    -m "Created from $CIRCLE_REPOSITORY_URL/commit/$CIRCLE_SHA1 and $private_bqetl_sha" \
                     && git push \
                     || echo "Skipping push since it looks like there were no changes"
                 # yamllint enable rule:line-length


### PR DESCRIPTION
## Description
This adds a line to the generated-sql commit messages to link to the commits used for generation to make it easier to see what triggered the change.  Similar to pipeline-schemas https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/9df5ea1e3cd61651bfcaf9d71c4ce392a6be454c

So https://github.com/mozilla/private-bigquery-etl/commit/3fc8193c2a0526256479c17e1f26ee29b1920295 would have a line like "Created from 604d7794d7803069b0312f0fa15cc4f244374877 and https://github.com/mozilla/private-bigquery-etl/commit/4c888d9ec0378bc817ebf72f3c72a5d71e88400a"

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
