### PR TITLE
deng_8998 add view.sql and metadata.yaml files for view of google_play_store re…

### DIFF
--- a/sql/moz-fx-data-shared-prod/google_play_store/reviews/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_play_store/reviews/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: Google Play Store Reviews (444337733603)
+description: |-
+  Google Play Store Reviews (Analytics 444337733603)
+owners:
+  - mhirose@mozilla.com
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/google_play_store/reviews/view.sql
+++ b/sql/moz-fx-data-shared-prod/google_play_store/reviews/view.sql
@@ -1,0 +1,6 @@
+SELECT
+  *,
+  MAX(DATE(_PARTITIONTIME)) OVER () AS _LATEST_DATE,
+  DATE(_PARTITIONTIME) AS _DATA_DATE
+FROM
+  `moz-fx-data-marketing-prod.google_play_store.p_Reviews_v1`


### PR DESCRIPTION
…views from the marketing-prod table

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR adds view.sql and metadata.yaml files for google_play_store.reviews. The base table is in `moz-fx-data-marketing-prod` and the view is needed so data will be in `mozdata` and accessible outside of `marketing-prod`

## Related Tickets & Documents
* DENG-8998
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
