### PR TITLE
fix: initial backfill for newtab_content_items_daily

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2025-09-18:
+  start_date: 2023-01-01
+  end_date: 2025-08-07
+  reason: Intitial backfill for newtab_content_items_daily_v1 table.
+  watchers:
+  - lmcfall@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
Backfills the new `newtab_content_items_daily` table

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
