### PR TITLE
Update Docker base image and CircleCI executor image

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -33,7 +33,7 @@ parameters:
 executors:
   ubuntu-machine-executor:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,8 @@ ARG PYTHON_VERSION=3.11
 # pin Google Cloud SDK to old version due to https://stackoverflow.com/questions/76159439/job-failing-with-error-gcloud-crashed-attributeerror-bool-object-has-no-at
 ARG GOOGLE_CLOUD_SDK_VERSION=417.0.0
 
-# use buster image because the default bullseye image released 2021-08-17
-# sha256:ffb6539b4b233743c62170989024c6f56dcefa69a83c4bd9710d4264b19a98c0
-# has updated coreutils that require a newer linux kernel than provided by CircleCI, per
-# https://forums.docker.com/t/multiple-projects-stopped-building-on-docker-hub-operation-not-permitted/92570/6
-# and https://forums.docker.com/t/multiple-projects-stopped-building-on-docker-hub-operation-not-permitted/92570/11
 # --platform=linux/amd64 added to prevent pulling ARM images when run on Apple Silicon
-FROM --platform=linux/amd64 python:${PYTHON_VERSION}-slim-buster AS base
+FROM --platform=linux/amd64 python:${PYTHON_VERSION}-slim-bullseye AS base
 WORKDIR /app
 
 # build typed-ast in separate stage because it requires gcc and libc-dev


### PR DESCRIPTION
This should fix the [build error](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/50793/workflows/e2156eec-be81-4109-93f1-05e1f3bc8ff0/jobs/614600/parallel-runs/0/steps/0-107) occurring because Debian Buster has reached its end of life and its package repositories have been archived.