### PR TITLE
fix: Remove incorrect extra column added to new_profiles_aggregates_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/new_profiles_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/new_profiles_aggregates_v1/schema.yaml
@@ -87,8 +87,3 @@ fields:
   name: new_profiles
   type: INTEGER
   mode: NULLABLE
-- name: city
-  type: STRING
-  mode: NULLABLE
-  description: Name of the city in which the activity took place, as determined by
-    the IP geolocation.


### PR DESCRIPTION
## Description

* This PR is a minor follow-up to [PR-7981](https://github.com/mozilla/bigquery-etl/pull/7981), removing 1 column (city) that was added accidentally at the end of `firefox_desktop_derived.new_profiles_aggregates_v1` that is not needed as it's not a part of the query.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
