### PR TITLE
Exclude experiments from clients_last_seen_joined queries

### DIFF
--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -1,6 +1,6 @@
 WITH baseline AS (
   SELECT
-    * EXCEPT (profile_group_id),
+    * EXCEPT (profile_group_id, experiments),
     profile_group_id AS baseline_profile_group_id
   FROM
     `{{ project_id }}.{{ app_name }}.baseline_clients_last_seen`


### PR DESCRIPTION
## Description
This PR updates the SQL generator for `clients_last_seen_joined_v1` queries to exclude the new column `experiments` which was added to the upstream table `baseline_clients_last_seen_v1`.

This is a follow up fix related to:
* [PR-7978](https://github.com/mozilla/bigquery-etl/pull/7978) - Adding experiments to baseline_clients_daily_v1
* [PR-7983](https://github.com/mozilla/bigquery-etl/pull/7983) - Adding experiments to baseline_clients_last_seen_v1

## Related Tickets & Documents
* [DENG-9445](https://mozilla-hub.atlassian.net/browse/DENG-9445)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9445]: https://mozilla-hub.atlassian.net/browse/DENG-9445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ