### PR TITLE
fix(DENG-9504): Make release summary DAG work on airflow

### DIFF
--- a/sql/moz-fx-data-shared-prod/external_derived/chrome_release_summary_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/chrome_release_summary_v1/query.py
@@ -155,7 +155,7 @@ def main():
 
     # Save both summaries to GCS
     client = storage.Client(project="moz-fx-data-shared-prod")
-    bucket = client.get_bucket(BUCKET_NO_GS)
+    bucket = client.bucket(BUCKET_NO_GS)
     blob = bucket.blob(final_output_fpath1)
     blob.upload_from_string(final_output_1)
     print(f"Summary uploaded to gs://{BUCKET_NO_GS}/{final_output_fpath1}")


### PR DESCRIPTION
## Description

This PR fixes the code to work better with the Airflow permissions of the service account.  The code worked fine before locally but when running on Airflow, the service account didn't have bucket level permissions, but it did have object level permissions.  So this enables the code to run from Airflow using the service account, by switching it to just access the object and not the bucket itself.

## Related Tickets & Documents
* [DENG-9504](https://mozilla-hub.atlassian.net/browse/DENG-9504)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9504]: https://mozilla-hub.atlassian.net/browse/DENG-9504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ