### PR TITLE
fix(CI): Use `venv` rather than `virtualenv` in the `validate-dags` CI job

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -425,7 +425,7 @@ jobs:
                 name: Install telemetry-airflow dependencies
                 command: |
                   cd ~/telemetry-airflow
-                  virtualenv .venv
+                  python3 -m venv .venv
                   source .venv/bin/activate
                   pip install -r requirements.txt
                   pip install -r requirements-dev.txt


### PR DESCRIPTION
## Description
Because `virtualenv` is apparently automatically [seeding](https://virtualenv.pypa.io/en/latest/user_guide.html#seeders) the virtual environment with Python packages, but we want to have full control of that process.

## Related Tickets & Documents
N/A

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
