### PR TITLE
feat(DENG-8732): Rename view to be more explicit & add comments to sessions tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_sessions_v2/script.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/ga_sessions_v2/script.sql
@@ -1,3 +1,22 @@
+/*
+This script looks at all unique "GA Client ID" / "GA Session IDs" combos that 
+have had events between 3 days before the submission date and the submission date.
+
+For all these sessions, it re-calculates the session level information, 
+and inserts it into the table if not already in there, or,
+overwrites the session row with the latest data if it is already in the table.
+We only maintain a row for sessions that:
+1) have a session_start event
+2) have a non-null ga_session_id
+
+(This is nearly all sessions, but some sessions might be dropped if they don't meet this criteria).
+
+We essentially do 2 main things:
+1) Get the attributes of the user at the time of their "session_start" event
+   For example, columns like os, browser, manual_campaign_id, ad_google_campaign_id, etc.
+2) Get the attributes of the user based on the first non-null value found in the nested "event_params" field across that session.
+   For example, columns like first_campaign_from_event_params, first_term_from_event_params, etc.
+*/
 MERGE INTO
   `moz-fx-data-shared-prod.firefoxdotcom_derived.ga_sessions_v2` T
   USING (

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v3/script.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v3/script.sql
@@ -1,3 +1,22 @@
+/*
+This script looks at all unique "GA Client ID" / "GA Session IDs" combos that 
+have had events between 3 days before the submission date and the submission date.
+
+For all these sessions, it re-calculates the session level information, 
+and inserts it into the table if not already in there, or,
+overwrites the session row with the latest data if it is already in the table.
+We only maintain a row for sessions that:
+1) have a session_start event
+2) have a non-null ga_session_id
+
+(This is nearly all sessions, but some sessions might be dropped if they don't meet this criteria).
+
+We essentially do 2 main things:
+1) Get the attributes of the user at the time of their "session_start" event
+   For example, columns like os, browser, manual_campaign_id, ad_google_campaign_id, etc.
+2) Get the attributes of the user based on the first non-null value found in the nested "event_params" field across that session.
+   For example, columns like first_campaign_from_event_params, first_term_from_event_params, etc.
+*/
 MERGE INTO
   `moz-fx-data-shared-prod.mozilla_org_derived.ga_sessions_v3` T
   USING (

--- a/sql/moz-fx-data-shared-prod/telemetry/ga4_sessions_firefoxcom_mozillaorg_combined/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/ga4_sessions_firefoxcom_mozillaorg_combined/view.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.telemetry.ga4_sessions_combined`
+  `moz-fx-data-shared-prod.telemetry.ga4_sessions_firefoxcom_mozillaorg_combined`
 AS
 SELECT
   'MOZILLA.ORG' AS flag,


### PR DESCRIPTION
## Description

* This PR renames the view `moz-fx-data-shared-prod.telemetry.ga4_sessions_combined` to `moz-fx-data-shared-prod.telemetry.ga4_sessions_firefoxcom_mozillaorg_combined` to be more explicit about which GA4 sites it contains data for.   (After this merges, will delete the old view that was already deployed to production).

* It also adds some comments to the 2 source tables to explain the logic to any future people since it's a bit complicated.

## Related Tickets & Documents
* [DENG-8732](https://mozilla-hub.atlassian.net/browse/DENG-8732)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-8732]: https://mozilla-hub.atlassian.net/browse/DENG-8732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ