### PR TITLE
fix: invalid query error (firefox_desktop_derived.enterprise_metrics_clients_v1)

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/enterprise_metrics_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/enterprise_metrics_clients_v1/query.sql
@@ -84,9 +84,9 @@ SELECT
   policies_is_enterprise,
 FROM
   client_baseline
-WHERE
-  -- enterprise is always only "esr" or "release" channels
-  normalized_channel IN ("release", "esr")
 LEFT JOIN
   most_recent_client_policy_metrics
   USING (client_id, normalized_channel)
+WHERE
+  -- enterprise is always only "esr" or "release" channels
+  normalized_channel IN ("release", "esr")


### PR DESCRIPTION
# fix: invalid query error (firefox_desktop_derived.enterprise_metrics_clients_v1)