### PR TITLE
 fix composite_active_users_aggregates.view.sql.jinja

### DIFF
--- a/sql_generators/usage_reporting/templates/composite_active_users_aggregates.view.sql.jinja
+++ b/sql_generators/usage_reporting/templates/composite_active_users_aggregates.view.sql.jinja
@@ -90,11 +90,10 @@ SELECT
   SUM(monthly_users) AS monthly_users,
 FROM
   `{{ project_id }}.{{ app_name }}.usage_reporting_active_users_aggregates`
-WHERE
-  {% if app_name == "firefox_desktop" %}
-    WHERE
-      mozfun.norm.browser_version_info(app_version).major_version >= 136
-  {% endif %}
+{% if app_name == "firefox_desktop" %}
+  WHERE
+    app_version_major >= 136
+{% endif %}
 GROUP BY
   submission_date,
   first_seen_year,

--- a/sql_generators/usage_reporting/templates/composite_active_users_aggregates.view.sql.jinja
+++ b/sql_generators/usage_reporting/templates/composite_active_users_aggregates.view.sql.jinja
@@ -37,11 +37,7 @@ FROM
   `{{ project_id }}.{{ app_name }}.active_users_aggregates`
   {% endif %}
 WHERE
-  {% if app_name == "fenix" %}
-  app_version_major < 137
-  {% else %}
   app_version_major < 136
-  {% endif %}
 GROUP BY
   submission_date,
   first_seen_year,
@@ -95,10 +91,9 @@ SELECT
 FROM
   `{{ project_id }}.{{ app_name }}.usage_reporting_active_users_aggregates`
 WHERE
-  {% if app_name == "fenix" %}
-  app_version_major >= 137
-  {% else %}
-  app_version_major >= 136
+  {% if app_name == "firefox_desktop" %}
+    WHERE
+      mozfun.norm.browser_version_info(app_version).major_version >= 136
   {% endif %}
 GROUP BY
   submission_date,

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix/composite_active_users_aggregates/view.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix/composite_active_users_aggregates/view.sql
@@ -28,7 +28,7 @@ SELECT
 FROM
   `moz-fx-data-shared-prod.fenix.active_users_aggregates`
 WHERE
-  app_version_major < 137
+  app_version_major < 136
 GROUP BY
   submission_date,
   first_seen_year,
@@ -74,8 +74,6 @@ SELECT
   SUM(monthly_users) AS monthly_users,
 FROM
   `moz-fx-data-shared-prod.fenix.usage_reporting_active_users_aggregates`
-WHERE
-  app_version_major >= 137
 GROUP BY
   submission_date,
   first_seen_year,

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios/composite_active_users_aggregates/view.sql
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios/composite_active_users_aggregates/view.sql
@@ -74,8 +74,6 @@ SELECT
   SUM(monthly_users) AS monthly_users,
 FROM
   `moz-fx-data-shared-prod.firefox_ios.usage_reporting_active_users_aggregates`
-WHERE
-  app_version_major >= 136
 GROUP BY
   submission_date,
   first_seen_year,


### PR DESCRIPTION
## Description

Fixes an additional filter similar to what was done in https://github.com/mozilla/bigquery-etl/pull/7776

Intention is to match the behavior [here](https://github.com/mozilla/bigquery-etl/blob/main/sql_generators/usage_reporting/templates/composite_active_users.view.sql.jinja#L72-L76)


## Related Tickets & Documents
* DENG-9112


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
