### PR TITLE
Correct field name in request_payload_suggest_v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_suggest_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/request_payload_suggest_v2/query.sql
@@ -21,7 +21,7 @@ ping_data AS (
     -- As of Firefox 141, the quick_suggest ping is sent via OHTTP and now
     -- receives geo information from the client rather than from Glean ingestion's
     -- IP geolocation. We no longer send subdivision, only country.
-    COALESCE(metadata.geo.country, metrics.string.quick_suggest_country) AS country,
+    COALESCE(metadata.geo.country, metrics.string.quick_suggest_country) AS country_code,
     metadata.geo.subdivision1 AS region_code,
     metadata.user_agent.os AS os_family,
     metadata.user_agent.version AS product_version,


### PR DESCRIPTION
## Description

Fixes a field name in `contextual_services_derived.request_payload_suggest_v2`

## Related Tickets & Documents
[Bug 1986729](https://bugzilla.mozilla.org/show_bug.cgi?id=1986729)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
