### PR TITLE
Bug 1990081 - Skip getting lineage for shredder_tmp tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_targets_v1/query.py
@@ -112,7 +112,7 @@ def get_upstream_stable_tables(id_tables: List[str]) -> Dict[str, Set[str]]:
                 link_parts = upstream_link.source.fully_qualified_name.split(":")
                 source = link_parts[0]
                 parent_table = link_parts[-1]
-                if not source.startswith("bigquery"):
+                if not source.startswith("bigquery") or parent_table.startswith("moz-fx-data-shredder.shredder_tmp"):
                     break
                 upstream_stable_tables[base_table] = upstream_stable_tables[
                     base_table


### PR DESCRIPTION
## Description

I'm not sure why it's getting a `502:Bad Gateway` but I was able to reproduce it locally and I noticed that the task duration increased over the last couple of months from a few minutes to 2.5 hours. I'm guessing this is because it's make api calls for the thousands of `shredder_tmp` tables.  Skipping them worked locally

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1990081

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
