### PR TITLE
Grant DS team access to stub_attribution_service_derived tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/dataset_metadata.yaml
@@ -9,3 +9,4 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:data-science/duet
+  - workgroup:data-science/developers


### PR DESCRIPTION
## Description

This PR grants the full DS team read access to the dataset `stub_attribution_service_derived`, instead of to a subset of the DS team only. This is needed to enable their ability to query views that use this table as a join key between telemetry data and GA4 data.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
