### PR TITLE
Remove shredder mitigation from urlbar_events_daily_engagement_by_product_result_type_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/backfill.yaml
@@ -5,4 +5,4 @@
   watchers:
   - ascholtz@mozilla.com
   status: Initiate
-  shredder_mitigation: true
+  shredder_mitigation: false

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/metadata.yaml
@@ -8,7 +8,7 @@ owners:
 labels:
   incremental: true
   schedule: daily
-  shredder_mitigation: true
+  shredder_mitigation: false
   table_type: aggregate
 scheduling:
   dag_name: bqetl_urlbar


### PR DESCRIPTION
Shredder mitigation is not needed for this dataset and is blocking the backfill.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
