### PR TITLE
deng_9755 use future dates to account for 27 day look back

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
@@ -1,10 +1,10 @@
-2025-10-01:
-  start_date: 2024-08-24
-  end_date: 2024-10-14
-  reason: Backfill as there is missing data for this date period (DENG-9755).
+2025-10-02:
+  start_date: 2024-09-20
+  end_date: 2024-11-10
+  reason: Backfill for missing data 2024-08-24 to 2024-10-14, query looks back 27 days - need future dates in params (DENG-9755).
   watchers:
   - mhirose@mozilla.com
-  status: Initiate
+  status: initiate
   shredder_mitigation: false
 
 2025-01-22:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
@@ -4,7 +4,7 @@
   reason: Backfill for missing data 2024-08-24 to 2024-10-14, query looks back 27 days - need future dates in params (DENG-9755).
   watchers:
   - mhirose@mozilla.com
-  status: initiate
+  status: Initiate
   shredder_mitigation: false
 
 2025-01-22:


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR backfills `fenix_derived.retention_v1`. It takes precedence over [this PR]( https://github.com/mozilla/bigquery-etl/pull/8191) because of the date parameters. 8191 did not take into account the 27 day look back for the query and backfilled for the wrong date range.
## Related Tickets & Documents
* DENG-9755
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
