### PR TITLE
[DENG-9520] Add * event extra to event monitoring and create backfill table

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/event_monitoring_aggregates_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/event_monitoring_aggregates_v1/backfill.yaml
@@ -1,0 +1,14 @@
+2025-09-05:
+  start_date: 2025-06-01
+  end_date: 2025-09-04
+  reason: |-
+    https://mozilla-hub.atlassian.net/browse/DENG-9520
+    Using a custom query because the regular query is too expensive.
+  watchers:
+  - bewu@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false
+  custom_query_path: sql/moz-fx-data-shared-prod/monitoring_derived/event_monitoring_aggregates_v1/backfill_deng9520.sql

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/event_monitoring_aggregates_v1/backfill_deng9520.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/event_monitoring_aggregates_v1/backfill_deng9520.sql
@@ -1,0 +1,26 @@
+SELECT
+  * REPLACE ("*" AS event_extra_key, MAX(total_events) AS total_events)
+FROM
+  `moz-fx-data-shared-prod.monitoring_derived.event_monitoring_aggregates_v1`
+WHERE
+  submission_date = @submission_date
+GROUP BY
+  submission_date,
+  window_start,
+  window_end,
+  event_category,
+  event_name,
+  event_extra_key,
+  country,
+  normalized_app_name,
+  channel,
+  version,
+  experiment,
+  experiment_branch
+UNION ALL
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.monitoring_derived.event_monitoring_aggregates_v1`
+WHERE
+  submission_date = @submission_date

--- a/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.query.sql
@@ -28,7 +28,8 @@ WITH
         -- Add one more for aggregating events across all experiments
         UNNEST(GENERATE_ARRAY(0, ARRAY_LENGTH(ping_info.experiments))) AS experiment_index
       LEFT JOIN
-        UNNEST(event.extra) AS event_extra
+        -- Add * extra to every event to get total event count
+        UNNEST(event.extra || [STRUCT<key STRING, value STRING>('*', NULL)]) AS event_extra
     ),
   {% endfor %}
   {{ dataset['bq_dataset_family'] }}_aggregated AS (

--- a/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
+++ b/sql_generators/glean_usage/templates/event_monitoring_live_v1.materialized_view.sql
@@ -29,7 +29,8 @@ IF
           -- Add one more for aggregating events across all experiments
           UNNEST(GENERATE_ARRAY(0, ARRAY_LENGTH(ping_info.experiments))) AS experiment_index
         LEFT JOIN
-          UNNEST(event.extra) AS event_extra
+          -- Add * extra to every event to get total event count
+          UNNEST(event.extra || [STRUCT<key STRING, value STRING>('*', NULL)]) AS event_extra
       ){{ "," if not loop.last }}
     {% endfor -%},
     combined AS (


### PR DESCRIPTION
## Description

Adds * extra to every event to get total event counts.  

event_monitoring_aggregates is one of the most expensive ETLs so a normal backfill isn't feasible.  The custom query derives the * rows from event_monitoring_aggregates using the most common event extra.  This isn't exact but it's a good enough approximation: https://sql.telemetry.mozilla.org/queries/110452/source where 3.1K out of 8.44M counts aren't exact matches with fenix beta.

## Related Tickets & Documents
* DENG-9520

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
