### PR TITLE
feat(DENG-9748): Add event_params to firefoxdotcom.www_site_hits

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_hits_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_hits_v1/schema.yaml
@@ -6,15 +6,18 @@ fields:
 - mode: NULLABLE
   name: visit_identifier
   type: STRING
-  description: Visit Identifier - Uniquely identifies a visit; concatenation of user_pseudo_id and ga_session_id
+  description: Visit Identifier - Uniquely identifies a visit; concatenation of user_pseudo_id
+    and ga_session_id
 - mode: NULLABLE
   name: full_visitor_id
   type: STRING
-  description: Full Visitor ID - Uniquely identifies a visitor - this is the same as GA4 user_pseudo_id
+  description: Full Visitor ID - Uniquely identifies a visitor - this is the same
+    as GA4 user_pseudo_id
 - mode: NULLABLE
   name: visit_start_time
-  type: INT64
-  description: Visit Start Time - The event timestamp from the first event in the visit
+  type: INTEGER
+  description: Visit Start Time - The event timestamp from the first event in the
+    visit
 - mode: NULLABLE
   name: page_path
   type: STRING
@@ -26,22 +29,26 @@ fields:
 - mode: NULLABLE
   name: hit_type
   type: STRING
-  description: Hit Type - PAGE if event_name is a page view, EVENT for all other event types
+  description: Hit Type - PAGE if event_name is a page view, EVENT for all other event
+    types
 - mode: NULLABLE
   name: is_exit
   type: BOOLEAN
-  description: Is Exit - The specific page view event that is considered the exit to the visit
+  description: Is Exit - The specific page view event that is considered the exit
+    to the visit
 - mode: NULLABLE
   name: is_entrance
   type: BOOLEAN
-  description: Is Entrance - The specific page view event that is considered the entrance to the visit
+  description: Is Entrance - The specific page view event that is considered the entrance
+    to the visit
 - mode: NULLABLE
   name: hit_number
-  type: INT64
-  description: Hit Number - Densely ranked, since there can be multiple events at the same time for a user
+  type: INTEGER
+  description: Hit Number - Densely ranked, since there can be multiple events at
+    the same time for a user
 - mode: NULLABLE
   name: hit_timestamp
-  type: INT64
+  type: INTEGER
   description: Hit Timestamp - Same as the "Event Timestamp"
 - mode: NULLABLE
   name: event_category
@@ -62,27 +69,33 @@ fields:
 - mode: NULLABLE
   name: device_category
   type: STRING
-  description: Device Category - The device category the visitor used to visit the site
+  description: Device Category - The device category the visitor used to visit the
+    site
 - mode: NULLABLE
   name: operating_system
   type: STRING
-  description: Operating System - The operating system the visitor used to visit the site
+  description: Operating System - The operating system the visitor used to visit the
+    site
 - mode: NULLABLE
   name: language
   type: STRING
-  description: Language - The language the visiting device was using when it visited the site
+  description: Language - The language the visiting device was using when it visited
+    the site
 - mode: NULLABLE
   name: browser
   type: STRING
-  description: Browser - The browser the visiting device was using when it visited the site
+  description: Browser - The browser the visiting device was using when it visited
+    the site
 - mode: NULLABLE
   name: browser_version
   type: STRING
-  description: Browser Version - The version that the visiting device's browser was using when it visited the site
+  description: Browser Version - The version that the visiting device's browser was
+    using when it visited the site
 - mode: NULLABLE
   name: country
   type: STRING
-  description: Country - The country from which events were reported, based on IP address
+  description: Country - The country from which events were reported, based on IP
+    address
 - mode: NULLABLE
   name: traffic_source_name
   type: STRING
@@ -110,46 +123,54 @@ fields:
 - mode: NULLABLE
   name: medium
   type: STRING
-  description: Medium - Category of the source, such as 'organic' for a search engine (comes from collected traffic source)
+  description: Medium - Category of the source, such as 'organic' for a search engine
+    (comes from collected traffic source)
 - mode: NULLABLE
   name: campaign
   type: STRING
-  description: Campaign - Identifier for the marketing campaign (comes from collected traffic source)
+  description: Campaign - Identifier for the marketing campaign (comes from collected
+    traffic source)
 - mode: NULLABLE
   name: ad_content
   type: STRING
-  description: Ad Content - Indicates the particular link within a campaign (comes from collected traffic source)
+  description: Ad Content - Indicates the particular link within a campaign (comes
+    from collected traffic source)
 - mode: NULLABLE
   name: visits
-  type: INT64
-  description: Visits - A flag that indicates if the hit belongs to a visit that had 1 or more engaged event during the visit
+  type: INTEGER
+  description: Visits - A flag that indicates if the hit belongs to a visit that had
+    1 or more engaged event during the visit
 - mode: NULLABLE
   name: bounces
-  type: INT64
-  description: Bounces - Indicator that displays a 1 for each hit in a bounce session (a session with only 1 page view)
+  type: INTEGER
+  description: Bounces - Indicator that displays a 1 for each hit in a bounce session
+    (a session with only 1 page view)
 - mode: NULLABLE
   name: hit_time
   type: FLOAT
-  description: Hit Time - The number of seconds after the visitStartTime that the hit was registered
+  description: Hit Time - The number of seconds after the visitStartTime that the
+    hit was registered
 - mode: NULLABLE
   name: engagement_time
   type: FLOAT
   description: Engagement Time - Engagement Time in Seconds
 - mode: NULLABLE
   name: first_interaction
-  type: INT64
-  description: First Interaction - The first hit number in the visit associated with an engaged session event
+  type: INTEGER
+  description: First Interaction - The first hit number in the visit associated with
+    an engaged session event
 - mode: NULLABLE
   name: last_interaction
   type: FLOAT
-  description: Last Interaction - The last hit number in the visit associated with an engaged session event
+  description: Last Interaction - The last hit number in the visit associated with
+    an engaged session event
 - mode: NULLABLE
   name: entrances
-  type: INT64
+  type: INTEGER
   description: Entrances - Denotes which pageview was the first in the session
 - mode: NULLABLE
   name: exits
-  type: INT64
+  type: INTEGER
   description: Exits - Denotes which page view was the last in the session
 - mode: NULLABLE
   name: event_id
@@ -182,7 +203,8 @@ fields:
 - mode: NULLABLE
   name: single_page_session
   type: BOOLEAN
-  description: Single Page Session - Indicator if the hit belongs to a single page session
+  description: Single Page Session - Indicator if the hit belongs to a single page
+    session
 - mode: NULLABLE
   name: product_type
   type: STRING
@@ -190,4 +212,28 @@ fields:
 - mode: NULLABLE
   name: platform_type
   type: STRING
-  description: Platform Type - For product download events, what platform type was the download requested from
+  description: Platform Type - For product download events, what platform type was
+    the download requested from
+- name: event_params
+  type: RECORD
+  mode: REPEATED
+  fields:
+  - name: key
+    type: STRING
+    mode: NULLABLE
+  - name: value
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: string_value
+      type: STRING
+      mode: NULLABLE
+    - name: int_value
+      type: INTEGER
+      mode: NULLABLE
+    - name: float_value
+      type: FLOAT
+      mode: NULLABLE
+    - name: double_value
+      type: FLOAT
+      mode: NULLABLE


### PR DESCRIPTION
## Description

This PR adds the new column `event_params` to the table & view:
- `moz-fx-data-shared-prod.firefoxdotcom.www_site_hits`
- `moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_hits_v1`

## Related Tickets & Documents
* [DENG-9748](https://mozilla-hub.atlassian.net/browse/DENG-9748)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9748]: https://mozilla-hub.atlassian.net/browse/DENG-9748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ