### PR TITLE
fix(mdn.legacy_*): add `glean_error_invalid_type`

### DIFF
--- a/sql/moz-fx-data-shared-prod/mdn/legacy_action/view.sql
+++ b/sql/moz-fx-data-shared-prod/mdn/legacy_action/view.sql
@@ -77,7 +77,8 @@ CREATE OR REPLACE VIEW
               glean_error_invalid_label ARRAY<STRUCT<key STRING, value INT64>>,
               glean_error_invalid_overflow ARRAY<STRUCT<key STRING, value INT64>>,
               glean_error_invalid_state ARRAY<STRUCT<key STRING, value INT64>>,
-              glean_error_invalid_value ARRAY<STRUCT<key STRING, value INT64>>
+              glean_error_invalid_value ARRAY<STRUCT<key STRING, value INT64>>,
+              glean_error_invalid_type ARRAY<STRUCT<key STRING, value INT64>>
             >
         ) AS labeled_counter,
         STRUCT(

--- a/sql/moz-fx-data-shared-prod/mdn/legacy_page/view.sql
+++ b/sql/moz-fx-data-shared-prod/mdn/legacy_page/view.sql
@@ -52,7 +52,8 @@ CREATE OR REPLACE VIEW
               glean_error_invalid_label ARRAY<STRUCT<key STRING, value INT64>>,
               glean_error_invalid_overflow ARRAY<STRUCT<key STRING, value INT64>>,
               glean_error_invalid_state ARRAY<STRUCT<key STRING, value INT64>>,
-              glean_error_invalid_value ARRAY<STRUCT<key STRING, value INT64>>
+              glean_error_invalid_value ARRAY<STRUCT<key STRING, value INT64>>,
+              glean_error_invalid_type ARRAY<STRUCT<key STRING, value INT64>>
             >
         ) AS labeled_counter,
         STRUCT(


### PR DESCRIPTION
## Description

Adds the missing `glean_error_invalid_type` field to the `mdn.legacy_{action,page}` views.

The UNION very recently started to have incompatible types.

## Related Tickets & Documents
* (None.)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
