### PR TITLE
[DENG-10000] Support running managed backfills on public tables

### DIFF
--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -904,6 +904,17 @@ def _copy_backfill_staging_to_prod(
        un-partitioned: copy the entire staging table to production.
        partitioned: determine and copy each partition from staging to production.
     """
+    # If this is a public dataset, change the destination to the public project
+    if table_metadata.is_public_bigquery():
+        project, dataset, table = qualified_table_name_matching(qualified_table_name)
+        public_project_id = ConfigLoader.get(
+            "default", "public_project", fallback="mozilla-public-data"
+        )
+        qualified_table_name = f"{public_project_id}.{dataset}.{table}"
+        click.echo(
+            f"Public dataset detected. Copying to public project: {qualified_table_name}"
+        )
+
     partitioning_type = None
     if table_metadata.bigquery and table_metadata.bigquery.time_partitioning:
         partitioning_type = table_metadata.bigquery.time_partitioning.type

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -552,6 +552,7 @@ def _backfill_query(
         ),
         query_arguments=arguments,
         billing_project=billing_project,
+        ignore_public_dataset=True,
     )
 
     # Run checks on the query
@@ -957,6 +958,7 @@ def _run_query(
     query_arguments,
     addl_templates: Optional[dict] = None,
     billing_project: Optional[str] = None,
+    ignore_public_dataset: bool = False,
 ):
     """Run a query.
 
@@ -964,6 +966,9 @@ def _run_query(
     do not have a project id qualifier.
     billing_project is the project to run the query in for the purposes of billing and
     slot reservation selection.  This is project_id if billing_project is not set
+    ignore_public_dataset is a flag to ignore public dataset metadata checks and
+    destination table overrides. This is useful when running backfills where you want to
+    write to the standard (non-public) destination table.
     """
     if billing_project is not None:
         query_arguments.append(f"--project_id={billing_project}")
@@ -979,7 +984,7 @@ def _run_query(
         query_file = Path(query_file)
         try:
             metadata = Metadata.of_query_file(query_file)
-            if metadata.is_public_bigquery():
+            if not ignore_public_dataset and metadata.is_public_bigquery():
                 if not validate_metadata.validate_public_data(metadata, query_file):
                     sys.exit(1)
 


### PR DESCRIPTION
## Description

Fixes https://github.com/mozilla/bigquery-etl/issues/8351
This adds support for running backfills on public tables. It was previously failing as the project IDs didn't get substituted correctly for the public project one.

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/DENG-10000

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
