### PR TITLE
feat(scheduling): Support specifying days in timedelta strings

### DIFF
--- a/bigquery_etl/query_scheduling/utils.py
+++ b/bigquery_etl/query_scheduling/utils.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime
 
 TIMEDELTA_RE = re.compile(
-    r"^-?((?P<hours>\d+)h)?((?P<minutes>\d+)m)?((?P<seconds>\d+)s)?$"
+    r"^-?((?P<days>\d+)d)?((?P<hours>\d+)h)?((?P<minutes>\d+)m)?((?P<seconds>\d+)s)?$"
 )
 
 


### PR DESCRIPTION
## Description
With some DAGs being scheduled for longer time periods (e.g. weekly, monthly, quarterly), being able to specify a number of days for execution deltas would be helpful (e.g. https://github.com/mozilla/private-bigquery-etl/pull/1020).

## Related Tickets & Documents
* https://github.com/mozilla/private-bigquery-etl/pull/1020

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
