### PR TITLE
[DENG-9396] Skip dry running query when getting table schema

### DIFF
--- a/bigquery_etl/schema/__init__.py
+++ b/bigquery_etl/schema/__init__.py
@@ -61,16 +61,11 @@ class Schema:
     @classmethod
     def for_table(cls, project, dataset, table, partitioned_by=None, *args, **kwargs):
         """Get the schema for a BigQuery table."""
-        query = f"SELECT * FROM `{project}.{dataset}.{table}`"
-
-        if partitioned_by:
-            query += f" WHERE DATE(`{partitioned_by}`) = DATE('2020-01-01')"
-
         try:
             return cls(
                 dryrun.DryRun(
                     os.path.join(project, dataset, table, "query.sql"),
-                    query,
+                    None,
                     project=project,
                     dataset=dataset,
                     table=table,


### PR DESCRIPTION
## Description

Depends on https://github.com/mozilla-services/cloudops-infra/pull/6665

Some generation and dry run tasks only depend on getting table metadata via the `for_table()` method. By rewriting the cloud function (https://github.com/mozilla-services/cloudops-infra/pull/6665) we can skip dryruns and only return the table metadata (which should speed things up in CI)


## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/DENG-9396

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
