### PR TITLE
fix(SubPlat): Fix join in `google_subscriptions_changelog_v1` ETL (DENG-975)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_changelog_v1/query.sql
@@ -47,7 +47,7 @@ subscriptions_new_changelog AS (
     subscriptions_changelog
   LEFT JOIN
     existing_subscriptions_changelog
-    ON subscriptions_changelog.subscription.purchase_token = existing_subscriptions_changelog.purchase_token
+    ON subscriptions_changelog.document_id = existing_subscriptions_changelog.purchase_token
   WHERE
     subscriptions_changelog.timestamp > existing_subscriptions_changelog.max_timestamp
     OR existing_subscriptions_changelog.max_timestamp IS NULL


### PR DESCRIPTION
## Description
To avoid repeatedly adding duplicate Firestore delete operation changelog records.

Fixup for #7750.

## Related Tickets & Documents
* DENG-975: Google subscriptions ETL v2
* https://github.com/mozilla/bigquery-etl/pull/7750

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
