### PR TITLE
Bug 1987722 - Update bigeye_derived schemas

### DIFF
--- a/sql/moz-fx-data-shared-prod/bigeye_derived/issue_service_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/bigeye_derived/issue_service_v1/schema.yaml
@@ -425,3 +425,15 @@ fields:
   name: metric_configuration_muted_until_epoch_seconds
   type: FLOAT
   description: Metric Configuration Muted Until Epoch Seconds
+- mode: NULLABLE
+  name: dimension_id
+  type: FLOAT
+  description: Dimension ID
+- mode: NULLABLE
+  name: metric_configuration_dimension_id
+  type: FLOAT
+  description: Metric Configuration Dimension ID
+- mode: NULLABLE
+  name: metric_configuration_dimension_display_name
+  type: STRING
+  description: Metric Configuration Dimension Display Name

--- a/sql/moz-fx-data-shared-prod/bigeye_derived/metric_service_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/bigeye_derived/metric_service_v1/schema.yaml
@@ -541,3 +541,11 @@ fields:
   mode: NULLABLE
   name: refreshed_at
   type: TIMESTAMP
+- mode: NULLABLE
+  name: metric_configuration_dimension_id
+  type: FLOAT
+  description: Metric Configuration Dimension ID
+- mode: NULLABLE
+  name: metric_configuration_dimension_display_name
+  type: STRING
+  description: Metric Configuration Dimension Display Name


### PR DESCRIPTION
## Description

These are the new columns I found with:

```python
from pathlib import Path

from bigquery_etl.schema import Schema

prod = Schema.for_table("moz-fx-data-shared-prod", "bigeye_derived", "metric_service_v1")
local = Schema.from_schema_file(Path("sql/moz-fx-data-shared-prod/bigeye_derived/metric_service_v1/schema.yaml"))

prod.compatible(local)
```

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1987722

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
