### PR TITLE
chore(requirements): Unpin `flake8`

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,6 @@ cattrs==25.2.0
 click==8.2.1
 cryptography==46.0.1
 exceptiongroup==1.3.0 # for backwards compatibility with python < 3.11
-flake8<5 # pytest-flake8 does not support flake8 5+
 fredapi==0.5.2
 gcsfs==2025.3.2
 gitpython==3.1.45

--- a/requirements.txt
+++ b/requirements.txt
@@ -523,9 +523,7 @@ filelock==3.16.1 \
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via
-    #   -r requirements.in
-    #   pytest-flake8
+    # via pytest-flake8
 fredapi==0.5.2 \
     --hash=sha256:405ca048abed4207d93dbc9b7ee8c46d6b473483650323e2f1c094af83d4b247 \
     --hash=sha256:961817ec8d70e58886ff7302d3dda908614ad99f77831a59833c4fc3f6150155


### PR DESCRIPTION
## Description
[pytest-flake8](https://pypi.org/project/pytest-flake8/) now supports [flake8](https://pypi.org/project/flake8/) v5+:
- `pytest-flake8` v1.1.3 added support for `flake8` v5.
- `pytest-flake8` v1.3.0 added support for newer versions of `flake8`.

## Related Tickets & Documents
N/A

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
