### PR TITLE
Grant external-ads-dataproc SA metadataViewer access to firefoxdotcom & firefoxdotcom_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/dataset_metadata.yaml
@@ -8,3 +8,6 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
+- role: roles/bigquery.metadataViewer
+  members:
+  - workgroup:google-managed/external-ads-dataproc

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/dataset_metadata.yaml
@@ -8,3 +8,6 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
+- role: roles/bigquery.metadataViewer
+  members:
+  - workgroup:google-managed/external-ads-dataproc


### PR DESCRIPTION
## Description

This PR grants the external-ads-dataproc service account "roles/bigquery.metadataViewer" access to the below 2 datasets: 
- `moz-fx-data-shared-prod.firefoxdotcom`
- `moz-fx-data-shared-prod.firefoxdotcom_derived`

This is needed to finish setting up permissions to switch from the old marketing feed based on mozilla.org to the new feed based on firefox.com. (The old datasets mozilla_org and mozilla_org_derived had the same permissions before).

## Related Tickets & Documents
* [DENG-9073](https://mozilla-hub.atlassian.net/browse/DENG-9073)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9073]: https://mozilla-hub.atlassian.net/browse/DENG-9073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ