### PR TITLE
fix(DENG-9503): python issue with class vars

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -686,10 +686,10 @@ bqetl_search_terms_daily:
 bqetl_experimenter_experiments_import:
   schedule_interval: "*/10 * * * *"
   description: |
-    Imports experiments from the Experimenter V4 and V6 API.
+    Imports experiments from the Experimenter V8 API.
 
     Imported experiment data is used for experiment monitoring in
-    [Grafana](https://grafana.telemetry.mozilla.org/d/XspgvdxZz/experiment-enrollment).
+    [Looker](https://mozilla.cloud.looker.com/dashboards/experimentation::experiment_enrollments).
 
     *Triage notes*
 

--- a/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
@@ -103,7 +103,7 @@ class NimbusExperiment:
     outcomes: list[Outcome] | None = None
     segments: list[Segment] | None = None
     isEnrollmentPaused: bool | None = None
-    isFirefoxLabsOptIn: bool
+    isFirefoxLabsOptIn: bool = False
 
     @classmethod
     def from_dict(cls, d) -> "NimbusExperiment":


### PR DESCRIPTION
## Description

* Fixes a bug in the class vars (cannot have var without default after vars with default values)
* also updates outdated info in the DAG description

## Related Tickets & Documents
* DENG-9503

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
