### PR TITLE
fix(DENG-10638): reinitiate back fill for GA4 CX Sumo Metrics table

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2026-04-09:
+2026-04-10:
   start_date: 2024-04-10
-  end_date: 2026-04-09
+  end_date: 2026-04-10
   reason: Initial backfill to populate data in ga4_engagement_sessions_daily
   watchers:
   - phlee@mozilla.com


### PR DESCRIPTION
## Description

This PR reinitiates the back fill for GA4 CX Sumo Metrics table. This needs to be re-run after implementing a fix to the query so the data gets written to the correct partitions HERE: https://github.com/mozilla/bigquery-etl/pull/9194

## Related Tickets & Documents
* DENG-10638

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
