### PR TITLE
initiate backfill for urlbar_events_daily_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v1/backfill.yaml
@@ -1,0 +1,13 @@
+2026-03-20:
+  start_date: 2025-01-01
+  end_date: 2026-03-20
+  reason: Populate the new fields with data https://mozilla-hub.atlassian.net/browse/DENG-10604
+  watchers:
+  - kbammarito@mozilla.com
+  - lmcfall@mozilla.com
+  - nflorez@mozilla.com
+  status: Initiate
+  shredder_mitigation: true
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR backfills new fields for `urlbar_events_daily_v1` from Jan 2025 onward.

## Related Tickets & Documents
* DENG-10720

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
