### PR TITLE
fix: make a new daily dag for win10 models

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2487,3 +2487,17 @@ bqetl_firefox_enterprise:
     retry_delay: 30m
   tags:
     - impact/tier_3
+
+bqetl_braze_win10_sync:
+  schedule_interval: 0 9 * * *
+  description: |
+    Daily run to pull inactive Win10 users and sync them to Braze.
+  default_args:
+    owner: lmcfall@mozilla.com
+    email:
+      - lmcfall@mozilla.com
+    start_date: '2025-10-06'
+    retries: 1
+    retry_delay: 30m
+  tags:
+    - impact/tier_3

--- a/sql/moz-fx-data-shared-prod/braze_derived/fxa_win10_users_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/fxa_win10_users_daily_v1/metadata.yaml
@@ -9,4 +9,4 @@ labels:
   schedule: daily
   owner: lmcfall
 scheduling:
-  dag_name: bqetl_braze
+  dag_name: bqetl_braze_win10_sync

--- a/sql/moz-fx-data-shared-prod/braze_derived/fxa_win10_users_historical_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/fxa_win10_users_historical_v1/metadata.yaml
@@ -9,7 +9,7 @@ labels:
   schedule: daily
   owner: lmcfall
 scheduling:
-  dag_name: bqetl_braze
+  dag_name: bqetl_braze_win10_sync
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/braze_external/win10_users_sync_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_external/win10_users_sync_v1/metadata.yaml
@@ -8,4 +8,4 @@ labels:
   incremental: true
   owner1: lmcfall
 scheduling:
-  dag_name: bqetl_braze
+  dag_name: bqetl_braze_win10_sync


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR creates a new dag to run daily in the mornings for the windows 10 inactive users models.

## Related Tickets & Documents
* [Bug 1992701](https://bugzilla.mozilla.org/show_bug.cgi?id=1992701)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
