### PR TITLE
add option and unittest to allow using where instead of having for mi…

### DIFF
--- a/bigquery_etl/backfill/shredder_mitigation.py
+++ b/bigquery_etl/backfill/shredder_mitigation.py
@@ -15,7 +15,7 @@ import attrs
 import click
 from dateutil import parser
 from google.cloud import bigquery
-from google.cloud.exceptions import NotFound, BadRequest  # type: ignore
+from google.cloud.exceptions import BadRequest, NotFound  # type: ignore
 from jinja2 import Environment, FileSystemLoader
 
 from bigquery_etl.format_sql.formatter import reformat
@@ -530,9 +530,9 @@ def generate_query_with_shredder_mitigation(
 
     try:
         sample_rows = new.get_query_path_results(
-        backfill_date=backfill_date,
-        row_limit=1,
-        having_clause=f"HAVING {' IS NOT NULL AND '.join(new_group_by)} IS NOT NULL",
+            backfill_date=backfill_date,
+            row_limit=1,
+            having_clause=f"HAVING {' IS NOT NULL AND '.join(new_group_by)} IS NOT NULL",
         )
     except BadRequest:
         # For queries that don't have a GROUP BY at the end.

--- a/bigquery_etl/backfill/shredder_mitigation.py
+++ b/bigquery_etl/backfill/shredder_mitigation.py
@@ -15,7 +15,7 @@ import attrs
 import click
 from dateutil import parser
 from google.cloud import bigquery
-from google.cloud.exceptions import NotFound  # type: ignore
+from google.cloud.exceptions import NotFound, BadRequest  # type: ignore
 from jinja2 import Environment, FileSystemLoader
 
 from bigquery_etl.format_sql.formatter import reformat
@@ -528,11 +528,19 @@ def generate_query_with_shredder_mitigation(
         query_with_mitigation_path / dataset / destination_table / "schema.yaml"
     ).to_bigquery_schema()
 
-    sample_rows = new.get_query_path_results(
+    try:
+        sample_rows = new.get_query_path_results(
         backfill_date=backfill_date,
         row_limit=1,
         having_clause=f"HAVING {' IS NOT NULL AND '.join(new_group_by)} IS NOT NULL",
-    )
+        )
+    except BadRequest:
+        # For queries that don't have a GROUP BY at the end.
+        sample_rows = new.get_query_path_results(
+            backfill_date=backfill_date,
+            row_limit=1,
+            where_clause=f"WHERE {' IS NOT NULL AND '.join(new_group_by)} IS NOT NULL",
+        )
     if not sample_rows:
         sample_rows = new.get_query_path_results(
             backfill_date=backfill_date, row_limit=1

--- a/tests/backfill/test_shredder_mitigation.py
+++ b/tests/backfill/test_shredder_mitigation.py
@@ -3,6 +3,7 @@
 import os
 from datetime import date, datetime, time
 from pathlib import Path
+import re
 from unittest.mock import call, patch
 
 import click
@@ -1941,3 +1942,176 @@ class TestGenerateQueryWithShredderMitigation:
                     backfill_date=PREVIOUS_DATE,
                 )
                 assert result[0] == self.path
+
+    @patch("google.cloud.bigquery.Client")
+    @patch("bigquery_etl.backfill.shredder_mitigation.classify_columns")
+    def test_generate_query_when_last_select_is_not_grouped_by(
+        self, mock_classify_columns, mock_client, runner
+    ):
+        """Test that query is generated as expected given a set of mock dimensions and metrics."""
+
+        expected = (
+            Path("sql") / self.project_id / self.dataset / self.destination_table,
+            """-- Query generated using a template for shredder mitigation.
+                        WITH new_version AS (
+                            WITH upstream_1 AS(
+                              SELECT
+                                column_1,
+                                column_2,
+                                metric_1
+                              FROM
+                                upstream_1
+                              GROUP BY
+                                column_1,
+                                column_2
+                            )
+                            SELECT * FROM upstream_1
+                        ),
+                        new_agg AS (
+                          SELECT
+                            submission_date,
+                            IF(column_1 IS NULL OR column_1 = '??', '???????', column_1) AS column_1,
+                            SUM(metric_1) AS metric_1
+                          FROM
+                            new_version
+                          GROUP BY
+                            ALL
+                        ),
+                        previous_agg AS (
+                          SELECT
+                            submission_date,
+                            IF(column_1 IS NULL OR column_1 = '??', '???????', column_1) AS column_1,
+                            SUM(metric_1) AS metric_1
+                          FROM
+                            `moz-fx-data-shared-prod.test.test_query_v1`
+                          WHERE
+                            submission_date = @submission_date
+                          GROUP BY
+                            ALL
+                        ),
+                        shredded AS (
+                          SELECT
+                            previous_agg.submission_date,
+                            previous_agg.column_1,
+                            CAST(NULL AS STRING) AS column_2,
+                            COALESCE(previous_agg.metric_1, 0) - COALESCE(new_agg.metric_1, 0) AS metric_1
+                          FROM
+                            previous_agg
+                          LEFT JOIN
+                            new_agg
+                            ON previous_agg.submission_date = new_agg.submission_date
+                            AND previous_agg.column_1 = new_agg.column_1
+                          WHERE
+                            COALESCE(previous_agg.metric_1, 0) > COALESCE(new_agg.metric_1, 0)
+                        )
+                        SELECT
+                          IF(column_1 = '???????', CAST(NULL AS STRING), column_1) AS column_1,
+                          IF(column_2 = '???????', CAST(NULL AS STRING), column_2) AS column_2,
+                          metric_1
+                        FROM
+                          new_version
+                        UNION ALL
+                        SELECT
+                          IF(column_1 = '???????', CAST(NULL AS STRING), column_1) AS column_1,
+                          IF(column_2 = '???????', CAST(NULL AS STRING), column_2) AS column_2,
+                          metric_1
+                        FROM
+                          shredded""",
+        )
+
+        existing_schema = {
+            "fields": [
+                {"name": "column_1", "type": "DATE", "mode": "NULLABLE"},
+                {"name": "metric_1", "type": "INTEGER", "mode": "NULLABLE"},
+            ]
+        }
+        new_schema = {
+            "fields": [
+                {"name": "column_1", "type": "DATE", "mode": "NULLABLE"},
+                {"name": "column_2", "type": "STRING", "mode": "NULLABLE"},
+                {"name": "metric_1", "type": "INTEGER", "mode": "NULLABLE"},
+            ]
+        }
+
+        with runner.isolated_filesystem():
+            os.makedirs(self.path, exist_ok=True)
+            os.makedirs(self.path_previous, exist_ok=True)
+            with open(self.path / "query.sql", "w") as f:
+                f.write(
+                    "WITH upstream_1 AS ("
+                    " SELECT column_1, column_2, metric_1 FROM upstream_1"
+                    " GROUP BY column_1, column_2) SELECT * FROM upstream_1"
+                )
+            with open(self.path_previous / "query.sql", "w") as f:
+                f.write("WITH upstream_1 AS ("
+                        " SELECT column_1, metric_1 FROM upstream_1 GROUP BY column_1"
+                        ") SELECT * FROM upstream_1")
+
+            with open(self.path / "schema.yaml", "w") as f:
+                f.write(yaml.safe_dump(new_schema))
+
+            with open(self.path_previous / "schema.yaml", "w") as f:
+                f.write(yaml.safe_dump(existing_schema))
+
+            with open(Path(self.path) / "metadata.yaml", "w") as f:
+                f.write(
+                    "bigquery:\n  time_partitioning:\n    type: day\n    "
+                    "field: submission_date\n    require_partition_filter: true\n"
+                    "labels:\n    shredder_mitigation: true"
+                )
+            with open(Path(self.path_previous) / "metadata.yaml", "w") as f:
+                f.write(
+                    "bigquery:\n  time_partitioning:\n    type: day\n    "
+                    "field: submission_date\n    require_partition_filter: true\n"
+                    "labels:\n    shredder_mitigation: true"
+                )
+
+            mock_classify_columns.return_value = (
+                [
+                    Column(
+                        "column_1",
+                        DataTypeGroup.STRING,
+                        ColumnType.DIMENSION,
+                        ColumnStatus.COMMON,
+                    )
+                ],
+                [
+                    Column(
+                        "column_2",
+                        DataTypeGroup.STRING,
+                        ColumnType.DIMENSION,
+                        ColumnStatus.ADDED,
+                    )
+                ],
+                [],
+                [
+                    Column(
+                        "metric_1",
+                        DataTypeGroup.INTEGER,
+                        ColumnType.METRIC,
+                        ColumnStatus.COMMON,
+                    )
+                ],
+                [],
+            )
+
+            with patch.object(
+                Subset,
+                "get_query_path_results",
+                return_value=[{"column_1": "ABC", "column_2": "DEF", "metric_1": 10.0}],
+            ):
+                assert os.path.isfile(self.path / "query.sql")
+                assert os.path.isfile(self.path_previous / "query.sql")
+                result = generate_query_with_shredder_mitigation(
+                    client=mock_client,
+                    project_id=self.project_id,
+                    dataset=self.dataset,
+                    destination_table=self.destination_table,
+                    staging_table_name=self.staging_table_name,
+                    backfill_date=PREVIOUS_DATE,
+                )
+                assert result[0] == expected[0]
+                assert re.sub(r"\s+", "", result[1]) == re.sub(r"\s+", "", expected[1])
+                assert os.path.isfile(
+                    expected[0] / f"{SHREDDER_MITIGATION_QUERY_NAME}.sql"
+                )

--- a/tests/backfill/test_shredder_mitigation.py
+++ b/tests/backfill/test_shredder_mitigation.py
@@ -1,9 +1,9 @@
 """Test cases for shredder mitigation."""
 
 import os
+import re
 from datetime import date, datetime, time
 from pathlib import Path
-import re
 from unittest.mock import call, patch
 
 import click
@@ -2043,9 +2043,11 @@ class TestGenerateQueryWithShredderMitigation:
                     " GROUP BY column_1, column_2) SELECT * FROM upstream_1"
                 )
             with open(self.path_previous / "query.sql", "w") as f:
-                f.write("WITH upstream_1 AS ("
-                        " SELECT column_1, metric_1 FROM upstream_1 GROUP BY column_1"
-                        ") SELECT * FROM upstream_1")
+                f.write(
+                    "WITH upstream_1 AS ("
+                    " SELECT column_1, metric_1 FROM upstream_1 GROUP BY column_1"
+                    ") SELECT * FROM upstream_1"
+                )
 
             with open(self.path / "schema.yaml", "w") as f:
                 f.write(yaml.safe_dump(new_schema))


### PR DESCRIPTION
The [PR-9191](https://github.com/mozilla/bigquery-etl/pull/9191) attempts a backlfill with shredder mitigation for a query that does not have a GROUP BY in the outter query. While shredder mitigation can find the required group by in the inner queries for the mitigation, an exception is raised for the piece in the code that retrieves a sample row in line 534.

`Errors: 400 The HAVING clause requires GROUP BY or aggregation to be present at [349:16]; reason: invalidQuery, location: query, message: The HAVING clause requires GROUP BY or aggregation   │
│ to be present at [349:16]`

cc / @kbammarito 

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
