### PR TITLE
fix(events_stream): Complete backfills of two `events_stream_v1` tables that were affected by a bug (DENG-9632)

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_background_defaultagent_derived/events_stream_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_background_defaultagent_derived/events_stream_v1/backfill.yaml
@@ -5,7 +5,7 @@
     That bug was fixed in https://github.com/mozilla/bigquery-etl/pull/8084.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/thunderbird_desktop_derived/events_stream_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/thunderbird_desktop_derived/events_stream_v1/backfill.yaml
@@ -5,7 +5,7 @@
     That bug was fixed in https://github.com/mozilla/bigquery-etl/pull/8084.
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description
I've confirmed this fixes the mixed up experiment type and enrollment ID data in the `events_stream_v1` tables for `firefox_desktop_background_defaultagent` and `thunderbird_desktop` (DENG-9632, #8084).

I also used this as an opportunity to check whether any event extra keys/values were ever actually mismatched in those two apps' `events_stream_v1` records (DENG-9633, #8094), and thankfully I found no evidence of that being a problem in practice.

### Deployment

Completing these managed backfills won't actually fix all the affected `firefox_desktop_background_defaultagent_derived.events_stream_v1` records because the underlying `firefox_desktop_background_defaultagent_stable.events_v1` table's partition expiration is set to 400 days, so it was only possible to backfill back to 2024-08-26, while the bug in question took effect on 2024-05-29 after #5668 was deployed.

To fix the `firefox_desktop_background_defaultagent_derived.events_stream_v1` records between 2024-05-29 and 2024-08-25 I plan to manually run the following `UPDATE` statement:
```sql
UPDATE `moz-fx-data-shared-prod.firefox_desktop_background_defaultagent_derived.events_stream_v1`
SET
  experiments = (
    SELECT
      JSON_OBJECT(
        ARRAY_AGG(experiment ORDER BY experiment_offset),
        ARRAY_AGG(
          JSON_SET(
            experiments[experiment],
            -- Swap the mixed up `type` and `enrollment_id` values back so they're correct (https://mozilla-hub.atlassian.net/browse/DENG-9632).
            '$.extra.type',
            experiments[experiment].extra.enrollment_id,
            '$.extra.enrollment_id',
            experiments[experiment].extra.type
          )
          ORDER BY experiment_offset
        )
      )
    FROM
      UNNEST(JSON_KEYS(experiments, 1)) AS experiment
      WITH OFFSET AS experiment_offset
  )
WHERE
  -- The bug took effect when https://github.com/mozilla/bigquery-etl/pull/5668 was deployed on 2024-05-29, and the
  -- managed backfill of this table to fix the bug went as far back as 2024-08-26 (https://github.com/mozilla/bigquery-etl/pull/8173).
  DATE(submission_timestamp) BETWEEN '2024-05-29' AND '2024-08-25'
  AND experiments IS NOT NULL
```

## Related Tickets & Documents
* DENG-9632: Events stream ETL can mix up experiment type and enrollment ID data
* https://github.com/mozilla/bigquery-etl/pull/8084
* https://github.com/mozilla/bigquery-etl/pull/8095
* https://github.com/mozilla/bigquery-etl/pull/8173
* DENG-9633: Events stream ETL might mismatch keys and values from unnested maps stored as arrays
* https://github.com/mozilla/bigquery-etl/pull/8094

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
