### PR TITLE
fix(SubPlat): Try to avoid window partition row ordering ties in SubPlat consolidated reporting ETLs (DENG-9772)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1_live/view.sql
@@ -5,8 +5,15 @@ WITH subscription_changes AS (
   SELECT
     id AS logical_subscriptions_history_id,
     valid_from AS `timestamp`,
+    valid_to AS next_subscription_change_at,
     subscription,
-    LAG(subscription) OVER (PARTITION BY subscription.id ORDER BY valid_from) AS old_subscription
+    LAG(subscription) OVER (
+      PARTITION BY
+        subscription.id
+      ORDER BY
+        valid_from,
+        valid_to
+    ) AS old_subscription
   FROM
     `moz-fx-data-shared-prod.subscription_platform_derived.logical_subscriptions_history_v1`
 ),
@@ -24,7 +31,13 @@ subscription_start_events AS (
   FROM
     subscription_changes
   QUALIFY
-    1 = ROW_NUMBER() OVER (PARTITION BY subscription.id ORDER BY `timestamp`)
+    1 = ROW_NUMBER() OVER (
+      PARTITION BY
+        subscription.id
+      ORDER BY
+        `timestamp`,
+        next_subscription_change_at
+    )
 ),
 subscription_end_events AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_revised_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_customers_revised_changelog_v1/query.sql
@@ -57,7 +57,8 @@ WITH original_changelog AS (
       PARTITION BY
         customer.id
       ORDER BY
-        `timestamp`
+        `timestamp`,
+        id
     )
 ),
 pre_fivetran_changelog AS (

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_history_v1/query.sql
@@ -55,7 +55,8 @@ active_subscriptions_history AS (
       PARTITION BY
         subscription.id
       ORDER BY
-        valid_from
+        valid_from,
+        valid_to
       ROWS BETWEEN
         UNBOUNDED PRECEDING
         AND CURRENT ROW

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_subscriptions_revised_changelog_v1/query.sql
@@ -146,7 +146,8 @@ WITH original_changelog AS (
       PARTITION BY
         subscription.id
       ORDER BY
-        `timestamp`
+        `timestamp`,
+        id
     )
 ),
 adjusted_original_changelog AS (
@@ -224,7 +225,8 @@ questionable_subscription_plan_changes AS (
         invoice_line_items.subscription_id
       ORDER BY
         invoice_line_items.period_start,
-        invoice_line_items.period_end
+        invoice_line_items.period_end,
+        invoice_line_items.id
     )
 ),
 questionable_subscription_plans_history AS (


### PR DESCRIPTION
## Description
I don't expect these changes to have any actual effect at the moment, especially since we're now guarding against zero-length history records (DENG-9771, #8177).  This is just about being consistent with the window partition row ordering to try to avoid potential ties and always get deterministic results.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
* DENG-9772: Handle window partition row ordering ties consistently in SubPlat consolidated reporting ETLs

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
