### PR TITLE
feat(DENG-9872): Add 2 new columns to mozilla_org_derived.ga_sessions_v3

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v3/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/ga_sessions_v3/schema.yaml
@@ -247,3 +247,11 @@ fields:
   type: STRING
   mode: REPEATED
   description: All non-null reported experiment branches from event_params for this session.
+- name: first_gad_campaignid_from_event_params
+  type: STRING
+  mode: NULLABLE
+  description: The first non-null reported gad_campaignid from event_params for this session.
+- name: distinct_gad_campaignid_from_event_params
+  type: STRING
+  mode: REPEATED
+  description: All non-null reported gad_campaignid from event_params for this session.


### PR DESCRIPTION
## Description

This PR adds 2 new columns, `first_gad_campaignid_from_event_params`, & `distinct_gad_campaignid_from_event_params` to the table & corresponding view:
- `moz-fx-data-shared-prod.mozilla_org_derived.ga_sessions_v3`
- `moz-fx-data-shared-prod.mozilla_org.ga_sessions`


## Related Tickets & Documents
* [DENG-9872](https://mozilla-hub.atlassian.net/browse/DENG-9872)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9872]: https://mozilla-hub.atlassian.net/browse/DENG-9872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ