### PR TITLE
[DENG-9604] Add circleci job number to stage dataset suffix

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -648,7 +648,7 @@ jobs:
                     PATHS="$(git diff --no-index --name-only --diff-filter=d generated-sql/sql sql)" || true
                     echo $PATHS
                     PATH="venv/bin:$PATH" script/bqetl stage deploy \
-                      --dataset-suffix="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}" \
+                      --dataset-suffix="${CIRCLE_SHA1}_${CIRCLE_WORKFLOW_ID:0:8}" \
                       --remove-updated-artifacts \
                       $PATHS
                   fi
@@ -1057,7 +1057,7 @@ jobs:
             - run:
                 name: "Delete stage datasets"
                 command: |
-                  PATH="venv/bin:$PATH" script/bqetl stage clean --dataset-suffix="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}" --delete-expired
+                  PATH="venv/bin:$PATH" script/bqetl stage clean --dataset-suffix="${CIRCLE_SHA1}_${CIRCLE_WORKFLOW_ID:0:8}" --delete-expired
       - unless:
           condition: *validate-sql-or-routines
           steps:

--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/firefox_ios_clients_v1/query.sql
@@ -22,7 +22,7 @@
   first_session_ping_base AS (
     SELECT
       client_info.client_id,
-      sample_id AS sample_id,
+      sample_id,
       submission_timestamp,
       NULLIF(metrics.string.adjust_ad_group, "") AS adjust_ad_group,
       NULLIF(metrics.string.adjust_campaign, "") AS adjust_campaign,


### PR DESCRIPTION
## Description

Fixes an issue where multiple CI runs can use the same datasets because they come from the same commit, usually because of a private-bq-etl change, which can cause failure when on reaches `reset-stage-env` before the other.

## Related Tickets & Documents
* DENG-9460
* 
**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
