### PR TITLE
deng_9755 start backfill for 2025-04-18 to 04-24

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
@@ -1,3 +1,12 @@
+2025-10-03:
+  start_date: 2025-05-15
+  end_date: 2025-05-21
+  reason: Backfill for missing data 2025-04-18 to 2025-04-24, query looks back 27 days - need future dates in params (DENG-9755).
+  watchers:
+  - mhirose@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+
 2025-10-02:
   start_date: 2024-09-20
   end_date: 2024-11-10


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR starts a backfill to add in data for fenix_derived.retention_v1 for the 2025-04-18 to 2025-04-24
## Related Tickets & Documents
* DENG-9755
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
