### PR TITLE
chore: Disable monitoring on ios_app_campaign_stats_v1 as deprecated

### DIFF
--- a/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/apple_ads_external/ios_app_campaign_stats_v1/metadata.yaml
@@ -24,5 +24,5 @@ bigquery:
     fields:
     - campaign
 monitoring:
-  enabled: true
+  enabled: false
 deprecated: true


### PR DESCRIPTION
# chore: Disable monitoring on ios_app_campaign_stats_v1 as deprecated

Making sure monitoring is disabled on this dataset as it has been deprecated.