### PR TITLE
Lower initialization parallelism and run in backfill slots

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -80,7 +80,7 @@ QUERY_NAME_RE = re.compile(r"(?P<dataset>[a-zA-z0-9_]+)\.(?P<name>[a-zA-z0-9_]+)
 VERSION_RE = re.compile(r"_v[0-9]+")
 DESTINATION_TABLE_RE = re.compile(r"^[a-zA-Z0-9_$]{0,1024}$")
 DEFAULT_DAG_NAME = "bqetl_default"
-DEFAULT_INIT_PARALLELISM = 10
+DEFAULT_INIT_PARALLELISM = 3
 DEFAULT_CHECKS_FILE_NAME = "checks.sql"
 VIEW_FILE = "view.sql"
 MATERIALIZED_VIEW = "materialized_view.sql"
@@ -1467,7 +1467,7 @@ def _initialize_in_parallel(
 @click.argument("name")
 @sql_dir_option
 @project_id_option()
-@billing_project_option()
+@billing_project_option(default="moz-fx-data-backfill-slots")
 @click.option(
     "--dry_run/--no_dry_run",
     "--dry-run/--no-dry-run",
@@ -1599,7 +1599,7 @@ def initialize(
                         dataset=dataset,
                         query_file=query_file,
                         arguments=arguments,
-                        parallelism=parallelism,
+                        parallelism=2,
                         sample_ids=sample_ids,
                         addl_templates={
                             "is_init": lambda: True,

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -81,6 +81,7 @@ VERSION_RE = re.compile(r"_v[0-9]+")
 DESTINATION_TABLE_RE = re.compile(r"^[a-zA-Z0-9_$]{0,1024}$")
 DEFAULT_DAG_NAME = "bqetl_default"
 DEFAULT_INIT_PARALLELISM = 3
+INIT_SAMPLE_ID_PARALLELISM = 2
 DEFAULT_CHECKS_FILE_NAME = "checks.sql"
 VIEW_FILE = "view.sql"
 MATERIALIZED_VIEW = "materialized_view.sql"
@@ -1599,7 +1600,7 @@ def initialize(
                         dataset=dataset,
                         query_file=query_file,
                         arguments=arguments,
-                        parallelism=2,
+                        parallelism=INIT_SAMPLE_ID_PARALLELISM,
                         sample_ids=sample_ids,
                         addl_templates={
                             "is_init": lambda: True,


### PR DESCRIPTION
## Description

Related to https://github.com/mozilla/bigquery-etl/pull/7974 and https://github.com/mozilla/bigquery-etl/pull/8046 which have large backfills that would be simpler in the is_init than in a managed backfill since they can run in a single query.  The current parallelism is fairly high at 10 since it's unlikely to run 10 queries without slot contention, and smaller queries will be fast anyway so parallelism wouldn't matter as much.  Lowering the parallelism to reduce the chances of running out of memory or query timeouts.  Also moving to backfill reservation so it doesn't get in the way of etl if it runs overnight.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
