### PR TITLE
Account for backfill more than 775 days old 

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_items_daily_v1/backfill.yaml
@@ -4,8 +4,9 @@
   reason: See https://mozilla-hub.atlassian.net/browse/DENG-9289
   watchers:
   - ctroy@mozilla.com
+  - chtroy@mozilla.com
   status: Initiate
   shredder_mitigation: false
-  override_retention_limit: false
+  override_retention_limit: true
   override_depends_on_past_end_date: false
   ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

This PR removes the days limit on a backfill for more than 775 days.

The table from the failed backfill, `moz-fx-data-shared-prod.backfills_staging_derived.firefox_desktop_derived__newtab_items_daily_v1_2025_08_05`, has already been deleted. 

## Related Tickets & Documents
* [DENG-9289](https://mozilla-hub.atlassian.net/browse/DENG-9289)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
