### PR TITLE
feat(SubPlat): Add revenue columns to logical subscription & service subscription views (DENG-9508)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_logical_subscriptions/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_logical_subscriptions/schema.yaml
@@ -400,6 +400,45 @@ fields:
     description: |-
       When the ongoing discount ends (if any).
       This will be null for Apple subscriptions.
+  - name: country_vat_rate
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      VAT rate for the country the subscription is in (if any).
+  - name: plan_currency_usd_exchange_rate
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Exchange rate for converting the subscription plan's currency into US dollars (if any).
+  - name: plan_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Subscription plan's amount in US dollars.
+      For Apple subscriptions prior to 2024-10-30 this may have fallen back to assuming a USD amount due to a lack of source data (FXA-10549).
+  - name: current_period_discount_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Current period discount amount in US dollars (if any).
+      This may be null for Apple subscriptions.
+  - name: ongoing_discount_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Ongoing discount amount in US dollars (if any).
+      This may be null for Apple subscriptions.
+  - name: monthly_recurring_revenue_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Projected monthly recurring revenue for the subscription in US dollars.
+  - name: annual_recurring_revenue_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Projected annual recurring revenue for the subscription in US dollars.
+      This will be null for Stripe subscriptions prior to 2023-02-27 (DENG-754).
 - name: was_active_at_day_start
   type: BOOLEAN
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_logical_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_logical_subscriptions/view.sql
@@ -1,19 +1,230 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.subscription_platform.daily_active_logical_subscriptions`
 AS
+WITH daily_subscriptions AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.daily_active_logical_subscriptions_v1`
+  WHERE
+    `date` < (
+      SELECT
+        COALESCE(MIN(`date`), '9999-12-31')
+      FROM
+        `moz-fx-data-shared-prod.subscription_platform_derived.recent_daily_active_logical_subscriptions_v1`
+    )
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.recent_daily_active_logical_subscriptions_v1`
+),
+vat_rates AS (
+  SELECT
+    country_code,
+    vat AS vat_rate,
+    effective_date,
+    LEAD(effective_date) OVER (
+      PARTITION BY
+        country_code
+      ORDER BY
+        effective_date
+    ) AS next_effective_date
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.vat_rates_v1`
+),
+usd_exchange_rates AS (
+  SELECT
+    base_currency,
+    price AS exchange_rate,
+    `date` AS effective_date,
+    LEAD(`date`) OVER (PARTITION BY base_currency ORDER BY `date`) AS next_effective_date
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.exchange_rates_v1`
+  WHERE
+    quote_currency = 'USD'
+),
+augmented_daily_subscriptions AS (
+  SELECT
+    daily_subscriptions.*,
+    vat_rates.vat_rate AS country_vat_rate,
+    usd_exchange_rates.exchange_rate AS plan_currency_usd_exchange_rate,
+  FROM
+    daily_subscriptions
+  LEFT JOIN
+    vat_rates
+    ON daily_subscriptions.subscription.country_code = vat_rates.country_code
+    AND daily_subscriptions.date >= vat_rates.effective_date
+    AND (
+      daily_subscriptions.date < vat_rates.next_effective_date
+      OR vat_rates.next_effective_date IS NULL
+    )
+  LEFT JOIN
+    usd_exchange_rates
+    ON daily_subscriptions.subscription.plan_currency = usd_exchange_rates.base_currency
+    AND daily_subscriptions.date >= usd_exchange_rates.effective_date
+    AND (
+      daily_subscriptions.date < usd_exchange_rates.next_effective_date
+      OR usd_exchange_rates.next_effective_date IS NULL
+    )
+),
+augmented_daily_subscriptions_2 AS (
+  SELECT
+    *,
+    LEAST(
+      (
+        mozfun.utils.timestamp_diff_complete_months(
+          subscription.current_period_ends_at,
+          LEAST(
+            TIMESTAMP_SUB(TIMESTAMP(`date` + 1), INTERVAL 1 MICROSECOND),
+            subscription.current_period_ends_at
+          )
+        ) + 1
+      ),
+      12
+    ) AS current_period_annual_recurring_revenue_months,
+    GREATEST(
+      mozfun.utils.timestamp_diff_complete_months(
+        TIMESTAMP_SUB(subscription.ongoing_discount_ends_at, INTERVAL 1 MICROSECOND),
+        subscription.current_period_ends_at
+      ),
+      0
+    ) AS months_after_current_period_before_ongoing_discount_ends
+  FROM
+    augmented_daily_subscriptions
+),
+augmented_daily_subscriptions_3 AS (
+  SELECT
+    *,
+    CASE
+      WHEN COALESCE(subscription.ongoing_discount_amount, 0) = 0
+        THEN 0
+      WHEN subscription.ongoing_discount_ends_at IS NULL
+        THEN (12 - current_period_annual_recurring_revenue_months)
+      ELSE LEAST(
+          (
+            (
+              DIV(
+                months_after_current_period_before_ongoing_discount_ends,
+                subscription.plan_interval_months
+              ) + 1
+            ) * subscription.plan_interval_months
+          ),
+          (12 - current_period_annual_recurring_revenue_months)
+        )
+    END AS ongoing_discounted_annual_recurring_revenue_months
+  FROM
+    augmented_daily_subscriptions_2
+)
 SELECT
-  *
+  id,
+  `date`,
+  logical_subscriptions_history_id,
+  (
+    SELECT AS STRUCT
+      subscription.*,
+      country_vat_rate,
+      plan_currency_usd_exchange_rate,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.plan_amount,
+        ROUND((subscription.plan_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS plan_amount_usd,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.current_period_discount_amount,
+        ROUND((subscription.current_period_discount_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS current_period_discount_amount_usd,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.ongoing_discount_amount,
+        ROUND((subscription.ongoing_discount_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS ongoing_discount_amount_usd,
+      IF(
+        subscription.is_active IS NOT TRUE
+        OR subscription.is_trial IS TRUE,
+        0,
+        ROUND(
+          (
+            -- Start with monthly recurring gross revenue...
+            (
+              GREATEST(
+                (
+                  subscription.plan_amount - COALESCE(
+                    subscription.current_period_discount_amount,
+                    0
+                  )
+                ),
+                0
+              ) / subscription.plan_interval_months
+            )
+            -- Remove VAT to get monthly recurring net revenue.
+            / (1 + COALESCE(country_vat_rate, 0))
+            -- Apply exchange rate to get monthly recurring revenue in USD.
+            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+          ),
+          2
+        )
+      ) AS monthly_recurring_revenue_usd,
+      IF(
+        subscription.is_active IS NOT TRUE,
+        0,
+        ROUND(
+          (
+            -- Start with annual recurring gross revenue...
+            (
+              -- Current period annual recurring gross revenue
+              IF(
+                subscription.is_trial IS TRUE,
+                0,
+                (
+                  GREATEST(
+                    (
+                      subscription.plan_amount - COALESCE(
+                        subscription.current_period_discount_amount,
+                        0
+                      )
+                    ),
+                    0
+                  ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
+                )
+              )
+              -- Ongoing discounted annual recurring gross revenue
+              + IF(
+                subscription.auto_renew IS NOT TRUE
+                OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
+                0,
+                (
+                  GREATEST(
+                    (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
+                    0
+                  ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
+                )
+              )
+              -- Ongoing undiscounted annual recurring gross revenue
+              + IF(
+                subscription.auto_renew IS NOT TRUE,
+                0,
+                (
+                  subscription.plan_amount / subscription.plan_interval_months * GREATEST(
+                    (
+                      12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
+                    ),
+                    0
+                  )
+                )
+              )
+            )
+            -- Remove VAT to get annual recurring net revenue.
+            / (1 + COALESCE(country_vat_rate, 0))
+            -- Apply exchange rate to get annual recurring revenue in USD.
+            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+          ),
+          2
+        )
+      ) AS annual_recurring_revenue_usd
+  ) AS subscription,
+  was_active_at_day_start,
+  was_active_at_day_end
 FROM
-  `moz-fx-data-shared-prod.subscription_platform_derived.daily_active_logical_subscriptions_v1`
-WHERE
-  `date` < (
-    SELECT
-      COALESCE(MIN(`date`), '9999-12-31')
-    FROM
-      `moz-fx-data-shared-prod.subscription_platform_derived.recent_daily_active_logical_subscriptions_v1`
-  )
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.subscription_platform_derived.recent_daily_active_logical_subscriptions_v1`
+  augmented_daily_subscriptions_3

--- a/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_service_subscriptions/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_service_subscriptions/schema.yaml
@@ -442,6 +442,45 @@ fields:
       mode: NULLABLE
       description: |-
         Last-touch attribution UTM term.
+  - name: country_vat_rate
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      VAT rate for the country the subscription is in (if any).
+  - name: plan_currency_usd_exchange_rate
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Exchange rate for converting the subscription plan's currency into US dollars (if any).
+  - name: plan_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Subscription plan's amount in US dollars.
+      For Apple subscriptions prior to 2024-10-30 this may have fallen back to assuming a USD amount due to a lack of source data (FXA-10549).
+  - name: current_period_discount_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Current period discount amount in US dollars (if any).
+      This may be null for Apple subscriptions.
+  - name: ongoing_discount_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Ongoing discount amount in US dollars (if any).
+      This may be null for Apple subscriptions.
+  - name: monthly_recurring_revenue_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Projected monthly recurring revenue for the subscription in US dollars.
+  - name: annual_recurring_revenue_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Projected annual recurring revenue for the subscription in US dollars.
+      This will be null for Stripe subscriptions prior to 2023-02-27 (DENG-754).
 - name: was_active_at_day_start
   type: BOOLEAN
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_service_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_service_subscriptions/view.sql
@@ -1,19 +1,203 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.subscription_platform.daily_active_service_subscriptions`
 AS
+WITH daily_subscriptions AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.daily_active_service_subscriptions_v1`
+  WHERE
+    `date` < (
+      SELECT
+        COALESCE(MIN(`date`), '9999-12-31')
+      FROM
+        `moz-fx-data-shared-prod.subscription_platform_derived.recent_daily_active_service_subscriptions_v1`
+    )
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.recent_daily_active_service_subscriptions_v1`
+),
+augmented_daily_subscriptions AS (
+  SELECT
+    daily_subscriptions.*,
+    vat_rates.vat_rate AS country_vat_rate,
+    usd_exchange_rates.exchange_rate AS plan_currency_usd_exchange_rate,
+  FROM
+    daily_subscriptions
+  LEFT JOIN
+    `moz-fx-data-shared-prod.subscription_platform.vat_rates_history` AS vat_rates
+    ON daily_subscriptions.subscription.country_code = vat_rates.country_code
+    AND (daily_subscriptions.date BETWEEN vat_rates.valid_from AND vat_rates.valid_to)
+  LEFT JOIN
+    `moz-fx-data-shared-prod.subscription_platform.exchange_rates_history` AS usd_exchange_rates
+    ON daily_subscriptions.subscription.plan_currency = usd_exchange_rates.base_currency
+    AND usd_exchange_rates.quote_currency = 'USD'
+    AND (
+      daily_subscriptions.date
+      BETWEEN usd_exchange_rates.valid_from
+      AND usd_exchange_rates.valid_to
+    )
+),
+augmented_daily_subscriptions_2 AS (
+  SELECT
+    *,
+    LEAST(
+      (
+        mozfun.utils.timestamp_diff_complete_months(
+          subscription.current_period_ends_at,
+          LEAST(
+            TIMESTAMP_SUB(TIMESTAMP(`date` + 1), INTERVAL 1 MICROSECOND),
+            subscription.current_period_ends_at
+          )
+        ) + 1
+      ),
+      12
+    ) AS current_period_annual_recurring_revenue_months,
+    GREATEST(
+      mozfun.utils.timestamp_diff_complete_months(
+        TIMESTAMP_SUB(subscription.ongoing_discount_ends_at, INTERVAL 1 MICROSECOND),
+        subscription.current_period_ends_at
+      ),
+      0
+    ) AS months_after_current_period_before_ongoing_discount_ends
+  FROM
+    augmented_daily_subscriptions
+),
+augmented_daily_subscriptions_3 AS (
+  SELECT
+    *,
+    CASE
+      WHEN COALESCE(subscription.ongoing_discount_amount, 0) = 0
+        THEN 0
+      WHEN subscription.ongoing_discount_ends_at IS NULL
+        THEN (12 - current_period_annual_recurring_revenue_months)
+      ELSE LEAST(
+          (
+            (
+              DIV(
+                months_after_current_period_before_ongoing_discount_ends,
+                subscription.plan_interval_months
+              ) + 1
+            ) * subscription.plan_interval_months
+          ),
+          (12 - current_period_annual_recurring_revenue_months)
+        )
+    END AS ongoing_discounted_annual_recurring_revenue_months
+  FROM
+    augmented_daily_subscriptions_2
+)
 SELECT
-  *
+  id,
+  `date`,
+  service_id,
+  service_subscriptions_history_id,
+  (
+    SELECT AS STRUCT
+      subscription.*,
+      country_vat_rate,
+      plan_currency_usd_exchange_rate,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.plan_amount,
+        ROUND((subscription.plan_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS plan_amount_usd,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.current_period_discount_amount,
+        ROUND((subscription.current_period_discount_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS current_period_discount_amount_usd,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.ongoing_discount_amount,
+        ROUND((subscription.ongoing_discount_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS ongoing_discount_amount_usd,
+      IF(
+        subscription.is_active IS NOT TRUE
+        OR subscription.is_trial IS TRUE,
+        0,
+        ROUND(
+          (
+            -- Start with monthly recurring gross revenue...
+            (
+              GREATEST(
+                (
+                  subscription.plan_amount - COALESCE(
+                    subscription.current_period_discount_amount,
+                    0
+                  )
+                ),
+                0
+              ) / subscription.plan_interval_months
+            )
+            -- Remove VAT to get monthly recurring net revenue.
+            / (1 + COALESCE(country_vat_rate, 0))
+            -- Apply exchange rate to get monthly recurring revenue in USD.
+            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+          ),
+          2
+        )
+      ) AS monthly_recurring_revenue_usd,
+      IF(
+        subscription.is_active IS NOT TRUE,
+        0,
+        ROUND(
+          (
+            -- Start with annual recurring gross revenue...
+            (
+              -- Current period annual recurring gross revenue
+              IF(
+                subscription.is_trial IS TRUE,
+                0,
+                (
+                  GREATEST(
+                    (
+                      subscription.plan_amount - COALESCE(
+                        subscription.current_period_discount_amount,
+                        0
+                      )
+                    ),
+                    0
+                  ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
+                )
+              )
+              -- Ongoing discounted annual recurring gross revenue
+              + IF(
+                subscription.auto_renew IS NOT TRUE
+                OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
+                0,
+                (
+                  GREATEST(
+                    (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
+                    0
+                  ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
+                )
+              )
+              -- Ongoing undiscounted annual recurring gross revenue
+              + IF(
+                subscription.auto_renew IS NOT TRUE,
+                0,
+                (
+                  subscription.plan_amount / subscription.plan_interval_months * GREATEST(
+                    (
+                      12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
+                    ),
+                    0
+                  )
+                )
+              )
+            )
+            -- Remove VAT to get annual recurring net revenue.
+            / (1 + COALESCE(country_vat_rate, 0))
+            -- Apply exchange rate to get annual recurring revenue in USD.
+            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+          ),
+          2
+        )
+      ) AS annual_recurring_revenue_usd
+  ) AS subscription,
+  was_active_at_day_start,
+  was_active_at_day_end
 FROM
-  `moz-fx-data-shared-prod.subscription_platform_derived.daily_active_service_subscriptions_v1`
-WHERE
-  `date` < (
-    SELECT
-      COALESCE(MIN(`date`), '9999-12-31')
-    FROM
-      `moz-fx-data-shared-prod.subscription_platform_derived.recent_daily_active_service_subscriptions_v1`
-  )
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.subscription_platform_derived.recent_daily_active_service_subscriptions_v1`
+  augmented_daily_subscriptions_3

--- a/sql/moz-fx-data-shared-prod/subscription_platform/exchange_rates_history/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/exchange_rates_history/view.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.subscription_platform.exchange_rates_history`
+AS
+SELECT
+  base_currency,
+  quote_currency,
+  price_type AS exchange_rate_type,
+  price AS exchange_rate,
+  `date` AS valid_from,
+  COALESCE(
+    (LEAD(`date`) OVER (PARTITION BY base_currency, quote_currency ORDER BY `date`) - 1),
+    '9999-12-31'
+  ) AS valid_to
+FROM
+  `moz-fx-data-shared-prod.subscription_platform_derived.exchange_rates_v1`

--- a/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/schema.yaml
@@ -379,3 +379,41 @@ fields:
     mode: NULLABLE
     description: |-
       Last-touch attribution UTM term.
+- name: country_vat_rate
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    VAT rate for the country the subscription is in (if any).
+- name: plan_currency_usd_exchange_rate
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Exchange rate for converting the subscription plan's currency into US dollars (if any).
+- name: plan_amount_usd
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Subscription plan's amount in US dollars.
+    For Apple subscriptions prior to 2024-10-30 this may have fallen back to assuming a USD amount due to a lack of source data (FXA-10549).
+- name: current_period_discount_amount_usd
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Current period discount amount in US dollars (if any).
+    This may be null for Apple subscriptions.
+- name: ongoing_discount_amount_usd
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Ongoing discount amount in US dollars (if any).
+    This may be null for Apple subscriptions.
+- name: monthly_recurring_revenue_usd
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Projected monthly recurring revenue for the subscription in US dollars.
+- name: annual_recurring_revenue_usd
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Projected annual recurring revenue for the subscription in US dollars.

--- a/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/view.sql
@@ -1,9 +1,203 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.subscription_platform.logical_subscriptions`
 AS
+WITH subscriptions AS (
+  SELECT
+    subscription.*,
+    COALESCE(DATE(subscription.ended_at), CURRENT_DATE()) AS effective_date
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.logical_subscriptions_history_v1`
+  WHERE
+    valid_to = '9999-12-31 23:59:59.999999'
+),
+vat_rates AS (
+  SELECT
+    country_code,
+    vat AS vat_rate,
+    effective_date,
+    LEAD(effective_date) OVER (
+      PARTITION BY
+        country_code
+      ORDER BY
+        effective_date
+    ) AS next_effective_date
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.vat_rates_v1`
+),
+usd_exchange_rates AS (
+  SELECT
+    base_currency,
+    price AS exchange_rate,
+    `date` AS effective_date,
+    LEAD(`date`) OVER (PARTITION BY base_currency ORDER BY `date`) AS next_effective_date
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.exchange_rates_v1`
+  WHERE
+    quote_currency = 'USD'
+),
+augmented_subscriptions AS (
+  SELECT
+    subscriptions.*,
+    vat_rates.vat_rate AS country_vat_rate,
+    usd_exchange_rates.exchange_rate AS plan_currency_usd_exchange_rate,
+  FROM
+    subscriptions
+  LEFT JOIN
+    vat_rates
+    ON subscriptions.country_code = vat_rates.country_code
+    AND subscriptions.effective_date >= vat_rates.effective_date
+    AND (
+      subscriptions.effective_date < vat_rates.next_effective_date
+      OR vat_rates.next_effective_date IS NULL
+    )
+  LEFT JOIN
+    usd_exchange_rates
+    ON subscriptions.plan_currency = usd_exchange_rates.base_currency
+    AND subscriptions.effective_date >= usd_exchange_rates.effective_date
+    AND (
+      subscriptions.effective_date < usd_exchange_rates.next_effective_date
+      OR usd_exchange_rates.next_effective_date IS NULL
+    )
+),
+augmented_subscriptions_2 AS (
+  SELECT
+    *,
+    LEAST(
+      (
+        mozfun.utils.timestamp_diff_complete_months(
+          current_period_ends_at,
+          LEAST(TIMESTAMP(CURRENT_DATE()), current_period_ends_at)
+        ) + 1
+      ),
+      12
+    ) AS current_period_annual_recurring_revenue_months,
+    GREATEST(
+      mozfun.utils.timestamp_diff_complete_months(
+        TIMESTAMP_SUB(ongoing_discount_ends_at, INTERVAL 1 MICROSECOND),
+        current_period_ends_at
+      ),
+      0
+    ) AS months_after_current_period_before_ongoing_discount_ends
+  FROM
+    augmented_subscriptions
+),
+augmented_subscriptions_3 AS (
+  SELECT
+    *,
+    CASE
+      WHEN COALESCE(ongoing_discount_amount, 0) = 0
+        THEN 0
+      WHEN ongoing_discount_ends_at IS NULL
+        THEN (12 - current_period_annual_recurring_revenue_months)
+      ELSE LEAST(
+          (
+            (
+              DIV(
+                months_after_current_period_before_ongoing_discount_ends,
+                plan_interval_months
+              ) + 1
+            ) * plan_interval_months
+          ),
+          (12 - current_period_annual_recurring_revenue_months)
+        )
+    END AS ongoing_discounted_annual_recurring_revenue_months
+  FROM
+    augmented_subscriptions_2
+)
 SELECT
-  subscription.*
+  * EXCEPT (
+    effective_date,
+    current_period_annual_recurring_revenue_months,
+    months_after_current_period_before_ongoing_discount_ends,
+    ongoing_discounted_annual_recurring_revenue_months
+  ),
+  IF(
+    plan_currency = 'USD',
+    plan_amount,
+    ROUND((plan_amount * plan_currency_usd_exchange_rate), 2)
+  ) AS plan_amount_usd,
+  IF(
+    plan_currency = 'USD',
+    current_period_discount_amount,
+    ROUND((current_period_discount_amount * plan_currency_usd_exchange_rate), 2)
+  ) AS current_period_discount_amount_usd,
+  IF(
+    plan_currency = 'USD',
+    ongoing_discount_amount,
+    ROUND((ongoing_discount_amount * plan_currency_usd_exchange_rate), 2)
+  ) AS ongoing_discount_amount_usd,
+  IF(
+    is_active IS NOT TRUE
+    OR is_trial IS TRUE,
+    0,
+    ROUND(
+      (
+        -- Start with monthly recurring gross revenue...
+        (
+          GREATEST(
+            (plan_amount - COALESCE(current_period_discount_amount, 0)),
+            0
+          ) / plan_interval_months
+        )
+        -- Remove VAT to get monthly recurring net revenue.
+        / (1 + COALESCE(country_vat_rate, 0))
+        -- Apply exchange rate to get monthly recurring revenue in USD.
+        * IF(plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+      ),
+      2
+    )
+  ) AS monthly_recurring_revenue_usd,
+  IF(
+    is_active IS NOT TRUE,
+    0,
+    ROUND(
+      (
+        -- Start with annual recurring gross revenue...
+        (
+          -- Current period annual recurring gross revenue
+          IF(
+            is_trial IS TRUE,
+            0,
+            (
+              GREATEST(
+                (plan_amount - COALESCE(current_period_discount_amount, 0)),
+                0
+              ) / plan_interval_months * current_period_annual_recurring_revenue_months
+            )
+          )
+          -- Ongoing discounted annual recurring gross revenue
+          + IF(
+            auto_renew IS NOT TRUE
+            OR COALESCE(ongoing_discount_amount, 0) = 0,
+            0,
+            (
+              GREATEST(
+                (plan_amount - COALESCE(ongoing_discount_amount, 0)),
+                0
+              ) / plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
+            )
+          )
+          -- Ongoing undiscounted annual recurring gross revenue
+          + IF(
+            auto_renew IS NOT TRUE,
+            0,
+            (
+              plan_amount / plan_interval_months * GREATEST(
+                (
+                  12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
+                ),
+                0
+              )
+            )
+          )
+        )
+        -- Remove VAT to get annual recurring net revenue.
+        / (1 + COALESCE(country_vat_rate, 0))
+        -- Apply exchange rate to get annual recurring revenue in USD.
+        * IF(plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+      ),
+      2
+    )
+  ) AS annual_recurring_revenue_usd
 FROM
-  `moz-fx-data-shared-prod.subscription_platform_derived.logical_subscriptions_history_v1`
-WHERE
-  valid_to = '9999-12-31 23:59:59.999999'
+  augmented_subscriptions_3

--- a/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_logical_subscriptions/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_logical_subscriptions/schema.yaml
@@ -405,6 +405,45 @@ fields:
     description: |-
       When the ongoing discount ends (if any).
       This will be null for Apple subscriptions.
+  - name: country_vat_rate
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      VAT rate for the country the subscription is in (if any).
+  - name: plan_currency_usd_exchange_rate
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Exchange rate for converting the subscription plan's currency into US dollars (if any).
+  - name: plan_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Subscription plan's amount in US dollars.
+      For Apple subscriptions prior to 2024-10-30 this may have fallen back to assuming a USD amount due to a lack of source data (FXA-10549).
+  - name: current_period_discount_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Current period discount amount in US dollars (if any).
+      This may be null for Apple subscriptions.
+  - name: ongoing_discount_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Ongoing discount amount in US dollars (if any).
+      This may be null for Apple subscriptions.
+  - name: monthly_recurring_revenue_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Projected monthly recurring revenue for the subscription in US dollars.
+  - name: annual_recurring_revenue_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Projected annual recurring revenue for the subscription in US dollars.
+      This will be null for Stripe subscriptions prior to 2023-02-01 (DENG-754).
 - name: was_active_at_month_start
   type: BOOLEAN
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_logical_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_logical_subscriptions/view.sql
@@ -19,31 +19,6 @@ WITH monthly_subscriptions AS (
   FROM
     `moz-fx-data-shared-prod.subscription_platform_derived.recent_monthly_active_logical_subscriptions_v1`
 ),
-vat_rates AS (
-  SELECT
-    country_code,
-    vat AS vat_rate,
-    effective_date,
-    LEAD(effective_date) OVER (
-      PARTITION BY
-        country_code
-      ORDER BY
-        effective_date
-    ) AS next_effective_date
-  FROM
-    `moz-fx-data-shared-prod.subscription_platform_derived.vat_rates_v1`
-),
-usd_exchange_rates AS (
-  SELECT
-    base_currency,
-    price AS exchange_rate,
-    `date` AS effective_date,
-    LEAD(`date`) OVER (PARTITION BY base_currency ORDER BY `date`) AS next_effective_date
-  FROM
-    `moz-fx-data-shared-prod.subscription_platform_derived.exchange_rates_v1`
-  WHERE
-    quote_currency = 'USD'
-),
 augmented_monthly_subscriptions AS (
   SELECT
     *,
@@ -59,20 +34,17 @@ augmented_monthly_subscriptions_2 AS (
   FROM
     augmented_monthly_subscriptions AS monthly_subscriptions
   LEFT JOIN
-    vat_rates
+    `moz-fx-data-shared-prod.subscription_platform.vat_rates_history` AS vat_rates
     ON monthly_subscriptions.subscription.country_code = vat_rates.country_code
-    AND monthly_subscriptions.effective_date >= vat_rates.effective_date
-    AND (
-      monthly_subscriptions.effective_date < vat_rates.next_effective_date
-      OR vat_rates.next_effective_date IS NULL
-    )
+    AND (monthly_subscriptions.effective_date BETWEEN vat_rates.valid_from AND vat_rates.valid_to)
   LEFT JOIN
-    usd_exchange_rates
+    `moz-fx-data-shared-prod.subscription_platform.exchange_rates_history` AS usd_exchange_rates
     ON monthly_subscriptions.subscription.plan_currency = usd_exchange_rates.base_currency
-    AND monthly_subscriptions.effective_date >= usd_exchange_rates.effective_date
+    AND usd_exchange_rates.quote_currency = 'USD'
     AND (
-      monthly_subscriptions.effective_date < usd_exchange_rates.next_effective_date
-      OR usd_exchange_rates.next_effective_date IS NULL
+      monthly_subscriptions.effective_date
+      BETWEEN usd_exchange_rates.valid_from
+      AND usd_exchange_rates.valid_to
     )
 ),
 augmented_monthly_subscriptions_3 AS (

--- a/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_logical_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_logical_subscriptions/view.sql
@@ -1,19 +1,239 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.subscription_platform.monthly_active_logical_subscriptions`
 AS
+WITH monthly_subscriptions AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.monthly_active_logical_subscriptions_v1`
+  WHERE
+    month_start_date < (
+      SELECT
+        COALESCE(MIN(month_start_date), '9999-12-31')
+      FROM
+        `moz-fx-data-shared-prod.subscription_platform_derived.recent_monthly_active_logical_subscriptions_v1`
+    )
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.recent_monthly_active_logical_subscriptions_v1`
+),
+vat_rates AS (
+  SELECT
+    country_code,
+    vat AS vat_rate,
+    effective_date,
+    LEAD(effective_date) OVER (
+      PARTITION BY
+        country_code
+      ORDER BY
+        effective_date
+    ) AS next_effective_date
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.vat_rates_v1`
+),
+usd_exchange_rates AS (
+  SELECT
+    base_currency,
+    price AS exchange_rate,
+    `date` AS effective_date,
+    LEAD(`date`) OVER (PARTITION BY base_currency ORDER BY `date`) AS next_effective_date
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.exchange_rates_v1`
+  WHERE
+    quote_currency = 'USD'
+),
+augmented_monthly_subscriptions AS (
+  SELECT
+    *,
+    COALESCE(DATE(subscription.ended_at), LEAST(month_end_date, CURRENT_DATE())) AS effective_date
+  FROM
+    monthly_subscriptions
+),
+augmented_monthly_subscriptions_2 AS (
+  SELECT
+    monthly_subscriptions.*,
+    vat_rates.vat_rate AS country_vat_rate,
+    usd_exchange_rates.exchange_rate AS plan_currency_usd_exchange_rate,
+  FROM
+    augmented_monthly_subscriptions AS monthly_subscriptions
+  LEFT JOIN
+    vat_rates
+    ON monthly_subscriptions.subscription.country_code = vat_rates.country_code
+    AND monthly_subscriptions.effective_date >= vat_rates.effective_date
+    AND (
+      monthly_subscriptions.effective_date < vat_rates.next_effective_date
+      OR vat_rates.next_effective_date IS NULL
+    )
+  LEFT JOIN
+    usd_exchange_rates
+    ON monthly_subscriptions.subscription.plan_currency = usd_exchange_rates.base_currency
+    AND monthly_subscriptions.effective_date >= usd_exchange_rates.effective_date
+    AND (
+      monthly_subscriptions.effective_date < usd_exchange_rates.next_effective_date
+      OR usd_exchange_rates.next_effective_date IS NULL
+    )
+),
+augmented_monthly_subscriptions_3 AS (
+  SELECT
+    *,
+    LEAST(
+      (
+        mozfun.utils.timestamp_diff_complete_months(
+          subscription.current_period_ends_at,
+          LEAST(
+            TIMESTAMP_SUB(TIMESTAMP(month_end_date + 1), INTERVAL 1 MICROSECOND),
+            TIMESTAMP(CURRENT_DATE()),
+            subscription.current_period_ends_at
+          )
+        ) + 1
+      ),
+      12
+    ) AS current_period_annual_recurring_revenue_months,
+    GREATEST(
+      mozfun.utils.timestamp_diff_complete_months(
+        TIMESTAMP_SUB(subscription.ongoing_discount_ends_at, INTERVAL 1 MICROSECOND),
+        subscription.current_period_ends_at
+      ),
+      0
+    ) AS months_after_current_period_before_ongoing_discount_ends
+  FROM
+    augmented_monthly_subscriptions_2
+),
+augmented_monthly_subscriptions_4 AS (
+  SELECT
+    *,
+    CASE
+      WHEN COALESCE(subscription.ongoing_discount_amount, 0) = 0
+        THEN 0
+      WHEN subscription.ongoing_discount_ends_at IS NULL
+        THEN (12 - current_period_annual_recurring_revenue_months)
+      ELSE LEAST(
+          (
+            (
+              DIV(
+                months_after_current_period_before_ongoing_discount_ends,
+                subscription.plan_interval_months
+              ) + 1
+            ) * subscription.plan_interval_months
+          ),
+          (12 - current_period_annual_recurring_revenue_months)
+        )
+    END AS ongoing_discounted_annual_recurring_revenue_months
+  FROM
+    augmented_monthly_subscriptions_3
+)
 SELECT
-  *
+  id,
+  month_start_date,
+  month_end_date,
+  logical_subscriptions_history_id,
+  (
+    SELECT AS STRUCT
+      subscription.*,
+      country_vat_rate,
+      plan_currency_usd_exchange_rate,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.plan_amount,
+        ROUND((subscription.plan_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS plan_amount_usd,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.current_period_discount_amount,
+        ROUND((subscription.current_period_discount_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS current_period_discount_amount_usd,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.ongoing_discount_amount,
+        ROUND((subscription.ongoing_discount_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS ongoing_discount_amount_usd,
+      IF(
+        subscription.is_active IS NOT TRUE
+        OR subscription.is_trial IS TRUE,
+        0,
+        ROUND(
+          (
+            -- Start with monthly recurring gross revenue...
+            (
+              GREATEST(
+                (
+                  subscription.plan_amount - COALESCE(
+                    subscription.current_period_discount_amount,
+                    0
+                  )
+                ),
+                0
+              ) / subscription.plan_interval_months
+            )
+            -- Remove VAT to get monthly recurring net revenue.
+            / (1 + COALESCE(country_vat_rate, 0))
+            -- Apply exchange rate to get monthly recurring revenue in USD.
+            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+          ),
+          2
+        )
+      ) AS monthly_recurring_revenue_usd,
+      IF(
+        subscription.is_active IS NOT TRUE,
+        0,
+        ROUND(
+          (
+            -- Start with annual recurring gross revenue...
+            (
+              -- Current period annual recurring gross revenue
+              IF(
+                subscription.is_trial IS TRUE,
+                0,
+                (
+                  GREATEST(
+                    (
+                      subscription.plan_amount - COALESCE(
+                        subscription.current_period_discount_amount,
+                        0
+                      )
+                    ),
+                    0
+                  ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
+                )
+              )
+              -- Ongoing discounted annual recurring gross revenue
+              + IF(
+                subscription.auto_renew IS NOT TRUE
+                OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
+                0,
+                (
+                  GREATEST(
+                    (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
+                    0
+                  ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
+                )
+              )
+              -- Ongoing undiscounted annual recurring gross revenue
+              + IF(
+                subscription.auto_renew IS NOT TRUE,
+                0,
+                (
+                  subscription.plan_amount / subscription.plan_interval_months * GREATEST(
+                    (
+                      12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
+                    ),
+                    0
+                  )
+                )
+              )
+            )
+            -- Remove VAT to get annual recurring net revenue.
+            / (1 + COALESCE(country_vat_rate, 0))
+            -- Apply exchange rate to get annual recurring revenue in USD.
+            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+          ),
+          2
+        )
+      ) AS annual_recurring_revenue_usd
+  ) AS subscription,
+  was_active_at_month_start,
+  was_active_at_month_end
 FROM
-  `moz-fx-data-shared-prod.subscription_platform_derived.monthly_active_logical_subscriptions_v1`
-WHERE
-  month_start_date < (
-    SELECT
-      COALESCE(MIN(month_start_date), '9999-12-31')
-    FROM
-      `moz-fx-data-shared-prod.subscription_platform_derived.recent_monthly_active_logical_subscriptions_v1`
-  )
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.subscription_platform_derived.recent_monthly_active_logical_subscriptions_v1`
+  augmented_monthly_subscriptions_4

--- a/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_service_subscriptions/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_service_subscriptions/schema.yaml
@@ -447,6 +447,45 @@ fields:
       mode: NULLABLE
       description: |-
         Last-touch attribution UTM term.
+  - name: country_vat_rate
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      VAT rate for the country the subscription is in (if any).
+  - name: plan_currency_usd_exchange_rate
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Exchange rate for converting the subscription plan's currency into US dollars (if any).
+  - name: plan_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Subscription plan's amount in US dollars.
+      For Apple subscriptions prior to 2024-10-30 this may have fallen back to assuming a USD amount due to a lack of source data (FXA-10549).
+  - name: current_period_discount_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Current period discount amount in US dollars (if any).
+      This may be null for Apple subscriptions.
+  - name: ongoing_discount_amount_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Ongoing discount amount in US dollars (if any).
+      This may be null for Apple subscriptions.
+  - name: monthly_recurring_revenue_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Projected monthly recurring revenue for the subscription in US dollars.
+  - name: annual_recurring_revenue_usd
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Projected annual recurring revenue for the subscription in US dollars.
+      This will be null for Stripe subscriptions prior to 2023-02-01 (DENG-754).
 - name: was_active_at_month_start
   type: BOOLEAN
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_service_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_service_subscriptions/view.sql
@@ -1,19 +1,212 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.subscription_platform.monthly_active_service_subscriptions`
 AS
+WITH monthly_subscriptions AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.monthly_active_service_subscriptions_v1`
+  WHERE
+    month_start_date < (
+      SELECT
+        COALESCE(MIN(month_start_date), '9999-12-31')
+      FROM
+        `moz-fx-data-shared-prod.subscription_platform_derived.recent_monthly_active_service_subscriptions_v1`
+    )
+  UNION ALL
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.recent_monthly_active_service_subscriptions_v1`
+),
+augmented_monthly_subscriptions AS (
+  SELECT
+    *,
+    COALESCE(DATE(subscription.ended_at), LEAST(month_end_date, CURRENT_DATE())) AS effective_date
+  FROM
+    monthly_subscriptions
+),
+augmented_monthly_subscriptions_2 AS (
+  SELECT
+    monthly_subscriptions.*,
+    vat_rates.vat_rate AS country_vat_rate,
+    usd_exchange_rates.exchange_rate AS plan_currency_usd_exchange_rate,
+  FROM
+    augmented_monthly_subscriptions AS monthly_subscriptions
+  LEFT JOIN
+    `moz-fx-data-shared-prod.subscription_platform.vat_rates_history` AS vat_rates
+    ON monthly_subscriptions.subscription.country_code = vat_rates.country_code
+    AND (monthly_subscriptions.effective_date BETWEEN vat_rates.valid_from AND vat_rates.valid_to)
+  LEFT JOIN
+    `moz-fx-data-shared-prod.subscription_platform.exchange_rates_history` AS usd_exchange_rates
+    ON monthly_subscriptions.subscription.plan_currency = usd_exchange_rates.base_currency
+    AND usd_exchange_rates.quote_currency = 'USD'
+    AND (
+      monthly_subscriptions.effective_date
+      BETWEEN usd_exchange_rates.valid_from
+      AND usd_exchange_rates.valid_to
+    )
+),
+augmented_monthly_subscriptions_3 AS (
+  SELECT
+    *,
+    LEAST(
+      (
+        mozfun.utils.timestamp_diff_complete_months(
+          subscription.current_period_ends_at,
+          LEAST(
+            TIMESTAMP_SUB(TIMESTAMP(month_end_date + 1), INTERVAL 1 MICROSECOND),
+            TIMESTAMP(CURRENT_DATE()),
+            subscription.current_period_ends_at
+          )
+        ) + 1
+      ),
+      12
+    ) AS current_period_annual_recurring_revenue_months,
+    GREATEST(
+      mozfun.utils.timestamp_diff_complete_months(
+        TIMESTAMP_SUB(subscription.ongoing_discount_ends_at, INTERVAL 1 MICROSECOND),
+        subscription.current_period_ends_at
+      ),
+      0
+    ) AS months_after_current_period_before_ongoing_discount_ends
+  FROM
+    augmented_monthly_subscriptions_2
+),
+augmented_monthly_subscriptions_4 AS (
+  SELECT
+    *,
+    CASE
+      WHEN COALESCE(subscription.ongoing_discount_amount, 0) = 0
+        THEN 0
+      WHEN subscription.ongoing_discount_ends_at IS NULL
+        THEN (12 - current_period_annual_recurring_revenue_months)
+      ELSE LEAST(
+          (
+            (
+              DIV(
+                months_after_current_period_before_ongoing_discount_ends,
+                subscription.plan_interval_months
+              ) + 1
+            ) * subscription.plan_interval_months
+          ),
+          (12 - current_period_annual_recurring_revenue_months)
+        )
+    END AS ongoing_discounted_annual_recurring_revenue_months
+  FROM
+    augmented_monthly_subscriptions_3
+)
 SELECT
-  *
+  id,
+  month_start_date,
+  month_end_date,
+  service_id,
+  service_subscriptions_history_id,
+  (
+    SELECT AS STRUCT
+      subscription.*,
+      country_vat_rate,
+      plan_currency_usd_exchange_rate,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.plan_amount,
+        ROUND((subscription.plan_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS plan_amount_usd,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.current_period_discount_amount,
+        ROUND((subscription.current_period_discount_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS current_period_discount_amount_usd,
+      IF(
+        subscription.plan_currency = 'USD',
+        subscription.ongoing_discount_amount,
+        ROUND((subscription.ongoing_discount_amount * plan_currency_usd_exchange_rate), 2)
+      ) AS ongoing_discount_amount_usd,
+      IF(
+        subscription.is_active IS NOT TRUE
+        OR subscription.is_trial IS TRUE,
+        0,
+        ROUND(
+          (
+            -- Start with monthly recurring gross revenue...
+            (
+              GREATEST(
+                (
+                  subscription.plan_amount - COALESCE(
+                    subscription.current_period_discount_amount,
+                    0
+                  )
+                ),
+                0
+              ) / subscription.plan_interval_months
+            )
+            -- Remove VAT to get monthly recurring net revenue.
+            / (1 + COALESCE(country_vat_rate, 0))
+            -- Apply exchange rate to get monthly recurring revenue in USD.
+            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+          ),
+          2
+        )
+      ) AS monthly_recurring_revenue_usd,
+      IF(
+        subscription.is_active IS NOT TRUE,
+        0,
+        ROUND(
+          (
+            -- Start with annual recurring gross revenue...
+            (
+              -- Current period annual recurring gross revenue
+              IF(
+                subscription.is_trial IS TRUE,
+                0,
+                (
+                  GREATEST(
+                    (
+                      subscription.plan_amount - COALESCE(
+                        subscription.current_period_discount_amount,
+                        0
+                      )
+                    ),
+                    0
+                  ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
+                )
+              )
+              -- Ongoing discounted annual recurring gross revenue
+              + IF(
+                subscription.auto_renew IS NOT TRUE
+                OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
+                0,
+                (
+                  GREATEST(
+                    (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
+                    0
+                  ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
+                )
+              )
+              -- Ongoing undiscounted annual recurring gross revenue
+              + IF(
+                subscription.auto_renew IS NOT TRUE,
+                0,
+                (
+                  subscription.plan_amount / subscription.plan_interval_months * GREATEST(
+                    (
+                      12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
+                    ),
+                    0
+                  )
+                )
+              )
+            )
+            -- Remove VAT to get annual recurring net revenue.
+            / (1 + COALESCE(country_vat_rate, 0))
+            -- Apply exchange rate to get annual recurring revenue in USD.
+            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+          ),
+          2
+        )
+      ) AS annual_recurring_revenue_usd
+  ) AS subscription,
+  was_active_at_month_start,
+  was_active_at_month_end
 FROM
-  `moz-fx-data-shared-prod.subscription_platform_derived.monthly_active_service_subscriptions_v1`
-WHERE
-  month_start_date < (
-    SELECT
-      COALESCE(MIN(month_start_date), '9999-12-31')
-    FROM
-      `moz-fx-data-shared-prod.subscription_platform_derived.recent_monthly_active_service_subscriptions_v1`
-  )
-UNION ALL
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.subscription_platform_derived.recent_monthly_active_service_subscriptions_v1`
+  augmented_monthly_subscriptions_4

--- a/sql/moz-fx-data-shared-prod/subscription_platform/service_subscriptions/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/service_subscriptions/schema.yaml
@@ -1,0 +1,461 @@
+fields:
+- name: id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Service subscription ID.
+- name: service_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    ID of the service provided by the subscription, as defined in the `services_v1` ETL.
+- name: provider
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider of the subscription ("Stripe", "Google", or "Apple").
+- name: payment_provider
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Payment provider for the subscription.
+    For Stripe subscriptions this will be "Stripe" or "PayPal".
+    For Google subscriptions this will be "Google".
+    For Apple subscriptions this will be "Apple".
+- name: logical_subscription_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    ID of the associated logical subscription this service subscription was derived from.
+- name: provider_subscription_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider subscription ID.
+    For Stripe subscriptions this will be the subscription ID.
+    For Google subscriptions this will be the purchase token.
+    For Apple subscriptions this will be the original transaction ID.
+- name: provider_subscription_item_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider subscription item ID (if any).
+    This will be null for Google and Apple subscriptions.
+- name: provider_subscription_created_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the provider subscription was created.
+- name: provider_subscription_updated_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the provider subscription was last updated.
+- name: provider_customer_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider customer ID (if any).
+    This will be null for Google and Apple subscriptions.
+- name: mozilla_account_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    ID of the Mozilla Account associated with the subscription (if any) as a hexadecimal string.
+    This may be missing for some subscriptions, particularly older subscriptions when we were only recording hashed Mozilla Account IDs.
+- name: mozilla_account_id_sha256
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    SHA256 hash of the `mozilla_account_id` string value (if any) as a hexadecimal string.
+    This may be missing for some subscriptions.
+- name: customer_logical_subscription_number
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Number of the associated logical subscription in the overall sequence of all of the customer's logical subscriptions.
+    For example, this should be `1` for their first logical subscription, `2` for their second logical subscription, etc.
+- name: customer_service_subscription_number
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Number of this service subscription in the overall sequence of all of the customer's service subscriptions to this service.
+    For example, this should be `1` for their first service subscription to this service, `2` for their second service subscription to this service, etc.
+- name: country_code
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    ISO 3166-1 alpha-2 code for the country the subscription is in.
+    This may be missing for some subscriptions.
+- name: country_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Name of the country the subscription is in.
+    This may be "Unknown" for some subscriptions.
+- name: service
+  type: RECORD
+  mode: NULLABLE
+  description: |-
+    The service provided by the subscription, as defined in the `services_v1` ETL.
+  fields:
+  - name: id
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Service ID.
+  - name: name
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Service name.
+  - name: tier
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Service tier.
+- name: other_services
+  type: RECORD
+  mode: REPEATED
+  description: |-
+    Array of zero or more other services provided by the subscription, as defined in the `services_v1` ETL.
+  fields:
+  - name: id
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Other service ID.
+  - name: name
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Other service name.
+  - name: tier
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Other service tier.
+- name: provider_product_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider product ID.
+    For Stripe subscriptions this will be the product ID.
+    For Google subscriptions this will be the package name.
+    For Apple subscriptions this will be the bundle ID.
+- name: product_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Product name.
+    For all subscriptions this will be the associated Stripe product name.
+- name: provider_plan_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider plan ID.
+    For Stripe subscriptions this will be the plan/price ID.
+    For Google subscriptions this will be the SKU.
+    For Apple subscriptions this will be the product ID.
+- name: plan_summary
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Text summary of the subscription plan's interval, currency, and amount, along with an indication if it's a bundle (i.e. providing multiple services).
+    For example, "1 month EUR 4.99" or "1 year USD 99.00 bundle".
+- name: plan_interval
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Text summary of the subscription plan's interval (e.g. "1 month", "6 months", "1 year").
+- name: plan_interval_type
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Subscription plan's interval type (e.g. "month" or "year").
+- name: plan_interval_count
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Subscription plan's interval count.
+- name: plan_interval_months
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Number of months in the subscription plan's interval.
+- name: plan_currency
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    ISO 4217 code for the subscription plan's currency.
+    For Apple subscriptions prior to 2024-10-30 this may have fallen back to assuming USD due to a lack of source data (FXA-10549).
+- name: plan_amount
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Subscription plan's amount in the specified currency.
+    For Apple subscriptions prior to 2024-10-30 this may have fallen back to assuming a USD amount due to a lack of source data (FXA-10549).
+- name: is_bundle
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription is a bundle (i.e. providing multiple services).
+- name: is_trial
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription is a free trial.
+- name: is_active
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription is active (i.e. providing the customer access to the services).
+- name: provider_status
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The provider's status indicator for the subscription.
+- name: logical_subscription_started_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the associated logical subscription started.
+- name: started_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the subscription started.
+- name: ended_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the subscription ended.
+    This will be null for active subscriptions.
+- name: current_period_started_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the current subscription period started.
+    This will be null for inactive subscriptions and for all Google subcriptions.
+- name: current_period_ends_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the current subscription period ends.
+    This will be null for inactive subscriptions.
+- name: auto_renew
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription is set to auto-renew.
+- name: auto_renew_disabled_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the subscription's auto-renewal setting was disabled.
+    This will be null for subscriptions set to auto-renew.
+- name: initial_discount_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Initial discount name (if any).
+    This will be null for Google and Apple subscriptions.
+- name: initial_discount_promotion_code
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Initial discount promotion code (if any).
+- name: current_period_discount_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Current period discount name (if any).
+    This will be null for Google and Apple subscriptions.
+- name: current_period_discount_promotion_code
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Current period discount promotion code (if any).
+- name: current_period_discount_amount
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Current period discount amount (if any).
+    This may be null for Apple subscriptions.
+- name: ongoing_discount_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Ongoing discount name (if any).
+    This will be null for Google and Apple subscriptions.
+- name: ongoing_discount_promotion_code
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Ongoing discount promotion code (if any).
+- name: ongoing_discount_amount
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Ongoing discount amount (if any).
+    This may be null for Apple subscriptions.
+- name: ongoing_discount_ends_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the ongoing discount ends (if any).
+    This will be null for Apple subscriptions.
+- name: has_refunds
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription has had refunds.
+    This will be null for Google subscriptions.
+- name: has_fraudulent_charges
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription has had fraudulent charges.
+    This will be null for Google and Apple subscriptions.
+- name: first_touch_attribution
+  type: RECORD
+  mode: NULLABLE
+  description: |-
+    Unbounded first-touch attribution for the service subscription (if any).
+    This will be null for Google and Apple subscriptions.
+  fields:
+  - name: impression_at
+    type: TIMESTAMP
+    mode: NULLABLE
+    description: |-
+      When the first-touch attribution impression occurred.
+  - name: entrypoint
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution entrypoint.
+  - name: entrypoint_experiment
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution entrypoint experiment.
+  - name: entrypoint_variation
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution entrypoint experiment variation.
+  - name: utm_campaign
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution UTM campaign.
+  - name: utm_content
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution UTM content.
+  - name: utm_medium
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution UTM medium.
+  - name: utm_source
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution UTM source.
+  - name: utm_term
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution UTM term.
+- name: last_touch_attribution
+  type: RECORD
+  mode: NULLABLE
+  description: |-
+    Unbounded last-touch attribution for the service subscription (if any).
+    This will be null for Google and Apple subscriptions.
+  fields:
+  - name: impression_at
+    type: TIMESTAMP
+    mode: NULLABLE
+    description: |-
+      When the last-touch attribution impression occurred.
+  - name: entrypoint
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint.
+  - name: entrypoint_experiment
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint experiment.
+  - name: entrypoint_variation
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint experiment variation.
+  - name: utm_campaign
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM campaign.
+  - name: utm_content
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM content.
+  - name: utm_medium
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM medium.
+  - name: utm_source
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM source.
+  - name: utm_term
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM term.
+- name: country_vat_rate
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    VAT rate for the country the subscription is in (if any).
+- name: plan_currency_usd_exchange_rate
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Exchange rate for converting the subscription plan's currency into US dollars (if any).
+- name: plan_amount_usd
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Subscription plan's amount in US dollars.
+    For Apple subscriptions prior to 2024-10-30 this may have fallen back to assuming a USD amount due to a lack of source data (FXA-10549).
+- name: current_period_discount_amount_usd
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Current period discount amount in US dollars (if any).
+    This may be null for Apple subscriptions.
+- name: ongoing_discount_amount_usd
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Ongoing discount amount in US dollars (if any).
+    This may be null for Apple subscriptions.
+- name: monthly_recurring_revenue_usd
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Projected monthly recurring revenue for the subscription in US dollars.
+- name: annual_recurring_revenue_usd
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Projected annual recurring revenue for the subscription in US dollars.

--- a/sql/moz-fx-data-shared-prod/subscription_platform/service_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/service_subscriptions/view.sql
@@ -1,7 +1,173 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.subscription_platform.service_subscriptions`
 AS
+WITH subscriptions AS (
+  SELECT
+    *,
+    COALESCE(DATE(ended_at), CURRENT_DATE()) AS effective_date
+  FROM
+    `moz-fx-data-shared-prod.subscription_platform_derived.service_subscriptions_v1`
+),
+augmented_subscriptions AS (
+  SELECT
+    subscriptions.*,
+    vat_rates.vat_rate AS country_vat_rate,
+    usd_exchange_rates.exchange_rate AS plan_currency_usd_exchange_rate,
+  FROM
+    subscriptions
+  LEFT JOIN
+    `moz-fx-data-shared-prod.subscription_platform.vat_rates_history` AS vat_rates
+    ON subscriptions.country_code = vat_rates.country_code
+    AND (subscriptions.effective_date BETWEEN vat_rates.valid_from AND vat_rates.valid_to)
+  LEFT JOIN
+    `moz-fx-data-shared-prod.subscription_platform.exchange_rates_history` AS usd_exchange_rates
+    ON subscriptions.plan_currency = usd_exchange_rates.base_currency
+    AND usd_exchange_rates.quote_currency = 'USD'
+    AND (
+      subscriptions.effective_date
+      BETWEEN usd_exchange_rates.valid_from
+      AND usd_exchange_rates.valid_to
+    )
+),
+augmented_subscriptions_2 AS (
+  SELECT
+    *,
+    LEAST(
+      (
+        mozfun.utils.timestamp_diff_complete_months(
+          current_period_ends_at,
+          LEAST(TIMESTAMP(CURRENT_DATE()), current_period_ends_at)
+        ) + 1
+      ),
+      12
+    ) AS current_period_annual_recurring_revenue_months,
+    GREATEST(
+      mozfun.utils.timestamp_diff_complete_months(
+        TIMESTAMP_SUB(ongoing_discount_ends_at, INTERVAL 1 MICROSECOND),
+        current_period_ends_at
+      ),
+      0
+    ) AS months_after_current_period_before_ongoing_discount_ends
+  FROM
+    augmented_subscriptions
+),
+augmented_subscriptions_3 AS (
+  SELECT
+    *,
+    CASE
+      WHEN COALESCE(ongoing_discount_amount, 0) = 0
+        THEN 0
+      WHEN ongoing_discount_ends_at IS NULL
+        THEN (12 - current_period_annual_recurring_revenue_months)
+      ELSE LEAST(
+          (
+            (
+              DIV(
+                months_after_current_period_before_ongoing_discount_ends,
+                plan_interval_months
+              ) + 1
+            ) * plan_interval_months
+          ),
+          (12 - current_period_annual_recurring_revenue_months)
+        )
+    END AS ongoing_discounted_annual_recurring_revenue_months
+  FROM
+    augmented_subscriptions_2
+)
 SELECT
-  *
+  * EXCEPT (
+    effective_date,
+    current_period_annual_recurring_revenue_months,
+    months_after_current_period_before_ongoing_discount_ends,
+    ongoing_discounted_annual_recurring_revenue_months
+  ),
+  IF(
+    plan_currency = 'USD',
+    plan_amount,
+    ROUND((plan_amount * plan_currency_usd_exchange_rate), 2)
+  ) AS plan_amount_usd,
+  IF(
+    plan_currency = 'USD',
+    current_period_discount_amount,
+    ROUND((current_period_discount_amount * plan_currency_usd_exchange_rate), 2)
+  ) AS current_period_discount_amount_usd,
+  IF(
+    plan_currency = 'USD',
+    ongoing_discount_amount,
+    ROUND((ongoing_discount_amount * plan_currency_usd_exchange_rate), 2)
+  ) AS ongoing_discount_amount_usd,
+  IF(
+    is_active IS NOT TRUE
+    OR is_trial IS TRUE,
+    0,
+    ROUND(
+      (
+        -- Start with monthly recurring gross revenue...
+        (
+          GREATEST(
+            (plan_amount - COALESCE(current_period_discount_amount, 0)),
+            0
+          ) / plan_interval_months
+        )
+        -- Remove VAT to get monthly recurring net revenue.
+        / (1 + COALESCE(country_vat_rate, 0))
+        -- Apply exchange rate to get monthly recurring revenue in USD.
+        * IF(plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+      ),
+      2
+    )
+  ) AS monthly_recurring_revenue_usd,
+  IF(
+    is_active IS NOT TRUE,
+    0,
+    ROUND(
+      (
+        -- Start with annual recurring gross revenue...
+        (
+          -- Current period annual recurring gross revenue
+          IF(
+            is_trial IS TRUE,
+            0,
+            (
+              GREATEST(
+                (plan_amount - COALESCE(current_period_discount_amount, 0)),
+                0
+              ) / plan_interval_months * current_period_annual_recurring_revenue_months
+            )
+          )
+          -- Ongoing discounted annual recurring gross revenue
+          + IF(
+            auto_renew IS NOT TRUE
+            OR COALESCE(ongoing_discount_amount, 0) = 0,
+            0,
+            (
+              GREATEST(
+                (plan_amount - COALESCE(ongoing_discount_amount, 0)),
+                0
+              ) / plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
+            )
+          )
+          -- Ongoing undiscounted annual recurring gross revenue
+          + IF(
+            auto_renew IS NOT TRUE,
+            0,
+            (
+              plan_amount / plan_interval_months * GREATEST(
+                (
+                  12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
+                ),
+                0
+              )
+            )
+          )
+        )
+        -- Remove VAT to get annual recurring net revenue.
+        / (1 + COALESCE(country_vat_rate, 0))
+        -- Apply exchange rate to get annual recurring revenue in USD.
+        * IF(plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
+      ),
+      2
+    )
+  ) AS annual_recurring_revenue_usd
 FROM
-  `moz-fx-data-shared-prod.subscription_platform_derived.service_subscriptions_v1`
+  augmented_subscriptions_3

--- a/sql/moz-fx-data-shared-prod/subscription_platform/vat_rates_history/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/vat_rates_history/view.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.subscription_platform.vat_rates_history`
+AS
+SELECT
+  country_code,
+  country AS country_name,
+  vat AS vat_rate,
+  effective_date AS valid_from,
+  COALESCE(
+    (LEAD(effective_date) OVER (PARTITION BY country_code ORDER BY effective_date) - 1),
+    '9999-12-31'
+  ) AS valid_to
+FROM
+  `moz-fx-data-shared-prod.subscription_platform_derived.vat_rates_v1`


### PR DESCRIPTION
## Description
Monthly/annual recurring revenue projections for logical subscriptions and service subscriptions were originally implemented in Looker views ([example](https://github.com/mozilla/looker-spoke-default/blob/7ba7a8ac6f32d1711058a0a2678e85ac626ce99c/subscription_platform/views/logical_subscriptions.view.lkml#L102-L348)), and this PR implements those same monthly/annual recurring revenue projections in BigQuery views so they are more generally available (not just in Looker).

This PR also adds columns for USD conversions of subscription plan amounts and discount amounts (DENG-9507), and adds `exchange_rates_history` and `vat_rates_history` views to avoid repeating the associated logic.

## Related Tickets & Documents
* DENG-9508: Implement projected monthly/annual revenue for subscriptions in BigQuery
* DENG-9507: Convert subscriptions' foreign currency amounts into USD in BigQuery

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
