### PR TITLE
MC-1793 Remove scheduled_surface_id from aggregate calculations

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v1/query.sql
@@ -23,10 +23,6 @@ flattened_newtab_events AS (
     submission_timestamp,
     normalized_country_code,
     unnested_events.name AS event_name,
-    mozfun.map.get_key(
-      unnested_events.extra,
-      'scheduled_corpus_item_id'
-    ) AS scheduled_corpus_item_id,
     mozfun.map.get_key(unnested_events.extra, 'corpus_item_id') AS corpus_item_id,
     TIMESTAMP_MILLIS(
       SAFE_CAST(mozfun.map.get_key(unnested_events.extra, 'recommended_at') AS INT64)
@@ -39,55 +35,29 @@ flattened_newtab_events AS (
     -- Filter to Pocket events only
     unnested_events.category = 'pocket'
     AND unnested_events.name IN ('impression', 'click')
-    -- Keep only data with a non-null scheduled_corpus_item_id or corpus_item_id
-    AND (
-      mozfun.map.get_key(unnested_events.extra, 'scheduled_corpus_item_id') IS NOT NULL
-      OR mozfun.map.get_key(unnested_events.extra, 'corpus_item_id') IS NOT NULL
-    )
+    -- Keep only data with a non-null corpus_item_id
+    AND mozfun.map.get_key(unnested_events.extra, 'corpus_item_id') IS NOT NULL
     -- Only keep the last day's data.
     AND TIMESTAMP_MILLIS(
       SAFE_CAST(mozfun.map.get_key(unnested_events.extra, 'recommended_at') AS INT64)
     ) > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
 ),
-/* Map scheduled_corpus_item_id to corpus_item_id.
- * In the backend all scheduled_corpus_item_id with the same value map to the same corpus_item_id.
- * In these events some corpus_item_id are null because it is only emitted by Firefox >= 134.
- */
-aggregator_scheduled_lookup AS (
-  SELECT
-    scheduled_corpus_item_id,
-    -- Use MAX to get a non-null corpus_item_id if one exists. All non-null values are the same.
-    MAX(corpus_item_id) AS corpus_item_id
-  FROM
-    flattened_newtab_events
-  WHERE
-    scheduled_corpus_item_id IS NOT NULL
-  GROUP BY
-    scheduled_corpus_item_id
-),
-/* Aggregate clicks and impressions by scheduled_corpus_item_id, corpus_item_id, normalized_country_code. */
+/* Aggregate clicks and impressions by corpus_item_id, normalized_country_code. */
 aggregated_events AS (
   SELECT
-    fe.scheduled_corpus_item_id,
-    -- fe.corpus_item_id can be NULL because it's only emitted by Firefox >= 134.
-    COALESCE(fe.corpus_item_id, asl.corpus_item_id) AS corpus_item_id,
+    fe.corpus_item_id,
     fe.normalized_country_code,
     SUM(CASE WHEN fe.event_name = 'impression' THEN 1 ELSE 0 END) AS impression_count,
     SUM(CASE WHEN fe.event_name = 'click' THEN 1 ELSE 0 END) AS click_count
   FROM
     flattened_newtab_events fe
-  LEFT JOIN
-    aggregator_scheduled_lookup asl
-    ON fe.scheduled_corpus_item_id = asl.scheduled_corpus_item_id
   GROUP BY
     1,
-    2,
-    3
+    2
 ),
 /* Aggregate clicks and impressions across all countries. */
 global_aggregates AS (
   SELECT
-    scheduled_corpus_item_id,
     corpus_item_id,
     CAST(NULL AS STRING) AS region,
     SUM(impression_count) AS impression_count,
@@ -95,13 +65,11 @@ global_aggregates AS (
   FROM
     aggregated_events
   GROUP BY
-    scheduled_corpus_item_id,
     corpus_item_id
 ),
 /* Aggregate clicks and impressions for country-specific ranking in Merino. */
 country_aggregates AS (
   SELECT
-    scheduled_corpus_item_id,
     corpus_item_id,
     normalized_country_code AS region,
     impression_count,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v1/schema.yaml
@@ -1,8 +1,5 @@
 fields:
 - mode: NULLABLE
-  name: scheduled_corpus_item_id
-  type: STRING
-- mode: NULLABLE
   name: corpus_item_id
   type: STRING
 - mode: NULLABLE


### PR DESCRIPTION
## Description
On June 18th Merino stopped sending scheduled_surface_id as a parameter for many content telemetry events as part of the transition to sections.

This ETL job was creating separate entries in the click totals with and without schedule_surface_id, causing multiple entries that was confusing merino stats analysis.

For example, these two entries were in the output:
`{
  "scheduled_corpus_item_id": "7d7b8897-c501-4731-acde-149aeca48645",
  "corpus_item_id": "3e1a3d24-7e5f-4d9d-a375-122924a4069d",
  "region": "US",
  "impression_count": "3357924",
  "click_count": "16905"
 },

 
{
  "corpus_item_id": "3e1a3d24-7e5f-4d9d-a375-122924a4069d",
  "region": "US",
  "impression_count": "198119",
  "click_count": "1199"
 },`

Since we have been sending corpus_item_id since Fx134, it is safe to remove scheduled_corpus_item_id entirely for this job.

## Related Tickets & Documents
* MC-1793
https://mozilla-hub.atlassian.net/browse/MC-1793

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
