### PR TITLE
chore(requirements): Remove `gcloud` package which is no longer necessary

### DIFF
--- a/bigquery_etl/backfill/shredder_mitigation.py
+++ b/bigquery_etl/backfill/shredder_mitigation.py
@@ -14,8 +14,8 @@ from typing import Any, Optional, Tuple
 import attrs
 import click
 from dateutil import parser
-from gcloud.exceptions import NotFound  # type: ignore
 from google.cloud import bigquery
+from google.cloud.exceptions import NotFound  # type: ignore
 from jinja2 import Environment, FileSystemLoader
 
 from bigquery_etl.format_sql.formatter import reformat

--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,6 @@ exceptiongroup==1.3.0 # for backwards compatibility with python < 3.11
 flake8<5 # pytest-flake8 does not support flake8 5+
 fredapi==0.5.2
 gcsfs==2025.3.2
-gcloud==0.18.3
 gitpython==3.1.45
 google-auth>=2.30.0  # To try to fix "Compute Engine Metadata server call to universe/universe_domain returned 404" errors.
 google-cloud-bigquery==3.35.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -575,9 +575,6 @@ fsspec==2025.3.2 \
     --hash=sha256:2daf8dc3d1dfa65b6aa37748d112773a7a08416f6c70d96b264c96476ecaf711 \
     --hash=sha256:e52c77ef398680bbd6a98c0e628fbc469491282981209907bbc8aea76a04fdc6
     # via gcsfs
-gcloud==0.18.3 \
-    --hash=sha256:0af2dec59fce20561752f86e42d981c6a255e306a6c5e5d1fa3d358a8857e4fb
-    # via -r requirements.in
 gcsfs==2025.3.2 \
     --hash=sha256:1bdecb530fbf3604a31f00f858a208e0770baf24d405a0b9df99fdde35737745 \
     --hash=sha256:fe300179492e63e309fecb11e4de7c15a51172eefa2b846d4b3659960216bba8
@@ -733,7 +730,6 @@ googleapis-common-protos==1.58.0 \
     --hash=sha256:c727251ec025947d545184ba17e3578840fc3a24a0516a020479edab660457df \
     --hash=sha256:ca3befcd4580dab6ad49356b46bf165bb68ff4b32389f028f1abd7c10ab9519a
     # via
-    #   gcloud
     #   google-api-core
     #   grpcio-status
 grpcio==1.54.3 \
@@ -802,12 +798,6 @@ hpack==4.1.0 \
     --hash=sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496 \
     --hash=sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca
     # via h2
-httplib2==0.21.0 \
-    --hash=sha256:987c8bb3eb82d3fa60c68699510a692aa2ad9c4bd4f123e51dfb1488c14cdd01 \
-    --hash=sha256:fc144f091c7286b82bec71bdbd9b27323ba709cc612568d3000893bfd9cb4b34
-    # via
-    #   gcloud
-    #   oauth2client
 hyperframe==6.1.0 \
     --hash=sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5 \
     --hash=sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08
@@ -1222,10 +1212,6 @@ numpy==1.24.2 \
     --hash=sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780 \
     --hash=sha256:f9006288bcf4895917d02583cf3411f98631275bc67cce355a7f39f8c14338fa
     # via pandas
-oauth2client==4.1.3 \
-    --hash=sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac \
-    --hash=sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6
-    # via gcloud
 oauthlib==3.2.2 \
     --hash=sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca \
     --hash=sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918
@@ -1457,7 +1443,6 @@ protobuf==4.21.12 \
     --hash=sha256:f45460f9ee70a0ec1b6694c6e4e348ad2019275680bd68a1d9314b8c7e01e574
     # via
     #   betterproto
-    #   gcloud
     #   google-api-core
     #   google-cloud-bigquery-storage
     #   google-cloud-datacatalog-lineage
@@ -1525,15 +1510,12 @@ pyasn1==0.4.8 \
     --hash=sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d \
     --hash=sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba
     # via
-    #   oauth2client
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.2.8 \
     --hash=sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e \
     --hash=sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74
-    # via
-    #   google-auth
-    #   oauth2client
+    # via google-auth
 pycodestyle==2.8.0 \
     --hash=sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20 \
     --hash=sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f
@@ -1713,10 +1695,6 @@ pynacl==1.5.0 \
     --hash=sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b \
     --hash=sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543
     # via paramiko
-pyparsing==3.0.9 \
-    --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
-    --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
-    # via httplib2
 pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5
@@ -2096,9 +2074,7 @@ rpds-py==0.8.10 \
 rsa==4.9 \
     --hash=sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7 \
     --hash=sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21
-    # via
-    #   google-auth
-    #   oauth2client
+    # via google-auth
 ruamel-yaml==0.18.6 \
     --hash=sha256:57b53ba33def16c4f3d807c0ccbc00f8a6081827e81ba2491691b76882d0c636 \
     --hash=sha256:8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b
@@ -2176,10 +2152,7 @@ siggen==2.2.20241029 \
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-    # via
-    #   gcloud
-    #   oauth2client
-    #   python-dateutil
+    # via python-dateutil
 slack-sdk==3.32.0 \
     --hash=sha256:af8fc4ef1d1cbcecd28d01acf6955a3bb5b13d56f0a43a1b1c7e3b212cc5ec5b \
     --hash=sha256:f35e85f2847e6c25cf7c2d1df206ca0ad75556263fb592457bf03cca68ef64bb

--- a/tests/backfill/test_shredder_mitigation.py
+++ b/tests/backfill/test_shredder_mitigation.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 from click.exceptions import ClickException
 from click.testing import CliRunner
-from gcloud import bigquery  # type: ignore
+from google.cloud import bigquery  # type: ignore
 
 from bigquery_etl.backfill.shredder_mitigation import (
     PREVIOUS_DATE,
@@ -57,21 +57,21 @@ class TestClassifyColumns:
             "os_build",
         ]
         existing_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("app_name", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE", None, None),
-            bigquery.SchemaField("os", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("app_name", "STRING", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE"),
+            bigquery.SchemaField("os", "STRING", "NULLABLE"),
+            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE"),
         ]
         new_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("app_name", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE", None, None),
-            bigquery.SchemaField("os_build", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("app_name", "STRING", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE"),
+            bigquery.SchemaField("os_build", "STRING", "NULLABLE"),
+            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE"),
+            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE"),
         ]
 
         expected_common_dimensions = [
@@ -164,21 +164,19 @@ class TestClassifyColumns:
             "is_default_browser",
         ]
         existing_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE"),
+            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE"),
+            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE"),
         ]
         new_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE", None, None),
-            bigquery.SchemaField(
-                "is_default_browser", "BOOLEAN", "NULLABLE", None, None
-            ),
-            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE"),
+            bigquery.SchemaField("is_default_browser", "BOOLEAN", "NULLABLE"),
+            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE"),
+            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE"),
         ]
 
         expected_common_dimensions = [
@@ -257,23 +255,19 @@ class TestClassifyColumns:
         ]
         new_columns = ["submission_date", "channel", "is_default_browser"]
         existing_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE", None, None),
-            bigquery.SchemaField(
-                "is_default_browser", "BOOLEAN", "NULLABLE", None, None
-            ),
-            bigquery.SchemaField("metric_integer", "INTEGER", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE"),
+            bigquery.SchemaField("is_default_browser", "BOOLEAN", "NULLABLE"),
+            bigquery.SchemaField("metric_integer", "INTEGER", "NULLABLE"),
+            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE"),
         ]
         new_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField(
-                "is_default_browser", "BOOLEAN", "NULLABLE", None, None
-            ),
-            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("is_default_browser", "BOOLEAN", "NULLABLE"),
+            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE"),
+            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE"),
         ]
 
         expected_common_dimensions = [
@@ -361,26 +355,22 @@ class TestClassifyColumns:
             "segment",
         ]
         existing_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE", None, None),
-            bigquery.SchemaField(
-                "is_default_browser", "BOOLEAN", "NULLABLE", None, None
-            ),
-            bigquery.SchemaField("metric_integer", "INTEGER", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("first_seen_year", "INT", "NULLABLE"),
+            bigquery.SchemaField("is_default_browser", "BOOLEAN", "NULLABLE"),
+            bigquery.SchemaField("metric_integer", "INTEGER", "NULLABLE"),
+            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE"),
         ]
         new_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField(
-                "is_default_browser", "BOOLEAN", "NULLABLE", None, None
-            ),
-            bigquery.SchemaField("os_version", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("os_version_build", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("segment", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("is_default_browser", "BOOLEAN", "NULLABLE"),
+            bigquery.SchemaField("os_version", "STRING", "NULLABLE"),
+            bigquery.SchemaField("os_version_build", "STRING", "NULLABLE"),
+            bigquery.SchemaField("segment", "STRING", "NULLABLE"),
+            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE"),
+            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE"),
         ]
 
         expected_common_dimensions = [
@@ -467,18 +457,18 @@ class TestClassifyColumns:
         existing_columns = ["submission_date", "channel"]
         new_columns = ["submission_date", "channel"]
         existing_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_bigint", "INTEGER", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE"),
+            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE"),
+            bigquery.SchemaField("metric_bigint", "INTEGER", "NULLABLE"),
         ]
         new_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_bigint", "INTEGER", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE"),
+            bigquery.SchemaField("metric_numeric", "NUMERIC", "NULLABLE"),
+            bigquery.SchemaField("metric_bigint", "INTEGER", "NULLABLE"),
         ]
 
         expected_common_dimensions = [
@@ -543,18 +533,16 @@ class TestClassifyColumns:
         existing_columns = ["submission_date", "channel"]
         new_columns = ["submission_date", "channel", "os", "is_default_browser"]
         existing_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE"),
         ]
         new_schema = [
-            bigquery.SchemaField("submission_date", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("channel", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField("os", "STRING", "NULLABLE", None, None),
-            bigquery.SchemaField(
-                "is_default_browser", "BOOLEAN", "NULLABLE", None, None
-            ),
-            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE", None, None),
+            bigquery.SchemaField("submission_date", "DATE", "NULLABLE"),
+            bigquery.SchemaField("channel", "STRING", "NULLABLE"),
+            bigquery.SchemaField("os", "STRING", "NULLABLE"),
+            bigquery.SchemaField("is_default_browser", "BOOLEAN", "NULLABLE"),
+            bigquery.SchemaField("metric_float", "FLOAT", "NULLABLE"),
         ]
         expected_exception_text = (
             "Existing dimensions don't match columns retrieved by query."
@@ -589,12 +577,10 @@ class TestClassifyColumns:
 
         new_row = {"column_1": "2024-01-01", "column_2": "Windows"}
         existing_columns = ["column_1"]
-        existing_schema = [
-            bigquery.SchemaField("column1", "DATE", "NULLABLE", None, None)
-        ]
+        existing_schema = [bigquery.SchemaField("column1", "DATE", "NULLABLE")]
         new_schema = [
-            bigquery.SchemaField("column1", "DATE", "NULLABLE", None, None),
-            bigquery.SchemaField("column2", "STRING", "NULLABLE", None, None),
+            bigquery.SchemaField("column1", "DATE", "NULLABLE"),
+            bigquery.SchemaField("column2", "STRING", "NULLABLE"),
         ]
         expected_exception_text = (
             f"\n\nMissing one or more required parameters. Received:\nnew_row= {new_row}\n"
@@ -650,9 +636,9 @@ class TestValidateTypes:
 
     columns = ["column1", "column2", "column3"]
     schema = [
-        bigquery.SchemaField("column1", "STRING", "NULLABLE", None, None),
-        bigquery.SchemaField("column2", "STRING", "NULLABLE", None, None),
-        bigquery.SchemaField("column3", "NUMERIC", "NULLABLE", None, None),
+        bigquery.SchemaField("column1", "STRING", "NULLABLE"),
+        bigquery.SchemaField("column2", "STRING", "NULLABLE"),
+        bigquery.SchemaField("column3", "NUMERIC", "NULLABLE"),
     ]
 
     def test_validate_types_match(self):
@@ -681,8 +667,8 @@ class TestValidateTypes:
         """Test function get_bigquery_type when columns are not found in schema file."""
         names = ["column1", "column2", "column_not_in_schema"]
         schema = [
-            bigquery.SchemaField("column1", "STRING", "NULLABLE", None),
-            bigquery.SchemaField("column2", "STRING", "NULLABLE", None),
+            bigquery.SchemaField("column1", "STRING", "NULLABLE"),
+            bigquery.SchemaField("column2", "STRING", "NULLABLE"),
         ]
         sample_row = {
             "column1": "abcd",


### PR DESCRIPTION
## Description
In 2016 the [gcloud](https://pypi.org/project/gcloud/) package was replaced with the [google-cloud](https://pypi.org/project/google-cloud/) package, which in turn was deprecated in 2018, with its docs now saying "_Please install the [product-specific google-cloud-* packages](https://github.com/GoogleCloudPlatform/google-cloud-python#google-cloud-python-client) needed for your application._"

So the [various `google-cloud-*` packages we install](https://github.com/mozilla/bigquery-etl/blob/2967d80e844e7dfbc510439ad383af751f7d8e4a/requirements.in#L16-L19) should be sufficient for our needs.

## Related Tickets & Documents
N/A

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
