### PR TITLE
feat(DENG-9088): Deprecate some glean tables in firefox_reality, firefox_reality_pc, org_mozilla_firefoxreality, & org_mozilla_vrbrowser

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -321,6 +321,7 @@ generate:
     - firefox_reality
     - firefox_reality_pc
     - org.mozilla.firefoxreality
+    - org.mozilla.vrbrowser
     skip_existing: # Skip automatically updating the following artifacts
     - sql/moz-fx-data-shared-prod/fenix/client_deduplication/**
     - sql/moz-fx-data-shared-prod/org_mozilla_tv_firefox_derived/baseline_clients_last_seen_v1/checks.sql

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -320,6 +320,7 @@ generate:
     deprecated_apps:
     - firefox_reality
     - firefox_reality_pc
+    - org.mozilla.firefoxreality
     skip_existing: # Skip automatically updating the following artifacts
     - sql/moz-fx-data-shared-prod/fenix/client_deduplication/**
     - sql/moz-fx-data-shared-prod/org_mozilla_tv_firefox_derived/baseline_clients_last_seen_v1/checks.sql

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -317,6 +317,9 @@ metadata:
 
 generate:
   glean_usage:
+    deprecated_apps:
+    - firefox_reality
+    - firefox_reality_pc
     skip_existing: # Skip automatically updating the following artifacts
     - sql/moz-fx-data-shared-prod/fenix/client_deduplication/**
     - sql/moz-fx-data-shared-prod/org_mozilla_tv_firefox_derived/baseline_clients_last_seen_v1/checks.sql

--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -33,7 +33,7 @@ BIGCONFIG_SKIP_APPS_METRICS = ConfigLoader.get(
     "generate", "glean_usage", "bigconfig", "skip_app_metrics", fallback=[]
 )
 
-DEPRECATED_APP_NAMES = ConfigLoader.get(
+DEPRECATED_APP_LIST = ConfigLoader.get(
     "generate", "glean_usage", "deprecated_apps", fallback=[]
 )
 
@@ -264,7 +264,7 @@ class GleanTable:
         enable_monitoring = app_name not in list(set(BIGCONFIG_SKIP_APPS))
 
         # Some apps' tables have been deprecated
-        deprecated_app = app_name in list(set(DEPRECATED_APP_NAMES))
+        deprecated_app = app_name in list(set(DEPRECATED_APP_LIST))
 
         render_kwargs = dict(
             header="-- Generated via bigquery_etl.glean_usage\n",
@@ -437,7 +437,7 @@ class GleanTable:
         )
 
         # Some apps' tables have been deprecated
-        deprecated_app = app_name in list(set(DEPRECATED_APP_NAMES))
+        deprecated_app = app_name in list(set(DEPRECATED_APP_LIST))
 
         render_kwargs = dict(
             header="-- Generated via bigquery_etl.glean_usage\n",

--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -263,6 +263,9 @@ class GleanTable:
         # but do not do so actively anymore. This is why they get excluded.
         enable_monitoring = app_name not in list(set(BIGCONFIG_SKIP_APPS))
 
+        # Some apps' tables have been deprecated
+        deprecated_app = app_name in list(set(DEPRECATED_APP_NAMES))
+
         render_kwargs = dict(
             header="-- Generated via bigquery_etl.glean_usage\n",
             header_yaml="---\n# Generated via bigquery_etl.glean_usage\n",
@@ -272,6 +275,7 @@ class GleanTable:
             app_name=app_name,
             has_profile_group_id=app_name in APPS_WITH_PROFILE_GROUP_ID,
             enable_monitoring=enable_monitoring,
+            deprecated_app=deprecated_app,
         )
 
         render_kwargs.update(self.custom_render_kwargs)

--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -33,7 +33,7 @@ BIGCONFIG_SKIP_APPS_METRICS = ConfigLoader.get(
     "generate", "glean_usage", "bigconfig", "skip_app_metrics", fallback=[]
 )
 
-BIGCONFIG_DEPRECATED_APPS = ConfigLoader.get(
+DEPRECATED_APP_NAMES = ConfigLoader.get(
     "generate", "glean_usage", "deprecated_apps", fallback=[]
 )
 
@@ -263,9 +263,6 @@ class GleanTable:
         # but do not do so actively anymore. This is why they get excluded.
         enable_monitoring = app_name not in list(set(BIGCONFIG_SKIP_APPS))
 
-        # Some apps' tables have been deprecated
-        deprecated_apps = app_name in list(set(BIGCONFIG_DEPRECATED_APPS))
-
         render_kwargs = dict(
             header="-- Generated via bigquery_etl.glean_usage\n",
             header_yaml="---\n# Generated via bigquery_etl.glean_usage\n",
@@ -275,7 +272,6 @@ class GleanTable:
             app_name=app_name,
             has_profile_group_id=app_name in APPS_WITH_PROFILE_GROUP_ID,
             enable_monitoring=enable_monitoring,
-            deprecated_apps=deprecated_apps,
         )
 
         render_kwargs.update(self.custom_render_kwargs)
@@ -436,6 +432,9 @@ class GleanTable:
             set(BIGCONFIG_SKIP_APPS + BIGCONFIG_SKIP_APPS_METRICS)
         )
 
+        # Some apps' tables have been deprecated
+        deprecated_app = app_name in list(set(DEPRECATED_APP_NAMES))
+
         render_kwargs = dict(
             header="-- Generated via bigquery_etl.glean_usage\n",
             header_yaml="---\n# Generated via bigquery_etl.glean_usage\n",
@@ -446,6 +445,7 @@ class GleanTable:
             target_table=f"{target_dataset}_derived.{self.target_table_id}",
             app_name=app_name,
             enable_monitoring=enable_monitoring,
+            deprecated_app = deprecated_app,
         )
         render_kwargs.update(self.custom_render_kwargs)
 

--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -33,6 +33,10 @@ BIGCONFIG_SKIP_APPS_METRICS = ConfigLoader.get(
     "generate", "glean_usage", "bigconfig", "skip_app_metrics", fallback=[]
 )
 
+BIGCONFIG_DEPRECATED_APPS = ConfigLoader.get(
+    "generate", "glean_usage", "deprecated_apps", fallback=[]
+)
+
 APPS_WITH_PROFILE_GROUP_ID = ("firefox_desktop",)
 
 
@@ -259,6 +263,9 @@ class GleanTable:
         # but do not do so actively anymore. This is why they get excluded.
         enable_monitoring = app_name not in list(set(BIGCONFIG_SKIP_APPS))
 
+        # Some apps' tables have been deprecated
+        deprecated_apps = app_name in list(set(BIGCONFIG_DEPRECATED_APPS))
+
         render_kwargs = dict(
             header="-- Generated via bigquery_etl.glean_usage\n",
             header_yaml="---\n# Generated via bigquery_etl.glean_usage\n",
@@ -268,6 +275,7 @@ class GleanTable:
             app_name=app_name,
             has_profile_group_id=app_name in APPS_WITH_PROFILE_GROUP_ID,
             enable_monitoring=enable_monitoring,
+            deprecated_apps=deprecated_apps,
         )
 
         render_kwargs.update(self.custom_render_kwargs)

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.metadata.yaml
@@ -27,3 +27,6 @@ bigquery:
     - sample_id
 monitoring:
   enabled: {% if enable_monitoring %}true{% else %}false{% endif %}
+{%- if deprecated_app %}
+deprecated: true
+{%- endif -%}

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.metadata.yaml
@@ -39,3 +39,6 @@ bigquery:
     - submission_date
 monitoring:
   enabled: {% if enable_monitoring %}true{% else %}false{% endif %}
+{%- if deprecated_app %}
+deprecated: true
+{%- endif -%}

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
@@ -32,3 +32,6 @@ monitoring:
 schema:
   derived_from:
   - table: ['moz-fx-data-shared-prod', '{{ derived_dataset }}', 'baseline_clients_daily_v1']
+{%- if deprecated_app %}
+deprecated: true
+{%- endif -%}

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
@@ -31,6 +31,6 @@ bigquery:
     fields:
       - normalized_channel
       - sample_id
-{%- if deprecated_apps %}
+{%- if deprecated_app %}
 deprecated: true
 {%- endif -%}

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
@@ -31,3 +31,6 @@ bigquery:
     fields:
       - normalized_channel
       - sample_id
+{%- if deprecated_apps %}
+deprecated: true
+{%- endif -%}

--- a/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
@@ -23,3 +23,6 @@ bigquery:
       - sample_id
 monitoring:
   enabled: {% if enable_monitoring %}true{% else %}false{% endif %}
+{%- if deprecated_apps %}
+deprecated: true
+{%- endif -%}

--- a/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
@@ -23,6 +23,6 @@ bigquery:
       - sample_id
 monitoring:
   enabled: {% if enable_monitoring %}true{% else %}false{% endif %}
-{%- if deprecated_apps %}
+{%- if deprecated_app %}
 deprecated: true
 {%- endif -%}

--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
@@ -28,3 +28,6 @@ bigquery:
       - sample_id
 monitoring:
   enabled: {% if enable_monitoring %}true{% else %}false{% endif %}
+{%- if deprecated_apps %}
+deprecated: true
+{%- endif -%}

--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
@@ -28,6 +28,6 @@ bigquery:
       - sample_id
 monitoring:
   enabled: {% if enable_monitoring %}true{% else %}false{% endif %}
-{%- if deprecated_apps %}
+{%- if deprecated_app %}
 deprecated: true
 {%- endif -%}


### PR DESCRIPTION
## Description

This PR adds a new config option to glean_usage, called "deprecated_apps".  You can include an "app_id" or "app_name" in bqetl_project.yaml under generate > glean_usage > deprecated_apps.

It uses this config file information to label tables with "deprecated: true".

This change should add this label to the following tables: 
- `moz-fx-data-shared-prod.firefox_reality_derived.metrics_clients_daily_v1`
- `moz-fx-data-shared-prod.firefox_reality_derived.metrics_clients_last_seen_v1`
- `moz-fx-data-shared-prod.firefox_reality_derived.clients_last_seen_joined_v1`
- `moz-fx-data-shared-prod.firefox_reality_pc_derived.metrics_clients_daily_v1`
- `moz-fx-data-shared-prod.firefox_reality_pc_derived.metrics_clients_last_seen_v1`
- `moz-fx-data-shared-prod.firefox_reality_pc_derived.clients_last_seen_joined_v1`
- `moz-fx-data-shared-prod.org_mozilla_firefoxreality_derived.baseline_clients_daily_v1`
- `moz-fx-data-shared-prod.org_mozilla_firefoxreality_derived.baseline_clients_last_seen_v1`
- `moz-fx-data-shared-prod.org_mozilla_firefoxreality_derived.baseline_clients_first_seen_v1`
- `moz-fx-data-shared-prod.org_mozilla_vrbrowser_derived.baseline_clients_daily_v1`
- `moz-fx-data-shared-prod.org_mozilla_vrbrowser_derived.baseline_clients_first_seen_v1`
- `moz-fx-data-shared-prod.org_mozilla_vrbrowser_derived.baseline_clients_last_seen_v1`

## Related Tickets & Documents
* [DENG-9088](https://mozilla-hub.atlassian.net/browse/DENG-9088)
* [Usage checks](https://docs.google.com/spreadsheets/d/16uvMJcjHVd_Nu6luhXZ8_OTTY-Jbj96zW_vkzWq8jzA/edit?usp=sharing)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9088]: https://mozilla-hub.atlassian.net/browse/DENG-9088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ