### PR TITLE
feat(DENG-9553): Add search_with_ads_count_all to metrics_clients_daily

### DIFF
--- a/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
@@ -22,7 +22,20 @@
       {% endfor -%}
     {% endif -%}
     {% if app_name == "firefox_desktop" -%}
-      ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS profile_group_id
+      ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS profile_group_id,
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar) kv), 0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar_searchmode) kv),0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_contextmenu) kv),0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_about_home) kv),0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_about_newtab) kv),0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_searchbar) kv),0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_system) kv),0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_webextension) kv),0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_tabhistory) kv),0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_reload) kv),0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_unknown) kv),0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar_handoff) kv),0) + 
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar_persisted) kv),0)  AS search_with_ads_count_all
     {% endif -%}
   FROM
     `moz-fx-data-shared-prod.{{ dataset }}.metrics` AS m


### PR DESCRIPTION
…rics_clients_daily

## Description

This PR adds the new column `search_with_ads_count_all` to the table: 
- moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_daily_v1`

## Related Tickets & Documents
* [DENG-9553](https://mozilla-hub.atlassian.net/browse/DENG-9553)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
