### PR TITLE
fix: add new name for country code ST inside country_code_lookup generator

### DIFF
--- a/sql_generators/country_code_lookup/aliases.yaml
+++ b/sql_generators/country_code_lookup/aliases.yaml
@@ -635,6 +635,7 @@ ST:
     - "SÃ£o TomÃ© and PrÃ­ncipe"
     - "The Democratic Republic of São Tomé and Príncipe"
     - "São Tomé & Príncipe"
+    - "São Tomé and Principe"
 SA:
     - "Saudi Arabia"
     - "The Kingdom of Saudi Arabia"


### PR DESCRIPTION
# fix: add new name for country code ST inside country_code_lookup generator

This was previously added inside the data.csv directly which was being overwritten by this generator. Now this entry should be correctly added to the BQ table.