### PR TITLE
fix: update the source_type filter to ignore casing

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_funnel_v1/query.sql
@@ -12,7 +12,7 @@ WITH historical_store_data AS (
       -- for compatibility with the new report we only want to count impressions from specific source types?
       SUM(
         CASE
-          WHEN source_type IN ('App Referrer', 'Unavailable', 'Web Referrer')
+          WHEN LOWER(source_type) IN ("app referrer", "unavailable", "web referrer")
             THEN 0
           ELSE impressions_unique_device
         END


### PR DESCRIPTION
# fix: update the source_type filter to ignore casing

In the v2 the value has changed to be `Institutional purchase`, to be on the safer side just ignoring casing when in this filter.