### PR TITLE
feat(DENG-8732): Update timezone used to create session_start_timestamp

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v3/script.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v3/script.sql
@@ -31,7 +31,7 @@ MERGE INTO
         CAST(e.value.int_value AS string) AS ga_session_id,
         DATETIME(
           TIMESTAMP_MICROS(all_sess_strt_events.event_timestamp),
-          "America/Los_Angeles"
+          "Europe/London"
         ) AS session_start_timestamp,
         (
           SELECT


### PR DESCRIPTION
## Description

This PR is a minor adjustment to the query logic that builds the table: 
`moz-fx-data-shared-prod.mozilla_org_derived.ga_sessions_v3`

It ensures the date of the session start timestamp always matches the session date.

## Related Tickets & Documents
* [DENG-8732](https://mozilla-hub.atlassian.net/browse/DENG-8732)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8732]: https://mozilla-hub.atlassian.net/browse/DENG-8732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ