### PR TITLE
fix(util): Have `import_google_sheet()` redeploy the table schema to add back field descriptions

### DIFF
--- a/bigquery_etl/util/google_sheets.py
+++ b/bigquery_etl/util/google_sheets.py
@@ -107,3 +107,11 @@ def import_google_sheet(
     print(
         f"Imported {result.total_rows} rows from {sheet_url} into `{destination_table}`."
     )
+
+    # Redeploy the table schema to add back field descriptions, which get removed when overwriting the table.
+    client.update_table(
+        bigquery.Table(
+            destination_table, schema=destination_schema.to_bigquery_schema()
+        ),
+        fields=["schema"],
+    )


### PR DESCRIPTION
## Description
Because the field descriptions get removed when overwriting the table.

## Related Tickets & Documents
N/A

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
