### PR TITLE
fix(SubPlat): Initiate backfills of SubPlat ETLs (DENG-9565, DENG-4043)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-10-29:
+  start_date: 2019-10-10
+  end_date: 2025-10-21
+  reason: Fix some known issues (DENG-9565) and populate the new `ended_reason` field (DENG-4043).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-06-25:
   start_date: 2021-12-17
   end_date: 2025-06-15

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-10-29:
+  start_date: 2019-10-10
+  end_date: 2025-10-21
+  reason: Fix some known issues (DENG-9565) and populate the new `ended_reason` field (DENG-4043).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-06-25:
   start_date: 2021-12-17
   end_date: 2025-06-15

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-10-29:
+  start_date: 2019-10-10
+  end_date: 2025-10-21
+  reason: Fix some known issues (DENG-9565) and populate the new `ended_reason` field (DENG-4043).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-06-25:
   start_date: 2021-12-17
   end_date: 2025-06-15

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-10-29:
+  start_date: 2019-10-01
+  end_date: 2025-09-01
+  reason: Fix some known issues (DENG-9565) and populate the new `ended_reason` field (DENG-4043).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-06-25:
   start_date: 2021-12-01
   end_date: 2025-05-01

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-10-29:
+  start_date: 2019-10-01
+  end_date: 2025-09-01
+  reason: Fix some known issues (DENG-9565) and populate the new `ended_reason` field (DENG-4043).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-06-25:
   start_date: 2021-12-01
   end_date: 2025-05-01

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-10-29:
+  start_date: 2019-10-10
+  end_date: 2025-10-21
+  reason: Fix some known issues (DENG-9565) and populate the new `ended_reason` field (DENG-4043).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-06-25:
   start_date: 2021-12-17
   end_date: 2025-06-15


### PR DESCRIPTION
## Description
To fix some known issues (DENG-9565) and populate the new `ended_reason` field (DENG-4043).

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
* DENG-4043: Implement `ended_reason` for logical & service subscriptions

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
