### PR TITLE
fix(SubPlat): Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_logical_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_logical_subscriptions/view.sql
@@ -87,6 +87,79 @@ augmented_daily_subscriptions_3 AS (
     END AS ongoing_discounted_annual_recurring_revenue_months
   FROM
     augmented_daily_subscriptions_2
+),
+augmented_daily_subscriptions_4 AS (
+  SELECT
+    *,
+    IF(
+      subscription.is_active IS NOT TRUE
+      OR subscription.is_trial IS TRUE,
+      0,
+      (
+        GREATEST(
+          (subscription.plan_amount - COALESCE(subscription.current_period_discount_amount, 0)),
+          0
+        ) / subscription.plan_interval_months
+      )
+    ) AS monthly_recurring_gross_revenue,
+    IF(
+      subscription.is_active IS NOT TRUE,
+      0,
+      (
+        -- Current period annual recurring gross revenue
+        IF(
+          subscription.is_trial IS TRUE,
+          0,
+          (
+            GREATEST(
+              (subscription.plan_amount - COALESCE(subscription.current_period_discount_amount, 0)),
+              0
+            ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
+          )
+        )
+        -- Ongoing discounted annual recurring gross revenue
+        + IF(
+          subscription.auto_renew IS NOT TRUE
+          OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
+          0,
+          (
+            GREATEST(
+              (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
+              0
+            ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
+          )
+        )
+        -- Ongoing undiscounted annual recurring gross revenue
+        + IF(
+          subscription.auto_renew IS NOT TRUE,
+          0,
+          (
+            subscription.plan_amount / subscription.plan_interval_months * GREATEST(
+              (
+                12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
+              ),
+              0
+            )
+          )
+        )
+      )
+    ) AS annual_recurring_gross_revenue
+  FROM
+    augmented_daily_subscriptions_3
+),
+augmented_daily_subscriptions_5 AS (
+  SELECT
+    *,
+    ROUND(
+      (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      2
+    ) AS monthly_recurring_revenue,
+    ROUND(
+      (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      2
+    ) AS annual_recurring_revenue
+  FROM
+    augmented_daily_subscriptions_4
 )
 SELECT
   id,
@@ -113,90 +186,17 @@ SELECT
         ROUND((subscription.ongoing_discount_amount * plan_currency_usd_exchange_rate), 2)
       ) AS ongoing_discount_amount_usd,
       IF(
-        subscription.is_active IS NOT TRUE
-        OR subscription.is_trial IS TRUE,
-        0,
-        ROUND(
-          (
-            -- Start with monthly recurring gross revenue...
-            (
-              GREATEST(
-                (
-                  subscription.plan_amount - COALESCE(
-                    subscription.current_period_discount_amount,
-                    0
-                  )
-                ),
-                0
-              ) / subscription.plan_interval_months
-            )
-            -- Remove VAT to get monthly recurring net revenue.
-            / (1 + COALESCE(country_vat_rate, 0))
-            -- Apply exchange rate to get monthly recurring revenue in USD.
-            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
-          ),
-          2
-        )
+        subscription.plan_currency = 'USD',
+        monthly_recurring_revenue,
+        ROUND((monthly_recurring_revenue * plan_currency_usd_exchange_rate), 2)
       ) AS monthly_recurring_revenue_usd,
       IF(
-        subscription.is_active IS NOT TRUE,
-        0,
-        ROUND(
-          (
-            -- Start with annual recurring gross revenue...
-            (
-              -- Current period annual recurring gross revenue
-              IF(
-                subscription.is_trial IS TRUE,
-                0,
-                (
-                  GREATEST(
-                    (
-                      subscription.plan_amount - COALESCE(
-                        subscription.current_period_discount_amount,
-                        0
-                      )
-                    ),
-                    0
-                  ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
-                )
-              )
-              -- Ongoing discounted annual recurring gross revenue
-              + IF(
-                subscription.auto_renew IS NOT TRUE
-                OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
-                0,
-                (
-                  GREATEST(
-                    (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
-                    0
-                  ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
-                )
-              )
-              -- Ongoing undiscounted annual recurring gross revenue
-              + IF(
-                subscription.auto_renew IS NOT TRUE,
-                0,
-                (
-                  subscription.plan_amount / subscription.plan_interval_months * GREATEST(
-                    (
-                      12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
-                    ),
-                    0
-                  )
-                )
-              )
-            )
-            -- Remove VAT to get annual recurring net revenue.
-            / (1 + COALESCE(country_vat_rate, 0))
-            -- Apply exchange rate to get annual recurring revenue in USD.
-            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
-          ),
-          2
-        )
+        subscription.plan_currency = 'USD',
+        annual_recurring_revenue,
+        ROUND((annual_recurring_revenue * plan_currency_usd_exchange_rate), 2)
       ) AS annual_recurring_revenue_usd
   ) AS subscription,
   was_active_at_day_start,
   was_active_at_day_end
 FROM
-  augmented_daily_subscriptions_3
+  augmented_daily_subscriptions_5

--- a/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_logical_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_logical_subscriptions/view.sql
@@ -151,11 +151,27 @@ augmented_daily_subscriptions_5 AS (
   SELECT
     *,
     ROUND(
-      (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(
+          subscription.provider IN ('Apple', 'Google'),
+          (monthly_recurring_gross_revenue * 0.15),
+          0
+        )
+      ),
       2
     ) AS monthly_recurring_revenue,
     ROUND(
-      (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(
+          subscription.provider IN ('Apple', 'Google'),
+          (annual_recurring_gross_revenue * 0.15),
+          0
+        )
+      ),
       2
     ) AS annual_recurring_revenue
   FROM

--- a/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_service_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_service_subscriptions/view.sql
@@ -151,11 +151,27 @@ augmented_daily_subscriptions_5 AS (
   SELECT
     *,
     ROUND(
-      (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(
+          subscription.provider IN ('Apple', 'Google'),
+          (monthly_recurring_gross_revenue * 0.15),
+          0
+        )
+      ),
       2
     ) AS monthly_recurring_revenue,
     ROUND(
-      (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(
+          subscription.provider IN ('Apple', 'Google'),
+          (annual_recurring_gross_revenue * 0.15),
+          0
+        )
+      ),
       2
     ) AS annual_recurring_revenue
   FROM

--- a/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_service_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/daily_active_service_subscriptions/view.sql
@@ -87,6 +87,79 @@ augmented_daily_subscriptions_3 AS (
     END AS ongoing_discounted_annual_recurring_revenue_months
   FROM
     augmented_daily_subscriptions_2
+),
+augmented_daily_subscriptions_4 AS (
+  SELECT
+    *,
+    IF(
+      subscription.is_active IS NOT TRUE
+      OR subscription.is_trial IS TRUE,
+      0,
+      (
+        GREATEST(
+          (subscription.plan_amount - COALESCE(subscription.current_period_discount_amount, 0)),
+          0
+        ) / subscription.plan_interval_months
+      )
+    ) AS monthly_recurring_gross_revenue,
+    IF(
+      subscription.is_active IS NOT TRUE,
+      0,
+      (
+        -- Current period annual recurring gross revenue
+        IF(
+          subscription.is_trial IS TRUE,
+          0,
+          (
+            GREATEST(
+              (subscription.plan_amount - COALESCE(subscription.current_period_discount_amount, 0)),
+              0
+            ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
+          )
+        )
+        -- Ongoing discounted annual recurring gross revenue
+        + IF(
+          subscription.auto_renew IS NOT TRUE
+          OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
+          0,
+          (
+            GREATEST(
+              (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
+              0
+            ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
+          )
+        )
+        -- Ongoing undiscounted annual recurring gross revenue
+        + IF(
+          subscription.auto_renew IS NOT TRUE,
+          0,
+          (
+            subscription.plan_amount / subscription.plan_interval_months * GREATEST(
+              (
+                12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
+              ),
+              0
+            )
+          )
+        )
+      )
+    ) AS annual_recurring_gross_revenue
+  FROM
+    augmented_daily_subscriptions_3
+),
+augmented_daily_subscriptions_5 AS (
+  SELECT
+    *,
+    ROUND(
+      (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      2
+    ) AS monthly_recurring_revenue,
+    ROUND(
+      (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      2
+    ) AS annual_recurring_revenue
+  FROM
+    augmented_daily_subscriptions_4
 )
 SELECT
   id,
@@ -114,90 +187,17 @@ SELECT
         ROUND((subscription.ongoing_discount_amount * plan_currency_usd_exchange_rate), 2)
       ) AS ongoing_discount_amount_usd,
       IF(
-        subscription.is_active IS NOT TRUE
-        OR subscription.is_trial IS TRUE,
-        0,
-        ROUND(
-          (
-            -- Start with monthly recurring gross revenue...
-            (
-              GREATEST(
-                (
-                  subscription.plan_amount - COALESCE(
-                    subscription.current_period_discount_amount,
-                    0
-                  )
-                ),
-                0
-              ) / subscription.plan_interval_months
-            )
-            -- Remove VAT to get monthly recurring net revenue.
-            / (1 + COALESCE(country_vat_rate, 0))
-            -- Apply exchange rate to get monthly recurring revenue in USD.
-            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
-          ),
-          2
-        )
+        subscription.plan_currency = 'USD',
+        monthly_recurring_revenue,
+        ROUND((monthly_recurring_revenue * plan_currency_usd_exchange_rate), 2)
       ) AS monthly_recurring_revenue_usd,
       IF(
-        subscription.is_active IS NOT TRUE,
-        0,
-        ROUND(
-          (
-            -- Start with annual recurring gross revenue...
-            (
-              -- Current period annual recurring gross revenue
-              IF(
-                subscription.is_trial IS TRUE,
-                0,
-                (
-                  GREATEST(
-                    (
-                      subscription.plan_amount - COALESCE(
-                        subscription.current_period_discount_amount,
-                        0
-                      )
-                    ),
-                    0
-                  ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
-                )
-              )
-              -- Ongoing discounted annual recurring gross revenue
-              + IF(
-                subscription.auto_renew IS NOT TRUE
-                OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
-                0,
-                (
-                  GREATEST(
-                    (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
-                    0
-                  ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
-                )
-              )
-              -- Ongoing undiscounted annual recurring gross revenue
-              + IF(
-                subscription.auto_renew IS NOT TRUE,
-                0,
-                (
-                  subscription.plan_amount / subscription.plan_interval_months * GREATEST(
-                    (
-                      12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
-                    ),
-                    0
-                  )
-                )
-              )
-            )
-            -- Remove VAT to get annual recurring net revenue.
-            / (1 + COALESCE(country_vat_rate, 0))
-            -- Apply exchange rate to get annual recurring revenue in USD.
-            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
-          ),
-          2
-        )
+        subscription.plan_currency = 'USD',
+        annual_recurring_revenue,
+        ROUND((annual_recurring_revenue * plan_currency_usd_exchange_rate), 2)
       ) AS annual_recurring_revenue_usd
   ) AS subscription,
   was_active_at_day_start,
   was_active_at_day_end
 FROM
-  augmented_daily_subscriptions_3
+  augmented_daily_subscriptions_5

--- a/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/view.sql
@@ -139,11 +139,19 @@ augmented_subscriptions_5 AS (
   SELECT
     *,
     ROUND(
-      (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(provider IN ('Apple', 'Google'), (monthly_recurring_gross_revenue * 0.15), 0)
+      ),
       2
     ) AS monthly_recurring_revenue,
     ROUND(
-      (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(provider IN ('Apple', 'Google'), (annual_recurring_gross_revenue * 0.15), 0)
+      ),
       2
     ) AS annual_recurring_revenue
   FROM

--- a/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/view.sql
@@ -75,13 +75,90 @@ augmented_subscriptions_3 AS (
     END AS ongoing_discounted_annual_recurring_revenue_months
   FROM
     augmented_subscriptions_2
+),
+augmented_subscriptions_4 AS (
+  SELECT
+    *,
+    IF(
+      is_active IS NOT TRUE
+      OR is_trial IS TRUE,
+      0,
+      (
+        GREATEST(
+          (plan_amount - COALESCE(current_period_discount_amount, 0)),
+          0
+        ) / plan_interval_months
+      )
+    ) AS monthly_recurring_gross_revenue,
+    IF(
+      is_active IS NOT TRUE,
+      0,
+      (
+        -- Current period annual recurring gross revenue
+        IF(
+          is_trial IS TRUE,
+          0,
+          (
+            GREATEST(
+              (plan_amount - COALESCE(current_period_discount_amount, 0)),
+              0
+            ) / plan_interval_months * current_period_annual_recurring_revenue_months
+          )
+        )
+        -- Ongoing discounted annual recurring gross revenue
+        + IF(
+          auto_renew IS NOT TRUE
+          OR COALESCE(ongoing_discount_amount, 0) = 0,
+          0,
+          (
+            GREATEST(
+              (plan_amount - COALESCE(ongoing_discount_amount, 0)),
+              0
+            ) / plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
+          )
+        )
+        -- Ongoing undiscounted annual recurring gross revenue
+        + IF(
+          auto_renew IS NOT TRUE,
+          0,
+          (
+            plan_amount / plan_interval_months * GREATEST(
+              (
+                12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
+              ),
+              0
+            )
+          )
+        )
+      )
+    ) AS annual_recurring_gross_revenue
+  FROM
+    augmented_subscriptions_3
+),
+augmented_subscriptions_5 AS (
+  SELECT
+    *,
+    ROUND(
+      (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      2
+    ) AS monthly_recurring_revenue,
+    ROUND(
+      (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      2
+    ) AS annual_recurring_revenue
+  FROM
+    augmented_subscriptions_4
 )
 SELECT
   * EXCEPT (
     effective_date,
     current_period_annual_recurring_revenue_months,
     months_after_current_period_before_ongoing_discount_ends,
-    ongoing_discounted_annual_recurring_revenue_months
+    ongoing_discounted_annual_recurring_revenue_months,
+    monthly_recurring_gross_revenue,
+    annual_recurring_gross_revenue,
+    monthly_recurring_revenue,
+    annual_recurring_revenue
   ),
   IF(
     plan_currency = 'USD',
@@ -99,77 +176,14 @@ SELECT
     ROUND((ongoing_discount_amount * plan_currency_usd_exchange_rate), 2)
   ) AS ongoing_discount_amount_usd,
   IF(
-    is_active IS NOT TRUE
-    OR is_trial IS TRUE,
-    0,
-    ROUND(
-      (
-        -- Start with monthly recurring gross revenue...
-        (
-          GREATEST(
-            (plan_amount - COALESCE(current_period_discount_amount, 0)),
-            0
-          ) / plan_interval_months
-        )
-        -- Remove VAT to get monthly recurring net revenue.
-        / (1 + COALESCE(country_vat_rate, 0))
-        -- Apply exchange rate to get monthly recurring revenue in USD.
-        * IF(plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
-      ),
-      2
-    )
+    plan_currency = 'USD',
+    monthly_recurring_revenue,
+    ROUND((monthly_recurring_revenue * plan_currency_usd_exchange_rate), 2)
   ) AS monthly_recurring_revenue_usd,
   IF(
-    is_active IS NOT TRUE,
-    0,
-    ROUND(
-      (
-        -- Start with annual recurring gross revenue...
-        (
-          -- Current period annual recurring gross revenue
-          IF(
-            is_trial IS TRUE,
-            0,
-            (
-              GREATEST(
-                (plan_amount - COALESCE(current_period_discount_amount, 0)),
-                0
-              ) / plan_interval_months * current_period_annual_recurring_revenue_months
-            )
-          )
-          -- Ongoing discounted annual recurring gross revenue
-          + IF(
-            auto_renew IS NOT TRUE
-            OR COALESCE(ongoing_discount_amount, 0) = 0,
-            0,
-            (
-              GREATEST(
-                (plan_amount - COALESCE(ongoing_discount_amount, 0)),
-                0
-              ) / plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
-            )
-          )
-          -- Ongoing undiscounted annual recurring gross revenue
-          + IF(
-            auto_renew IS NOT TRUE,
-            0,
-            (
-              plan_amount / plan_interval_months * GREATEST(
-                (
-                  12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
-                ),
-                0
-              )
-            )
-          )
-        )
-        -- Remove VAT to get annual recurring net revenue.
-        / (1 + COALESCE(country_vat_rate, 0))
-        -- Apply exchange rate to get annual recurring revenue in USD.
-        * IF(plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
-      ),
-      2
-    )
+    plan_currency = 'USD',
+    annual_recurring_revenue,
+    ROUND((annual_recurring_revenue * plan_currency_usd_exchange_rate), 2)
   ) AS annual_recurring_revenue_usd
 FROM
-  augmented_subscriptions_3
+  augmented_subscriptions_5

--- a/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_logical_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_logical_subscriptions/view.sql
@@ -159,11 +159,27 @@ augmented_monthly_subscriptions_6 AS (
   SELECT
     *,
     ROUND(
-      (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(
+          subscription.provider IN ('Apple', 'Google'),
+          (monthly_recurring_gross_revenue * 0.15),
+          0
+        )
+      ),
       2
     ) AS monthly_recurring_revenue,
     ROUND(
-      (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(
+          subscription.provider IN ('Apple', 'Google'),
+          (annual_recurring_gross_revenue * 0.15),
+          0
+        )
+      ),
       2
     ) AS annual_recurring_revenue
   FROM

--- a/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_logical_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_logical_subscriptions/view.sql
@@ -95,6 +95,79 @@ augmented_monthly_subscriptions_4 AS (
     END AS ongoing_discounted_annual_recurring_revenue_months
   FROM
     augmented_monthly_subscriptions_3
+),
+augmented_monthly_subscriptions_5 AS (
+  SELECT
+    *,
+    IF(
+      subscription.is_active IS NOT TRUE
+      OR subscription.is_trial IS TRUE,
+      0,
+      (
+        GREATEST(
+          (subscription.plan_amount - COALESCE(subscription.current_period_discount_amount, 0)),
+          0
+        ) / subscription.plan_interval_months
+      )
+    ) AS monthly_recurring_gross_revenue,
+    IF(
+      subscription.is_active IS NOT TRUE,
+      0,
+      (
+        -- Current period annual recurring gross revenue
+        IF(
+          subscription.is_trial IS TRUE,
+          0,
+          (
+            GREATEST(
+              (subscription.plan_amount - COALESCE(subscription.current_period_discount_amount, 0)),
+              0
+            ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
+          )
+        )
+        -- Ongoing discounted annual recurring gross revenue
+        + IF(
+          subscription.auto_renew IS NOT TRUE
+          OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
+          0,
+          (
+            GREATEST(
+              (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
+              0
+            ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
+          )
+        )
+        -- Ongoing undiscounted annual recurring gross revenue
+        + IF(
+          subscription.auto_renew IS NOT TRUE,
+          0,
+          (
+            subscription.plan_amount / subscription.plan_interval_months * GREATEST(
+              (
+                12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
+              ),
+              0
+            )
+          )
+        )
+      )
+    ) AS annual_recurring_gross_revenue
+  FROM
+    augmented_monthly_subscriptions_4
+),
+augmented_monthly_subscriptions_6 AS (
+  SELECT
+    *,
+    ROUND(
+      (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      2
+    ) AS monthly_recurring_revenue,
+    ROUND(
+      (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      2
+    ) AS annual_recurring_revenue
+  FROM
+    augmented_monthly_subscriptions_5
 )
 SELECT
   id,
@@ -122,90 +195,17 @@ SELECT
         ROUND((subscription.ongoing_discount_amount * plan_currency_usd_exchange_rate), 2)
       ) AS ongoing_discount_amount_usd,
       IF(
-        subscription.is_active IS NOT TRUE
-        OR subscription.is_trial IS TRUE,
-        0,
-        ROUND(
-          (
-            -- Start with monthly recurring gross revenue...
-            (
-              GREATEST(
-                (
-                  subscription.plan_amount - COALESCE(
-                    subscription.current_period_discount_amount,
-                    0
-                  )
-                ),
-                0
-              ) / subscription.plan_interval_months
-            )
-            -- Remove VAT to get monthly recurring net revenue.
-            / (1 + COALESCE(country_vat_rate, 0))
-            -- Apply exchange rate to get monthly recurring revenue in USD.
-            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
-          ),
-          2
-        )
+        subscription.plan_currency = 'USD',
+        monthly_recurring_revenue,
+        ROUND((monthly_recurring_revenue * plan_currency_usd_exchange_rate), 2)
       ) AS monthly_recurring_revenue_usd,
       IF(
-        subscription.is_active IS NOT TRUE,
-        0,
-        ROUND(
-          (
-            -- Start with annual recurring gross revenue...
-            (
-              -- Current period annual recurring gross revenue
-              IF(
-                subscription.is_trial IS TRUE,
-                0,
-                (
-                  GREATEST(
-                    (
-                      subscription.plan_amount - COALESCE(
-                        subscription.current_period_discount_amount,
-                        0
-                      )
-                    ),
-                    0
-                  ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
-                )
-              )
-              -- Ongoing discounted annual recurring gross revenue
-              + IF(
-                subscription.auto_renew IS NOT TRUE
-                OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
-                0,
-                (
-                  GREATEST(
-                    (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
-                    0
-                  ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
-                )
-              )
-              -- Ongoing undiscounted annual recurring gross revenue
-              + IF(
-                subscription.auto_renew IS NOT TRUE,
-                0,
-                (
-                  subscription.plan_amount / subscription.plan_interval_months * GREATEST(
-                    (
-                      12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
-                    ),
-                    0
-                  )
-                )
-              )
-            )
-            -- Remove VAT to get annual recurring net revenue.
-            / (1 + COALESCE(country_vat_rate, 0))
-            -- Apply exchange rate to get annual recurring revenue in USD.
-            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
-          ),
-          2
-        )
+        subscription.plan_currency = 'USD',
+        annual_recurring_revenue,
+        ROUND((annual_recurring_revenue * plan_currency_usd_exchange_rate), 2)
       ) AS annual_recurring_revenue_usd
   ) AS subscription,
   was_active_at_month_start,
   was_active_at_month_end
 FROM
-  augmented_monthly_subscriptions_4
+  augmented_monthly_subscriptions_6

--- a/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_service_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_service_subscriptions/view.sql
@@ -225,4 +225,4 @@ SELECT
   was_active_at_month_start,
   was_active_at_month_end
 FROM
-  augmented_monthly_subscriptions_4
+  augmented_monthly_subscriptions_6

--- a/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_service_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_service_subscriptions/view.sql
@@ -159,11 +159,27 @@ augmented_monthly_subscriptions_6 AS (
   SELECT
     *,
     ROUND(
-      (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(
+          subscription.provider IN ('Apple', 'Google'),
+          (monthly_recurring_gross_revenue * 0.15),
+          0
+        )
+      ),
       2
     ) AS monthly_recurring_revenue,
     ROUND(
-      (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(
+          subscription.provider IN ('Apple', 'Google'),
+          (annual_recurring_gross_revenue * 0.15),
+          0
+        )
+      ),
       2
     ) AS annual_recurring_revenue
   FROM

--- a/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_service_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/monthly_active_service_subscriptions/view.sql
@@ -95,6 +95,79 @@ augmented_monthly_subscriptions_4 AS (
     END AS ongoing_discounted_annual_recurring_revenue_months
   FROM
     augmented_monthly_subscriptions_3
+),
+augmented_monthly_subscriptions_5 AS (
+  SELECT
+    *,
+    IF(
+      subscription.is_active IS NOT TRUE
+      OR subscription.is_trial IS TRUE,
+      0,
+      (
+        GREATEST(
+          (subscription.plan_amount - COALESCE(subscription.current_period_discount_amount, 0)),
+          0
+        ) / subscription.plan_interval_months
+      )
+    ) AS monthly_recurring_gross_revenue,
+    IF(
+      subscription.is_active IS NOT TRUE,
+      0,
+      (
+        -- Current period annual recurring gross revenue
+        IF(
+          subscription.is_trial IS TRUE,
+          0,
+          (
+            GREATEST(
+              (subscription.plan_amount - COALESCE(subscription.current_period_discount_amount, 0)),
+              0
+            ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
+          )
+        )
+        -- Ongoing discounted annual recurring gross revenue
+        + IF(
+          subscription.auto_renew IS NOT TRUE
+          OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
+          0,
+          (
+            GREATEST(
+              (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
+              0
+            ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
+          )
+        )
+        -- Ongoing undiscounted annual recurring gross revenue
+        + IF(
+          subscription.auto_renew IS NOT TRUE,
+          0,
+          (
+            subscription.plan_amount / subscription.plan_interval_months * GREATEST(
+              (
+                12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
+              ),
+              0
+            )
+          )
+        )
+      )
+    ) AS annual_recurring_gross_revenue
+  FROM
+    augmented_monthly_subscriptions_4
+),
+augmented_monthly_subscriptions_6 AS (
+  SELECT
+    *,
+    ROUND(
+      (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      2
+    ) AS monthly_recurring_revenue,
+    ROUND(
+      (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      2
+    ) AS annual_recurring_revenue
+  FROM
+    augmented_monthly_subscriptions_5
 )
 SELECT
   id,
@@ -123,87 +196,14 @@ SELECT
         ROUND((subscription.ongoing_discount_amount * plan_currency_usd_exchange_rate), 2)
       ) AS ongoing_discount_amount_usd,
       IF(
-        subscription.is_active IS NOT TRUE
-        OR subscription.is_trial IS TRUE,
-        0,
-        ROUND(
-          (
-            -- Start with monthly recurring gross revenue...
-            (
-              GREATEST(
-                (
-                  subscription.plan_amount - COALESCE(
-                    subscription.current_period_discount_amount,
-                    0
-                  )
-                ),
-                0
-              ) / subscription.plan_interval_months
-            )
-            -- Remove VAT to get monthly recurring net revenue.
-            / (1 + COALESCE(country_vat_rate, 0))
-            -- Apply exchange rate to get monthly recurring revenue in USD.
-            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
-          ),
-          2
-        )
+        subscription.plan_currency = 'USD',
+        monthly_recurring_revenue,
+        ROUND((monthly_recurring_revenue * plan_currency_usd_exchange_rate), 2)
       ) AS monthly_recurring_revenue_usd,
       IF(
-        subscription.is_active IS NOT TRUE,
-        0,
-        ROUND(
-          (
-            -- Start with annual recurring gross revenue...
-            (
-              -- Current period annual recurring gross revenue
-              IF(
-                subscription.is_trial IS TRUE,
-                0,
-                (
-                  GREATEST(
-                    (
-                      subscription.plan_amount - COALESCE(
-                        subscription.current_period_discount_amount,
-                        0
-                      )
-                    ),
-                    0
-                  ) / subscription.plan_interval_months * current_period_annual_recurring_revenue_months
-                )
-              )
-              -- Ongoing discounted annual recurring gross revenue
-              + IF(
-                subscription.auto_renew IS NOT TRUE
-                OR COALESCE(subscription.ongoing_discount_amount, 0) = 0,
-                0,
-                (
-                  GREATEST(
-                    (subscription.plan_amount - COALESCE(subscription.ongoing_discount_amount, 0)),
-                    0
-                  ) / subscription.plan_interval_months * ongoing_discounted_annual_recurring_revenue_months
-                )
-              )
-              -- Ongoing undiscounted annual recurring gross revenue
-              + IF(
-                subscription.auto_renew IS NOT TRUE,
-                0,
-                (
-                  subscription.plan_amount / subscription.plan_interval_months * GREATEST(
-                    (
-                      12 - current_period_annual_recurring_revenue_months - ongoing_discounted_annual_recurring_revenue_months
-                    ),
-                    0
-                  )
-                )
-              )
-            )
-            -- Remove VAT to get annual recurring net revenue.
-            / (1 + COALESCE(country_vat_rate, 0))
-            -- Apply exchange rate to get annual recurring revenue in USD.
-            * IF(subscription.plan_currency = 'USD', 1, plan_currency_usd_exchange_rate)
-          ),
-          2
-        )
+        subscription.plan_currency = 'USD',
+        annual_recurring_revenue,
+        ROUND((annual_recurring_revenue * plan_currency_usd_exchange_rate), 2)
       ) AS annual_recurring_revenue_usd
   ) AS subscription,
   was_active_at_month_start,

--- a/sql/moz-fx-data-shared-prod/subscription_platform/service_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/service_subscriptions/view.sql
@@ -137,11 +137,19 @@ augmented_subscriptions_5 AS (
   SELECT
     *,
     ROUND(
-      (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (monthly_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(provider IN ('Apple', 'Google'), (monthly_recurring_gross_revenue * 0.15), 0)
+      ),
       2
     ) AS monthly_recurring_revenue,
     ROUND(
-      (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0))),
+      (
+        (annual_recurring_gross_revenue / (1 + COALESCE(country_vat_rate, 0)))
+        -- Subtract service fees charged by Apple App Store and Google Play Store (DENG-9773).
+        - IF(provider IN ('Apple', 'Google'), (annual_recurring_gross_revenue * 0.15), 0)
+      ),
       2
     ) AS annual_recurring_revenue
   FROM


### PR DESCRIPTION
## Description
Apple and Google each take ~15% of our subscription revenue (DENG-9773).

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
* DENG-9773: Subtract service fees charged by Apple App Store and Google Play Store from subscription revenue projections

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
