### PR TITLE
Revert "chore(mdn): derive legacy country name from iso"

### DIFF
--- a/sql/moz-fx-data-shared-prod/mdn/legacy_action/view.sql
+++ b/sql/moz-fx-data-shared-prod/mdn/legacy_action/view.sql
@@ -85,13 +85,13 @@ CREATE OR REPLACE VIEW
           IFNULL(JSON_VALUE(event_extra.referrer), '') AS page_referrer
         ) AS url2,
         STRUCT(
-          IFNULL(country_codes_v1.name, 'Unknown') AS navigator_geo,
+          CAST(NULL AS STRING) AS navigator_geo,
           'unknown' AS navigator_subscription_type,
           CAST(NULL AS STRING) AS navigator_user_agent,
           CAST(NULL AS STRING) AS navigator_viewport_breakpoint,
           CAST(NULL AS STRING) AS page_http_status,
           CAST(NULL AS STRING) AS page_is_baseline,
-          IFNULL(metadata.geo.country, '??') AS navigator_geo_iso,
+          metadata.geo.country AS navigator_geo_iso,
           CAST(NULL AS STRING) AS glean_client_annotation_experimentation_id
         ) AS `string`,
         STRUCT(
@@ -145,9 +145,6 @@ CREATE OR REPLACE VIEW
       is_bot_generated
     FROM
       `moz-fx-data-shared-prod.mdn_fred.events_stream`
-    LEFT JOIN
-      `moz-fx-data-shared-prod.static.country_codes_v1` country_codes_v1
-      ON country_codes_v1.code = metadata.geo.country
     WHERE
       event_category = 'glean'
       AND event_name = 'element_click'

--- a/sql/moz-fx-data-shared-prod/mdn/legacy_page/view.sql
+++ b/sql/moz-fx-data-shared-prod/mdn/legacy_page/view.sql
@@ -60,13 +60,13 @@ CREATE OR REPLACE VIEW
           IFNULL(JSON_VALUE(event_extra.referrer), '') AS page_referrer
         ) AS url2,
         STRUCT(
-          IFNULL(country_codes_v1.name, 'Unknown') AS navigator_geo,
+          CAST(NULL AS STRING) AS navigator_geo,
           'unknown' AS navigator_subscription_type,
           CAST(NULL AS STRING) AS navigator_user_agent,
           CAST(NULL AS STRING) AS navigator_viewport_breakpoint,
           CAST(NULL AS STRING) AS page_http_status,
           CAST(NULL AS STRING) AS page_is_baseline,
-          IFNULL(metadata.geo.country, '??') AS navigator_geo_iso,
+          metadata.geo.country AS navigator_geo_iso,
           CAST(NULL AS STRING) AS glean_client_annotation_experimentation_id
         ) AS `string`,
         STRUCT(
@@ -120,9 +120,6 @@ CREATE OR REPLACE VIEW
       is_bot_generated
     FROM
       `moz-fx-data-shared-prod.mdn_fred.events_stream`
-    LEFT JOIN
-      `moz-fx-data-shared-prod.static.country_codes_v1` country_codes_v1
-      ON country_codes_v1.code = metadata.geo.country
     WHERE
       event_category = 'glean'
       AND event_name = 'page_load'


### PR DESCRIPTION
Unfortunatey, itt looks like this caused column mismatches. Queris with `mdn.legacy_page` fail with the following:

> Error running query: Column 6 in UNION ALL has incompatible types: STRUCT<labeled_counter STRUCT<glean_error_invalid_label ARRAY<STRUCT<key STRING, value INT64>>, glean_error_invalid_overflow ARRAY<STRUCT<key STRING, value INT64>>, glean_error_invalid_state ARRAY<STRUCT<key STRING, value INT64>>, ...>, url2 STRUCT<page_path STRING, page_referrer STRING>, string STRUCT<navigator_geo STRING, navigator_subscription_type STRING, navigator_user_agent STRING, ...>, ...>, STRUCT<labeled_counter STRUCT<glean_error_invalid_label ARRAY<STRUCT<key STRING, value INT64>>, glean_error_invalid_overflow ARRAY<STRUCT<key STRING, value INT64>>, glean_error_invalid_state ARRAY<STRUCT<key STRING, value INT64>>, ...>, url2 STRUCT<page_path STRING, page_referrer STRING>, string STRUCT<navigator_geo STRING, navigator_subscription_type STRING, navigator_user_agent STRING, ...>, ...>; failed to parse view 'mdn.legacy_page' at [128:5]

Reverts mozilla/bigquery-etl#8100