### PR TITLE
fix(query): Don't have `bqetl query run` table schema redeploys create the table if it doesn't exist

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -1103,36 +1103,37 @@ def _run_query(
             and schema_file.exists()
         ):
             schema = Schema.from_schema_file(schema_file)
-            if ":" in destination_table:
-                schema_destination_table = destination_table.replace(":", ".")
-            elif dataset_id and ":" in dataset_id:
-                schema_destination_table = ".".join(
-                    (dataset_id.replace(":", "."), destination_table)
-                )
-            else:
-                schema_destination_table = ".".join(
-                    (
-                        (project_id or default_project),
-                        (dataset_id or default_dataset),
-                        destination_table,
+            if any("description" in field for field in schema.schema["fields"]):
+                if ":" in destination_table:
+                    schema_destination_table = destination_table.replace(":", ".")
+                elif dataset_id and ":" in dataset_id:
+                    schema_destination_table = ".".join(
+                        (dataset_id.replace(":", "."), destination_table)
                     )
-                )
-            click.echo(
-                f"Redeploying schema for `{schema_destination_table}` table because it was overwritten."
-            )
-            try:
-                client = bigquery.Client()
-                client.update_table(
-                    bigquery.Table(
-                        schema_destination_table, schema=schema.to_bigquery_schema()
-                    ),
-                    fields=["schema"],
-                )
-            except Exception as e:
+                else:
+                    schema_destination_table = ".".join(
+                        (
+                            (project_id or default_project),
+                            (dataset_id or default_dataset),
+                            destination_table,
+                        )
+                    )
                 click.echo(
-                    f"Failed to redeploy schema for `{schema_destination_table}` table: {e}",
-                    err=True,
+                    f"Redeploying schema for `{schema_destination_table}` table because it was overwritten."
                 )
+                try:
+                    client = bigquery.Client()
+                    client.update_table(
+                        bigquery.Table(
+                            schema_destination_table, schema=schema.to_bigquery_schema()
+                        ),
+                        fields=["schema"],
+                    )
+                except Exception as e:
+                    click.echo(
+                        f"Failed to redeploy schema for `{schema_destination_table}` table: {e}",
+                        err=True,
+                    )
 
 
 def create_query_session(


### PR DESCRIPTION
## Description
Fixup for #8445, just in case the logic for determining the fully qualified destination table ID gets it wrong (the logic for what destination project/dataset/table arguments to pass to `bq query` is convoluted enough it makes me a bit nervous, and I already missed one edge case, necessitating #8450).

And I also added an optimization to check whether the `schema.yaml` actually contains any field descriptions, because if it doesn't then there's no need to bother redeploying the table schema.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/8445
* https://github.com/mozilla/bigquery-etl/pull/8450

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
