### PR TITLE
fix(DENG-9112): Update tests for composite_active_users & usage_reporting_active_users

### DIFF
--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix/composite_active_users/view.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix/composite_active_users/view.sql
@@ -60,5 +60,3 @@ SELECT
   is_monthly_user,
 FROM
   `moz-fx-data-shared-prod.fenix.usage_reporting_active_users`
-WHERE
-  mozfun.norm.browser_version_info(app_version).major_version >= 136

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix/usage_reporting_active_users/view.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix/usage_reporting_active_users/view.sql
@@ -2,6 +2,40 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.fenix.usage_reporting_active_users`
 AS
+WITH cls AS (
+  SELECT
+    submission_date,
+    usage_profile_id,
+    days_seen_bits,
+    days_active_bits,
+    days_created_profile_bits
+  FROM
+    `moz-fx-data-shared-prod.fenix.usage_reporting_clients_last_seen`
+  WHERE
+    submission_date >= '2025-03-01'
+),
+cd AS (
+  SELECT
+    normalized_app_id,
+    normalized_channel,
+    submission_date,
+    usage_profile_id,
+    first_run_date,
+    app_channel,
+    normalized_country_code,
+    os,
+    os_version,
+    app_build,
+    app_display_version,
+    distribution_id,
+    is_default_browser,
+    reason,
+    is_active,
+  FROM
+    `moz-fx-data-shared-prod.fenix.usage_reporting_clients_daily`
+  WHERE
+    submission_date >= '2025-03-01'
+)
 SELECT
   * EXCEPT (submission_date, app_channel, normalized_country_code, app_display_version),
   last_seen.submission_date,
@@ -51,9 +85,9 @@ SELECT
   IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 7, FALSE) AS is_weekly_user,
   IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 28, FALSE) AS is_monthly_user,
 FROM
-  `moz-fx-data-shared-prod.fenix.usage_reporting_clients_last_seen` AS last_seen
+  cls AS last_seen
 LEFT JOIN
-  `moz-fx-data-shared-prod.fenix.usage_reporting_clients_daily` AS daily
+  cd AS daily
   USING (submission_date, usage_profile_id)
 LEFT JOIN
   `moz-fx-data-shared-prod.fenix.usage_reporting_clients_first_seen` AS first_seen

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop/usage_reporting_active_users/view.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop/usage_reporting_active_users/view.sql
@@ -2,6 +2,41 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_desktop.usage_reporting_active_users`
 AS
+WITH cls AS (
+  SELECT
+    submission_date,
+    usage_profile_id,
+    days_seen_bits,
+    days_active_bits,
+    days_created_profile_bits
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.usage_reporting_clients_last_seen`
+  WHERE
+    submission_date >= '2025-03-01'
+),
+cd AS (
+  SELECT
+    normalized_app_id,
+    normalized_channel,
+    submission_date,
+    usage_profile_id,
+    first_run_date,
+    app_channel,
+    normalized_country_code,
+    os,
+    os_version,
+    app_build,
+    app_display_version,
+    distribution_id,
+    is_default_browser,
+    reason,
+    is_active,
+    windows_build_number,
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.usage_reporting_clients_daily`
+  WHERE
+    submission_date >= '2025-03-01'
+)
 SELECT
   * EXCEPT (submission_date, app_channel, normalized_country_code, app_display_version),
   last_seen.submission_date,
@@ -71,9 +106,9 @@ SELECT
   IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 7, FALSE) AS is_weekly_user,
   IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 28, FALSE) AS is_monthly_user,
 FROM
-  `moz-fx-data-shared-prod.firefox_desktop.usage_reporting_clients_last_seen` AS last_seen
+  cls AS last_seen
 LEFT JOIN
-  `moz-fx-data-shared-prod.firefox_desktop.usage_reporting_clients_daily` AS daily
+  cd AS daily
   USING (submission_date, usage_profile_id)
 LEFT JOIN
   `moz-fx-data-shared-prod.firefox_desktop.usage_reporting_clients_first_seen` AS first_seen

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_clients_last_seen_v1/schema.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_clients_last_seen_v1/schema.yaml
@@ -29,3 +29,5 @@ fields:
   type: INTEGER
   description: |
     bit field indicating how many days lapsed since profile creation.
+
+

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios/composite_active_users/view.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios/composite_active_users/view.sql
@@ -60,5 +60,3 @@ SELECT
   is_monthly_user,
 FROM
   `moz-fx-data-shared-prod.firefox_ios.usage_reporting_active_users`
-WHERE
-  mozfun.norm.browser_version_info(app_version).major_version >= 136

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios/usage_reporting_active_users/view.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios/usage_reporting_active_users/view.sql
@@ -2,6 +2,40 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_ios.usage_reporting_active_users`
 AS
+WITH cls AS (
+  SELECT
+    submission_date,
+    usage_profile_id,
+    days_seen_bits,
+    days_active_bits,
+    days_created_profile_bits
+  FROM
+    `moz-fx-data-shared-prod.firefox_ios.usage_reporting_clients_last_seen`
+  WHERE
+    submission_date >= '2025-03-01'
+),
+cd AS (
+  SELECT
+    normalized_app_id,
+    normalized_channel,
+    submission_date,
+    usage_profile_id,
+    first_run_date,
+    app_channel,
+    normalized_country_code,
+    os,
+    os_version,
+    app_build,
+    app_display_version,
+    distribution_id,
+    is_default_browser,
+    reason,
+    is_active,
+  FROM
+    `moz-fx-data-shared-prod.firefox_ios.usage_reporting_clients_daily`
+  WHERE
+    submission_date >= '2025-03-01'
+)
 SELECT
   * EXCEPT (submission_date, app_channel, normalized_country_code, app_display_version),
   last_seen.submission_date,
@@ -47,9 +81,9 @@ SELECT
   IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 7, FALSE) AS is_weekly_user,
   IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 28, FALSE) AS is_monthly_user,
 FROM
-  `moz-fx-data-shared-prod.firefox_ios.usage_reporting_clients_last_seen` AS last_seen
+  cls AS last_seen
 LEFT JOIN
-  `moz-fx-data-shared-prod.firefox_ios.usage_reporting_clients_daily` AS daily
+  cd AS daily
   USING (submission_date, usage_profile_id)
 LEFT JOIN
   `moz-fx-data-shared-prod.firefox_ios.usage_reporting_clients_first_seen` AS first_seen

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/usage_reporting_clients_last_seen_v1/schema.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/usage_reporting_clients_last_seen_v1/schema.yaml
@@ -29,3 +29,5 @@ fields:
   type: INTEGER
   description: |
     bit field indicating how many days lapsed since profile creation.
+
+

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_derived/usage_reporting_clients_last_seen_v1/schema.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_derived/usage_reporting_clients_last_seen_v1/schema.yaml
@@ -29,3 +29,5 @@ fields:
   type: INTEGER
   description: |
     bit field indicating how many days lapsed since profile creation.
+
+

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/usage_reporting_clients_last_seen_v1/schema.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/usage_reporting_clients_last_seen_v1/schema.yaml
@@ -29,3 +29,5 @@ fields:
   type: INTEGER
   description: |
     bit field indicating how many days lapsed since profile creation.
+
+


### PR DESCRIPTION
## Description

[PR-7776](https://github.com/mozilla/bigquery-etl/pull/7776) changed the logic for the views `composite_active_users` & `usage_reporting_active_users` but didn't update the corresponding tests. This PR is a follow up PR to update the corresponding tests to match the new logic.

## Related Tickets & Documents
* [DENG-9112](https://mozilla-hub.atlassian.net/browse/DENG-9112)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9112]: https://mozilla-hub.atlassian.net/browse/DENG-9112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ