### PR TITLE
Allow missing metadata.yaml for `backfill create`

### DIFF
--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -177,7 +177,7 @@ def create(
     A backfill.yaml file will be created if it does not already exist.
     """
     if errors := validate_table_metadata(
-        sql_dir, qualified_table_name, ignore_missing_metadata=False
+        sql_dir, qualified_table_name, ignore_missing_metadata=True
     ):
         click.echo("\n".join(errors))
         sys.exit(1)
@@ -207,7 +207,9 @@ def create(
 
     validate_duplicate_entry_with_initiate_status(new_entry, existing_backfills)
 
-    validate_depends_on_past_end_date(new_entry, backfill_file)
+    project, dataset, table = qualified_table_name_matching(qualified_table_name)
+    if (Path(sql_dir) / project / dataset / table / METADATA_FILE).exists():
+        validate_depends_on_past_end_date(new_entry, backfill_file)
 
     existing_backfills.insert(0, new_entry)
 


### PR DESCRIPTION
## Description

This allows using `bqetl backfill create` for generated sql, re: https://mozilla.slack.com/archives/C01E8GDG80N/p1759437906397399

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
