### PR TITLE
GENAI-2114 Redo prior calculation for Merino Thompson sampling of content recommendations

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
@@ -54,7 +54,7 @@ per_region_ctr AS (
   FROM
     aggregated_events
   WHERE
-    impression_count > 2000
+    impression_count > 2000 -- 1/min_ctr protects against CTRs form low sample size
 ),
   -- Average impressions per item per region (rounded)
 per_region_impressions_per_item AS (


### PR DESCRIPTION
## Description

Priors used for Merino thompson sampling are based on schedule_corpus_item_id which is being phased out. They also didn’t take into account the newtab_content ping which was causing a big drop in US impression per day value.

Comparison of the result are in the JIRA ticket to protect data.

**Duration of job**
 Duration
    2 sec
Bytes processed
    3.42 GB
Bytes billed
    3.42 GB
Slot milliseconds
    403457

Before PR
Slot time was over 3 days (I canceled before it was finished)

## Related Tickets & Documents
https://mozilla-hub.atlassian.net/browse/GENAI-2114


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
