### PR TITLE
feat(DENG-9088): Deprecate Pocket tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket_derived/events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/events_v1/metadata.yaml
@@ -12,3 +12,4 @@ bigquery:
     type: day
     field: submission_timestamp
     require_partition_filter: false
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -18,3 +18,4 @@ bigquery:
   clustering:
     fields:
       - event_name
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -18,4 +18,3 @@ bigquery:
   clustering:
     fields:
       - event_name
-deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/rolling_monthly_active_user_counts_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/rolling_monthly_active_user_counts_history_v1/metadata.yaml
@@ -18,3 +18,4 @@ scheduling:
   dag_name: bqetl_pocket
   arguments: ["--date", "{{ ds }}"]
   referenced_tables: []
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/rolling_monthly_active_user_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/rolling_monthly_active_user_counts_v1/metadata.yaml
@@ -11,3 +11,4 @@ scheduling:
   dag_name: bqetl_pocket
   date_partition_parameter: null
   parameters: ["submission_date:DATE:{{ds}}"]
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_history_v1/metadata.yaml
@@ -16,3 +16,4 @@ scheduling:
   dag_name: bqetl_pocket
   arguments: ["--date", "{{ ds }}"]
   referenced_tables: []
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/twice_weekly_active_user_counts_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/twice_weekly_active_user_counts_history_v1/metadata.yaml
@@ -18,3 +18,4 @@ scheduling:
   dag_name: bqetl_pocket
   arguments: ["--date", "{{ ds }}"]
   referenced_tables: []
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/twice_weekly_active_user_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/twice_weekly_active_user_counts_v1/metadata.yaml
@@ -12,3 +12,4 @@ scheduling:
   dag_name: bqetl_pocket
   date_partition_parameter: null
   parameters: ["submission_date:DATE:{{ds}}"]
+deprecated: true


### PR DESCRIPTION
## Description

This PR marks the following tables as deprecated:
* `moz-fx-data-shared-prod.pocket_derived.events_v1`
* `moz-fx-data-shared-prod.pocket_derived.rolling_monthly_active_user_counts_v1`
* `moz-fx-data-shared-prod.pocket_derived.rolling_monthly_active_user_counts_history_v1`
* `moz-fx-data-shared-prod.pocket_derived.spoc_tile_ids_history_v1`
* `moz-fx-data-shared-prod.pocket_derived.twice_weekly_active_user_counts_v1`
* `moz-fx-data-shared-prod.pocket_derived.twice_weekly_active_user_counts_history_v1`

The lineage of what each of these is used in can be seen here: [Pocket Deprecation](https://docs.google.com/document/d/13asqR2f7R0oVl3xwg5gU4phJ8Ei0-OrcFbqaW1tD0bI/edit?usp=sharing)

The goal is to deprecate them for awhile, make sure no one still needs them, before permanently deleting them.

Will also deprecate the looker views off of `moz-fx-data-shared-prod.pocket_derived.spoc_tile_ids_history_v1` before this merges.
- First this one: [PR-1106](https://github.com/mozilla/looker-spoke-default/pull/1106)
- Then this one: [PR-1259](https://github.com/mozilla/lookml-generator/pull/1259)

## Related Tickets & Documents
* [DENG-9088]()

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9088]: https://mozilla-hub.atlassian.net/browse/DENG-9088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ