### PR TITLE
Update schema in events stream script if needed

### DIFF
--- a/sql_generators/glean_usage/templates/events_stream_v1.query.py
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.py
@@ -64,7 +64,7 @@ def main(submission_date, billing_project, destination_table, temp_dataset, slic
             query=query,
             job_config=bigquery.QueryJobConfig(
                 destination=temp_table,
-                write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+                write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
                 query_parameters=[
                     bigquery.ScalarQueryParameter(
                         "min_sample_id", "INT64", min_sample_id
@@ -76,6 +76,7 @@ def main(submission_date, billing_project, destination_table, temp_dataset, slic
                         "submission_date", "DATE", submission_date.date()
                     ),
                 ],
+                schema_update_options=bigquery.SchemaUpdateOption.ALLOW_FIELD_ADDITION,
             ),
         )
         logging.info(


### PR DESCRIPTION
## Description

Desktop and background update [failing](https://workflow.telemetry.mozilla.org/dags/bqetl_glean_usage/grid?dag_run_id=scheduled__2025-09-07T02%3A00%3A00%2B00%3A00&task_id=firefox_desktop_background_update.firefox_desktop_background_update_derived__events_stream__v1&tab=logs) because https://github.com/mozilla/bigquery-etl/pull/8066 added columns. This script uses a copy job which doesn't support `schema_update_options` so they can't add the columns like the regular queries.  I already manually updated the desktop schema because it has downstream things.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
