### PR TITLE
fix(SubPlat): Initiate backfills of SubPlat ETLs to fix some more issues (DENG-9565, DENG-10152)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-12:
+  start_date: 2019-10-10
+  end_date: 2025-11-04
+  reason: Fix some more issues (DENG-9565, DENG-10152).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-10-29:
   start_date: 2019-10-10
   end_date: 2025-10-21

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-12:
+  start_date: 2019-10-10
+  end_date: 2025-11-04
+  reason: Fix some more issues (DENG-9565, DENG-10152).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-10-29:
   start_date: 2019-10-10
   end_date: 2025-10-21

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-12:
+  start_date: 2019-10-10
+  end_date: 2025-11-04
+  reason: Fix some more issues (DENG-9565, DENG-10152).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-10-29:
   start_date: 2019-10-10
   end_date: 2025-10-21

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-12:
+  start_date: 2019-10-01
+  end_date: 2025-10-01
+  reason: Fix some more issues (DENG-9565, DENG-10152).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-10-29:
   start_date: 2019-10-01
   end_date: 2025-09-01

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-12:
+  start_date: 2019-10-01
+  end_date: 2025-10-01
+  reason: Fix some more issues (DENG-9565, DENG-10152).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-10-29:
   start_date: 2019-10-01
   end_date: 2025-09-01

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-12:
+  start_date: 2019-10-10
+  end_date: 2025-11-04
+  reason: Fix some more issues (DENG-9565, DENG-10152).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-10-29:
   start_date: 2019-10-10
   end_date: 2025-10-21


### PR DESCRIPTION
## Description
See the linked tickets and PRs for details.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs
  * https://github.com/mozilla/bigquery-etl/pull/8409
  * https://github.com/mozilla/bigquery-etl/pull/8419
  * https://github.com/mozilla/bigquery-etl/pull/8420
  * https://github.com/mozilla/bigquery-etl/pull/8421
* DENG-10152: Some Fivetran Stripe `subscription_history` records incorrectly show subscriptions' status switching from "active" to "incomplete"
  * https://github.com/mozilla/bigquery-etl/pull/8418

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
