### PR TITLE
Support ./bqetl target share command

### DIFF
--- a/bigquery_etl/cli/target.py
+++ b/bigquery_etl/cli/target.py
@@ -7,15 +7,40 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import click
+import yaml
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 
 from ..cli.utils import sql_dir_option
 from ..query_scheduling.formatters import format_timedelta
 from ..util.common import block_coding_agents
-from ..util.target import render_artifact_prefix_pattern, render_dataset_pattern
+from ..util.target import (
+    IAM_ROLE_MAP,
+    MANIFEST_FILENAME,
+    render_artifact_prefix_pattern,
+    render_dataset_pattern,
+)
 
 log = logging.getLogger(__name__)
+
+
+def _find_matching_datasets(client, target_config, branch=None):
+    """Find datasets in the target project matching the target's naming pattern.
+
+    Returns a list of dataset references, or an empty list (with user message).
+    """
+    dataset_re = re.compile(render_dataset_pattern(target_config, branch=branch))
+    all_datasets = list(client.list_datasets())
+
+    if not all_datasets:
+        click.echo(f"No datasets found in project {target_config.project_id}.")
+        return []
+
+    matching = [ds for ds in all_datasets if dataset_re.match(ds.dataset_id)]
+    if not matching:
+        click.echo("No matching datasets found.")
+
+    return matching
 
 
 def _parse_duration(value: str) -> timedelta:
@@ -116,8 +141,12 @@ def clean(ctx, older_than, branch, all_deployments, dry_run, yes, sql_dir):
     target_config = ctx.obj["target"]
     project_id = target_config.project_id
 
-    # build filters from target config
-    dataset_re = re.compile(render_dataset_pattern(target_config, branch=branch))
+    client = bigquery.Client(project=project_id)
+    matching = _find_matching_datasets(client, target_config, branch)
+    if not matching:
+        return
+
+    # build table-level filters
     cutoff = (
         datetime.now(timezone.utc) - _parse_duration(older_than) if older_than else None
     )
@@ -130,18 +159,6 @@ def clean(ctx, older_than, branch, all_deployments, dry_run, yes, sql_dir):
         artifact_re = re.compile(
             render_artifact_prefix_pattern(target_config, branch=branch)
         )
-
-    client = bigquery.Client(project=project_id)
-    all_datasets = list(client.list_datasets())
-
-    if not all_datasets:
-        click.echo(f"No datasets found in project {project_id}.")
-        return
-
-    matching = [ds for ds in all_datasets if dataset_re.match(ds.dataset_id)]
-    if not matching:
-        click.echo("No matching deployments found.")
-        return
 
     # table-level cleanup when we have table-level filters
     if artifact_re or cutoff:
@@ -181,11 +198,218 @@ def clean(ctx, older_than, branch, all_deployments, dry_run, yes, sql_dir):
         click.echo(f"\nDeleted {deleted}/{len(matching)} dataset(s).")
 
 
-def _find_matching_tables(client, project_id, datasets, artifact_re, cutoff):
+@target.command(help="""Share target artifacts with a teammate.
+
+    Discovers datasets via the target's naming pattern (same as `clean`) and
+    grants access. Use --branch to narrow to a specific branch.
+
+    Without --table, grants dataset-level access. With --table, grants
+    table-level IAM access to specific tables within matched datasets.
+    Table-level sharing is persisted in the local manifest so it is re-applied
+    automatically when artifacts are re-deployed.
+
+    --dataset and --table filter the template-discovered results and can be
+    repeated. They can also be combined: --dataset narrows datasets, --table
+    selects tables within those datasets.
+
+    Examples:
+
+      ./bqetl --target dev target share --email teammate@mozilla.com
+
+      ./bqetl --target dev target share --email teammate@mozilla.com --role WRITER
+
+      ./bqetl --target dev target share --branch feature-xyz --email teammate@mozilla.com
+
+      ./bqetl --target dev target share --dataset telemetry_derived --email teammate@mozilla.com
+
+      ./bqetl --target dev target share --table tbl1 --table tbl2 --email teammate@mozilla.com
+
+      ./bqetl --target dev target share --dataset telemetry_derived --table clients_daily_v6 --email teammate@mozilla.com
+
+      ./bqetl --target dev target share --dry-run --email teammate@mozilla.com
+    """)
+@click.option("--email", required=True, help="Email address of the user to share with.")
+@click.option(
+    "--role",
+    type=click.Choice(["READER", "WRITER", "OWNER"], case_sensitive=False),
+    default="READER",
+    help="Access role to grant (default: READER).",
+)
+@click.option(
+    "--branch", default=None, help="Share only datasets for a specific branch."
+)
+@click.option(
+    "--dataset",
+    "dataset_filters",
+    multiple=True,
+    help="Narrow to datasets whose name contains this string (repeatable).",
+)
+@click.option(
+    "--table",
+    "table_names",
+    multiple=True,
+    help="Share specific tables within matched datasets (repeatable).",
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    "--dry_run/--no_dry_run",
+    default=False,
+    help="Show what would be shared without actually sharing.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip confirmation prompt.",
+)
+@sql_dir_option
+@block_coding_agents
+@click.pass_context
+def share(
+    ctx, email, role, branch, dataset_filters, table_names, dry_run, yes, sql_dir
+):
+    """Share target artifacts with a teammate."""
+    target_config = ctx.obj["target"]
+    project_id = target_config.project_id
+    client = bigquery.Client(project=project_id)
+
+    matching = _find_matching_datasets(client, target_config, branch)
+    if not matching:
+        return
+
+    if dataset_filters:
+        matching = [
+            ds for ds in matching if any(f in ds.dataset_id for f in dataset_filters)
+        ]
+        if not matching:
+            click.echo("No datasets match the given --dataset filter(s).")
+            return
+
+    if table_names:
+        tables_by_ds = _find_matching_tables(
+            client, project_id, matching, names=table_names
+        )
+        if not tables_by_ds:
+            click.echo("No matching tables found in target datasets.")
+            return
+
+        total = sum(len(tbls) for tbls in tables_by_ds.values())
+        click.echo(f"\nWill grant {role} to {email} on {total} table(s):\n")
+        for ds_id in sorted(tables_by_ds):
+            click.echo(f"  {ds_id}:")
+            for tbl in sorted(tables_by_ds[ds_id], key=lambda t: t.table_id):
+                click.echo(f"    {tbl.table_id}")
+        click.echo()
+
+        if not _confirm(total, "table(s)", dry_run, yes, verb="share"):
+            return
+
+        updated = 0
+        for ds_id, tables in tables_by_ds.items():
+            for tbl in tables:
+                try:
+                    if _grant_table_access(client, tbl.reference, email, role):
+                        click.echo(
+                            f"  {ds_id}.{tbl.table_id}: granted {role} to {email}"
+                        )
+                        updated += 1
+                    else:
+                        click.echo(
+                            f"  {ds_id}.{tbl.table_id}: {email} already has {role}"
+                        )
+                except Exception as e:
+                    click.echo(f"  {ds_id}.{tbl.table_id}: failed - {e}", err=True)
+                _persist_share(sql_dir, project_id, ds_id, tbl.table_id, email, role)
+        click.echo(f"\nUpdated {updated}/{total} table(s).")
+    else:
+        click.echo(f"\nWill grant {role} to {email} on {len(matching)} dataset(s):\n")
+        for ds in sorted(matching, key=lambda d: d.dataset_id):
+            click.echo(f"  {ds.dataset_id}")
+        click.echo()
+
+        if not _confirm(len(matching), "dataset(s)", dry_run, yes, verb="share"):
+            return
+
+        _share_datasets(client, matching, email, role)
+
+
+def _grant_dataset_access(client, dataset_ref, email, role):
+    """Grant dataset-level access. Returns True if updated, False if already granted.
+
+    Raises NotFound if dataset doesn't exist.
+    """
+    dataset = client.get_dataset(dataset_ref)
+    entries = list(dataset.access_entries)
+
+    if any(e.entity_id == email and e.role == role for e in entries):
+        return False
+
+    entries.append(
+        bigquery.AccessEntry(role=role, entity_type="userByEmail", entity_id=email)
+    )
+    dataset.access_entries = entries
+    client.update_dataset(dataset, ["access_entries"])
+    return True
+
+
+def _grant_table_access(client, table_ref, email, role):
+    """Grant table-level IAM access. Returns True if updated, False if already granted.
+
+    Raises NotFound if table doesn't exist.
+    """
+    table = client.get_table(table_ref)
+    iam_role = IAM_ROLE_MAP[role]
+    member = f"user:{email}"
+
+    policy = client.get_iam_policy(table)
+    if any(
+        b["role"] == iam_role and member in b.get("members", set())
+        for b in policy.bindings
+    ):
+        return False
+
+    policy.bindings.append({"role": iam_role, "members": {member}})
+    client.set_iam_policy(table, policy)
+    return True
+
+
+def _share_datasets(client, datasets, email, role):
+    """Grant dataset-level access to multiple datasets."""
+    updated = 0
+    for ds in sorted(datasets, key=lambda d: d.dataset_id):
+        if _grant_dataset_access(client, ds.reference, email, role):
+            click.echo(f"  {ds.dataset_id}: granted {role} to {email}")
+            updated += 1
+        else:
+            click.echo(f"  {ds.dataset_id}: {email} already has {role}")
+
+    click.echo(f"\nUpdated {updated}/{len(datasets)} dataset(s).")
+
+
+def _persist_share(sql_dir, project_id, dataset_id, table_id, email, role):
+    """Persist table sharing to manifest so it survives re-deploys."""
+    manifest_path = (
+        Path(sql_dir) / project_id / dataset_id / table_id / MANIFEST_FILENAME
+    )
+    if not manifest_path.exists():
+        return
+    manifest = yaml.safe_load(manifest_path.read_text()) or {}
+    shared_with = manifest.get("shared_with", [])
+    if not any(s["email"] == email and s["role"] == role for s in shared_with):
+        shared_with.append({"email": email, "role": role})
+        manifest["shared_with"] = shared_with
+        manifest_path.write_text(yaml.dump(manifest))
+
+
+def _find_matching_tables(
+    client, project_id, datasets, artifact_re=None, cutoff=None, names=None
+):
     """Find tables within datasets that match the given filters.
 
     Returns a dict of dataset_id -> list of table references.
     """
+    name_set = set(names) if names else None
     result = {}
     for ds in datasets:
         try:
@@ -194,6 +418,8 @@ def _find_matching_tables(client, project_id, datasets, artifact_re, cutoff):
             continue
         matched = []
         for tbl in tables:
+            if name_set and not any(n in tbl.table_id for n in name_set):
+                continue
             if artifact_re and not artifact_re.match(tbl.table_id):
                 continue
             if cutoff:
@@ -266,12 +492,12 @@ def _delete_datasets(client, project_id, datasets, sql_dir):
     return deleted
 
 
-def _confirm(count, label, dry_run, yes):
+def _confirm(count, label, dry_run, yes, verb="delete"):
     """Prompt for confirmation. Returns True to proceed."""
     if dry_run:
-        click.echo(f"Dry run: no {label} were deleted.")
+        click.echo(f"Dry run: would {verb} {count} {label}.")
         return False
-    if not yes and not click.confirm(f"Delete {count} {label}?"):
+    if not yes and not click.confirm(f"{verb.title()} {count} {label}?"):
         click.echo("Aborted.")
         return False
     return True

--- a/bigquery_etl/cli/target.py
+++ b/bigquery_etl/cli/target.py
@@ -45,12 +45,11 @@ def _find_matching_datasets(client, target_config, branch=None):
 
 def _parse_duration(value: str) -> timedelta:
     """Parse a duration string like '7d', '24h', '2w', '30m' into a timedelta."""
-    result = format_timedelta(value)
-    if not isinstance(result, timedelta):
+    if not value or not re.fullmatch(r"(\d+[wdhm])+", value):
         raise click.BadParameter(
             f"Invalid duration '{value}'. Use format like '7d', '24h', '2w', '30m'."
         )
-    return result
+    return format_timedelta(value)
 
 
 @click.group(help="Commands for managing target environments.")
@@ -146,7 +145,6 @@ def clean(ctx, older_than, branch, all_deployments, dry_run, yes, sql_dir):
     if not matching:
         return
 
-    # build table-level filters
     cutoff = (
         datetime.now(timezone.utc) - _parse_duration(older_than) if older_than else None
     )
@@ -212,9 +210,13 @@ def clean(ctx, older_than, branch, all_deployments, dry_run, yes, sql_dir):
     repeated. They can also be combined: --dataset narrows datasets, --table
     selects tables within those datasets.
 
+    --email can be repeated to grant access to multiple users in one command.
+
     Examples:
 
       ./bqetl --target dev target share --email teammate@mozilla.com
+
+      ./bqetl --target dev target share --email a@mozilla.com --email b@mozilla.com
 
       ./bqetl --target dev target share --email teammate@mozilla.com --role WRITER
 
@@ -228,7 +230,13 @@ def clean(ctx, older_than, branch, all_deployments, dry_run, yes, sql_dir):
 
       ./bqetl --target dev target share --dry-run --email teammate@mozilla.com
     """)
-@click.option("--email", required=True, help="Email address of the user to share with.")
+@click.option(
+    "--email",
+    "emails",
+    required=True,
+    multiple=True,
+    help="Email address of the user to share with (repeatable).",
+)
 @click.option(
     "--role",
     type=click.Choice(["READER", "WRITER", "OWNER"], case_sensitive=False),
@@ -267,7 +275,7 @@ def clean(ctx, older_than, branch, all_deployments, dry_run, yes, sql_dir):
 @block_coding_agents
 @click.pass_context
 def share(
-    ctx, email, role, branch, dataset_filters, table_names, dry_run, yes, sql_dir
+    ctx, emails, role, branch, dataset_filters, table_names, dry_run, yes, sql_dir
 ):
     """Share target artifacts with a teammate."""
     target_config = ctx.obj["target"]
@@ -286,6 +294,8 @@ def share(
             click.echo("No datasets match the given --dataset filter(s).")
             return
 
+    emails_str = ", ".join(emails)
+
     if table_names:
         tables_by_ds = _find_matching_tables(
             client, project_id, matching, names=table_names
@@ -295,7 +305,7 @@ def share(
             return
 
         total = sum(len(tbls) for tbls in tables_by_ds.values())
-        click.echo(f"\nWill grant {role} to {email} on {total} table(s):\n")
+        click.echo(f"\nWill grant {role} to {emails_str} on {total} table(s):\n")
         for ds_id in sorted(tables_by_ds):
             click.echo(f"  {ds_id}:")
             for tbl in sorted(tables_by_ds[ds_id], key=lambda t: t.table_id):
@@ -306,24 +316,33 @@ def share(
             return
 
         updated = 0
+        total_grants = total * len(emails)
         for ds_id, tables in tables_by_ds.items():
             for tbl in tables:
-                try:
-                    if _grant_table_access(client, tbl.reference, email, role):
+                for email in emails:
+                    try:
+                        if _grant_table_access(client, tbl.reference, email, role):
+                            click.echo(
+                                f"  {ds_id}.{tbl.table_id}: granted {role} to {email}"
+                            )
+                            updated += 1
+                        else:
+                            click.echo(
+                                f"  {ds_id}.{tbl.table_id}: {email} already has {role}"
+                            )
+                    except Exception as e:
                         click.echo(
-                            f"  {ds_id}.{tbl.table_id}: granted {role} to {email}"
+                            f"  {ds_id}.{tbl.table_id}: failed for {email} - {e}",
+                            err=True,
                         )
-                        updated += 1
-                    else:
-                        click.echo(
-                            f"  {ds_id}.{tbl.table_id}: {email} already has {role}"
-                        )
-                except Exception as e:
-                    click.echo(f"  {ds_id}.{tbl.table_id}: failed - {e}", err=True)
-                _persist_share(sql_dir, project_id, ds_id, tbl.table_id, email, role)
-        click.echo(f"\nUpdated {updated}/{total} table(s).")
+                    _persist_share(
+                        sql_dir, project_id, ds_id, tbl.table_id, email, role
+                    )
+        click.echo(f"\nUpdated {updated}/{total_grants} grant(s).")
     else:
-        click.echo(f"\nWill grant {role} to {email} on {len(matching)} dataset(s):\n")
+        click.echo(
+            f"\nWill grant {role} to {emails_str} on {len(matching)} dataset(s):\n"
+        )
         for ds in sorted(matching, key=lambda d: d.dataset_id):
             click.echo(f"  {ds.dataset_id}")
         click.echo()
@@ -331,7 +350,7 @@ def share(
         if not _confirm(len(matching), "dataset(s)", dry_run, yes, verb="share"):
             return
 
-        _share_datasets(client, matching, email, role)
+        _share_datasets(client, matching, emails, role)
 
 
 def _grant_dataset_access(client, dataset_ref, email, role):
@@ -374,17 +393,19 @@ def _grant_table_access(client, table_ref, email, role):
     return True
 
 
-def _share_datasets(client, datasets, email, role):
-    """Grant dataset-level access to multiple datasets."""
+def _share_datasets(client, datasets, emails, role):
+    """Grant dataset-level access to multiple datasets for multiple users."""
     updated = 0
+    total_grants = len(datasets) * len(emails)
     for ds in sorted(datasets, key=lambda d: d.dataset_id):
-        if _grant_dataset_access(client, ds.reference, email, role):
-            click.echo(f"  {ds.dataset_id}: granted {role} to {email}")
-            updated += 1
-        else:
-            click.echo(f"  {ds.dataset_id}: {email} already has {role}")
+        for email in emails:
+            if _grant_dataset_access(client, ds.reference, email, role):
+                click.echo(f"  {ds.dataset_id}: granted {role} to {email}")
+                updated += 1
+            else:
+                click.echo(f"  {ds.dataset_id}: {email} already has {role}")
 
-    click.echo(f"\nUpdated {updated}/{len(datasets)} dataset(s).")
+    click.echo(f"\nUpdated {updated}/{total_grants} grant(s).")
 
 
 def _persist_share(sql_dir, project_id, dataset_id, table_id, email, role):

--- a/bigquery_etl/cli/target.py
+++ b/bigquery_etl/cli/target.py
@@ -44,8 +44,8 @@ def _find_matching_datasets(client, target_config, branch=None):
 
 
 def _parse_duration(value: str) -> timedelta:
-    """Parse a duration string like '7d', '24h', '2w', '30m' into a timedelta."""
-    if not value or not re.fullmatch(r"(\d+[wdhm])+", value):
+    """Parse a duration string like '7d', '24h', '2w', '30m', '30s' into a timedelta."""
+    if not value or not re.fullmatch(r"(\d+[wdhms])+", value):
         raise click.BadParameter(
             f"Invalid duration '{value}'. Use format like '7d', '24h', '2w', '30m'."
         )

--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -557,12 +557,20 @@ def prepare_target_directory(
             if item.is_file():
                 shutil.copy2(item, target_dir / item.name)
 
+        # Preserve non-source keys (e.g. shared_with from `target share`) so
+        # _reapply_shared_access can re-apply them after re-deploy.
+        manifest_path = target_dir / MANIFEST_FILENAME
+        existing = {}
+        if manifest_path.exists():
+            existing = yaml.safe_load(manifest_path.read_text()) or {}
+
         manifest = {
+            **existing,
             "source_project": source_project,
             "source_dataset": source_dataset,
             "source_table": source_table,
         }
-        (target_dir / MANIFEST_FILENAME).write_text(yaml.dump(manifest))
+        manifest_path.write_text(yaml.dump(manifest))
 
         if copied_target_dirs is not None:
             copied_target_dirs.add(target_dir)

--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -642,6 +642,47 @@ def ensure_dataset_exists(client: bigquery.Client, dataset_ref: str) -> bool:
         return False
 
 
+IAM_ROLE_MAP = {
+    "READER": "roles/bigquery.dataViewer",
+    "WRITER": "roles/bigquery.dataEditor",
+    "OWNER": "roles/bigquery.dataOwner",
+}
+
+
+def _reapply_shared_access(client: bigquery.Client, table_ref: str, query_file: Path):
+    """Re-apply table-level sharing from the manifest after deploy."""
+    manifest_path = query_file.parent / MANIFEST_FILENAME
+    if not manifest_path.exists():
+        return
+
+    manifest = yaml.safe_load(manifest_path.read_text()) or {}
+    shared_with = manifest.get("shared_with", [])
+    if not shared_with:
+        return
+
+    try:
+        table = client.get_table(table_ref)
+        policy = client.get_iam_policy(table)
+
+        for entry in shared_with:
+            iam_role = IAM_ROLE_MAP.get(entry["role"])
+            if not iam_role:
+                continue
+            member = f"user:{entry['email']}"
+
+            already = any(
+                b["role"] == iam_role and member in b.get("members", set())
+                for b in policy.bindings
+            )
+            if not already:
+                policy.bindings.append({"role": iam_role, "members": {member}})
+
+        client.set_iam_policy(table, policy)
+        click.echo(f"  Re-applied sharing for {len(shared_with)} user(s)")
+    except Exception as e:
+        logging.warning(f"Could not re-apply sharing: {e}")
+
+
 def auto_deploy_if_needed(
     query_file: Path,
     target_project: str,
@@ -661,6 +702,9 @@ def auto_deploy_if_needed(
         click.echo(f"✅ Deployed: {table_ref}")
     except Exception as e:
         click.echo(f"⚠️  Deployment failed: {e}")
+        return
+
+    _reapply_shared_access(client, table_ref, query_file)
 
 
 def prepare_target_files(

--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -560,7 +560,7 @@ def prepare_target_directory(
         # Preserve non-source keys (e.g. shared_with from `target share`) so
         # _reapply_shared_access can re-apply them after re-deploy.
         manifest_path = target_dir / MANIFEST_FILENAME
-        existing = {}
+        existing: dict = {}
         if manifest_path.exists():
             existing = yaml.safe_load(manifest_path.read_text()) or {}
 

--- a/docs/cookbooks/development_workflows.md
+++ b/docs/cookbooks/development_workflows.md
@@ -91,7 +91,7 @@ With `--defer-to-target`:
 
 Without `--defer-to-target` (default): no rewrites — all references stay pointed at prod.
 
-### 3. Deploy artifacts without running _(future)_
+### 3. Deploy artifacts without running
 
 ```bash
 # Deploy table schema only (no data)
@@ -102,7 +102,14 @@ Without `--defer-to-target` (default): no rewrites — all references stay point
 
 # Deploy a UDF
 ./bqetl --target dev deploy --routines udf.normalize_metadata
+
+# Deploy tables and views together, rewriting references to target
+./bqetl --target dev deploy --tables --views --defer-to-target \
+  telemetry_derived.clients_daily_v6
 ```
+
+Supports `--defer-to-target` (same as `query run`) and `--dry-run` to preview
+without making changes.
 
 ### 4. Backfill testing  _(future)_
 
@@ -113,13 +120,42 @@ Without `--defer-to-target` (default): no rewrites — all references stay point
   telemetry_derived.clients_daily_v6
 ```
 
-### 5. Share with teammates _(future)_
+### 5. Share with teammates
 
 ```bash
-./bqetl --target dev share telemetry_derived.clients_daily_v6 \
-  --email teammate@mozilla.com \
-  --role READER
+# Grant read access to all datasets for the current branch
+./bqetl --target dev target share --email teammate@mozilla.com
+
+# Grant write access
+./bqetl --target dev target share --email teammate@mozilla.com --role WRITER
+
+# Share only datasets for a specific branch
+./bqetl --target dev target share --branch feature-xyz --email teammate@mozilla.com
+
+# Narrow to datasets containing "telemetry_derived"
+./bqetl --target dev target share --dataset telemetry_derived --email teammate@mozilla.com
+
+# Share specific tables within matched datasets
+./bqetl --target dev target share --table tbl1 --table tbl2 --email teammate@mozilla.com
+
+# Combine: specific table within specific dataset
+./bqetl --target dev target share --dataset telemetry_derived --table clients_daily_v6 --email teammate@mozilla.com
+
+# Preview without sharing
+./bqetl --target dev target share --dry-run --email teammate@mozilla.com
 ```
+
+Datasets are discovered automatically from the target's naming pattern in
+`bqetl_targets.yaml` (same as `target clean`). Use `--branch` to narrow by branch,
+`--dataset` to filter by dataset name substring. Both are repeatable.
+
+Without `--table`, grants dataset-level access to matched datasets.
+With `--table`, grants table-level IAM access to specific tables within matched
+datasets (repeatable). `--dataset` and `--table` can be combined.
+Table-level sharing is persisted in the local manifest so it is re-applied
+automatically on re-deploy.
+
+Supports `READER` (default), `WRITER`, and `OWNER` roles.
 
 ### 6. Clean up dev deployments
 

--- a/tests/cli/test_cli_target.py
+++ b/tests/cli/test_cli_target.py
@@ -21,9 +21,15 @@ class TestParseDuration:
     def test_minutes(self):
         assert _parse_duration("30m") == timedelta(minutes=30)
 
+    def test_seconds(self):
+        assert _parse_duration("30s") == timedelta(seconds=30)
+
+    def test_compound(self):
+        assert _parse_duration("1d12h") == timedelta(days=1, hours=12)
+
     def test_invalid_unit(self):
         with pytest.raises(click.BadParameter):
-            _parse_duration("7s")
+            _parse_duration("7y")
 
     def test_invalid_format(self):
         with pytest.raises(click.BadParameter):

--- a/tests/cli/test_cli_target.py
+++ b/tests/cli/test_cli_target.py
@@ -4,7 +4,7 @@ import click
 import pytest
 import yaml
 
-from bigquery_etl.cli.target import _confirm, _parse_duration, _persist_share
+from bigquery_etl.cli.target import _parse_duration, _persist_share
 from bigquery_etl.util.target import MANIFEST_FILENAME
 
 

--- a/tests/cli/test_cli_target.py
+++ b/tests/cli/test_cli_target.py
@@ -2,8 +2,10 @@ from datetime import timedelta
 
 import click
 import pytest
+import yaml
 
-from bigquery_etl.cli.target import _parse_duration
+from bigquery_etl.cli.target import _confirm, _parse_duration, _persist_share
+from bigquery_etl.util.target import MANIFEST_FILENAME
 
 
 class TestParseDuration:
@@ -19,12 +21,58 @@ class TestParseDuration:
     def test_minutes(self):
         assert _parse_duration("30m") == timedelta(minutes=30)
 
-    def test_seconds(self):
-        assert _parse_duration("30s") == timedelta(seconds=30)
-
-    def test_compound(self):
-        assert _parse_duration("1d12h") == timedelta(days=1, hours=12)
+    def test_invalid_unit(self):
+        with pytest.raises(click.BadParameter):
+            _parse_duration("7s")
 
     def test_invalid_format(self):
         with pytest.raises(click.BadParameter):
             _parse_duration("abc")
+
+    def test_empty_string(self):
+        with pytest.raises(click.BadParameter):
+            _parse_duration("")
+
+
+class TestPersistShare:
+    def test_writes_new_entry(self, tmp_path):
+        table_dir = tmp_path / "proj" / "ds" / "tbl"
+        table_dir.mkdir(parents=True)
+        manifest_path = table_dir / MANIFEST_FILENAME
+        manifest_path.write_text(yaml.dump({"source": "test"}))
+
+        _persist_share(tmp_path, "proj", "ds", "tbl", "a@b.com", "READER")
+
+        manifest = yaml.safe_load(manifest_path.read_text())
+        assert manifest["shared_with"] == [{"email": "a@b.com", "role": "READER"}]
+        assert manifest["source"] == "test"
+
+    def test_deduplicates(self, tmp_path):
+        table_dir = tmp_path / "proj" / "ds" / "tbl"
+        table_dir.mkdir(parents=True)
+        manifest_path = table_dir / MANIFEST_FILENAME
+        manifest_path.write_text(
+            yaml.dump({"shared_with": [{"email": "a@b.com", "role": "READER"}]})
+        )
+
+        _persist_share(tmp_path, "proj", "ds", "tbl", "a@b.com", "READER")
+
+        manifest = yaml.safe_load(manifest_path.read_text())
+        assert len(manifest["shared_with"]) == 1
+
+    def test_allows_different_roles(self, tmp_path):
+        table_dir = tmp_path / "proj" / "ds" / "tbl"
+        table_dir.mkdir(parents=True)
+        manifest_path = table_dir / MANIFEST_FILENAME
+        manifest_path.write_text(
+            yaml.dump({"shared_with": [{"email": "a@b.com", "role": "READER"}]})
+        )
+
+        _persist_share(tmp_path, "proj", "ds", "tbl", "a@b.com", "WRITER")
+
+        manifest = yaml.safe_load(manifest_path.read_text())
+        assert len(manifest["shared_with"]) == 2
+
+    def test_no_manifest_is_noop(self, tmp_path):
+        _persist_share(tmp_path, "proj", "ds", "tbl", "a@b.com", "READER")
+        assert not (tmp_path / "proj" / "ds" / "tbl" / MANIFEST_FILENAME).exists()


### PR DESCRIPTION
## Description

Adds `bqetl target share` to grant access to dev-target datasets or tables to teammates using the same template-driven discovery as `target clean`.                                                                            
- Without `--table`: dataset-level access to matched datasets.
- With `--table`: table-level IAM access to specific tables.                                                                         
- `--email`, `--dataset`, `--table` are repeatable and composable.                                                                   
 - Roles: `READER` (default), `WRITER`, `OWNER`. Supports `--dry-run`.
                                                                                                                                       
Grants persist across re-deploys: Table-level shares are written to the local manifest and re-applied automatically after the table is re-deployed.                                                          
                                                                                                                                       
Usage examples:
                                                                                                                                       
```bash         
  # Share all dev datasets for the current branch
  ./bqetl --target dev target share --email teammate@mozilla.com
                                                                                                                                       
  # Narrow to a specific table, WRITER role
  ./bqetl --target dev target share \                                                                                                  
    --dataset telemetry_derived --table clients_daily_v6 \                                                                             
    --email teammate@mozilla.com --role WRITER
```
<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
