### PR TITLE
AD-9356 fixing issue where os is null after fx version 139

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/query.sql
@@ -126,7 +126,7 @@ combined AS (
     'remote settings' AS provider,
     -- Only standard suggestions are in use on mobile
     'firefox-suggest' AS match_type,
-    SPLIT(metadata.user_agent.os, ' ')[SAFE_OFFSET(0)] AS normalized_os,
+    'Android' AS normalized_os,
     -- This is the opt-in for Merino, not in use on mobile
     CAST(NULL AS BOOLEAN) AS suggest_data_sharing_enabled,
     blocks.query_type,


### PR DESCRIPTION
## Description

This PR fixes an issue with `event_aggregates` where we see null values for `fenix` data due to pulling from `metadata.user_agent.os` - which is null after version 139 and not the appropriate place to pull from. Being that all of this data is coming from `fenix`, it should all be `Android`

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
[AD-9356](https://mozilla-hub.atlassian.net/browse/AD-1007?focusedCommentId=1126981&sourceType=mention)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
