### PR TITLE
Move authorized flag to labels in metadata.yaml

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_content_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_content_live/metadata.yaml
@@ -11,4 +11,5 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozsoc-ml/service
-authorized: true
+labels:
+  authorized: true


### PR DESCRIPTION
## Description
https://github.com/mozilla/bigquery-etl/pull/8136/files#r2370422586
Fix metadata.yaml formatting for `authorized: true`

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
