### PR TITLE
feat(DENG-9984): Create fx_health_ind_bookmarks tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/fx_health_ind_bookmarks_by_country/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/fx_health_ind_bookmarks_by_country/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.fx_health_ind_bookmarks_by_country`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.fx_health_ind_bookmarks_by_country_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/fx_health_ind_bookmarks_by_os/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/fx_health_ind_bookmarks_by_os/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.fx_health_ind_bookmarks_by_os`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.fx_health_ind_bookmarks_by_os_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/fx_health_ind_bookmarks_by_os_version/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/fx_health_ind_bookmarks_by_os_version/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.fx_health_ind_bookmarks_by_os_version`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.fx_health_ind_bookmarks_by_os_version_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_country_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Firefox Health Indicator - Bookmarks By Country
+description: |-
+  Aggregate table of bookmarks added per client per day.
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_country_code
+references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_country_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_country_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_country_code,
+  SUM(metrics.counter.browser_engagement_bookmarks_toolbar_bookmark_opened) / COUNT(
+    DISTINCT client_info.client_id
+  ) AS bookmarks_added_per_dau,
+  SUM(metrics.counter.browser_engagement_bookmarks_toolbar_bookmark_opened) / COUNT(
+    DISTINCT client_info.client_id
+  ) AS bookmarks_opened_per_dau
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop.metrics`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND normalized_channel = 'release'
+  AND app_version_major >= 84
+GROUP BY
+  submission_date,
+  normalized_country_code

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_country_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_country_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: The date when the telemetry ping is received on the server side.
+- mode: NULLABLE
+  name: normalized_country_code
+  type: STRING
+  description: Normalized Country Code
+- name: bookmarks_added_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Added per DAU
+- name: bookmarks_opened_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Opened per DAU

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Firefox Health Indicators - Bookmarks By OS by DAU
+description: |-
+  Bookmarks per DAU by PS, for release channel only, app version >= 84
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_os
+references: {}

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_os,
+  SUM(metrics.counter.browser_engagement_bookmarks_toolbar_bookmark_opened) / COUNT(
+    DISTINCT client_info.client_id
+  ) AS bookmarks_added_per_dau,
+  SUM(metrics.counter.browser_engagement_bookmarks_toolbar_bookmark_opened) / COUNT(
+    DISTINCT client_info.client_id
+  ) AS bookmarks_opened_per_dau
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop.metrics`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND app_version_major >= 84
+  AND normalized_channel = 'release'
+GROUP BY
+  DATE(submission_timestamp),
+  normalized_os

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: The date when the telemetry ping is received on the server side.
+- mode: NULLABLE
+  name: normalized_os
+  type: STRING
+  description: Normalized Operating System
+- name: bookmarks_added_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Added per Daily Active User
+- name: bookmarks_opened_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Opened per DAU

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_version_v1/metadata.yaml
@@ -1,0 +1,25 @@
+friendly_name: Firefox Health Indicator - Bookmarks By Windows OS Version
+description: |-
+  Bookmarks per DAU by OS and channel, app version >= 84
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+  dag: bqetl_fx_health_ind_dashboard
+scheduling:
+  dag_name: bqetl_fx_health_ind_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - normalized_os_version
+references: {}
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_version_v1/query.sql
@@ -1,0 +1,21 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_channel,
+  normalized_os,
+  normalized_os_version,
+  SUM(metrics.counter.browser_engagement_bookmarks_toolbar_bookmark_opened) / COUNT(
+    DISTINCT client_info.client_id
+  ) AS bookmarks_added_per_dau,
+  SUM(metrics.counter.browser_engagement_bookmarks_toolbar_bookmark_opened) / COUNT(
+    DISTINCT client_info.client_id
+  ) AS bookmarks_opened_per_dau
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop.metrics`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND app_version_major >= 84
+GROUP BY
+  submission_date,
+  normalized_channel,
+  normalized_os,
+  normalized_os_version

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_version_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_health_ind_bookmarks_by_os_version_v1/schema.yaml
@@ -1,0 +1,25 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: The date when the telemetry ping is received on the server side.
+- name: normalized_channel
+  type: STRING
+  mode: NULLABLE
+  description: The normalized channel the application is being distributed on.
+- name: normalized_os
+  type: STRING
+  mode: NULLABLE
+  description: The normalized name of the operating system running at the client.
+- name: normalized_os_version
+  type: STRING
+  mode: NULLABLE
+  description: Normalized Operating System Version
+- name: bookmarks_added_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Added per DAU
+- name: bookmarks_opened_per_dau
+  type: FLOAT
+  mode: NULLABLE
+  description: Bookmarks Opened per DAU


### PR DESCRIPTION
## Description

This PR creates 3 new Glean tables to be used to migrate off of legacy telemetry for the Firefox Health Indicator dashboard.

- `moz-fx-data-shared-prod.firefox_desktop_derived.fx_health_ind_bookmarks_by_country_v1`
- `moz-fx-data-shared-prod.firefox_desktop.fx_health_ind_bookmarks_by_country`
- `moz-fx-data-shared-prod.firefox_desktop_derived.fx_health_ind_bookmarks_by_os_v1`
- `moz-fx-data-shared-prod.firefox_desktop.fx_health_ind_bookmarks_by_os`
- `moz-fx-data-shared-prod.firefox_desktop_derived.fx_health_ind_bookmarks_by_os_version_v1`
- `moz-fx-data-shared-prod.firefox_desktop.fx_health_ind_bookmarks_by_os_version`

## Related Tickets & Documents
* [DENG-9984](https://mozilla-hub.atlassian.net/browse/DENG-9984)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9984]: https://mozilla-hub.atlassian.net/browse/DENG-9984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ