### PR TITLE
feat(DENG-10036): Add column to baseline_clients_first_seen_v1

### DIFF
--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.query.sql
@@ -85,6 +85,10 @@ WITH
         metadata.isp.name
         ORDER BY submission_timestamp ASC LIMIT 1
       )[OFFSET(0)] AS isp,
+     ARRAY_AGG(
+        metrics.string.startup_profile_selection_reason
+        ORDER BY submission_timestamp ASC LIMIT 1
+      )[OFFSET(0)] AS startup_profile_selection_reason_first,
       {% endif %}
     FROM
       `{{ baseline_table }}`
@@ -196,6 +200,10 @@ _baseline AS (
         metadata.isp.name
         ORDER BY submission_timestamp ASC LIMIT 1
       )[OFFSET(0)] AS isp,
+      ARRAY_AGG(
+        metrics.string.startup_profile_selection_reason
+        ORDER BY submission_timestamp ASC LIMIT 1
+      )[OFFSET(0)] AS startup_profile_selection_reason_first,
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -228,6 +236,7 @@ _current AS (
     normalized_channel,
     normalized_os_version,
     isp,
+    startup_profile_selection_reason_first,
     {% endif %}
   FROM
     _baseline
@@ -261,6 +270,7 @@ _previous AS (
     normalized_channel,
     normalized_os_version,
     isp,
+    startup_profile_selection_reason_first,
     {% endif %}
   FROM
     `{{ first_seen_table }}` fs
@@ -350,6 +360,10 @@ _current AS (
         metadata.isp.name
         ORDER BY submission_timestamp ASC LIMIT 1
       )[OFFSET(0)] AS isp,
+      ARRAY_AGG(
+        metrics.string.startup_profile_selection_reason
+        ORDER BY submission_timestamp ASC LIMIT 1
+      )[OFFSET(0)] AS startup_profile_selection_reason_first,
     {% endif %}
   FROM
     `{{ baseline_table }}`
@@ -385,6 +399,7 @@ _previous AS (
     normalized_channel,
     normalized_os_version,
     isp,
+    startup_profile_selection_reason_first,
     {% endif %}
   FROM
     `{{ first_seen_table }}`
@@ -433,6 +448,7 @@ SELECT
   normalized_channel,
   normalized_os_version,
   isp,
+  startup_profile_selection_reason_first
   {% endif %}
 FROM _joined
 QUALIFY

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.schema.yaml
@@ -110,4 +110,8 @@ fields:
   name: isp
   type: STRING
   description: Internet Service Provider
+- mode: NULLABLE
+  name: startup_profile_selection_reason_first
+  type: STRING
+  description: How the profile was selected during startup
 {% endif %}


### PR DESCRIPTION
## Description

This PR adds the new column `startup_profile_selection_reason_first` to:
- `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_clients_first_seen_v1`
- `moz-fx-data-shared-prod.firefox_desktop.baseline_clients_first_seen`

## Related Tickets & Documents
* [DENG-10036](https://mozilla-hub.atlassian.net/browse/DENG-10036)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-10036]: https://mozilla-hub.atlassian.net/browse/DENG-10036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ