### PR TITLE
chore(metadata-completeness): Add metadata.yaml files for views

### DIFF
--- a/sql/moz-fx-data-shared-prod/apple_ads/ad_group_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/apple_ads/ad_group_report/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Ad Group Report (Apple)
+description: |-
+  Each record represents the daily ad performance of each ad group.
+owners:
+- kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/apple_ads/campaign_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/apple_ads/campaign_report/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Campaign Report (Apple)
+description: |-
+  Each record represents the daily ad performance of each campaign.
+owners:
+- kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/apple_ads/organization_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/apple_ads/organization_report/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Organization Report (Apple)
+description: |-
+  Each record represents the daily ad performance of each organization.
+owners:
+- kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/default_browser_agent/default_browser_agg/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/default_browser_agent/default_browser_agg/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Default Browser Aggregates
+description: |-
+  Aggregate table for default browser setting
+owners:
+- wichan@mozilla.com

--- a/sql/moz-fx-data-shared-prod/default_browser_agent/default_browser_agg_by_os/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/default_browser_agent/default_browser_agg_by_os/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Default Browser Aggregates By OS version
+description: |-
+  Aggregate table for default browser setting by os version
+owners:
+- wichan@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fenix/clients_yearly/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/clients_yearly/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: Fenix Clients Yearly
+description: |
+  Captures activity of each Fenix client in the past 365 days for each submission date.
+  Used as the basis for LTV calculations.
+owners:
+- kwindau@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fenix/feature_usage_events/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/feature_usage_events/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: Feature Usage Events (Android - Fenix)
+description: |-
+  Metrics from events pings for mobile feature usage dashboards (Fenix).
+  `distribution_id` was added as a dimension to this table beginning on
+  2024-10-08.
+owners:
+- rzhao@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fenix/firefox_android_clients/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/firefox_android_clients/metadata.yaml
@@ -1,0 +1,22 @@
+friendly_name: Firefox Android Clients
+description: |-
+  Contains a list of Firefox Android clients along with their first attributes
+  retrieved from baseline, first_session and metrics pings.
+
+  This includes information such as their initial geo, OS, ISP, and attribution info.
+
+  For analysis purposes, use first_seen_date to query clients that
+  effectively appeared on that date. The submission_date indicates
+  when the server received the data.
+
+  Note that the query for the underlying table this view references
+  overwrites the whole table instead of writing to a single partition.
+
+  Proposal:
+  https://docs.google.com/document/d/12bj4DhCybelqHVgOVq8KJlzgtbbUw3f68palNrv-gaM/.
+
+  For more details about attribution and campaign structure see:
+  https://help.adjust.com/en/article/tracker-urls#campaign-structure-parameters.
+owners:
+- lvargas@mozilla.com
+- kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fenix/locale_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/locale_aggregates/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Locale Aggregates
+description: |-
+  Fenix DAU, WAU, MAU and client counts by locale and core dimensions of analysis.
+owners:
+- lvargas@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fenix/ltv_android_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/ltv_android_aggregates/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: LTV Android Aggregates
+description: |-
+  Aggregated historical data for LTV estimates beyond a 2-year horizon.
+owners:
+- mbowerman@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fenix/ltv_state_values/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/ltv_state_values/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: Ltv State Values
+description: |-
+  Android state values, in terms of Ad Clicks.
+  Each country has their own ad click LTV for each state.
+owners:
+- frank@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fenix/nimbus_recorded_targeting_context/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix/nimbus_recorded_targeting_context/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Nimbus Recorded Targeting Context (Fenix)
+description: |-
+  A query to obtain the previous day's recorded Nimbus targeting context values for each client.
+owners:
+- chumphreys@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/enterprise_metrics/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/enterprise_metrics/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: Enterprise Metrics
+description: |-
+  Enterprise Metrics.
+owners:
+- pissac@mozilla.com
+- kik@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/locale_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/locale_aggregates/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Locale Aggregates
+description: |-
+  Firefox Desktop DAU, WAU, MAU and client counts by locale and core dimensions of analysis.
+owners:
+- lvargas@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/new_profiles_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/new_profiles_aggregates/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: New Profiles Aggregates
+description: |-
+  This view aggregates the number of new profiles on a given day.
+owners:
+- lmcfall@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fx_quant_user_research/fxqur_viewpoint_desktop/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fx_quant_user_research/fxqur_viewpoint_desktop/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: Alchemer Survey data for Viewpoint 2023 Expansion - Desktop
+description: >
+  An import of survey data from Alchemer (SurveyGizmo) for Viewpoint 2023 Expansion - Desktop
+owners:
+  - ago@mozilla.com
+  - eshallal@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fx_quant_user_research/fxqur_viewpoint_mobile/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fx_quant_user_research/fxqur_viewpoint_mobile/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: Alchemer Survey data for Viewpoint 2023 Expansion - Mobile
+description: >
+  An import of survey data from Alchemer (SurveyGizmo) for Viewpoint 2023 Expansion - Mobile
+owners:
+  - ago@mozilla.com
+  - eshallal@mozilla.com

--- a/sql/moz-fx-data-shared-prod/glean_telemetry/active_users_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry/active_users_aggregates/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: Active Users Aggregates
+description: |-
+  A unioned view of desktop & mobile active users aggregates.
+  Used to calculate DAU, WAU, and MAU for KPIs.
+  Solely based off of Glean data for both desktop & mobile.
+owners:
+- kwindau@mozilla.com

--- a/sql/moz-fx-data-shared-prod/glean_telemetry/cohort_daily_churn/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry/cohort_daily_churn/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Cohort Daily Churn
+description: |-
+  Calculates churn for new users over time, for users first seen in last 180 days
+
+  Related Documentation:
+  - Parent Jira ticket: https://mozilla-hub.atlassian.net/browse/DENG-9509
+  - Jira ticket: https://mozilla-hub.atlassian.net/browse/DENG-9511
+  - Data Model README: ./README.md
+owners:
+- mhirose@mozilla.com

--- a/sql/moz-fx-data-shared-prod/glean_telemetry/cohort_daily_statistics/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry/cohort_daily_statistics/metadata.yaml
@@ -1,0 +1,15 @@
+friendly_name: Cohort Daily Statistics
+description: |-
+  Cohort Daily Statistics tracks retention for a cohort with
+  the same first seen date and same set of attributes over the next 180 days
+
+  Note that the values for client attributes are based on the
+  attributes at the time the cohort started (rather than the
+  values at activity time)
+
+  Related Documentation:
+  - Parent Jira ticket: https://mozilla-hub.atlassian.net/browse/DENG-9509
+  - Jira ticket: https://mozilla-hub.atlassian.net/browse/DENG-9516
+  - Data Model README: ./README.md
+owners:
+- mhirose@mozilla.com

--- a/sql/moz-fx-data-shared-prod/glean_telemetry/cohort_weekly_statistics/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry/cohort_weekly_statistics/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Cohort Weekly Statistics
+description: |-
+  Contains weekly retention by multiple different attributes as of first seen date
+
+  Related Documentation:
+  - Parent Jira ticket: https://mozilla-hub.atlassian.net/browse/DENG-9509
+  - Jira ticket: https://mozilla-hub.atlassian.net/browse/DENG-9513
+  - Data Model README: ./README.md
+owners:
+- mhirose@mozilla.com

--- a/sql/moz-fx-data-shared-prod/stripe/itemized_tax_transactions/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/stripe/itemized_tax_transactions/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Stripe itemized tax transactions report
+description: >
+  Itemized tax transactions report from the Stripe API.
+owners:
+  - srose@mozilla.com


### PR DESCRIPTION
## Description

This PR adds metadata.yaml files with object level descriptions for the following views:
- `apple_ads.ad_group_report`
- `apple_ads.campaign_report`
- `apple_ads.organization_report`
- `default_browser_agent.default_browser_agg`
- `default_browser_agent.default_browser_agg_by_os`
- `fenix.clients_yearly`
- `fenix.feature_usage_events`
- `fenix.firefox_android_clients`
- `fenix.locale_aggregates`
- `fenix.ltv_android_aggregates`
- `fenix.ltv_state_values`
- `fenix.nimbus_recorded_targeting_context`
- `firefox_desktop.enterprise_metrics`
- `firefox_desktop.locale_aggregates`
- `firefox_desktop.new_profiles_aggregates`
- `fx_quant_user_research.fxqur_viewpoint_desktop`
- `fx_quant_user_research.fxqur_viewpoint_mobile`
- `glean_telemetry.active_users_aggregates`
- `glean_telemetry.cohort_daily_churn`
- `glean_telemetry.cohort_daily_statistics`
- `glean_telemetry.cohort_weekly_statistics`
- `stripe.itemized_tax_transactions`


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
