### PR TITLE
feat(DENG-9793): Add column to glean_baseline_clients_first_seen

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/glean_baseline_clients_first_seen/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/glean_baseline_clients_first_seen/view.sql
@@ -2,40 +2,58 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefox_desktop.glean_baseline_clients_first_seen`
 AS
 SELECT
-  submission_date,
-  first_seen_date,
-  sample_id,
-  client_id,
-  attribution,
-  `distribution`,
-  attribution_ext,
-  JSON_VALUE(attribution_ext.dlsource) AS attribution_dlsource,
-  JSON_VALUE(attribution_ext.dltoken) AS attribution_dltoken,
-  JSON_VALUE(attribution_ext.ua) AS attribution_ua,
-  JSON_VALUE(attribution_ext.experiment) AS attribution_experiment,
-  JSON_VALUE(attribution_ext.variation) AS attribution_variation,
-  distribution_ext,
-  legacy_telemetry_client_id,
-  legacy_telemetry_profile_group_id,
-  country,
-  distribution_id,
-  windows_build_number,
-  locale,
-  normalized_os,
-  app_display_version,
-  normalized_channel,
-  normalized_os_version,
-  isp,
+  bcfs.submission_date,
+  bcfs.first_seen_date,
+  bcfs.sample_id,
+  bcfs.client_id,
+  bcfs.attribution,
+  bcfs.`distribution`,
+  bcfs.attribution_ext,
+  JSON_VALUE(bcfs.attribution_ext.dlsource) AS attribution_dlsource,
+  JSON_VALUE(bcfs.attribution_ext.dltoken) AS attribution_dltoken,
+  JSON_VALUE(bcfs.attribution_ext.ua) AS attribution_ua,
+  JSON_VALUE(bcfs.attribution_ext.experiment) AS attribution_experiment,
+  JSON_VALUE(bcfs.attribution_ext.variation) AS attribution_variation,
+  bcfs.distribution_ext,
+  bcfs.legacy_telemetry_client_id,
+  bcfs.legacy_telemetry_profile_group_id,
+  bcfs.country,
+  bcfs.distribution_id,
+  bcfs.windows_build_number,
+  bcfs.locale,
+  bcfs.normalized_os,
+  bcfs.app_display_version,
+  bcfs.normalized_channel,
+  bcfs.normalized_os_version,
+  bcfs.isp,
   IF(
-    LOWER(IFNULL(isp, '')) <> "browserstack"
-    AND LOWER(IFNULL(COALESCE(distribution_id, distribution.name), '')) <> "mozillaonline",
+    LOWER(IFNULL(bcfs.isp, '')) <> "browserstack"
+    AND LOWER(
+      IFNULL(COALESCE(bcfs.distribution_id, bcfs.distribution.name), '')
+    ) <> "mozillaonline",
     TRUE,
     FALSE
   ) AS is_desktop,
   mozfun.norm.glean_windows_version_info(
-    normalized_os,
-    normalized_os_version,
-    windows_build_number
-  ) AS windows_version
+    bcfs.normalized_os,
+    bcfs.normalized_os_version,
+    bcfs.windows_build_number
+  ) AS windows_version,
+  CASE
+    WHEN LOWER(IFNULL(bcfs.isp, '')) = 'browserstack'
+      THEN CONCAT('Firefox Desktop', ' ', isp)
+    WHEN LOWER(
+        IFNULL(COALESCE(bcfs.distribution_id, distribution_mapping.distribution_id), '')
+      ) = 'mozillaonline'
+      THEN CONCAT(
+          'Firefox Desktop',
+          ' ',
+          COALESCE(bcfs.distribution_id, distribution_mapping.distribution_id)
+        )
+    ELSE 'Firefox Desktop'
+  END AS normalized_app_name
 FROM
-  `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_clients_first_seen_v1`
+  `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_clients_first_seen_v1` bcfs
+LEFT JOIN
+  `moz-fx-data-shared-prod.firefox_desktop_derived.desktop_dau_distribution_id_history_v1` AS distribution_mapping
+  USING (submission_date, client_id)


### PR DESCRIPTION
## Description

This PR adds the new column `normalized_app_name` to the view: 
- `moz-fx-data-shared-prod.firefox_desktop.glean_baseline_clients_first_seen`

## Related Tickets & Documents
* [DENG-9793](https://mozilla-hub.atlassian.net/browse/DENG-9793)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9793]: https://mozilla-hub.atlassian.net/browse/DENG-9793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ