### PR TITLE
feat(DENG-9765): Add wait for task

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/blog_performance_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/blog_performance_v1/metadata.yaml
@@ -9,6 +9,9 @@ labels:
   table_type: aggregate
 scheduling:
   dag_name: bqetl_google_analytics_derived_ga4
+  depends_on:
+  - task_id: wait_for_blogs_events_table
+    dag_name: bqetl_google_analytics_derived_ga4
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description

This PR updates the metadata.yaml file for mozilla_org_derived.blog_performance_v1 to ensure the job doesn't run until the data from GA4 has loaded for the blogs table.

## Related Tickets & Documents
* [DENG-9765](https://mozilla-hub.atlassian.net/browse/DENG-9765)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
