### PR TITLE
chore(metadata-completeness): Add column descriptions to multiple tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/clients_yearly_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/clients_yearly_v1/schema.yaml
@@ -78,6 +78,7 @@ fields:
 - name: telemetry_sdk_build
   type: STRING
   mode: NULLABLE
+  description: The version of the Glean SDK at the time the ping was collected (e.g. 25.0.0).
 - name: first_seen_date
   type: DATE
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/schema.yaml
@@ -14,9 +14,11 @@ fields:
 - name: adjust_network
   type: STRING
   mode: NULLABLE
+  description: The name of the Adjust Network that sourced this installation.
 - name: is_default_browser
   type: BOOLEAN
   mode: NULLABLE
+  description: A flag indicating whether the browser is set as the default browser on the client side.
 - name: autofill_password_detected_logins
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_metrics_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_metrics_v1/schema.yaml
@@ -8,15 +8,18 @@ fields:
 - name: channel
   type: STRING
   mode: NULLABLE
+  description: The normalized channel the application is being distributed on.
 - name: country
   type: STRING
   mode: NULLABLE
 - name: adjust_network
   type: STRING
   mode: NULLABLE
+  descriptin: The name of the Adjust Network that sourced this installation.
 - name: is_default_browser
   type: BOOLEAN
   mode: NULLABLE
+  description: A flag indicating whether the browser is set as the default browser on the client side.
 - name: logins_deleted_users
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_metrics_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_metrics_v2/schema.yaml
@@ -14,7 +14,7 @@ fields:
 - name: channel
   type: STRING
   mode: NULLABLE
-  description: Channel
+  description: The normalized channel the application is being distributed on.
 - name: country
   type: STRING
   mode: NULLABLE
@@ -22,11 +22,11 @@ fields:
 - name: adjust_network
   type: STRING
   mode: NULLABLE
-  description: Adjust Network
+  description: The name of the Adjust Network that sourced this installation.
 - name: is_default_browser
   type: BOOLEAN
   mode: NULLABLE
-  description: Is Default Browser
+  description: A flag indicating whether the browser is set as the default browser on the client side.
 - name: logins_deleted_users
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/baseline_clients_yearly_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/baseline_clients_yearly_v1/schema.yaml
@@ -78,6 +78,7 @@ fields:
 - name: architecture
   type: STRING
   mode: NULLABLE
+  description: The architecture of the device, (e.g. "arm", "x86").
 - name: device_manufacturer
   type: STRING
   mode: NULLABLE
@@ -99,6 +100,7 @@ fields:
 - name: isp
   type: STRING
   mode: NULLABLE
+  description: The name of the internet service provider associated with the client's IP address.
 - name: distribution_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/baseline_clients_yearly_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/baseline_clients_yearly_v1/schema.yaml
@@ -52,6 +52,7 @@ fields:
 - name: android_sdk_version
   type: STRING
   mode: NULLABLE
+  description: The optional Android specific SDK version of the software running on this hardware device.
 - name: locale
   type: STRING
   mode: NULLABLE
@@ -80,12 +81,15 @@ fields:
 - name: device_manufacturer
   type: STRING
   mode: NULLABLE
+  description: The manufacturer of the device the application is running on.
 - name: device_model
   type: STRING
   mode: NULLABLE
+  description: The model of the device the application is running on.
 - name: telemetry_sdk_build
   type: STRING
   mode: NULLABLE
+  description: The version of the Glean SDK at the time the ping was collected (e.g. 25.0.0).
 - name: first_seen_date
   type: DATE
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v1/schema.yaml
@@ -9,21 +9,25 @@ fields:
 - name: channel
   type: STRING
   mode: NULLABLE
+  description: The normalized channel the application is being distributed on.
 - name: country
   type: STRING
   mode: NULLABLE
 - name: adjust_network
   type: STRING
   mode: NULLABLE
+  description: A string containing the Adjust network ID from which the user installed Firefox.
 - name: is_default_browser
   type: BOOLEAN
   mode: NULLABLE
+  description: A flag indicating whether the browser is set as the default browser on the client side.
 - name: logins_deleted_users
   type: INTEGER
   mode: NULLABLE
 - name: logins_deleted
   type: INTEGER
   mode: NULLABLE
+  description: A counter of the number of passwords that have been deleted.
 - name: logins_modified_users
   type: INTEGER
   mode: NULLABLE
@@ -36,12 +40,14 @@ fields:
 - name: logins_saved
   type: INTEGER
   mode: NULLABLE
+  description: A counter of the number of passwords that have been saved.
 - name: logins_saved_all_users
   type: INTEGER
   mode: NULLABLE
 - name: logins_saved_all
   type: INTEGER
   mode: NULLABLE
+  description: A counter of all the passwords that are currently stored.
 - name: credit_card_autofill_enabled_users
   type: INTEGER
   mode: NULLABLE
@@ -60,12 +66,14 @@ fields:
 - name: credit_card_deleted
   type: INTEGER
   mode: NULLABLE
+  description: A counter of the number of credit cards that have been deleted.
 - name: credit_card_modified_users
   type: INTEGER
   mode: NULLABLE
 - name: credit_card_modified
   type: INTEGER
   mode: NULLABLE
+  description: A counter of the number of credit cards that have been modified.
 - name: credit_card_saved_users
   type: INTEGER
   mode: NULLABLE
@@ -126,6 +134,7 @@ fields:
 - name: sync_create_account_pressed
   type: INTEGER
   mode: NULLABLE
+  description: The number of times a user taps on create account button in sync library view.
 - name: sync_open_tab_users
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/feature_usage_metrics_v2/schema.yaml
@@ -14,7 +14,7 @@ fields:
 - name: channel
   type: STRING
   mode: NULLABLE
-  description: Channel
+  description: The normalized channel the application is being distributed on.
 - name: country
   type: STRING
   mode: NULLABLE
@@ -22,11 +22,11 @@ fields:
 - name: adjust_network
   type: STRING
   mode: NULLABLE
-  description: Adjust Network
+  description: The name of the Adjust Network that sourced this installation.
 - name: is_default_browser
   type: BOOLEAN
   mode: NULLABLE
-  description: Is Default Browser
+  description: A flag indicating whether the browser is set as the default browser on the client side.
 - name: logins_deleted_users
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/ltv_ios_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/ltv_ios_aggregates_v1/schema.yaml
@@ -34,9 +34,11 @@ fields:
 - mode: NULLABLE
   name: sponsored_tiles_enabled
   type: BOOLEAN
+  description: Tracks if the user has enabled sponsored shortcuts.
 - mode: NULLABLE
   name: pocket_enabled
   type: BOOLEAN
+  description: Measures the state of the show Pocket stories preference.
 - mode: NULLABLE
   name: client_count
   type: INTEGER

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/tos_rollout_enrollments_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/tos_rollout_enrollments_v1/schema.yaml
@@ -2,7 +2,7 @@ fields:
 - name: client_id
   type: STRING
   mode: NULLABLE
-  description: Client ID
+  description: A unique identifier (UUID) for the client.
 - name: submission_timestamp
   type: TIMESTAMP
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/review_checker_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/review_checker_clients_v1/schema.yaml
@@ -24,6 +24,7 @@ fields:
 - name: shopping_product_page_visits
   type: INTEGER
   mode: NULLABLE
+  description: A count of the number of eligible product pages the user has visited.
 - name: experiments
   type: RECORD
   mode: REPEATED
@@ -69,6 +70,7 @@ fields:
 - name: is_nimbus_disabled
   type: INTEGER
   mode: NULLABLE
+  description: Indicates if Nimbus has disabled the use the shopping component.
 - name: is_fx_dau
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_last_seen_v1/schema.yaml
@@ -24,15 +24,18 @@ fields:
 - name: locale
   type: STRING
   mode: NULLABLE
+  description: Set of language- and/or country-based preferences for a user interface.
 - name: app_version
   type: STRING
   mode: NULLABLE
 - name: channel
   type: STRING
   mode: NULLABLE
+  description: The normalized channel the application is being distributed on.
 - name: os
   type: STRING
   mode: NULLABLE
+  description: The normalized name of the operating system running at the client.
 - name: os_version
   type: STRING
   mode: NULLABLE
@@ -45,6 +48,7 @@ fields:
 - name: distribution_id
   type: STRING
   mode: NULLABLE
+  description: The distribution id associated with the install of Firefox.
 - name: profile_creation_date
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/search_clients_daily_v8/schema.yaml
@@ -43,6 +43,7 @@ fields:
 - mode: NULLABLE
   name: os
   type: STRING
+  description: The normalized name of the operating system running at the client.
 - mode: NULLABLE
   name: os_version
   type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_active_daily_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_accounts_active_daily_clients_v1/schema.yaml
@@ -71,7 +71,7 @@ fields:
 - name: telemetry_sdk_build
   type: STRING
   mode: NULLABLE
-  description: Telemetry SDK Build
+  description: The version of the Glean SDK at the time the ping was collected (e.g. 25.0.0).
 - name: windows_build_number
   type: INTEGER
   mode: NULLABLE

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.schema.yaml
@@ -2,12 +2,16 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
+  description: The date when the telemetry ping is received on the server side.
 - mode: NULLABLE
   name: client_id
   type: STRING
+  description: A unique identifier (UUID) for the client.
 - mode: NULLABLE
   name: sample_id
   type: INTEGER
+  description: A number, 0-99, that samples by client_id and allows filtering data for analysis.
+    It is a pipeline-generated artifact that should match between pings.
 - mode: NULLABLE
   name: first_run_date
   type: DATE
@@ -23,18 +27,22 @@ fields:
 - mode: NULLABLE
   name: normalized_channel
   type: STRING
+  description: The normalized channel the application is being distributed on.
 - mode: NULLABLE
   name: normalized_os
   type: STRING
+  description: The normalized name of the operating system running at the client.
 - mode: NULLABLE
   name: normalized_os_version
   type: STRING
 - mode: NULLABLE
   name: android_sdk_version
   type: STRING
+  description: The optional Android specific SDK version of the software running on this hardware device.
 - mode: NULLABLE
   name: locale
   type: STRING
+  description: Set of language- and/or country-based preferences for a user interface.
 - mode: NULLABLE
   name: city
   type: STRING
@@ -53,12 +61,18 @@ fields:
 - mode: NULLABLE
   name: architecture
   type: STRING
+  description: The architecture of the device, (e.g. "arm", "x86").
 - mode: NULLABLE
   name: device_manufacturer
   type: STRING
+  description: The manufacturer of the device the application is running on.
+    Not set if the device manufacturer can't be determined (e.g. on Desktop).
 - mode: NULLABLE
   name: device_model
   type: STRING
+  description: The model of the device the application is running on.
+    On Android, this is Build.MODEL, the user-visible marketing name, like "Pixel 2 XL".
+    Not set if the device model can't be determined (e.g. on Desktop).
 - mode: NULLABLE
   name: telemetry_sdk_build
   type: STRING
@@ -71,15 +85,18 @@ fields:
 - mode: NULLABLE
   name: isp
   type: STRING
+  description: The name of the internet service provider associated with the client's IP address.
 - mode: NULLABLE
   name: distribution_id
   type: STRING
+  description: The distribution id associated with the install of Firefox.
 - mode: NULLABLE
   name: geo_subdivision
   type: STRING
 - mode: NULLABLE
   name: profile_group_id
   type: STRING
+  description: A UUID uniquely identifying the profile group, not shared with other telemetry data.
 - mode: NULLABLE
   name: install_source
   type: STRING
@@ -98,6 +115,7 @@ fields:
 - mode: NULLABLE
   name: is_default_browser
   type: BOOLEAN
+  description: A flag indicating whether the browser is set as the default browser on the client side.
 - mode: NULLABLE
   name: attribution
   type: RECORD

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
@@ -2,15 +2,19 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
+  description: The date when the telemetry ping is received on the server side.
 - mode: NULLABLE
   name: first_seen_date
   type: DATE
 - mode: NULLABLE
   name: sample_id
   type: INTEGER
+  description: A number, 0-99, that samples by client_id and allows filtering data for analysis.
+    It is a pipeline-generated artifact that should match between pings.
 - mode: NULLABLE
   name: client_id
   type: STRING
+  description: A unique identifier (UUID) for the client.
 - mode: NULLABLE
   name: attribution
   type: RECORD
@@ -57,11 +61,11 @@ fields:
   name: legacy_telemetry_client_id
   type: STRING
   description: |-
-    The client_id according to Telemetry. 
-    Might not always have a value due to being too early for it to have loaded. 
-    Value may be the canary client id `c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0` in pings near when 
-    the data upload pref is disabled (if Telemetry gets to go first), or between when a client_id 
-    has been removed and when it has been regenerated. 
+    The client_id according to Telemetry.
+    Might not always have a value due to being too early for it to have loaded.
+    Value may be the canary client id `c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0` in pings near when
+    the data upload pref is disabled (if Telemetry gets to go first), or between when a client_id
+    has been removed and when it has been regenerated.
     Does not need to be sent in the Glean "deletion-request" ping.
 - mode: NULLABLE
   name: legacy_telemetry_profile_group_id

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
@@ -1,6 +1,7 @@
 fields:
 - name: submission_date
   type: DATE
+  description: The date when the telemetry ping is received on the server side.
 - name: days_seen_bits
   type: INTEGER
 - name: days_active_bits
@@ -15,8 +16,11 @@ fields:
   type: INTEGER
 - name: client_id
   type: STRING
+  description: A unique identifier (UUID) for the client.
 - name: sample_id
   type: INTEGER
+  description: A number, 0-99, that samples by client_id and allows filtering data for analysis.
+    It is a pipeline-generated artifact that should match between pings.
 - name: first_run_date
   type: DATE
 - name: durations
@@ -27,14 +31,17 @@ fields:
   type: INTEGER
 - name: normalized_channel
   type: STRING
+  description: The normalized channel the application is being distributed on.
 - name: normalized_os
   type: STRING
 - name: normalized_os_version
   type: STRING
 - name: android_sdk_version
   type: STRING
+  description: The optional Android specific SDK version of the software running on this hardware device.
 - name: locale
   type: STRING
+  description: Set of language- and/or country-based preferences for a user interface.
 - name: city
   type: STRING
 - name: country
@@ -47,10 +54,16 @@ fields:
   type: STRING
 - name: architecture
   type: STRING
+  description: The architecture of the device, (e.g. "arm", "x86").
 - name: device_manufacturer
   type: STRING
+  description: The manufacturer of the device the application is running on.
+    Not set if the device manufacturer can't be determined (e.g. on Desktop).
 - name: device_model
   type: STRING
+  description: The model of the device the application is running on.
+    On Android, this is Build.MODEL, the user-visible marketing name, like "Pixel 2 XL".
+    Not set if the device model can't be determined (e.g. on Desktop).
 - name: telemetry_sdk_build
   type: STRING
 - name: first_seen_date
@@ -60,15 +73,18 @@ fields:
 - mode: NULLABLE
   name: isp
   type: STRING
+  description: The name of the internet service provider associated with the client's IP address.
 - mode: NULLABLE
   name: distribution_id
   type: STRING
+  description: The distribution id associated with the install of Firefox.
 - mode: NULLABLE
   name: geo_subdivision
   type: STRING
 - mode: NULLABLE
   name: profile_group_id
   type: STRING
+  description: A UUID uniquely identifying the profile group, not shared with other telemetry data.
 - mode: NULLABLE
   name: install_source
   type: STRING
@@ -87,6 +103,7 @@ fields:
 - mode: NULLABLE
   name: is_default_browser
   type: BOOLEAN
+  description: A flag indicating whether the browser is set as the default browser on the client side.
 - mode: NULLABLE
   name: attribution
   type: RECORD

--- a/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.schema.yaml
@@ -2,6 +2,7 @@ fields:
 - name: submission_date
   type: DATE
   mode: NULLABLE
+  description: The date when the telemetry ping is received on the server side.
 - name: window_start
   type: TIMESTAMP
   mode: NULLABLE
@@ -26,6 +27,7 @@ fields:
 - name: channel
   type: STRING
   mode: NULLABLE
+  description: The normalized channel the application is being distributed on.
 - name: version
   type: STRING
   mode: NULLABLE

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.schema.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.schema.yaml
@@ -2,22 +2,23 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
-  description:
+  description: The date when the telemetry ping is received on the server side.
 
 - mode: NULLABLE
   name: client_id
   type: STRING
-  description:
+  description: A unique identifier (UUID) for the client.
 
 - mode: NULLABLE
   name: sample_id
   type: INTEGER
-  description:
+  description: A number, 0-99, that samples by client_id and allows filtering data for analysis.
+    It is a pipeline-generated artifact that should match between pings.
 
 - mode: NULLABLE
   name: normalized_channel
   type: STRING
-  description:
+  description: The normalized channel the application is being distributed on.
 {% for attribution_group in product_attribution_groups %}
 {% if attribution_group.name in ["meta", "adjust", "play_store"] -%}
 - mode: NULLABLE

--- a/sql_generators/urlbar_events/templates/schema.yaml
+++ b/sql_generators/urlbar_events/templates/schema.yaml
@@ -3,15 +3,19 @@ fields:
   - name: submission_date
     type: DATE
     mode: NULLABLE
+    description: The date when the telemetry ping is received on the server side.
   - name: glean_client_id
     type: STRING
     mode: NULLABLE
+    description: A unique identifier (UUID) for the client.
   - name: legacy_telemetry_client_id
     type: STRING
     mode: NULLABLE
   - name: sample_id
     type: INTEGER
     mode: NULLABLE
+    description: A number, 0-99, that samples by client_id and allows filtering data for analysis.
+      It is a pipeline-generated artifact that should match between pings.
   - name: event_name
     type: STRING
     mode: NULLABLE
@@ -58,9 +62,12 @@ fields:
   - name: normalized_channel
     type: STRING
     mode: NULLABLE
+    description: The normalized channel the application is being distributed on.
   - name: normalized_country_code
     type: STRING
     mode: NULLABLE
+    description: Code of the country in which the activity took place, as determined by
+      the IP geolocation. Unknown or NULL values are normally stored as '??'.
   - name: normalized_engine
     type: STRING
     mode: NULLABLE
@@ -155,4 +162,4 @@ fields:
   - name: profile_group_id
     type: STRING
     mode: NULLABLE
-    description: A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data
+    description: A UUID uniquely identifying the profile group, not shared with other telemetry data.


### PR DESCRIPTION
## Description

This PR adds column descriptions to tables created by the SQL generators, like: 
- `baseline_clients_last_seen_v1`
- `baseline_clients_daily_v1`
- `baseline_clients_first_seen_v1`
- `event_monitoring_aggregates_v1`
- `attribution_clients_v1`
- `urlbar_events_v1`

It also adds column descriptions to some other tables, such as: 
- `moz-fx-data-shared-prod.search_derived.mobile_search_clients_last_seen_v1`
- `moz-fx-data-shared-prod.search_derived.search_clients_daily_v8`
- `moz-fx-data-shared-prod.fenix_derived.clients_yearly_v1`
- `moz-fx-data-shared-prod.fenix_derived.feature_usage_events_v1`
- `moz-fx-data-shared-prod.fenix_derived.feature_usage_metrics_v1`
- `moz-fx-data-shared-prod.fenix_derived.feature_usage_metrics_v2`
- `moz-fx-data-shared-prod.firefox_ios_derived.baseline_clients_yearly_v1`
- `moz-fx-data-shared-prod.firefox_ios_derived.feature_usage_metrics_v1`
- `moz-fx-data-shared-prod.firefox_ios_derived.feature_usage_metrics_v2`
- `moz-fx-data-shared-prod.firefox_ios_derived.ltv_ios_aggregates_v1`
- `moz-fx-data-shared-prod.firefox_ios_derived.tos_rollout_enrollments_v1`
- `moz-fx-data-shared-prod.org_mozilla_ios_firefox_derived.review_checker_clients_v1`
- `moz-fx-data-shared-prod.telemetry_derived.fx_accounts_active_daily_clients_v1`

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
