### PR TITLE
feat(DENG-10182): Add xpcom_abi to metrics_clients_daily

### DIFF
--- a/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
@@ -267,7 +267,8 @@
       ANY_VALUE(metrics.string.system_apple_model_id) AS apple_model_id,
       `moz-fx-data-shared-prod.udf.mode_last`(
         ARRAY_AGG(metrics.string.search_engine_default_engine_id ORDER BY submission_timestamp ASC)
-      ) AS default_search_engine
+      ) AS default_search_engine,
+      ANY_VALUE(metrics.string.xpcom_abi) AS xpcom_abi
     {% endif -%}
   FROM
     `moz-fx-data-shared-prod.{{ dataset }}.metrics` AS m


### PR DESCRIPTION
## Description

This PR adds the column `xpcom_abi` to `moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_daily_v1`

## Related Tickets & Documents
* [DENG-10182](https://mozilla-hub.atlassian.net/browse/DENG-10182)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-10182]: https://mozilla-hub.atlassian.net/browse/DENG-10182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ