### PR TITLE
fix(DENG-9942): use env to pass input parameters

### DIFF
--- a/.github/workflows/push-to-upstream.yml
+++ b/.github/workflows/push-to-upstream.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - name: push-upstream
+      env:
+        NAME: ${{ github.event.inputs.name }}
       run: |
         eval "$(ssh-agent -s)"
         ssh-add - <<< "${{ secrets.GH_ACTION_SSH_KEY }}"
@@ -36,4 +38,4 @@ jobs:
 
         ../bin/git-push-fork-to-upstream-branch \
           git@github.com:mozilla/bigquery-etl.git \
-          ${{ github.event.inputs.name }}
+          $NAME


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

use env to pass input and output parameters to prevent attacks from malicious input and dangerous writes, as described in [our guidelines](https://wiki.mozilla.org/GitHub/Repository_Security/GitHub_Workflows_%26_Actions#Perform_input_validation_and_encoding_on_Github_parameters).

## Related Tickets & Documents
* [DENG-9942](https://mozilla-hub.atlassian.net/browse/DENG-9942)


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9942]: https://mozilla-hub.atlassian.net/browse/DENG-9942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ