### PR TITLE
chore(glam): Use latest_versions instead of aggregates for version info

### DIFF
--- a/sql/moz-fx-data-shared-prod/glam_etl/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glam_etl/dataset_metadata.yaml
@@ -17,6 +17,7 @@ syndication:
     - glam_fog_beta_aggregates
     - glam_fog_nightly_aggregates
     - glam_fog_release_aggregates
+    - latest_versions
   administer_views: false
 workgroup_access:
   - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-glam-prod/glam_etl/latest_versions/metadata.yaml
+++ b/sql/moz-fx-glam-prod/glam_etl/latest_versions/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Latest Versions
+description: |-
+  Most recent major release versions per channel.
+owners:
+- efilho@mozilla.com

--- a/sql/moz-fx-glam-prod/glam_etl/latest_versions/schema.yaml
+++ b/sql/moz-fx-glam-prod/glam_etl/latest_versions/schema.yaml
@@ -1,0 +1,7 @@
+fields:
+- mode: NULLABLE
+  name: channel
+  type: STRING
+- mode: NULLABLE
+  name: latest_version
+  type: NUMERIC

--- a/sql/moz-fx-glam-prod/glam_etl/latest_versions/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/latest_versions/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-glam-prod.glam_etl.latest_versions` AS (
+    SELECT
+      *
+    FROM
+      `moz-fx-data-shared-prod.telemetry_derived.latest_versions`
+  )


### PR DESCRIPTION
## Description

Working on [the related ticket](https://mozilla-hub.atlassian.net/jira/software/c/projects/DENG/boards/2647?selectedIssue=DENG-9374) I noticed that I could improve read times on the GLAM app by reading from `latest_versions` instead of querying the aggregates tables for version information. The reason for this whole dance here is that the GLAM app only reads from `moz-fx-data-shared-prod.glam_etl` dataset, so I have to create a view and syndicate it there.  

## Related Tickets & Documents
* DENG-9374

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
