### PR TITLE
fix(DENG-10638): Modify query so correct partitions are written to in BigQuery

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/query.sql
@@ -76,3 +76,5 @@ GROUP BY
   event_date,
   product,
   content_type
+HAVING
+  event_date = @submission_date

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/query.sql
@@ -58,7 +58,7 @@ events_with_product AS (
     ep.key = 'products'
 )
 SELECT
-  DATE(TIMESTAMP_MICROS(event_timestamp)) AS event_date,
+  submission_date AS event_date,
   product,
   CASE
     WHEN content_type = 'kb-article'
@@ -73,8 +73,6 @@ SELECT
 FROM
   events_with_product
 GROUP BY
-  event_date,
+  submission_date,
   product,
   content_type
-HAVING
-  event_date = @submission_date

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/schema.yaml
@@ -2,7 +2,10 @@ fields:
 - name: event_date
   type: DATE
   mode: NULLABLE
-  description: Submission date of the GA4 events (partition key).
+  description: |
+    Date when the event is received in our servers UTC+1. This date has a mismatch of ~3-4%
+    with the date when the event occurred, but this impact is minimal, thus we use it as the
+    official reporting date.
 - name: product
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/schema.yaml
@@ -2,7 +2,7 @@ fields:
 - name: event_date
   type: DATE
   mode: NULLABLE
-  description: Date (UTC) when the event occurred as reported by GA4.
+  description: Submission date of the GA4 events (partition key).
 - name: product
   type: STRING
   mode: NULLABLE


### PR DESCRIPTION
## Description

After merging the GA4 table for CX in ticket DENG-10638, the DAG is failing with [this error](https://workflow.telemetry.mozilla.org/dags/bqetl_sumo_metrics/grid?search=bqetl_sumo_metrics&dag_run_id=scheduled__2026-04-09T03%3A00%3A00%2B00%3A00&tab=logs&task_id=sumo_metrics_derived__ga4_engagement_sessions_daily__v1) :
```
 Some rows belong to different partitions rather than destination partition
```

There are two ways to fix it:

**Option A**: submission_date AS event_date
Uses the GA4 export date directly as the partition key. Guarantees every row lands in the correct partition, fixing the backfill error. Simple and reliable. Downside: submission_date reflects when GA4 processed/exported the event (in the property's configured timezone), not when the event actually occurred in UTC — so sessions near midnight may be attributed to the wrong day from a UTC perspective.

**Option B**: DATE(TIMESTAMP_MICROS(event_timestamp)) AS event_date + HAVING event_date = @submission_date
Derives the date from the raw event timestamp in UTC, preserving true UTC alignment. The HAVING filter then drops the small number of edge-case rows whose UTC event date doesn't match submission_date, ensuring the partition constraint is satisfied. Downside: those cross-midnight rows are silently excluded — each day's run will miss events that occurred UTC-side on that day but were exported under an adjacent submission_date, and vice versa.

The core tradeoff: Option A is complete (no data dropped) but may mislabel the day for timezone-boundary events. Option B is UTC-accurate but loses a small slice of events at day boundaries. For a daily metrics table, Option B is generally preferable if UTC consistency matters to downstream consumers — the data loss is minimal and the semantics are cleaner.

## Related Tickets & Documents
* DENG-10638

## Recommendation

**Option A**. The query below validates two 'Tier 0 KPIs': `SSER for KB` and `SSER for Forums` and each KPI drops ~3-4% of events using Option B when trying to preserve UTC alignment. A 3-4% under count of events would make SSSR appear slightly higher on any given day :

<details>

<summary> Validation Query  </summary>

```sql
-- Comparison query: Option A (submission_date) vs Option B (UTC event_timestamp + HAVING)
-- Run with: --parameter=submission_date:DATE:YYYY-MM-DD
--
-- Option A: submission_date AS event_date
--   All rows kept; event_date = submission_date always (no drops).
--   Risk: timezone-boundary events may be attributed to the wrong UTC day.
--
-- Option B: DATE(TIMESTAMP_MICROS(event_timestamp)) AS event_date + HAVING event_date = @submission_date
--   True UTC date; cross-midnight edge-case rows are dropped.
--   Risk: small data loss for events near midnight UTC.
WITH
  engagement_events AS (
    SELECT
      *,
      CONCAT(user_pseudo_id, CAST(event_timestamp AS STRING)) AS event_id
    FROM
      `mozdata.sumo_ga.ga4_events`,
      UNNEST(event_params) AS ep
    WHERE
      submission_date = '2025-05-02'
      AND event_name = 'user_engagement'
      AND ep.key = 'content_group'
      AND ep.value.string_value IN ('kb-article', 'support-forum-question-details')
  ),
  events_with_content_type AS (
    SELECT
      ee.*,
      ep.value.string_value AS content_type
    FROM
      engagement_events ee,
      UNNEST(ee.event_params) AS ep
    WHERE
      ep.key = 'content_group'
  ),
  engaged_events AS (
    SELECT
      *
    FROM
      events_with_content_type,
      UNNEST(event_params) AS ep
    WHERE
      ep.key = 'engagement_time_msec'
      AND ep.value.int_value > 1000 * 30
  ),
  events_with_sessions AS (
    SELECT
      ep.value.int_value AS ga_session_id,
      ee.*
    FROM
      engaged_events ee,
      UNNEST(ee.event_params) AS ep
    WHERE
      ep.key = 'ga_session_id'
  ),
  events_with_product AS (
    SELECT
      mozfun.sumo.map_product_slug(ep.value.string_value) AS product,
      ews.*
    FROM
      events_with_sessions ews,
      UNNEST(ews.event_params) AS ep
    WHERE
      ep.key = 'products'
  ),
  -- Label each event row by which option(s) would include it
  labeled AS (
    SELECT
      submission_date,
      DATE(TIMESTAMP_MICROS(event_timestamp)) AS event_date_utc,
      ga_session_id,
      event_id,
      CASE
        WHEN content_type = 'kb-article' THEN 'kb'
        WHEN content_type = 'support-forum-question-details' THEN 'forum_question'
      END AS content_type,
      CASE
        WHEN DATE(TIMESTAMP_MICROS(event_timestamp)) = submission_date THEN 'both'
        ELSE 'option_a_only'  -- dropped by Option B's HAVING filter
      END AS included_in
    FROM
      events_with_product
  ),
  aggregated AS (
    SELECT
      content_type,
      included_in,
      COUNT(DISTINCT ga_session_id) AS sessions,
      COUNT(DISTINCT event_id) AS events
    FROM
      labeled
    GROUP BY
      content_type,
      included_in
  )
SELECT
  content_type,
  included_in,
  sessions,
  events,
  ROUND(
    100.0 * sessions / SUM(sessions) OVER (PARTITION BY content_type),
    2
  ) AS pct_of_content_type_sessions
FROM
  aggregated
ORDER BY
  content_type,
  included_in
;