### PR TITLE
chore: update documentation for hnt model with new approach

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_combined_v1/README.md
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_combined_v1/README.md
@@ -1,0 +1,8 @@
+# newtab_content_items_daily_combined
+
+## Description
+A view of the combined (Newtab + Newtab-Content) daily aggregation of newtab content actions on content/items, joined with the latest corpus item details from the corpus_items_current table so that the most current values for the corpus item are available.
+
+Previously, all content data was coming in via the newtab ping. With the addition of the newtab-content ping, we needed to be able to aggregate and combine these data sources.
+
+As of 2025-09-16, the newtab-content ping was rolled out to all users. So most data should now be coming through this ping exclusively, but we will still need to keep the newtab modeling as part of this for historical analysis.

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_combined_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_combined_v1/metadata.yaml
@@ -3,6 +3,14 @@ description: |-
   A view of the combined (Newtab + Newtab-Content) daily aggregation of newtab content actions on content/items,
   joined with the latest corpus item details from the corpus_items_current table so that the most current values for
   the corpus item are available.
+
+  Related documentation:
+  - Firefox New Tab Feed Engagement: https://mozilla.cloud.looker.com/dashboards/2205?Submission+Date=30+day&Newtab+Content+Surface+ID=%22NEW_TAB_EN_US%22
+  - Jira ticket: https://mozilla-hub.atlassian.net/browse/DENG-9057?focusedCommentId=1106194
+  - Proposal Doc: https://docs.google.com/document/d/1dQfwddq1_3WoLctFqmT4L2aFiNgeFNsSd78PnV0GpmU/edit?usp=sharing
+  - Data Model README: ./README.md
+  - Newtab Content Ping: https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/pings/newtab-content
+  - Newtab Content Ping Rollout Doc: https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/1517617439/Rollout+of+NewTab+Content+Ping
 owners:
 - lmcfall@mozilla.com
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/metadata.yaml
@@ -2,6 +2,13 @@ friendly_name: Newtab Content Items Daily
 description: |-
   A daily aggregation of newtab content actions on content/items (example: impressions, clicks, dismissals)
   for Firefox desktop, partitioned by day.
+
+  Related documentation:
+  - Jira ticket: https://mozilla-hub.atlassian.net/browse/DENG-9057?focusedCommentId=1106194
+  - Proposal Doc: https://docs.google.com/document/d/1dQfwddq1_3WoLctFqmT4L2aFiNgeFNsSd78PnV0GpmU/edit?usp=sharing
+  - Data Model README: ./README.md
+  - Newtab Content Ping: https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/pings/newtab-content
+  - Newtab Content Ping Rollout Doc: https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/1517617439/Rollout+of+NewTab+Content+Ping
 owners:
 - lmcfall@mozilla.com
 labels:


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR adds the documentation for the newtab-content items modeling using the new approach to data docs defined [here](https://docs.google.com/document/d/1kGwI2sTXSdpNlUKiNlEWj1Ijl0vq1xT1FVVVI59s8rc/edit?tab=t.0).

## Related Tickets & Documents
* [DENG-9692](https://mozilla-hub.atlassian.net/browse/DENG-9692)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
