### PR TITLE
fix(events_stream): Ensure unnested event extra map values are always matched with the appropriate key (DENG-9633)

### DIFF
--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -5,20 +5,25 @@ RETURNS json AS (
   IF(
     ARRAY_LENGTH(input) = 0,
     NULL,
-    JSON_OBJECT(
-      ARRAY(SELECT key FROM UNNEST(input)),
-      ARRAY(
-        SELECT
-          CASE
-            WHEN SAFE_CAST(value AS NUMERIC) IS NOT NULL
-              THEN TO_JSON(SAFE_CAST(value AS NUMERIC))
-            WHEN SAFE_CAST(value AS BOOL) IS NOT NULL
-              THEN TO_JSON(SAFE_CAST(value AS BOOL))
-            ELSE TO_JSON(value)
-          END
-        FROM
-          UNNEST(input)
-      )
+    (
+      SELECT
+        JSON_OBJECT(
+          ARRAY_AGG(key ORDER BY offset),
+          ARRAY_AGG(
+            CASE
+              WHEN SAFE_CAST(value AS NUMERIC) IS NOT NULL
+                THEN TO_JSON(SAFE_CAST(value AS NUMERIC))
+              WHEN SAFE_CAST(value AS BOOL) IS NOT NULL
+                THEN TO_JSON(SAFE_CAST(value AS BOOL))
+              ELSE TO_JSON(value)
+            END
+            ORDER BY
+              offset
+          )
+        )
+      FROM
+        UNNEST(input)
+        WITH OFFSET
     )
   )
 );


### PR DESCRIPTION
## Description
Per the [BigQuery docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#unnest_operator) "`UNNEST` destroys the order of elements in the input array", but some `events_stream_v1` ETL code is relying on multiple `UNNEST`s returning elements in the exact same order, and if it doesn’t do that then the keys and values from the maps-as-arrays being unnested could get mismatched.

## Related Tickets & Documents
* DENG-9633: Events stream ETL might mismatch keys and values from unnested maps stored as arrays

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
