### PR TITLE
feat(DENG-9558): Create glean_telemetry.active_users view

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry/active_users/view.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry/active_users/view.sql
@@ -1,0 +1,38 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.glean_telemetry.active_users`
+AS
+SELECT
+  submission_date,
+  client_id,
+  sample_id,
+  app_name,
+  days_seen_bits,
+  days_active_bits,
+  is_dau,
+  is_wau,
+  is_mau,
+  is_daily_user,
+  is_weekly_user,
+  is_monthly_user,
+  is_desktop,
+  FALSE AS is_mobile
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop.baseline_active_users`
+UNION ALL
+SELECT
+  submission_date,
+  client_id,
+  sample_id,
+  app_name,
+  days_seen_bits,
+  days_active_bits,
+  is_dau,
+  is_wau,
+  is_mau,
+  is_daily_user,
+  is_weekly_user,
+  is_monthly_user,
+  FALSE AS is_desktop,
+  is_mobile
+FROM
+  `moz-fx-data-shared-prod.telemetry.mobile_active_users`

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_weekly_active_clients_staging_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_weekly_active_clients_staging_v1/query.sql
@@ -3,7 +3,7 @@ SELECT DISTINCT
   client_id,
   submission_date
 FROM
-  `moz-fx-data-shared-prod.firefox_desktop.baseline_active_users`
+  `moz-fx-data-shared-prod.glean_telemetry.active_users`
 WHERE
   submission_date = @submission_date
   AND is_dau IS TRUE


### PR DESCRIPTION
## Description

This PR does 2 things.

1. It creates the new view: `moz-fx-data-shared-prod.glean_telemetry.active_users`

2. It is also a follow-up fix to [PR-8039](https://github.com/mozilla/bigquery-etl/pull/8039), fixing the new table `moz-fx-data-shared-prod.glean_telemetry_derived.cohort_weekly_active_clients_staging_v1` so it references this view which is a combination of desktop & mobile data (equivalent to the old `telemetry.active_users`), instead of desktop data only (`firefox_desktop.baseline_active_users`).

## Related Tickets & Documents
* [DENG-9558](https://mozilla-hub.atlassian.net/browse/DENG-9558)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9558]: https://mozilla-hub.atlassian.net/browse/DENG-9558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ