### PR TITLE
DENG-9216-UDF to identify newtab grid layout type

### DIFF
--- a/sql/mozfun/newtab/determine_grid_layout_v1/README.md
+++ b/sql/mozfun/newtab/determine_grid_layout_v1/README.md
@@ -1,0 +1,54 @@
+# UDF: Grid Type Determination for Firefox New Tab Layout
+
+This User-Defined Function (UDF) determines the appropriate grid layout type for Firefox new tab pages based on various input parameters including whether the new tab is section-based, the browser version, and experiment enrollment metadata.
+
+## 📥 Input Parameters
+
+| Name          | Type          | Description                                                                                                                                                                         |
+|---------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `is_section`  | BOOLEAN       | Indicates whether the new tab impressions are based on section layout.                                                                                                              |
+| `app_version` | INTEGER       | Represents the Firefox major version number.                                                                                                                                        |
+| `experiment`  | ARRAY<STRUCT> | An array of experimental configurations assigned to the client. Each entry is a `STRUCT<key STRING, value STRUCT<branch STRING, extra STRUCT<type STRING, enrollment_id STRING>>>`. |
+
+## 📌 Evaluation Criteria
+
+The UDF returns one of three possible values based on the following conditions:
+
+### 🔲 `SECTION_GRID`
+Returned when:
+- `is_section = TRUE`
+
+### 🆕 `NEW_GRID`
+Returned when:
+- `is_section = FALSE` AND
+- One of the following holds:
+  - `app_version >= 136`
+  - `app_version < 136` AND `experiment.key` matches one of the following:
+    - `default-ui-experiment`
+    - `new-tab-layout-variant-b-and-content-card-ui-rollout-global`
+    - `new-tab-layout-variant-b-and-content-card-ui-release-rollout-global-v2`
+    - `default-ui-experiment-logo-in-corner-rollout`
+
+### 🧓 `OLD_GRID`
+Returned when:
+- `is_section = FALSE` AND
+- `app_version < 136` AND
+- No matching experiment from the above list is found
+
+## 🏁 Return Values
+
+- `SECTION_GRID`
+- `NEW_GRID`
+- `OLD_GRID`
+
+## 🛠 Example Usage
+
+```sql
+SELECT determine_grid_layout(
+  TRUE,
+  135,
+  ARRAY[
+    STRUCT('default-ui-experiment', STRUCT('branch1', STRUCT('type1', 'enroll123')))
+  ]
+) AS grid_type;
+-- Returns: SECTION_GRID

--- a/sql/mozfun/newtab/determine_grid_layout_v1/metadata.yaml
+++ b/sql/mozfun/newtab/determine_grid_layout_v1/metadata.yaml
@@ -1,0 +1,5 @@
+description: |-
+  Determine the grid layout type for the Newtab
+  Context: this layout type can help in identifying the number of tiles that are displayed per row on the newtab
+  homepage
+friendly_name: Grid Layout Type

--- a/sql/mozfun/newtab/determine_grid_layout_v1/udf.sql
+++ b/sql/mozfun/newtab/determine_grid_layout_v1/udf.sql
@@ -1,0 +1,65 @@
+-- newtab.determine_grid_layout_v1 figures out the layout typefor the tiles on the Newtab homepage
+CREATE OR REPLACE FUNCTION newtab.determine_grid_layout_v1(
+  is_section BOOLEAN,
+  app_version INTEGER,
+  experiments ARRAY<
+    STRUCT<key STRING, value STRUCT<branch STRING, extra STRUCT<type STRING, enrollment_id STRING>>>
+  >
+)
+RETURNS STRING AS (
+  CASE
+    WHEN is_section
+      THEN 'SECTION_GRID'
+    WHEN app_version >= 136
+      THEN 'NEW_GRID'
+    WHEN EXISTS(
+        SELECT
+          1
+        FROM
+          UNNEST(experiments) AS ex
+        WHERE
+          ex.key IN (
+            'default-ui-experiment',
+            'new-tab-layout-variant-b-and-content-card-ui-rollout-global',
+            'new-tab-layout-variant-b-and-content-card-ui-release-rollout-global-v2',
+            'default-ui-experiment-logo-in-corner-rollout'
+          )
+      )
+      THEN 'NEW_GRID'
+    ELSE 'OLD_GRID'
+  END
+);
+
+-- Tests
+WITH new_grid AS (
+  SELECT
+    [
+      STRUCT(
+        'default-ui-experiment' AS key,
+        STRUCT(
+          'experiment-name' AS branch,
+          STRUCT('nimbus-nimbus' AS type, 'n/a' AS enrollment_id) AS extra
+        ) AS value
+      )
+    ] AS experiments
+),
+old_grid AS (
+  SELECT
+    [
+      STRUCT(
+        'some-old-experiment' AS key,
+        STRUCT(
+          'experiment-name' AS branch,
+          STRUCT('nimbus-nimbus' AS type, 'n/a' AS enrollment_id) AS extra
+        ) AS value
+      )
+    ] AS experiments
+)
+SELECT
+  newtab.determine_grid_layout_v1(FALSE, 130, new_grid.experiments),
+  newtab.determine_grid_layout_v1(FALSE, 130, old_grid.experiments),
+  newtab.determine_grid_layout_v1(FALSE, 136, old_grid.experiments),
+  newtab.determine_grid_layout_v1(TRUE, 136, old_grid.experiments),
+FROM
+  new_grid,
+  old_grid;


### PR DESCRIPTION
## Description

Create a UDF to determine the newtab grid types based on firefox version, section specifiers and experiments

## Related Tickets & Documents
* DENG-9216

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
