### PR TITLE
chore(experiment_monitoring): add config for experimenter and subplat

### DIFF
--- a/sql_generators/experiment_monitoring/templates/templating.yaml
+++ b/sql_generators/experiment_monitoring/templates/templating.yaml
@@ -128,6 +128,14 @@ search_metrics:
     ad_clicks_count: null
     search_with_ads_count: null
     search_count: null
+  experimenter_cirrus:
+    ad_clicks_count: null
+    search_with_ads_count: null
+    search_count: null
+  subplat_cirrus:
+    ad_clicks_count: null
+    search_with_ads_count: null
+    search_count: null
 applications:
   - org_mozilla_firefox_beta
   - org_mozilla_fenix
@@ -145,3 +153,5 @@ applications:
   - org_mozilla_ios_focus
   - monitor_cirrus
   - accounts_cirrus
+  - experimenter_cirrus
+  - subplat_cirrus


### PR DESCRIPTION
## Description

This PR adds experiment monitoring config for experimenter_cirrus and subplat_cirrus

## Related Tickets & Documents
* Fixes [EXP-6110](https://mozilla-hub.atlassian.net/browse/EXP-6110)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[EXP-6110]: https://mozilla-hub.atlassian.net/browse/EXP-6110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ