### PR TITLE
fix(site_engagement_events_v1): corrected product download events

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/site_engagement_events_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/site_engagement_events_v1/query.sql
@@ -80,11 +80,7 @@ WITH all_events AS (
 )
 SELECT
   event_date,
-  CASE
-    WHEN ENDS_WITH(event_name, '_download')
-      THEN 'product_download'
-    ELSE event_name
-  END AS event_name,
+  event_name,
   event_timestamp,
   ga_client_id,
   ga_session_id,


### PR DESCRIPTION
## Description
Updated logic for product_download event to differentiate between different event types. 

## Related Tickets & Documents
* WT-1033

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
