### PR TITLE
fix(SubPlat): Remove workarounds for logical subscription schema inconsistencies (DENG-9903)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/recent_daily_active_logical_subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/recent_daily_active_logical_subscriptions_v1/query.sql
@@ -1,30 +1,5 @@
 SELECT
-  -- Match the deployed `daily_active_logical_subscriptions_v1` table schema so this table can be easily unioned with it.
-  * REPLACE (
-    (
-      SELECT AS STRUCT
-        subscription.* EXCEPT (
-          initial_discount_name,
-          initial_discount_promotion_code,
-          current_period_discount_name,
-          current_period_discount_promotion_code,
-          current_period_discount_amount,
-          ongoing_discount_name,
-          ongoing_discount_promotion_code,
-          ongoing_discount_amount,
-          ongoing_discount_ends_at
-        ),
-        subscription.initial_discount_name,
-        subscription.initial_discount_promotion_code,
-        subscription.current_period_discount_name,
-        subscription.current_period_discount_promotion_code,
-        subscription.current_period_discount_amount,
-        subscription.ongoing_discount_name,
-        subscription.ongoing_discount_promotion_code,
-        subscription.ongoing_discount_amount,
-        subscription.ongoing_discount_ends_at
-    ) AS subscription
-  )
+  *
 FROM
   `moz-fx-data-shared-prod.subscription_platform_derived.daily_active_logical_subscriptions_v1_live`
 WHERE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/recent_logical_subscription_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/recent_logical_subscription_events_v1/query.sql
@@ -1,53 +1,5 @@
 SELECT
-  -- Match the deployed `logical_subscription_events_v1` table schema so this table can be easily unioned with it.
-  * REPLACE (
-    (
-      SELECT AS STRUCT
-        subscription.* EXCEPT (
-          initial_discount_name,
-          initial_discount_promotion_code,
-          current_period_discount_name,
-          current_period_discount_promotion_code,
-          current_period_discount_amount,
-          ongoing_discount_name,
-          ongoing_discount_promotion_code,
-          ongoing_discount_amount,
-          ongoing_discount_ends_at
-        ),
-        subscription.initial_discount_name,
-        subscription.initial_discount_promotion_code,
-        subscription.current_period_discount_name,
-        subscription.current_period_discount_promotion_code,
-        subscription.current_period_discount_amount,
-        subscription.ongoing_discount_name,
-        subscription.ongoing_discount_promotion_code,
-        subscription.ongoing_discount_amount,
-        subscription.ongoing_discount_ends_at
-    ) AS subscription,
-    (
-      SELECT AS STRUCT
-        old_subscription.* EXCEPT (
-          initial_discount_name,
-          initial_discount_promotion_code,
-          current_period_discount_name,
-          current_period_discount_promotion_code,
-          current_period_discount_amount,
-          ongoing_discount_name,
-          ongoing_discount_promotion_code,
-          ongoing_discount_amount,
-          ongoing_discount_ends_at
-        ),
-        old_subscription.initial_discount_name,
-        old_subscription.initial_discount_promotion_code,
-        old_subscription.current_period_discount_name,
-        old_subscription.current_period_discount_promotion_code,
-        old_subscription.current_period_discount_amount,
-        old_subscription.ongoing_discount_name,
-        old_subscription.ongoing_discount_promotion_code,
-        old_subscription.ongoing_discount_amount,
-        old_subscription.ongoing_discount_ends_at
-    ) AS old_subscription
-  )
+  *
 FROM
   `moz-fx-data-shared-prod.subscription_platform_derived.logical_subscription_events_v1_live`
 WHERE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/recent_monthly_active_logical_subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/recent_monthly_active_logical_subscriptions_v1/query.sql
@@ -1,30 +1,5 @@
 SELECT
-  -- Match the deployed `monthly_active_logical_subscriptions_v1` table schema so this table can be easily unioned with it.
-  * REPLACE (
-    (
-      SELECT AS STRUCT
-        subscription.* EXCEPT (
-          initial_discount_name,
-          initial_discount_promotion_code,
-          current_period_discount_name,
-          current_period_discount_promotion_code,
-          current_period_discount_amount,
-          ongoing_discount_name,
-          ongoing_discount_promotion_code,
-          ongoing_discount_amount,
-          ongoing_discount_ends_at
-        ),
-        subscription.initial_discount_name,
-        subscription.initial_discount_promotion_code,
-        subscription.current_period_discount_name,
-        subscription.current_period_discount_promotion_code,
-        subscription.current_period_discount_amount,
-        subscription.ongoing_discount_name,
-        subscription.ongoing_discount_promotion_code,
-        subscription.ongoing_discount_amount,
-        subscription.ongoing_discount_ends_at
-    ) AS subscription
-  )
+  *
 FROM
   `moz-fx-data-shared-prod.subscription_platform_derived.monthly_active_logical_subscriptions_v1_live`
 WHERE


### PR DESCRIPTION
## Description
These workarounds are no longer necessary now that the `logical_subscriptions_history_v1` ETL's schema has been changed to be consistent with the downstream logical subscription ETLs' schemas (#8268).

Also, these workarounds weren't updated for the new `ended_reason` field that got added today (#8222), which is currently causing the views that union these `recent_...` ETL tables with the corresponding daily ETL table to fail.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
* DENG-9903: Make logical subscription ETL/view schemas more consistent
* https://github.com/mozilla/bigquery-etl/pull/8268
* https://github.com/mozilla/bigquery-etl/pull/8222

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
