### PR TITLE
fix(DENG-10047): Add engaged_session flag 

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/firefox_whatsnew_summary/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/firefox_whatsnew_summary/view.sql
@@ -2,10 +2,16 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.firefoxdotcom.firefox_whatsnew_summary`
 AS
 SELECT
+  wns.ga_client_id || "-" || wns.ga_session_id AS visit_identifier,
   wns.*,
-  map.english_text
+  map.english_text,
+  s.engaged_session
 FROM
   `moz-fx-data-shared-prod.firefoxdotcom_derived.firefox_whatsnew_summary_v2` wns
+JOIN
+  `moz-fx-data-shared-prod.firefoxdotcom_derived.ga_sessions_v2` s
+  ON wns.ga_client_id = s.ga_client_id
+  AND wns.ga_session_id = s.ga_session_id
 LEFT JOIN
   (
   --this is an extra safeguard, there should only ever be 1 row per UID & locale
@@ -21,3 +27,5 @@ LEFT JOIN
   ) map
   ON wns.cta_click_uid = map.data_cta_uid
   AND wns.page_location_locale = map.locale
+WHERE
+  REGEXP_CONTAINS(s.ga_client_id || '-' || s.ga_session_id, r"^[0-9]+\.{1}[0-9]+\-{1}[0-9]+$")


### PR DESCRIPTION
## Description

* This PR updates the logic for the view: `moz-fx-data-shared-prod.firefoxdotcom.firefox_whatsnew_summary`
* It adds a join to the session level table, to add a flag as to whether or not the session was an engaged session, and it adds logic to filter out malformed session IDs.

## Related Tickets & Documents
* [DENG-10047](https://mozilla-hub.atlassian.net/browse/DENG-10047)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-10047]: https://mozilla-hub.atlassian.net/browse/DENG-10047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ