### PR TITLE
fix(SubPlat): Adjust the `stripe_logical_subscriptions_history_v1` ETL's join condition for invoices (DENG-9565)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_history_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/stripe_logical_subscriptions_history_v1/query.sql
@@ -126,7 +126,7 @@ subscriptions_history_invoice_summaries AS (
   JOIN
     active_subscriptions_history AS history
     ON invoices.subscription_id = history.subscription.id
-    AND invoices.created < history.valid_to
+    AND COALESCE(invoices.status_transitions_finalized_at, invoices.created) < history.valid_to
   LEFT JOIN
     `moz-fx-data-shared-prod.stripe_external.charge_v1` AS charges
     ON invoices.id = charges.invoice_id


### PR DESCRIPTION
## Description
To try to avoid incorrectly attributing PayPal refunds to an earlier subscription period, because invoices are typically getting created just before the start of the subscription period in question.

## Related Tickets & Documents
* DENG-9565: Fix some known issues in SubPlat consolidated reporting ETLs

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
