### PR TITLE
(brwells) Add temporary forecast datasets

### DIFF
--- a/sql/moz-fx-data-shared-prod/forecasts/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/forecasts/dataset_metadata.yaml
@@ -5,10 +5,6 @@ description: |-
 dataset_base_acl: view
 user_facing: true
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 default_table_expiration_ms: null
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/forecasts_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/forecasts_derived/dataset_metadata.yaml
@@ -6,10 +6,6 @@ description: |-
 dataset_base_acl: derived
 user_facing: false
 labels: {}
-default_table_workgroup_access:
-- role: roles/bigquery.dataViewer
-  members:
-  - workgroup:mozilla-confidential
 default_table_expiration_ms: null
 workgroup_access:
 - role: roles/bigquery.dataViewer


### PR DESCRIPTION
## Description

The PR adds datasets for a forecasting table and a view. Officially, these are temporary datasets pending a conversation between the PDS and AE teams about naming conventions for forecasting output tables. However, we are naming them generically in the hope that we have guessed the final naming convention correctly and these won't have to be migrated.

There is no ticket for this PR, but it relates to the discussion today in the PDS x AE meeting, documented here: https://docs.google.com/document/d/1DL_Nr1e-7YC05F2ssdplcH2cmsjmtzzFWyPKbS2rgqs/edit?tab=t.0#heading=h.4itj0ra86mg6 . The original project proposal is found here: https://docs.google.com/document/d/15RNNhlcE9oj3GLlCWns6DOUWHKjZpnaEbz7OiAQZi_E/edit?tab=t.0 .

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
