### PR TITLE
Remove unsupported country, and clamp to known regions

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
@@ -103,7 +103,7 @@ country_aggregates AS (
   WHERE
     -- Gather country (a.k.a. region) specific engagement for all countries that share a feed.
     -- https://mozilla-hub.atlassian.net/wiki/x/JY3LB
-    normalized_country_code IN ('US', 'CA', 'DE', 'CH', 'AT', 'BE', 'GB', 'IE')
+    normalized_country_code IN ('US', 'CA', 'DE', 'CH', 'AT', 'GB', 'IE')
 ),
 /* Combine the "global" (no region) with the "regional" breakdown. */
 combined_results AS (

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
@@ -182,6 +182,8 @@ SELECT
   impressions_per_item
 FROM
   per_region_stats_with_impressions
+WHERE
+  region IN ('US', 'CA', 'DE', 'CH', 'AT', 'GB', 'IE')
 UNION ALL
 SELECT
   region,


### PR DESCRIPTION
## Description

As part of the international rollout of the newtab content ping, we are reviewing ETL jobs to ensure compatibility.

Country sent by the new tab ping is now clamped to the supported country for the surface, with a default country set.

Belgium wasn't included in what was shipped in Fx145, so we'll have to update in a future revision to restore localized Belgium ranking. The ranking will default to global ranking for the same items instead.

See doc linked in the ticket for details. You can see how countries are [mapped for the NewTab ping here](https://searchfox.org/firefox-main/source/browser/extensions/newtab/lib/TelemetryFeed.sys.mjs)

Another impact of the change is that India would use the global prior rather than the country one. Since interaction data had already been clamped to global behavior, I believe this is an improvement having prior data and interaction data in the same 'channel' (i.e. global, vs IN for prior and global for interaction data). 

## Related Tickets & Documents
https://mozilla-hub.atlassian.net/browse/GENAI-2627

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


Before

<img width="512" height="460" alt="image" src="https://github.com/user-attachments/assets/00d3ad80-553f-468e-b54f-303ab3ab7a8d" />

After

<img width="517" height="254" alt="image" src="https://github.com/user-attachments/assets/388f5d1a-44cc-4461-bfa9-67dffdede337" />

