### PR TITLE
fix(events_stream): Don't unintentionally exclude events due to null values (DENG-9726)

### DIFF
--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -141,32 +141,32 @@ CROSS JOIN
   {% if app_name == "firefox_desktop" %}
     WHERE
       -- See https://mozilla-hub.atlassian.net/browse/DENG-7513
-      NOT (
+      (
         normalized_channel = 'release'
         AND event.category = 'security'
         AND event.name = 'unexpected_load'
         AND app_version_major BETWEEN 132 AND 135
-      )
+      ) IS NOT TRUE
       -- See https://bugzilla.mozilla.org/show_bug.cgi?id=1974286
-      AND NOT (
+      AND (
         event.category = 'nimbus_events'
         AND event.name = 'enrollment_status'
         AND app_version_major = 140
-      )
+      ) IS NOT TRUE
   {% elif app_name == "firefox_desktop_background_update" %}
     WHERE
       -- See https://mozilla-hub.atlassian.net/browse/DENG-8432
-      NOT (
+      (
         app_version_major IN (138, 139)
           AND (
             (event.category = 'nimbus_events' AND event.name = 'validation_failed')
             OR (event.category = 'normandy' AND event.name = 'validation_failed_nimbus_experiment')
           )
-      )
+      ) IS NOT TRUE
       -- See https://bugzilla.mozilla.org/show_bug.cgi?id=1974286
-      AND NOT (
+      AND (
         event.category = 'nimbus_events'
         AND event.name = 'enrollment_status'
         AND app_version_major = 140
-      )
+      ) IS NOT TRUE
   {% endif %}


### PR DESCRIPTION
## Description
This PR switches the events stream ETLs to use the null-safe `IS NOT TRUE` operator in the `WHERE` clause conditions to avoid unintentionally excluding events due to null values.

## Related Tickets & Documents
* DENG-9726: Some `events_stream_v1` ETLs can unintentionally exclude events due to null values

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
