### PR TITLE
deng_8901 remove deprecated checks.sql files

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_sessions_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_sessions_v1/checks.sql
@@ -1,2 +1,0 @@
-#warn
-{{ not_null(["session_date", "ga_client_id", "ga_session_id"])}}

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_hits_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_hits_v1/checks.sql
@@ -1,2 +1,0 @@
-#warn
-{{ matches_pattern(column="visit_identifier", pattern="^[0-9]+\\.{1}[0-9]+\\-{1}[0-9]+$", where="date = @submission_date", threshold_fail_percentage=0, message="Warn - some visit_identifier not matching expected pattern") }}


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR removed checks.sql files for firefoxdotcom_derived.www_site_hits_v1 and firefoxdotcom_derived.ga_sessions_v1 that are covered by bigeye checks
## Related Tickets & Documents
* DENG-8901
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
