### PR TITLE
fix: re-add curator field for corpus items

### DIFF
--- a/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_current_v1/view.sql
+++ b/sql/moz-fx-data-shared-prod/snowflake_migration_derived/corpus_items_current_v1/view.sql
@@ -8,6 +8,11 @@ WITH corpus_item_id_row_nums AS (
     url AS recommendation_url,
     authors,
     publisher,
+    CASE
+      WHEN curator_created_by = 'ML'
+        THEN "ML"
+      ELSE "Curator"
+    END AS curator,
     reviewed_corpus_item_updated_at AS corpus_item_updated_at,
     ROW_NUMBER() OVER (
       PARTITION BY


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
Adds back in if an item was scheduled via ML or by a curator that this old report had in Mode.

## Related Tickets & Documents
* DENG-9317

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
