### PR TITLE
feat(DENG-9972): Add browser_backup_enabled & browser_backup_scheduler_enabled

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_daily_v1/schema.yaml
@@ -98,3 +98,11 @@ fields:
   type: STRING
   mode: NULLABLE
   description: The application version installed by the installer (not necessarily the current version)
+- name: browser_backup_enabled
+  type: BOOLEAN
+  mode: NULLABLE
+  description: True if the BackupService has initialized and reached idle.
+- name: browser_backup_scheduler_enabled
+  type: BOOLEAN
+  mode: NULLABLE
+  description: True if the BackupService is configured to automatically create backups in the background.

--- a/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.query.sql
@@ -323,7 +323,13 @@
         metrics.string.installation_first_seen_version RESPECT NULLS
         ORDER BY
           submission_timestamp
-      )[SAFE_OFFSET(0)] AS installation_first_seen_version
+      )[SAFE_OFFSET(0)] AS installation_first_seen_version,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(metrics.boolean.browser_backup_enabled ORDER BY submission_timestamp)
+      ) AS browser_backup_enabled,
+      mozfun.stats.mode_last(
+        ARRAY_AGG(metrics.boolean.browser_backup_scheduler_enabled ORDER BY submission_timestamp)
+      ) AS browser_backup_scheduler_enabled
     {% endif -%}
   FROM
     `moz-fx-data-shared-prod.{{ dataset }}.metrics` AS m


### PR DESCRIPTION
## Description

This PR adds 2 new columns to `moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_daily_v1`:
- browser_backup_enabled
- browser_backup_scheduler_enabled

## Related Tickets & Documents
* [DENG-9972](https://mozilla-hub.atlassian.net/browse/DENG-9972)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-9972]: https://mozilla-hub.atlassian.net/browse/DENG-9972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ