### PR TITLE
fix usage_reporting_active_users_aggregates

### DIFF
--- a/sql_generators/usage_reporting/templates/usage_reporting_active_users_aggregates_v1.query.sql.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_active_users_aggregates_v1.query.sql.jinja
@@ -24,7 +24,6 @@ FROM
   `{{ project_id }}.{{ app_name }}.usage_reporting_active_users`
 WHERE
   submission_date = @submission_date
-  AND `date` = @submission_date
 GROUP BY
   submission_date,
   first_seen_year,

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/query.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/query.sql
@@ -21,7 +21,6 @@ FROM
   `moz-fx-data-shared-prod.fenix.usage_reporting_active_users`
 WHERE
   submission_date = @submission_date
-  AND `date` = @submission_date
 GROUP BY
   submission_date,
   first_seen_year,

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/query.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/query.sql
@@ -22,7 +22,6 @@ FROM
   `moz-fx-data-shared-prod.firefox_desktop.usage_reporting_active_users`
 WHERE
   submission_date = @submission_date
-  AND `date` = @submission_date
 GROUP BY
   submission_date,
   first_seen_year,

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/query.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/query.sql
@@ -21,7 +21,6 @@ FROM
   `moz-fx-data-shared-prod.firefox_ios.usage_reporting_active_users`
 WHERE
   submission_date = @submission_date
-  AND `date` = @submission_date
 GROUP BY
   submission_date,
   first_seen_year,


### PR DESCRIPTION
## Description


This PR removes a line no longer needed after https://github.com/mozilla/bigquery-etl/pull/7776. 

## Related Tickets & Documents
* DENG-9112


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
