### PR TITLE
[DO-2049] Add urlbar_events_daily_engagement_by_product_result_type

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/urlbar_events_daily_engagement_by_product_result_type/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/urlbar_events_daily_engagement_by_product_result_type/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.urlbar_events_daily_engagement_by_product_result_type`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.urlbar_events_daily_engagement_by_product_result_type_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/metadata.yaml
@@ -1,0 +1,19 @@
+friendly_name: Urlbar Events Daily Engagement By Product Result Type
+description: |-
+  Derived table from the urlbar_events ping to compute daily urlbar metrics per client.
+  This table will be used to power experiments, as querying the raw ping tables causes
+  Jetstream runs to either time out or run considerably longer.
+owners:
+- ascholtz@mozilla.com
+labels:
+  incremental: true
+  schedule: daily
+  shredder_mitigation: true
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_urlbar
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/query.sql
@@ -1,0 +1,47 @@
+WITH temp_unnested AS (
+  SELECT
+    submission_date,
+    legacy_telemetry_client_id AS client_id,
+    profile_group_id,
+    experiments,
+    event_id,
+    event_action,
+    res.product_result_type AS product_result_type,
+    normalized_channel,
+    normalized_country_code,
+    pref_fx_suggestions AS firefox_suggest_enabled,
+    pref_sponsored_suggestions AS sponsored_suggestions_enabled,
+    is_terminal,
+    (
+      product_selected_result = res.product_result_type
+      AND event_action = 'engaged'
+      AND is_terminal
+    ) AS is_clicked,
+    (product_selected_result = res.product_result_type AND event_action = 'annoyance') AS is_annoyed
+  FROM
+    `mozdata.firefox_desktop.urlbar_events`
+  CROSS JOIN
+    UNNEST(results) AS res
+  WHERE
+    submission_date = @submission_date
+)
+SELECT
+  submission_date,
+  client_id,
+  profile_group_id,
+  product_result_type,
+  ANY_VALUE(experiments) AS experiments,
+  ANY_VALUE(normalized_channel) AS normalized_channel,
+  ANY_VALUE(normalized_country_code) AS normalized_country_code,
+  ANY_VALUE(firefox_suggest_enabled) AS firefox_suggest_enabled,
+  ANY_VALUE(sponsored_suggestions_enabled) AS sponsored_suggestions_enabled,
+  COUNTIF(is_clicked) AS urlbar_clicks,
+  COUNTIF(is_annoyed) AS urlbar_annoyances,
+  COUNTIF(is_terminal = TRUE) AS urlbar_impressions,
+FROM
+  temp_unnested
+GROUP BY
+  submission_date,
+  client_id,
+  profile_group_id,
+  product_result_type

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/schema.yaml
@@ -1,0 +1,58 @@
+fields:
+  - mode: NULLABLE
+    name: submission_date
+    type: DATE
+  - mode: NULLABLE
+    name: client_id
+    type: STRING
+  - mode: NULLABLE
+    name: profile_group_id
+    type: STRING
+  - mode: NULLABLE
+    name: product_result_type
+    type: STRING
+  - fields:
+      - mode: NULLABLE
+        name: key
+        type: STRING
+      - fields:
+          - mode: NULLABLE
+            name: branch
+            type: STRING
+          - fields:
+              - mode: NULLABLE
+                name: type
+                type: STRING
+              - mode: NULLABLE
+                name: enrollment_id
+                type: STRING
+            mode: NULLABLE
+            name: extra
+            type: RECORD
+        mode: NULLABLE
+        name: value
+        type: RECORD
+    mode: REPEATED
+    name: experiments
+    type: RECORD
+  - mode: NULLABLE
+    name: normalized_channel
+    type: STRING
+  - mode: NULLABLE
+    name: normalized_country_code
+    type: STRING
+  - mode: NULLABLE
+    name: firefox_suggest_enabled
+    type: BOOLEAN
+  - mode: NULLABLE
+    name: sponsored_suggestions_enabled
+    type: BOOLEAN
+  - mode: NULLABLE
+    name: urlbar_clicks
+    type: INTEGER
+  - mode: NULLABLE
+    name: urlbar_annoyances
+    type: INTEGER
+  - mode: NULLABLE
+    name: urlbar_impressions
+    type: INTEGER


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DO-2049

This creates a new `urlbar_events_daily_engagement_by_product_result_type_v1` dataset which was simply copied from the SQL provided by DS

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
