### PR TITLE
feat(DENG-10740): desktop marketing funnel capture latest data

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/metadata.yaml
@@ -1,0 +1,49 @@
+friendly_name: Firefox Desktop Marketing Funnel - Temporary Analysis Table
+description: |-
+  PURPOSE:
+  Creates a unified funnel metrics table combining web analytics (GA4) with
+  Firefox telemetry data to track the full user journey:
+    Visits -> Downloads -> Installs -> New Profiles -> Repeat Users -> Retained Week 4
+
+  FUNNEL TYPES:
+    - mozorg windows funnel: Windows users from mozilla.org (full funnel with installs)
+    - mozorg mac funnel: Mac users from mozilla.org (no install data - Mac has no installer telemetry)
+    - partner: Partner distribution channels (no visits/downloads - starts at profiles)
+    - Unknown: EU countries and unattributed "other" traffic
+
+  KEY EXCLUSIONS:
+    - EU countries excluded from core funnels due to cookie banner impact on tracking
+    - Existing Firefox users excluded from visits (browser != Firefox/Mozilla)
+    - Internal cross-site traffic excluded (mozilla.org <-> firefox.com referrals)
+
+  ATTRIBUTION:
+    - Uses dltoken (download token) to link GA4 sessions -> installs -> profiles
+    - Campaign attribution from Google Ads with campaigns_v2 fallback
+    - Channel derived from campaign presence and GA4 channel grouping
+
+  Note:
+    Some data may only become available after certain amount of time past.
+    For example, retained_week4 will only become available 4 weeks after new profile is seen for the first time.
+owners:
+- sbedwell@mozilla.com
+- kik@mozilla.com
+labels:
+  level: bronze
+  # This query results in the table being rebuilt on each run
+  # by merging the existing and new records to update changes and insert new records.
+  incremental: false
+  table_type: aggregate
+  dag: bqetl_marketing_analysis
+scheduling:
+  dag_name: bqetl_marketing_analysis
+  depends_on_past: true
+  date_partition_parameter: null
+  parameters:
+  - submission_date:DATE:{{ds}}
+bigquery:
+  time_partitioning:
+    type: day
+    field: funnel_date
+    require_partition_filter: false
+    expiration_days: null
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/query.sql
@@ -1,0 +1,492 @@
+-- =============================================================================
+-- CTE 1: TOF (Top of Funnel) - Web Analytics from GA4
+-- =============================================================================
+-- Source: GA4 sessions from mozilla.org and firefox.com
+-- Metrics: Visits (sessions) and Downloads (click events)
+-- Granularity: Daily, by country, funnel type, and attribution dimensions
+-- =============================================================================
+-- TODO: may need to grab a 28 day window for first seen for late available metrics to work
+WITH clients_first_seen AS (
+  SELECT
+    *,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.clients_first_seen`
+  -- Join to GA4 attribution directly (no dltoken dedup here as multiple client_ids could come from the same dltoken)
+  WHERE
+    first_seen_date = @submission_date
+    -- OR first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
+),
+top_of_funnel_base AS (
+  SELECT
+    session_date AS submission_date,
+    country_names.code AS country_code,
+    LOWER(os) AS os,
+    -- Attribution dimensions for channel/campaign analysis
+    ad_crosschannel_primary_channel_group AS channel_raw,
+    ad_google_campaign_id AS campaign_id,
+    COALESCE(ad_google_campaign, campaigns_v2.campaign_name) AS campaign,
+    ad_crosschannel_source AS `source`,
+    ad_crosschannel_medium AS medium,
+    -- Logic: Exclude sessions where mozilla.org referred to firefox.com or vice versa
+    -- This prevents double-counting users who navigate between our properties
+    COALESCE(
+      (
+        -- Exclude: mozilla.org traffic landing on firefox.com
+        (
+          (
+            REGEXP_CONTAINS(manual_source, r'(?i)^(.*www.)?mozilla.org.*')
+            OR REGEXP_CONTAINS(first_source_from_event_params, r'(?i)^(.*www.)?mozilla.org.*')
+          )
+          AND flag = 'FIREFOX.COM'
+        )
+        -- Exclude: firefox.com traffic landing on mozilla.org
+        OR (
+          (
+            LOWER(manual_source) IN ('www.firefox.com', 'firefox.com', 'firefox-com')
+            OR LOWER(first_source_from_event_params) IN (
+              'www.firefox.com',
+              'firefox.com',
+              'firefox-com'
+            )
+          )
+          AND flag = 'MOZILLA.ORG'
+        )
+      ),
+      FALSE
+    ) IS FALSE AS has_visits,
+    firefox_desktop_downloads,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.ga4_sessions_firefoxcom_mozillaorg_combined` AS ga4
+  LEFT JOIN
+    `moz-fx-data-shared-prod.google_ads_derived.campaigns_v2` AS campaigns_v2
+    ON SAFE_CAST(ga4.first_gad_campaignid_from_event_params AS INT64) = campaigns_v2.campaign_id
+  LEFT JOIN
+    `moz-fx-data-shared-prod.static.country_names_v1` AS country_names
+    ON ga4.country = country_names.name
+  WHERE
+    session_date = @submission_date
+    AND device_category = 'desktop'
+    -- Exclude existing Firefox users - we want new acquisition only
+    AND COALESCE(browser, '') NOT IN ('Firefox', 'Mozilla')
+),
+top_of_funnel AS (
+  SELECT
+    top_of_funnel_base.* EXCEPT (os, has_visits, firefox_desktop_downloads),
+    -- Determine funnel type based on OS
+    CASE
+      WHEN os = 'windows'
+        THEN 'mozorg windows funnel'
+      WHEN os = 'macintosh'
+        THEN 'mozorg mac funnel'
+      ELSE 'mozorg other'
+    END AS funnel_derived,
+    -- VISITS: Count sessions, excluding internal cross-site traffic
+    COUNTIF(has_visits) AS visits,
+    -- DOWNLOADS: Count sessions with at least one Firefox desktop download
+    COUNTIF(firefox_desktop_downloads > 0) AS downloads
+  FROM
+    top_of_funnel_base
+  GROUP BY
+    ALL
+),
+-- =============================================================================
+-- CTE 2: ga4_attr_by_dltoken - Deduplicated Attribution by Download Token
+-- =============================================================================
+-- PURPOSE: Get one attribution record per download token (dltoken)
+-- PROBLEM: One dltoken can map to multiple client_ids in cfs_ga4_attr
+--          (e.g., user creates multiple Firefox profiles from same download)
+-- SOLUTION: Pick the "best" record per dltoken using priority:
+--   1. Records with channel data (ga4_ad_crosschannel_primary_channel_group IS NOT NULL)
+--   2. Earliest first_seen_date
+--   3. client_id as tiebreaker
+-- USED BY: installs CTE for attribution lookup
+-- =============================================================================
+-- deduplicated attribution data (prevents many-to-many explosion)
+ga4_attribution AS (
+  SELECT
+    ga4_attr.client_id,
+    ga4_attr.first_seen_date,
+    ga4_attr.ga4_session_date,
+    ga4_attr.attribution_dltoken AS dltoken,
+    ga4_attr.ga4_ad_crosschannel_primary_channel_group AS channel_raw,
+    ga4_attr.ga4_ad_google_campaign,
+    ga4_attr.ga4_ad_google_campaign_id AS campaign_id,
+    ga4_attr.ga4_ad_crosschannel_source AS `source`,
+    ga4_attr.ga4_ad_crosschannel_medium AS medium,
+    ga4_attr.ga4_first_gad_campaignid_from_event_params,
+    COALESCE(ga4_attr.ga4_ad_google_campaign, campaigns_v2.campaign_name) AS campaign,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.cfs_ga4_attr` AS ga4_attr
+  LEFT JOIN
+    `moz-fx-data-shared-prod.google_ads_derived.campaigns_v2` AS campaigns_v2
+    ON SAFE_CAST(ga4_first_gad_campaignid_from_event_params AS INT64) = campaigns_v2.campaign_id
+  WHERE
+    attribution_dltoken IS NOT NULL
+),
+ga4_attr_by_dltoken_dedup AS (
+  SELECT
+    client_id,
+    first_seen_date,
+    ga4_session_date,
+    dltoken,
+    channel_raw,
+    `source`,
+    medium,
+    ga4_first_gad_campaignid_from_event_params,
+    campaign_id,
+    campaign,
+  FROM
+    ga4_attribution
+  QUALIFY
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        dltoken
+      ORDER BY
+        CASE
+          WHEN channel_raw IS NOT NULL
+            THEN 0
+          ELSE 1
+        END,
+        first_seen_date,
+        client_id
+    ) = 1
+),
+-- =============================================================================
+-- CTE 3: installs - Windows Installer Telemetry
+-- =============================================================================
+-- Source: Firefox installer ping (Windows only - Mac has no installer telemetry)
+-- Metrics: Successful new installs (not upgrades/reinstalls)
+-- Attribution: Joined to ga4_attr_by_dltoken via dltoken extracted from attribution URL
+-- Note: ~10% of dltokens map to multiple profiles, hence the deduplication above
+-- =============================================================================
+windows_installer_installs_base AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    normalized_country_code AS country_code,
+  -- Extract dltoken from URL-encoded attribution string
+    REGEXP_EXTRACT(attribution, r'dltoken%3D([^%&]+)') AS dltoken,
+  FROM
+    `moz-fx-data-shared-prod.firefox_installer.install` AS installs
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND succeeded  -- Only successful installs
+    AND NOT had_old_install  -- Exclude upgrades/reinstalls (new installs only)
+  -- Only count installs from tracked mozilla.org downloads
+    AND funnel_derived = 'mozorg windows funnel'
+    AND build_channel = 'release'
+),
+windows_installer_installs AS (
+  SELECT
+    submission_date,
+    country_code,
+    'mozorg windows funnel' AS funnel_derived,  -- Always Windows (Mac has no installer data)
+    -- Get attribution from ga4_attr_by_dltoken lookup
+    channel_raw,
+    campaign,
+    campaign_id,
+    `source`,
+    medium,
+    COUNT(*) AS installs,
+  FROM
+    windows_installer_installs_base
+  LEFT JOIN
+    ga4_attr_by_dltoken_dedup
+    USING (dltoken)
+  GROUP BY
+    ALL
+),
+-- =============================================================================
+-- CTE 4: fresh_download_profiles - Profile Filtering (Currently Unused)
+-- =============================================================================
+-- PURPOSE: Identify profiles that were created shortly after a tracked download
+-- LOGIC: Only count the FIRST profile per download token within 30 days
+-- USE CASE: Could be used to filter desktop_funnels_telemetry for stricter attribution
+-- STATUS: Currently not used in final join but kept for potential future use
+-- =============================================================================
+fresh_download_profiles AS (
+  SELECT
+    client_id,
+    cfs.first_seen_date,
+    cfs.attribution_dltoken,
+  FROM
+    clients_first_seen AS cfs
+  INNER JOIN
+    ga4_attr_by_dltoken_dedup AS ga4_attr
+    USING (client_id)
+  WHERE
+    cfs.funnel_derived IN ('mozorg windows funnel', 'mozorg mac funnel')
+    AND cfs.is_desktop
+    AND cfs.attribution_dltoken IS NOT NULL
+  -- Download must have occurred within 30 days before profile creation
+    AND ga4_attr.ga4_session_date
+    BETWEEN DATE_SUB(cfs.first_seen_date, INTERVAL 30 DAY)
+    AND cfs.first_seen_date
+  -- Assign row id to profiles per download to identify the first one
+  QUALIFY
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        cfs.attribution_dltoken
+      ORDER BY
+        cfs.first_seen_date,
+        cfs.client_id
+    ) = 1
+),
+-- =============================================================================
+-- CTE 5: desktop_funnels_telemetry - Firefox Profile Metrics
+-- =============================================================================
+-- Source: Firefox telemetry (clients_first_seen_28_days_later)
+-- Metrics:
+--   - new_profiles: Count of new Firefox profiles created
+--   - return_user: Profiles that were active on day 2 (qualified_second_day)
+--   - retained_week4: Profiles still active in week 4 (qualified_week4)
+-- Granularity: Daily, by country, funnel type, and attribution dimensions
+-- =============================================================================
+desktop_funnels_telemetry AS (
+  SELECT
+    clients_first_seen.first_seen_date AS submission_date,
+    clients_first_seen.country,
+    IF(
+      clients_first_seen.funnel_derived = 'other',
+      'Unknown',
+      clients_first_seen.funnel_derived
+    ) AS funnel_derived,
+    clients_first_seen.normalized_os,
+    -- Partner-specific dimensions (NULL for non-partner funnels to reduce cardinality)
+    IF(
+      clients_first_seen.funnel_derived = 'partner',
+      clients_first_seen.partner_org,
+      CAST(NULL AS STRING)
+    ) AS partner_org,
+    IF(
+      clients_first_seen.funnel_derived = 'partner',
+      clients_first_seen.distribution_model,
+      CAST(NULL AS STRING)
+    ) AS distribution_model,
+    IF(
+      clients_first_seen.funnel_derived = 'partner',
+      clients_first_seen.distribution_id,
+      CAST(NULL AS STRING)
+    ) AS distribution_id,
+    -- Attribution dimensions from GA4
+    ga4_attr.channel_raw,
+    ga4_attr.campaign,
+    ga4_attr.campaign_id,
+    ga4_attr.`source`,
+    ga4_attr.medium,
+    -- Profile metrics
+    COUNT(clients_first_seen.*) AS new_profiles,
+    COUNTIF(cfs28.qualified_second_day) AS return_user,      -- Active on day 2
+    COUNTIF(cfs28.qualified_week4) AS retained_week4         -- Active in week 4
+  FROM
+    clients_first_seen
+  -- Join to GA4 attribution directly (no dltoken dedup here as multiple client_ids could come from the same dltoken)
+  LEFT JOIN
+    ga4_attribution AS ga4_attr
+    USING (client_id)
+  LEFT JOIN
+    `moz-fx-data-shared-prod.telemetry.clients_first_seen_28_days_later` AS cfs28
+    ON clients_first_seen.client_id = cfs28.client_id
+    AND clients_first_seen.first_seen_date = cfs28.first_seen_date
+  WHERE
+    clients_first_seen.is_desktop
+    AND clients_first_seen.normalized_channel = 'release'
+    AND cfs28.normalized_channel = 'release'
+  GROUP BY
+    ALL
+),
+-- =============================================================================
+-- CTE 6: final - Unified Funnel Metrics
+-- =============================================================================
+-- Combines TOF (visits/downloads), installs, and telemetry (profiles/retention)
+-- Join strategy: FULL JOINs to preserve all data even when metrics don't align
+-- Attribution dimensions must match for rows to combine
+-- =============================================================================
+combined AS (
+  SELECT
+    -- Use COALESCE to get dimensions from whichever source has data (TOF, installs, or telemetry)
+    COALESCE(
+      top_of_funnel.submission_date,
+      windows_installer.submission_date,
+      desktop_funnels_telemetry.submission_date
+    ) AS funnel_date,
+    COALESCE(
+      top_of_funnel.country_code,
+      windows_installer.country_code,
+      desktop_funnels_telemetry.country
+    ) AS country,
+    COALESCE(
+      top_of_funnel.funnel_derived,
+      windows_installer.funnel_derived,
+      desktop_funnels_telemetry.funnel_derived
+    ) AS funnel_derived,
+    COALESCE(
+      top_of_funnel.channel_raw,
+      windows_installer.channel_raw,
+      desktop_funnels_telemetry.channel_raw
+    ) AS channel_raw,
+    COALESCE(
+      top_of_funnel.campaign,
+      windows_installer.campaign,
+      desktop_funnels_telemetry.campaign
+    ) AS campaign,
+    COALESCE(
+      top_of_funnel.campaign_id,
+      windows_installer.campaign_id,
+      desktop_funnels_telemetry.campaign_id
+    ) AS campaign_id,
+    COALESCE(
+      top_of_funnel.`source`,
+      windows_installer.`source`,
+      desktop_funnels_telemetry.`source`
+    ) AS `source`,
+    COALESCE(
+      top_of_funnel.medium,
+      windows_installer.medium,
+      desktop_funnels_telemetry.medium
+    ) AS medium,
+    desktop_funnels_telemetry.normalized_os,
+    desktop_funnels_telemetry.partner_org,
+    desktop_funnels_telemetry.distribution_model,
+    NULLIF(desktop_funnels_telemetry.distribution_id, "") AS distribution_id,
+    -- Partner funnel has no web visits/downloads (starts at profiles)
+    IF(
+      desktop_funnels_telemetry.funnel_derived = 'partner',
+      CAST(NULL AS INTEGER),
+      COALESCE(top_of_funnel.visits, 0)
+    ) AS visits,
+    IF(
+      desktop_funnels_telemetry.funnel_derived = 'partner',
+      CAST(NULL AS INTEGER),
+      COALESCE(top_of_funnel.downloads, 0)
+    ) AS downloads,
+    -- Installs only available for Windows funnel (Mac has no installer telemetry)
+    CASE
+      WHEN COALESCE(
+          top_of_funnel.funnel_derived,
+          desktop_funnels_telemetry.funnel_derived
+        ) = 'mozorg windows funnel'
+        THEN COALESCE(windows_installer.installs, 0)
+      WHEN COALESCE(
+          top_of_funnel.funnel_derived,
+          desktop_funnels_telemetry.funnel_derived
+        ) = 'mozorg mac funnel'
+        THEN CAST(NULL AS INTEGER)
+      ELSE CAST(NULL AS INTEGER)
+    END AS installs,
+    COALESCE(desktop_funnels_telemetry.new_profiles, 0) AS new_profiles,
+    COALESCE(desktop_funnels_telemetry.return_user) AS return_user,
+    COALESCE(desktop_funnels_telemetry.retained_week4) AS retained_week4
+  FROM
+    top_of_funnel
+  -- Join installs on all attribution dimensions
+  FULL JOIN
+    windows_installer_installs AS windows_installer
+    ON top_of_funnel.submission_date = windows_installer.submission_date
+    AND top_of_funnel.country_code = windows_installer.country_code
+    AND top_of_funnel.funnel_derived = windows_installer.funnel_derived
+    AND COALESCE(top_of_funnel.channel_raw, '') = COALESCE(windows_installer.channel_raw, '')
+    AND COALESCE(top_of_funnel.campaign, '') = COALESCE(windows_installer.campaign, '')
+    AND COALESCE(top_of_funnel.campaign_id, '') = COALESCE(windows_installer.campaign_id, '')
+    AND COALESCE(top_of_funnel.source, '') = COALESCE(windows_installer.source, '')
+    AND COALESCE(top_of_funnel.medium, '') = COALESCE(windows_installer.medium, '')
+  -- Join telemetry (profiles) on all attribution dimensions
+  FULL JOIN
+    desktop_funnels_telemetry
+    ON top_of_funnel.submission_date = desktop_funnels_telemetry.submission_date
+    AND top_of_funnel.country_code = desktop_funnels_telemetry.country
+    AND top_of_funnel.funnel_derived = desktop_funnels_telemetry.funnel_derived
+    AND COALESCE(top_of_funnel.channel_raw, '') = COALESCE(
+      desktop_funnels_telemetry.channel_raw,
+      ''
+    )
+    AND COALESCE(top_of_funnel.campaign, '') = COALESCE(desktop_funnels_telemetry.campaign, '')
+    AND COALESCE(top_of_funnel.campaign_id, '') = COALESCE(
+      desktop_funnels_telemetry.campaign_id,
+      ''
+    )
+    AND COALESCE(top_of_funnel.source, '') = COALESCE(desktop_funnels_telemetry.source, '')
+    AND COALESCE(top_of_funnel.medium, '') = COALESCE(desktop_funnels_telemetry.medium, '')
+),
+final AS (
+  SELECT
+    *,
+  -- Derived channel: simplify attribution into three buckets
+  --   - Paid Search: Has a campaign (from Google Ads)
+  --   - Organic Search: GA4 classified as Organic Search
+  --   - Web - Organic/Other: Everything else (direct, referral, social, etc.)
+  -- TODO: should we consider moving the channel and subchannel definitions into the view?
+    CASE
+      WHEN campaign IS NOT NULL
+        THEN 'Paid Search'
+      WHEN channel_raw = 'Organic Search'
+        THEN 'Organic Search'
+      ELSE 'Web - Organic/Other'
+    END AS channel,
+  -- Subchannel: Campaign type classification for Paid Search
+  -- Based on naming conventions: _brand_, _nonbrand_, _comp_, pmax
+    CASE
+      WHEN campaign IS NOT NULL
+        THEN
+          CASE
+            WHEN REGEXP_CONTAINS(campaign, r'_brand_')
+              THEN 'Brand'
+            WHEN REGEXP_CONTAINS(campaign, r'_nonbrand_')
+              THEN 'Non-Brand'
+            WHEN REGEXP_CONTAINS(campaign, r'_comp_')
+              THEN 'Competitor'
+            WHEN REGEXP_CONTAINS(LOWER(campaign), r'pmax')
+              THEN 'PMax'
+            ELSE 'Other'
+          END
+      ELSE 'All'  -- Non-Paid Search has no subchannel
+    END AS subchannel,
+  FROM
+    combined
+),
+previous AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.telemetry_derived.firefox_desktop_marketing_funnel_v2`
+  WHERE
+    funnel_date < @submission_date
+)
+SELECT
+  COALESCE(previous.funnel_date, final.funnel_date) AS funnel_date,
+  COALESCE(previous.country, final.country) AS country,
+  COALESCE(previous.funnel_derived, final.funnel_derived) AS funnel_derived,
+  COALESCE(previous.channel_raw, final.channel_raw) AS channel_raw,
+  COALESCE(previous.campaign, final.campaign) AS campaign,
+  COALESCE(previous.campaign_id, final.campaign_id) AS campaign_id,
+  COALESCE(previous.source, final.source) AS source,
+  COALESCE(previous.medium, final.medium) AS medium,
+  COALESCE(previous.normalized_os, final.normalized_os) AS normalized_os,
+  COALESCE(previous.partner_org, final.partner_org) AS partner_org,
+  COALESCE(previous.distribution_model, final.distribution_model) AS distribution_model,
+  COALESCE(previous.distribution_id, final.distribution_id) AS distribution_id,
+  COALESCE(previous.channel, final.channel) AS channel,
+  COALESCE(previous.subchannel, final.subchannel) AS subchannel,
+  COALESCE(previous.visits, final.visits) AS visits,
+  COALESCE(previous.downloads, final.downloads) AS downloads,
+  COALESCE(previous.installs, final.installs) AS installs,
+  COALESCE(previous.new_profiles, final.new_profiles) AS new_profiles,
+  COALESCE(previous.return_user, final.return_user) AS return_user,
+  COALESCE(previous.retained_week4, final.retained_week4) AS retained_week4,
+FROM
+  final
+FULL OUTER JOIN
+  previous
+  ON final.funnel_date = previous.funnel_date
+  AND COALESCE(final.country, "") = COALESCE(previous.country, "")
+  AND COALESCE(final.funnel_derived, "") = COALESCE(previous.funnel_derived, "")
+  AND COALESCE(final.channel_raw, "") = COALESCE(previous.channel_raw, "")
+  AND COALESCE(final.campaign, "") = COALESCE(previous.campaign, "")
+  AND COALESCE(final.campaign_id, "") = COALESCE(previous.campaign_id, "")
+  AND COALESCE(final.source, "") = COALESCE(previous.source, "")
+  AND COALESCE(final.medium, "") = COALESCE(previous.medium, "")
+  AND COALESCE(final.normalized_os, "") = COALESCE(previous.normalized_os, "")
+  AND COALESCE(final.partner_org, "") = COALESCE(previous.partner_org, "")
+  AND COALESCE(final.distribution_model, "") = COALESCE(previous.distribution_model, "")
+  AND COALESCE(final.distribution_id, "") = COALESCE(previous.distribution_id, "")
+  AND COALESCE(final.channel, "") = COALESCE(previous.channel, "")
+  AND COALESCE(final.subchannel, "") = COALESCE(previous.subchannel, "")

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/query.sql
@@ -10,7 +10,6 @@ WITH clients_first_seen AS (
     *,
   FROM
     `moz-fx-data-shared-prod.telemetry.clients_first_seen`
-  -- Join to GA4 attribution directly (no dltoken dedup here as multiple client_ids could come from the same dltoken)
   WHERE
     first_seen_date = @submission_date
     OR first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
@@ -121,6 +120,9 @@ ga4_attribution AS (
     ON SAFE_CAST(ga4_first_gad_campaignid_from_event_params AS INT64) = campaigns_v2.campaign_id
   WHERE
     attribution_dltoken IS NOT NULL
+    AND ga4_attr.first_seen_date
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 27 DAY)
+    AND @submission_date
 ),
 ga4_attr_by_dltoken_dedup AS (
   SELECT
@@ -265,6 +267,13 @@ desktop_funnels_telemetry AS (
   GROUP BY
     ALL
 ),
+-- =============================================================================
+-- CTE 5: combined - Firefox Profile Metrics
+-- =============================================================================
+-- Source: top_of_funnel, windows_installer, desktop_funnels_telemetry
+-- Combines all metrics from different funnels together with the following priority: top_of_funnel, windows_installer, desktop_funnels_telemetry
+-- Granularity: Daily, by country, funnel type, and attribution dimensions
+-- =============================================================================
 combined AS (
   SELECT
     -- Use COALESCE to get dimensions from whichever source has data (TOF, installs, or telemetry)

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/query.sql
@@ -13,8 +13,9 @@ WITH clients_first_seen AS (
     `moz-fx-data-shared-prod.telemetry.clients_first_seen`
   -- Join to GA4 attribution directly (no dltoken dedup here as multiple client_ids could come from the same dltoken)
   WHERE
-    first_seen_date = @submission_date
-    -- OR first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
+    first_seen_date
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 27 DAY)
+    AND @submission_date
 ),
 top_of_funnel_base AS (
   SELECT
@@ -64,7 +65,9 @@ top_of_funnel_base AS (
     `moz-fx-data-shared-prod.static.country_names_v1` AS country_names
     ON ga4.country = country_names.name
   WHERE
-    session_date = @submission_date
+    session_date
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 27 DAY)
+    AND @submission_date
     AND device_category = 'desktop'
     -- Exclude existing Firefox users - we want new acquisition only
     AND COALESCE(browser, '') NOT IN ('Firefox', 'Mozilla')
@@ -168,7 +171,9 @@ windows_installer_installs_base AS (
   FROM
     `moz-fx-data-shared-prod.firefox_installer.install` AS installs
   WHERE
-    DATE(submission_timestamp) = @submission_date
+    DATE(submission_timestamp)
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 27 DAY)
+    AND @submission_date
     AND succeeded  -- Only successful installs
     AND NOT had_old_install  -- Exclude upgrades/reinstalls (new installs only)
   -- Only count installs from tracked mozilla.org downloads
@@ -274,7 +279,7 @@ desktop_funnels_telemetry AS (
     ga4_attr.`source`,
     ga4_attr.medium,
     -- Profile metrics
-    COUNT(clients_first_seen.*) AS new_profiles,
+    COUNT(clients_first_seen.client_id) AS new_profiles,
     COUNTIF(cfs28.qualified_second_day) AS return_user,      -- Active on day 2
     COUNTIF(cfs28.qualified_week4) AS retained_week4         -- Active in week 4
   FROM
@@ -470,8 +475,8 @@ SELECT
   COALESCE(previous.downloads, final.downloads) AS downloads,
   COALESCE(previous.installs, final.installs) AS installs,
   COALESCE(previous.new_profiles, final.new_profiles) AS new_profiles,
-  COALESCE(previous.return_user, final.return_user) AS return_user,
-  COALESCE(previous.retained_week4, final.retained_week4) AS retained_week4,
+  COALESCE(final.return_user, previous.return_user) AS return_user,
+  COALESCE(final.retained_week4, previous.retained_week4) AS retained_week4,
 FROM
   final
 FULL OUTER JOIN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/query.sql
@@ -5,7 +5,6 @@
 -- Metrics: Visits (sessions) and Downloads (click events)
 -- Granularity: Daily, by country, funnel type, and attribution dimensions
 -- =============================================================================
--- TODO: may need to grab a 28 day window for first seen for late available metrics to work
 WITH clients_first_seen AS (
   SELECT
     *,
@@ -13,9 +12,8 @@ WITH clients_first_seen AS (
     `moz-fx-data-shared-prod.telemetry.clients_first_seen`
   -- Join to GA4 attribution directly (no dltoken dedup here as multiple client_ids could come from the same dltoken)
   WHERE
-    first_seen_date
-    BETWEEN DATE_SUB(@submission_date, INTERVAL 27 DAY)
-    AND @submission_date
+    first_seen_date = @submission_date
+    OR first_seen_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
 ),
 top_of_funnel_base AS (
   SELECT
@@ -65,9 +63,7 @@ top_of_funnel_base AS (
     `moz-fx-data-shared-prod.static.country_names_v1` AS country_names
     ON ga4.country = country_names.name
   WHERE
-    session_date
-    BETWEEN DATE_SUB(@submission_date, INTERVAL 27 DAY)
-    AND @submission_date
+    session_date = @submission_date
     AND device_category = 'desktop'
     -- Exclude existing Firefox users - we want new acquisition only
     AND COALESCE(browser, '') NOT IN ('Firefox', 'Mozilla')
@@ -171,9 +167,7 @@ windows_installer_installs_base AS (
   FROM
     `moz-fx-data-shared-prod.firefox_installer.install` AS installs
   WHERE
-    DATE(submission_timestamp)
-    BETWEEN DATE_SUB(@submission_date, INTERVAL 27 DAY)
-    AND @submission_date
+    DATE(submission_timestamp) = @submission_date
     AND succeeded  -- Only successful installs
     AND NOT had_old_install  -- Exclude upgrades/reinstalls (new installs only)
   -- Only count installs from tracked mozilla.org downloads
@@ -201,43 +195,7 @@ windows_installer_installs AS (
     ALL
 ),
 -- =============================================================================
--- CTE 4: fresh_download_profiles - Profile Filtering (Currently Unused)
--- =============================================================================
--- PURPOSE: Identify profiles that were created shortly after a tracked download
--- LOGIC: Only count the FIRST profile per download token within 30 days
--- USE CASE: Could be used to filter desktop_funnels_telemetry for stricter attribution
--- STATUS: Currently not used in final join but kept for potential future use
--- =============================================================================
-fresh_download_profiles AS (
-  SELECT
-    client_id,
-    cfs.first_seen_date,
-    cfs.attribution_dltoken,
-  FROM
-    clients_first_seen AS cfs
-  INNER JOIN
-    ga4_attr_by_dltoken_dedup AS ga4_attr
-    USING (client_id)
-  WHERE
-    cfs.funnel_derived IN ('mozorg windows funnel', 'mozorg mac funnel')
-    AND cfs.is_desktop
-    AND cfs.attribution_dltoken IS NOT NULL
-  -- Download must have occurred within 30 days before profile creation
-    AND ga4_attr.ga4_session_date
-    BETWEEN DATE_SUB(cfs.first_seen_date, INTERVAL 30 DAY)
-    AND cfs.first_seen_date
-  -- Assign row id to profiles per download to identify the first one
-  QUALIFY
-    ROW_NUMBER() OVER (
-      PARTITION BY
-        cfs.attribution_dltoken
-      ORDER BY
-        cfs.first_seen_date,
-        cfs.client_id
-    ) = 1
-),
--- =============================================================================
--- CTE 5: desktop_funnels_telemetry - Firefox Profile Metrics
+-- CTE 4: desktop_funnels_telemetry - Firefox Profile Metrics
 -- =============================================================================
 -- Source: Firefox telemetry (clients_first_seen_28_days_later)
 -- Metrics:
@@ -246,9 +204,10 @@ fresh_download_profiles AS (
 --   - retained_week4: Profiles still active in week 4 (qualified_week4)
 -- Granularity: Daily, by country, funnel type, and attribution dimensions
 -- =============================================================================
-desktop_funnels_telemetry AS (
+desktop_funnels_telemetry_base AS (
   SELECT
-    clients_first_seen.first_seen_date AS submission_date,
+    client_id,
+    clients_first_seen.first_seen_date,
     clients_first_seen.country,
     IF(
       clients_first_seen.funnel_derived = 'other',
@@ -278,34 +237,37 @@ desktop_funnels_telemetry AS (
     ga4_attr.campaign_id,
     ga4_attr.`source`,
     ga4_attr.medium,
-    -- Profile metrics
-    COUNT(clients_first_seen.client_id) AS new_profiles,
-    COUNTIF(cfs28.qualified_second_day) AS return_user,      -- Active on day 2
-    COUNTIF(cfs28.qualified_week4) AS retained_week4         -- Active in week 4
   FROM
     clients_first_seen
   -- Join to GA4 attribution directly (no dltoken dedup here as multiple client_ids could come from the same dltoken)
   LEFT JOIN
     ga4_attribution AS ga4_attr
     USING (client_id)
-  LEFT JOIN
-    `moz-fx-data-shared-prod.telemetry.clients_first_seen_28_days_later` AS cfs28
-    ON clients_first_seen.client_id = cfs28.client_id
-    AND clients_first_seen.first_seen_date = cfs28.first_seen_date
   WHERE
     clients_first_seen.is_desktop
-    AND clients_first_seen.normalized_channel = 'release'
-    AND cfs28.normalized_channel = 'release'
+    AND normalized_channel = 'release'
+),
+desktop_funnels_telemetry AS (
+  SELECT
+    desktop_funnels_telemetry_base.* EXCEPT (client_id, first_seen_date),
+    first_seen_date AS submission_date,
+    -- Profile metrics
+    COUNT(
+      IF(first_seen_date = @submission_date, desktop_funnels_telemetry_base.client_id, NULL)
+    ) AS new_profiles,
+    COUNTIF(cfs28.qualified_second_day) AS return_user,      -- Active on day 2
+    COUNTIF(cfs28.qualified_week4) AS retained_week4         -- Active in week 4
+  FROM
+    desktop_funnels_telemetry_base
+  LEFT JOIN
+    `moz-fx-data-shared-prod.telemetry.clients_first_seen_28_days_later` AS cfs28
+    USING (client_id, first_seen_date)
+  WHERE
+    cfs28.normalized_channel = "release"
+    AND cfs28.is_desktop
   GROUP BY
     ALL
 ),
--- =============================================================================
--- CTE 6: final - Unified Funnel Metrics
--- =============================================================================
--- Combines TOF (visits/downloads), installs, and telemetry (profiles/retention)
--- Join strategy: FULL JOINs to preserve all data even when metrics don't align
--- Attribution dimensions must match for rows to combine
--- =============================================================================
 combined AS (
   SELECT
     -- Use COALESCE to get dimensions from whichever source has data (TOF, installs, or telemetry)
@@ -378,7 +340,7 @@ combined AS (
         THEN CAST(NULL AS INTEGER)
       ELSE CAST(NULL AS INTEGER)
     END AS installs,
-    COALESCE(desktop_funnels_telemetry.new_profiles, 0) AS new_profiles,
+    COALESCE(desktop_funnels_telemetry.new_profiles) AS new_profiles,
     COALESCE(desktop_funnels_telemetry.return_user) AS return_user,
     COALESCE(desktop_funnels_telemetry.retained_week4) AS retained_week4
   FROM
@@ -412,6 +374,13 @@ combined AS (
     AND COALESCE(top_of_funnel.source, '') = COALESCE(desktop_funnels_telemetry.source, '')
     AND COALESCE(top_of_funnel.medium, '') = COALESCE(desktop_funnels_telemetry.medium, '')
 ),
+-- =============================================================================
+-- CTE 6: final - Unified Funnel Metrics
+-- =============================================================================
+-- Combines TOF (visits/downloads), installs, and telemetry (profiles/retention)
+-- Join strategy: FULL JOINs to preserve all data even when metrics don't align
+-- Attribution dimensions must match for rows to combine
+-- =============================================================================
 final AS (
   SELECT
     *,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/query.sql
@@ -262,9 +262,6 @@ desktop_funnels_telemetry AS (
   LEFT JOIN
     `moz-fx-data-shared-prod.telemetry.clients_first_seen_28_days_later` AS cfs28
     USING (client_id, first_seen_date)
-  WHERE
-    cfs28.normalized_channel = "release"
-    AND cfs28.is_desktop
   GROUP BY
     ALL
 ),
@@ -340,9 +337,9 @@ combined AS (
         THEN CAST(NULL AS INTEGER)
       ELSE CAST(NULL AS INTEGER)
     END AS installs,
-    COALESCE(desktop_funnels_telemetry.new_profiles) AS new_profiles,
-    COALESCE(desktop_funnels_telemetry.return_user) AS return_user,
-    COALESCE(desktop_funnels_telemetry.retained_week4) AS retained_week4
+    desktop_funnels_telemetry.new_profiles,
+    desktop_funnels_telemetry.return_user,
+    desktop_funnels_telemetry.retained_week4,
   FROM
     top_of_funnel
   -- Join installs on all attribution dimensions

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_marketing_funnel_v2/schema.yaml
@@ -1,0 +1,126 @@
+fields:
+
+- mode: NULLABLE
+  name: funnel_date
+  type: DATE
+  description: Date of the funnel activity (submission_date for TOF/installs, first_seen_date for profiles)
+
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: >
+    Country with tier label, e.g. "US (Core)", "DE (Growth)", or "Emerging" for Rest of World (Tier 3).
+    EU countries are excluded from core funnels due to cookie banner impact on tracking.
+
+- mode: NULLABLE
+  name: funnel_derived
+  type: STRING
+  description: >
+    Funnel type based on OS and acquisition source. Values: "mozorg windows funnel" (full funnel with installs),
+    "mozorg mac funnel" (no install data), "mozorg other" (non-Windows/Mac OS),
+    "partner" (partner distribution, starts at profiles), "Unknown" (EU countries and unattributed traffic).
+
+- mode: NULLABLE
+  name: channel_raw
+  type: STRING
+  description: GA4 cross-channel primary channel group from web session attribution (e.g. "Organic Search", "Paid Search", "Direct")
+
+- mode: NULLABLE
+  name: campaign
+  type: STRING
+  description: Google Ads campaign name, with fallback to campaigns_v2 lookup by campaign ID. NULL for non-paid traffic.
+
+- mode: NULLABLE
+  name: campaign_id
+  type: STRING
+  description: Google Ads campaign ID from GA4 attribution
+
+- mode: NULLABLE
+  name: source
+  type: STRING
+  description: GA4 cross-channel traffic source (e.g. "google", "bing", "mozilla.org")
+
+- mode: NULLABLE
+  name: medium
+  type: STRING
+  description: GA4 cross-channel traffic medium (e.g. "organic", "cpc", "referral")
+
+- mode: NULLABLE
+  name: normalized_os
+  type: STRING
+  description: Normalized operating system of the Firefox profile (e.g. "Windows", "Mac", "Linux"). Only populated from telemetry (profiles CTE).
+
+- mode: NULLABLE
+  name: partner_org
+  type: STRING
+  description: Partner organization name. Only populated when funnel_derived = "partner", NULL otherwise.
+
+- mode: NULLABLE
+  name: distribution_model
+  type: STRING
+  description: Partner distribution model. Only populated when funnel_derived = "partner", NULL otherwise.
+
+- mode: NULLABLE
+  name: distribution_id
+  type: STRING
+  description: Partner distribution ID. Only populated when funnel_derived = "partner", NULL otherwise.
+
+- mode: NULLABLE
+  name: channel
+  type: STRING
+  description: >
+    Derived channel bucket. Values: "Paid Search" (has a Google Ads campaign),
+    "Organic Search" (GA4 classified as Organic Search),
+    "Web - Organic/Other" (everything else including direct, referral, social).
+
+- mode: NULLABLE
+  name: subchannel
+  type: STRING
+  description: >
+    Campaign type classification for Paid Search, based on campaign naming conventions.
+    Values: "Brand" (_brand_), "Non-Brand" (_nonbrand_), "Competitor" (_comp_),
+    "PMax" (pmax), "Other" (paid but unclassified), "All" (non-Paid Search).
+
+- mode: NULLABLE
+  name: visits
+  type: INTEGER
+  description: >
+    Count of GA4 desktop sessions on mozilla.org and firefox.com.
+    Excludes existing Firefox users, internal cross-site referrals (mozilla.org <-> firefox.com),
+    and EU countries. NULL for partner funnel.
+
+- mode: NULLABLE
+  name: downloads
+  type: INTEGER
+  description: >
+    Count of GA4 sessions with at least one Firefox desktop download event.
+    NULL for partner funnel.
+
+- mode: NULLABLE
+  name: installs
+  type: INTEGER
+  description: >
+    Count of successful new Firefox installations from Windows installer telemetry.
+    Excludes silent installs, upgrades/reinstalls, non-release channels, and partner distributions.
+    Only available for "mozorg windows funnel" (NULL for Mac and other funnels).
+
+- mode: NULLABLE
+  name: new_profiles
+  type: INTEGER
+  description: >
+    Count of new Firefox profiles created, from clients_first_seen_28_days_later telemetry.
+    Filtered to release channel only.
+
+- mode: NULLABLE
+  name: return_user
+  type: INTEGER
+  description: >
+    Count of new profiles that were active on any day after their first day (qualified_second_day).
+    Requires both a URI visit and browser interaction on the same day within days 2-28.
+
+- mode: NULLABLE
+  name: retained_week4
+  type: INTEGER
+  description: >
+    Count of new profiles still active in week 4 of the 28-day observation window (qualified_week4).
+    Requires both a URI visit and browser interaction on the same day within days 22-28.


### PR DESCRIPTION
# feat(DENG-10740): desktop marketing funnel capture latest data

This adds `telemetry_derived.firefox_desktop_marketing_funnel_v2` which unlike the v1 populates metrics available immediately and later on populates other metrics we expect to arrive with a delay.