### PR TITLE
chore(DENG-10777): complete urlbar_events_daily_v1 backfill

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v1/backfill.yaml
@@ -4,7 +4,7 @@
   reason: backfill reverted v1 from 20-Mar (without shredder_mitigation because it last ran on 17-Mar) https://mozilla-hub.atlassian.net/browse/DENG-10777
   watchers:
   - kbammarito@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v1/metadata.yaml
@@ -8,7 +8,7 @@ owners:
 labels:
   incremental: true
   schedule: daily
-  shredder_mitigation: false
+  shredder_mitigation: true
   table_type: aggregate
   dag: bqetl_urlbar
   owner1: tbrooks


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR sets the `urlbar_events_daily_v1` backfill status to `Complete` and sets the `metadata.yaml`'s `shredder_mitigation` back to `true` (follow-up to https://github.com/mozilla/bigquery-etl/pull/9183).

## Related Tickets & Documents
* DENG-10777

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
