### PR TITLE
Complete backfill for urlbar_events_daily_engagement_by_product_result_type_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/backfill.yaml
@@ -4,4 +4,4 @@
   reason: Backfill of urlbar events daily engagement by product result type data after fix \#8290
   watchers:
   - ascholtz@mozilla.com
-  status: Initiate
+  status: Complete


### PR DESCRIPTION
Backfill tables have been validated and backfill can be completed

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
