### PR TITLE
Bug 1990074 - Skip publishing monitoring.event_monitoring_live

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -300,6 +300,8 @@ view:
     - sql/moz-fx-data-shared-prod/activity_stream/tile_id_types/view.sql
     - sql/moz-fx-data-shared-prod/pocket/pocket_reach_mau/view.sql
     - sql/moz-fx-data-shared-prod/telemetry/buildhub2/view.sql
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1990074
+    - sql/moz-fx-data-shared-prod/monitoring/event_monitoring_live/view.sql
     # Dataset glam-fenix-dev:glam_etl was not found
     # TODO: this should be removed if views are to be automatically deployed
     - sql/glam-fenix-dev/glam_etl/**/view.sql


### PR DESCRIPTION
## Description

broken with `Table metadata used for the query is too large`; don't want to fix right now

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1990074

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
