### PR TITLE
[DENG-9715] Remove firefox_desktop_background_update from event monit…

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -393,6 +393,10 @@ generate:
     events_monitoring:
       skip_apps:
       - ads_backend  # restricted dataset, we don't want to include it aggregate view
+      # event pings for this app were removed but still high volume due to nimbus bugs in versions 138 to 140
+      # events are still sent in the background-update ping, but they are being skipped
+      # See: https://mozilla-hub.atlassian.net/browse/DENG-9715
+      - firefox_desktop_background_update
       skip_pings:
       - topsites-impression # access denied
       - serp-categorization # access denied
@@ -402,7 +406,6 @@ generate:
         - events_v1
       manual_refresh:  # apps to use manual materialized view refreshes for on-demand billing
       - firefox_desktop
-      - firefox_desktop_background_update
     event_flow_monitoring:
       include_apps:
       - accounts_backend


### PR DESCRIPTION
…oring

## Description

Event monitoring hasn't been queried for this app (see [comment](https://mozilla-hub.atlassian.net/browse/DENG-9715?focusedCommentId=1141198)) but it's a fairly large part of the query.  This is unlikely to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1989142 but it should be an improvement.

The `events` ping was turned off in Firefox 142 but there are events in the `background-update` ping.  We're already ignoring that ping for this and nobody has complained so the materialized view will just be removed

## Related Tickets & Documents
* DENG-9715
* https://bugzilla.mozilla.org/show_bug.cgi?id=1989142

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
