### PR TITLE
DENG-9951 - Unschedule messaging_system events_daily tables

### DIFF
--- a/sql_generators/events_daily/templates/event_types/templating.yaml
+++ b/sql_generators/events_daily/templates/event_types/templating.yaml
@@ -2,10 +2,6 @@
 fenix:
   base_dataset: fenix_derived
   view_dataset: fenix
-# Firefox telemetry (non-Glean)
-telemetry:
-  base_dataset: telemetry_derived
-  view_dataset: telemetry
 # Mozilla VPN
 mozilla_vpn:
   base_dataset: mozilla_vpn_derived

--- a/sql_generators/events_daily/templates/event_types_history_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/event_types_history_v1/templating.yaml
@@ -9,14 +9,6 @@ fenix_derived:
     - time_ms
   max_property_values: 1000
   dag_name: bqetl_fenix_event_rollup
-# see https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
-#telemetry_derived:
-#  name: Firefox
-#  dataset: telemetry
-#  source_table: telemetry_derived.deanonymized_events
-#  start_date: 2020-01-01
-#  max_property_values: 5000
-#  dag_name: bqetl_event_rollup
 mozilla_vpn_derived:
   name: Mozilla VPN
   dataset: mozilla_vpn

--- a/sql_generators/events_daily/templates/event_types_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/event_types_v1/templating.yaml
@@ -2,11 +2,6 @@ fenix_derived:
   name: Firefox for Android
   dataset: fenix
   dag_name: bqetl_fenix_event_rollup
-# see https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
-#telemetry_derived:
-#  name: Firefox
-#  dataset: telemetry
-#  dag_name: bqetl_event_rollup
 mozilla_vpn_derived:
   name: Mozilla VPN
   dataset: mozilla_vpn

--- a/sql_generators/events_daily/templates/events_daily/templating.yaml
+++ b/sql_generators/events_daily/templates/events_daily/templating.yaml
@@ -2,10 +2,6 @@
 fenix:
   base_dataset: fenix_derived
   view_dataset: fenix
-# Firefox telemetry (non-Glean)
-telemetry:
-  base_dataset: telemetry_derived
-  view_dataset: telemetry
 mozilla_vpn:
   base_dataset: mozilla_vpn_derived
   view_dataset: mozilla_vpn

--- a/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
+++ b/sql_generators/events_daily/templates/events_daily_v1/templating.yaml
@@ -29,39 +29,6 @@ fenix_derived:
       dest: telemetry_sdk_build
     - src: client_info.locale
       dest: locale
-# see https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10
-#telemetry_derived:
-#  name: Firefox
-#  include_normalized_fields: True
-#  include_metadata_fields: True
-#  glean: False
-#  dataset: telemetry
-#  source_table: telemetry_derived.deanonymized_events
-#  start_date: 2020-01-01
-#  dag_name: bqetl_event_rollup
-#  user_properties:
-#    - src: application.build_id
-#      dest: build_id
-#    - src: environment.build.architecture
-#      dest: build_architecture
-#    - src: environment.profile.creation_date
-#      dest: profile_creation_date
-#      type: FLOAT64
-#    - src: environment.settings.is_default_browser
-#      dest: is_default_browser
-#      type: BOOL
-#    - src: environment.settings.attribution.source
-#      dest: attribution_source
-#    - src: metadata.uri.app_version
-#      dest: app_version
-#    - src: environment.settings.locale
-#      dest: locale
-#    - src: environment.partner.distribution_id
-#      dest: distribution_id
-#    - src: environment.settings.attribution.ua
-#      dest: attribution_ua
-#    - src: application.display_version
-#      dest: display_version
 mozilla_vpn_derived:
   name: Mozilla VPN
   include_normalized_fields: True


### PR DESCRIPTION
## Description

This unschedules events_daily tables related to messaging_system. In https://mozilla-hub.atlassian.net/browse/DENG-9951 I confirmed with the users who used these tables in the last 90 days that it's OK to remove them.
Second commit cleans up leftover comments and unused configuration entries related to already deprecated desktop events_daily tables (see https://bugzilla.mozilla.org/show_bug.cgi?id=1805722#c10).

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/DENG-9951
* https://bugzilla.mozilla.org/show_bug.cgi?id=1805722


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
