### PR TITLE
fix(SubPlat): Properly synthesize service subscription end history records if subscriptions get downgraded to no longer include a service (DENG-9565)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscriptions_history_v1/query.sql
@@ -194,10 +194,16 @@ synthetic_subscription_ends_history AS (
         )
     ) AS subscription
   FROM
-    subscriptions_history
+    subscriptions_history AS history
   QUALIFY
-    1 = ROW_NUMBER() OVER (PARTITION BY subscription.id ORDER BY valid_from DESC, valid_to DESC)
-    AND valid_to < '9999-12-31 23:59:59.999999'
+    1 = ROW_NUMBER() OVER (
+      PARTITION BY
+        history.subscription.id
+      ORDER BY
+        history.valid_from DESC,
+        history.valid_to DESC
+    )
+    AND history.valid_to < '9999-12-31 23:59:59.999999'
 )
 SELECT
   *


### PR DESCRIPTION
## Description
The existing logic hasn't been synthesizing any service subscription end history records for downgrades, because unqualified column references in a `QUALIFY` clause accidentally ended up referencing columns in the `SELECT` list rather than columns in the underlying CTE being selected from.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
