### PR TITLE
[DO-2049] Backfill urlbar_events_daily_engagement_by_product_result_type_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/backfill.yaml
@@ -1,0 +1,8 @@
+2025-07-18:
+  start_date: 2025-04-01
+  end_date: 2025-07-17
+  reason: Created new table and would like to have the historical data, which dates back to the start date of the backfill
+  watchers:
+  - ascholtz@mozilla.com
+  status: Initiate
+  shredder_mitigation: true


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DO-2049

Start backfill for urlbar_events_daily_engagement_by_product_result_type_v1

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
