### PR TITLE
chore: delete ads.fakespot_daily_events_rollup view definition as it is pointing to bq asset that no longer exists

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads/fakespot_daily_events_rollup/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads/fakespot_daily_events_rollup/metadata.yaml
@@ -1,9 +1,0 @@
-friendly_name: Fakespot daily events rollup
-description: |-
-  Daily events rollup from Fakespot, pulled from syndicate dataset
-owners:
-  - cmorales@mozilla.com
-  - cbeck@mozilla.com
-  - lvargas@mozilla.com
-labels:
-  authorized: true

--- a/sql/moz-fx-data-shared-prod/ads/fakespot_daily_events_rollup/view.sql
+++ b/sql/moz-fx-data-shared-prod/ads/fakespot_daily_events_rollup/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.ads.fakespot_daily_events_rollup`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.fakespot_syndicate.daily_events_rollup`


### PR DESCRIPTION
# chore: delete ads.fakespot_daily_events_rollup view definition as it is pointing to bq asset that no longer exists

The upstream resource has been dropped via: https://github.com/mozilla/bigquery-etl/commit/a894dec99b4ad09f59faa26a8403dc672d6301c3

This is currently causing one of the CI steps to fail.