### PR TITLE
External tables should not require "options" to be set

### DIFF
--- a/bigquery_etl/metadata/publish_metadata.py
+++ b/bigquery_etl/metadata/publish_metadata.py
@@ -145,7 +145,8 @@ def attach_external_data_config(artifact_file_path, table) -> None:
     external_config.ignore_unknown_values = True
     external_config.autodetect = False
 
-    for key, v in metadata.external_data.options.items():
-        setattr(external_config.options, key, v)
+    if metadata.external_data.options:
+        for key, v in metadata.external_data.options.items():
+            setattr(external_config.options, key, v)
 
     table.external_data_configuration = external_config


### PR DESCRIPTION
## Description

Artifact deployment is currently failing due to how we handle config for external (e.g., Google Sheets-backed) tables:

```
 File "/app/bigquery_etl/metadata/publish_metadata.py", line 148, in attach_external_data_config
     for key, v in metadata.external_data.options.items():
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 AttributeError: 'NoneType' object has no attribute 'items'
```

This updates the logic in `attach_external_data_config` to allow for `external_data` metadata that does not include an `options` field (which is an optional field)

I'll add a test in a followup PR.

## Related Tickets & Documents

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
