### PR TITLE
[DENG-10196] Cache telemetry-airflow dependencies for validate-dags CI task

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -407,6 +407,11 @@ jobs:
                 command: |
                   rm ~/telemetry-airflow/dags/* -f || true
                   cp -a /tmp/workspace/generated-sql/dags/. ~/telemetry-airflow/dags/
+            - restore_cache:
+                keys:
+                  - telemetry-airflow-deps-v1-{{ checksum "~/telemetry-airflow/requirements.txt" }}-{{ checksum "~/telemetry-airflow/requirements-dev.txt" }}-{{ checksum "~/telemetry-airflow/requirements-override.txt" }}
+                  - telemetry-airflow-deps-v1-{{ checksum "~/telemetry-airflow/requirements.txt" }}-{{ checksum "~/telemetry-airflow/requirements-dev.txt" }}-
+                  - telemetry-airflow-deps-v1-
             - run:
                 name: Install telemetry-airflow dependencies
                 command: |
@@ -416,6 +421,10 @@ jobs:
                   pip install -r requirements.txt
                   pip install -r requirements-dev.txt
                   pip install -r requirements-override.txt
+            - save_cache:
+                paths:
+                  - ~/telemetry-airflow/.venv
+                key: telemetry-airflow-deps-v1-{{ checksum "~/telemetry-airflow/requirements.txt" }}-{{ checksum "~/telemetry-airflow/requirements-dev.txt" }}-{{ checksum "~/telemetry-airflow/requirements-override.txt" }}
             - run:
                 name: 🧪 Test valid DAGs
                 command: |


### PR DESCRIPTION
## Description

This adds caching for the telemetry-airflow dependencies required to run validation tests. Installing the dependencies took around 2min ([to compare](https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/55181/workflows/d6485678-e643-4e4a-9eea-a1c0ceb559aa/jobs/703393)), but is down to a few seconds with caching.

## Related Tickets & Documents
* [DENG-10196](https://mozilla-hub.atlassian.net/browse/DENG-10196)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-10196]: https://mozilla-hub.atlassian.net/browse/DENG-10196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ