### PR TITLE
[DENG-10166] Blobless checkout in CI

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -4,7 +4,6 @@ version: 2.1
 orbs:
   gcp-gcr: circleci/gcp-gcr@0.16
   docker: circleci/docker@2.6
-  python: circleci/python@2.1.1
   gcp-cli: circleci/gcp-cli@3.2
 
 parameters:
@@ -38,7 +37,7 @@ executors:
 jobs:
   build:
     docker: &docker
-      - image: python:<< pipeline.parameters.python-version >>
+      - image: cimg/python:<< pipeline.parameters.python-version >>
     steps:
       - checkout:
           method: blobless
@@ -49,12 +48,12 @@ jobs:
             # patterns to restore cache
             - &python_cache_key
               # yamllint disable-line rule:line-length
-              python-<< pipeline.parameters.python-version >>-packages-v1-{{ .Branch }}-{{ checksum "requirements.in" }}-{{ checksum "requirements.txt" }}
+              python-<< pipeline.parameters.python-version >>-packages-v2-{{ .Branch }}-{{ checksum "requirements.in" }}-{{ checksum "requirements.txt" }}
             # yamllint disable-line rule:line-length
-            - python-<< pipeline.parameters.python-version >>-packages-v1-{{ .Branch }}-{{ checksum "requirements.in" }}-
+            - python-<< pipeline.parameters.python-version >>-packages-v2-{{ .Branch }}-{{ checksum "requirements.in" }}-
             # yamllint disable-line rule:line-length
-            - python-<< pipeline.parameters.python-version >>-packages-v1-{{ .Branch }}-
-            - python-<< pipeline.parameters.python-version >>-packages-v1-main-
+            - python-<< pipeline.parameters.python-version >>-packages-v2-{{ .Branch }}-
+            - python-<< pipeline.parameters.python-version >>-packages-v2-main-
       - &build
         run:
           name: Build
@@ -390,9 +389,7 @@ jobs:
           steps:
             - *skip
   validate-dags:
-    executor:
-      name: python/default
-      tag: 3.11.8
+    docker: *docker
     steps:
       - when:
           condition: *validate-sql


### PR DESCRIPTION
## Description

Using the `blobless` checkout method in CI reduces the checkout time from around 30s to 5s. Blobless clones reduce the amount of data fetched from the remote by asking the remote to filter out objects that are not attached to the current commit: https://circleci.com/docs/reference/configuration-reference/#checkout

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/DENG-10166

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
