### PR TITLE
feat(DENG-9101): Deprecate / unschedule apple_ads_external.ios_app_campaign_stats_v1

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1548,23 +1548,6 @@ bqetl_desktop_retention_model:
   tags:
     - impact/tier_2
 
-bqetl_ios_campaign_reporting:
-  schedule_interval: 0 12 * * *
-  description: Loads the apple ads ios_app_campaign_stats table
-  default_args:
-    depends_on_past: false
-    owner: kwindau@mozilla.com
-    email:
-      - kwindau@mozilla.com
-      - telemetry-alerts@mozilla.com
-    email_on_failure: true
-    email_on_retry: false
-    start_date: "2024-05-08"
-    retries: 2
-    retry_delay: 30m
-  tags:
-    - impact/tier_2
-
 bqetl_mobile_kpi_metrics:
   schedule_interval: 0 12 * * *
   description: Generates support metrics for mobile KPI's

--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
@@ -8,13 +8,13 @@ labels:
   owner1: kwindau@mozilla.com
   table_type: aggregate
   shredder_mitigation: true
-scheduling:
-  dag_name: bqetl_ios_campaign_reporting
-  depends_on_past: false
-  date_partition_parameter: date
-  date_partition_offset: -27
-  parameters:
-  - submission_date:DATE:{{ds}}
+#scheduling:
+#  dag_name: bqetl_ios_campaign_reporting
+#  depends_on_past: false
+#  date_partition_parameter: date
+#  date_partition_offset: -27
+#  parameters:
+#  - submission_date:DATE:{{ds}}
 bigquery:
   time_partitioning:
     type: day
@@ -25,3 +25,4 @@ bigquery:
     - campaign
 monitoring:
   enabled: true
+deprecated: true


### PR DESCRIPTION
## Description

This PR deprecates and un-schedules:
- `moz-fx-data-shared-prod.apple_ads_external.ios_app_campaign_stats_v1`

It also deletes the associated DAG `bqetl_ios_campaign_reporting` since this was the only task scheduled using this DAG.

## Related Tickets & Documents
* [DENG-9101](https://mozilla-hub.atlassian.net/browse/DENG-9101)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9101]: https://mozilla-hub.atlassian.net/browse/DENG-9101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ