### PR TITLE
feat(DENG-9073): Add metadata.yaml for desktop_conversion_events view

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/desktop_conversion_events/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/desktop_conversion_events/metadata.yaml
@@ -1,0 +1,5 @@
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:google-managed/external-ads-datafusion
+  - workgroup:google-managed/external-ads-dataproc


### PR DESCRIPTION
## Description

This PR adds a metadata.yaml file for the view, granting data viewer access to `external-ads-datafusion` & `external-ads-dataproc`:
- `moz-fx-data-shared-prod.firefoxdotcom.desktop_conversion_events`

## Related Tickets & Documents
* [DENG-9073](https://mozilla-hub.atlassian.net/browse/DENG-9073)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9073]: https://mozilla-hub.atlassian.net/browse/DENG-9073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ