### PR TITLE
fix(SubPlat): Re-map FPN and Hubs subscriptions to the associated services (DENG-9774)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/services_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/services_v1/query.sql
@@ -82,6 +82,12 @@ WITH services AS (
           'Hubs' AS name,
           [
             STRUCT(
+              'Business' AS name,
+              ['hubs-business'] AS subplat_capabilities,
+              -- Workaround for capabilities metadata being removed from the Hubs Stripe products (DENG-9774).
+              ['prod_PELUqOPlucjXFE'] AS stripe_product_ids
+            ),
+            STRUCT(
               'Professional' AS name,
               ['hubs-professional'] AS subplat_capabilities,
               -- Workaround for capabilities metadata being removed from the Hubs Stripe products (DENG-9774).
@@ -94,7 +100,7 @@ WITH services AS (
               ['prod_Mo4tS8uH9y3Mj5'] AS stripe_product_ids
             )
           ] AS tiers,
-          ['hubs-professional', 'managed-hubs'] AS subplat_capabilities,
+          ['hubs-business', 'hubs-professional', 'managed-hubs'] AS subplat_capabilities,
           [
             STRUCT('8c3e3e6de4ee9731' AS id, 'mozilla-hubs' AS name),
             STRUCT('34bc0d0a6add7329' AS id, 'mozilla-hubs-dev' AS name)


### PR DESCRIPTION
## Description
It appears some SubPlat capabilities metadata was removed from the FPN and Hubs Stripe products in July (probably something to do with the migration to SubPlat 3), which resulted in the associated subscriptions no longer being mapped to services in the SubPlat consolidated reporting ETLs.  This PR implements workarounds to manually re-map those Stripe products to the associated services.

Also, there was a Hubs Business tier which never actually launched, but there were a handful of test subscriptions created for that, so this PR adds the service tier mapping config for that.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
* DENG-9774: Map all logical subscriptions to at least one service where reasonable

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
