### PR TITLE
fix(SubPlat): Fix syntax error in `stripe_external.subscriptions_changelog_v1` ETL (DENG-4043)

### DIFF
--- a/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/stripe_external/subscriptions_changelog_v1/query.sql
@@ -295,7 +295,7 @@ SELECT
       subscriptions_history.cancellation_details_comment AS comment,
       subscriptions_history.cancellation_details_feedback AS feedback,
       subscriptions_history.cancellation_details_reason AS reason
-    ) AS cancellation_details,
+    ) AS cancellation_details
   ) AS subscription
 FROM
   subscriptions_history_with_plan_ids AS subscriptions_history


### PR DESCRIPTION
## Description
Fixup for #7927.

(CC @phil-lee70)

## Related Tickets & Documents
* DENG-4043: Implement `ended_reason` for logical & service subscriptions
* https://github.com/mozilla/bigquery-etl/pull/7927

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
