### PR TITLE
fix(events_stream): Initiate backfills of two `events_stream_v1` tables that were affected by a bug (DENG-9632)

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_background_defaultagent_derived/events_stream_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_background_defaultagent_derived/events_stream_v1/backfill.yaml
@@ -10,3 +10,5 @@
   override_retention_limit: false
   override_depends_on_past_end_date: false
   ignore_date_partition_offset: false
+  # Using on-demand billing is cheaper for this ETL.
+  billing_project: moz-fx-data-backfill-2

--- a/sql/moz-fx-data-shared-prod/thunderbird_desktop_derived/events_stream_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/thunderbird_desktop_derived/events_stream_v1/backfill.yaml
@@ -10,3 +10,5 @@
   override_retention_limit: false
   override_depends_on_past_end_date: false
   ignore_date_partition_offset: false
+  # Using on-demand billing is cheaper for this ETL.
+  billing_project: moz-fx-data-backfill-2


### PR DESCRIPTION
## Description
Of the [31 apps potentially affected by the bug](https://mozilla-hub.atlassian.net/browse/DENG-9632?focusedCommentId=1134954), it turns out only `firefox_desktop_background_defaultagent` and `thunderbird_desktop` have had recent events with experiments data.

## Related Tickets & Documents
* DENG-9632: Events stream ETL can mix up experiment type and enrollment ID data
* https://github.com/mozilla/bigquery-etl/pull/8084

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
