### PR TITLE
fix(bug-1994315): app_store_funnel_v1/bigconfig.yml using invalid column in metric definitions

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/bigconfig.yml
@@ -7,20 +7,16 @@ tag_deployments:
 
   deployments:
   - column_selectors:
-    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.firefox_ios_derived.app_store_funnel_v1.session_date
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.firefox_ios_derived.app_store_funnel_v1.submission_date
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.firefox_ios_derived.app_store_funnel_v1.first_seen_date
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.firefox_ios_derived.app_store_funnel_v1.country
     metrics:
     - saved_metric_id: is_not_null
-      rct_overrides:
-      - date
   - column_selectors:
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.firefox_ios_derived.app_store_funnel_v1.submission_date
     - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.firefox_ios_derived.app_store_funnel_v1.country
     metrics:
     - saved_metric_id: composite_key_uniqueness_2_column
-      rct_overrides:
-      - date
       parameters:
       - key: col_1
         column_name: submission_date


### PR DESCRIPTION
# fix(bug-1994315): app_store_funnel_v1/bigconfig.yml using invalid column in metric definitions