### PR TITLE
Update country_names_v1 metadata to allow tapclicks access

### DIFF
--- a/sql/moz-fx-data-shared-prod/static/country_names_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/static/country_names_v1/metadata.yaml
@@ -5,3 +5,7 @@ description: |-
 
   Generated automatically by `sql_generators/country_code_lookup`; modify `aliases.yaml` to add a mapping to the
   appropriate country code.
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:ads/external-tapclicks


### PR DESCRIPTION
## Description

Added workgroup access for external tapclicks. It seems that the views that TapClicks uses are referencing this table now


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
