### PR TITLE
feat(DENG-9088): Deprecate Firefox Fire TV related Glean usage tables

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -318,6 +318,8 @@ metadata:
 generate:
   glean_usage:
     deprecated_apps:
+    - firefox_fire_tv
+    - org.mozilla.tv.firefox
     - firefox_reality
     - firefox_reality_pc
     - org.mozilla.firefoxreality


### PR DESCRIPTION
## Description
This PR deprecates the following tables: 
- `moz-fx-data-shared-prod.?
- `moz-fx-data-shared-prod.?
- `moz-fx-data-shared-prod.?
- `moz-fx-data-shared-prod.?
- `moz-fx-data-shared-prod.?
- `moz-fx-data-shared-prod.?

## Related Tickets & Documents
* [DENG-9088](https://mozilla-hub.atlassian.net/browse/DENG-9088)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
