### PR TITLE
GLAM: filter out bots with raw logic; Exclude certain pings

### DIFF
--- a/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
@@ -17,7 +17,7 @@ WITH extracted AS (
   WHERE
     DATE(submission_timestamp) = {{ submission_date }}
     AND client_info.client_id IS NOT NULL
-    AND is_bot_generated = FALSE
+    AND LOWER(IFNULL(metadata.isp.name, "")) <> "browserstack" -- Removes bots data.
 ),
 histograms AS (
   SELECT

--- a/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
@@ -17,7 +17,7 @@ WITH extracted AS (
   WHERE
     DATE(submission_timestamp) = {{ submission_date }}
     AND client_info.client_id IS NOT NULL
-    AND is_bot_generated = FALSE
+    AND LOWER(IFNULL(metadata.isp.name, "")) <> "browserstack" -- Removes bots data.
 ),
 unlabeled_metrics AS (
   SELECT

--- a/script/glam/generate_glean_sql
+++ b/script/glam/generate_glean_sql
@@ -5,14 +5,13 @@ set -ex
 function write_scalars {
     local product=$1
     local dataset=$2
-    local view=$3
+    local table=$3
     local dst_project=$4
     local sql_dir=$5
-    local table_name="${view}_v1"
-    local directory="${sql_dir}/${dst_project}/glam_etl/${product}__clients_daily_scalar_aggregates_${table_name}"
+    local directory="${sql_dir}/${dst_project}/glam_etl/${product}__clients_daily_scalar_aggregates_${table}"
     mkdir -p "$directory"
     if ! python3 -m bigquery_etl.glam.clients_daily_scalar_aggregates \
-        --source-table "$dataset.$view" \
+        --source-table "$dataset.$table" \
         --product "$product" \
         > "$directory/query.sql"; then
             echo "skipping $directory/query.sql: no probes found"
@@ -25,14 +24,13 @@ function write_scalars {
 function write_histograms {
     local product=$1
     local dataset=$2
-    local view=$3
+    local table=$3
     local dst_project=$4
     local sql_dir=$5
-    local table_name="${view}_v1"
-    local directory="${sql_dir}/${dst_project}/glam_etl/${product}__clients_daily_histogram_aggregates_${table_name}"
+    local directory="${sql_dir}/${dst_project}/glam_etl/${product}__clients_daily_histogram_aggregates_${table}"
     mkdir -p "$directory"
     if ! python3 -m bigquery_etl.glam.clients_daily_histogram_aggregates \
-        --source-table "$dataset.$view" \
+        --source-table "$dataset.$table" \
         --product "$product" \
         > "$directory/query.sql"; then
             echo "skipping $directory/query.sql: no probes found"
@@ -47,13 +45,9 @@ function write_clients_daily_aggregates {
     local src_project=$2
     local dst_project=$3
     local sql_dir=$4
+    local dataset="${product}_stable"
 
-    # We want to use metadata from the tables for validation
-    # But we fetch the actual data from the views
-    local dataset_tbls="${product}_stable"
-    local dataset_views="${product}"
-
-    local qualified="$src_project:$dataset_tbls"
+    local qualified="$src_project:$dataset"
     # validate inputs with set -e, however note that this will fail silently
     if ! bq ls "$qualified" &> /dev/null; then
         echo "could not list $qualified"
@@ -66,31 +60,31 @@ function write_clients_daily_aggregates {
 
     # e.g. baseline_v1
     local tables;
+    # Pings to exclude
+    local excluded_tables=(
+        "use_counters.*"            # Use counters bring too many rows to process and GLAM doesn't support them.
+        "^migration$"               # Migration tables are not supported by GLAM and don't have `is_bot_generated` flag.
+        "^client_deduplication$"    # Client deduplication tables are not supported by GLAM and don't have `is_bot_generated` flag.
+    )
+    local exclude_pattern=$(IFS='|'; echo "${excluded_tables[*]}")
+
     # GLAM only supports tables with glean_ping_* schema.
-    # Also excluding use_counters because they are not supported
-    # and their generated query is too big to run
+    # Also excluding tables matching patterns in excluded_tables list
+    # because they are not supported or their generated query is too big to run
     tables=$(bq ls --format=json "$qualified" | \
-        jq -r '.[] |
+        jq -r --arg exclude_pattern "$exclude_pattern" '.[] |
         select(.labels.schema_id | test("^glean_ping_[0-9]+")) |
         select(.type == "TABLE") |
-        select(.tableReference.tableId | test("^use_counters.*") | not) |
+        select(.tableReference.tableId | test($exclude_pattern) | not) |
         "\(.tableReference.tableId)"')
 
     # generate schemas in parallel
     for table in $tables; do
-        # We actually want to query the table's corresponding stable views
-        # because they have the `is_bot_generated` flag,
-        # so skip if no corresponding view exists for this table.
-        local view="${table%%_v[0-9]*}"
-        if ! bq show "$src_project:$dataset_views.$view" &> /dev/null; then
-            echo "skipping $table: no corresponding view found"
-            continue
-        fi
-        # 2 views at a time to limit concurrent python processes
+        # 2 tables at a time to limit concurrent python processes
         i=$((i % 2))
         ((i++==0)) && wait
-        write_scalars "$product" "$dataset_views" "$view" "$dst_project" "$sql_dir" &
-        write_histograms "$product" "$dataset_views" "$view" "$dst_project" "$sql_dir" &
+        write_scalars "$product" "$dataset" "$table" "$dst_project" "$sql_dir" &
+        write_histograms "$product" "$dataset" "$table" "$dst_project" "$sql_dir" &
     done
 
     wait


### PR DESCRIPTION
## Description

This PR reverts part of https://github.com/mozilla/bigquery-etl/pull/8465. More specifically the GLAM ETL daily jobs' source tables got reverted to the stable tables instead of the stable views, to process less data. In turn it uses the raw logic to filter out bot data. This PR also adds the ability to exclude specific ping tables from being extracted, with a few tables already in place, along with the reason for exclusion.

## Related Tickets & Documents
* DENG-10192


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
