### PR TITLE
feat: add back scheduling settings for firefox_ios_derived/app_store_choice_screen_selection_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_ios_derived/app_store_choice_screen_selection_v1/metadata.yaml
@@ -11,6 +11,7 @@ description: |
 
 owners:
 - kik@mozilla.com
+- ebrandi@mozilla.com
 labels:
   schedule: daily
   incremental: true
@@ -20,7 +21,7 @@ scheduling:
   dag_name: bqetl_firefox_ios
   depends_on_past: false
   arguments:
-  - --date={{macros.ds_add(ds, -7)}}
+  - --date={{macros.ds_add(ds, -10)}}
   - --connect_app_id=989804926
   - --partition_field=logical_date
 
@@ -32,7 +33,7 @@ scheduling:
   - deploy_target: CONNECT_KEY
     key: bqetl_firefox_ios__app_store_connect_key
 
-  date_partition_offset: -7
+  date_partition_offset: -10
   retry_delay: 30m
   retries: 2
   email_on_retry: false


### PR DESCRIPTION
# feat: add back scheduling settings for firefox_ios_derived/app_store_choice_screen_selection_v1

Apple confirmed a 7 day window is expected for this report.