### PR TITLE
fix: terms of use status set date partition to null

### DIFF
--- a/sql_generators/terms_of_use/templates/terms_of_use_status_v1/metadata.yaml.jinja
+++ b/sql_generators/terms_of_use/templates/terms_of_use_status_v1/metadata.yaml.jinja
@@ -16,10 +16,10 @@ scheduling:
   task_group: {{ app_name }}
   depends_on_past: true
   date_partition_parameter: null
-  {% raw -%}
+  {%- raw %}
   parameters:
     - submission_date:DATE:{{ds}}
-  {% endraw -%}
+  {%- endraw %}
 bigquery:
   clustering:
     fields:

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/metadata.yaml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/metadata.yaml
@@ -18,7 +18,7 @@ scheduling:
   date_partition_parameter: null
   parameters:
     - submission_date:DATE:{{ds}}
-  bigquery:
+bigquery:
   clustering:
     fields:
       - sample_id

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/metadata.yaml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/metadata.yaml
@@ -18,7 +18,7 @@ scheduling:
   date_partition_parameter: null
   parameters:
     - submission_date:DATE:{{ds}}
-  bigquery:
+bigquery:
   clustering:
     fields:
       - sample_id


### PR DESCRIPTION
# fix: terms of use status set date partition to null

This is to address the ETL error related to the table not being partitioned.