### PR TITLE
feat: add a backfill 2025-09-23 entry to enterprise_metrics_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/enterprise_metrics_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/enterprise_metrics_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2025-09-23:
+  start_date: 2023-08-11
+  end_date: 2025-09-23
+  reason: Initial backfill of the dataset.
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false


### PR DESCRIPTION
# feat: add a backfill 2025-09-23 entry to enterprise_metrics_v1

depends on: https://github.com/mozilla/bigquery-etl/pull/8155 (only once the backfill process is completed this PR can be merged)