### PR TITLE
[DENG-9999] Use GCPv2 sumo projects in jobs_by_organization

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/jobs_by_organization_v1/query.py
@@ -14,8 +14,8 @@ DEFAULT_PROJECTS = [
     "moz-fx-data-bq-data-science",
     "moz-fx-glam-prod",
     "moz-fx-glam-nonprod",
-    "moz-fx-data-sumo-prod",
-    "moz-fx-data-sumo-nonprod",
+    "moz-fx-sumo-prod",
+    "moz-fx-sumo-nonprod",
     "moz-fx-mozsocial-dw-prod",
     "moz-fx-data-bq-people",
 ]


### PR DESCRIPTION
## Description

The `moz-fx-data-sumo` projects were deleted in [SVCSE-3709](https://mozilla-hub.atlassian.net/browse/SVCSE-3709). There's bigquery activity in the `moz-fx-sumo` projects and they don't interact with data in shared-prod so adding these will allow getting cost info without looking at the billing data.

## Related Tickets & Documents
* DENG-9999

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[SVCSE-3709]: https://mozilla-hub.atlassian.net/browse/SVCSE-3709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ