### PR TITLE
feat(DENG-9518): Update delay to account for built in delay in source

### DIFF
--- a/sql/moz-fx-data-shared-prod/external_derived/fred_daily_exchange_rates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/fred_daily_exchange_rates_v1/metadata.yaml
@@ -1,7 +1,7 @@
 friendly_name: FRED Daily Exchange Rates
 description: |-
   Daily currency exchange rates from the Federal Reserve Bank of St. Louis
-  Does not contain data every day, for example, no data available on weekends &  holidays
+  Does not contain data every day, for example, no data available on weekends & holidays
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/external_derived/fred_daily_exchange_rates_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/fred_daily_exchange_rates_v1/query.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
         }
     )
 
-    # We want to always run for 4 days ago to give time for data to load
+    # We want to always run for 21 days ago to give time for data to load
     logical_dag_date = datetime.strptime(args.date, "%Y-%m-%d").date()
     execution_date = logical_dag_date - timedelta(days=21)
     print(

--- a/sql/moz-fx-data-shared-prod/external_derived/fred_daily_exchange_rates_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/fred_daily_exchange_rates_v1/query.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
 
     # We want to always run for 4 days ago to give time for data to load
     logical_dag_date = datetime.strptime(args.date, "%Y-%m-%d").date()
-    execution_date = logical_dag_date - timedelta(days=4)
+    execution_date = logical_dag_date - timedelta(days=21)
     print(
         f"Pulling data for execution_date: {execution_date} for logical dag date {logical_dag_date}"
     )


### PR DESCRIPTION
## Description

This PR changes the timing of the DAG to include a larger built in delay, since the FRED API only releases data on a set schedule (for example, by Monday EOD, they typically release the data for the week prior, but this can also be delayed by holidays as well).

## Related Tickets & Documents
* [DENG-9518](https://mozilla-hub.atlassian.net/browse/DENG-9518)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9518]: https://mozilla-hub.atlassian.net/browse/DENG-9518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ