### PR TITLE
fix(SubPlat): Only generate "Mozilla Account Change" and "Plan Change" events for active subscriptions (DENG-9770)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1_live/view.sql
@@ -60,6 +60,7 @@ mozilla_account_change_events AS (
   WHERE
     old_subscription IS NOT NULL
     AND subscription.mozilla_account_id_sha256 IS DISTINCT FROM old_subscription.mozilla_account_id_sha256
+    AND subscription.ended_at IS NULL
 ),
 plan_change_events AS (
   SELECT
@@ -91,6 +92,7 @@ plan_change_events AS (
     subscription_changes
   WHERE
     subscription.provider_plan_id != old_subscription.provider_plan_id
+    AND subscription.ended_at IS NULL
 ),
 trial_change_events AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1_live/view.sql
@@ -64,6 +64,7 @@ mozilla_account_change_events AS (
   WHERE
     old_subscription IS NOT NULL
     AND subscription.mozilla_account_id_sha256 IS DISTINCT FROM old_subscription.mozilla_account_id_sha256
+    AND subscription.ended_at IS NULL
 ),
 plan_change_events AS (
   SELECT
@@ -105,6 +106,7 @@ plan_change_events AS (
     subscription_changes
   WHERE
     subscription.provider_plan_id != old_subscription.provider_plan_id
+    AND subscription.ended_at IS NULL
 ),
 trial_change_events AS (
   SELECT


### PR DESCRIPTION
## Description
The other event types already check appropriately whether the subscription is active.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
* DENG-9770: Only generate most logical/service subscription events for active subscriptions

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
