### PR TITLE
fix(CI): Run SQL generation when `requirements.txt` changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ workflows:
             requirements.txt validate-bqetl true
             requirements.txt validate-sql true
             requirements.txt validate-routines true
+            requirements.txt trigger-sql-generation true
             bigquery_etl/.* validate-bqetl true
             tests/.* validate-bqetl true
             bigquery_etl/query_scheduling/.* validate-sql true


### PR DESCRIPTION
## Description
To catch cases where requirements changes might break SQL generation (e.g. #8260 -> #8294).

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/8260
* https://github.com/mozilla/bigquery-etl/pull/8294

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
