### PR TITLE
feat(DENG-100370): Add apple_model_id to metrics_clients_daily

### DIFF
--- a/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
@@ -23,32 +23,32 @@
     {% endif -%}
     {% if app_name == "firefox_desktop" -%}
       ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS profile_group_id,
-      SUM(COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar) kv), 0) + 
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar_searchmode) kv),0) + 
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_contextmenu) kv),0) + 
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_about_home) kv),0) + 
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_about_newtab) kv),0) + 
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_searchbar) kv),0) + 
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_system) kv),0) + 
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_webextension) kv),0) + 
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_tabhistory) kv),0) + 
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_reload) kv),0) + 
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_unknown) kv),0) + 
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar_handoff) kv),0) + 
+      SUM(COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar) kv), 0) +
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar_searchmode) kv),0) +
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_contextmenu) kv),0) +
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_about_home) kv),0) +
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_about_newtab) kv),0) +
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_searchbar) kv),0) +
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_system) kv),0) +
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_webextension) kv),0) +
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_tabhistory) kv),0) +
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_reload) kv),0) +
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_unknown) kv),0) +
+      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar_handoff) kv),0) +
       COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar_persisted) kv),0)) AS search_with_ads_count_all,
       SUM(
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_about_home) kv), 0) + 
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_about_newtab) kv), 0) + 
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_contextmenu) kv), 0) + 
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_reload) kv), 0) + 
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_searchbar) kv), 0) + 
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_system) kv), 0) + 
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_tabhistory) kv), 0) + 
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_unknown) kv), 0) + 
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar) kv), 0) + 
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar_handoff) kv), 0) + 
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar_persisted) kv), 0) + 
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar_searchmode) kv), 0) + 
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_about_home) kv), 0) +
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_about_newtab) kv), 0) +
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_contextmenu) kv), 0) +
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_reload) kv), 0) +
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_searchbar) kv), 0) +
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_system) kv), 0) +
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_tabhistory) kv), 0) +
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_unknown) kv), 0) +
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar) kv), 0) +
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar_handoff) kv), 0) +
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar_persisted) kv), 0) +
+        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar_searchmode) kv), 0) +
         COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_webextension) kv), 0)
       ) AS search_count_all,
   SUM(
@@ -70,7 +70,8 @@
         IFNULL(metrics.labeled_counter.browser_search_adclicks_webextension, [])
       )) AS kv
     ), 0)
-  ) AS ad_clicks_count_all
+  ) AS ad_clicks_count_all,
+  ANY_VALUE(metrics.string.system_apple_model_id) AS apple_model_id
     {% endif -%}
   FROM
     `moz-fx-data-shared-prod.{{ dataset }}.metrics` AS m


### PR DESCRIPTION
## Description
This PR adds the column `apple_model_id` to the table & corresponding view:
- `moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_daily_v1`
- `moz-fx-data-shared-prod.firefox_desktop.metrics_clients_daily`

## Related Tickets & Documents
* [DENG-10037](https://mozilla-hub.atlassian.net/browse/DENG-10037)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-10037]: https://mozilla-hub.atlassian.net/browse/DENG-10037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ