### PR TITLE
 feat: remove submission_date field from terms_of_use_status to avoid confusion

### DIFF
--- a/sql_generators/terms_of_use/templates/terms_of_use_status_v1/bigconfig.yml.jinja
+++ b/sql_generators/terms_of_use/templates/terms_of_use_status_v1/bigconfig.yml.jinja
@@ -11,7 +11,7 @@ table_deployments:
           - saved_metric_id: volume
           - saved_metric_id: freshness
         columns:
-          - column_name: submission_date
+          - column_name: terms_of_use_date_accepted
             metrics:
               - saved_metric_id: is_not_null
           - column_name: client_id

--- a/sql_generators/terms_of_use/templates/terms_of_use_status_v1/metadata.yaml.jinja
+++ b/sql_generators/terms_of_use/templates/terms_of_use_status_v1/metadata.yaml.jinja
@@ -1,7 +1,7 @@
 # {{ header }}
 friendly_name: Terms of Use - Status
 description: |-
-  This dataset contains the most recent status
+  This dataset contains the most recent status.
 
   Cluster by: sample_id
 

--- a/sql_generators/terms_of_use/templates/terms_of_use_status_v1/query.sql.jinja
+++ b/sql_generators/terms_of_use/templates/terms_of_use_status_v1/query.sql.jinja
@@ -1,7 +1,6 @@
 -- {{ header }}
 WITH _previous AS (
   SELECT
-    submission_date,
     client_id,
     sample_id,
     app_version_major,
@@ -21,11 +20,10 @@ WITH _previous AS (
 FROM
   `{{ project_id }}.{{ app_name }}_derived.{{ table_name }}`
 WHERE
-  submission_date <> @submission_date
+  DATE(terms_of_use_date_accepted) <> @submission_date
 ),
 _current AS (
   SELECT
-    DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
     sample_id,
     `moz-fx-data-shared-prod`.udf.mode_last(ARRAY_AGG(app_version_major) OVER _window) AS app_version_major,

--- a/sql_generators/terms_of_use/templates/terms_of_use_status_v1/schema.yaml.jinja
+++ b/sql_generators/terms_of_use/templates/terms_of_use_status_v1/schema.yaml.jinja
@@ -1,13 +1,6 @@
 # {{ header }}
 fields:
 - mode: NULLABLE
-  name: submission_date
-  type: DATE
-  description: |
-    Date when the ping is received on the server side. Also used as the logical date
-    by the ETL process.
-
-- mode: NULLABLE
   name: client_id
   type: STRING
   description: |
@@ -84,7 +77,7 @@ fields:
   name: terms_of_use_date_accepted
   type: TIMESTAMP
   description: |
-    The timestamp when the user accepted the Terms of Use.
+    The timestamp when the user accepted the Terms of Use. Also used in ETL for retrieving previous entries.
 {% if app_name == "firefox_desktop" %}
 - mode: NULLABLE
   name: legacy_telemetry_client_id

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/bigconfig.yml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/bigconfig.yml
@@ -11,7 +11,7 @@ table_deployments:
           - saved_metric_id: volume
           - saved_metric_id: freshness
         columns:
-          - column_name: submission_date
+          - column_name: terms_of_use_date_accepted
             metrics:
               - saved_metric_id: is_not_null
           - column_name: client_id

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/metadata.yaml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/metadata.yaml
@@ -1,7 +1,7 @@
 # Generated via `terms_of_use` SQL generator.
 friendly_name: Terms of Use - Status
 description: |-
-  This dataset contains the most recent status
+  This dataset contains the most recent status.
 
   Cluster by: sample_id
 

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/query.sql
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/query.sql
@@ -1,7 +1,6 @@
 -- Generated via `terms_of_use` SQL generator.
 WITH _previous AS (
   SELECT
-    submission_date,
     client_id,
     sample_id,
     app_version_major,
@@ -19,11 +18,10 @@ WITH _previous AS (
   FROM
     `moz-fx-data-shared-prod.firefox_desktop_derived.terms_of_use_status_v1`
   WHERE
-    submission_date <> @submission_date
+    DATE(terms_of_use_date_accepted) <> @submission_date
 ),
 _current AS (
   SELECT
-    DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
     sample_id,
     `moz-fx-data-shared-prod`.udf.mode_last(

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/schema.yaml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/schema.yaml
@@ -1,13 +1,6 @@
 # Generated via `terms_of_use` SQL generator.
 fields:
 - mode: NULLABLE
-  name: submission_date
-  type: DATE
-  description: |
-    Date when the ping is received on the server side. Also used as the logical date
-    by the ETL process.
-
-- mode: NULLABLE
   name: client_id
   type: STRING
   description: |
@@ -84,7 +77,7 @@ fields:
   name: terms_of_use_date_accepted
   type: TIMESTAMP
   description: |
-    The timestamp when the user accepted the Terms of Use.
+    The timestamp when the user accepted the Terms of Use. Also used in ETL for retrieving previous entries.
 
 - mode: NULLABLE
   name: legacy_telemetry_client_id

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/bigconfig.yml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/bigconfig.yml
@@ -11,7 +11,7 @@ table_deployments:
           - saved_metric_id: volume
           - saved_metric_id: freshness
         columns:
-          - column_name: submission_date
+          - column_name: terms_of_use_date_accepted
             metrics:
               - saved_metric_id: is_not_null
           - column_name: client_id

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/metadata.yaml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/metadata.yaml
@@ -1,7 +1,7 @@
 # Generated via `terms_of_use` SQL generator.
 friendly_name: Terms of Use - Status
 description: |-
-  This dataset contains the most recent status
+  This dataset contains the most recent status.
 
   Cluster by: sample_id
 

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/query.sql
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/query.sql
@@ -1,7 +1,6 @@
 -- Generated via `terms_of_use` SQL generator.
 WITH _previous AS (
   SELECT
-    submission_date,
     client_id,
     sample_id,
     app_version_major,
@@ -18,11 +17,10 @@ WITH _previous AS (
   FROM
     `moz-fx-data-shared-prod.firefox_ios_derived.terms_of_use_status_v1`
   WHERE
-    submission_date <> @submission_date
+    DATE(terms_of_use_date_accepted) <> @submission_date
 ),
 _current AS (
   SELECT
-    DATE(submission_timestamp) AS submission_date,
     client_info.client_id,
     sample_id,
     `moz-fx-data-shared-prod`.udf.mode_last(

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/schema.yaml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/schema.yaml
@@ -1,13 +1,6 @@
 # Generated via `terms_of_use` SQL generator.
 fields:
 - mode: NULLABLE
-  name: submission_date
-  type: DATE
-  description: |
-    Date when the ping is received on the server side. Also used as the logical date
-    by the ETL process.
-
-- mode: NULLABLE
   name: client_id
   type: STRING
   description: |
@@ -84,5 +77,5 @@ fields:
   name: terms_of_use_date_accepted
   type: TIMESTAMP
   description: |
-    The timestamp when the user accepted the Terms of Use.
+    The timestamp when the user accepted the Terms of Use. Also used in ETL for retrieving previous entries.
 


### PR DESCRIPTION
# feat: remove submission_date field from terms_of_use_status to avoid confusion