### PR TITLE
Fix schema metric service

### DIFF
--- a/sql/moz-fx-data-shared-prod/bigeye_derived/collection_service_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/bigeye_derived/collection_service_v1/schema.yaml
@@ -44,11 +44,25 @@ fields:
   mode: REPEATED
   name: collection_configuration_metric_ids
   type: INTEGER
-- description: |
-    collection_configuration_notification_channels associated with this record.
+- fields:
+  - mode: NULLABLE
+    name: email
+    type: STRING
+  - fields:
+    - mode: NULLABLE
+      name: channelId
+      type: STRING
+    - mode: NULLABLE
+      name: channelName
+      type: STRING
+    mode: NULLABLE
+    name: slackChannelInfo
+    type: RECORD
+    description: Slack Channel Information
   mode: REPEATED
   name: collection_configuration_notification_channels
   type: RECORD
+  description: collection_configuration_notification_channels associated with this record.
 - description: |
     collection_configuration_muted_until_timestamp associated with this record.
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/bigeye_derived/metric_service_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/bigeye_derived/metric_service_v1/schema.yaml
@@ -371,6 +371,11 @@ fields:
   name: metric_configuration_metric_schedule_schedule_frequency_interval_value
   type: FLOAT
 - description: |
+    metric_configuration_rct_override associated with this record.
+  mode: NULLABLE
+  name: metric_configuration_rct_override
+  type: STRING
+- description: |
     metric_configuration_is_lookback_using_current_time associated with this record.
   mode: NULLABLE
   name: metric_configuration_is_lookback_using_current_time
@@ -510,11 +515,6 @@ fields:
     metric_configuration_metric_schedule_named_schedule_cron associated with this record.
   mode: NULLABLE
   name: metric_configuration_metric_schedule_named_schedule_cron
-  type: STRING
-- description: |
-    metric_configuration_rct_override associated with this record.
-  mode: NULLABLE
-  name: metric_configuration_rct_override
   type: STRING
 - description: |
     metric_configuration_metric_type_template_metric_template_id associated with this record.

--- a/sql/moz-fx-data-shared-prod/bigeye_derived/metric_service_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/bigeye_derived/metric_service_v1/schema.yaml
@@ -4,6 +4,115 @@ fields:
   mode: REPEATED
   name: latest_metric_runs
   type: RECORD
+  fields:
+  - mode: NULLABLE
+    name: exceptionClass
+    type: STRING
+    description: Exception Class
+  - mode: NULLABLE
+    name: exceptionMessage
+    type: STRING
+    description: Exception Message
+  - mode: NULLABLE
+    name: failureReason
+    type: STRING
+  - mode: NULLABLE
+    name: grainEndEpochSeconds
+    type: INTEGER
+  - mode: NULLABLE
+    name: grainStartEpochSeconds
+    type: INTEGER
+  - fields:
+    - mode: NULLABLE
+      name: columnName
+      type: STRING
+    - mode: NULLABLE
+      name: columnValue
+      type: STRING
+    mode: REPEATED
+    name: groupDimensions
+    type: RECORD
+    description: Group Dimensions
+  - mode: NULLABLE
+    name: groupName
+    type: STRING
+    description: Group Name
+  - mode: NULLABLE
+    name: hasRowCounts
+    type: BOOLEAN
+    description: Has Row Counts
+  - mode: NULLABLE
+    name: hasRowsMatched
+    type: BOOLEAN
+    description: Has Rows Matched
+  - mode: NULLABLE
+    name: id
+    type: INTEGER
+  - mode: NULLABLE
+    name: isPosthoc
+    type: BOOLEAN
+  - fields:
+    - fields:
+      - mode: NULLABLE
+        name: createdBy
+        type: INTEGER
+      - mode: NULLABLE
+        name: createdEpochSeconds
+        type: INTEGER
+      - mode: NULLABLE
+        name: updatedBy
+        type: INTEGER
+      - mode: NULLABLE
+        name: updatedEpochSeconds
+        type: INTEGER
+      mode: NULLABLE
+      name: entityInfo
+      type: RECORD
+      description: Entity Information
+    - mode: NULLABLE
+      name: id
+      type: INTEGER
+    - mode: NULLABLE
+      name: metricRunId
+      type: INTEGER
+    - mode: NULLABLE
+      name: metricRunLabel
+      type: STRING
+    mode: NULLABLE
+    name: metricRunAnnotation
+    type: RECORD
+  - mode: NULLABLE
+    name: observedValue
+    type: FLOAT
+  - mode: NULLABLE
+    name: rowsMatched
+    type: INTEGER
+  - mode: NULLABLE
+    name: rowsScanned
+    type: INTEGER
+  - mode: NULLABLE
+    name: runAtEpochSeconds
+    type: INTEGER
+  - mode: NULLABLE
+    name: status
+    type: STRING
+  - mode: NULLABLE
+    name: summaryStatus
+    type: STRING
+  - fields:
+    - fields:
+      - mode: NULLABLE
+        name: boundType
+        type: STRING
+      - mode: NULLABLE
+        name: value
+        type: FLOAT
+      mode: NULLABLE
+      name: bound
+      type: RECORD
+    mode: REPEATED
+    name: thresholds
+    type: RECORD
 - description: |
     is_snoozed associated with this record.
   mode: NULLABLE
@@ -29,11 +138,20 @@ fields:
   mode: NULLABLE
   name: can_backfill
   type: BOOLEAN
-- description: |
-    collections associated with this record.
+- fields:
+  - mode: NULLABLE
+    name: displayName
+    type: STRING
+  - mode: NULLABLE
+    name: id
+    type: INTEGER
   mode: REPEATED
   name: collections
   type: RECORD
+- mode: NULLABLE
+  name: reason_cannot_backfill
+  type: STRING
+  description: Reason Cannot Backfill
 - description: |
     no_value_group_count associated with this record.
   mode: NULLABLE
@@ -50,6 +168,16 @@ fields:
   name: metric_configuration_id
   type: INTEGER
 - description: |
+    metric_configuration_schedule_frequency_interval_type associated with this record.
+  mode: NULLABLE
+  name: metric_configuration_schedule_frequency_interval_type
+  type: STRING
+- description: |
+    metric_configuration_schedule_frequency_interval_value associated with this record.
+  mode: NULLABLE
+  name: metric_configuration_schedule_frequency_interval_value
+  type: FLOAT
+- description: |
     metric_configuration_filters associated with this record.
   mode: REPEATED
   name: metric_configuration_filters
@@ -59,16 +187,95 @@ fields:
   mode: REPEATED
   name: metric_configuration_group_bys
   type: STRING
-- description: |
-    metric_configuration_thresholds associated with this record.
+- fields:
+  - fields:
+    - fields:
+      - mode: NULLABLE
+        name: boundType
+        type: STRING
+      - mode: NULLABLE
+        name: value
+        type: FLOAT
+      mode: NULLABLE
+      name: bound
+      type: RECORD
+    - mode: NULLABLE
+      name: forecastValue
+      type: FLOAT
+    - mode: NULLABLE
+      name: modelType
+      type: STRING
+    - mode: NULLABLE
+      name: sensitivity
+      type: STRING
+    mode: NULLABLE
+    name: autoThreshold
+    type: RECORD
+  - fields:
+    - fields:
+      - mode: NULLABLE
+        name: boundType
+        type: STRING
+      - mode: NULLABLE
+        name: value
+        type: FLOAT
+      mode: NULLABLE
+      name: bound
+      type: RECORD
+    mode: NULLABLE
+    name: constantThreshold
+    type: RECORD
+  - fields:
+    - fields:
+      - mode: NULLABLE
+        name: boundType
+        type: STRING
+      - mode: NULLABLE
+        name: value
+        type: FLOAT
+      mode: NULLABLE
+      name: bound
+      type: RECORD
+    - mode: NULLABLE
+      name: cron
+      type: STRING
+    - fields:
+      - mode: NULLABLE
+        name: intervalType
+        type: STRING
+      - mode: NULLABLE
+        name: intervalValue
+        type: INTEGER
+      mode: NULLABLE
+      name: delayAtUpdate
+      type: RECORD
+    - mode: NULLABLE
+      name: timezone
+      type: STRING
+    mode: NULLABLE
+    name: freshnessScheduleThreshold
+    type: RECORD
   mode: REPEATED
   name: metric_configuration_thresholds
   type: RECORD
-- description: |
-    metric_configuration_notification_channels associated with this record.
+- fields:
+  - mode: NULLABLE
+    name: email
+    type: STRING
+  - fields:
+    - mode: NULLABLE
+      name: channelId
+      type: STRING
+    - mode: NULLABLE
+      name: channelName
+      type: STRING
+    mode: NULLABLE
+    name: slackChannelInfo
+    type: RECORD
   mode: REPEATED
   name: metric_configuration_notification_channels
   type: RECORD
+  description: metric_configuration_notification_channels associated with this record.
 - description: |
     metric_configuration_warehouse_id associated with this record.
   mode: NULLABLE
@@ -94,11 +301,20 @@ fields:
   mode: NULLABLE
   name: metric_configuration_metric_type_is_table_metric
   type: BOOLEAN
-- description: |
-    metric_configuration_parameters associated with this record.
+- fields:
+  - mode: NULLABLE
+    name: columnName
+    type: STRING
+  - mode: NULLABLE
+    name: key
+    type: STRING
+  - mode: NULLABLE
+    name: stringValue
+    type: STRING
   mode: REPEATED
   name: metric_configuration_parameters
   type: RECORD
+  description: metric_configuration_parameters associated with this record.
 - description: |
     metric_configuration_lookback_interval_type associated with this record.
   mode: NULLABLE
@@ -145,20 +361,15 @@ fields:
   name: metric_configuration_metric_group_overrides
   type: INTEGER
 - description: |
-    metric_configuration_metric_schedule_named_schedule_id associated with this record.
+    metric_configuration_metric_schedule_schedule_frequency_interval_type associated with this record.
   mode: NULLABLE
-  name: metric_configuration_metric_schedule_named_schedule_id
+  name: metric_configuration_metric_schedule_schedule_frequency_interval_type
+  type: STRING
+- description: |
+    metric_configuration_metric_schedule_schedule_frequency_interval_value associated with this record.
+  mode: NULLABLE
+  name: metric_configuration_metric_schedule_schedule_frequency_interval_value
   type: FLOAT
-- description: |
-    metric_configuration_metric_schedule_named_schedule_name associated with this record.
-  mode: NULLABLE
-  name: metric_configuration_metric_schedule_named_schedule_name
-  type: STRING
-- description: |
-    metric_configuration_metric_schedule_named_schedule_cron associated with this record.
-  mode: NULLABLE
-  name: metric_configuration_metric_schedule_named_schedule_cron
-  type: STRING
 - description: |
     metric_configuration_is_lookback_using_current_time associated with this record.
   mode: NULLABLE
@@ -224,11 +435,27 @@ fields:
   mode: NULLABLE
   name: metric_metadata_created_at
   type: INTEGER
-- description: |
-    metric_metadata_companion_metrics associated with this record.
+- fields:
+  - mode: NULLABLE
+    name: id
+    type: INTEGER
+  - fields:
+    - mode: NULLABLE
+      name: displayName
+      type: STRING
+    - mode: NULLABLE
+      name: id
+      type: INTEGER
+    mode: NULLABLE
+    name: metricInfo
+    type: RECORD
+  - mode: NULLABLE
+    name: type
+    type: STRING
   mode: REPEATED
   name: metric_metadata_companion_metrics
   type: RECORD
+  description: metric_metadata_companion_metrics associated with this record.
 - description: |
     metric_metadata_is_favorite associated with this record.
   mode: NULLABLE
@@ -270,25 +497,25 @@ fields:
   name: active_issue_display_name
   type: STRING
 - description: |
-    reason_cannot_backfill associated with this record.
+    metric_configuration_metric_schedule_named_schedule_id associated with this record.
   mode: NULLABLE
-  name: reason_cannot_backfill
+  name: metric_configuration_metric_schedule_named_schedule_id
+  type: FLOAT
+- description: |
+    metric_configuration_metric_schedule_named_schedule_name associated with this record.
+  mode: NULLABLE
+  name: metric_configuration_metric_schedule_named_schedule_name
+  type: STRING
+- description: |
+    metric_configuration_metric_schedule_named_schedule_cron associated with this record.
+  mode: NULLABLE
+  name: metric_configuration_metric_schedule_named_schedule_cron
   type: STRING
 - description: |
     metric_configuration_rct_override associated with this record.
   mode: NULLABLE
   name: metric_configuration_rct_override
   type: STRING
-- description: |
-    metric_configuration_schedule_frequency_interval_type associated with this record.
-  mode: NULLABLE
-  name: metric_configuration_schedule_frequency_interval_type
-  type: STRING
-- description: |
-    metric_configuration_schedule_frequency_interval_value associated with this record.
-  mode: NULLABLE
-  name: metric_configuration_schedule_frequency_interval_value
-  type: FLOAT
 - description: |
     metric_configuration_metric_type_template_metric_template_id associated with this record.
   mode: NULLABLE
@@ -304,16 +531,6 @@ fields:
   mode: NULLABLE
   name: metric_configuration_metric_type_template_metric_template_name
   type: STRING
-- description: |
-    metric_configuration_metric_schedule_schedule_frequency_interval_type associated with this record.
-  mode: NULLABLE
-  name: metric_configuration_metric_schedule_schedule_frequency_interval_type
-  type: STRING
-- description: |
-    metric_configuration_metric_schedule_schedule_frequency_interval_value associated with this record.
-  mode: NULLABLE
-  name: metric_configuration_metric_schedule_schedule_frequency_interval_value
-  type: FLOAT
 - description: |
     metric_configuration_bigconfig_namespace associated with this record.
   mode: NULLABLE


### PR DESCRIPTION
## Description

This PR is a follow-up fix to [PR-7878](https://github.com/mozilla/bigquery-etl/pull/7878), it fixes the schema.yaml to match the schema existing in production for the new table, `moz-fx-data-shared-prod.bigeye_derived.metric_service_v1`


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
