### PR TITLE
feat: firefox_desktop_derived/enterprise_metrics_clients_v1 add 2025-10-13 backfill entry

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/enterprise_metrics_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/enterprise_metrics_clients_v1/backfill.yaml
@@ -1,3 +1,13 @@
+2025-10-13:
+  start_date: 2025-09-20
+  end_date: 2025-10-13
+  reason: Backfill to populate dates missing data due to the delay between the backfill completion and enabling the DAG.
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+
 2025-09-21:
   start_date: 2023-08-10
   end_date: 2025-09-21


### PR DESCRIPTION
# feat: firefox_desktop_derived/enterprise_metrics_clients_v1 add 2025-10-13 backfill entry

This is to populate the few dates that are missing due to the delay in enabling the corresponding DAG.