### PR TITLE
AD-953 For iOS suggest data, pull country from metrics.string going forward

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_suggest_v1/query.sql
@@ -136,7 +136,7 @@ combined AS (
     metrics.uuid.fx_suggest_context_id AS context_id,
     DATE(submission_timestamp) AS submission_date,
     'phone' AS form_factor,
-    normalized_country_code AS country,
+    COALESCE(metrics.string.fx_suggest_country, normalized_country_code) AS country,
     metrics.string.fx_suggest_advertiser AS advertiser,
     -- This is now hardcoded, we can use the derived `normalized_os` once
     -- https://bugzilla.mozilla.org/show_bug.cgi?id=1773722 is fixed

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/query.sql
@@ -153,7 +153,7 @@ combined AS (
       "impression"
     ) AS event_type,
     'phone' AS form_factor,
-    normalized_country_code AS country,
+    COALESCE(metrics.string.fx_suggest_country, normalized_country_code) AS country,
     metadata.geo.subdivision1 AS subdivision1,
     metrics.string.fx_suggest_advertiser AS advertiser,
     client_info.app_channel AS release_channel,

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/expect.yaml
@@ -40,7 +40,8 @@
   query_type: branded
 - <<: *suggest_mobile
   normalized_os: iOS
-- submission_date: "2030-01-01"
+- &suggest_mobile_ohttp
+  submission_date: "2030-01-01"
   source: suggest
   provider: remote settings
   event_type: impression
@@ -54,6 +55,8 @@
   event_count: 1
   user_count: 1
   query_type: branded
+- <<: *suggest_mobile_ohttp
+  normalized_os: iOS
 - &topsites_base
   submission_date: "2030-01-01"
   source: topsites

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/moz-fx-data-shared-prod.firefox_ios.fx_suggest.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_aggregation/moz-fx-data-shared-prod.firefox_ios.fx_suggest.yaml
@@ -1,6 +1,7 @@
 ---
-- submission_timestamp: "2030-01-01 01:00:00"
-  metrics:
+- &suggest_base
+  submission_timestamp: "2030-01-01 01:00:00"
+  metrics: &suggest_metrics
     quantity:
       fx_suggest_block_id: 123
       fx_suggest_position: 1
@@ -14,4 +15,17 @@
       subdivision1: DC
   client_info:
     app_channel: release
+  normalized_country_code: US
+- <<: *suggest_base
+  metrics:
+    <<: *suggest_metrics
+    string:
+      fx_suggest_advertiser: ad4
+      fx_suggest_ping_type: fxsuggest-impression
+      fx_suggest_country: VN
+  metadata:
+    geo:
+      subdivision1: null
+    user_agent:
+      os: Android
   normalized_country_code: US

--- a/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/moz-fx-data-shared-prod.firefox_ios.fx_suggest.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/contextual_services_derived/event_aggregates_v1/test_overactive_filter/moz-fx-data-shared-prod.firefox_ios.fx_suggest.yaml
@@ -8,6 +8,7 @@
     string:
       fx_suggest_advertiser: ad4
       fx_suggest_ping_type: fxsuggest-click
+      fx_suggest_country: US
     uuid:
       fx_suggest_context_id: fenix-b
   metadata:


### PR DESCRIPTION
## Description

Updates `contextual_services_derived.event_aggregates_v1` and `contextual_services_derived.event_aggregates_suggest_v1` to pull country values from the new `metrics.string.fx_suggest_country` field, which was added to the OHTTP Suggest ping on iOS in version 143.

Falls back to `normalized_country_code` where `metrics.string.fx_suggest_country` is NULL (e.g., users on older versions).

There is a broader review of this logic that should be done (e.g., https://github.com/mozilla/bigquery-etl/pull/7508/files#r2320076398) but I'm leaving that for another PR.

## Related Tickets & Documents
* [AD-953](https://mozilla-hub.atlassian.net/browse/AD-953)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[AD-953]: https://mozilla-hub.atlassian.net/browse/AD-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ