### PR TITLE
Fix column_sizes task dependency and add progress logs

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/column_size_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/column_size_v1/metadata.yaml
@@ -28,6 +28,7 @@ scheduling:
   ]
   referenced_tables:
     - ['moz-fx-data-shared-prod', 'telemetry_stable', 'main_v5']
+    - ['moz-fx-data-shared-prod', 'firefox_desktop_stable', 'metrics_v1']
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description

`column_sizes_v1` currently only depends on `compy_deduplicate_main` so it's missing the rest of the stable tables that complete in the 30-60 minutes after main

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
