### PR TITLE
feat(SubPlat): Enable `catchup` setting for SubPlat DAGs

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -161,6 +161,7 @@ bqetl_accounts_derived:
 
 bqetl_subplat:
   schedule_interval: 30 1 * * *
+  catchup: true
   description: |
     Daily imports for Subscription Platform data from Stripe, Firestore, and the Mozilla VPN
     operational DB as well as derived tables based on that data.
@@ -183,6 +184,7 @@ bqetl_subplat:
 
 bqetl_subplat_hourly:
   schedule_interval: 30 * * * *
+  catchup: true
   description: |
     Hourly imports for Subscription Platform data from Stripe and Firestore,
     as well as derived tables based on that data.


### PR DESCRIPTION
## Description
Now that some SubPlat ETLs run hourly, with `catchup` disabled by default there's a much higher risk of some hourly DAG runs getting accidentally skipped if eight hourly DAG runs take an abnormally long time (e.g. [bug 1978407](https://bugzilla.mozilla.org/show_bug.cgi?id=1978407)).

While enabling `catchup` for the hourly DAG does have the downside that catching up could take a while and delay subsequent hourly DAG runs from happening in a timely manner, I think that's an easier situation to deal with (by manually marking unnecessary DAG runs as failed or successful) compared to having to manually trigger missed DAG runs which could be easily forgotten or done incorrectly.

## Related Tickets & Documents
* [Bug 1978407](https://bugzilla.mozilla.org/show_bug.cgi?id=1978407): Airflow task `bqetl_subplat_hourly.fivetran_stripe_task` failing since `scheduled__2025-07-18T20:30:00+00:00`

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
