### PR TITLE
[DENG-9121] Use backfill projects for dry runs by default

### DIFF
--- a/bigquery_etl/cli/dryrun.py
+++ b/bigquery_etl/cli/dryrun.py
@@ -5,6 +5,7 @@ import glob
 import os
 import re
 import sys
+import time
 from functools import partial
 from multiprocessing.pool import Pool
 from typing import List, Set, Tuple
@@ -13,7 +14,7 @@ import rich_click as click
 
 from ..cli.utils import billing_project_option, is_authenticated
 from ..config import ConfigLoader
-from ..dryrun import DryRun, get_credentials, get_id_token
+from ..dryrun import DryRun, get_credentials, get_id_token, DEFAULT_DRY_RUN_PROJECTS
 
 
 @click.command(
@@ -121,9 +122,10 @@ def dryrun(
         id_token=id_token,
         billing_project=billing_project,
     )
-
-    with Pool(8) as p:
+    start_time = time.time()
+    with Pool(12) as p:
         result = p.map(sql_file_valid, sql_files, chunksize=1)
+    print(f"Dryrun time: {time.time() - start_time:.2f}")
 
     failures = sorted([r[1] for r in result if not r[0]])
     if len(failures) > 0:

--- a/bigquery_etl/cli/dryrun.py
+++ b/bigquery_etl/cli/dryrun.py
@@ -123,7 +123,7 @@ def dryrun(
         billing_project=billing_project,
     )
     start_time = time.time()
-    with Pool(12) as p:
+    with Pool(8) as p:
         result = p.map(sql_file_valid, sql_files, chunksize=1)
     print(f"Total dryrun time: {time.time() - start_time:.2f}s")
 

--- a/bigquery_etl/cli/dryrun.py
+++ b/bigquery_etl/cli/dryrun.py
@@ -14,7 +14,7 @@ import rich_click as click
 
 from ..cli.utils import billing_project_option, is_authenticated
 from ..config import ConfigLoader
-from ..dryrun import DryRun, get_credentials, get_id_token, DEFAULT_DRY_RUN_PROJECTS
+from ..dryrun import DryRun, get_credentials, get_id_token
 
 
 @click.command(
@@ -125,7 +125,7 @@ def dryrun(
     start_time = time.time()
     with Pool(12) as p:
         result = p.map(sql_file_valid, sql_files, chunksize=1)
-    print(f"Dryrun time: {time.time() - start_time:.2f}")
+    print(f"Total dryrun time: {time.time() - start_time:.2f}s")
 
     failures = sorted([r[1] for r in result if not r[0]])
     if len(failures) > 0:

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -2563,7 +2563,7 @@ def validate_schema(
         id_token=id_token,
     )
 
-    with Pool(8) as p:
+    with Pool(12) as p:
         result = p.map(_validate_schema, query_files, chunksize=1)
 
     all_valid = True

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -649,7 +649,7 @@ def _backfill_query(
 )
 @click.option(
     "--checks_file_name",
-    "--checks_file_name",
+    "--checks-file-name",
     help="Name of a custom data checks file to run after each partition backfill. E.g. custom_checks.sql. Optional.",
     default=None,
 )
@@ -2563,7 +2563,7 @@ def validate_schema(
         id_token=id_token,
     )
 
-    with Pool(12) as p:
+    with Pool(8) as p:
         result = p.map(_validate_schema, query_files, chunksize=1)
 
     all_valid = True

--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -128,7 +128,9 @@ class DryRun:
         self.billing_project = (
             billing_project
             if billing_project or not use_cloud_function
-            else random.choice(ConfigLoader.get("dry_run", "default_projects", fallback=[None]))
+            else random.choice(
+                ConfigLoader.get("dry_run", "default_projects", fallback=[None])
+            )
         )
         try:
             self.metadata = Metadata.of_query_file(self.sqlfile)

--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -129,8 +129,8 @@ class DryRun:
         # if using cloud function and billing project isn't set, randomly select project to use
         self.billing_project = (
             billing_project
-            if billing_project or not use_cloud_function
-            else random.choice(DEFAULT_DRY_RUN_PROJECTS)
+            # if billing_project or not use_cloud_function
+            # else random.choice(DEFAULT_DRY_RUN_PROJECTS)
         )
         try:
             self.metadata = Metadata.of_query_file(self.sqlfile)

--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -39,8 +39,6 @@ except ImportError:
     # python 3.7 compatibility
     from backports.cached_property import cached_property  # type: ignore
 
-DEFAULT_DRY_RUN_PROJECTS = [f"moz-fx-data-backfill-{i}" for i in range(10, 32)]
-
 QUERY_PARAMETER_TYPE_VALUES = {
     "DATE": "2019-01-01",
     "DATETIME": "2019-01-01 00:00:00",
@@ -129,8 +127,8 @@ class DryRun:
         # if using cloud function and billing project isn't set, randomly select project to use
         self.billing_project = (
             billing_project
-            # if billing_project or not use_cloud_function
-            # else random.choice(DEFAULT_DRY_RUN_PROJECTS)
+            if billing_project or not use_cloud_function
+            else random.choice(ConfigLoader.get("dry_run", "default_projects", fallback=[None]))
         )
         try:
             self.metadata = Metadata.of_query_file(self.sqlfile)

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -182,18 +182,18 @@ dry_run:
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/query.sql
-  - sql/moz-fx-data-shared-prod/telemetry_derived/latest_versions/query.sql
-  - sql/moz-fx-data-shared-prod/telemetry_derived/italy_covid19_outage_v1/query.sql
-  - sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/query.sql
-  - sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/query.sql
+  - sql/moz-fx-data-shared-prod/telemetry_derived/latest_versions/query.sql #
+  - sql/moz-fx-data-shared-prod/telemetry_derived/italy_covid19_outage_v1/query.sql #
+  - sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/query.sql #
+  - sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/query.sql #
   - sql/moz-fx-data-shared-prod/telemetry_derived/fog_decision_support_percentiles_v1/query.sql
-  - sql/moz-fx-data-shared-prod/fenix_derived/android_onboarding_v1/query.sql
-  - sql/moz-fx-data-shared-prod/firefox_ios_derived/ios_onboarding_v1/query.sql
+  - sql/moz-fx-data-shared-prod/fenix_derived/android_onboarding_v1/query.sql #
+  - sql/moz-fx-data-shared-prod/firefox_ios_derived/ios_onboarding_v1/query.sql #
   - sql/moz-fx-data-shared-prod/fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
-  - sql/moz-fx-data-shared-prod/telemetry_derived/ech_adoption_rate_v1/query.sql
-  - sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_clients_v1/query.sql
-  - sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql
-  - sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_daily_v1/query.sql
+  - sql/moz-fx-data-shared-prod/telemetry_derived/ech_adoption_rate_v1/query.sql #
+  - sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_clients_v1/query.sql #
+  - sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql #
+  - sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_daily_v1/query.sql #
   # Query parameter not found
   - sql/moz-fx-data-shared-prod/telemetry_derived/experiments_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -182,17 +182,11 @@ dry_run:
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/query.sql
-  - sql/moz-fx-data-shared-prod/telemetry_derived/latest_versions/query.sql #
-  - sql/moz-fx-data-shared-prod/telemetry_derived/italy_covid19_outage_v1/query.sql #
-  - sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/query.sql #
-  - sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/query.sql #
+  - sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/query.sql
+  - sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/fog_decision_support_percentiles_v1/query.sql
-  - sql/moz-fx-data-shared-prod/fenix_derived/android_onboarding_v1/query.sql #
   - sql/moz-fx-data-shared-prod/fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
-  - sql/moz-fx-data-shared-prod/telemetry_derived/ech_adoption_rate_v1/query.sql #
-  - sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_clients_v1/query.sql #
   - sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql
-  - sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_daily_v1/query.sql #
   # Query parameter not found
   - sql/moz-fx-data-shared-prod/telemetry_derived/experiments_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_scalar_aggregates_v1/query.sql
@@ -226,7 +220,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/monitoring_derived/outerbounds_cost_per_flow_v1/view.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_v1/view.sql
   - sql/moz-fx-data-shared-prod/monitoring_derived/rayserve_cost_fakespot_tenant_prod_v1/view.sql
-    # Query templates
+  # Query templates
   - sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/fenix_metrics.template.sql
   - sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/mobile_search_clients_daily.template.sql
   - sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v2/fenix_metrics.template.sql

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -188,11 +188,10 @@ dry_run:
   - sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/query.sql #
   - sql/moz-fx-data-shared-prod/telemetry_derived/fog_decision_support_percentiles_v1/query.sql
   - sql/moz-fx-data-shared-prod/fenix_derived/android_onboarding_v1/query.sql #
-  - sql/moz-fx-data-shared-prod/firefox_ios_derived/ios_onboarding_v1/query.sql #
   - sql/moz-fx-data-shared-prod/fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
   - sql/moz-fx-data-shared-prod/telemetry_derived/ech_adoption_rate_v1/query.sql #
   - sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_clients_v1/query.sql #
-  - sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql #
+  - sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_v1/query.sql
   - sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_daily_v1/query.sql #
   # Query parameter not found
   - sql/moz-fx-data-shared-prod/telemetry_derived/experiments_v1/query.sql
@@ -236,6 +235,29 @@ dry_run:
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/event_types_history_v1/query.sql
   # Tests
   - sql/moz-fx-data-test-project/test/simple_view/view.sql
+  default_projects:  # projects to use for query dry run jobs
+  - moz-fx-data-backfill-10
+  - moz-fx-data-backfill-11
+  - moz-fx-data-backfill-12
+  - moz-fx-data-backfill-13
+  - moz-fx-data-backfill-14
+  - moz-fx-data-backfill-15
+  - moz-fx-data-backfill-16
+  - moz-fx-data-backfill-17
+  - moz-fx-data-backfill-18
+  - moz-fx-data-backfill-19
+  - moz-fx-data-backfill-20
+  - moz-fx-data-backfill-21
+  - moz-fx-data-backfill-22
+  - moz-fx-data-backfill-23
+  - moz-fx-data-backfill-24
+  - moz-fx-data-backfill-25
+  - moz-fx-data-backfill-26
+  - moz-fx-data-backfill-27
+  - moz-fx-data-backfill-28
+  - moz-fx-data-backfill-29
+  - moz-fx-data-backfill-30
+  - moz-fx-data-backfill-31
 
 deprecation:
   retain_dataset_roles: # the following roles are retain permissions on datasets when a dataset table is deprecated

--- a/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v1/query.sql
+++ b/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v1/query.sql
@@ -9,7 +9,7 @@ WITH
         e.value AS branch,
         client_id
       FROM
-        telemetry.clients_daily
+        `moz-fx-data-shared-prod.telemetry.clients_daily`
       CROSS JOIN
         UNNEST(experiments) AS e
     )

--- a/sql_generators/feature_usage/templates/query.sql
+++ b/sql_generators/feature_usage/templates/query.sql
@@ -11,7 +11,7 @@ WITH
         {{ measure.sql }} AS {{ measure.name }},
     {% endfor %}
     FROM
-        {{ source.ref }}
+        `{{ source.ref }}`
     WHERE
         {% for filter in source.filters %}
             {% if loop.first %}

--- a/sql_generators/feature_usage/templating.yaml
+++ b/sql_generators/feature_usage/templating.yaml
@@ -4,7 +4,7 @@
 # The general structure of this config file is as follows:
 #   sources:
 #     - name: <source_name>
-#       ref: <dataset>.<table>  # corresponds to BQ table identifier
+#       ref: <project>.<dataset>.<table>  # corresponds to BQ table identifier
 #       filters:              # optional, SQL filter statements
 #         - sql: <SQL snippet>
 #       group_by:             # optional, names of fields to GROUP BY
@@ -39,7 +39,7 @@
 sources:
   ### User Type ###
   - name: user_type
-    ref: telemetry.clients_last_seen
+    ref: moz-fx-data-shared-prod.telemetry.clients_last_seen
     filters:
       - sql: submission_date = @submission_date
       - sql: sample_id = 0
@@ -290,7 +290,7 @@ sources:
         type: INT64
   ### Main ###
   - name: main
-    ref: telemetry.main_remainder_1pct
+    ref: moz-fx-data-shared-prod.telemetry.main_remainder_1pct
     group_by: ["submission_date", "client_id"]
     filters:
       - sql: DATE(submission_timestamp) = @submission_date
@@ -742,7 +742,7 @@ sources:
         type: INT64
   ### Events ###
   - name: events
-    ref: telemetry.events
+    ref: moz-fx-data-shared-prod.telemetry.events
     group_by: ["submission_date", "client_id"]
     filters:
       - sql: submission_date = @submission_date
@@ -1001,7 +1001,7 @@ sources:
         type: INT64
   ### Activity Stream Events ###
   - name: activity_stream_events
-    ref: activity_stream.events
+    ref: moz-fx-data-shared-prod.activity_stream.events
     group_by: ["submission_date", "client_id"]
     filters:
       - sql: DATE(submission_timestamp) = @submission_date
@@ -1088,7 +1088,7 @@ sources:
         vetted: false
   ### Activity Stream Sessions ###
   - name: activity_stream_sessions
-    ref: activity_stream.sessions
+    ref: moz-fx-data-shared-prod.activity_stream.sessions
     group_by: ["submission_date", "client_id"]
     filters:
       - sql: DATE(submission_timestamp) = @submission_date
@@ -1128,7 +1128,7 @@ sources:
         vetted: false
   ### Addons ###
   - name: addons
-    ref: telemetry.addons
+    ref: moz-fx-data-shared-prod.telemetry.addons
     group_by: ["submission_date", "client_id"]
     filters:
       - sql: submission_date = @submission_date

--- a/tests/test_dryrun.py
+++ b/tests/test_dryrun.py
@@ -80,7 +80,7 @@ class TestDryRun:
     def test_get_referenced_tables(self, tmp_query_path):
         query_file = tmp_query_path / "query.sql"
         query_file.write_text(
-            "SELECT * FROM telemetry_derived.clients_daily_v6 "
+            "SELECT * FROM `moz-fx-data-shared-prod.telemetry_derived.clients_daily_v6` "
             "WHERE submission_date = '2020-01-01'"
         )
         query_dryrun = DryRun(str(query_file)).get_referenced_tables()


### PR DESCRIPTION
## Description

Changes dry runs to use a backfill project instead of shared-prod because some dry runs are a lot slower in shared-prod for some queries.  It doesn't really make CI faster because the most problematic queries were already being skipped but it should be more consistent.

This breaks dry runs for queries with non-fully qualified table names which I think is ok because there's a CI check for that but that doesn't run on generated sql.

## Related Tickets & Documents
* DENG-9121

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
