### PR TITLE
Parallelize dependency record, metadata update, monitoring update (generate-sql CI task)

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1052,6 +1052,7 @@ jobs:
           steps:
             - *skip_forked_pr
             - checkout
+            - *restore_venv_cache
             - *build
             - *authenticate
             - run:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -602,7 +602,7 @@ jobs:
                     cp -a sql/. /tmp/workspace/generated-sql/sql
                   fi
 
-                  PATH="venv/bin:$PATH" script/bqetl format /tmp/workspace/generated-sql/sql/ -p 32
+                  PATH="venv/bin:$PATH" script/bqetl format /tmp/workspace/generated-sql/sql/
                   PATH="venv/bin:$PATH" script/bqetl dependency record \
                     --skip-existing \
                     "/tmp/workspace/generated-sql/sql/"

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -602,7 +602,7 @@ jobs:
                     cp -a sql/. /tmp/workspace/generated-sql/sql
                   fi
 
-                  PATH="venv/bin:$PATH" script/bqetl format /tmp/workspace/generated-sql/sql/
+                  PATH="venv/bin:$PATH" script/bqetl format /tmp/workspace/generated-sql/sql/ -p 32
                   PATH="venv/bin:$PATH" script/bqetl dependency record \
                     --skip-existing \
                     "/tmp/workspace/generated-sql/sql/"

--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -75,7 +75,7 @@ def update(
     )
 
     # group table metadata files by dataset
-    datasets = {}
+    datasets: dict[Path, list[Path]] = {}
     for table_metadata_file in table_metadata_files:
         dataset_path = Path(table_metadata_file).parent.parent
         if dataset_path not in datasets:

--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -151,7 +151,7 @@ def _update_single_metadata_file(retained_dataset_roles, table_metadata_file):
                     dataset_metadata.workgroup_access.append(
                         {
                             "role": "roles/bigquery.metadataViewer",
-                            "members": data_viewer.get("members", []),
+                            "members": sorted(data_viewer.get("members", [])),
                         }
                     )
         else:
@@ -179,7 +179,7 @@ def _update_single_metadata_file(retained_dataset_roles, table_metadata_file):
                     table_metadata.workgroup_access.append(
                         WorkgroupAccessMetadata(
                             role=default_workgroup_access["role"],
-                            members=default_workgroup_access.get("members", []),
+                            members=sorted(default_workgroup_access.get("members", [])),
                         )
                     )
                     table_metadata_updated = True

--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -66,8 +66,12 @@ def update(
     name: str, sql_dir: Optional[str], project_id: Optional[str], parallelism: int
 ) -> None:
     """Update metadata yaml file."""
-    table_metadata_files = paths_matching_name_pattern(
-        name, sql_dir, project_id=project_id, files=["metadata.yaml"]
+    table_metadata_files = list(
+        set(
+            paths_matching_name_pattern(
+                name, sql_dir, project_id=project_id, files=["metadata.yaml"]
+            )
+        )
     )
     retained_dataset_roles = ConfigLoader.get(
         "deprecation", "retain_dataset_roles", fallback=[]
@@ -212,8 +216,12 @@ def publish(
     name: str, sql_dir: Optional[str], project_id: Optional[str], parallelism: int
 ) -> None:
     """Publish Bigquery metadata."""
-    table_metadata_files = paths_matching_name_pattern(
-        name, sql_dir, project_id=project_id, files=["metadata.yaml"]
+    table_metadata_files = list(
+        set(
+            paths_matching_name_pattern(
+                name, sql_dir, project_id=project_id, files=["metadata.yaml"]
+            )
+        )
     )
 
     if parallelism > 0:
@@ -272,8 +280,12 @@ def deprecate(
     deletion_date: datetime,
 ) -> None:
     """Deprecate Bigquery table by updating metadata yaml file(s)."""
-    table_metadata_files = paths_matching_name_pattern(
-        name, sql_dir, project_id=project_id, files=["metadata.yaml"]
+    table_metadata_files = list(
+        set(
+            paths_matching_name_pattern(
+                name, sql_dir, project_id=project_id, files=["metadata.yaml"]
+            )
+        )
     )
 
     for metadata_file in table_metadata_files:
@@ -310,8 +322,12 @@ def validate_workgroups(
     """Validate workgroup_access and default_table_workgroup_access configuration."""
     failed_files = set()
 
-    table_metadata_files = paths_matching_name_pattern(
-        name, sql_dir, project_id=project_id, files=["metadata.yaml"]
+    table_metadata_files = list(
+        set(
+            paths_matching_name_pattern(
+                name, sql_dir, project_id=project_id, files=["metadata.yaml"]
+            )
+        )
     )
     skip_validation = ConfigLoader.get("metadata", "validation", "skip", fallback=[])
 

--- a/bigquery_etl/cli/metadata.py
+++ b/bigquery_etl/cli/metadata.py
@@ -66,13 +66,10 @@ def update(
     name: str, sql_dir: Optional[str], project_id: Optional[str], parallelism: int
 ) -> None:
     """Update metadata yaml file."""
-    table_metadata_files = list(
-        set(
-            paths_matching_name_pattern(
-                name, sql_dir, project_id=project_id, files=["metadata.yaml"]
-            )
-        )
+    table_metadata_files = paths_matching_name_pattern(
+        name, sql_dir, project_id=project_id, files=["metadata.yaml"]
     )
+
     retained_dataset_roles = ConfigLoader.get(
         "deprecation", "retain_dataset_roles", fallback=[]
     )
@@ -192,6 +189,7 @@ def _update_single_metadata_file(retained_dataset_roles, table_metadata_file):
             click.echo(f"Updated {table_metadata_file}")
     except Exception as e:
         click.echo(f"Error processing {table_metadata_file}: {e}", err=True)
+        raise e
 
 
 @metadata.command(
@@ -216,12 +214,8 @@ def publish(
     name: str, sql_dir: Optional[str], project_id: Optional[str], parallelism: int
 ) -> None:
     """Publish Bigquery metadata."""
-    table_metadata_files = list(
-        set(
-            paths_matching_name_pattern(
-                name, sql_dir, project_id=project_id, files=["metadata.yaml"]
-            )
-        )
+    table_metadata_files = paths_matching_name_pattern(
+        name, sql_dir, project_id=project_id, files=["metadata.yaml"]
     )
 
     if parallelism > 0:

--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 from collections import defaultdict
+from multiprocessing.pool import Pool
 from pathlib import Path
 from typing import Optional
 
@@ -38,7 +39,12 @@ from bigeye_sdk.model.protobuf_message_facade import (
 from bigquery_etl.config import ConfigLoader
 from bigquery_etl.metadata.parse_metadata import METADATA_FILE, Metadata
 
-from ..cli.utils import paths_matching_name_pattern, project_id_option, sql_dir_option
+from ..cli.utils import (
+    parallelism_option,
+    paths_matching_name_pattern,
+    project_id_option,
+    sql_dir_option,
+)
 from ..util import extract_from_query_path
 from ..util.common import render as render_template
 
@@ -482,49 +488,62 @@ def _update_bigconfig(
 @click.argument("name")
 @project_id_option()
 @sql_dir_option
-def update(name: str, sql_dir: Optional[str], project_id: Optional[str]) -> None:
+@parallelism_option()
+def update(
+    name: str, sql_dir: Optional[str], project_id: Optional[str], parallelism: int
+) -> None:
     """Update BigConfig files based on monitoring metadata."""
     metadata_files = paths_matching_name_pattern(
         name, sql_dir, project_id=project_id, files=["metadata.yaml"]
     )
+    if parallelism == 1:
+        for metadata_file in metadata_files:
+            _update_single_monitoring_file(metadata_file)
+    else:
+        with Pool(parallelism) as pool:
+            pool.map(_update_single_monitoring_file, metadata_files)
 
-    for metadata_file in list(set(metadata_files)):
-        project, dataset, table = extract_from_query_path(metadata_file)
-        try:
-            metadata = Metadata.from_file(metadata_file)
-            if metadata.monitoring and metadata.monitoring.enabled:
-                bigconfig_file = metadata_file.parent / BIGCONFIG_FILE
 
-                if bigconfig_file.exists():
-                    bigconfig = BigConfig.load(bigconfig_file)
-                else:
-                    bigconfig = BigConfig(type="BIGCONFIG_FILE")
+def _update_single_monitoring_file(metadata_file: Path) -> None:
+    """Process a single metadata file for monitoring updates."""
+    project, dataset, table = extract_from_query_path(metadata_file)
+    try:
+        metadata = Metadata.from_file(metadata_file)
+        if metadata.monitoring and metadata.monitoring.enabled:
+            bigconfig_file = metadata_file.parent / BIGCONFIG_FILE
 
-                if (
-                    metadata_file.parent / QUERY_FILE
-                ).exists() and "public_bigquery" not in metadata.labels:
-                    default_metrics = []
-                    if metadata.monitoring.freshness:
-                        default_metrics.append(SimplePredefinedMetricName.FRESHNESS)
-                    if metadata.monitoring.volume:
-                        default_metrics.append(SimplePredefinedMetricName.VOLUME)
+            if bigconfig_file.exists():
+                bigconfig = BigConfig.load(bigconfig_file)
+            else:
+                bigconfig = BigConfig(type="BIGCONFIG_FILE")
 
-                    _update_bigconfig(
-                        bigconfig=bigconfig,
-                        metadata=metadata,
-                        project=project,
-                        dataset=dataset,
-                        table=table,
-                        default_metrics=default_metrics,
-                    )
+            if (
+                metadata_file.parent / QUERY_FILE
+            ).exists() and "public_bigquery" not in metadata.labels:
+                default_metrics = []
+                if metadata.monitoring.freshness:
+                    default_metrics.append(SimplePredefinedMetricName.FRESHNESS)
+                if metadata.monitoring.volume:
+                    default_metrics.append(SimplePredefinedMetricName.VOLUME)
 
-                bigconfig.save(
-                    output_path=bigconfig_file.parent,
-                    default_file_name=bigconfig_file.stem,
+                _update_bigconfig(
+                    bigconfig=bigconfig,
+                    metadata=metadata,
+                    project=project,
+                    dataset=dataset,
+                    table=table,
+                    default_metrics=default_metrics,
                 )
 
-        except FileNotFoundError:
-            print("No metadata file for: {}.{}.{}".format(project, dataset, table))
+            bigconfig.save(
+                output_path=bigconfig_file.parent,
+                default_file_name=bigconfig_file.stem,
+            )
+
+    except FileNotFoundError:
+        print("No metadata file for: {}.{}.{}".format(project, dataset, table))
+    except Exception as e:
+        print(f"Error processing {metadata_file}: {e}")
 
 
 @monitoring.command(

--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -134,7 +134,6 @@ def paths_matching_name_pattern(
             all_matching_files.extend(
                 map(Path, glob(f"{sql_path}/**/{file}", recursive=True))
             )
-
         for query_file in all_matching_files:
             match = file_regex.match(str(query_file))
             if match:
@@ -150,7 +149,7 @@ def paths_matching_name_pattern(
     if len(matching_files) == 0:
         print(f"No files matching: {pattern}, {files}")
 
-    return matching_files
+    return list(set(matching_files))
 
 
 sql_dir_option = click.option(

--- a/bigquery_etl/dependency.py
+++ b/bigquery_etl/dependency.py
@@ -76,6 +76,7 @@ def extract_table_references_without_views(path: Path) -> Iterator[str]:
 
     def _get_stable_views():
         nonlocal local_stable_views
+        global stable_views
         if local_stable_views is None:
             # lazy read stable views (works in both main thread and worker processes)
             local_stable_views = {

--- a/bigquery_etl/dependency.py
+++ b/bigquery_etl/dependency.py
@@ -2,6 +2,7 @@
 
 import re
 import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from glob import glob
 from itertools import groupby
 from pathlib import Path
@@ -12,6 +13,7 @@ import rich_click as click
 import sqlglot
 import yaml
 
+from bigquery_etl.cli.utils import parallelism_option
 from bigquery_etl.config import ConfigLoader
 from bigquery_etl.schema.stable_table_schema import get_stable_table_schemas
 from bigquery_etl.util.common import render
@@ -68,7 +70,24 @@ def extract_table_references(sql: str) -> List[str]:
 
 def extract_table_references_without_views(path: Path) -> Iterator[str]:
     """Recursively search for non-view tables referenced in the given SQL file."""
+    # handle both global and local stable_views for thread/process safety
     global stable_views
+    local_stable_views = stable_views
+
+    def _get_stable_views():
+        nonlocal local_stable_views
+        if local_stable_views is None:
+            # lazy read stable views (works in both main thread and worker processes)
+            local_stable_views = {
+                tuple(schema.user_facing_view.split(".")): tuple(
+                    schema.stable_table.split(".")
+                )
+                for schema in get_stable_table_schemas()
+            }
+            # update global variable if we're in the main thread and it's still None
+            if stable_views is None:
+                stable_views = local_stable_views
+        return local_stable_views
 
     sql = render(path.name, template_folder=path.parent)
     for table in extract_table_references(sql):
@@ -112,26 +131,33 @@ def extract_table_references_without_views(path: Path) -> Iterator[str]:
                     ),
                 ),
             ):
-                if stable_views is None:
-                    # lazy read stable views
-                    stable_views = {
-                        tuple(schema.user_facing_view.split(".")): tuple(
-                            schema.stable_table.split(".")
-                        )
-                        for schema in get_stable_table_schemas()
-                    }
-                if parts[-2:] in stable_views:
+                stable_views_dict = _get_stable_views()
+                if parts[-2:] in stable_views_dict:
                     parts = (
                         ConfigLoader.get(
                             "default", "project", fallback="moz-fx-data-shared-prod"
                         ),
-                        *stable_views[parts[-2:]],
+                        *stable_views_dict[parts[-2:]],
                     )
             yield ".".join(parts)
 
 
+def _process_single_file(
+    path: Path, without_views: bool = False
+) -> Tuple[Path, List[str]]:
+    """Process a single SQL file to extract table references."""
+    try:
+        if without_views:
+            return path, list(extract_table_references_without_views(path))
+        else:
+            sql = render(path.name, template_folder=path.parent)
+            return path, extract_table_references(sql)
+    except (CalledProcessError, ImportError, ValueError) as e:
+        return path, f"ERROR: {e}"
+
+
 def _get_references(
-    paths: Tuple[str, ...], without_views: bool = False
+    paths: Tuple[str, ...], without_views: bool = False, parallelism: int = None
 ) -> Iterator[Tuple[Path, List[str]]]:
     file_paths = {
         path
@@ -143,31 +169,70 @@ def _get_references(
         )
         if not path.name.endswith(".template.sql")  # skip templates
     }
+
     fail = False
-    for path in sorted(file_paths):
-        try:
-            if without_views:
-                yield path, list(extract_table_references_without_views(path))
-            else:
-                sql = render(path.name, template_folder=path.parent)
-                yield path, extract_table_references(sql)
-        except CalledProcessError as e:
-            raise click.ClickException(f"failed to import jnius: {e}")
-        except ImportError as e:
-            raise click.ClickException(*e.args)
-        except ValueError as e:
-            fail = True
-            print(f"Failed to parse file {path}: {e}", file=sys.stderr)
+    sorted_paths = sorted(file_paths)
+
+    if parallelism is None:
+        parallelism = 1
+
+    if parallelism and parallelism > 1 and len(sorted_paths) > 1:
+        with ProcessPoolExecutor(max_workers=parallelism) as executor:
+            future_to_path = {
+                executor.submit(_process_single_file, path, without_views): path
+                for path in sorted_paths
+            }
+
+            for future in as_completed(future_to_path):
+                path = future_to_path[future]
+                try:
+                    result_path, table_references = future.result()
+                    if isinstance(
+                        table_references, str
+                    ) and table_references.startswith("ERROR:"):
+                        fail = True
+                        error_msg = table_references[7:]  # Remove "ERROR: " prefix
+                        if "failed to import jnius" in error_msg:
+                            raise click.ClickException(
+                                f"failed to import jnius: {error_msg}"
+                            )
+                        elif "ImportError" in error_msg:
+                            raise click.ClickException(error_msg)
+                        else:
+                            print(
+                                f"Failed to parse file {path}: {error_msg}",
+                                file=sys.stderr,
+                            )
+                    else:
+                        yield result_path, table_references
+                except Exception as e:
+                    fail = True
+                    print(f"Failed to process file {path}: {e}", file=sys.stderr)
+    else:
+        for path in sorted_paths:
+            try:
+                if without_views:
+                    yield path, list(extract_table_references_without_views(path))
+                else:
+                    sql = render(path.name, template_folder=path.parent)
+                    yield path, extract_table_references(sql)
+            except CalledProcessError as e:
+                raise click.ClickException(f"failed to import jnius: {e}")
+            except ImportError as e:
+                raise click.ClickException(*e.args)
+            except ValueError as e:
+                fail = True
+                print(f"Failed to parse file {path}: {e}", file=sys.stderr)
 
     if fail:
         raise click.ClickException("Some paths could not be analyzed")
 
 
 def get_dependency_graph(
-    paths: Tuple[str, ...], without_views: bool = False
+    paths: Tuple[str, ...], without_views: bool = False, parallelism: int = None
 ) -> Dict[str, List[str]]:
     """Return the query dependency graph."""
-    refs = _get_references(paths, without_views=without_views)
+    refs = _get_references(paths, without_views=without_views, parallelism=parallelism)
     dependency_graph = {}
 
     for ref in refs:
@@ -199,9 +264,10 @@ def dependency():
     is_flag=True,
     help="recursively resolve view references to underlying tables",
 )
-def show(paths: Tuple[str, ...], without_views: bool):
+@parallelism_option()
+def show(paths: Tuple[str, ...], without_views: bool, parallelism: int):
     """Show table references in sql files."""
-    for path, table_references in _get_references(paths, without_views):
+    for path, table_references in _get_references(paths, without_views, parallelism):
         if table_references:
             for table in table_references:
                 print(f"{path}: {table}")
@@ -224,9 +290,12 @@ def show(paths: Tuple[str, ...], without_views: bool):
     is_flag=True,
     help="Skip files with existing references rather than failing",
 )
-def record(paths: Tuple[str, ...], skip_existing):
+@parallelism_option()
+def record(paths: Tuple[str, ...], skip_existing, parallelism: int):
     """Record table references in metadata."""
-    for parent, group in groupby(_get_references(paths), lambda e: e[0].parent):
+    for parent, group in groupby(
+        _get_references(paths, parallelism=parallelism), lambda e: e[0].parent
+    ):
         references = {
             path.name: table_references
             for path, table_references in group


### PR DESCRIPTION
## Description

This PR parallelizes the following commands that run as part of the `generate-sql` CI task:
* `./bqetl dependency record`
* `./bqetl metadata update`
* `./bqetl monitoring update`

This shaves off around 2.5 minutes from the `generate-sql` CI task (e.g. compare with https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/52810/workflows/910fe13d-e797-4b56-964d-4bb9eda82430/jobs/655557).

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
