### PR TITLE
feat(DENG-9733): Updates to new Fx Whats New Summary V3

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/firefox_whatsnew_summary_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/firefox_whatsnew_summary_v3/metadata.yaml
@@ -1,6 +1,6 @@
 friendly_name: Firefox Whats New Page Summary V3
 description: |-
-  Each row represents a page view of a Firefox What's New Page
+  Each row represents an event where the page_location is a what's new page.
 owners:
 - kwindau@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/mozilla_org_derived/firefox_whatsnew_summary_v3/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/mozilla_org_derived/firefox_whatsnew_summary_v3/schema.yaml
@@ -2,7 +2,15 @@ fields:
 - name: event_date
   mode: NULLABLE
   type: DATE
-  description: The date the page view event took place.
+  description: The date of the event
+- name: event_name
+  mode: NULLABLE
+  type: STRING
+  description: The name of the event
+- name: event_timestamp
+  mode: NULLABLE
+  type: INTEGER
+  description: The timestamp of the event
 - name: ga_client_id
   type: STRING
   mode: NULLABLE


### PR DESCRIPTION
## Description

This PR adds the "event_name" & "event_timestamp" columns to the table (will manually delete and redeploy the new table).
It also expands the table to include more event types - before it was only page views of Firefox what's new pages, now it will be all events where the "page_location" is a Firefox what's new page.

## Related Tickets & Documents
* [DENG-9733](https://mozilla-hub.atlassian.net/browse/DENG-9733)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9733]: https://mozilla-hub.atlassian.net/browse/DENG-9733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ