### PR TITLE
chore(DENG-9132): add dataEditor access to snowflake migration dataset

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/dataset_metadata.yaml
@@ -12,3 +12,6 @@ workgroup_access:
       - workgroup:mozilla-confidential
       - workgroup:mozsoc-ml/service
       - workgroup:mozsoc-ml/developers
+  - role: roles/bigquery.dataEditor
+    members:
+      - workgroup:pocket/apps


### PR DESCRIPTION
## Description

add dataEditor access to the `snowflake_migration_derived` dataset.

## Related Tickets & Documents
* DENG-9132

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
