### PR TITLE
Move is_materialized_view_refresh to bigquery_usage

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.sql
@@ -49,6 +49,7 @@ jobs_by_project AS (
       REGEXP_EXTRACT(query, r'Username: (.*?),') AS username,
       REGEXP_EXTRACT(query, r'Query ID: (\w+), ') AS query_id,
       labels,
+      UPPER(LTRIM(REGEXP_REPLACE(query, r'\s+', ' '))) LIKE 'CALL BQ.REFRESH_MATERIALIZED_VIEW%' AS is_materialized_view_refresh,
     FROM
       `{{project}}.region-us.INFORMATION_SCHEMA.JOBS_BY_PROJECT` AS jp
     LEFT JOIN
@@ -85,6 +86,7 @@ SELECT DISTINCT
   jo.resource_warning,
   @submission_date AS submission_date,
   jp.labels,
+  jp.is_materialized_view_refresh,
 FROM
   jobs_by_org AS jo
 LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/query.sql
@@ -49,7 +49,9 @@ jobs_by_project AS (
       REGEXP_EXTRACT(query, r'Username: (.*?),') AS username,
       REGEXP_EXTRACT(query, r'Query ID: (\w+), ') AS query_id,
       labels,
-      UPPER(LTRIM(REGEXP_REPLACE(query, r'\s+', ' '))) LIKE 'CALL BQ.REFRESH_MATERIALIZED_VIEW%' AS is_materialized_view_refresh,
+      UPPER(
+        LTRIM(REGEXP_REPLACE(query, r'\s+', ' '))
+      ) LIKE 'CALL BQ.REFRESH_MATERIALIZED_VIEW%' AS is_materialized_view_refresh,
     FROM
       `{{project}}.region-us.INFORMATION_SCHEMA.JOBS_BY_PROJECT` AS jp
     LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/schema.yaml
@@ -147,4 +147,4 @@ fields:
 - mode: NULLABLE
   name: is_materialized_view_refresh
   type: BOOLEAN
-  description: Whether or not the query is a materialized view refresh, based on teh query string.
+  description: Whether or not the query is a materialized view refresh, based on the query string.

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/bigquery_usage_v2/schema.yaml
@@ -143,3 +143,8 @@ fields:
     name: value
     type: STRING
     description: Label value.
+
+- mode: NULLABLE
+  name: is_materialized_view_refresh
+  type: BOOLEAN
+  description: Whether or not the query is a materialized view refresh, based on teh query string.

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
@@ -62,7 +62,6 @@ def create_query(job_date: date, project: str):
           DATE(creation_time) as creation_date,
           materialized_view_statistics,
           query_dialect,
-          UPPER(LTRIM(REGEXP_REPLACE(query, r'\s+', " "))) LIKE 'CALL BQ.REFRESH_MATERIALIZED_VIEW%' AS is_materialized_view_refresh,
         FROM
           `{project}.region-us.INFORMATION_SCHEMA.JOBS_BY_ORGANIZATION`
         WHERE

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/schema.yaml
@@ -222,8 +222,3 @@ fields:
   name: query_dialect
   type: STRING
   description: The query dialect used for the job.
-
-- mode: NULLABLE
-  name: is_materialized_view_refresh
-  type: BOOLEAN
-  description: Whether or not the query is a materialized view refresh, based on teh query string.


### PR DESCRIPTION
## Description

I just found out jobs_by_organization doesn't even have a `query` field: https://cloud.google.com/bigquery/docs/information-schema-jobs-by-organization#schema. So moving to bigquery_usage

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
