### PR TITLE
Remove workgroup:ads write access  to incrementality_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads_dap_derived/incrementality_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_dap_derived/incrementality_v1/metadata.yaml
@@ -6,7 +6,3 @@ description: |-
 owners:
   - gleonard@mozilla.com
   - mlifshin@mozilla.com
-workgroup_access:
-  - role: roles/bigquery.dataEditor
-    members:
-      - workgroup:ads


### PR DESCRIPTION
## Description
Removes write access to `incrementality_v1` added by [PR-8475](https://github.com/mozilla/bigquery-etl/pull/8475).  Data has been added manually and write access is no longer required.

## Related Tickets & Documents
* [AE-782](https://mozilla-hub.atlassian.net/browse/AE-782)
*  [PR-8475](https://github.com/mozilla/bigquery-etl/pull/8475)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[AE-782]: https://mozilla-hub.atlassian.net/browse/AE-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ