### PR TITLE
Fix updating query schemas that are not dry run

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -2313,7 +2313,8 @@ def _update_query_schema(
 
         if query_schema:
             updated_schema = existing_schema.merge(query_schema)
-            changed = not existing_schema.equal(old_schema)
+        existing_schema.to_yaml_file(existing_schema_path)
+        changed = not existing_schema.equal(old_schema)
     else:
         updated_schema = query_schema.merge(table_schema)
 


### PR DESCRIPTION
## Description

This fixes a regression introduced in https://github.com/mozilla/bigquery-etl/commit/4776a2766bc1e04fa02917af71768e5720bb834f#r162544939 which is causing table deploy to fail. The line: https://github.com/mozilla/bigquery-etl/commit/4776a2766bc1e04fa02917af71768e5720bb834f#r162544939 got accidentally deleted which results in some outdated query schemas not being updated in Airflow.


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
