### PR TITLE
chore(glam): DENG-9113 create clients_hist snapshot and sample clients_hist_new

### DIFF
--- a/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
@@ -2,7 +2,7 @@
 {% set aggregate_filter_clause %}
 {% if filter_version %}
   LEFT JOIN
-    glam_etl.{{ prefix }}__latest_versions_v1
+    glam_etl.{{ prefix }} __latest_versions_v1
     USING (channel)
 {% endif %}
 WHERE
@@ -21,7 +21,7 @@ WITH extracted_accumulated AS (
   SELECT
     *
   FROM
-    glam_etl.{{ prefix }}__clients_histogram_aggregates_v1
+    glam_etl.{{ prefix }} __clients_histogram_aggregates_snapshot_v1
     {% if parameterize %}
       WHERE
         sample_id >= @min_sample_id
@@ -39,7 +39,12 @@ transformed_daily AS (
   SELECT
     *
   FROM
-    glam_etl.{{ prefix }}__clients_histogram_aggregates_new_v1
+    glam_etl.{{ prefix }} __clients_histogram_aggregates_new_v1
+    {% if parameterize %}
+      WHERE
+        sample_id >= @min_sample_id
+        AND sample_id <= @max_sample_id
+    {% endif %}
 )
 SELECT
   {% for attribute in attributes_list %}

--- a/sql/moz-fx-glam-prod/glam_etl/firefox_desktop_glam_release__clients_histogram_aggregates_snapshot_v1/init.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/firefox_desktop_glam_release__clients_histogram_aggregates_snapshot_v1/init.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE TABLE
+  `moz-fx-glam-prod`.glam_etl.firefox_desktop_glam_release__clients_histogram_aggregates_snapshot_v1 CLONE `moz-fx-glam-prod`.glam_etl.firefox_desktop_glam_release__clients_histogram_aggregates_v1

--- a/sql/moz-fx-glam-prod/glam_etl/org_mozilla_fenix_glam_release__clients_histogram_aggregates_snapshot_v1/init.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/org_mozilla_fenix_glam_release__clients_histogram_aggregates_snapshot_v1/init.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE TABLE
+  `moz-fx-glam-prod`.glam_etl.org_mozilla_fenix_glam_release__clients_histogram_aggregates_snapshot_v1 CLONE `moz-fx-glam-prod`.glam_etl.org_mozilla_fenix_glam_release__clients_histogram_aggregates_v1;


### PR DESCRIPTION
## Description

GLAM ETL will take a snapshot of `clients_histogram_aggregates` to read from in release, instead of updating the table "in place".
This allows us to split the job into tasks that process a chunk of samples each time with the first job overwriting the destination table and the subsequent ones appending to it.
https://github.com/mozilla/bigquery-etl/pull/7774

## Related Tickets & Documents
* DENG-9113

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
