### PR TITLE
fix(DENG-9040): Correct schema to match desired schema in production

### DIFF
--- a/sql/moz-fx-data-shared-prod/bigeye_derived/group_service_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/bigeye_derived/group_service_v1/schema.yaml
@@ -34,11 +34,19 @@ fields:
   mode: NULLABLE
   name: user_email
   type: STRING
-- description: |
-    user_groups associated with this record.
+- description: user_groups associated with this record.
+  fields:
+  - description: Display Name
+    mode: NULLABLE
+    name: displayName
+    type: STRING
+  - description: ID
+    mode: NULLABLE
+    name: id
+    type: INTEGER
   mode: REPEATED
   name: user_groups
-  type: STRING
+  type: RECORD
 - description: |
     user_picture_url associated with this record.
   mode: NULLABLE
@@ -74,10 +82,22 @@ fields:
   mode: NULLABLE
   name: role_role_type
   type: STRING
-- description: |
-    role_role_permissions associated with this record.
+- description: role_role_permissions associated with this record.
+  fields:
+  - description: The date associated with the ad_click value
+    mode: NULLABLE
+    name: actions
+    type: STRING
+  - description: The total number of ad_clicks for the submission_date
+    mode: NULLABLE
+    name: domains
+    type: STRING
   mode: REPEATED
   name: role_role_permissions
+  type: RECORD
+- description: Role Description
+  mode: NULLABLE
+  name: role_description
   type: STRING
 - description: |
     group_display_name associated with this record.
@@ -99,8 +119,3 @@ fields:
   mode: NULLABLE
   name: refreshed_at
   type: TIMESTAMP
-- description: |
-    role_description associated with this record.
-  mode: NULLABLE
-  name: role_description
-  type: STRING


### PR DESCRIPTION
## Description

This PR resolves the error in the bqetl_artifact_deployment table creation job by making the schema.yaml file match the production schema.  It is a minor follow-up fix to [PR-7829](https://github.com/mozilla/bigquery-etl/pull/7829).

## Related Tickets & Documents
* [DENG-9040](https://mozilla-hub.atlassian.net/browse/DENG-9040)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9040]: https://mozilla-hub.atlassian.net/browse/DENG-9040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ