### PR TITLE
Deprecate moso_mastodon_backend_derived tables

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -328,6 +328,7 @@ generate:
     - firefox_reality_pc
     - org.mozilla.firefoxreality
     - org.mozilla.vrbrowser
+    - moso_mastodon_backend
     skip_existing: # Skip automatically updating the following artifacts
     - sql/moz-fx-data-shared-prod/fenix/client_deduplication/**
     - sql/moz-fx-data-shared-prod/org_mozilla_tv_firefox_derived/baseline_clients_last_seen_v1/checks.sql


### PR DESCRIPTION
## Description

This PR will deprecate the following tables: 
- `moz-fx-data-shared-prod.moso_mastodon_backend_derived.baseline_clients_daily_v1`
- `moz-fx-data-shared-prod.moso_mastodon_backend_derived.baseline_clients_first_seen_v1`
- `moz-fx-data-shared-prod.moso_mastodon_backend_derived.baseline_clients_last_seen_v1`

## Related Tickets & Documents
* [DENG-9088](https://mozilla-hub.atlassian.net/browse/DENG-9088)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
