### PR TITLE
fix(SubPlat): Correct `schema.yaml` for `stripe_subscriptions_v2` ETL (DENG-4043)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_v2/schema.yaml
@@ -669,3 +669,20 @@ fields:
   type: TIMESTAMP
   mode: NULLABLE
   description: If the subscription has a trial, the start time of that trial.
+- name: cancellation_details
+  type: RECORD
+  mode: NULLABLE
+  description: Details about why this subscription was cancelled.
+  fields:
+  - name: comment
+    type: STRING
+    mode: NULLABLE
+    description: Additional comments about why the user canceled the subscription, if the subscription was canceled explicitly by the user.
+  - name: feedback
+    type: STRING
+    mode: NULLABLE
+    description: The customer submitted reason for why they canceled, if the subscription was canceled explicitly by the user.
+  - name: reason
+    type: STRING
+    mode: NULLABLE
+    description: Details about the reason this subscription was cancelled.


### PR DESCRIPTION
## Description
Fixup for https://github.com/mozilla/bigquery-etl/pull/7927.

This is causing dry-run failures for the `stripe_subscriptions_v2` ETL.

## Related Tickets & Documents
* DENG-4043: Implement `ended_reason` for logical & service subscriptions
* https://github.com/mozilla/bigquery-etl/pull/7927

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
