### PR TITLE
Pocket component table

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_component_content/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_component_content/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: Newtab Component-level Content Table
+description: Contains information about content interactions, both organic and sponsored,
+  from the newtab ping.  Each record represents a specific content position during a specific visit
+owners:
+  - jsnyder@mozilla.com
+  - gkatre@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_component_content/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_component_content/view.sql
@@ -1,0 +1,3 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.newtab_component_context`
+AS

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_component_content/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_component_content/view.sql
@@ -1,3 +1,7 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_desktop.newtab_component_context`
 AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.newtab_component_context_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_component_content_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_component_content_v1/metadata.yaml
@@ -1,0 +1,28 @@
+friendly_name: Newtab Component-level Content Table
+description: Contains information about content interactions, both organic and sponsored,
+  from the newtab ping.  Each record represents a specific content position during a specific visit
+owners:
+  - jsnyder@mozilla.com
+  - gkatre@mozilla.com
+labels:
+  application: newtab
+  incremental: true
+  schedule: daily
+  dag: bqetl_newtab
+  owner1: gkatre
+  table_type: client_level
+scheduling:
+  dag_name: bqetl_newtab
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+  clustering:
+    fields:
+      - channel
+      - country
+      - newtab_category
+    expiration_days: 775
+  range_partitioning: null
+references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_component_content_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_component_content_v1/query.sql
@@ -56,7 +56,7 @@ raw_content_info AS (
     CAST(mozfun.map.get_key(event_details, 'is_sponsored') AS BOOLEAN) AS is_sponsored,
     mozfun.map.get_key(event_details, 'format') AS format,
     CAST(LOGICAL_OR(event_name = 'impression') AS INT) AS impression_count,
-    COUNTIF(event_name = 'click') AS clicks_count,
+    CAST(LOGICAL_OR(event_name = 'click') AS INT) AS clicks_count,
     CAST(LOGICAL_OR(event_name = 'dismiss') AS INT) AS dismiss_count,
     CAST(
       LOGICAL_OR(

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_component_content_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_component_content_v1/query.sql
@@ -1,0 +1,113 @@
+WITH visit_window_width AS (
+  SELECT
+    MIN(
+      IF(
+        category = 'newtab'
+        AND name = "opened",
+        SAFE_CAST(mozfun.map.get_key(extra, "window_inner_width") AS INT),
+        NULL
+      )
+    ) AS newtab_window_inner_width,
+    mozfun.map.get_key(extra, 'newtab_visit_id') AS newtab_visit_id
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_stable.newtab_v1`,
+    UNNEST(events)
+  WHERE
+    DATE(submission_timestamp) = '2025-06-01'
+  GROUP BY
+    newtab_visit_id
+),
+pocket_events_unnested AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    sample_id,
+    client_info.client_id AS client_id,
+    mozfun.map.get_key(extra, 'newtab_visit_id') AS newtab_visit_id,
+    SAFE_CAST(
+      mozfun.norm.browser_version_info(client_info.app_display_version).major_version AS INT64
+    ) AS app_version,
+    normalized_country_code AS country,
+    name AS event_name,
+    extra AS event_details,
+    ping_info
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_stable.newtab_v1`,
+    UNNEST(events)
+  WHERE
+    DATE(submission_timestamp) = '2025-06-01'
+    AND category = 'pocket'
+),
+raw_content_info AS (
+  SELECT
+    submission_date,
+    sample_id,
+    country,
+    app_version,
+    client_id,
+    newtab_visit_id,
+    SAFE_CAST(
+      mozfun.map.get_key_with_null(event_details, 'section_position') AS INT
+    ) AS section_position,
+    CAST(
+      mozfun.map.get_key(event_details, 'is_section_followed') AS BOOLEAN
+    ) AS is_section_followed,
+    ANY_VALUE(ping_info.experiments) AS experiments,
+    CAST(mozfun.map.get_key(event_details, 'position') AS INT) AS position,
+    CAST(mozfun.map.get_key(event_details, 'is_sponsored') AS BOOLEAN) AS is_sponsored,
+    mozfun.map.get_key(event_details, 'format') AS format,
+    CAST(LOGICAL_OR(event_name = 'impression') AS INT) AS impression_count,
+    COUNTIF(event_name = 'click') AS clicks_count,
+    CAST(LOGICAL_OR(event_name = 'dismiss') AS INT) AS dismiss_count,
+    CAST(
+      LOGICAL_OR(
+        event_name IN ('thumb_voting_interaction')
+        AND SAFE_CAST(mozfun.map.get_key(event_details, 'thumbs_up') AS BOOLEAN)
+      ) AS INT
+    ) AS thumbs_up_count,
+    CAST(
+      LOGICAL_OR(
+        event_name IN ('thumb_voting_interaction')
+        AND SAFE_CAST(mozfun.map.get_key(event_details, 'thumbs_down') AS BOOLEAN)
+      ) AS INT
+    ) AS thumbs_down_count,
+  FROM
+    pocket_events_unnested
+  GROUP BY
+    ALL
+),
+content_and_visit_info AS (
+  SELECT
+    raw_content_info.*,
+    mozfun.newtab.determine_grid_layout_v1(
+      section_position IS NOT NULL,
+      app_version,
+      experiments
+    ) AS layout_type,
+    newtab_window_inner_width
+  FROM
+    raw_content_info
+  INNER JOIN
+    visit_window_width
+    USING (newtab_visit_id)
+),
+add_tiles_per_row AS (
+  SELECT
+    content_and_visit_info.*,
+    mozfun.newtab.determine_tiles_per_row_v1(
+      layout_type,
+      newtab_window_inner_width
+    ) AS num_tiles_per_row
+  FROM
+    content_and_visit_info
+)
+SELECT
+  add_tiles_per_row.*,
+  CAST(
+    CASE
+      WHEN layout_type = 'SECTION_GRID'
+        THEN section_position
+      ELSE FLOOR(position / num_tiles_per_row)
+    END AS INT
+  ) AS row_number
+FROM
+  add_tiles_per_row

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_component_content_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_component_content_v1/schema.yaml
@@ -1,0 +1,103 @@
+fields:
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+  description: Day the event was received in the newtab ping
+- name: sample_id
+  type: INTEGER
+  description: Hashed version of client_id (0-99). Useful for distribution analysis
+- name: client_id
+  type: STRING
+  mode: NULLABLE
+  description: Unique ID for the client installation.
+- name: newtab_visit_id
+  type: STRING
+  mode: NULLABLE
+  description: The id of newtab visit
+- name: app_version
+  type: INTEGER
+  mode: NULLABLE
+  description: Firefox Desktop major version
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: country where the newtab event is reported
+- name: section_position
+  type: INTEGER
+  mode: NULLABLE
+  description: For the section layout, the 0-indexed position of the section.  Null for the grid layout
+- name: position
+  type: INTEGER
+  mode: NULLABLE
+  description: 0-indexed ordinal position of the content element
+- name: experiments
+  type: RECORD
+  mode: REPEATED
+  description: Array of experiments to associate with each visit
+  fields:
+  - name: key
+    type: STRING
+    mode: NULLABLE
+  - name: value
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: branch
+      type: STRING
+      mode: NULLABLE
+    - name: extra
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: type
+        type: STRING
+        mode: NULLABLE
+      - name: enrollment_id
+        type: STRING
+        mode: NULLABLE
+- name: is_sponsored
+  type: BOOLEAN
+  mode: NULLABLE
+  description: indicates whether or not story in position is sponsored (TRUE) or organic (FALSE)
+- name: format
+  type: STRING
+  mode: NULLABLE
+  description: >
+    Format of the content. Possible responses are "spoc", "rectangle" (for ads) "billboard", "leaderboard",
+     "small-card", "medium-card", "large-card" (for organic content).
+- name: impression_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of impressions for position
+- name: clicks_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of clicks for position
+- name: dismiss_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of dismissals for position
+- name: thumbs_up_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of thumbs up interactions for position
+- name: thumbs_down_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of thumbs down interactions for position
+- name: layout_type
+  type: STRING
+  mode: NULLABLE
+  description: Layout of the newtab homepage the content appears on, can be "SECTION_GRID", "NEW_GRID" or "OLD_GRID"
+- name: newtab_window_inner_width
+  type: INTEGER
+  mode: NULLABLE
+  description: Width of window in pixels
+- name: num_tiles_per_row
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of tiles in each row
+- name: row_number
+  type: INTEGER
+  mode: NULLABLE
+  description: 0-index vertical position of the row the story appears in.


### PR DESCRIPTION
## Description

This PR creates a table for the content component of the newtab ping.  Idea was to include only tiles specific to the component interaction, and any additional metadata about the visit can be obtained from the visit-level table.

## Related Tickets & Documents
* DENG-8971


## Checklist for review

- [ ] Ensure the validation done in [this notebook](https://colab.research.google.com/drive/1Xk_oo5Zc50tNzh-g7V7HOeC2dFNABJa8#scrollTo=rgxKmr2dV7GL&uniqifier=1) is sufficient
- [ ] Check that included columns are sufficient for analytical needs, keeping in mind metadata about the visit itself can be obtained from the visits-level table
- [ ] validate query and schema

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
