### PR TITLE
fix(SubPlat): Guard against zero-length SubPlat consolidated reporting history records (DENG-9771)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_logical_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_logical_subscriptions_history_v1/query.sql
@@ -52,6 +52,7 @@ WITH subscriptions_history AS (
     `moz-fx-data-shared-prod.subscription_platform_derived.apple_subscriptions_history_v1`
   WHERE
     subscription.last_transaction.in_app_ownership_type = 'PURCHASED'
+    AND valid_to > valid_from
   WINDOW
     subscription_changes_asc AS (
       PARTITION BY

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_logical_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_logical_subscriptions_history_v1/query.sql
@@ -72,6 +72,7 @@ WITH subscriptions_history AS (
     `moz-fx-data-shared-prod.subscription_platform_derived.google_subscriptions_history_v1`
   WHERE
     subscription.purchase_type IS DISTINCT FROM 0  -- 0 = Test
+    AND valid_to > valid_from
 ),
 subscription_starts AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_attribution_v2/query.sql
@@ -33,6 +33,7 @@ FROM
 JOIN
   `moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_history_v2` AS history
   ON subscription_starts.stripe_subscriptions_history_id = history.id
+  AND history.valid_to > history.valid_from
 WHERE
   history.subscription.metadata.session_flow_id IS NOT NULL
   OR history.subscription.metadata.session_entrypoint IS NOT NULL

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_history_v1/query.sql
@@ -36,6 +36,8 @@ WITH subscriptions_history AS (
     subscription.status IN ('active', 'past_due', 'trialing') AS subscription_is_active
   FROM
     `moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_history_v2`
+  WHERE
+    valid_to > valid_from
 ),
 active_subscriptions_history AS (
   -- Only include a subscription's history once it becomes active.

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v2/query.sql
@@ -51,6 +51,7 @@ FROM
 JOIN
   `moz-fx-data-shared-prod.subscription_platform_derived.stripe_subscriptions_history_v2` AS history
   ON subscription_starts.stripe_subscriptions_history_id = history.id
+  AND history.valid_to > history.valid_from
 WHERE
   history.subscription.metadata.session_flow_id IS NOT NULL
   OR history.subscription.metadata.session_entrypoint IS NOT NULL

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_history_v2/query.sql
@@ -60,6 +60,7 @@ subscriptions_customers_history AS (
     ON subscriptions_history.subscription.customer_id = customers_history.customer.id
     AND subscriptions_history.valid_from < customers_history.valid_from
     AND subscriptions_history.valid_to > customers_history.valid_from
+    AND customers_history.valid_to > customers_history.valid_from
   WHERE
     subscriptions_history.subscription.ended_at IS NULL
 )


### PR DESCRIPTION
## Description
Zero-length history records shouldn't happen, but if they do occur they can cause undesirable side effects like duplicate primary key values in downstream ETL tables unless they're filtered out.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
* DENG-9771: Guard against zero-length SubPlat consolidated reporting history records

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
