### PR TITLE
fix(DENG-9445): Add new experiments column to baseline_clients_last_seen_v1

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
@@ -139,3 +139,28 @@ fields:
   name: attribution_ua
   type: STRING
   description: Identifier derived from the user agent downloading the installer.
+- mode: REPEATED
+  name: experiments
+  type: RECORD
+  description: A dictionary of active experiments.
+  fields:
+  - name: key
+    type: STRING
+    description: Experiment Key
+  - fields:
+      - name: branch
+        type: STRING
+        description: Experiment Branch
+      - fields:
+          - name: type
+            type: STRING
+            description: Experiment Type
+          - name: enrollment_id
+            type: STRING
+            description: Experiment Enrollment ID
+        name: extra
+        type: RECORD
+        description: Experiment Extras
+    name: value
+    type: RECORD
+    description: Experiment Value


### PR DESCRIPTION
## Description
This PR is a follow-up fix to [PR-7978](https://github.com/mozilla/bigquery-etl/pull/7978), which added the new column `experiments` to the `baseline_clients_daily_v1` tables.  This PR adds the new column to the downstream `baseline_clients_last_seen_v1` tables also.

## Related Tickets & Documents
* [DENG-9445](https://mozilla-hub.atlassian.net/browse/DENG-9445)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
