### PR TITLE
chore(DENG-9088): Stop generating views for data to be deleted

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -445,6 +445,10 @@ generate:
   stable_views:
     skip_datasets:
     - mlhackweek_search
+    - org_mozilla_firefox_reality
+    - firefox_reality
+    - org_mozilla_vrbrowser
+    - org_mozilla_tv_firefox
     skip_tables:
       telemetry:
       - modules


### PR DESCRIPTION
## Description

This PR stops generating views for the following datasets:
    - org_mozilla_firefox_reality
    - firefox_reality
    - org_mozilla_vrbrowser
    - org_mozilla_tv_firefox

## Related Tickets & Documents
* [DENG-9088](https://mozilla-hub.atlassian.net/browse/DENG-9088)
* Research done checking usage of all tables that are referenced from these views: <INSERT HERE>

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9088]: https://mozilla-hub.atlassian.net/browse/DENG-9088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ