### PR TITLE
Add is_materialized_view_refresh to jobs_by_org

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
@@ -62,6 +62,7 @@ def create_query(job_date: date, project: str):
           DATE(creation_time) as creation_date,
           materialized_view_statistics,
           query_dialect,
+          UPPER(LTRIM(REGEXP_REPLACE(query, r'\s+', " "))) LIKE 'CALL BQ.REFRESH_MATERIALIZED_VIEW%' AS is_materialized_view_refresh,
         FROM
           `{project}.region-us.INFORMATION_SCHEMA.JOBS_BY_ORGANIZATION`
         WHERE

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/schema.yaml
@@ -222,3 +222,8 @@ fields:
   name: query_dialect
   type: STRING
   description: The query dialect used for the job.
+
+- mode: NULLABLE
+  name: is_materialized_view_refresh
+  type: BOOLEAN
+  description: Whether or not the query is a materialized view refresh, based on teh query string.


### PR DESCRIPTION
## Description

Adds `is_materialized_view_refresh` based on the query string. Some views use manual refreshes so they can't be determined just from the job id anymore

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
