### PR TITLE
fix(SubPlat): Complete backfill of `stripe_service_subscriptions_attribution_v1` (DENG-9776, DENG-8885)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_service_subscriptions_attribution_v1/backfill.yaml
@@ -5,7 +5,7 @@
     correctly pass through FxA log-based logical subscriptions attribution (DENG-8885).
   watchers:
   - srose@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description
Complete the backfill most recently initiated in #8330 for DENG-8885, and previously initiated in #8241 and #8304 for DENG-9776.

(CC @phil-lee70)

## Related Tickets & Documents
* DENG-8885: Update SubPlat ETLs to use Stripe subscription attribution metadata
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
* DENG-9776: Exclude nonsensical subscription attribution values in logs-based subscription attribution ETLs
* https://github.com/mozilla/bigquery-etl/pull/8241
* https://github.com/mozilla/bigquery-etl/pull/8304
* https://github.com/mozilla/bigquery-etl/pull/8330

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
