### PR TITLE
fix: android_app_campaign_stats_v1 retention reference

### DIFF
--- a/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/query.sql
@@ -37,15 +37,15 @@ retention_aggs AS (
   SELECT
     first_seen_date AS `date`,
     CAST(REGEXP_EXTRACT(adjust_ad_group, r' \((\d+)\)$') AS INT64) AS ad_group_id,
-    SUM(repeat_user) AS repeat_users,
+    SUM(repeat_profiles) AS repeat_users,
     SUM(retained_week_4) AS retained_week_4
   FROM
-    `moz-fx-data-shared-prod.fenix.funnel_retention_week_4`
+    `moz-fx-data-shared-prod.fenix.retention`
   WHERE
     {% if is_init() %}
-      submission_date <= CURRENT_DATE
+      metric_date <= CURRENT_DATE
     {% else %}
-      submission_date = @submission_date
+      metric_date = @submission_date
     {% endif %}
   GROUP BY
     `date`,


### PR DESCRIPTION
# fix: android_app_campaign_stats_v1 retention reference

The previously referenced retention dataset has been deprecated.