### PR TITLE
[DENG-8497] Remove pre-fenix app from fenix.metrics view

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -438,6 +438,10 @@ generate:
       - moso_mastodon_backend
       - mozphab
       - mozregression
+    app_ping_views:
+      skip:  # don't add the following pings to the combined-channel ping view
+      - org_mozilla_fennec_aurora.metrics
+      - org_mozilla_fenix_nightly.metrics
   stable_views:
     skip_datasets:
     - mlhackweek_search


### PR DESCRIPTION
## Description

To reduce the bigquery metadata issues when querying `fenix.metrics`.  This only changes the metrics ping since that's  where the issues are and I want to limit the impact/things to look at.  Shredder still uses `fenix.deletion_requests`

## Related Tickets & Documents
* DENG-8497

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
