### PR TITLE
feat(DENG-9918): Filter out malformed sessions / clients from the GA4 sessions views

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/ga_sessions/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/ga_sessions/view.sql
@@ -5,3 +5,5 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.firefoxdotcom_derived.ga_sessions_v2`
+WHERE
+  REGEXP_CONTAINS(ga_client_id || '-' || ga_session_id, r"^[0-9]+\.{1}[0-9]+\-{1}[0-9]+$")

--- a/sql/moz-fx-data-shared-prod/mozilla_org/ga_sessions/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozilla_org/ga_sessions/view.sql
@@ -5,3 +5,5 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.mozilla_org_derived.ga_sessions_v3`
+WHERE
+  REGEXP_CONTAINS(ga_client_id || '-' || ga_session_id, r"^[0-9]+\.{1}[0-9]+\-{1}[0-9]+$")

--- a/sql/moz-fx-data-shared-prod/telemetry/ga4_sessions_firefoxcom_mozillaorg_combined/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/ga4_sessions_firefoxcom_mozillaorg_combined/view.sql
@@ -66,7 +66,7 @@ SELECT
   mo.ad_crosschannel_primary_channel_group,
   mo.ad_crosschannel_default_channel_group
 FROM
-  `moz-fx-data-shared-prod.mozilla_org_derived.ga_sessions_v3` mo
+  `moz-fx-data-shared-prod.mozilla_org.ga_sessions` mo
 UNION ALL
 SELECT
   'FIREFOX.COM' AS flag,
@@ -133,4 +133,4 @@ SELECT
   fx.ad_crosschannel_primary_channel_group,
   fx.ad_crosschannel_default_channel_group
 FROM
-  `moz-fx-data-shared-prod.firefoxdotcom_derived.ga_sessions_v2` fx
+  `moz-fx-data-shared-prod.firefoxdotcom.ga_sessions` fx


### PR DESCRIPTION
## Description

This PR filters out unique visits (composed of a website, a ga_client_id, and a ga_session_id) where the client ID or session ID is malformed.  It leaves the data in the source table but hides it from the business-facing view layers, in case we ever need to look at the bad sessions in the future.

## Related Tickets & Documents
* [DENG-9918](https://mozilla-hub.atlassian.net/browse/DENG-9918)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9918]: https://mozilla-hub.atlassian.net/browse/DENG-9918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ