### PR TITLE
[DENG-9970] Add dataViewer access to monitoring dataset views for chicory poc

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/dataset_metadata.yaml
@@ -10,3 +10,4 @@ workgroup_access:
   members:
   - workgroup:mozilla-confidential
   - workgroup:dataops-managed/external-fides
+  - workgroup:platform-infra/chicory-poc


### PR DESCRIPTION
## Description

Adding dataViewer access to monitoring dataset views for chicory poc service account

We have already given access to the underlying tables in monitoring_derived (https://github.com/mozilla/bigquery-etl/pull/8244)

## Related Tickets & Documents
* DENG-9970

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
