### PR TITLE
fix(events_stream): Avoid mixing up experiment `type` and `enrollment_id` data (DENG-9632)

### DIFF
--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -23,21 +23,6 @@ RETURNS json AS (
   )
 );
 
--- convert array of key value pairs to a json object
--- values are nested structs and will be converted to json objects
-CREATE TEMP FUNCTION from_map_experiment(
-  input ARRAY<
-    STRUCT<key STRING, value STRUCT<branch STRING, extra STRUCT<type STRING, enrollment_id STRING>>>
-  >
-)
-RETURNS json AS (
-  IF(
-    ARRAY_LENGTH(input) = 0,
-    NULL,
-    JSON_OBJECT(ARRAY(SELECT key FROM UNNEST(input)), ARRAY(SELECT value FROM UNNEST(input)))
-  )
-);
-
 CREATE TEMP FUNCTION metrics_to_json(metrics JSON)
 RETURNS JSON AS (
   JSON_STRIP_NULLS(
@@ -101,7 +86,20 @@ WITH base AS (
     ),
     client_info.client_id AS client_id,
     ping_info.reason AS reason,
-    from_map_experiment(ping_info.experiments) AS experiments,
+    IF(
+      ARRAY_LENGTH(ping_info.experiments) > 0,
+      (
+        SELECT
+          JSON_OBJECT(
+            ARRAY_AGG(experiment.key ORDER BY experiment_offset),
+            ARRAY_AGG(experiment.value ORDER BY experiment_offset)
+          )
+        FROM
+          UNNEST(ping_info.experiments) AS experiment
+          WITH OFFSET AS experiment_offset
+      ),
+      NULL
+    ) AS experiments,
     {% if has_profile_group_id %}
       metrics.uuid.legacy_telemetry_profile_group_id AS profile_group_id,
     {% else %}


### PR DESCRIPTION
## Description
Currently it appears 56 apps have event pings where the `ping_info.experiments[].value.extra` field is of type `STRUCT<type STRING, enrollment_id STRING>`, while 31 apps have event pings where the `ping_info.experiments[].value.extra` field is of type `STRUCT<enrollment_id STRING, type STRING>`, and for the latter cases the current events stream ETL logic is unfortunately reversing the experiment `type` and `enrollment_id` values (DENG-9632).

This PR fixes the events stream ETL so both flavors of event ping experiments schema are handled properly.

## Related Tickets & Documents
* DENG-9632: Events stream ETL can mix up experiment type and enrollment ID data

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
