### PR TITLE
fix: Have `bqetl deploy` include ETLs that use SQL scripts

### DIFF
--- a/bigquery_etl/cli/deploy.py
+++ b/bigquery_etl/cli/deploy.py
@@ -393,7 +393,7 @@ def _discover_artifacts(
     """Find artifacts."""
     artifacts = {}
     patterns = {
-        "table": [QUERY_FILE, QUERY_SCRIPT],
+        "table": [QUERY_FILE, QUERY_SCRIPT, "script.sql"],
         "view": [VIEW_FILE],
     }
 


### PR DESCRIPTION
## Description
Fixup for https://github.com/mozilla/bigquery-etl/pull/8716.

For example, when https://github.com/mozilla/private-bigquery-etl/pull/1297 was merged the new schema for the `daily_active_employees_v1` ETL should have been deployed, but it wasn't.

Also, I'm on PTO tomorrow, so if someone else ends up merging this in my absence, please make sure https://github.com/mozilla/private-bigquery-etl/pull/1301 is merged first, otherwise the current incorrect schema for the `daily_active_employees_v1` ETL will get deployed and the columns will end up in the wrong order. (CC @kbammarito)

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/8716
* https://github.com/mozilla/private-bigquery-etl/pull/1297
* https://github.com/mozilla/private-bigquery-etl/pull/1301

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
