### PR TITLE
Deprecate macroeconomic_indices table

### DIFF
--- a/sql/moz-fx-data-shared-prod/external_derived/macroeconomic_indices_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/macroeconomic_indices_v1/metadata.yaml
@@ -19,11 +19,6 @@ labels:
   incremental: true
   owner1: cmorales@mozilla.com
   owner2: akommasani@mozilla.com
-scheduling:
-  dag_name: bqetl_reference
-  arguments:
-    - --market-date={{ ds }}
-    - --api-key={{ var.value.fmp_api_key }}
 bigquery:
   time_partitioning:
     type: day
@@ -31,3 +26,4 @@ bigquery:
     expiration_days: null
     require_partition_filter: true
 references: {}
+deprecated: true


### PR DESCRIPTION
## Description

Deprecate `external_derived.macroeconomic_indices_v1` table. Data Science has confirmed that this data is no longer in use, and we are not renewing our contract with FinancialModelingPrep (who we get this data from)

## Related Tickets & Documents

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
