### PR TITLE
fix(CI): Run SQL generation when `bqetl_project.yaml` changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ workflows:
             sql/mozfun/.* validate-routines true
             sql/moz-fx-data-shared-prod/udf/.* validate-routines true
             sql/moz-fx-data-shared-prod/udf_js/.* validate-routines true
+            bqetl_project.yaml trigger-sql-generation true
             bqetl_project.yaml validate-sql true
             bqetl_project.yaml validate-routines true
             dags.yaml validate-sql true


### PR DESCRIPTION
## Description
Because `bqetl_project.yaml` contains many SQL generator settings.

## Related Tickets & Documents
N/A

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
