### PR TITLE
fix(SubPlat): Correct `schema.yaml` for `stripe_subscriptions_v2` ETL (DENG-9663)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_v2/schema.yaml
@@ -191,6 +191,19 @@ fields:
 
       This isn''t available for customers that were deleted before the initial Fivetran
       Stripe sync.'
+  - name: invoice_settings
+    type: RECORD
+    mode: NULLABLE
+    description: 'The customer''s default invoice settings.
+
+      This isn''t available for customers that were deleted before the initial Fivetran
+      Stripe sync.'
+    fields:
+    - name: default_payment_method_id
+      type: STRING
+      mode: NULLABLE
+      description: ID of a payment method that's attached to the customer, to be used as
+        the customer's default payment method for subscriptions and invoices.
 - name: billing_cycle_anchor
   type: TIMESTAMP
   mode: NULLABLE


### PR DESCRIPTION
## Description
This is currently causing a dry-run error for `stripe_subscriptions_v2`, and should have been done as part of #8106.

## Related Tickets & Documents
* DENG-9663: Save Stripe customer default payment methods in BigQuery
* https://github.com/mozilla/bigquery-etl/pull/8106

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
