### PR TITLE
feat(DENG-9984): Create fx_privacy_dau_agg using Glean

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/fx_privacy_dau_agg/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/fx_privacy_dau_agg/metadata.yaml
@@ -1,0 +1,8 @@
+friendly_name: Firefox Privacy Dashboard - DAU interracting with the privacy panel
+description: |-
+  DAU interacting with the privacy panel
+owners:
+- kwindau@mozilla.com
+labels:
+  owner: kwindau
+require_column_descriptions: false

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/fx_privacy_dau_agg/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/fx_privacy_dau_agg/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.fx_privacy_dau_agg`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.fx_privacy_dau_agg_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_privacy_dau_agg_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_privacy_dau_agg_v1/metadata.yaml
@@ -1,0 +1,19 @@
+friendly_name: Firefox Privacy Dashboard - DAU interracting with the privacy panel
+description: |-
+  DAU interacting with the privacy panel
+owners:
+- kwindau@mozilla.com
+labels:
+  incremental: true
+  owner1: kwindau
+  table_type: aggregate
+  shredder_mitigation: true
+scheduling:
+  dag_name: bqetl_fx_cert_error_privacy_dashboard
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  range_partitioning: null

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_privacy_dau_agg_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_privacy_dau_agg_v1/query.sql
@@ -1,0 +1,13 @@
+SELECT
+  event_name AS event_object,
+  DATE(submission_timestamp) AS submission_date,
+  COUNT(*) AS nbr_events,
+  COUNT(DISTINCT client_id) AS nbr_distinct_users,
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop.events_stream`
+WHERE
+  event_category = 'security.ui.protectionspopup'
+  AND DATE(submission_timestamp) = @submission_date
+GROUP BY
+  event_name,
+  DATE(submission_timestamp)

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_privacy_dau_agg_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/fx_privacy_dau_agg_v1/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Submission Date
+- mode: NULLABLE
+  name: event_object
+  type: STRING
+  description: Submission Date
+- mode: NULLABLE
+  name: nbr_events
+  type: INTEGER
+  description: Number of events
+- name: nbr_distinct_users
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of distinct users


### PR DESCRIPTION
## Description
This PR creates the new Glean table & view:
- `moz-fx-data-shared-prod.firefox_desktop_derived.fx_privacy_dau_agg_v1`
- `moz-fx-data-shared-prod.firefox_desktop.fx_privacy_dau_agg`

This will be used to deprecate and replace the existing legacy telemetry Glean table & view:
- `moz-fx-data-shared-prod.telemetry_derived.fx_privacy_dau_agg_v1`
- `moz-fx-data-shared-prod.telemetry.fx_privacy_dau_agg`

## Related Tickets & Documents
* [DENG-9984](https://mozilla-hub.atlassian.net/browse/DENG-9984)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9984]: https://mozilla-hub.atlassian.net/browse/DENG-9984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ