### PR TITLE
Deprecate legacy pocket tables and view

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/spoc_tile_ids/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket/spoc_tile_ids/metadata.yaml
@@ -7,3 +7,4 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:pocket/prefect
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket/spoc_tile_ids/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/spoc_tile_ids/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.spoc_tile_ids`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.spoc_tile_ids_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_history_v1/metadata.yaml
@@ -12,8 +12,4 @@ bigquery:
     type: day
     field: submission_date
     require_partition_filter: false
-scheduling:
-  dag_name: bqetl_pocket
-  arguments: ["--date", "{{ ds }}"]
-  referenced_tables: []
 deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/spoc_tile_ids_v1/metadata.yaml
@@ -7,11 +7,8 @@ labels:
   incremental: false
   table_type: tile_id
   shredder_mitigation: false
-scheduling:
-  dag_name: bqetl_pocket
-  date_partition_parameter: null
-  parameters: ["submission_date:DATE:{{ds}}"]
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:pocket/prefect
+deprecated: true


### PR DESCRIPTION
## Description
Deprecate legacy tables with pocket data without recent usage.

## Related Tickets & Documents
* [AD-1094](https://mozilla-hub.atlassian.net/browse/AD-1094)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[AD-1094]: https://mozilla-hub.atlassian.net/browse/AD-1094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ