### PR TITLE
GLAM ETL fix snapshot

### DIFF
--- a/bigquery_etl/glam/generate.py
+++ b/bigquery_etl/glam/generate.py
@@ -272,12 +272,17 @@ def main():
         ),
         init(
             "clients_histogram_aggregates_v1",
-            **models.clients_histogram_aggregates(parameterize=True),
+            **models.clients_histogram_aggregates(
+                parameterize=True,
+                channel=channel_prefixes[args.prefix],
+            ),
         ),
         table(
             "clients_histogram_aggregates_v1",
             **models.clients_histogram_aggregates(
-                parameterize=True, **config[args.prefix]
+                parameterize=True,
+                **config[args.prefix],
+                channel=channel_prefixes[args.prefix],
             ),
         ),
         table(

--- a/bigquery_etl/glam/models.py
+++ b/bigquery_etl/glam/models.py
@@ -97,7 +97,7 @@ def clients_histogram_aggregates_new(**kwargs):
     )
 
 
-def clients_histogram_aggregates(**kwargs):
+def clients_histogram_aggregates(channel, **kwargs):
     """Variables for histogram aggregates."""
     attributes_list = [
         "sample_id",
@@ -110,6 +110,12 @@ def clients_histogram_aggregates(**kwargs):
     ]
     fixed_attributes = ["app_version", "channel"]
     cubed_attributes = [x for x in attributes_list if x not in fixed_attributes]
+    source_table_suffix = (
+        "clients_histogram_aggregates_snapshot_v1"
+        if channel == "release"
+        else "clients_histogram_aggregates_v2"
+    )
+
     return dict(
         attributes_list=attributes_list,
         attributes=",".join(attributes_list),
@@ -121,6 +127,7 @@ def clients_histogram_aggregates(**kwargs):
             key,
             agg_type
         """,
+        suffix=source_table_suffix,
         **kwargs,
     )
 

--- a/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_histogram_aggregates_v1.sql
@@ -21,7 +21,7 @@ WITH extracted_accumulated AS (
   SELECT
     *
   FROM
-    `glam_etl.{{ prefix }}__clients_histogram_aggregates_snapshot_v1`
+    `glam_etl.{{ prefix }}__{{ suffix }}`
     {% if parameterize %}
       WHERE
         sample_id >= @min_sample_id

--- a/sql/moz-fx-glam-prod/glam_etl/firefox_desktop_glam_release__clients_histogram_aggregates_snapshot_v1/init.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/firefox_desktop_glam_release__clients_histogram_aggregates_snapshot_v1/init.sql
@@ -1,2 +1,2 @@
 CREATE OR REPLACE TABLE
-  `moz-fx-glam-prod`.glam_etl.firefox_desktop_glam_release__clients_histogram_aggregates_snapshot_v1 CLONE `moz-fx-glam-prod`.glam_etl.firefox_desktop_glam_release__clients_histogram_aggregates_v1
+  `moz-fx-glam-prod.glam_etl.firefox_desktop_glam_release__clients_histogram_aggregates_snapshot_v1` CLONE `moz-fx-glam-prod.glam_etl.firefox_desktop_glam_release__clients_histogram_aggregates_v1`

--- a/sql/moz-fx-glam-prod/glam_etl/org_mozilla_fenix_glam_release__clients_histogram_aggregates_snapshot_v1/init.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/org_mozilla_fenix_glam_release__clients_histogram_aggregates_snapshot_v1/init.sql
@@ -1,2 +1,2 @@
 CREATE OR REPLACE TABLE
-  `moz-fx-glam-prod`.glam_etl.org_mozilla_fenix_glam_release__clients_histogram_aggregates_snapshot_v1 CLONE `moz-fx-glam-prod`.glam_etl.org_mozilla_fenix_glam_release__clients_histogram_aggregates_v1;
+  `moz-fx-glam-prod.glam_etl.org_mozilla_fenix_glam_release__clients_histogram_aggregates_snapshot_v1` CLONE `moz-fx-glam-prod.glam_etl.org_mozilla_fenix_glam_release__clients_histogram_aggregates_v1`;


### PR DESCRIPTION
## Description

This PR fixes two things:
1 - Only release `clients_histogram_aggregates` queries read from the snapshot
2 - Adds backticks around the fully qualified table name to avoid bad replacement of project name due to peculiar GNU sed implementation.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
