### PR TITLE
[DENG-10006] TapClicks read access to country_codes_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/static/country_codes_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/country_codes_v1/metadata.yaml
@@ -10,3 +10,4 @@ workgroup_access:
   - workgroup:dataops-managed/external-census
   - workgroup:google-managed/external-ads-datafusion
   - workgroup:google-managed/external-ads-dataproc
+  - workgroup:ads/external-tapclicks


### PR DESCRIPTION
## Description

Grant read access to tapclicks SA to country_codes_v1, which is part of one of the views it indirectly queries

## Related Tickets & Documents
* DENG-10006

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
