### PR TITLE
feat(SubPlat): Save Stripe customer default payment methods (DENG-9663)

### DIFF
--- a/sql/moz-fx-data-shared-prod/stripe_external/customer_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/customer_v1/query.sql
@@ -21,5 +21,6 @@ SELECT
   shipping_address_postal_code,
   shipping_address_state,
   shipping_address_country,
+  invoice_settings_default_payment_method,
 FROM
   `moz-fx-data-bq-fivetran`.stripe.customer

--- a/sql/moz-fx-data-shared-prod/stripe_external/customer_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/customer_v1/schema.yaml
@@ -65,3 +65,6 @@ fields:
 - mode: NULLABLE
   name: shipping_address_country
   type: STRING
+- mode: NULLABLE
+  name: invoice_settings_default_payment_method
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/stripe_external/customers_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/customers_changelog_v1/query.sql
@@ -8,6 +8,7 @@ WITH customers AS (
     address_state,
     created,
     default_card_id,
+    invoice_settings_default_payment_method,
     is_deleted,
     PARSE_JSON(metadata) AS metadata,
     shipping_address_country,
@@ -93,7 +94,10 @@ SELECT
         customers.shipping_address_state AS state
       ) AS address
     ) AS shipping,
-    customers.tax_exempt
+    customers.tax_exempt,
+    STRUCT(
+      customers.invoice_settings_default_payment_method AS default_payment_method_id
+    ) AS invoice_settings
   ) AS customer
 FROM
   customers

--- a/sql/moz-fx-data-shared-prod/stripe_external/customers_changelog_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe_external/customers_changelog_v1/schema.yaml
@@ -177,3 +177,13 @@ fields:
     mode: NULLABLE
     description: The customer's tax exemption status. One of "none", "exempt", or
       "reverse".
+  - name: invoice_settings
+    type: RECORD
+    mode: NULLABLE
+    description: The customer's default invoice settings.
+    fields:
+    - name: default_payment_method_id
+      type: STRING
+      mode: NULLABLE
+      description: ID of a payment method that's attached to the customer, to be used as
+        the customer's default payment method for subscriptions and invoices.

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_history_v1/schema.yaml
@@ -208,3 +208,16 @@ fields:
 
       This isn''t available for customers that were deleted before the initial Fivetran
       Stripe sync.'
+  - name: invoice_settings
+    type: RECORD
+    mode: NULLABLE
+    description: 'The customer''s default invoice settings.
+
+      This isn''t available for customers that were deleted before the initial Fivetran
+      Stripe sync.'
+    fields:
+    - name: default_payment_method_id
+      type: STRING
+      mode: NULLABLE
+      description: ID of a payment method that's attached to the customer, to be used as
+        the customer's default payment method for subscriptions and invoices.

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_revised_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_revised_changelog_v1/query.sql
@@ -104,7 +104,8 @@ pre_fivetran_changelog AS (
         JSON_VALUE(metadata.userid_sha256) AS userid_sha256
       ) AS metadata,
       CAST(NULL AS STRUCT<address STRUCT<country STRING>>) AS shipping,
-      CAST(NULL AS STRING) AS tax_exempt
+      CAST(NULL AS STRING) AS tax_exempt,
+      CAST(NULL AS STRUCT<default_payment_method_id STRING>) AS invoice_settings
     ) AS customer,
     1 AS customer_change_number
   FROM

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_revised_changelog_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_revised_changelog_v1/schema.yaml
@@ -218,3 +218,16 @@ fields:
 
       This isn''t available for customers that were deleted before the initial Fivetran
       Stripe sync.'
+  - name: invoice_settings
+    type: RECORD
+    mode: NULLABLE
+    description: 'The customer''s default invoice settings.
+
+      This isn''t available for customers that were deleted before the initial Fivetran
+      Stripe sync.'
+    fields:
+    - name: default_payment_method_id
+      type: STRING
+      mode: NULLABLE
+      description: ID of a payment method that's attached to the customer, to be used as
+        the customer's default payment method for subscriptions and invoices.

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/schema.yaml
@@ -226,6 +226,19 @@ fields:
 
         This isn''t available for customers that were deleted before the initial Fivetran
         Stripe sync.'
+    - name: invoice_settings
+      type: RECORD
+      mode: NULLABLE
+      description: 'The customer''s default invoice settings.
+
+        This isn''t available for customers that were deleted before the initial Fivetran
+        Stripe sync.'
+      fields:
+      - name: default_payment_method_id
+        type: STRING
+        mode: NULLABLE
+        description: ID of a payment method that's attached to the customer, to be used as
+          the customer's default payment method for subscriptions and invoices.
   - name: billing_cycle_anchor
     type: TIMESTAMP
     mode: NULLABLE


### PR DESCRIPTION
## Description
SubPlat is about to add support for additional payment methods for Stripe subscriptions ([PAY-2029](https://mozilla-hub.atlassian.net/browse/PAY-2029)), and which payment method is used for a customer's subscriptions will currently be determined by the customer's [invoice_settings.default_payment_method](https://docs.stripe.com/api/customers/object#customer_object-invoice_settings-default_payment_method) attribute.

This PR updates the SubPlat ETLs to save the customer's `invoice_settings.default_payment_method` attribute and capture any changes to it over time (DENG-9663), so that eventually we can implement a `payment_method` field in downstream SubPlat tables/views (DENG-9664).

## Related Tickets & Documents
* [PAY-2029](https://mozilla-hub.atlassian.net/browse/PAY-2029): Expanded Payment Methods
* DENG-9394: Handle expanded Stripe subscription payment methods in subscriptions reporting
* DENG-9663: Save Stripe customer default payment methods in BigQuery
* DENG-9664: Implement a `payment_method` field in SubPlat consolidated reporting 

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[PAY-2029]: https://mozilla-hub.atlassian.net/browse/PAY-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAY-2029]: https://mozilla-hub.atlassian.net/browse/PAY-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ