### PR TITLE
Remove Mofo GA4 view, moving to separate mofo project

### DIFF
--- a/sql/moz-fx-data-shared-prod/mofo/analytics_321347134_events/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mofo/analytics_321347134_events/metadata.yaml
@@ -1,7 +1,0 @@
-friendly_name: MOFO Google Analytics Website Events Data (321347134)
-description: |-
-  MOFO Google Analytics Website Events Data (321347134)
-owners:
-  - kwindau@mozilla.com
-labels:
-  authorized: true

--- a/sql/moz-fx-data-shared-prod/mofo/analytics_321347134_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/mofo/analytics_321347134_events/view.sql
@@ -1,9 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.mofo.analytics_321347134_events`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-marketing-prod.analytics_321347134.events_*`
-WHERE
-  _TABLE_SUFFIX >= '20250719'


### PR DESCRIPTION
## Description
This PR is removing the view: 
- `moz-fx-data-shared-prod.mofo.analytics_321347134_events`


We will be deleteing this dataset and setting up the extract directly in the new mofo project itself.


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
