### PR TITLE
chore(DENG-9088): Label some mozsocial tables as deprecated

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -330,6 +330,9 @@ generate:
     - firefox_reality_pc
     - org.mozilla.firefoxreality
     - org.mozilla.vrbrowser
+    - org.mozilla.social.nightly
+    - moso_mastodon_backend
+    - moso_mastodon_web
     skip_existing: # Skip automatically updating the following artifacts
     - sql/moz-fx-data-shared-prod/fenix/client_deduplication/**
     - sql/moz-fx-data-shared-prod/org_mozilla_tv_firefox_derived/baseline_clients_last_seen_v1/checks.sql


### PR DESCRIPTION
## Description

This PR marks the following Mozilla Social tables as deprecated: 
- `moz-fx-data-shared-prod.?
- `moz-fx-data-shared-prod.?
- `moz-fx-data-shared-prod.?
- `moz-fx-data-shared-prod.?
- `moz-fx-data-shared-prod.?
- `moz-fx-data-shared-prod.?
- `moz-fx-data-shared-prod.?

## Related Tickets & Documents
* [DENG-9088](https://mozilla-hub.atlassian.net/browse/DENG-9088)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9088]: https://mozilla-hub.atlassian.net/browse/DENG-9088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ