### PR TITLE
Add support for unquoted hyphenated project names in sql formatter

### DIFF
--- a/bigquery_etl/format_sql/tokenizer.py
+++ b/bigquery_etl/format_sql/tokenizer.py
@@ -706,11 +706,17 @@ class Identifier(Token):
     pattern = re.compile(r"[A-Za-z_][A-Za-z_0-9]*|`(?:\\.|[^\\`])+`")
 
 
+class ProjectIdentifier(Identifier):
+    """Identifier for a GCP project, can contain hyphens unlike Identifier."""
+
+    pattern = re.compile(r"[A-Za-z](?:[A-Za-z_0-9-]*[A-Za-z_0-9])?|`(?:\\.|[^\\`])+`")
+
+
 class QualifiedIdentifier(Identifier):
     """Fully or partially qualified identifier for a column, table, or other database object."""
 
     pattern = re.compile(
-        rf"(?:(?:{Identifier.pattern.pattern})\.)+(?:{Identifier.pattern.pattern})"
+        rf"(?:(?:{ProjectIdentifier.pattern.pattern}\.)?(?:{Identifier.pattern.pattern})\.)+(?:{Identifier.pattern.pattern})"
     )
 
 

--- a/tests/format_sql/qualified_table_name/expect.sql
+++ b/tests/format_sql/qualified_table_name/expect.sql
@@ -1,0 +1,8 @@
+SELECT
+  a,
+  b,
+  c
+FROM
+  moz-fx-data-shared-prod.telemetry.main
+CROSS JOIN
+  telemetry.main

--- a/tests/format_sql/qualified_table_name/input.sql
+++ b/tests/format_sql/qualified_table_name/input.sql
@@ -1,0 +1,1 @@
+SELECT a, b, c FROM moz-fx-data-shared-prod.telemetry.main CROSS JOIN telemetry.main


### PR DESCRIPTION
## Description

This allows the sql formatter to handle things like `moz-fx-data-shared.telemetry.main` without turning it into `moz - fx - data - shared.telemetry.main` 

This might make https://github.com/mozilla/bigquery-etl/issues/6655 easier to deal with

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
