### PR TITLE
feat(DENG-10141): Add default_search_engine to metrics_clients_daily

### DIFF
--- a/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
@@ -23,55 +23,251 @@
     {% endif -%}
     {% if app_name == "firefox_desktop" -%}
       ANY_VALUE(metrics.uuid.legacy_telemetry_profile_group_id) AS profile_group_id,
-      SUM(COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar) kv), 0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar_searchmode) kv),0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_contextmenu) kv),0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_about_home) kv),0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_about_newtab) kv),0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_searchbar) kv),0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_system) kv),0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_webextension) kv),0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_tabhistory) kv),0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_reload) kv),0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_unknown) kv),0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar_handoff) kv),0) +
-      COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_withads_urlbar_persisted) kv),0)) AS search_with_ads_count_all,
       SUM(
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_about_home) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_about_newtab) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_contextmenu) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_reload) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_searchbar) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_system) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_tabhistory) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_unknown) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar_handoff) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar_persisted) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_urlbar_searchmode) kv), 0) +
-        COALESCE((SELECT SUM(kv.value) FROM unnest(metrics.labeled_counter.browser_search_content_webextension) kv), 0)
+        COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_urlbar) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_urlbar_searchmode) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_contextmenu) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_about_home) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_about_newtab) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_searchbar) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_system) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_webextension) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_tabhistory) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_reload) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_unknown) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_urlbar_handoff) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_withads_urlbar_persisted) kv
+          ),
+          0
+        )
+      ) AS search_with_ads_count_all,
+      SUM(
+        COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_about_home) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_about_newtab) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_contextmenu) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_reload) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_searchbar) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_system) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_tabhistory) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_unknown) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_urlbar) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_urlbar_handoff) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_urlbar_persisted) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_urlbar_searchmode) kv
+          ),
+          0
+        ) + COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(metrics.labeled_counter.browser_search_content_webextension) kv
+          ),
+          0
+        )
       ) AS search_count_all,
-  SUM(
-    COALESCE((
-      SELECT SUM(kv.value)
-      FROM UNNEST(ARRAY_CONCAT(
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_about_home, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_about_newtab, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_contextmenu, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_reload, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_searchbar, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_system, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_tabhistory, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_unknown, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_urlbar, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_urlbar_handoff, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_urlbar_persisted, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_urlbar_searchmode, []),
-        IFNULL(metrics.labeled_counter.browser_search_adclicks_webextension, [])
-      )) AS kv
-    ), 0)
-  ) AS ad_clicks_count_all,
-  ANY_VALUE(metrics.string.system_apple_model_id) AS apple_model_id
+      SUM(
+        COALESCE(
+          (
+            SELECT
+              SUM(kv.value)
+            FROM
+              UNNEST(
+                ARRAY_CONCAT(
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_about_home, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_about_newtab, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_contextmenu, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_reload, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_searchbar, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_system, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_tabhistory, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_unknown, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_urlbar, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_urlbar_handoff, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_urlbar_persisted, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_urlbar_searchmode, []),
+                  IFNULL(metrics.labeled_counter.browser_search_adclicks_webextension, [])
+                )
+              ) AS kv
+          ),
+          0
+        )
+      ) AS ad_clicks_count_all,
+      ANY_VALUE(metrics.string.system_apple_model_id) AS apple_model_id,
+      `moz-fx-data-shared-prod.udf.mode_last`(
+        ARRAY_AGG(metrics.string.search_engine_default_engine_id ORDER BY submission_timestamp ASC)
+      ) AS default_search_engine
     {% endif -%}
   FROM
     `moz-fx-data-shared-prod.{{ dataset }}.metrics` AS m


### PR DESCRIPTION
## Description

This PR adds the new column `default_search_engine`, calculated as the most commonly reported search engine ID for that client for that date (in case of ties, whichever default_search_engine was last observed chronologically is the winner) to the table & corresponding view:
- `moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_daily_v1`
- `moz-fx-data-shared-prod.firefox_desktop.metrics_clients_daily`

## Related Tickets & Documents
* [DENG-10141](https://mozilla-hub.atlassian.net/browse/DENG-10141)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-10141]: https://mozilla-hub.atlassian.net/browse/DENG-10141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ