### PR TITLE
fix(monitoring): Remove SubPlat ETLs' Bigeye freshness and volume metrics (DENG-9400)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_logical_subscriptions_history_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_logical_subscriptions_history_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.apple_logical_subscriptions_history_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_logical_subscriptions_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_logical_subscriptions_history_v1/metadata.yaml
@@ -27,3 +27,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_changelog_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_changelog_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.apple_subscriptions_changelog_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_changelog_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_changelog_v1/metadata.yaml
@@ -28,3 +28,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.apple_subscriptions_history_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/metadata.yaml
@@ -31,3 +31,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_revised_changelog_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_revised_changelog_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.apple_subscriptions_revised_changelog_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_revised_changelog_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_revised_changelog_v1/metadata.yaml
@@ -28,3 +28,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_logical_subscriptions_history_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_logical_subscriptions_history_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.google_logical_subscriptions_history_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_logical_subscriptions_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_logical_subscriptions_history_v1/metadata.yaml
@@ -24,3 +24,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_changelog_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_changelog_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.google_subscriptions_changelog_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_changelog_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_changelog_v1/metadata.yaml
@@ -28,3 +28,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_history_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_history_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.google_subscriptions_history_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_history_v1/metadata.yaml
@@ -28,3 +28,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_revised_changelog_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_revised_changelog_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.google_subscriptions_revised_changelog_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_revised_changelog_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_revised_changelog_v1/metadata.yaml
@@ -28,3 +28,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_history_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_history_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.stripe_customers_history_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_history_v1/metadata.yaml
@@ -28,3 +28,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_revised_changelog_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_revised_changelog_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.stripe_customers_revised_changelog_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_revised_changelog_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_revised_changelog_v1/metadata.yaml
@@ -28,3 +28,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.stripe_logical_subscriptions_attribution_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: subscription_id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v1/metadata.yaml
@@ -27,3 +27,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.stripe_logical_subscriptions_attribution_v2
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: subscription_id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/metadata.yaml
@@ -21,3 +21,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.stripe_service_subscriptions_attribution_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: subscription_id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v1/metadata.yaml
@@ -27,3 +27,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.stripe_service_subscriptions_attribution_v2
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: subscription_id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/metadata.yaml
@@ -21,3 +21,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_history_v2
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/metadata.yaml
@@ -31,3 +31,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/bigconfig.yml
@@ -7,9 +7,6 @@ table_deployments:
     - email: 'phlee@mozilla.com, srose@mozilla.com'
   deployments:
   - fq_table_name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_revised_changelog_v1
-    table_metrics:
-    - saved_metric_id: freshness
-    - saved_metric_id: volume
     columns:
     - column_name: id
       metrics:

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/metadata.yaml
@@ -30,3 +30,5 @@ references: {}
 require_column_descriptions: true
 monitoring:
   enabled: true
+  freshness: null
+  volume: null


### PR DESCRIPTION
## Description
When the SubPlat ETLs' `bqetl` checks were migrated to Bigeye monitoring (#7962) the `bqetl monitoring update` logic forced the tables to also have freshness and volume metrics, which have been problematic (despite three weeks of diligently trying to train the metrics about the normal freshness/volume levels they continue to regularly produce false positive alerts).

Now, thanks to #8067, this PR is removing those freshness and volume metrics from the SubPlat ETLs, saving @phil-lee70 and myself the headache of getting those false positive freshness/volume alerts.

## Related Tickets & Documents
* DENG-9400: Migrate SubPlat `checks.sql` to Bigeye
* DENG-9443: Make BigQuery ETL's Bigeye freshness & volume monitoring configurable

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
