### PR TITLE
feat(DENG-9088): Update view SQL for telemetry.nondesktop_clients_last_seen_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/nondesktop_clients_last_seen_v1/view.sql
@@ -73,6 +73,7 @@ WITH glean_final AS (
     'Reference Browser Baseline' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_reference_browser.baseline_clients_last_seen`
+/*
   UNION ALL
   SELECT
     submission_date,
@@ -109,6 +110,7 @@ WITH glean_final AS (
     'VR Browser Baseline' AS app_name,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_vrbrowser.baseline_clients_last_seen`
+*/
   UNION ALL
   SELECT
     submission_date,


### PR DESCRIPTION
## Description

This PR updates the view SQL for the view `moz-fx-data-shared-prod.telemetry.nondesktop_clients_last_seen_v1` to no longer include data from:
- `moz-fx-data-shared-prod.org_mozilla_tv_firefox.baseline_clients_last_seen`
- `moz-fx-data-shared-prod.org_mozilla_vrbrowser.baseline_clients_last_seen`

## Related Tickets & Documents
* [DENG-9088](https://mozilla-hub.atlassian.net/browse/DENG-9088)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
