### PR TITLE
fix: newtab_merino_propensity_v1 schema validation error

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_propensity_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_propensity_v1/query.sql
@@ -212,7 +212,7 @@ SELECT
   unormalized_weight * normalization_factor.factor AS weight,
   position,
   tile_format,
-  NULL AS section_position,
+  CAST(NULL AS INTEGER) AS section_position,
   impressions
 FROM
   stories_weights

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_propensity_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_propensity_v1/schema.yaml
@@ -6,6 +6,9 @@ fields:
   name: position
   type: INTEGER
 - mode: NULLABLE
+  name: tile_format
+  type: STRING
+- mode: NULLABLE
   name: impressions
   type: INTEGER
 - mode: NULLABLE


### PR DESCRIPTION
# fix: newtab_merino_propensity_v1 schema validation error

Also making sure when the value of `section_position` is set to null we cast it to INTEGER to match the schema.
