### PR TITLE
feat: unschedule app_store_choice_screen_selection_v1 for now

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/metadata.yaml
@@ -16,26 +16,29 @@ labels:
   incremental: true
   table_type: aggregate
   shredder_mitigation: false
-scheduling:
-  dag_name: bqetl_firefox_ios
-  depends_on_past: false
-  arguments:
-  - --date={{macros.ds_add(ds, -5)}}
-  - --connect_app_id=989804926
-  - --partition_field=logical_date
+# 2025-09-24:
+# temporarily unscheduled due to a wider issue
+# once that issue has been resolved this task will be rescheduled.
+# scheduling:
+#   dag_name: bqetl_firefox_ios
+#   depends_on_past: false
+#   arguments:
+#   - --date={{macros.ds_add(ds, -5)}}
+#   - --connect_app_id=989804926
+#   - --partition_field=logical_date
 
-  secrets:
-  - deploy_target: CONNECT_ISSUER_ID
-    key: bqetl_firefox_ios__app_store_connect_issuer_id
-  - deploy_target: CONNECT_KEY_ID
-    key: bqetl_firefox_ios__app_store_connect_key_id
-  - deploy_target: CONNECT_KEY
-    key: bqetl_firefox_ios__app_store_connect_key
+#   secrets:
+#   - deploy_target: CONNECT_ISSUER_ID
+#     key: bqetl_firefox_ios__app_store_connect_issuer_id
+#   - deploy_target: CONNECT_KEY_ID
+#     key: bqetl_firefox_ios__app_store_connect_key_id
+#   - deploy_target: CONNECT_KEY
+#     key: bqetl_firefox_ios__app_store_connect_key
 
-  date_partition_offset: -5
-  retry_delay: 30m
-  retries: 2
-  email_on_retry: false
+#   date_partition_offset: -5
+#   retry_delay: 30m
+#   retries: 2
+#   email_on_retry: false
 
 bigquery:
   time_partitioning:


### PR DESCRIPTION
# feat: unschedule app_store_choice_screen_selection_v1 for now

This is because there appears to be a wider issue currently around the browser choice data with ongoing discussions. Until then descheduling this task to reduce the noise.