### PR TITLE
feat(DENG-9792): Add search_with_ads_count_all to firefox_desktop.metrics_clients_last_seen

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/schema.yaml
@@ -25,3 +25,7 @@ fields:
   type: STRING
   mode: NULLABLE
   description: A UUID uniquely identifying the profile group, not shared with other telemetry data.
+- name: search_with_ads_count_all
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of searches with ads on client's last seen date in last 28 days.

--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
@@ -16,6 +16,7 @@ labels:
 {%- if not deprecated_app %}
 scheduling:
   dag_name: bqetl_glean_usage
+  depends_on_past: true
   task_group: {{ app_name }}
 {%- endif %}
 bigquery:

--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.query.sql
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.query.sql
@@ -37,6 +37,7 @@ SELECT
   {% endif -%}
   {% if app_name == "firefox_desktop" -%}
     _current.profile_group_id,
+    COALESCE(_current.search_with_ads_count_all, _previous.search_with_ads_count_all) AS search_with_ads_count_all
   {% endif -%}
 FROM
   _previous


### PR DESCRIPTION
## Description

This PR adds the column `search_with_ads_count_all` to the table and view:
- `moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_last_seen_v1`
- `moz-fx-data-shared-prod.firefox_desktop.metrics_clients_last_seen`

I also noticed that the generated `metrics_clients_last_seen_v1` were missing the "depends_on_past: true" labels, so I fixed that in this PR as well.

## Related Tickets & Documents
* [DENG-9792](https://mozilla-hub.atlassian.net/browse/DENG-9792)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9792]: https://mozilla-hub.atlassian.net/browse/DENG-9792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ