### PR TITLE
feat(DENG-9558): Exclude nil client ID from active_users view

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry/active_users/view.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry/active_users/view.sql
@@ -18,6 +18,8 @@ SELECT
   FALSE AS is_mobile
 FROM
   `moz-fx-data-shared-prod.firefox_desktop.baseline_active_users`
+WHERE
+  client_id <> '00000000-0000-0000-0000-000000000000' --exclude nil client ID
 UNION ALL
 SELECT
   submission_date,
@@ -36,3 +38,5 @@ SELECT
   is_mobile
 FROM
   `moz-fx-data-shared-prod.telemetry.mobile_active_users`
+WHERE
+  client_id <> '00000000-0000-0000-0000-000000000000' --exclude nil client ID


### PR DESCRIPTION
## Description

This PR makes an update to the view logic for the new view `glean_telemetry.active_users`, excluding the nil client ID.

## Related Tickets & Documents
* [DENG-9558](https://mozilla-hub.atlassian.net/browse/DENG-9558)
* Nil Client ID info: https://datatracker.ietf.org/doc/html/rfc4122.html#section-4.1.7

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9558]: https://mozilla-hub.atlassian.net/browse/DENG-9558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ