### PR TITLE
[DENG-10153] Ignore derived_view_schemas generator in CI

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -591,7 +591,10 @@ jobs:
 
                     cp -r sql/ /tmp/workspace/generated-sql/sql
                     # Don't depend on dry run for PRs
+                    # Ignore derived_view_schemas as this will add descriptions to view which take a long time;
+                    # Schemas with descriptions will be generated before deployment instead
                     PATH="venv/bin:$PATH" script/bqetl generate all \
+                      --ignore derived_view_schemas \
                       --output-dir /tmp/workspace/generated-sql/sql/ \
                       --target-project moz-fx-data-shared-prod
                   else
@@ -968,6 +971,7 @@ jobs:
                   if [ "$GENERATED_SQL_CHANGED" = "true" ]; then
                     # re-run SQL generation and re-generate DAGs
                     $bqetl_script generate all \
+                      --ignore derived_view_schemas \
                       --target-project moz-fx-data-shared-prod
                   else
                     echo "Changes made don't affect generated SQL. Use content from generated-sql"


### PR DESCRIPTION
## Description

The `derived_view_schemas` SQL generator is with about 7min the longest running generator (makes about 1/2 of the 15min long generate-sql generation process). This generator creates schemas for views in order to propagate description from referenced tables. These schemas are only useful before deploying a view, so in order to save time, the generator can be skipped in CI. This will result in view schemas being removed from the generated-sql branch, but these schemas aren’t generally useful to users or used anywhere other than for deployment.

An implication of this change is that the `derived_view_schemas always` needs to run before view deploys. 

Depends on https://github.com/mozilla/telemetry-airflow/pull/2279

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/DENG-10153

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
