### PR TITLE
fix: undeprecate clients_activation_v1 as still in use

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/clients_activation_v1/metadata.yaml
@@ -25,4 +25,4 @@ scheduling:
   dag_name: bqetl_firefox_ios
   date_partition_parameter: submission_date
   depends_on_past: false
-deprecated: true
+deprecated: false


### PR DESCRIPTION
# fix: undeprecate clients_activation_v1 as still in use