### PR TITLE
fix(DENG-9617): re-deploy experiment_events_live_v1 materialized view

### DIFF
--- a/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/materialized_view.sql
+++ b/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/materialized_view.sql
@@ -1,7 +1,6 @@
 -- Generated via ./bqetl generate experiment_monitoring
-CREATE MATERIALIZED VIEW
-IF
-  NOT EXISTS {{ dataset }}_derived.{{ destination_table }}
+CREATE OR REPLACE MATERIALIZED VIEW
+  {{ dataset }}_derived.{{ destination_table }}
   PARTITION BY DATE(partition_date)
   OPTIONS
     (enable_refresh = TRUE, refresh_interval_minutes = 5)


### PR DESCRIPTION
## Description

#8116 updated `experiment_events_live_v1` materialized view, but it did not get re-deployed, which appears to be due to the `CREATE IF NOT EXISTS` statement. This changes that to `CREATE OR REPLACE` so it will get re-deployed.

## Related Tickets & Documents
* DENG-9617


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
