### PR TITLE
fix(Google Search Console): Wait an extra day before expecting Google Search Console export data to exist

### DIFF
--- a/sql/moz-fx-data-shared-prod/google_search_console_derived/search_impressions_by_page_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_search_console_derived/search_impressions_by_page_v2/metadata.yaml
@@ -23,27 +23,28 @@ labels:
 scheduling:
   dag_name: bqetl_google_search_console
   date_partition_parameter: date
-  # Google Search Console exports typically happen two days after the data date in UTC.
-  date_partition_offset: -1
+  # Google Search Console exports typically happen two days after the data date in UTC, but we wait
+  # an extra day beyond that because Google Search Console exports have often been further delayed.
+  date_partition_offset: -2
   depends_on_table_partitions_existing:
   - task_id: wait_for_google_search_console_addons_url_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_addons.searchdata_url_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
   - task_id: wait_for_google_search_console_blog_url_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_blog.searchdata_url_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
   - task_id: wait_for_google_search_console_getpocket_url_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_getpocket.searchdata_url_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
   - task_id: wait_for_google_search_console_mdn_url_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_mdn.searchdata_url_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
   - task_id: wait_for_google_search_console_support_url_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_support.searchdata_url_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
   - task_id: wait_for_google_search_console_www_url_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_www.searchdata_url_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/google_search_console_derived/search_impressions_by_site_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_search_console_derived/search_impressions_by_site_v2/metadata.yaml
@@ -23,27 +23,28 @@ labels:
 scheduling:
   dag_name: bqetl_google_search_console
   date_partition_parameter: date
-  # Google Search Console exports typically happen two days after the data date in UTC.
-  date_partition_offset: -1
+  # Google Search Console exports typically happen two days after the data date in UTC, but we wait
+  # an extra day beyond that because Google Search Console exports have often been further delayed.
+  date_partition_offset: -2
   depends_on_table_partitions_existing:
   - task_id: wait_for_google_search_console_addons_site_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_addons.searchdata_site_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
   - task_id: wait_for_google_search_console_blog_site_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_blog.searchdata_site_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
   - task_id: wait_for_google_search_console_getpocket_site_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_getpocket.searchdata_site_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
   - task_id: wait_for_google_search_console_mdn_site_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_mdn.searchdata_site_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
   - task_id: wait_for_google_search_console_support_site_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_support.searchdata_site_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
   - task_id: wait_for_google_search_console_www_site_impressions
     table_id: moz-fx-data-marketing-prod.searchconsole_www.searchdata_site_impression
-    partition_id: '{{ data_interval_start.subtract(days=1) | ds_nodash }}'
+    partition_id: '{{ data_interval_start.subtract(days=2) | ds_nodash }}'
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description
The table partition sensors in the [`bqetl_google_search_console` DAG](https://workflow.telemetry.mozilla.org/dags/bqetl_google_search_console/grid) have timed out waiting for Google Search Console export data in 18 of the last 30 days, so it seems Google Search Console has been struggling to keep up with its typical schedule for BigQuery exports.

## Related Tickets & Documents
N/A

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
