### PR TITLE
feat(DENG-9077): Update desktop_retention_clients query

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/desktop_retention_clients_v1/query.sql
@@ -21,7 +21,7 @@ new_profiles AS (
     cfs.client_id,
     cfs.legacy_telemetry_client_id,
     cfs.sample_id,
-    cfs.profile_group_id,
+    cfs.legacy_telemetry_profile_group_id AS profile_group_id,
     cfs.first_seen_date,
     cfs.country,
     cfs.locale,
@@ -51,7 +51,7 @@ new_profiles AS (
       mozfun.bits28.from_string('0111111111111111111111111111') & au.days_desktop_active_bits
     ) > 0 AS repeat_profile
   FROM
-    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_first_seen` cfs
+    `moz-fx-data-shared-prod.firefox_desktop.glean_baseline_clients_first_seen` cfs
   LEFT JOIN
     active_users AS au
     ON cfs.first_seen_date = au.retention_active.day_27.metric_date


### PR DESCRIPTION
## Description
This PR updates the query logic for `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_retention_clients_v1` to pull from `moz-fx-data-shared-prod.firefox_desktop.glean_baseline_clients_first_seen` rather than `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_first_seen`.

## Related Tickets & Documents
* [DENG-9077](https://mozilla-hub.atlassian.net/browse/DENG-9077)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9077]: https://mozilla-hub.atlassian.net/browse/DENG-9077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ