### PR TITLE
fix(SubPlat): Improve the `stripe_logical_subscriptions_history_v1` ETL's join for refunds data to use a date condition (DENG-9769)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_history_v1/query.sql
@@ -121,6 +121,7 @@ subscriptions_history_charge_summaries AS (
   LEFT JOIN
     `moz-fx-data-shared-prod.stripe_external.refund_v1` AS refunds
     ON charges.id = refunds.charge_id
+    AND refunds.created < history.valid_to
   GROUP BY
     subscriptions_history_id
 ),


### PR DESCRIPTION
## Description
The current `stripe_logical_subscriptions_history_v1` refunds join condition is accidentally including some refunds that occurred after the history period in question, which I noticed when doing some backfills of downstream SubPlat consolidated reporting ETLs.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
* DENG-9769: Improve the `stripe_logical_subscriptions_history_v1` ETL's join for refunds data to use a date condition

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
