### PR TITLE
fix(CI): Use sudo for apt commands in manual-trigger-required-for-fork job

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1134,8 +1134,8 @@ jobs:
           name: Manually trigger integration tests for fork
           # yamllint disable rule:line-length
           command: |
-            apt update
-            apt install jq -y
+            sudo apt update
+            sudo apt install jq -y
 
             CIRCLE_PR_BRANCH=`curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.head.label'`
 


### PR DESCRIPTION
## Description

This fixes the `manual-trigger-required-for-fork` job.

Before the fix: https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/55497/workflows/5dad2202-6cb6-447e-bc3c-e084d7c0d023/jobs/709894
After: https://app.circleci.com/pipelines/github/mozilla/bigquery-etl/55500/workflows/2303528c-c83f-4dc3-be8a-2313d065bdc8/jobs/709954