### PR TITLE
fix(SubPlat): Complete backfills of SubPlat ETLs (DENG-10213)

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_logical_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - srose@mozilla.com
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/daily_active_service_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - srose@mozilla.com
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscription_events_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - srose@mozilla.com
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_logical_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - srose@mozilla.com
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/monthly_active_service_subscriptions_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - srose@mozilla.com
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/service_subscription_events_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - srose@mozilla.com
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description
Complete the backfills initiated in #8488 to update historical records after some wrong Stripe changelog data was manually corrected (DENG-10213).

[My QA of the backfills](https://mozilla-hub.atlassian.net/browse/DENG-10213?focusedCommentId=1181745) didn't find any major issues

## Related Tickets & Documents
* DENG-10213: The `stripe_external.subscriptions_changelog_v1` ETL has archived some incorrect subscription plan data
* https://github.com/mozilla/bigquery-etl/pull/8488

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
