### PR TITLE
Backfill for urlbar_events_daily_engagement_by_product_result_type_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/backfill.yaml
@@ -4,4 +4,4 @@
   reason: Backfill of urlbar events daily engagement by product result type data after fix \#8290
   watchers:
   - ascholtz@mozilla.com
-  status: Initiated
+  status: Initiate


### PR DESCRIPTION
## Description
Follow-up to https://github.com/mozilla/bigquery-etl/pull/8290 to backfill urlbar_events_daily_engagement_by_product_result_type_v1


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
