### PR TITLE
[DENG-9795] Remove unneeded deletion req sources from cohort_weekly_a…

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -313,7 +313,7 @@ DELETE_TARGETS: DeleteIndex = {
     client_id_target(table="telemetry_stable.voice_v4"): DESKTOP_SRC,
     DeleteTarget(
         table="telemetry_derived.cohort_weekly_active_clients_staging_v1",
-        field=(CLIENT_ID,) * 15,
+        field=(CLIENT_ID,) * 10,
     ): (
         DESKTOP_SRC,
         DeleteSource(table="focus_android.deletion_request", field=GLEAN_CLIENT_ID),
@@ -323,11 +323,10 @@ DELETE_TARGETS: DeleteIndex = {
         DeleteSource(table="focus_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="klar_android.deletion_request", field=GLEAN_CLIENT_ID),
         *FOCUS_ADDITIONAL_DELETIONS,
-        *LEGACY_MOBILE_SOURCES,
     ),
     DeleteTarget(
         table="glean_telemetry_derived.cohort_weekly_active_clients_staging_v1",
-        field=(CLIENT_ID,) * 15,
+        field=(CLIENT_ID,) * 10,
     ): (
         DESKTOP_GLEAN_SRC,
         DeleteSource(table="focus_android.deletion_request", field=GLEAN_CLIENT_ID),
@@ -337,21 +336,6 @@ DELETE_TARGETS: DeleteIndex = {
         DeleteSource(table="focus_ios.deletion_request", field=GLEAN_CLIENT_ID),
         DeleteSource(table="klar_android.deletion_request", field=GLEAN_CLIENT_ID),
         *FOCUS_ADDITIONAL_DELETIONS,
-        *LEGACY_MOBILE_SOURCES,
-    ),
-    DeleteTarget(
-        table="telemetry_derived.cohort_weekly_active_clients_v1",
-        field=(CLIENT_ID,) * 15,
-    ): (
-        DESKTOP_SRC,
-        DeleteSource(table="focus_android.deletion_request", field=GLEAN_CLIENT_ID),
-        DeleteSource(table="firefox_ios.deletion_request", field=GLEAN_CLIENT_ID),
-        DeleteSource(table="fenix.deletion_request", field=GLEAN_CLIENT_ID),
-        DeleteSource(table="klar_ios.deletion_request", field=GLEAN_CLIENT_ID),
-        DeleteSource(table="focus_ios.deletion_request", field=GLEAN_CLIENT_ID),
-        DeleteSource(table="klar_android.deletion_request", field=GLEAN_CLIENT_ID),
-        *FOCUS_ADDITIONAL_DELETIONS,
-        *LEGACY_MOBILE_SOURCES,
     ),
     DeleteTarget(
         table="telemetry_derived.cohort_weekly_cfs_staging_v1",


### PR DESCRIPTION
…ctive_clients

## Description

These tables are very expensive to shred because of the number of deletion request tables.  Removing the legacy mobile tables makes them slightly less expensive.  Legacy mobile isn't needed because the data is from the baseline clients tables. `telemetry_derived.cohort_weekly_active_clients_v1` doesn't need to be shredded as long as the staging table is shredded because it's replaced everyday.

## Related Tickets & Documents
* DENG-9795

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
