### PR TITLE
Collect Newtab Rec Performance Data Closer to When it is Reviewed

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -848,6 +848,25 @@ bqetl_newtab:
   tags:
     - impact/tier_1
 
+bqetl_newtab_late_morning:
+# Facilitates new tab metrics populated from the current calendar day in US time zones
+  default_args:
+    depends_on_past: false
+    email:
+      - telemetry-alerts@mozilla.com
+      - mbowerman@mozilla.com
+    email_on_failure: true
+    email_on_retry: true
+    end_date: null
+    owner: mbowerman@mozilla.com
+    retries: 2
+    retry_delay: 30m
+    start_date: '2025-08-20'
+  description: Schedules newtab related queries.
+  schedule_interval: 0 10 * * *
+  tags:
+    - impact/tier_1
+
 bqetl_desktop_mobile_search_monthly:
   default_args:
     depends_on_past: false

--- a/dags.yaml
+++ b/dags.yaml
@@ -862,7 +862,7 @@ bqetl_newtab_late_morning:
     retries: 2
     retry_delay: 30m
     start_date: '2025-08-20'
-  description: Schedules newtab related queries.
+  description: Schedules newtab related queries to run later to capture more recent activity.
   schedule_interval: 0 10 * * *
   tags:
     - impact/tier_1

--- a/dags.yaml
+++ b/dags.yaml
@@ -854,7 +854,7 @@ bqetl_newtab_late_morning:
     depends_on_past: false
     email:
       - telemetry-alerts@mozilla.com
-      - mbowerman@mozilla.com
+      - ctroy@mozilla.com
     email_on_failure: true
     email_on_retry: true
     end_date: null

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_clients_daily_v1/metadata.yaml
@@ -9,11 +9,11 @@ labels:
   application: firefox
   incremental: true
   schedule: daily
-  dag: bqetl_newtab
+  dag: bqetl_newtab_late_morning
   owner1: mbowerman
   table_type: client_level
 scheduling:
-  dag_name: bqetl_newtab
+  dag_name: bqetl_newtab_late_morning
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
Add a DAG for bqetl new tab jobs that should specifically run late enough to capture recent activity relative to when editorial arrives at work in those US time zones

## Description

This PR runs the update to newtab_clients_daily_v1 about ten hours later in the day than previously, such that the Looker dashboard displaying this data has relatively recent content to show when editorial arrives at work in the UTC-5 time zone to analyze new tab article performance.

## Related Tickets & Documents
* [DENG-9184](https://mozilla-hub.atlassian.net/browse/DENG-9184)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9184]: https://mozilla-hub.atlassian.net/browse/DENG-9184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ