### PR TITLE
fix(SubPlat): Calculate correct `valid_to` values for Apple & Google logical subscriptions history (DENG-9565)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_logical_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_logical_subscriptions_history_v1/query.sql
@@ -195,7 +195,16 @@ SELECT
     FORMAT_TIMESTAMP('%FT%H:%M:%E6S', history.valid_from)
   ) AS id,
   history.valid_from,
-  history.valid_to,
+  COALESCE(
+    LEAD(history.valid_from) OVER (
+      PARTITION BY
+        history_period.subscription_id
+      ORDER BY
+        history.valid_from,
+        history.valid_to
+    ),
+    '9999-12-31 23:59:59.999999'
+  ) AS valid_to,
   history.id AS provider_subscriptions_history_id,
   STRUCT(
     history_period.subscription_id AS id,

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_logical_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_logical_subscriptions_history_v1/query.sql
@@ -165,7 +165,16 @@ SELECT
     FORMAT_TIMESTAMP('%FT%H:%M:%E6S', history.valid_from)
   ) AS id,
   history.valid_from,
-  history.valid_to,
+  COALESCE(
+    LEAD(history.valid_from) OVER (
+      PARTITION BY
+        history_period.subscription_id
+      ORDER BY
+        history.valid_from,
+        history.valid_to
+    ),
+    '9999-12-31 23:59:59.999999'
+  ) AS valid_to,
   history.id AS provider_subscriptions_history_id,
   (
     SELECT AS STRUCT


### PR DESCRIPTION
## Description
In particular, when an Apple or Google subscription has been reactivated and is considered a new logical subscription, then the current logic passing through the `valid_to` value from the underlying `apple_subscriptions_history_v1` or `google_subscriptions_history_v1` record was leaving the previous logical subscription(s) associated with the Apple/Google subscription with a final logical subscription history record where `valid_to` wasn't `9999-12-31 23:59:59.999999` like it should be.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
