### PR TITLE
fix(DENG-10047): Add step to wait for upstream data to load

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/firefox_whatsnew_summary_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/firefox_whatsnew_summary_v2/metadata.yaml
@@ -10,6 +10,9 @@ labels:
   owner2: sherrera
 scheduling:
   dag_name: bqetl_ga4_firefoxdotcom
+  depends_on:
+  - task_id: wait_for_firefoxdotcom_events_table
+    dag_name: bqetl_ga4_firefoxdotcom
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description

This is a follow-up PR related to [PR-8388](https://github.com/mozilla/bigquery-etl/pull/8388), I initially forgot to add logic to tell it to wait for the data to be loaded by Google before the query runs.  

This will ensure upstream data from Google Analytics has been received before the DAG runs for the table: 
* `moz-fx-data-shared-prod.firefoxdotcom_derived.firefox_whatsnew_summary_v2`

## Related Tickets & Documents
* [DENG-10047](https://mozilla-hub.atlassian.net/browse/DENG-10047)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-10047]: https://mozilla-hub.atlassian.net/browse/DENG-10047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ