### PR TITLE
style: Allow a blank line at the end of YAML files

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -6,6 +6,8 @@ rules:
     max: 160
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: true
+  empty-lines:
+    max-end: 1
   document-start: disable
   indentation:
     indent-sequences: consistent


### PR DESCRIPTION
## Description
By default `yamllint` requires files to end with a newline ([docs](https://yamllint.readthedocs.io/en/v1.37.1/configuration.html#default-configuration)) but doesn't allow any blank lines at the end of YAML files ([docs](https://yamllint.readthedocs.io/en/v1.37.1/rules.html#module-yamllint.rules.empty_lines)).  This can sometimes be tricky for developers to get exactly right, especially depending on their particular text editor settings (e.g. [Slack thread](https://mozilla.slack.com/archives/C01E8GDG80N/p1764191028017649)).

This PR relaxes the `yamllint` configuration to allow one blank line at the end of YAML files to avoid that gotcha.

## Related Tickets & Documents
N/A

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
