### PR TITLE
Fix shredder sampling task regex in shredder_job_stats

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/query.sql
@@ -21,8 +21,9 @@ SELECT
   total_slot_ms / 1000 / 60 / 60 AS slot_hours,
   shredder_rows_deleted.deleted_row_count,
   shredder_rows_deleted.partition_id,
-  REGEXP_REPLACE(task_id, r"__sample_([0-9]+)$", "") AS parent_task_id,
-  SAFE_CAST(REGEXP_EXTRACT(task_id, r"__sample_([0-9]+)$") AS INT) AS shredded_sample_id,
+  -- sampling task ids end with [0-9]+_[0-9]+ as of 2025-10-15
+  REGEXP_REPLACE(task_id, r"__sample_([0-9_]+)?$", "") AS parent_task_id,
+  SAFE_CAST(REGEXP_EXTRACT(task_id, r"__sample_([0-9]+)(?:_[0-9]+)?") AS INT) AS shredded_sample_id,
   shredder_jobs.error_result.reason AS error_reason,
   shredder_jobs.error_result.message AS error_message,
 FROM


### PR DESCRIPTION
## Description

Forgot to update this in https://github.com/mozilla/bigquery-etl/pull/8245 where the task id format changed

## Related Tickets & Documents
* DENG-9868
<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
