### PR TITLE
feat: remove app_channel for focus_ios from usage_reporting_clients_last_seen template

### DIFF
--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_last_seen_v1.query.sql.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_last_seen_v1.query.sql.jinja
@@ -11,9 +11,6 @@ WITH _current AS (
     udf.days_since_created_profile_as_28_bits(
       DATE_DIFF(submission_date, first_run_date, DAY)
     ) AS days_created_profile_bits,
-    {% if channel_dataset == "org_mozilla_ios_focus" %}
-      app_channel,
-    {% endif %}
   FROM
     `{{ project_id }}.{{ channel_dataset }}.usage_reporting_clients_daily`
   WHERE
@@ -25,9 +22,6 @@ _previous AS (
     days_seen_bits,
     days_active_bits,
     days_created_profile_bits,
-    {% if channel_dataset == "org_mozilla_ios_focus" %}
-      app_channel,
-    {% endif %}
   FROM
     `{{ project_id }}.{{ channel_dataset }}_derived.{{ view_name }}_v1`
   WHERE

--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_last_seen_v1.schema.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_last_seen_v1.schema.yaml.jinja
@@ -29,11 +29,3 @@ fields:
   type: INTEGER
   description: |
     bit field indicating how many days lapsed since profile creation.
-
-{% if app_name  == "focus_ios" %}
-- mode: NULLABLE
-  name: app_channel
-  type: STRING
-  description: |
-    The channel the application is being distributed on.
-{% endif %}

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_clients_last_seen_v1/schema.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_clients_last_seen_v1/schema.yaml
@@ -29,5 +29,3 @@ fields:
   type: INTEGER
   description: |
     bit field indicating how many days lapsed since profile creation.
-
-

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/usage_reporting_clients_last_seen_v1/schema.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/usage_reporting_clients_last_seen_v1/schema.yaml
@@ -29,5 +29,3 @@ fields:
   type: INTEGER
   description: |
     bit field indicating how many days lapsed since profile creation.
-
-

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_derived/usage_reporting_clients_last_seen_v1/schema.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_derived/usage_reporting_clients_last_seen_v1/schema.yaml
@@ -29,5 +29,3 @@ fields:
   type: INTEGER
   description: |
     bit field indicating how many days lapsed since profile creation.
-
-

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/usage_reporting_clients_last_seen_v1/schema.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/usage_reporting_clients_last_seen_v1/schema.yaml
@@ -29,5 +29,3 @@ fields:
   type: INTEGER
   description: |
     bit field indicating how many days lapsed since profile creation.
-
-


### PR DESCRIPTION
# feat: remove app_channel for focus_ios from usage_reporting_clients_last_seen template

This field should not exist in this dataset. The field has now been deployed to the dataset and will be dropped once this change is merged.