### PR TITLE
feat(monitoring): Make Bigeye freshness & volume monitoring configurable (DENG-9443)

### DIFF
--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -153,6 +153,13 @@ class ExternalDataMetadata:
 
 
 @attr.s(auto_attribs=True)
+class MonitoringMetricMetadata:
+    """Metadata for specifying observability and monitoring metric configuration."""
+
+    blocking: bool = attr.ib()
+
+
+@attr.s(auto_attribs=True)
 class MonitoringMetadata:
     """Metadata for specifying observability and monitoring configuration."""
 
@@ -160,6 +167,12 @@ class MonitoringMetadata:
     collection: Optional[str] = attr.ib(None)
     partition_column: Optional[str] = attr.ib(None)
     partition_column_set: bool = attr.ib(False)
+    freshness: Optional[MonitoringMetricMetadata] = attr.ib(
+        MonitoringMetricMetadata(blocking=False)
+    )
+    volume: Optional[MonitoringMetricMetadata] = attr.ib(
+        MonitoringMetricMetadata(blocking=True)
+    )
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
## Description
Freshness and volume metrics are currently always added when Bigeye monitoring is enabled for an ETL, with the default freshness metric being non-blocking for downstream Airflow tasks and the default volume metric being blocking for downstream Airflow tasks.

This PR allows us to specify in ETL metadata whether the freshness and volume metrics should be added, and whether those metrics should be blocking or not, with the default behavior still being to add a non-blocking freshness metric and a blocking volume metric.

## Related Tickets & Documents
* DENG-9443: Make BigQuery ETL's Bigeye freshness & volume monitoring configurable

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
