### PR TITLE
feat(DENG-9063): Add is_desktop and windows_version

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/glean_baseline_clients_first_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/glean_baseline_clients_first_seen/view.sql
@@ -26,5 +26,16 @@ SELECT
   normalized_channel,
   normalized_os_version,
   isp,
+  IF(
+    LOWER(IFNULL(isp, '')) <> "browserstack"
+    AND LOWER(IFNULL(COALESCE(distribution_id, distribution.name), '')) <> "mozillaonline",
+    TRUE,
+    FALSE
+  ) AS is_desktop,
+  mozfun.norm.glean_windows_version_info(
+    normalized_os,
+    normalized_os_version,
+    windows_build_number
+  ) AS windows_version
 FROM
   `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_clients_first_seen_v1`


### PR DESCRIPTION
## Description

This PR adds the columns `is_desktop` and `windows_build_number` to the view:
- `moz-fx-data-shared-prod.firefox_desktop.glean_baseline_clients_first_seen`

## Related Tickets & Documents
* [DENG-9063](https://mozilla-hub.atlassian.net/browse/DENG-9063)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
