### PR TITLE
feat: uncomment scheduling settings for app_store_choice_screen_selection_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/metadata.yaml
@@ -1,3 +1,7 @@
+# Note: in the past this task had a history of failing due to not being able to find a report
+#       for the logical date. In this case feel free to ignore the failure
+#       (if a re-run did not resolve the problem) and observe the task over the next few days.
+#       If it continues failing please file a bug and contact the owner.
 friendly_name: Apple App Store Choice Screen Selection (post-iOS 18.2 only)
 description: |
   Apple App Store Choice Screen Engagement (post-iOS 18.2 only)


### PR DESCRIPTION
# feat: uncomment scheduling settings for app_store_choice_screen_selection_v1

We've been informed by the data producer that the data should now be available for consumption.