### PR TITLE
feat: add partner code to serp_events

### DIFF
--- a/sql_generators/serp_events_v2/templates/desktop_query.sql
+++ b/sql_generators/serp_events_v2/templates/desktop_query.sql
@@ -70,6 +70,7 @@ impressions AS (
       FALSE
     ) AS is_signed_in,
     mozfun.map.get_key(event.extra, 'provider') AS search_engine,
+    mozfun.map.get_key(event.extra, 'partner_code') AS partner_code,
     mozfun.map.get_key(event.extra, 'source') AS sap_source,
     COALESCE(SAFE_CAST(mozfun.map.get_key(event.extra, 'tagged') AS bool), FALSE) AS is_tagged
   FROM
@@ -202,6 +203,7 @@ SELECT
   engagements,
   component_impressions,
   impressions.profile_group_id AS profile_group_id,
+  partner_code
 FROM
   -- 1 row per impression_id
   impressions


### PR DESCRIPTION
## Description

This PR adds `partner_code` to `serp_events` as requested in [#7744](https://github.com/mozilla/bigquery-etl/pull/7744)

## Related Tickets & Documents
* [DENG-8178](https://mozilla-hub.atlassian.net/browse/DENG-8178)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8178]: https://mozilla-hub.atlassian.net/browse/DENG-8178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ