### PR TITLE
feat: attribution_clients bigconfig add condition to only check for uniqueness when normalized_channel is not null

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.bigconfig.yml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.bigconfig.yml
@@ -33,6 +33,8 @@ tag_deployments:
                 string_value: {{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}
             rct_overrides:
               - FULL_SCAN
+            conditions:
+              - normalized_channel IS NOT NULL
       - column_selectors:
         - name: {{ project_id }}.{{ project_id }}.{{ dataset }}_derived.{{ name }}_{{ version }}.*
         metrics:


### PR DESCRIPTION
# feat: attribution_clients bigconfig add condition to only check for uniqueness when normalized_channel is not null

Currently this is causing the metric to fail with 50% duplication which is actually not the case.