### PR TITLE
fix(SubPlat): Make logical subscription ETL/view schemas more consistent (DENG-9903)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/schema.yaml
@@ -212,57 +212,6 @@ fields:
   description: |-
     When the subscription's auto-renewal setting was disabled.
     This will be null for subscriptions set to auto-renew.
-- name: initial_discount_name
-  type: STRING
-  mode: NULLABLE
-  description: |-
-    Initial discount name (if any).
-    This will be null for Google and Apple subscriptions.
-- name: initial_discount_promotion_code
-  type: STRING
-  mode: NULLABLE
-  description: |-
-    Initial discount promotion code (if any).
-- name: current_period_discount_name
-  type: STRING
-  mode: NULLABLE
-  description: |-
-    Current period discount name (if any).
-    This will be null for Google and Apple subscriptions.
-- name: current_period_discount_promotion_code
-  type: STRING
-  mode: NULLABLE
-  description: |-
-    Current period discount promotion code (if any).
-- name: current_period_discount_amount
-  type: NUMERIC
-  mode: NULLABLE
-  description: |-
-    Current period discount amount (if any).
-    This may be null for Apple subscriptions.
-- name: ongoing_discount_name
-  type: STRING
-  mode: NULLABLE
-  description: |-
-    Ongoing discount name (if any).
-    This will be null for Google and Apple subscriptions.
-- name: ongoing_discount_promotion_code
-  type: STRING
-  mode: NULLABLE
-  description: |-
-    Ongoing discount promotion code (if any).
-- name: ongoing_discount_amount
-  type: NUMERIC
-  mode: NULLABLE
-  description: |-
-    Ongoing discount amount (if any).
-    This may be null for Apple subscriptions.
-- name: ongoing_discount_ends_at
-  type: TIMESTAMP
-  mode: NULLABLE
-  description: |-
-    When the ongoing discount ends (if any).
-    This will be null for Apple subscriptions.
 - name: has_refunds
   type: BOOLEAN
   mode: NULLABLE
@@ -327,6 +276,57 @@ fields:
     mode: NULLABLE
     description: |-
       Last-touch attribution UTM term.
+- name: initial_discount_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Initial discount name (if any).
+    This will be null for Google and Apple subscriptions.
+- name: initial_discount_promotion_code
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Initial discount promotion code (if any).
+- name: current_period_discount_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Current period discount name (if any).
+    This will be null for Google and Apple subscriptions.
+- name: current_period_discount_promotion_code
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Current period discount promotion code (if any).
+- name: current_period_discount_amount
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Current period discount amount (if any).
+    This may be null for Apple subscriptions.
+- name: ongoing_discount_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Ongoing discount name (if any).
+    This will be null for Google and Apple subscriptions.
+- name: ongoing_discount_promotion_code
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Ongoing discount promotion code (if any).
+- name: ongoing_discount_amount
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Ongoing discount amount (if any).
+    This may be null for Apple subscriptions.
+- name: ongoing_discount_ends_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the ongoing discount ends (if any).
+    This will be null for Apple subscriptions.
 - name: ended_reason
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1_live/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1_live/schema.yaml
@@ -349,16 +349,6 @@ fields:
       mode: NULLABLE
       description: |-
         Last-touch attribution UTM term.
-  - name: ended_reason
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Reason why the subscription ended.
-      Possible values:
-        * `Admin Initiated` - An admin at Mozilla ended the subscription, either directly or by deleting the customer's Mozilla Account.
-        * `Customer Initiated` - The customer ended their subscription, either directly or by turning off auto-renewal or deleting their Mozilla Account.
-        * `Payment Failure` - The subscription was unable to auto-renew due to a payment failure.
-        * `Other` - The subscription ended for some other reason, such as unverified Mozilla Accounts being automatically deleted.
   - name: initial_discount_name
     type: STRING
     mode: NULLABLE
@@ -410,6 +400,16 @@ fields:
     description: |-
       When the ongoing discount ends (if any).
       This will be null for Apple subscriptions.
+  - name: ended_reason
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Reason why the subscription ended.
+      Possible values:
+        * `Admin Initiated` - An admin at Mozilla ended the subscription, either directly or by deleting the customer's Mozilla Account.
+        * `Customer Initiated` - The customer ended their subscription, either directly or by turning off auto-renewal or deleting their Mozilla Account.
+        * `Payment Failure` - The subscription was unable to auto-renew due to a payment failure.
+        * `Other` - The subscription ended for some other reason, such as unverified Mozilla Accounts being automatically deleted.
 - name: was_active_at_day_start
   type: BOOLEAN
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1_live/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1_live/schema.yaml
@@ -359,16 +359,6 @@ fields:
       mode: NULLABLE
       description: |-
         Last-touch attribution UTM term.
-  - name: ended_reason
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Reason why the subscription ended.
-      Possible values:
-        * `Admin Initiated` - An admin at Mozilla ended the subscription, either directly or by deleting the customer's Mozilla Account.
-        * `Customer Initiated` - The customer ended their subscription, either directly or by turning off auto-renewal or deleting their Mozilla Account.
-        * `Payment Failure` - The subscription was unable to auto-renew due to a payment failure.
-        * `Other` - The subscription ended for some other reason, such as unverified Mozilla Accounts being automatically deleted.
   - name: initial_discount_name
     type: STRING
     mode: NULLABLE
@@ -420,6 +410,16 @@ fields:
     description: |-
       When the ongoing discount ends (if any).
       This will be null for Apple subscriptions.
+  - name: ended_reason
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Reason why the subscription ended.
+      Possible values:
+        * `Admin Initiated` - An admin at Mozilla ended the subscription, either directly or by deleting the customer's Mozilla Account.
+        * `Customer Initiated` - The customer ended their subscription, either directly or by turning off auto-renewal or deleting their Mozilla Account.
+        * `Payment Failure` - The subscription was unable to auto-renew due to a payment failure.
+        * `Other` - The subscription ended for some other reason, such as unverified Mozilla Accounts being automatically deleted.
 - name: old_subscription
   type: RECORD
   mode: NULLABLE
@@ -755,16 +755,6 @@ fields:
       mode: NULLABLE
       description: |-
         Last-touch attribution UTM term.
-  - name: ended_reason
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Reason why the subscription ended.
-      Possible values:
-        * `Admin Initiated` - An admin at Mozilla ended the subscription, either directly or by deleting the customer's Mozilla Account.
-        * `Customer Initiated` - The customer ended their subscription, either directly or by turning off auto-renewal or deleting their Mozilla Account.
-        * `Payment Failure` - The subscription was unable to auto-renew due to a payment failure.
-        * `Other` - The subscription ended for some other reason, such as unverified Mozilla Accounts being automatically deleted.
   - name: initial_discount_name
     type: STRING
     mode: NULLABLE
@@ -816,3 +806,13 @@ fields:
     description: |-
       When the ongoing discount ends (if any).
       This will be null for Apple subscriptions.
+  - name: ended_reason
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Reason why the subscription ended.
+      Possible values:
+        * `Admin Initiated` - An admin at Mozilla ended the subscription, either directly or by deleting the customer's Mozilla Account.
+        * `Customer Initiated` - The customer ended their subscription, either directly or by turning off auto-renewal or deleting their Mozilla Account.
+        * `Payment Failure` - The subscription was unable to auto-renew due to a payment failure.
+        * `Other` - The subscription ended for some other reason, such as unverified Mozilla Accounts being automatically deleted.

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_history_v1/query.sql
@@ -118,6 +118,10 @@ SELECT
     history.subscription.current_period_ends_at,
     history.subscription.auto_renew,
     history.subscription.auto_renew_disabled_at,
+    history.subscription.has_refunds,
+    history.subscription.has_fraudulent_charges,
+    subscription_attributions.first_touch_attribution,
+    subscription_attributions.last_touch_attribution,
     history.subscription.initial_discount_name,
     history.subscription.initial_discount_promotion_code,
     history.subscription.current_period_discount_name,
@@ -127,10 +131,6 @@ SELECT
     history.subscription.ongoing_discount_promotion_code,
     history.subscription.ongoing_discount_amount,
     history.subscription.ongoing_discount_ends_at,
-    history.subscription.has_refunds,
-    history.subscription.has_fraudulent_charges,
-    subscription_attributions.first_touch_attribution,
-    subscription_attributions.last_touch_attribution,
     history.subscription.ended_reason
   ) AS subscription
 FROM

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_history_v1/schema.yaml
@@ -239,57 +239,6 @@ fields:
     description: |-
       When the subscription's auto-renewal setting was disabled.
       This will be null for subscriptions set to auto-renew.
-  - name: initial_discount_name
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Initial discount name (if any).
-      This will be null for Google and Apple subscriptions.
-  - name: initial_discount_promotion_code
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Initial discount promotion code (if any).
-  - name: current_period_discount_name
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Current period discount name (if any).
-      This will be null for Google and Apple subscriptions.
-  - name: current_period_discount_promotion_code
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Current period discount promotion code (if any).
-  - name: current_period_discount_amount
-    type: NUMERIC
-    mode: NULLABLE
-    description: |-
-      Current period discount amount (if any).
-      This may be null for Apple subscriptions.
-  - name: ongoing_discount_name
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Ongoing discount name (if any).
-      This will be null for Google and Apple subscriptions.
-  - name: ongoing_discount_promotion_code
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Ongoing discount promotion code (if any).
-  - name: ongoing_discount_amount
-    type: NUMERIC
-    mode: NULLABLE
-    description: |-
-      Ongoing discount amount (if any).
-      This may be null for Apple subscriptions.
-  - name: ongoing_discount_ends_at
-    type: TIMESTAMP
-    mode: NULLABLE
-    description: |-
-      When the ongoing discount ends (if any).
-      This will be null for Apple subscriptions.
   - name: has_refunds
     type: BOOLEAN
     mode: NULLABLE
@@ -406,6 +355,57 @@ fields:
       mode: NULLABLE
       description: |-
         Last-touch attribution UTM term.
+  - name: initial_discount_name
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Initial discount name (if any).
+      This will be null for Google and Apple subscriptions.
+  - name: initial_discount_promotion_code
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Initial discount promotion code (if any).
+  - name: current_period_discount_name
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Current period discount name (if any).
+      This will be null for Google and Apple subscriptions.
+  - name: current_period_discount_promotion_code
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Current period discount promotion code (if any).
+  - name: current_period_discount_amount
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Current period discount amount (if any).
+      This may be null for Apple subscriptions.
+  - name: ongoing_discount_name
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Ongoing discount name (if any).
+      This will be null for Google and Apple subscriptions.
+  - name: ongoing_discount_promotion_code
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Ongoing discount promotion code (if any).
+  - name: ongoing_discount_amount
+    type: NUMERIC
+    mode: NULLABLE
+    description: |-
+      Ongoing discount amount (if any).
+      This may be null for Apple subscriptions.
+  - name: ongoing_discount_ends_at
+    type: TIMESTAMP
+    mode: NULLABLE
+    description: |-
+      When the ongoing discount ends (if any).
+      This will be null for Apple subscriptions.
   - name: ended_reason
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1_live/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1_live/schema.yaml
@@ -354,16 +354,6 @@ fields:
       mode: NULLABLE
       description: |-
         Last-touch attribution UTM term.
-  - name: ended_reason
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Reason why the subscription ended.
-      Possible values:
-        * `Admin Initiated` - An admin at Mozilla ended the subscription, either directly or by deleting the customer's Mozilla Account.
-        * `Customer Initiated` - The customer ended their subscription, either directly or by turning off auto-renewal or deleting their Mozilla Account.
-        * `Payment Failure` - The subscription was unable to auto-renew due to a payment failure.
-        * `Other` - The subscription ended for some other reason, such as unverified Mozilla Accounts being automatically deleted.
   - name: initial_discount_name
     type: STRING
     mode: NULLABLE
@@ -415,6 +405,16 @@ fields:
     description: |-
       When the ongoing discount ends (if any).
       This will be null for Apple subscriptions.
+  - name: ended_reason
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Reason why the subscription ended.
+      Possible values:
+        * `Admin Initiated` - An admin at Mozilla ended the subscription, either directly or by deleting the customer's Mozilla Account.
+        * `Customer Initiated` - The customer ended their subscription, either directly or by turning off auto-renewal or deleting their Mozilla Account.
+        * `Payment Failure` - The subscription was unable to auto-renew due to a payment failure.
+        * `Other` - The subscription ended for some other reason, such as unverified Mozilla Accounts being automatically deleted.
 - name: was_active_at_month_start
   type: BOOLEAN
   mode: NULLABLE


### PR DESCRIPTION
## Description
Currently the schemas are different depending on whether the ETLs overwrite the entire table or incrementally write to specific partitions, which is confusing.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
* DENG-9903: Make logical subscription ETL/view schemas more consistent

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
