### PR TITLE
fix: add missing partition filter in the query

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/enterprise_metrics_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/enterprise_metrics_v1/query.sql
@@ -6,5 +6,7 @@ SELECT
   COUNT(*) AS client_count,
 FROM
   `moz-fx-data-shared-prod.firefox_desktop.enterprise_metrics_clients`
+WHERE
+  submission_date = @submission_date
 GROUP BY
   ALL


### PR DESCRIPTION
# fix: add missing partition filter in the query

Without this filter the ETL task fails due to the result set containing data for partitions other than the specific partition it tries to write to.
