### PR TITLE
feat(DENG-9088): Unschedule some deprecated Pocket tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/events/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/events/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.events`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.events_v1`

--- a/sql/moz-fx-data-shared-prod/pocket/rolling_monthly_active_user_counts/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket/rolling_monthly_active_user_counts/metadata.yaml
@@ -1,5 +1,0 @@
-friendly_name: Rolling Monthly Active User Counts
-description: |-
-  Rolling count of monthly active users (MAU) for Pocket.
-owners:
-  - jklukas@mozilla.com

--- a/sql/moz-fx-data-shared-prod/pocket/rolling_monthly_active_user_counts/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/rolling_monthly_active_user_counts/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.rolling_monthly_active_user_counts`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.rolling_monthly_active_user_counts_v1`

--- a/sql/moz-fx-data-shared-prod/pocket/twice_weekly_active_user_counts/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket/twice_weekly_active_user_counts/metadata.yaml
@@ -1,6 +1,0 @@
-friendly_name: Twice Weekly Active User Counts
-description: |-
-  Count of twice weekly active users (T-WAU) for Pocket,
-  measured each calendar week.
-owners:
-  - jklukas@mozilla.com

--- a/sql/moz-fx-data-shared-prod/pocket/twice_weekly_active_user_counts/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/twice_weekly_active_user_counts/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.twice_weekly_active_user_counts`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.twice_weekly_active_user_counts_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/rolling_monthly_active_user_counts_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/rolling_monthly_active_user_counts_history_v1/metadata.yaml
@@ -14,8 +14,8 @@ bigquery:
     type: day
     field: submission_date
     require_partition_filter: false
-scheduling:
-  dag_name: bqetl_pocket
-  arguments: ["--date", "{{ ds }}"]
-  referenced_tables: []
+#scheduling:
+#  dag_name: bqetl_pocket
+#  arguments: ["--date", "{{ ds }}"]
+#  referenced_tables: []
 deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/rolling_monthly_active_user_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/rolling_monthly_active_user_counts_v1/metadata.yaml
@@ -7,8 +7,8 @@ labels:
   incremental: false
   table_type: aggregate
   shredder_mitigation: false
-scheduling:
-  dag_name: bqetl_pocket
-  date_partition_parameter: null
-  parameters: ["submission_date:DATE:{{ds}}"]
+#scheduling:
+#  dag_name: bqetl_pocket
+#  date_partition_parameter: null
+#  parameters: ["submission_date:DATE:{{ds}}"]
 deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_history_v1/metadata.yaml
@@ -12,8 +12,8 @@ bigquery:
     type: day
     field: submission_date
     require_partition_filter: false
-scheduling:
-  dag_name: bqetl_pocket
-  arguments: ["--date", "{{ ds }}"]
-  referenced_tables: []
+#scheduling:
+#  dag_name: bqetl_pocket
+#  arguments: ["--date", "{{ ds }}"]
+#  referenced_tables: []
 deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_history_v1/metadata.yaml
@@ -12,8 +12,8 @@ bigquery:
     type: day
     field: submission_date
     require_partition_filter: false
-#scheduling:
-#  dag_name: bqetl_pocket
-#  arguments: ["--date", "{{ ds }}"]
-#  referenced_tables: []
+scheduling:
+  dag_name: bqetl_pocket
+  arguments: ["--date", "{{ ds }}"]
+  referenced_tables: []
 deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/twice_weekly_active_user_counts_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/twice_weekly_active_user_counts_history_v1/metadata.yaml
@@ -14,8 +14,8 @@ bigquery:
     type: day
     field: submission_date
     require_partition_filter: false
-scheduling:
-  dag_name: bqetl_pocket
-  arguments: ["--date", "{{ ds }}"]
-  referenced_tables: []
+#scheduling:
+#  dag_name: bqetl_pocket
+#  arguments: ["--date", "{{ ds }}"]
+#  referenced_tables: []
 deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/twice_weekly_active_user_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/twice_weekly_active_user_counts_v1/metadata.yaml
@@ -8,8 +8,8 @@ labels:
   incremental: false
   table_type: aggregate
   shredder_mitigation: false
-scheduling:
-  dag_name: bqetl_pocket
-  date_partition_parameter: null
-  parameters: ["submission_date:DATE:{{ds}}"]
+#scheduling:
+#  dag_name: bqetl_pocket
+#  date_partition_parameter: null
+#  parameters: ["submission_date:DATE:{{ds}}"]
 deprecated: true


### PR DESCRIPTION
## Description

This PR un-schedules the data loads of the following tables, which were previously deprecated: 
- `moz-fx-data-shared-prod.pocket_derived.rolling_monthly_active_user_counts_history_v1`
- `moz-fx-data-shared-prod.pocket_derived.rolling_monthly_active_user_counts_v1`
- `moz-fx-data-shared-prod.pocket_derived.twice_weekly_active_user_counts_history_v1`
- `moz-fx-data-shared-prod.pocket_derived.twice_weekly_active_user_counts_v1`

This PR also deletes the following views: 
- `moz-fx-data-shared-prod.pocket.rolling_monthly_active_user_counts`
- `moz-fx-data-shared-prod.pocket.twice_weekly_active_user_counts`
- `moz-fx-data-shared-prod.pocket.events`

## Related Tickets & Documents
* [DENG-9088](https://mozilla-hub.atlassian.net/browse/DENG-9088)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9088]: https://mozilla-hub.atlassian.net/browse/DENG-9088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ