### PR TITLE
Add write access for workgroup:ads

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads_dap_derived/incrementality_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_dap_derived/incrementality_v1/metadata.yaml
@@ -7,9 +7,6 @@ owners:
   - gleonard@mozilla.com
   - mlifshin@mozilla.com
 workgroup_access:
-  - role: roles/bigquery.dataViewer
-    members:
-      - workgroup:ads
   - role: roles/bigquery.dataEditor
     members:
       - workgroup:ads


### PR DESCRIPTION
## Description

Prior to the merge of [docker-etl PR-409]( https://github.com/mozilla/docker-etl/pull/409) and [telemetry-airflow PR-2268](https://github.com/mozilla/telemetry-airflow/pull/2268) data was processed manually.

This PR grants write access to `moz-fx-data-shared-prod.ads_dap_derived.incrementality_v1` for `workgroup:ads` to allow that manual data to be added to the table.  A followup PR will reverse this permission.

## Related Tickets & Documents
* [AE-782](https://mozilla-hub.atlassian.net/browse/AE-782)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[AE-782]: https://mozilla-hub.atlassian.net/browse/AE-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ