### PR TITLE
feat(DENG-9791): Create google_ads.glean_conversion_event_categorization

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -276,6 +276,9 @@ DELETE_TARGETS: DeleteIndex = {
         table="firefox_desktop_derived.desktop_retention_clients_v1"
     ): DESKTOP_GLEAN_SRC,
     client_id_target(
+        table="google_ads_derived.glean_conversion_event_categorization_v1"
+    ): DESKTOP_GLEAN_SRC,
+    client_id_target(
         table="firefox_desktop_derived.desktop_engagement_clients_v1"
     ): DESKTOP_GLEAN_SRC,
     client_id_target(

--- a/sql/moz-fx-data-shared-prod/google_ads/glean_conversion_event_categorization/view.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads/glean_conversion_event_categorization/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.google_ads.glean_conversion_event_categorization`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.google_ads_derived.glean_conversion_event_categorization_v1`

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/checks.sql
@@ -1,0 +1,2 @@
+#warn
+{{ is_unique(["client_id"], "first_seen_date <= current_date") }}

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/metadata.yaml
@@ -1,0 +1,27 @@
+friendly_name: Glean Conversion Event Categorization
+description: |-
+  Classifies conversion events
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+scheduling:
+  dag_name: bqetl_desktop_conv_evnt_categorization
+  depends_on_past: false
+  date_partition_parameter: report_date
+  date_partition_offset: -9
+  parameters:
+  - submission_date:DATE:{{ds}}
+bigquery:
+  time_partitioning:
+    type: day
+    field: first_seen_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - country
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Glean Conversion Event Categorization
 description: |-
-  Classifies conversion events
+  Classifies behavior of new clients based on their behavior in first 7 days of activity
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/query.sql
@@ -14,7 +14,7 @@ WITH clients_first_seen_9_days_ago AS (
   WHERE
     first_seen_date = @report_date --this is 9 days before {{ds}}
 ),
---Step 2: Get the first 7 days of these new clients' behavior after they were first seen
+--Step 2: Get the first 7 days of these new clients' behavior from baseline_clients_last_seen
 clients_last_seen_info AS (
   SELECT
     cls.client_id,
@@ -24,22 +24,127 @@ clients_last_seen_info AS (
     cls.days_since_seen,
     cls.active_hours_sum,
     cls.days_visited_1_uri_bits,
-    cls.days_interacted_bits,
-    --cls.search_with_ads_count_all --not available yet
+    cls.days_interacted_bits
   FROM
     `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_last_seen` cls
   JOIN
     clients_first_seen_9_days_ago clients
     ON cls.client_id = clients.client_id
   WHERE
-    cls.submission_date BETWEEN clients.first_seen_date AND DATE_ADD(clients.first_seen_date, INTERVAL 6 DAY)
-), 
-metrics_clients_last_seen AS (
-  SELECT 
-  submission_date,
-  client_id,
-  search_with_ads_count_all
-  FROM `moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_daily_v1`
-  WHERE submission_date BETWEEN  @report_date AND DATE_ADD(@report_date, INTERVAL 6 DAYS)
+    cls.submission_date
+    BETWEEN clients.first_seen_date
+    AND DATE_ADD(clients.first_seen_date, INTERVAL 6 DAY)
 ),
-
+--Step 3: Get the first 7 days of these new clients' behavior from metrics_clients_last_seen
+metrics_clients_last_seen AS (
+  SELECT
+    mcls.submission_date,
+    mcls.client_id,
+    mcls.search_with_ads_count_all
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.metrics_clients_last_seen` mcls
+  JOIN
+    clients_first_seen_9_days_ago clients
+    ON mcls.client_id = clients.client_id
+  WHERE
+    mcls.submission_date
+    BETWEEN @report_date
+    AND DATE_ADD(@report_date, INTERVAL 6 DAY)
+),
+--Step 4: Aggregate the info about these new clients first 7 days into 1 CTE
+clients_last_seen_raw AS (
+  SELECT
+    COALESCE(a.client_id, b.client_id) AS client_id,
+    COALESCE(a.submission_date, b.submission_date) AS submission_date,
+    a.first_seen_date,
+    a.country,
+    a.days_since_seen,
+    a.active_hours_sum,
+    a.days_visited_1_uri_bits,
+    a.days_interacted_bits,
+    b.search_with_ads_count_all
+  FROM
+    clients_last_seen_info a
+  FULL OUTER JOIN
+    metrics_clients_last_seen b
+    ON a.client_id = b.client_id
+    AND a.submission_date = b.submission_date
+),
+--for each client, create 1 row with the summary of their behavior in first 7 days
+client_activity_first_7_days AS (
+  SELECT
+    client_id,
+    ANY_VALUE(
+      first_seen_date
+    ) AS first_seen_date, --date we got first main ping (potentially different than above first seen date)
+    ANY_VALUE(country) AS country, --any country from their first day in clients_last_seen
+    ANY_VALUE(
+      CASE
+        WHEN submission_date = DATE_ADD(first_seen_date, INTERVAL 6 DAY)
+          THEN BIT_COUNT(days_visited_1_uri_bits & days_interacted_bits)
+      END
+    ) AS dou, --total # of days of activity during their first 7 days of main pings
+  -- if a client doesn't send a ping on `submission_date` their last active day's value will be carried forward
+  -- so we only take measurements from days that they send a ping.
+    SUM(
+      CASE
+        WHEN days_since_seen = 0
+          THEN COALESCE(active_hours_sum, 0)
+        ELSE 0
+      END
+    ) AS active_hours_sum,
+    SUM(
+      CASE
+        WHEN days_since_seen = 0
+          THEN COALESCE(search_with_ads_count_all, 0)
+        ELSE 0
+      END
+    ) AS search_with_ads_count_all
+  FROM
+    clients_last_seen_raw
+  GROUP BY
+    client_id
+),
+combined AS (
+  SELECT
+    cfs.client_id,
+    cfs.first_seen_date,
+    cfs.attribution_campaign,
+    cfs.attribution_content,
+    cfs.attribution_dltoken,
+    cfs.attribution_medium,
+    cfs.attribution_source,
+    COALESCE(
+      cls.country,
+      cfs.country
+    ) AS country, -- Conversion events & LTV are based on their first observed country in CLS, use that country if its available
+    COALESCE(dou, 0) AS dou,
+    COALESCE(active_hours_sum, 0) AS active_hours_sum,
+    COALESCE(search_with_ads_count_all, 0) AS search_with_ads_count_all
+  FROM
+    clients_first_seen_9_days_ago AS cfs
+  LEFT JOIN
+    client_activity_first_7_days AS cls
+    USING (client_id)
+)
+SELECT
+  client_id,
+  first_seen_date,
+  attribution_campaign,
+  attribution_content,
+  attribution_dltoken,
+  attribution_medium,
+  attribution_source,
+  @submission_date AS report_date,
+  country,
+  dou,
+  active_hours_sum,
+  search_with_ads_count_all,
+  IF(search_with_ads_count_all > 0 AND dou >= 5, TRUE, FALSE) AS event_1,
+  IF(search_with_ads_count_all > 0 AND dou >= 3, TRUE, FALSE) AS event_2,
+  IF(active_hours_sum >= 0.4 AND dou >= 3, TRUE, FALSE) AS event_3,
+  IF(dou >= 4, TRUE, FALSE) AS is_dau_at_least_4_of_first_7_days,
+  IF(dou >= 3, TRUE, FALSE) AS is_dau_at_least_3_of_first_7_days,
+  IF(dou >= 2, TRUE, FALSE) AS is_dau_at_least_2_of_first_7_days,
+FROM
+  combined

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/query.sql
@@ -33,8 +33,8 @@ clients_last_seen_info AS (
     ON cls.client_id = clients.client_id
   WHERE
     cls.submission_date
-    BETWEEN clients.first_seen_date
-    AND DATE_ADD(clients.first_seen_date, INTERVAL 6 DAY)
+    BETWEEN @report_date
+    AND DATE_ADD(@report_date, INTERVAL 6 DAY)
 ),
 --Step 3: Get the first 7 days of these new clients' behavior from metrics_clients_last_seen
 metrics_clients_last_seen AS (

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/query.sql
@@ -13,6 +13,7 @@ WITH clients_first_seen_9_days_ago AS (
     `moz-fx-data-shared-prod.firefox_desktop.glean_baseline_clients_first_seen` cfs
   WHERE
     first_seen_date = @report_date --this is 9 days before {{ds}}
+    AND submission_date = @report_date --this is 9 days before {{ds}}
 ),
 --Step 2: Get the first 7 days of these new clients' behavior from baseline_clients_last_seen
 clients_last_seen_info AS (

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/query.sql
@@ -1,0 +1,45 @@
+--Step 1:  Get clients with a first seen date = submission date - 9 days
+WITH clients_first_seen_9_days_ago AS (
+  SELECT
+    client_id,
+    first_seen_date,
+    country,
+    attribution.campaign AS attribution_campaign,
+    attribution.content AS attribution_content,
+    attribution_dltoken,
+    attribution.medium AS attribution_medium,
+    attribution.source AS attribution_source
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.glean_baseline_clients_first_seen` cfs
+  WHERE
+    first_seen_date = @report_date --this is 9 days before {{ds}}
+),
+--Step 2: Get the first 7 days of these new clients' behavior after they were first seen
+clients_last_seen_info AS (
+  SELECT
+    cls.client_id,
+    cls.first_seen_date,
+    cls.country,
+    cls.submission_date,
+    cls.days_since_seen,
+    cls.active_hours_sum,
+    cls.days_visited_1_uri_bits,
+    cls.days_interacted_bits,
+    --cls.search_with_ads_count_all --not available yet
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_last_seen` cls
+  JOIN
+    clients_first_seen_9_days_ago clients
+    ON cls.client_id = clients.client_id
+  WHERE
+    cls.submission_date BETWEEN clients.first_seen_date AND DATE_ADD(clients.first_seen_date, INTERVAL 6 DAY)
+), 
+metrics_clients_last_seen AS (
+  SELECT 
+  submission_date,
+  client_id,
+  search_with_ads_count_all
+  FROM `moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_daily_v1`
+  WHERE submission_date BETWEEN  @report_date AND DATE_ADD(@report_date, INTERVAL 6 DAYS)
+),
+

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/schema.yaml
@@ -2,11 +2,11 @@ fields:
 - mode: NULLABLE
   name: client_id
   type: STRING
-  description: Client ID
+  description: A unique identifier (UUID) for the client.
 - mode: NULLABLE
   name: first_seen_date
   type: DATE
-  description: First Seen Date
+  description: Date the server received the first baseline ping for this client_id.
 - mode: NULLABLE
   name: attribution_campaign
   type: STRING
@@ -30,15 +30,12 @@ fields:
 - mode: NULLABLE
   name: report_date
   type: DATE
-  description: Report Date
-- mode: NULLABLE
-  name: first_main_ping_date
-  type: DATE
-  description: First Main Ping Date
+  description: The date used to report the first 7 days of activity, 9 days after the client's first seen date.
 - mode: NULLABLE
   name: country
   type: STRING
-  description: Country
+  description: Name of the country in which the activity took place, as determined by
+    the IP geolocation.
 - mode: NULLABLE
   name: dou
   type: INT64

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/schema.yaml
@@ -39,7 +39,7 @@ fields:
 - mode: NULLABLE
   name: dou
   type: INT64
-  description: DOU
+  description: Days of Use
 - mode: NULLABLE
   name: active_hours_sum
   type: FLOAT

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/glean_conversion_event_categorization_v1/schema.yaml
@@ -1,0 +1,77 @@
+fields:
+- mode: NULLABLE
+  name: client_id
+  type: STRING
+  description: Client ID
+- mode: NULLABLE
+  name: first_seen_date
+  type: DATE
+  description: First Seen Date
+- mode: NULLABLE
+  name: attribution_campaign
+  type: STRING
+  description: Attribution Campaign
+- mode: NULLABLE
+  name: attribution_content
+  type: STRING
+  description: Attribution Content
+- mode: NULLABLE
+  name: attribution_dltoken
+  type: STRING
+  description: Attribution Download Token
+- mode: NULLABLE
+  name: attribution_medium
+  type: STRING
+  description: Attribution Medium
+- mode: NULLABLE
+  name: attribution_source
+  type: STRING
+  description: Attribution Source
+- mode: NULLABLE
+  name: report_date
+  type: DATE
+  description: Report Date
+- mode: NULLABLE
+  name: first_main_ping_date
+  type: DATE
+  description: First Main Ping Date
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: Country
+- mode: NULLABLE
+  name: dou
+  type: INT64
+  description: DOU
+- mode: NULLABLE
+  name: active_hours_sum
+  type: FLOAT
+  description: Active Hours Sum
+- mode: NULLABLE
+  name: search_with_ads_count_all
+  type: INTEGER
+  description: Search With Ads Count All
+- mode: NULLABLE
+  name: event_1
+  type: BOOLEAN
+  description: Event 1 Indicator - 5 or more days of use and 1 or more search with ads (strictest event)
+- mode: NULLABLE
+  name: event_2
+  type: BOOLEAN
+  description: Event 2 Indicator - 3 or more days of use and 1 or more search with ads (medium event)
+- mode: NULLABLE
+  name: event_3
+  type: BOOLEAN
+  description: Event 3 Indicator - 3 or more days of use and 0.4 or more active hours (most lenient event)
+- mode: NULLABLE
+  name: is_dau_at_least_4_of_first_7_days
+  type: BOOLEAN
+  description: Client was a daily active user in at least 4 of first 7 days
+- mode: NULLABLE
+  name: is_dau_at_least_3_of_first_7_days
+  type: BOOLEAN
+  description: Client was a daily active user in at least 3 of first 7 days
+- mode: NULLABLE
+  name: is_dau_at_least_2_of_first_7_days
+  type: BOOLEAN
+  description: Client was a daily active user in at least 2 of first 7 days


### PR DESCRIPTION
## Description

This PR builds the following table & view, which are based off of Glean data instead of legacy telemetry data:
- `moz-fx-data-shared-prod.google_ads_derived.glean_conversion_event_categorization_v1`
- `moz-fx-data-shared-prod.google_ads.glean_conversion_event_categorization`

It also adds the new table to Shredder.

## Related Tickets & Documents
* [DENG-9791](https://mozilla-hub.atlassian.net/browse/DENG-9791)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9791]: https://mozilla-hub.atlassian.net/browse/DENG-9791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ