### PR TITLE
feat(DENG-9538): Exclude new column from clients_last_seen_joined tables

### DIFF
--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -1,6 +1,6 @@
 WITH baseline AS (
   SELECT
-    * EXCEPT (profile_group_id, experiments),
+    * EXCEPT (profile_group_id, experiments, days_visited_1_uri_bits),
     profile_group_id AS baseline_profile_group_id
   FROM
     `{{ project_id }}.{{ app_name }}.baseline_clients_last_seen`


### PR DESCRIPTION
## Description

This PR is a follow-up related to [PR-8047](https://github.com/mozilla/bigquery-etl/pull/8047/commits), which added a new column to `baseline_clients_daily_v1` tables.  This PR excludes the new column from being included in the clients_last_seen_joined_v1 tables.

## Related Tickets & Documents
* [DENG-9538](https://mozilla-hub.atlassian.net/browse/DENG-9538)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9538]: https://mozilla-hub.atlassian.net/browse/DENG-9538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ