### PR TITLE
fix: subscription_groups must be an array to sync in braze

### DIFF
--- a/sql/moz-fx-data-shared-prod/braze_external/win10_users_sync_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_external/win10_users_sync_v1/query.sql
@@ -5,10 +5,12 @@ SELECT
     STRUCT(
       email AS email,
       "subscribed" AS email_subscribe,
-      STRUCT(
-        "718eea53-371c-4cc6-9fdc-1260b1311bd8" AS subscription_group_id,
-        "subscribed" AS subscription_state
-      ) AS subscription_groups,
+      [
+        STRUCT(
+          "718eea53-371c-4cc6-9fdc-1260b1311bd8" AS subscription_group_id,
+          "subscribed" AS subscription_state
+        )
+      ] AS subscription_groups,
       locale AS locale,
       fxa_id_sha256
     )


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
Quick fix, braze syncing needs a field as an array.

## Related Tickets & Documents
* DENG-9051

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
