### PR TITLE
chore(DENG-9313): replace person_mozilla_com implementation

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -177,6 +177,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/query.sql
   - sql/moz-fx-data-shared-prod/jira_service_desk/**/*.sql
   - sql/moz-fx-data-shared-prod/zoom/**/*.sql
+  - sql/moz-fx-data-shared-prod/taskclusteretl/person_mozilla_com/view.sql
   # No matching signature for function IF
   - sql/moz-fx-data-shared-prod/static/fxa_amplitude_export_users_last_seen/query.sql
   # Duplicate UDF

--- a/sql/moz-fx-data-shared-prod/taskclusteretl/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/taskclusteretl/dataset_metadata.yaml
@@ -34,7 +34,6 @@ syndication:
       - error
       - perfherder
       - perfherder_alert
-      - person_mozilla_com
       - pulse_task
       - resource_monitor
       - task_definition

--- a/sql/moz-fx-data-shared-prod/taskclusteretl/person_mozilla_com/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/taskclusteretl/person_mozilla_com/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: person_mozilla_com
+description: |-
+  See https://mozilla-hub.atlassian.net/browse/DENG-9313.
+owners:
+  - telemetry-alerts@mozilla.com
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/taskclusteretl/person_mozilla_com/view.sql
+++ b/sql/moz-fx-data-shared-prod/taskclusteretl/person_mozilla_com/view.sql
@@ -1,0 +1,128 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.taskclusteretl.person_mozilla_com`
+AS
+WITH RECURSIVE management_path AS (
+  -- Base case
+  SELECT
+    manager_email,
+    email,
+    [manager_email] AS management_chain,
+    [manager_email, email] AS visited_chain
+  FROM
+    `moz-fx-data-bq-people.composer_workday.worker`
+  WHERE
+    currently_active = TRUE
+  UNION ALL
+  -- Recursive step
+  SELECT
+    er.manager_email,
+    mp.email,
+    ARRAY_CONCAT([er.manager_email], mp.management_chain) AS management_chain,
+    ARRAY_CONCAT(mp.visited_chain, [er.manager_email]) AS visited_chain
+  FROM
+    `moz-fx-data-bq-people.composer_workday.worker` AS er
+  JOIN
+    management_path AS mp
+    ON er.email = mp.manager_email
+  WHERE
+    er.manager_email NOT IN UNNEST(mp.visited_chain)
+    AND ARRAY_LENGTH(mp.management_chain) < 50
+),
+deduped_chain AS (
+  SELECT
+    email,
+    ARRAY_REVERSE(management_chain) AS management_chain
+  FROM
+    (
+      SELECT
+        email,
+        management_chain,
+        ROW_NUMBER() OVER (PARTITION BY email ORDER BY ARRAY_LENGTH(management_chain) DESC) AS rn
+      FROM
+        management_path
+    )
+  WHERE
+    rn = 1
+),
+manager_names AS (
+  SELECT
+    dc.email,
+    off AS manager_index,
+    CONCAT(w.first_name, ' ', w.last_name) AS manager_name
+  FROM
+    `deduped_chain` AS dc
+  CROSS JOIN
+    UNNEST(dc.management_chain) AS mgr_email
+    WITH OFFSET off
+  LEFT JOIN
+    `moz-fx-data-bq-people.composer_workday.worker` AS w
+    ON w.email = mgr_email
+),
+manager_chain_final AS (
+  SELECT
+    email,
+    ARRAY_AGG(manager_name ORDER BY manager_index) AS manager
+  FROM
+    manager_names
+  GROUP BY
+    email
+),
+final_with_name AS (
+  SELECT
+    mcf.manager,
+    CONCAT(w.first_name, ' ', w.last_name) AS name,
+    w.email
+  FROM
+    manager_chain_final AS mcf
+  JOIN
+    `moz-fx-data-bq-people.composer_workday.worker` AS w
+    ON mcf.email = w.email
+  WHERE
+    w.currently_active = TRUE
+),
+bugzilla_alternates AS (
+  SELECT
+    fwn.manager,
+    fwn.name,
+    b.email AS email
+  FROM
+    final_with_name AS fwn
+  JOIN
+    `moz-fx-data-shared-prod.bugzilla_metrics.users` AS b
+    ON fwn.email = b.ldap_email
+  WHERE
+    b.email IS NOT NULL
+    AND b.email != b.ldap_email
+),
+combined AS (
+  SELECT
+    manager,
+    name,
+    email
+  FROM
+    final_with_name
+  UNION ALL
+  SELECT
+    manager,
+    name,
+    email
+  FROM
+    bugzilla_alternates
+),
+deduplicated AS (
+  SELECT
+    manager,
+    name,
+    email,
+    ROW_NUMBER() OVER (PARTITION BY email ORDER BY name) AS rn
+  FROM
+    combined
+)
+SELECT
+  manager,
+  name,
+  email
+FROM
+  deduplicated
+WHERE
+  rn = 1;


### PR DESCRIPTION
## Description

Extensive background about this change in https://mozilla-hub.atlassian.net/browse/DENG-9313. The original table this syndicate view was referencing stopped updating in Oct. 2024. At some point it will be DE's responsibility to replace this view with something else, but since it's part of the user-facing platform there are considerations for doing that.

The authorization will be handled manually in https://github.com/mozilla-services/cloudops-infra/pull/6558/ since that isn't hooked up to any automation. The full deployment plan will be written in the Jira ticket.

Most DE won't be able to run this query, since you need `workgroup:people` access. You can see the output from the query in an attachment to the Jira ticket.

## Related Tickets & Documents
* DENG-9313

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
