### PR TITLE
Revert "chore(deps): bump click from 8.2.1 to 8.3.0 (#8260)"

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -325,7 +325,6 @@ def create(ctx, name, sql_dir, project_id, owner, dag, no_schedule):
         "Custom name for the Airflow task. By default the task name is a "
         "combination of the dataset and table name."
     ),
-    default=None,
 )
 def schedule(name, sql_dir, project_id, dag, depends_on_past, task_name):
     """CLI command for scheduling a query."""

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ beautifulsoup4==4.14.2
 bigeye-sdk==0.7.0
 black==25.9.0
 cattrs==25.2.0
-click==8.3.0
+click==8.2.1
 cryptography==46.0.3
 exceptiongroup==1.3.0 # for backwards compatibility with python < 3.11
 fredapi==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -374,9 +374,9 @@ charset-normalizer==2.1.1 \
     --hash=sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845 \
     --hash=sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
     # via requests
-click==8.3.0 \
-    --hash=sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc \
-    --hash=sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4
+click==8.2.1 \
+    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
+    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
     # via
     #   -r requirements.in
     #   black


### PR DESCRIPTION
## Description
This reverts #8260 because that has caused SQL generation to consistently [fail](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/54068/workflows/247fa974-68e8-4b57-a349-6a1890955e59/jobs/680748) when `bqetl generate all` runs the `glean_usage` SQL generator, due to the following error:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/root/project/bigquery_etl/cli/__init__.py", line 78, in cli
    group(prog_name=prog_name)
  File "/root/project/venv/lib/python3.11/site-packages/rich_click/rich_command.py", line 402, in __call__
    return super().__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/project/venv/lib/python3.11/site-packages/click/core.py", line 1462, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/project/venv/lib/python3.11/site-packages/rich_click/rich_command.py", line 216, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/root/project/venv/lib/python3.11/site-packages/click/core.py", line 1850, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/project/venv/lib/python3.11/site-packages/click/core.py", line 1850, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/project/venv/lib/python3.11/site-packages/click/core.py", line 1246, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/project/venv/lib/python3.11/site-packages/click/core.py", line 814, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/project/venv/lib/python3.11/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/project/bigquery_etl/cli/generate.py", line 128, in generate_all
    ctx.invoke(
  File "/root/project/venv/lib/python3.11/site-packages/click/core.py", line 814, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/project/sql_generators/glean_usage/__init__.py", line 145, in generate
    generate_per_app_id = [
                          ^
  File "/root/project/sql_generators/glean_usage/__init__.py", line 159, in <listcomp>
    for base_table in get_tables(table_name=table.base_table_name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/project/sql_generators/glean_usage/__init__.py", line 105, in get_tables
    tables = list_tables(
             ^^^^^^^^^^^^
  File "/root/project/sql_generators/glean_usage/common.py", line 85, in list_tables
    if only_tables and not _contains_glob(only_tables):
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/project/sql_generators/glean_usage/common.py", line 153, in _contains_glob
    return any({"*", "?", "["}.intersection(pattern) for pattern in patterns)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/project/sql_generators/glean_usage/common.py", line 153, in <genexpr>
    return any({"*", "?", "["}.intersection(pattern) for pattern in patterns)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'Sentinel' object is not iterable
```

It appears this is due to https://github.com/pallets/click/issues/3066 "_`ctx.invoke` passes `Sentinel` to command_".

While we could potentially work around that bug by adding `default=None` to a bunch of `click.option` definitions (like was done for one such option in #8260), given that [the bug is slated to be fixed in the next `click` release](https://github.com/pallets/click/blob/2d3b2435f29639eb01aab884ce706ed4b0eba515/CHANGES.rst?plain=1#L10-L11) I think it makes more sense to just revert the change and wait for the next `click` release.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/8260
* https://github.com/pallets/click/issues/3066

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
