### PR TITLE
fix(mdn): use metadata.geo.country as navigator_geo_iso

### DIFF
--- a/sql/moz-fx-data-shared-prod/mdn/legacy_action/view.sql
+++ b/sql/moz-fx-data-shared-prod/mdn/legacy_action/view.sql
@@ -85,13 +85,13 @@ CREATE OR REPLACE VIEW
           JSON_VALUE(event_extra.referrer) AS page_referrer
         ) AS url2,
         STRUCT(
-          metadata.geo.country AS navigator_geo,
+          CAST(NULL AS STRING) AS navigator_geo,
           CAST(NULL AS STRING) AS navigator_subscription_type,
           CAST(NULL AS STRING) AS navigator_user_agent,
           CAST(NULL AS STRING) AS navigator_viewport_breakpoint,
           CAST(NULL AS STRING) AS page_http_status,
           CAST(NULL AS STRING) AS page_is_baseline,
-          CAST(NULL AS STRING) AS navigator_geo_iso,
+          metadata.geo.country AS navigator_geo_iso,
           CAST(NULL AS STRING) AS glean_client_annotation_experimentation_id
         ) AS `string`,
         STRUCT(

--- a/sql/moz-fx-data-shared-prod/mdn/legacy_page/view.sql
+++ b/sql/moz-fx-data-shared-prod/mdn/legacy_page/view.sql
@@ -60,13 +60,13 @@ CREATE OR REPLACE VIEW
           JSON_VALUE(event_extra.referrer) AS page_referrer
         ) AS url2,
         STRUCT(
-          metadata.geo.country AS navigator_geo,
+          CAST(NULL AS STRING) AS navigator_geo,
           CAST(NULL AS STRING) AS navigator_subscription_type,
           CAST(NULL AS STRING) AS navigator_user_agent,
           CAST(NULL AS STRING) AS navigator_viewport_breakpoint,
           CAST(NULL AS STRING) AS page_http_status,
           CAST(NULL AS STRING) AS page_is_baseline,
-          CAST(NULL AS STRING) AS navigator_geo_iso,
+          metadata.geo.country AS navigator_geo_iso,
           CAST(NULL AS STRING) AS glean_client_annotation_experimentation_id
         ) AS `string`,
         STRUCT(


### PR DESCRIPTION
## Description

Fixes a small bug in the MDN legacy views: In Glean, `metadata.geo.country` is the ISO code, not the country name, so we need to map it to `navigator_geo_iso`.

## Related Tickets & Documents
* Follow-up of https://github.com/mozilla/bigquery-etl/pull/8054.
* Noticed while working on https://github.com/mdn/fred/issues/713.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
