### PR TITLE
feat(HNT-929): increase expiration of Merino GCS data

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_to_gcs_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_to_gcs_v2/metadata.yaml
@@ -16,7 +16,7 @@ scheduling:
   - --source-table=newtab_merino_extract_v2
   - --destination-bucket=merino-airflow-data-prodpy
   - --destination-prefix=newtab-merino-exports/engagement
-  - --deletion-days-old=3
+  - --deletion-days-old=90
   referenced_tables:
   - ['moz-fx-data-shared-prod', 'telemetry_derived', 'newtab_merino_extract_v2']
 bigquery: null

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_to_gcs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_to_gcs_v1/metadata.yaml
@@ -17,7 +17,7 @@ scheduling:
   - --source-table=newtab_merino_priors_v1
   - --destination-bucket=merino-airflow-data-prodpy
   - --destination-prefix=newtab-merino-exports/priors
-  - --deletion-days-old=3
+  - --deletion-days-old=90
   referenced_tables:
   - ['moz-fx-data-shared-prod', 'telemetry_derived', 'newtab_merino_priors_v1']
 bigquery: null


### PR DESCRIPTION
## Description
Allow ML to look back further into the history of New Tab engagement data stored on GCS for Merino.

## Related Tickets & Documents
* [HNT-929](https://mozilla-hub.atlassian.net/browse/HNT-929)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[HNT-929]: https://mozilla-hub.atlassian.net/browse/HNT-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ