### PR TITLE
backfill file for dates of newtab_items_daily_v1 not currently in prod

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2025-08-05:
+  start_date: 2022-06-21
+  end_date: 2025-07-26
+  reason: See https://mozilla-hub.atlassian.net/browse/DENG-9289
+  watchers:
+  - ctroy@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

This PR backfills newtab_items_daily_v1 up to July 27 of this year.

## Related Tickets & Documents
* [DENG-9289](https://mozilla-hub.atlassian.net/browse/DENG-9289)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9289]: https://mozilla-hub.atlassian.net/browse/DENG-9289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ