### PR TITLE
fix(SubPlat): Initiate backfills of SubPlat ETLs (DENG-10213)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-21:
+  start_date: 2023-07-20
+  end_date: 2025-11-13
+  reason: Update historical records after some wrong Stripe changelog data was manually corrected (DENG-10213).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-11-12:
   start_date: 2019-10-10
   end_date: 2025-11-04

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-21:
+  start_date: 2023-07-20
+  end_date: 2025-11-13
+  reason: Update historical records after some wrong Stripe changelog data was manually corrected (DENG-10213).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-11-12:
   start_date: 2019-10-10
   end_date: 2025-11-04

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-21:
+  start_date: 2023-07-20
+  end_date: 2025-11-13
+  reason: Update historical records after some wrong Stripe changelog data was manually corrected (DENG-10213).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-11-12:
   start_date: 2019-10-10
   end_date: 2025-11-04

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-21:
+  start_date: 2023-07-01
+  end_date: 2025-10-01
+  reason: Update historical records after some wrong Stripe changelog data was manually corrected (DENG-10213).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-11-12:
   start_date: 2019-10-01
   end_date: 2025-10-01

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-21:
+  start_date: 2023-07-01
+  end_date: 2025-10-01
+  reason: Update historical records after some wrong Stripe changelog data was manually corrected (DENG-10213).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-11-12:
   start_date: 2019-10-01
   end_date: 2025-10-01

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2025-11-21:
+  start_date: 2023-07-20
+  end_date: 2025-11-13
+  reason: Update historical records after some wrong Stripe changelog data was manually corrected (DENG-10213).
+  watchers:
+  - srose@mozilla.com
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: true
+
 2025-11-12:
   start_date: 2019-10-10
   end_date: 2025-11-04


### PR DESCRIPTION
## Description
Update historical records after some wrong Stripe changelog data was manually corrected (DENG-10213).

## Related Tickets & Documents
* DENG-10213: The `stripe_external.subscriptions_changelog_v1` ETL has archived some incorrect subscription plan data

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
