### PR TITLE
feat(DENG-9147): Create authorized_view for mofo GA4 data in shared-prod

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -217,6 +217,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
   - sql/moz-fx-data-shared-prod/sumo_ga/analytics_314096102/view.sql
   - sql/moz-fx-data-shared-prod/sumo_ga/analytics_432581103/view.sql
+  - sql/moz-fx-data-shared-prod/mofo/analytics_321347134_events/view.sql
   # Dataset sql/glam-fenix-dev:glam_etl was not found
   - sql/glam-fenix-dev/glam_etl/**/*.sql
   - sql/moz-fx-data-glam-prod-fca7/glam_etl/**/*.sql

--- a/sql/moz-fx-data-shared-prod/mofo/analytics_321347134_events/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mofo/analytics_321347134_events/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: MOFO Google Analytics Website Events Data (321347134)
+description: |-
+  MOFO Google Analytics Website Events Data (321347134)
+owners:
+  - kwindau@mozilla.com
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/mofo/analytics_321347134_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mofo/analytics_321347134_events/view.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mofo.analytics_321347134_events`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-marketing-prod.analytics_321347134.events_*`
+WHERE
+  _TABLE_SUFFIX >= '20250719'


### PR DESCRIPTION
## Description
This PR creates the following authorized view:
- `moz-fx-data-shared-prod.mofo.analytics_321347134_events`

It also adds the view to the skip dry run since it is sourced from marketing-prod.

## Related Tickets & Documents
* [DENG-9147](https://mozilla-hub.atlassian.net/browse/DENG-9147)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
