### PR TITLE
fix: terms_of_use_events_v1 template add missing surface field the schema template

### DIFF
--- a/sql_generators/terms_of_use/templates/terms_of_use_events_v1/query.sql.jinja
+++ b/sql_generators/terms_of_use/templates/terms_of_use_events_v1/query.sql.jinja
@@ -7,15 +7,6 @@ SELECT
   event_category,
   event_name,
   CASE
-    WHEN (event_category = "onboarding" OR JSON_VALUE(event_extra.surface) = "onboarding") THEN "onboarding"
-    ELSE
-    {% if app_name == "firefox_ios" %}
-      "bottom_sheet"
-    {% else %}
-      JSON_VALUE(event_extra.surface)
-    {% endif %}
-  END AS surface,
-  CASE
     {% if app_name == "firefox_ios" %}
     WHEN (event_name = "accepted" AND JSON_VALUE(event_extra.surface) = "bottom_sheet") OR (event_name = "terms_of_service_accepted") THEN "accepted"
     {% else %}
@@ -28,7 +19,16 @@ SELECT
     WHEN event_name IN ("dismiss") THEN "dismissed"
     {% endif %}
     ELSE event_name
-  END AS normalized_event_name
+  END AS normalized_event_name,
+  CASE
+    WHEN (event_category = "onboarding" OR JSON_VALUE(event_extra.surface) = "onboarding") THEN "onboarding"
+    ELSE
+    {% if app_name == "firefox_ios" %}
+      "bottom_sheet"
+    {% else %}
+      JSON_VALUE(event_extra.surface)
+    {% endif %}
+  END AS surface,
 FROM
     `{{ project_id }}.{{ app_name }}.events_stream`
 WHERE

--- a/sql_generators/terms_of_use/templates/terms_of_use_events_v1/schema.yaml.jinja
+++ b/sql_generators/terms_of_use/templates/terms_of_use_events_v1/schema.yaml.jinja
@@ -25,18 +25,27 @@ fields:
   type: TIMESTAMP
   description: |
     Timestamp when the event occurred.
+
 - mode: NULLABLE
   name: event_category
   type: STRING
   description: |
     Category of the recorded event.
+
 - mode: NULLABLE
   name: event_name
   type: STRING
   description: |
     Name of the recorded event.
+
 - mode: NULLABLE
   name: normalized_event_name
   type: STRING
   description: |
     Normalized name of the event, used to align events from both fenix and iOS as well as collapse across events from different surfaces.
+
+- mode: NULLABLE
+  name: surface
+  type: STRING
+  description: |
+    The surface the terms of use prompt/impression was served.

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/fenix_derived/terms_of_use_events_v1/query.sql
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/fenix_derived/terms_of_use_events_v1/query.sql
@@ -7,11 +7,6 @@ SELECT
   event_category,
   event_name,
   CASE
-    WHEN (event_category = "onboarding" OR JSON_VALUE(event_extra.surface) = "onboarding")
-      THEN "onboarding"
-    ELSE JSON_VALUE(event_extra.surface)
-  END AS surface,
-  CASE
     WHEN (event_name = "accepted")
       OR (event_name = "terms_of_service_accepted")
       THEN "accepted"
@@ -32,7 +27,12 @@ SELECT
     WHEN event_name IN ("dismiss")
       THEN "dismissed"
     ELSE event_name
-  END AS normalized_event_name
+  END AS normalized_event_name,
+  CASE
+    WHEN (event_category = "onboarding" OR JSON_VALUE(event_extra.surface) = "onboarding")
+      THEN "onboarding"
+    ELSE JSON_VALUE(event_extra.surface)
+  END AS surface,
 FROM
   `moz-fx-data-shared-prod.fenix.events_stream`
 WHERE

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/fenix_derived/terms_of_use_events_v1/schema.yaml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/fenix_derived/terms_of_use_events_v1/schema.yaml
@@ -25,18 +25,27 @@ fields:
   type: TIMESTAMP
   description: |
     Timestamp when the event occurred.
+
 - mode: NULLABLE
   name: event_category
   type: STRING
   description: |
     Category of the recorded event.
+
 - mode: NULLABLE
   name: event_name
   type: STRING
   description: |
     Name of the recorded event.
+
 - mode: NULLABLE
   name: normalized_event_name
   type: STRING
   description: |
     Normalized name of the event, used to align events from both fenix and iOS as well as collapse across events from different surfaces.
+
+- mode: NULLABLE
+  name: surface
+  type: STRING
+  description: |
+    The surface the terms of use prompt/impression was served.


### PR DESCRIPTION
# fix: terms_of_use_events_v1 template add missing surface field the schema template

Also, make sure the column order in the query matches the schema.