### PR TITLE
fix(glean_usage): Ouput `schema.yaml` files for generated Python ETLs

### DIFF
--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -282,6 +282,10 @@ class Schema:
         with open(yaml_path, "w") as out:
             yaml.dump(self.schema, out, default_flow_style=False, sort_keys=False)
 
+    def to_yaml(self):
+        """Return the schema data as YAML."""
+        return yaml.dump(self.schema, default_flow_style=False, sort_keys=False)
+
     def to_json_file(self, json_path: Path):
         """Write schema to the JSON file path."""
         with open(json_path, "w") as out:

--- a/sql_generators/glean_usage/events_stream.py
+++ b/sql_generators/glean_usage/events_stream.py
@@ -23,6 +23,11 @@ class EventsStreamTable(GleanTable):
         self.cross_channel_template = "cross_channel_events_stream.query.sql"
         self.base_table_name = "events_v1"
         self.common_render_kwargs = {}
+        self.possible_query_parameters = {
+            "submission_date": "DATE",
+            "min_sample_id": "INTEGER",
+            "max_sample_id": "INTEGER",
+        }
 
     def generate_per_app_id(
         self,

--- a/sql_generators/glean_usage/templates/events_stream_v1.query.sql
+++ b/sql_generators/glean_usage/templates/events_stream_v1.query.sql
@@ -117,7 +117,7 @@ WITH base AS (
       CAST(NULL AS STRING) AS legacy_telemetry_client_id,
     {% endif %}
   FROM
-    `{{ events_view }}`
+    `{{ project_id }}.{{ events_view }}`
   WHERE
     DATE(submission_timestamp) = @submission_date
     {% if slice_by_sample_id %}


### PR DESCRIPTION
## Description
Fixup for https://github.com/mozilla/bigquery-etl/pull/7708 so the Python ETL tables can be deployed to stage.

For example, the `deploy-changes-to-stage` CI job for #8361 is [failing](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/54456/workflows/367dfc73-21db-40f5-b995-9d50809fcadf/jobs/688459) because the `events_stream_v1` Python ETL tables for `firefox_desktop` and `firefox_desktop_background_update` aren't getting deployed to stage.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/7708
* https://github.com/mozilla/bigquery-etl/pull/8361

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
