### PR TITLE
fix: bigconfig errors in firefoxdotcom_derived-www_site_hits_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_hits_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_hits_v1/bigconfig.yml
@@ -6,15 +6,15 @@ tag_deployments:
     - slack: '#de-bigeye-triage'
   deployments:
   - column_selectors:
-    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_hits_v1.visit_identifier
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_hits_v1.*
     metrics:
-    - metric_id: row_count_with_filter
+    - metric_name: row_count_with_filter
       metric_type:
-        type: COUNT_ROWS
-      filters:
-      - regexp_contains(visit_identifier,  r'^[0-9]+\\.{1}[0-9]+\\-{1}[0-9]+$')
+        predefined_metric: COUNT_ROWS
+      conditions:
+      - regexp_contains(visit_identifier, r'^[0-9]+\\.{1}[0-9]+\\-{1}[0-9]+$')
       threshold:
-      - type: CONSTANT
+        type: CONSTANT
         lower_bound: 0.0
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_hits_v1.*


### PR DESCRIPTION
# fix: bigconfig errors in firefoxdotcom_derived-www_site_hits_v1