### PR TITLE
fix: add additional spelling of country name for code ST

### DIFF
--- a/sql/moz-fx-data-shared-prod/static/country_names_v1/data.csv
+++ b/sql/moz-fx-data-shared-prod/static/country_names_v1/data.csv
@@ -468,10 +468,11 @@ name,code
 "The Republic of South Sudan",SS
 "São Tomé and Príncipe",ST
 "Sao Tome and Principe",ST
+"São Tomé and Principe",ST
+"São Tomé and Principe",ST
 "SÃ£o TomÃ© and PrÃ­ncipe",ST
 "The Democratic Republic of São Tomé and Príncipe",ST
 "São Tomé & Príncipe",ST
-"São Tomé and Principe",ST
 "El Salvador",SV
 "The Republic of El Salvador",SV
 "Sint Maarten",SX


### PR DESCRIPTION
# fix: add additional spelling of country name for code ST

Currently this is causing a few country null values inside `firefox_ios_derived.app_store_funnel_v1`