### PR TITLE
Delete backfill.yaml

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/backfill.yaml
@@ -1,8 +1,0 @@
-2025-07-18:
-  start_date: 2025-04-01
-  end_date: 2025-07-17
-  reason: Created new table and would like to have the historical data, which dates back to the start date of the backfill
-  watchers:
-  - ascholtz@mozilla.com
-  status: Initiate
-  shredder_mitigation: false


### PR DESCRIPTION
This PR deletes the backfill.yaml file for `firefox_desktop_derived.urlbar_events_daily_engagement_by_product_result_type_v1`, since the start date was too long ago, it was starting to throw CI errors.
