### PR TITLE
Use @mozilla/dataplatform-wg as CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
-# require @mozilla/data-platform-infra-wg review for everything else
-* @mozilla/data-platform-infra-wg
+# require @mozilla/dataplatform-wg review for everything else
+* @mozilla/dataplatform-wg
 
 # do not require review from data platform for the following files and directories
 /sql/
@@ -7,7 +7,7 @@
 dags.yaml
 
 # require review on datasets, otherwise permissions could be changed without review
-**/dataset_metadata.yaml @mozilla/data-platform-infra-wg
+**/dataset_metadata.yaml @mozilla/dataplatform-wg
 
 # These datasets are subject to the additional change control procedures
 # described in https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/


### PR DESCRIPTION
## Description

Use @mozilla/dataplatform-wg in CODEOWNER instead, as it is automatically updated based on the https://protosaur.dev/dawg/workgroup/dataplatform/ workgroup

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
