### PR TITLE
fix(SubPlat): Properly synthesize Apple subscription period start history records (DENG-9565)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/query.sql
@@ -70,27 +70,27 @@ synthetic_subscription_period_start_changelog AS (
         )
     ) AS subscription
   FROM
-    subscriptions_revised_changelog
+    subscriptions_revised_changelog AS changelog
   QUALIFY
-    subscription.last_transaction.purchase_date IS DISTINCT FROM (
-      LAG(subscription.last_transaction.purchase_date) OVER subscription_changes_asc
+    changelog.subscription.last_transaction.purchase_date IS DISTINCT FROM (
+      LAG(changelog.subscription.last_transaction.purchase_date) OVER subscription_changes_asc
     )
-    AND subscription.last_transaction.purchase_date < `timestamp`
-    AND subscription.last_transaction.purchase_date > COALESCE(
-      LAG(`timestamp`) OVER subscription_changes_asc,
+    AND changelog.subscription.last_transaction.purchase_date < changelog.timestamp
+    AND changelog.subscription.last_transaction.purchase_date > COALESCE(
+      LAG(changelog.timestamp) OVER subscription_changes_asc,
       '0001-01-01 00:00:00'
     )
-    AND subscription.status IN (
+    AND changelog.subscription.status IN (
       1,  -- 1 = active
       4   -- 4 = in billing grace period
     )
   WINDOW
     subscription_changes_asc AS (
       PARTITION BY
-        subscription.original_transaction_id
+        changelog.subscription.original_transaction_id
       ORDER BY
-        `timestamp`,
-        id
+        changelog.timestamp,
+        changelog.id
     )
 ),
 changelog_union AS (


### PR DESCRIPTION
## Description
The existing `apple_subscriptions_history_v1` ETL logic wouldn't synthesize any Apple subscription period start history records, because unqualified column references in a `QUALIFY` clause accidentally ended up referencing columns in the `SELECT` list rather than columns in the underlying CTE being selected from.

Luckily, it looks like no such Apple subscription period start history records have actually needed to be synthesized by the `apple_subscriptions_history_v1` ETL to date, so this bug hasn't really had any effect.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
