### PR TITLE
[DENG-9685] Speed up test_run_query_no_query_file integration test

### DIFF
--- a/script/entrypoint
+++ b/script/entrypoint
@@ -37,6 +37,10 @@ elif [ "$1" = "query" ]; then
     #     query [options] FILE
     # we dispatch to a script that inspects metadata and emulates the following call:
     #     bq query [options] < FILE
+    if [ "$#" -lt 2 ]; then
+        echo "Error: 'query' command requires at least one argument (FILE)" >&2
+        exit 1
+    fi
     exec script/bqetl query run "${@: -1}" "${@:1:$#-1}"
 elif [ "$XCOM_PUSH" = "true" ]; then
     # KubernetesPodOperator will extract the contents of /airflow/xcom/return.json as an xcom

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -137,4 +137,7 @@ class TestEntrypoint:
                 check=True,
                 capture_output=True,
             )
-            assert b"No queries matching" in e.value.stderr
+            assert (
+                b"Error: 'query' command requires at least one argument (FILE)"
+                in e.value.stderr
+            )


### PR DESCRIPTION
## Description

The `test_run_query_no_query_file` integration test takes about 12 minutes to run. I changed the entrypoint script slightly to throw an error earlier if no query file is specified. The new runtime is about a minute

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/DENG-9685

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
