### PR TITLE
feat(DENG-9538): Add column to baseline_clients_last_seen_v1

### DIFF
--- a/sql_generators/glean_usage/baseline_clients_last_seen.py
+++ b/sql_generators/glean_usage/baseline_clients_last_seen.py
@@ -10,6 +10,7 @@ USAGE_TYPES = (
     "created_profile",
     "seen_session_start",
     "seen_session_end",
+    "visited_1_uri"
 )
 
 

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.query.sql
@@ -46,6 +46,7 @@ WITH _current AS (
     CAST(browser_engagement_active_ticks > 0 AS INT64) AS days_desktop_active_bits,
     {% endif %}
     isp,
+    CAST( browser_engagement_uri_count >= 1 AS INT64) AS days_visited_1_uri_bits,
     * EXCEPT(
         submission_date, 
         isp
@@ -66,6 +67,7 @@ _previous AS (
     {% endif %}
     days_created_profile_bits,
     isp,
+    days_visited_1_uri_bits,
     * EXCEPT (
         submission_date,
         days_seen_bits,
@@ -74,8 +76,9 @@ _previous AS (
         days_desktop_active_bits,
         {% endif %}
         days_created_profile_bits,
-        isp
-      ),
+        isp,
+        days_visited_1_uri_bits
+      )
   FROM
     `{{ last_seen_table }}`
   WHERE

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.schema.yaml
@@ -181,3 +181,6 @@ fields:
     name: value
     type: RECORD
     description: Experiment Value
+- name: days_visited_1_uri_bits
+  type: INTEGER
+  description: Days Visited 1 URI Bits

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -1,6 +1,6 @@
 WITH baseline AS (
   SELECT
-    * EXCEPT (profile_group_id, experiments),
+    * EXCEPT (profile_group_id, experiments, days_visited_1_uri_bits),
     profile_group_id AS baseline_profile_group_id
   FROM
     `{{ project_id }}.{{ app_name }}.baseline_clients_last_seen`

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -1,6 +1,6 @@
 WITH baseline AS (
   SELECT
-    * EXCEPT (profile_group_id, experiments, days_visited_1_uri_bits),
+    * EXCEPT (profile_group_id, experiments),
     profile_group_id AS baseline_profile_group_id
   FROM
     `{{ project_id }}.{{ app_name }}.baseline_clients_last_seen`


### PR DESCRIPTION
## Description

* This PR adds the new column `days_visited_1_uri_bits` to the `baseline_clients_last_seen_v1` tables created by the Glean Usage SQL generator. 
* After this PR is merged, the following PR needs to be merged, to exclude the new column from the downstream tables, `clients_last_seen_joined_v1`, [PR-8051](https://github.com/mozilla/bigquery-etl/pull/8051).

Note: The column `browser_engagement_uri_count` is on many of the SQL generated `baseline_clients_last_seen_v1` tables but it is only really filled in on the desktop one, so when backfilling, will only need to backfill `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_clients_last_seen_v1`. I debated adding it only to Firefox Desktop, but I think in the future, people may want to include it on mobile tables as well, in which case, it would be good to have this field already there (we'd just have to start filling in the browser_engagement_uri_count field in mobile then).

## Related Tickets & Documents
* [DENG-9538](https://mozilla-hub.atlassian.net/browse/DENG-9538)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9538]: https://mozilla-hub.atlassian.net/browse/DENG-9538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ