### PR TITLE
[DENG-9876] Adding dataViewer access to monitoring_derived dataset for chicory poc

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/dataset_metadata.yaml
@@ -8,3 +8,4 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential
+  - workgroup:platform-infra/chicory-poc


### PR DESCRIPTION
## Description

Adding dataViewer access to monitoring_derived dataset for chicory poc

## Related Tickets & Documents
* DENG-9876

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
