### PR TITLE
[DENG-211] Turn off extraction for closed mozilla vpn surveys

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_cancellation_of_service_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_cancellation_of_service_v1/metadata.yaml
@@ -3,26 +3,12 @@ friendly_name: Cancellation of Service - Firefox Private Network and Mozilla VPN
 description: >
   An import of survey data from Alchemer (SurveyGizmo) for Cancellation of
   Service -- Firefox Private Network and Mozilla VPN.
+
+  Survey extraction turned off in https://mozilla-hub.atlassian.net/browse/DENG-211
 owners:
   - amiyaguchi@mozilla.com
 labels:
   incremental: true
-  schedule: daily
-scheduling:
-  dag_name: bqetl_subplat
-  arguments:
-    [
-      "--date",
-      "{{ ds }}",
-      "--survey_id",
-      "5111573",
-      "--api_token",
-      "{{ var.value.surveygizmo_api_token }}",
-      "--api_secret",
-      "{{ var.value.surveygizmo_api_secret }}",
-      "--destination_table",
-      "moz-fx-data-shared-prod.mozilla_vpn_derived.survey_cancellation_of_service_v1",
-    ]
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_product_quality_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_product_quality_v1/metadata.yaml
@@ -3,26 +3,12 @@ friendly_name: Mozilla VPN Product Quality Survey (2019+)
 description: >
   An import of survey data from Alchemer (SurveyGizmo) for the Mozilla VPN
   Product Quality Survey (2019+).
+
+  Survey extraction turned off in https://mozilla-hub.atlassian.net/browse/DENG-211
 owners:
   - srose@mozilla.com
 labels:
   incremental: true
-  schedule: daily
-scheduling:
-  dag_name: bqetl_subplat
-  arguments:
-    [
-      "--date",
-      "{{ ds }}",
-      "--survey_id",
-      "5187896",
-      "--api_token",
-      "{{ var.value.surveygizmo_api_token }}",
-      "--api_secret",
-      "{{ var.value.surveygizmo_api_secret }}",
-      "--destination_table",
-      "moz-fx-data-shared-prod.mozilla_vpn_derived.survey_product_quality_v1",
-    ]
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DENG-211

The following surveys are now closed in alchemer so we don’t need ongoing etl

    5187896 - mozilla/bigquery-etl/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_product_quality_v1

    5111573 - mozilla/bigquery-etl/sql/moz-fx-data-shared-prod/mozilla_vpn_derived/survey_cancellation_of_service_v1


We do not want to lose the existing data.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
