### PR TITLE
fix: add glean_usage/templates/events_stream_v1.schema.yaml

### DIFF
--- a/sql_generators/glean_usage/templates/events_stream_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/events_stream_v1.schema.yaml
@@ -1,0 +1,269 @@
+fields:
+- name: additional_properties
+  type: STRING
+  mode: NULLABLE
+- name: client_info
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: app_build
+    type: STRING
+    mode: NULLABLE
+  - name: app_channel
+    type: STRING
+    mode: NULLABLE
+  - name: app_display_version
+    type: STRING
+    mode: NULLABLE
+  - name: architecture
+    type: STRING
+    mode: NULLABLE
+  - name: attribution
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: campaign
+      type: STRING
+      mode: NULLABLE
+    - name: content
+      type: STRING
+      mode: NULLABLE
+    - name: medium
+      type: STRING
+      mode: NULLABLE
+    - name: source
+      type: STRING
+      mode: NULLABLE
+    - name: term
+      type: STRING
+      mode: NULLABLE
+    - name: ext
+      type: JSON
+      mode: NULLABLE
+  - name: device_manufacturer
+    type: STRING
+    mode: NULLABLE
+  - name: device_model
+    type: STRING
+    mode: NULLABLE
+  - name: distribution
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: name
+      type: STRING
+      mode: NULLABLE
+    - name: ext
+      type: JSON
+      mode: NULLABLE
+  - name: first_run_date
+    type: STRING
+    mode: NULLABLE
+  - name: locale
+    type: STRING
+    mode: NULLABLE
+  - name: os
+    type: STRING
+    mode: NULLABLE
+  - name: os_version
+    type: STRING
+    mode: NULLABLE
+  - name: telemetry_sdk_build
+    type: STRING
+    mode: NULLABLE
+  - name: build_date
+    type: STRING
+    mode: NULLABLE
+  - name: session_id
+    type: STRING
+    mode: NULLABLE
+  - name: session_count
+    type: INTEGER
+    mode: NULLABLE
+  - name: windows_build_number
+    type: INTEGER
+    mode: NULLABLE
+- name: document_id
+  type: STRING
+  mode: NULLABLE
+- name: metadata
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: geo
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: city
+      type: STRING
+      mode: NULLABLE
+    - name: country
+      type: STRING
+      mode: NULLABLE
+    - name: db_version
+      type: STRING
+      mode: NULLABLE
+    - name: subdivision1
+      type: STRING
+      mode: NULLABLE
+    - name: subdivision2
+      type: STRING
+      mode: NULLABLE
+  - name: header
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: date
+      type: STRING
+      mode: NULLABLE
+    - name: dnt
+      type: STRING
+      mode: NULLABLE
+    - name: x_debug_id
+      type: STRING
+      mode: NULLABLE
+    - name: x_pingsender_version
+      type: STRING
+      mode: NULLABLE
+    - name: x_source_tags
+      type: STRING
+      mode: NULLABLE
+    - name: x_telemetry_agent
+      type: STRING
+      mode: NULLABLE
+    - name: x_foxsec_ip_reputation
+      type: STRING
+      mode: NULLABLE
+    - name: x_lb_tags
+      type: STRING
+      mode: NULLABLE
+    - name: parsed_date
+      type: TIMESTAMP
+      mode: NULLABLE
+    - name: parsed_x_source_tags
+      type: STRING
+      mode: REPEATED
+    - name: parsed_x_lb_tags
+      type: RECORD
+      mode: NULLABLE
+      fields:
+      - name: tls_version
+        type: STRING
+        mode: NULLABLE
+      - name: tls_cipher_hex
+        type: STRING
+        mode: NULLABLE
+  - name: isp
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: db_version
+      type: STRING
+      mode: NULLABLE
+    - name: name
+      type: STRING
+      mode: NULLABLE
+    - name: organization
+      type: STRING
+      mode: NULLABLE
+  - name: user_agent
+    type: RECORD
+    mode: NULLABLE
+    fields:
+    - name: browser
+      type: STRING
+      mode: NULLABLE
+    - name: os
+      type: STRING
+      mode: NULLABLE
+    - name: version
+      type: STRING
+      mode: NULLABLE
+- name: metrics
+  type: JSON
+  mode: NULLABLE
+- name: normalized_app_name
+  type: STRING
+  mode: NULLABLE
+- name: normalized_channel
+  type: STRING
+  mode: NULLABLE
+- name: normalized_country_code
+  type: STRING
+  mode: NULLABLE
+- name: normalized_os
+  type: STRING
+  mode: NULLABLE
+- name: normalized_os_version
+  type: STRING
+  mode: NULLABLE
+- name: ping_info
+  type: RECORD
+  mode: NULLABLE
+  fields:
+  - name: seq
+    type: INTEGER
+    mode: NULLABLE
+  - name: start_time
+    type: STRING
+    mode: NULLABLE
+  - name: parsed_start_time
+    type: TIMESTAMP
+    mode: NULLABLE
+  - name: end_time
+    type: STRING
+    mode: NULLABLE
+  - name: parsed_end_time
+    type: TIMESTAMP
+    mode: NULLABLE
+  - name: ping_type
+    type: STRING
+    mode: NULLABLE
+- name: sample_id
+  type: INTEGER
+  mode: NULLABLE
+- name: submission_timestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: app_version_major
+  type: NUMERIC
+  mode: NULLABLE
+- name: app_version_minor
+  type: NUMERIC
+  mode: NULLABLE
+- name: app_version_patch
+  type: NUMERIC
+  mode: NULLABLE
+- name: is_bot_generated
+  type: BOOLEAN
+  mode: NULLABLE
+- name: client_id
+  type: STRING
+  mode: NULLABLE
+- name: reason
+  type: STRING
+  mode: NULLABLE
+- name: experiments
+  type: JSON
+  mode: NULLABLE
+- name: profile_group_id
+  type: STRING
+  mode: NULLABLE
+- name: legacy_telemetry_client_id
+  type: STRING
+  mode: NULLABLE
+- name: event_timestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: event_category
+  type: STRING
+  mode: NULLABLE
+- name: event_name
+  type: STRING
+  mode: NULLABLE
+- name: event
+  type: STRING
+  mode: NULLABLE
+- name: event_extra
+  type: JSON
+  mode: NULLABLE


### PR DESCRIPTION
# fix: add glean_usage/templates/events_stream_v1.schema.yaml

caused by: https://github.com/mozilla/bigquery-etl/pull/8363

It looks like now schema files in the glean_usage generator are required for query.py templates. This seems to have caused the `'events_stream_v1.schema.yaml' not found in search path` error in our deployment.