### PR TITLE
bug: replace spoc tile id reference to current table

### DIFF
--- a/sql/moz-fx-data-shared-prod/activity_stream/impression_stats_by_experiment/view.sql
+++ b/sql/moz-fx-data-shared-prod/activity_stream/impression_stats_by_experiment/view.sql
@@ -8,5 +8,5 @@ SELECT
 FROM
   `moz-fx-data-shared-prod.activity_stream_bi.impression_stats_by_experiment_v1` AS stats
 LEFT JOIN
-  `moz-fx-data-shared-prod.pocket.spoc_tile_ids` AS spoc_tile_ids
+  `moz-fx-data-shared-prod.pocket_derived.spoc_tile_ids_v1` AS spoc_tile_ids
   USING (tile_id)

--- a/sql/moz-fx-data-shared-prod/activity_stream/impression_stats_flat/view.sql
+++ b/sql/moz-fx-data-shared-prod/activity_stream/impression_stats_flat/view.sql
@@ -8,5 +8,5 @@ SELECT
 FROM
   `moz-fx-data-shared-prod.activity_stream_bi.impression_stats_flat_v1` AS stats
 LEFT JOIN
-  `moz-fx-data-shared-prod.pocket.spoc_tile_ids` AS spoc_tile_ids
+  `moz-fx-data-shared-prod.pocket_derived.spoc_tile_ids_v1` AS spoc_tile_ids
   USING (tile_id)


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
The old spoc tile table was removed and needed to be replaced by the pocket_derived version.

## Related Tickets & Documents
* [DENG-9844](https://mozilla-hub.atlassian.net/browse/DENG-9844?atlOrigin=eyJpIjoiMDRmN2FmY2RmN2FiNDk5ZThmNjg3YjJhNmNiNzFmNjAiLCJwIjoiaiJ9)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
