### PR TITLE
refactor(SubPlat): Add `logical_subscriptions_v1` ETL (DENG-9904)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform/logical_subscriptions/view.sql
@@ -3,12 +3,10 @@ CREATE OR REPLACE VIEW
 AS
 WITH subscriptions AS (
   SELECT
-    subscription.*,
-    COALESCE(DATE(subscription.ended_at), CURRENT_DATE()) AS effective_date
+    *,
+    COALESCE(DATE(ended_at), CURRENT_DATE()) AS effective_date
   FROM
-    `moz-fx-data-shared-prod.subscription_platform_derived.logical_subscriptions_history_v1`
-  WHERE
-    valid_to = '9999-12-31 23:59:59.999999'
+    `moz-fx-data-shared-prod.subscription_platform_derived.logical_subscriptions_v1`
 ),
 augmented_subscriptions AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Logical subscriptions
+description: |-
+  Logical subscriptions, which are a continuous active period for a particular provider subscription.
+
+  Some caveats:
+    * We only have partial data for Stripe subscriptions prior to March 2023 due to a data loss incident (DENG-754).
+    * We only have partial data for Apple subscriptions prior to December 2022 when VPN's Apple subscriptions were migrated to SubPlat (VPN-3921).
+owners:
+- srose@mozilla.com
+labels:
+  incremental: false
+  schedule: hourly
+scheduling:
+  dag_name: bqetl_subplat_hourly
+  # The whole table is overwritten every time, not a specific date partition.
+  date_partition_parameter: null
+bigquery:
+  time_partitioning: null
+  clustering: null
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_v1/query.sql
@@ -1,0 +1,6 @@
+SELECT
+  subscription.*
+FROM
+  `moz-fx-data-shared-prod.subscription_platform_derived.logical_subscriptions_history_v1`
+WHERE
+  valid_to = '9999-12-31 23:59:59.999999'

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_v1/schema.yaml
@@ -1,0 +1,391 @@
+fields:
+- name: id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Logical subscription ID.
+- name: provider
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider of the subscription ("Stripe", "Google", or "Apple").
+- name: payment_provider
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Payment provider for the subscription.
+    For Stripe subscriptions this will be "Stripe" or "PayPal".
+    For Google subscriptions this will be "Google".
+    For Apple subscriptions this will be "Apple".
+- name: provider_subscription_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider subscription ID.
+    For Stripe subscriptions this will be the subscription ID.
+    For Google subscriptions this will be the purchase token.
+    For Apple subscriptions this will be the original transaction ID.
+- name: provider_subscription_item_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider subscription item ID (if any).
+    This will be null for Google and Apple subscriptions.
+- name: provider_subscription_created_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the provider subscription was created.
+- name: provider_subscription_updated_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the provider subscription was last updated.
+- name: provider_customer_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider customer ID (if any).
+    This will be null for Google and Apple subscriptions.
+- name: mozilla_account_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    ID of the Mozilla Account associated with the subscription (if any) as a hexadecimal string.
+    This may be missing for some subscriptions, particularly older subscriptions when we were only recording hashed Mozilla Account IDs.
+- name: mozilla_account_id_sha256
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    SHA256 hash of the `mozilla_account_id` string value (if any) as a hexadecimal string.
+    This may be missing for some subscriptions.
+- name: customer_subscription_number
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Number of this subscription in the overall sequence of all of the customer's logical subscriptions.
+    For example, this should be `1` for their first logical subscription, `2` for their second logical subscription, etc.
+- name: country_code
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    ISO 3166-1 alpha-2 code for the country the subscription is in.
+    This may be missing for some subscriptions.
+- name: country_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Name of the country the subscription is in.
+    This may be "Unknown" for some subscriptions.
+- name: services
+  type: RECORD
+  mode: REPEATED
+  description: |-
+    Array of one or more services provided by the subscription, as defined in the `services_v1` ETL.
+  fields:
+  - name: id
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Service ID.
+  - name: name
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Service name.
+  - name: tier
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Service tier.
+- name: provider_product_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider product ID.
+    For Stripe subscriptions this will be the product ID.
+    For Google subscriptions this will be the package name.
+    For Apple subscriptions this will be the bundle ID.
+- name: product_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Product name.
+    For all subscriptions this will be the associated Stripe product name.
+- name: provider_plan_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Provider plan ID.
+    For Stripe subscriptions this will be the plan/price ID.
+    For Google subscriptions this will be the SKU.
+    For Apple subscriptions this will be the product ID.
+- name: plan_summary
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Text summary of the subscription plan's interval, currency, and amount, along with an indication if it's a bundle (i.e. providing multiple services).
+    For example, "1 month EUR 4.99" or "1 year USD 99.00 bundle".
+- name: plan_interval
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Text summary of the subscription plan's interval (e.g. "1 month", "6 months", "1 year").
+- name: plan_interval_type
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Subscription plan's interval type (e.g. "month" or "year").
+- name: plan_interval_count
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Subscription plan's interval count.
+- name: plan_interval_months
+  type: INTEGER
+  mode: NULLABLE
+  description: |-
+    Number of months in the subscription plan's interval.
+- name: plan_currency
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    ISO 4217 code for the subscription plan's currency.
+    For Apple subscriptions prior to 2024-10-30 this may have fallen back to assuming USD due to a lack of source data (FXA-10549).
+- name: plan_amount
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Subscription plan's amount in the specified currency.
+    For Apple subscriptions prior to 2024-10-30 this may have fallen back to assuming a USD amount due to a lack of source data (FXA-10549).
+- name: is_bundle
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription is a bundle (i.e. providing multiple services).
+- name: is_trial
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription is a free trial.
+- name: is_active
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription is active (i.e. providing the customer access to the services).
+- name: provider_status
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    The provider's status indicator for the subscription.
+- name: started_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the subscription started.
+- name: ended_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the subscription ended.
+    This will be null for active subscriptions.
+- name: current_period_started_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the current subscription period started.
+    This will be null for inactive subscriptions and for all Google subcriptions.
+- name: current_period_ends_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the current subscription period ends.
+    This will be null for inactive subscriptions.
+- name: auto_renew
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription is set to auto-renew.
+- name: auto_renew_disabled_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the subscription's auto-renewal setting was disabled.
+    This will be null for subscriptions set to auto-renew.
+- name: has_refunds
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription has had refunds.
+    This will be null for Google subscriptions.
+- name: has_fraudulent_charges
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    Whether the subscription has had fraudulent charges.
+    This will be null for Google and Apple subscriptions.
+- name: first_touch_attribution
+  type: RECORD
+  mode: NULLABLE
+  description: |-
+    Unbounded first-touch attribution for the subscription (if any).
+    This will be null for Google and Apple subscriptions, and for nearly all Stripe subscriptions which started after 2025-07-25 (DENG-8885).
+  fields:
+  - name: impression_at
+    type: TIMESTAMP
+    mode: NULLABLE
+    description: |-
+      When the first-touch attribution impression occurred.
+  - name: entrypoint
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution entrypoint.
+  - name: entrypoint_experiment
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution entrypoint experiment.
+  - name: entrypoint_variation
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution entrypoint experiment variation.
+  - name: utm_campaign
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution UTM campaign.
+  - name: utm_content
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution UTM content.
+  - name: utm_medium
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution UTM medium.
+  - name: utm_source
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution UTM source.
+  - name: utm_term
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      First-touch attribution UTM term.
+- name: last_touch_attribution
+  type: RECORD
+  mode: NULLABLE
+  description: |-
+    Unbounded last-touch attribution for the subscription (if any).
+    This will be null for Google and Apple subscriptions.
+  fields:
+  - name: impression_at
+    type: TIMESTAMP
+    mode: NULLABLE
+    description: |-
+      When the last-touch attribution impression occurred.
+  - name: entrypoint
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint.
+  - name: entrypoint_experiment
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint experiment.
+  - name: entrypoint_variation
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution entrypoint experiment variation.
+  - name: utm_campaign
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM campaign.
+  - name: utm_content
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM content.
+  - name: utm_medium
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM medium.
+  - name: utm_source
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM source.
+  - name: utm_term
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Last-touch attribution UTM term.
+- name: initial_discount_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Initial discount name (if any).
+    This will be null for Google and Apple subscriptions.
+- name: initial_discount_promotion_code
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Initial discount promotion code (if any).
+- name: current_period_discount_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Current period discount name (if any).
+    This will be null for Google and Apple subscriptions.
+- name: current_period_discount_promotion_code
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Current period discount promotion code (if any).
+- name: current_period_discount_amount
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Current period discount amount (if any).
+    This may be null for Apple subscriptions.
+- name: ongoing_discount_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Ongoing discount name (if any).
+    This will be null for Google and Apple subscriptions.
+- name: ongoing_discount_promotion_code
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Ongoing discount promotion code (if any).
+- name: ongoing_discount_amount
+  type: NUMERIC
+  mode: NULLABLE
+  description: |-
+    Ongoing discount amount (if any).
+    This may be null for Apple subscriptions.
+- name: ongoing_discount_ends_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |-
+    When the ongoing discount ends (if any).
+    This will be null for Apple subscriptions.
+- name: ended_reason
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Reason why the subscription ended.
+    Possible values:
+      * `Admin Initiated` - An admin at Mozilla ended the subscription, either directly or by deleting the customer's Mozilla Account.
+      * `Customer Initiated` - The customer ended their subscription, either directly or by turning off auto-renewal or deleting their Mozilla Account.
+      * `Payment Failure` - The subscription was unable to auto-renew due to a payment failure.
+      * `Other` - The subscription ended for some other reason, such as unverified Mozilla Accounts being automatically deleted.


### PR DESCRIPTION
## Description
Like the `service_subscriptions_v1` ETL, to avoid any potential performance issues from querying the entire `logical_subscriptions_history_v1` table.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
* DENG-9904: Create `logical_subscriptions_v1` ETL

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
