### PR TITLE
DENG-8482, DENG-8871 - Propagate Accounts deletion requests to mobile fx-accounts pings

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -217,18 +217,24 @@ context_id_target = partial(DeleteTarget, field=(CONTEXT_ID, CONTEXT_ID))
 
 # App -> account_id_field mappings for mobile client association pings
 CLIENT_ASSOCIATION_MOBILE_APPS = {
-    **{app: MOZ_ACCOUNT_ID for app in [
-        "org_mozilla_fenix",
-        "org_mozilla_fenix_nightly", 
-        "org_mozilla_fennec_aurora",
-        "org_mozilla_firefox_beta",
-        "org_mozilla_firefox",
-    ]},
-    **{app: MOZ_ACCOUNT_ID_IOS for app in [
-        "org_mozilla_ios_fennec",
-        "org_mozilla_ios_firefoxbeta",
-        "org_mozilla_ios_firefox",
-    ]},
+    **{
+        app: MOZ_ACCOUNT_ID
+        for app in [
+            "org_mozilla_fenix",
+            "org_mozilla_fenix_nightly",
+            "org_mozilla_fennec_aurora",
+            "org_mozilla_firefox_beta",
+            "org_mozilla_firefox",
+        ]
+    },
+    **{
+        app: MOZ_ACCOUNT_ID_IOS
+        for app in [
+            "org_mozilla_ios_fennec",
+            "org_mozilla_ios_firefoxbeta",
+            "org_mozilla_ios_firefox",
+        ]
+    },
 }
 
 DELETE_TARGETS: DeleteIndex = {


### PR DESCRIPTION
## Description

This replicates desktop config: https://github.com/mozilla/bigquery-etl/blob/912ae859b6320091d054a45c891efea08ff5e206/bigquery_etl/shredder/config.py#L552-L556

Tested locally, generates queries like:
```sql
DELETE
  `moz-fx-data-shared-prod.org_mozilla_ios_firefox_stable.fx_accounts_v1`
WHERE
  (
    metrics.string.user_client_association_uid IN (
      SELECT
        user_id_unhashed
      FROM
        `moz-fx-data-shared-prod.firefox_accounts.fxa_delete_events`
      WHERE
        DATE(submission_timestamp) >= '2025-01-01'
        AND DATE(submission_timestamp) < '2025-03-02'
    )
    OR client_info.client_id IN (
      SELECT
        client_info.client_id
      FROM
        `moz-fx-data-shared-prod.org_mozilla_ios_firefox_stable.deletion_request_v1`
      WHERE
        DATE(submission_timestamp) >= '2025-01-01'
        AND DATE(submission_timestamp) < '2025-03-02'
    )
  )
  AND (CAST(submission_timestamp AS DATE) < '2025-03-02')
```

## Related Tickets & Documents
https://mozilla-hub.atlassian.net/browse/DENG-8482
https://mozilla-hub.atlassian.net/browse/DENG-8871


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
