### PR TITLE
[DENG-9181] Add reservation override option the shredder

### DIFF
--- a/tests/shredder/test_delete.py
+++ b/tests/shredder/test_delete.py
@@ -95,6 +95,7 @@ COMMON_DELETE_ARGS = {
     "target": DeleteTarget(table="dataset.table_v1", field="client_id"),
     "use_dml": False,
     "temp_dataset": "project.tmp",
+    "reservation_override": None,
 }
 
 
@@ -212,6 +213,7 @@ def test_context_id_brace_normalization(mock_sql_table_id):
             use_sampling=False,
             temp_dataset="project.tmp",
             priority="INTERACTIVE",
+            reservation_override=None,
         )
     )
 


### PR DESCRIPTION
## Description

desktop metrics shredding is borked, see https://mozilla-hub.atlassian.net/browse/DENG-9181?focusedCommentId=1108274.  This allows running in shared-prod while using the shredder reservation. The `reservation` option is pre-GA (https://cloud.google.com/bigquery/docs/reservations-assignments#reservation) but I think it's worth whatever risk there is because the job currently doesn't work at all

## Related Tickets & Documents
* DENG-9181

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
