### PR TITLE
feat(): mark android_app_campaign_stats_v1 as deprecated and disable monitoring

### DIFF
--- a/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v1/metadata.yaml
@@ -27,4 +27,5 @@ bigquery:
     field: date
     require_partition_filter: false
 monitoring:
-  enabled: true
+  enabled: false
+deprecated: true


### PR DESCRIPTION
# feat(): mark android_app_campaign_stats_v1 as deprecated and disable monitoring

Deprecating as a v2 exists and is exclusively used by the "user-facing" view.