### PR TITLE
[DENG-9112] Backfill usage reporting AUA v1 derived tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-07-14:
+2025-07-15:
   start_date: 2025-03-01
-  end_date: 2025-07-13
+  end_date: 2025-07-14
   reason: Fixed upstream table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,3 +1,13 @@
+2025-07-14:
+  start_date: 2025-03-01
+  end_date: 2025-07-13
+  reason: Initial backfill
+  watchers:
+  - kik@mozilla.com
+  - akommasani@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+
 2025-04-03:
   start_date: 2025-03-01
   end_date: 2025-04-03

--- a/sql/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,10 +1,11 @@
 2025-07-14:
   start_date: 2025-03-01
   end_date: 2025-07-13
-  reason: Initial backfill
+  reason: Fixed upstream table
   watchers:
   - kik@mozilla.com
   - akommasani@mozilla.com
+  - kwindau@mozilla.com
   status: Initiate
   shredder_mitigation: false
 

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-07-14:
+2025-07-15:
   start_date: 2025-03-01
-  end_date: 2025-07-13
+  end_date: 2025-07-14
   reason: Fixed upstream table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,3 +1,13 @@
+2025-07-14:
+  start_date: 2025-03-01
+  end_date: 2025-07-13
+  reason: Initial backfill
+  watchers:
+  - kik@mozilla.com
+  - akommasani@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+
 2025-04-03:
   start_date: 2025-03-01
   end_date: 2025-04-03

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,10 +1,11 @@
 2025-07-14:
   start_date: 2025-03-01
   end_date: 2025-07-13
-  reason: Initial backfill
+  reason: Fixed upstream table
   watchers:
   - kik@mozilla.com
   - akommasani@mozilla.com
+  - kwindau@mozilla.com
   status: Initiate
   shredder_mitigation: false
 

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-07-14:
+2025-07-15:
   start_date: 2025-03-01
-  end_date: 2025-07-13
+  end_date: 2025-07-14
   reason: Fixed upstream table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,3 +1,13 @@
+2025-07-14:
+  start_date: 2025-03-01
+  end_date: 2025-07-13
+  reason: Initial backfill
+  watchers:
+  - kik@mozilla.com
+  - akommasani@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+
 2025-04-03:
   start_date: 2025-03-01
   end_date: 2025-04-03

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,10 +1,11 @@
 2025-07-14:
   start_date: 2025-03-01
   end_date: 2025-07-13
-  reason: Initial backfill
+  reason: Fixed upstream table
   watchers:
   - kik@mozilla.com
   - akommasani@mozilla.com
+  - kwindau@mozilla.com
   status: Initiate
   shredder_mitigation: false
 

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-07-14:
+2025-07-15:
   start_date: 2025-03-01
-  end_date: 2025-07-13
+  end_date: 2025-07-14
   reason: Fixed upstream table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,3 +1,13 @@
+2025-07-14:
+  start_date: 2025-03-01
+  end_date: 2025-07-13
+  reason: Initial backfill
+  watchers:
+  - kik@mozilla.com
+  - akommasani@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+
 2025-04-03:
   start_date: 2025-03-01
   end_date: 2025-04-03

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,10 +1,11 @@
 2025-07-14:
   start_date: 2025-03-01
   end_date: 2025-07-13
-  reason: Initial backfill
+  reason: Fixed upstream table
   watchers:
   - kik@mozilla.com
   - akommasani@mozilla.com
+  - kwindau@mozilla.com
   status: Initiate
   shredder_mitigation: false
 

--- a/sql/moz-fx-data-shared-prod/focus_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2025-07-14:
+2025-07-15:
   start_date: 2025-03-01
-  end_date: 2025-07-13
+  end_date: 2025-07-14
   reason: Fixed upstream table
   watchers:
   - kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/focus_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,3 +1,13 @@
+2025-07-14:
+  start_date: 2025-03-01
+  end_date: 2025-07-13
+  reason: Initial backfill
+  watchers:
+  - kik@mozilla.com
+  - akommasani@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+
 2025-04-03:
   start_date: 2025-03-01
   end_date: 2025-04-03

--- a/sql/moz-fx-data-shared-prod/focus_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_ios_derived/usage_reporting_active_users_aggregates_v1/backfill.yaml
@@ -1,10 +1,11 @@
 2025-07-14:
   start_date: 2025-03-01
   end_date: 2025-07-13
-  reason: Initial backfill
+  reason: Fixed upstream table
   watchers:
   - kik@mozilla.com
   - akommasani@mozilla.com
+  - kwindau@mozilla.com
   status: Initiate
   shredder_mitigation: false
 


### PR DESCRIPTION
Related to https://mozilla-hub.atlassian.net/browse/DENG-9112

This PR backfills the `usage_reporting_active_users_aggregates_v1` derived tables 

