### PR TITLE
DENG-9849: Added remaining browser apps

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -561,6 +561,23 @@ generate:
 geo_deprecation:
   include_app_ids:
   - org_mozilla_ios_klar
+  - org_mozilla_klar
+  - org_mozilla_ios_focus
+  - org_mozilla_focus
+  - org_mozilla_focus_beta
+  - org_mozilla_focus_nightly
+  - org_mozilla_ios_firefox
+  - org_mozilla_ios_firefoxbeta
+  - org_mozilla_ios_fennec
+  - org_mozilla_firefox
+  - org_mozilla_firefox_beta
+  - org_mozilla_fenix
+  - org_mozilla_fenix_nightly
+  - org_mozilla_fennec_aurora
+  - firefox_desktop
+  - firefox_desktop_background_update
+  - firefox_desktop_background_defaultagent
+  - firefox_desktop_background_tasks
   skip_tables:
   - newtab
 


### PR DESCRIPTION
## Description

Given `org_mozilla_ios_klar` ran successful last night from #8362 , this PR adds the remaining browser apps.

## Related Tickets & Documents
* DENG-9849

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
