### PR TITLE
Bug 1990074 - Exclude deprecated apps from event monitoring

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -300,8 +300,6 @@ view:
     - sql/moz-fx-data-shared-prod/activity_stream/tile_id_types/view.sql
     - sql/moz-fx-data-shared-prod/pocket/pocket_reach_mau/view.sql
     - sql/moz-fx-data-shared-prod/telemetry/buildhub2/view.sql
-    # https://bugzilla.mozilla.org/show_bug.cgi?id=1990074
-    - sql/moz-fx-data-shared-prod/monitoring/event_monitoring_live/view.sql
     # Dataset glam-fenix-dev:glam_etl was not found
     # TODO: this should be removed if views are to be automatically deployed
     - sql/glam-fenix-dev/glam_etl/**/view.sql
@@ -395,6 +393,8 @@ generate:
     events_monitoring:
       skip_apps:
       - ads_backend  # restricted dataset, we don't want to include it aggregate view
+      - org_mozilla_fenix_nightly
+      - org_mozilla_fennec_aurora
       # event pings for this app were removed but still high volume due to nimbus bugs in versions 138 to 140
       # events are still sent in the background-update ping, but they are being skipped
       # See: https://mozilla-hub.atlassian.net/browse/DENG-9715

--- a/sql_generators/glean_usage/event_monitoring_live.py
+++ b/sql_generators/glean_usage/event_monitoring_live.py
@@ -115,12 +115,12 @@ class EventMonitoringLive(GleanTable):
             "generate", "glean_usage", "events_monitoring", "events_tables", fallback={}
         )
 
-        deprecated = [
-            app_dataset.get("deprecated", False)
-            for _, app in cached_app_info.items()
+        deprecated = all([
+            app_dataset.get("deprecated", False) is True
+            for app in cached_app_info.values()
             for app_dataset in app
             if dataset == app_dataset["bq_dataset_family"]
-        ][0] is True
+        ])
 
         # Skip any not-allowed or deprecated app
         if (


### PR DESCRIPTION
## Description

I tested and this allows `monitoring.event_monitoring_live` to be deployed from airflow-gke-prod

Removes
- pine
- org_mozilla_fenix_nightly
- org_mozilla_fennec_aurora
- org_mozilla_tv_firefox
- org_mozilla_vrbrowser
- mozilla_lockbox
- org_mozilla_ios_lockbox
- burnham
- org_mozilla_connect
- org_mozilla_firefoxreality
- org_mozilla_bergamot
- firefox_translations
- viu_politica
- treeherder

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1990074

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
