### PR TITLE
feat: Add two columns for verifying recommendation data to newtab_items_daily_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/query.sql
@@ -59,13 +59,18 @@ SELECT
   received_rank,
   section,
   section_position,
-  topic,
+  flattened_events.topic,
+  ANY_VALUE(corpus_items.title) AS title,
+  ANY_VALUE(corpus_items.url) AS recommendation_url,
   COUNTIF(event_name = 'impression') AS impression_count,
   COUNTIF(event_name = 'click') AS click_count,
   COUNTIF(event_name = 'save') AS save_count,
   COUNTIF(event_name = 'dismiss') AS dismiss_count
 FROM
   flattened_events
+LEFT OUTER JOIN
+  `moz-fx-data-shared-prod.snowflake_migration_derived.corpus_items_updated_v1` AS corpus_items
+  ON flattened_events.corpus_item_id = corpus_items.approved_corpus_item_external_id
 GROUP BY
   submission_date,
   app_version,

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/schema.yaml
@@ -61,6 +61,14 @@ fields:
   type: STRING
   mode: NULLABLE
   description: The topic of the recommendation. Like "entertainment".
+- name: title
+  type: STRING
+  mode: NULLABLE
+  description: The title of the recommendation.
+- name: recommendation_url
+  type: STRING
+  mode: NULLABLE
+  description: The URL of the recommendation at the publisher's domain
 - name: impression_count
   type: INTEGER
   mode: NULLABLE


### PR DESCRIPTION
## Description

This PR Adds columns with recommendation details to the newtab_items_daily_v1 table so that editorial team members looking at the New Tab Individual Recommendations dashboard table can quickly understand how specific articles are performing on the New Tab.

## Related Tickets & Documents
* [DENG-9185](https://mozilla-hub.atlassian.net/browse/DENG-9185)
=

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9185]: https://mozilla-hub.atlassian.net/browse/DENG-9185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ