### PR TITLE
Check snake_casing in object keys for recorded_nimbus_context

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
@@ -18,31 +18,58 @@ WITH filtered AS (
 SELECT
   m.client_id,
   DATE(m.submission_timestamp) AS submission_date,
-  CAST(JSON_VALUE(context, '$.androidSdkVersion') AS int) AS androidSdkVersion,
-  CAST(JSON_VALUE(context, '$.appVersion') AS string) AS appVersion,
-  CAST(JSON_VALUE(context, '$.daysSinceInstall') AS int) AS daysSinceInstall,
-  CAST(JSON_VALUE(context, '$.daysSinceUpdate') AS int) AS daysSinceUpdate,
-  CAST(JSON_VALUE(context, '$.deviceManufacturer') AS string) AS deviceManufacturer,
-  CAST(JSON_VALUE(context, '$.deviceModel') AS string) AS deviceModel,
-  CAST(
-    JSON_VALUE(context, '$.eventQueryValues.daysOpenedInLast28') AS int
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.android_sdk_version') AS int),
+    CAST(JSON_VALUE(context, '$.androidSdkVersion') AS int)
+  ) AS androidSdkVersion,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.app_version') AS string),
+    CAST(JSON_VALUE(context, '$.appVersion') AS string)
+  ) AS appVersion,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.days_since_install') AS int),
+    CAST(JSON_VALUE(context, '$.daysSinceInstall') AS int)
+  ) AS daysSinceInstall,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.days_since_update') AS int),
+    CAST(JSON_VALUE(context, '$.daysSinceUpdate') AS int)
+  ) AS daysSinceUpdate,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.device_manufacturer') AS string),
+    CAST(JSON_VALUE(context, '$.deviceManufacturer') AS string)
+  ) AS deviceManufacturer,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.device_model') AS string),
+    CAST(JSON_VALUE(context, '$.deviceModel') AS string)
+  ) AS deviceModel,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.event_query_values.days_opened_in_last_28') AS int),
+    CAST(JSON_VALUE(context, '$.eventQueryValues.daysOpenedInLast28') AS int)
   ) AS eventQuery_daysOpenedInLast28,
-  CAST(
-    JSON_VALUE(context, '$.installReferrerResponseUtmCampaign') AS string
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.install_referrer_response_utm_Campaign') AS string),
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmCampaign') AS string)
   ) AS installReferrerResponseUtmCampaign,
-  CAST(
-    JSON_VALUE(context, '$.installReferrerResponseUtmContent') AS string
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.install_referrer_response_utm_content') AS string),
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmContent') AS string)
   ) AS installReferrerResponseUtmContent,
-  CAST(
-    JSON_VALUE(context, '$.installReferrerResponseUtmMedium') AS string
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.install_referrer_response_utm_medium') AS string),
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmMedium') AS string)
   ) AS installReferrerResponseUtmMedium,
-  CAST(
-    JSON_VALUE(context, '$.installReferrerResponseUtmSource') AS string
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.install_referrer_response_utm_source') AS string),
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmSource') AS string)
   ) AS installReferrerResponseUtmSource,
-  CAST(
-    JSON_VALUE(context, '$.installReferrerResponseUtmTerm') AS string
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.install_referrer_response_utm_term') AS string),
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmTerm') AS string)
   ) AS installReferrerResponseUtmTerm,
-  CAST(JSON_VALUE(context, '$.isFirstRun') AS boolean) AS isFirstRun,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.is_first_run') AS boolean),
+    CAST(JSON_VALUE(context, '$.isFirstRun') AS boolean)
+  ) AS isFirstRun,
   CAST(JSON_VALUE(context, '$.language') AS string) AS language,
   CAST(JSON_VALUE(context, '$.locale') AS string) AS locale,
   CAST(JSON_VALUE(context, '$.region') AS string) AS region,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/nimbus_recorded_targeting_context_v1/query.sql
@@ -18,31 +18,58 @@ WITH filtered AS (
 SELECT
   m.client_id,
   DATE(m.submission_timestamp) AS submission_date,
-  CAST(JSON_VALUE(context, '$.androidSdkVersion') AS int) AS androidSdkVersion,
-  CAST(JSON_VALUE(context, '$.appVersion') AS string) AS appVersion,
-  CAST(JSON_VALUE(context, '$.daysSinceInstall') AS int) AS daysSinceInstall,
-  CAST(JSON_VALUE(context, '$.daysSinceUpdate') AS int) AS daysSinceUpdate,
-  CAST(JSON_VALUE(context, '$.deviceManufacturer') AS string) AS deviceManufacturer,
-  CAST(JSON_VALUE(context, '$.deviceModel') AS string) AS deviceModel,
-  CAST(
-    JSON_VALUE(context, '$.eventQueryValues.daysOpenedInLast28') AS int
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.android_sdk_version') AS int),
+    CAST(JSON_VALUE(context, '$.androidSdkVersion') AS int)
+  ) AS androidSdkVersion,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.app_version') AS string),
+    CAST(JSON_VALUE(context, '$.appVersion') AS string)
+  ) AS appVersion,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.days_since_install') AS int),
+    CAST(JSON_VALUE(context, '$.daysSinceInstall') AS int)
+  ) AS daysSinceInstall,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.days_since_update') AS int),
+    CAST(JSON_VALUE(context, '$.daysSinceUpdate') AS int)
+  ) AS daysSinceUpdate,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.device_manufacturer') AS string),
+    CAST(JSON_VALUE(context, '$.deviceManufacturer') AS string)
+  ) AS deviceManufacturer,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.device_model') AS string),
+    CAST(JSON_VALUE(context, '$.deviceModel') AS string)
+  ) AS deviceModel,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.event_query_values.days_opened_in_last_28') AS int),
+    CAST(JSON_VALUE(context, '$.eventQueryValues.daysOpenedInLast28') AS int)
   ) AS eventQuery_daysOpenedInLast28,
-  CAST(
-    JSON_VALUE(context, '$.installReferrerResponseUtmCampaign') AS string
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.install_referrer_response_utm_Campaign') AS string),
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmCampaign') AS string)
   ) AS installReferrerResponseUtmCampaign,
-  CAST(
-    JSON_VALUE(context, '$.installReferrerResponseUtmContent') AS string
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.install_referrer_response_utm_content') AS string),
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmContent') AS string)
   ) AS installReferrerResponseUtmContent,
-  CAST(
-    JSON_VALUE(context, '$.installReferrerResponseUtmMedium') AS string
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.install_referrer_response_utm_medium') AS string),
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmMedium') AS string)
   ) AS installReferrerResponseUtmMedium,
-  CAST(
-    JSON_VALUE(context, '$.installReferrerResponseUtmSource') AS string
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.install_referrer_response_utm_source') AS string),
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmSource') AS string)
   ) AS installReferrerResponseUtmSource,
-  CAST(
-    JSON_VALUE(context, '$.installReferrerResponseUtmTerm') AS string
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.install_referrer_response_utm_term') AS string),
+    CAST(JSON_VALUE(context, '$.installReferrerResponseUtmTerm') AS string)
   ) AS installReferrerResponseUtmTerm,
-  CAST(JSON_VALUE(context, '$.isFirstRun') AS boolean) AS isFirstRun,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.is_first_run') AS boolean),
+    CAST(JSON_VALUE(context, '$.isFirstRun') AS boolean)
+  ) AS isFirstRun,
   CAST(JSON_VALUE(context, '$.language') AS string) AS language,
   CAST(JSON_VALUE(context, '$.locale') AS string) AS locale,
   CAST(JSON_VALUE(context, '$.region') AS string) AS region,

--- a/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/nimbus_recorded_targeting_context_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_ios_firefox_derived/nimbus_recorded_targeting_context_v1/query.sql
@@ -18,16 +18,38 @@ WITH filtered AS (
 SELECT
   m.client_id,
   DATE(m.submission_timestamp) AS submission_date,
-  CAST(JSON_VALUE(context, '$.appVersion') AS string) AS androidSdkVersion,
-  CAST(JSON_VALUE(context, '$.daysSinceInstall') AS int) AS daysSinceInstall,
-  CAST(JSON_VALUE(context, '$.daysSinceUpdate') AS int) AS daysSinceUpdate,
-  CAST(
-    JSON_VALUE(context, '$.eventQueryValues.daysOpenedInLast28') AS int
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.app_version') AS string),
+    CAST(JSON_VALUE(context, '$.appVersion') AS string)
+  ) AS appVersion,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.days_since_install') AS int),
+    CAST(JSON_VALUE(context, '$.daysSinceInstall') AS int)
+  ) AS daysSinceInstall,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.days_since_update') AS int),
+    CAST(JSON_VALUE(context, '$.daysSinceUpdate') AS int)
+  ) AS daysSinceUpdate,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.event_query_values.days_opened_in_last_28') AS int),
+    CAST(JSON_VALUE(context, '$.eventQueryValues.daysOpenedInLast28') AS int)
   ) AS eventQuery_daysOpenedInLast28,
-  CAST(JSON_VALUE(context, '$.isDefaultBrowser') AS boolean) AS isDefaultBrowser,
-  CAST(JSON_VALUE(context, '$.isFirstRun') AS boolean) AS isFirstRun,
-  CAST(JSON_VALUE(context, '$.isPhone') AS boolean) AS isPhone,
-  CAST(JSON_VALUE(context, '$.isReviewCheckerEnabled') AS boolean) AS isReviewCheckerEnabled,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.is_default_browser') AS boolean),
+    CAST(JSON_VALUE(context, '$.isDefaultBrowser') AS boolean)
+  ) AS isDefaultBrowser,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.is_first_run') AS boolean),
+    CAST(JSON_VALUE(context, '$.isFirstRun') AS boolean)
+  ) AS isFirstRun,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.is_phone') AS boolean),
+    CAST(JSON_VALUE(context, '$.isPhone') AS boolean)
+  ) AS isPhone,
+  COALESCE(
+    CAST(JSON_VALUE(context, '$.is_review_checker_enabled') AS boolean),
+    CAST(JSON_VALUE(context, '$.isReviewCheckerEnabled') AS boolean)
+  ) AS isReviewCheckerEnabled,
   CAST(JSON_VALUE(context, '$.language') AS string) AS language,
   CAST(JSON_VALUE(context, '$.locale') AS string) AS locale,
   CAST(JSON_VALUE(context, '$.region') AS string) AS region,


### PR DESCRIPTION
Glean accidentally defaulted to language-specific casing in the JSON payload from Kotlin & Swift (bug 1931891). That was fixed in v66 and Glean now sends the `snake_case` version. This changes the `recorded_nimbus_context` data; for now we can see which key exists in the JSON object.
Note that the data will never contain both the snake_case and the camelCase version!

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1931891

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
