### PR TITLE
feat: Add two more columns to newtab_items_daily_v1 (#9205)

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/query.sql
@@ -63,6 +63,7 @@ SELECT
   ANY_VALUE(corpus_items.title) AS title,
   ANY_VALUE(corpus_items.url) AS recommendation_url,
   ANY_VALUE(corpus_items.authors) AS authors,
+  ANY_VALUE(corpus_items.publisher) AS publisher,
   COUNTIF(event_name = 'impression') AS impression_count,
   COUNTIF(event_name = 'click') AS click_count,
   COUNTIF(event_name = 'save') AS save_count,

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/query.sql
@@ -62,6 +62,7 @@ SELECT
   flattened_events.topic,
   ANY_VALUE(corpus_items.title) AS title,
   ANY_VALUE(corpus_items.url) AS recommendation_url,
+  ANY_VALUE(corpus_items.authors) AS authors,
   COUNTIF(event_name = 'impression') AS impression_count,
   COUNTIF(event_name = 'click') AS click_count,
   COUNTIF(event_name = 'save') AS save_count,

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/schema.yaml
@@ -73,6 +73,10 @@ fields:
   type: STRING
   mode: NULLABLE
   description: The names of the authors of the piece being recommended, concatenated with commas
+- name: publisher
+  type: STRING
+  mode: NULLABLE
+  description: The name of the recommendation publisher
 - name: impression_count
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/schema.yaml
@@ -69,6 +69,10 @@ fields:
   type: STRING
   mode: NULLABLE
   description: The URL of the recommendation at the publisher's domain
+- name: authors
+  type: STRING
+  mode: NULLABLE
+  description: The names of the authors of the piece being recommended, concatenated with commas
 - name: impression_count
   type: INTEGER
   mode: NULLABLE


### PR DESCRIPTION
## Description

This PR adds an `authors` column and a `publisher` column to the `newtab_items_daily_v1` table.

## Related Tickets & Documents
* [DENG-9205](https://mozilla-hub.atlassian.net/browse/DENG-9205)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9205]: https://mozilla-hub.atlassian.net/browse/DENG-9205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ