### PR TITLE
bug: adjust win10 dag schedule to detect upstream task correctly

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2476,7 +2476,7 @@ bqetl_firefox_enterprise:
     - impact/tier_3
 
 bqetl_braze_win10_sync:
-  schedule_interval: 0 6 * * *
+  schedule_interval: 0 5 * * *
   description: |
     Daily run to pull inactive Win10 users and sync them to Braze.
   default_args:


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
Fixes the bug where the win10 dag has tasks waiting to complete at incompatible times.

## Related Tickets & Documents
* [Bug 1994318](https://bugzilla.mozilla.org/show_bug.cgi?id=1994318)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
