### PR TITLE
Create mozilla_foundation & mozilla_foundation_derived datasets

### DIFF
--- a/sql/moz-fx-data-shared-prod/mofo/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mofo/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Mozilla Foundation
+description: |-
+  User-facing views for data from the Mozilla Foundation
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential

--- a/sql/moz-fx-data-shared-prod/mofo/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mofo/dataset_metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Mozilla Foundation
 description: |-
-  User-facing views for data from the Mozilla Foundation
+  User-facing views containing Mozilla Foundation data
 dataset_base_acl: view
 user_facing: true
 labels: {}

--- a/sql/moz-fx-data-shared-prod/mofo_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mofo_derived/dataset_metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Mozilla Foundation Derived
 description: |-
-  Derived tables relating to Mozilla Foundation
+  Derived tables containing Mozilla Foundation data
 dataset_base_acl: derived
 user_facing: false
 labels: {}

--- a/sql/moz-fx-data-shared-prod/mofo_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mofo_derived/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Mozilla Foundation Derived
+description: |-
+  Derived tables relating to Mozilla Foundation
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential


### PR DESCRIPTION
## Description

This PR creates 2 new datasets to help house GA4 data from the MoFo website.
- `moz-fx-data-shared-prod.mozilla_foundation`
- `moz-fx-data-shared-prod.mozilla_foundation_derived`

## Related Tickets & Documents
* [DENG-9147](https://mozilla-hub.atlassian.net/browse/DENG-9147)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
