### PR TITLE
feat(DENG-9984): Create Glean fx_cert_error_unique_users_normalized_channel

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/fx_cert_error_unique_users_normalized_channel/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/fx_cert_error_unique_users_normalized_channel/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.fx_cert_error_unique_users_normalized_channel`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.fx_cert_error_unique_users_normalized_channel_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_cert_error_unique_users_normalized_channel_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_cert_error_unique_users_normalized_channel_v1/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: Firefox Cert Error Dashboard - Unique users by normalized channel
+description: |-
+  Unique users experiencing cert error page per day per channel
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_cert_error_privacy_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_cert_error_unique_users_normalized_channel_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_cert_error_unique_users_normalized_channel_v1/query.sql
@@ -1,0 +1,13 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  normalized_channel,
+  COUNT(DISTINCT client_id) AS nbr_unique_users
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop.events_stream`
+WHERE
+  event_category = 'security.ui.certerror'
+  AND event_name = 'load_aboutcerterror'
+  AND DATE(submission_timestamp) = @submission_date
+GROUP BY
+  DATE(submission_timestamp),
+  normalized_channel

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_cert_error_unique_users_normalized_channel_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_cert_error_unique_users_normalized_channel_v1/schema.yaml
@@ -1,0 +1,13 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: normalized_channel
+  type: STRING
+  description: Normalized Channel
+- name: nbr_unique_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Unique users (distinct client ids)


### PR DESCRIPTION
## Description

This PR creates the new table & view:
- `moz-fx-data-shared-prod.firefox_desktop_derived.fx_cert_error_unique_users_normalized_channel_v1`
- `moz-fx-data-shared-prod.firefox_desktop.fx_cert_error_unique_users_normalized_channel`

This will be used to replace & eventually deprecate the corresponding legacy telemetry table & view:
- `moz-fx-data-shared-prod.telemetry_derived.fx_cert_error_unique_users_normalized_channel_v1`
- `moz-fx-data-shared-prod.telemetry.fx_cert_error_unique_users_normalized_channel`

## Related Tickets & Documents
* [DENG-9984](https://mozilla-hub.atlassian.net/browse/DENG-9984)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9984]: https://mozilla-hub.atlassian.net/browse/DENG-9984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ