### PR TITLE
Add 'surface' field to terms of use event schema

### DIFF
--- a/sql_generators/terms_of_use/templates/terms_of_use_events_v1/schema.yaml.jinja
+++ b/sql_generators/terms_of_use/templates/terms_of_use_events_v1/schema.yaml.jinja
@@ -40,3 +40,7 @@ fields:
   type: STRING
   description: |
     Normalized name of the event, used to align events from both fenix and iOS as well as collapse across events from different surfaces.
+- mode: NULLABLE
+  name: surface
+  type: STRING
+  description: Event surface.


### PR DESCRIPTION
Added 'surface' field to event schema with description.

## Description

This fixes the failing dryruns. Schema field is missing



<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
