### PR TITLE
chore(glam): aggregate views do not calculate percentiles for dual labeled counter

### DIFF
--- a/sql/moz-fx-glam-prod/glam_etl/glam_fenix_beta_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fenix_beta_aggregates/view.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE VIEW
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,
         IF(
-          metric_type IN ("counter", "labeled_counter", "quantity")
+          metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity")
           OR non_norm_percentiles IS NOT NULL,
           NULL,
           mozfun.glam.histogram_cast_struct(non_norm_histogram)
@@ -109,7 +109,7 @@ CREATE OR REPLACE VIEW
       total_sample,
       non_norm_histogram,
       IF(
-        metric_type IN ("counter", "labeled_counter", "quantity"),
+        metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity"),
         percentiles,
         non_norm_percentiles
       ) AS non_norm_percentiles

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fenix_nightly_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fenix_nightly_aggregates/view.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE VIEW
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,
         IF(
-          metric_type IN ("counter", "labeled_counter", "quantity")
+          metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity")
           OR non_norm_percentiles IS NOT NULL,
           NULL,
           mozfun.glam.histogram_cast_struct(non_norm_histogram)
@@ -109,7 +109,7 @@ CREATE OR REPLACE VIEW
       total_sample,
       non_norm_histogram,
       IF(
-        metric_type IN ("counter", "labeled_counter", "quantity"),
+        metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity"),
         percentiles,
         non_norm_percentiles
       ) AS non_norm_percentiles

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fenix_release_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fenix_release_aggregates/view.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE VIEW
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,
         IF(
-          metric_type IN ("counter", "labeled_counter", "quantity")
+          metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity")
           OR non_norm_percentiles IS NOT NULL,
           NULL,
           mozfun.glam.histogram_cast_struct(non_norm_histogram)
@@ -109,7 +109,7 @@ CREATE OR REPLACE VIEW
       total_sample,
       non_norm_histogram,
       IF(
-        metric_type IN ("counter", "labeled_counter", "quantity"),
+        metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity"),
         percentiles,
         non_norm_percentiles
       ) AS non_norm_percentiles

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fog_beta_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fog_beta_aggregates/view.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE VIEW
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,
         IF(
-          metric_type IN ("counter", "labeled_counter", "quantity")
+          metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity")
           OR non_norm_percentiles IS NOT NULL,
           NULL,
           mozfun.glam.histogram_cast_struct(non_norm_histogram)
@@ -102,7 +102,7 @@ CREATE OR REPLACE VIEW
       total_sample,
       non_norm_histogram,
       IF(
-        metric_type IN ("counter", "labeled_counter", "quantity"),
+        metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity"),
         percentiles,
         non_norm_percentiles
       ) AS non_norm_percentiles

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fog_nightly_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fog_nightly_aggregates/view.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE VIEW
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,
         IF(
-          metric_type IN ("counter", "labeled_counter", "quantity")
+          metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity")
           OR non_norm_percentiles IS NOT NULL,
           NULL,
           mozfun.glam.histogram_cast_struct(non_norm_histogram)
@@ -102,7 +102,7 @@ CREATE OR REPLACE VIEW
       total_sample,
       non_norm_histogram,
       IF(
-        metric_type IN ("counter", "labeled_counter", "quantity"),
+        metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity"),
         percentiles,
         non_norm_percentiles
       ) AS non_norm_percentiles

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fog_release_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fog_release_aggregates/view.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE VIEW
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,
         IF(
-          metric_type IN ("counter", "labeled_counter", "quantity")
+          metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity")
           OR non_norm_percentiles IS NOT NULL,
           NULL,
           mozfun.glam.histogram_cast_struct(non_norm_histogram)
@@ -102,7 +102,7 @@ CREATE OR REPLACE VIEW
       total_sample,
       non_norm_histogram,
       IF(
-        metric_type IN ("counter", "labeled_counter", "quantity"),
+        metric_type IN ("counter", "labeled_counter", "dual_labeled_counter", "quantity"),
         percentiles,
         non_norm_percentiles
       ) AS non_norm_percentiles


### PR DESCRIPTION
## Description
It was slowing the query down and spending more slots. Done as part of an effort to prevent keyed metrics from timing out (ticket below).

## Related Tickets & Documents
* DENG-9374

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
