### PR TITLE
Fix: Remove overactive clients

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_event_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_event_v1/query.sql
@@ -1,22 +1,40 @@
+--exclude significantly over-active clients
+WITH overactive AS (
+  SELECT
+    client_id,
+    COUNT(1) AS nbr_events
+  FROM
+    `moz-fx-data-shared-prod.telemetry.events`
+  WHERE
+    submission_date = @submission_date
+  GROUP BY
+    client_id
+  HAVING
+    COUNT(1) > 10000000
+)
 SELECT
-  submission_date,
-  sample_id,
-  client_id,
+  e.submission_date,
+  e.sample_id,
+  e.client_id,
   COUNT(*) AS n_logged_event,
   COUNTIF(
-    event_category = 'pictureinpicture'
-    AND event_method = 'create'
+    e.event_category = 'pictureinpicture'
+    AND e.event_method = 'create'
   ) AS n_created_pictureinpicture,
   COUNTIF(
-    event_category = 'security.ui.protections'
-    AND event_object = 'protection_report'
+    e.event_category = 'security.ui.protections'
+    AND e.event_object = 'protection_report'
   ) AS n_viewed_protection_report,
-  mozfun.stats.mode_last(ARRAY_AGG(profile_group_id ORDER BY `timestamp`)) AS profile_group_id,
+  mozfun.stats.mode_last(ARRAY_AGG(e.profile_group_id ORDER BY `timestamp`)) AS profile_group_id,
 FROM
-  `moz-fx-data-shared-prod.telemetry.events`
+  `moz-fx-data-shared-prod.telemetry.events` e
+LEFT JOIN
+  overactive o
+  ON e.client_id = o.client_id
 WHERE
-  submission_date = @submission_date
+  e.submission_date = @submission_date
+  AND o.client_id IS NULL
 GROUP BY
-  submission_date,
-  sample_id,
-  client_id
+  e.submission_date,
+  e.sample_id,
+  e.client_id


### PR DESCRIPTION
## Description
This PR adds logic to the build of table `moz-fx-data-shared-prod.telemetry_derived.clients_daily_event_v1` to exclude overactive clients sending more than 10M events per day.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
