### PR TITLE
feat: add new backfill entry 2025-10-13 for app_store_funnel_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2025-10-13:
+  start_date: 2024-01-01
+  end_date: 2025-10-10
+  reason: Backfill to recompute partitions with fixed upstream data source.
+  watchers:
+  - kik@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false


### PR DESCRIPTION
# feat: add new backfill entry 2025-10-13 for app_store_funnel_v1

This is to recompute partitions affected by data issues in the upstream data source. The upstream data should now be fixed and we need to do this to make sure the data in this dataset is accurate.