### PR TITLE
[DENG-9707] Add authorized view for firefox-desktop/newtab_content

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_content_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_content_live/metadata.yaml
@@ -1,0 +1,14 @@
+---
+# yamllint disable rule:line-length
+friendly_name: Live Pings for `firefox-desktop/newtab_content`
+description: |-
+  A live view of pings sent for the
+  `firefox-desktop/newtab_content`
+  document type.
+
+  Clustering fields: `submission_timestamp`
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozsoc-ml/service
+authorized: true

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_content_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_content_live/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.newtab_content_live`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_live.newtab_content_v1`


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DENG-9707

Add authorized view to firefox_desktop_live.newtab_content_v1 with read access for mozsoc-ml workgroup

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
