### PR TITLE
fix unnesting duplicate count

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/query.sql
@@ -35,9 +35,9 @@ SELECT
   ANY_VALUE(normalized_country_code) AS normalized_country_code,
   ANY_VALUE(firefox_suggest_enabled) AS firefox_suggest_enabled,
   ANY_VALUE(sponsored_suggestions_enabled) AS sponsored_suggestions_enabled,
-  COUNTIF(is_clicked) AS urlbar_clicks,
-  COUNTIF(is_annoyed) AS urlbar_annoyances,
-  COUNTIF(is_terminal = TRUE) AS urlbar_impressions,
+  COUNT(DISTINCT IF(is_clicked, event_id, NULL)) AS urlbar_clicks,
+  COUNT(DISTINCT IF(is_annoyed, event_id, NULL)) AS urlbar_annoyances,
+  COUNT(DISTINCT IF(is_terminal, event_id, NULL)) AS urlbar_impressions
 FROM
   temp_unnested
 GROUP BY


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR fixes overcounting of metrics in `urlbar_events_daily_engagement_by_product_result_type_v1`.
The bug is due to the unnesting duplicating results across event_id's, so I'm fixing it by essentially aggregating counts to event_id level. 

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


Recon:
I created a scratch table of the dev run (for 1 day) at `moz-fx-data-bq-data-science.msun.suggest_scratch`, the clients number hasn't changed, but annoyances are much smaller as expected.

<img width="984" height="868" alt="image" src="https://github.com/user-attachments/assets/68d61008-7eb4-48cf-bec1-c40dac16564f" />

Vanessa queried across the other tables (which is how she found the bug), and the expected annoyances for this day is ~840K, which aligns with the results in the dev table
<img width="896" height="780" alt="image" src="https://github.com/user-attachments/assets/5977a070-13f3-444c-a67f-36ad3a0db697" />

