### PR TITLE
fix(glean_usage): Include project ID in fake SQL file path for dry runs (bug 1997260)

### DIFF
--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -335,7 +335,7 @@ class GleanTable:
                 if query_sql:
                     schema = Schema(
                         DryRun(
-                            os.path.join(*table.split("."), "query.sql"),
+                            os.path.join(project_id, *table.split("."), "query.sql"),
                             content=query_sql,
                             query_parameters=self.possible_query_parameters,
                             use_cloud_function=use_cloud_function,


### PR DESCRIPTION
## Description
Fixup for https://github.com/mozilla/bigquery-etl/pull/8363.

[Some `DryRun` code](https://github.com/mozilla/bigquery-etl/blob/3d4890271206cec58362a634fe93741bf065be5b/bigquery_etl/dryrun.py#L270) assumes the SQL file path (real or not) will have a project directory.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/8363
* [Bug 1997260](https://bugzilla.mozilla.org/show_bug.cgi?id=1997260): Airflow task `bqetl_artifact_deployment.publish_new_tables` failed for run `manual__2025-10-30T05:10:36.701701+00:00`

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
