### PR TITLE
fix(format): Skip qualifying table references in `checks.sql` files (DENG-7005)

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -271,6 +271,7 @@ format:
   - sql/moz-fx-data-shared-prod/udf_legacy/to_iso8601.sql
   - stored_procedures/safe_crc32_uuid.sql
   skip_qualifying_references:
+  - sql/**/checks.sql
   - sql/mozfun/**/examples/*.sql
 
 routine:


### PR DESCRIPTION
## Description
Because `checks.sql` files can use more advanced Jinja templating that doesn't get rendered properly when running `bqetl format` and can cause problems for sqlglot ([example](https://github.com/mozilla/bigquery-etl/blob/f78bfcca3bb056a4689d608d70fe128820cf5cdf/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/checks.sql)).

I believe this would allow us to use @BenWu's [fix for sqlglot incompatibilites with `INFORMATION_SCHEMA` identifiers](https://mozilla-hub.atlassian.net/browse/DENG-7005?focusedCommentId=1132944) and upgrade sqlglot.

## Related Tickets & Documents
* DENG-7005: sqlglot incompatibilites with INFORMATION_SCHEMA identifiers

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
