### PR TITLE
fix(scheduling): Correct execution delta of `newtab_merino_priors_v1` ETL dependency on `corpus_items_updated_v1` ETL

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/metadata.yaml
@@ -13,3 +13,9 @@ bigquery:
 scheduling:
   dag_name: bqetl_merino_newtab_priors_to_gcs
   date_partition_parameter: null
+  # Adjust the execution delta for task dependencies in the bqetl_content_ml_hourly DAG
+  # to wait for the most recent bqetl_content_ml_hourly DAG tasks to complete.
+  depends_on:
+  - dag_name: bqetl_content_ml_hourly
+    task_id: snowflake_migration_derived__corpus_items_updated__v1
+    execution_delta: -22h30m


### PR DESCRIPTION
## Description
After #8300 was merged the `newtab_merino_priors_v1` ETL (which runs in the [bqetl_merino_newtab_priors_to_gcs](https://workflow.telemetry.mozilla.org/dags/bqetl_merino_newtab_priors_to_gcs/grid) DAG scheduled daily at 02:00) now depends on `corpus_items_updated_v1` ETL (which runs in the [bqetl_content_ml_hourly](https://workflow.telemetry.mozilla.org/dags/bqetl_content_ml_hourly/grid) DAG scheduled hourly at *:30).

Unfortunately, and with our current automatic Airflow dependency logic, when the `bqetl_merino_newtab_priors_to_gcs` DAG runs at 02:00 the `wait_for_snowflake_migration_derived__corpus_items_updated__v1` sensor ends up waiting on the `corpus_items_updated_v1` ETL run from 24.5 hours earlier rather than the most recent `corpus_items_updated_v1` ETL run from 30 minutes earlier.  This PR adds an override to fix that.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/8300
* [GENAI-2114](https://mozilla-hub.atlassian.net/browse/GENAI-2114): Fix prior calculation to transition of of scheduled_corpus_item_id

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[GENAI-2114]: https://mozilla-hub.atlassian.net/browse/GENAI-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ