### PR TITLE
Set @mozilla/data-platform-infra-wg CODEOWNER on most files, except sql/, sql_generators/, dags.yaml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,9 @@
 /tests/sql/
 dags.yaml
 
+# require review on datasets, otherwise permissions could be changed without review
+**/dataset_metadata.yaml @mozilla/data-platform-infra-wg
+
 # These datasets are subject to the additional change control procedures
 # described in https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/
 # Active Users

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,6 @@
 
 # do not require review from data platform for the following files and directories
 /sql/
-/sql_generators/
 /tests/sql/
 dags.yaml
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,12 @@
+# require @mozilla/data-platform-infra-wg review for everything else
+* @mozilla/data-platform-infra-wg
+
+# do not require review from data platform for the following files and directories
+/sql/
+/sql_generators/
+/tests/sql/
+dags.yaml
+
 # These datasets are subject to the additional change control procedures
 # described in https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/
 # Active Users
@@ -15,6 +24,3 @@
 /sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_tiles_v2 @mozilla/request_payload_reviewers
 /sql/moz-fx-data-shared-prod/contextual_services_derived/suggest_revenue_levers_daily_v1 @mozilla/revenue_forecasting_data_reviewers
 /sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1 @mozilla/dataops
-# Dependency updates
-requirements.txt @mozilla/data-platform-infra-wg
-requirements.in @mozilla/data-platform-infra-wg


### PR DESCRIPTION

This is required for https://mozilla-hub.atlassian.net/browse/DENG-9290

This PR configures `@mozilla/data-platform-infra-wg` as being required as reviewer for everything except `sql/`, `sql_generators/`, `tests/sql` and `dags.yaml`. The idea is to have more contributors added to the repo with write and review permissions so that they can operate more self-sufficiently without needing a DE to approve and merge their PRs. However, in order to ensure that no critical code gets changed we need to require reviews from DE on these more critical code paths.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
