### PR TITLE
fix(bqetl_search_terms_daily): AD-1342 reverting amp search term reporting tasks back to original schedule

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -709,12 +709,7 @@ bqetl_search_terms_daily:
     and can impact reporting to partners. If this task errors out, it could
     indicate trouble with an upstream task that runs in a restricted project
     outside of Airflow.
-
-    Tables that depend on merino_log_sanitized_v3 use date_partition_offset: -1 to
-    process data from 2 days ago, allowing time for the upstream Merino sanitization
-    job (~16 hours) to complete. This is a temporary measure until the sanitization
-    job is further optimized.
-  schedule_interval: 0 3 * * *
+  schedule_interval: 0 6 * * *
   tags:
     - impact/tier_1
 

--- a/dags.yaml
+++ b/dags.yaml
@@ -709,7 +709,7 @@ bqetl_search_terms_daily:
     and can impact reporting to partners. If this task errors out, it could
     indicate trouble with an upstream task that runs in a restricted project
     outside of Airflow.
-  schedule_interval: 0 6 * * *
+  schedule_interval: 0 7 * * *
   tags:
     - impact/tier_1
 

--- a/dags.yaml
+++ b/dags.yaml
@@ -709,7 +709,7 @@ bqetl_search_terms_daily:
     and can impact reporting to partners. If this task errors out, it could
     indicate trouble with an upstream task that runs in a restricted project
     outside of Airflow.
-  schedule_interval: 0 7 * * *
+  schedule_interval: 0 8 * * *
   tags:
     - impact/tier_1
 

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_qa_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_qa_v1/metadata.yaml
@@ -1,18 +1,13 @@
 friendly_name: Adm Daily Aggregates QA
 description: |-
   This is a table that is used to alert if there are less than 100 rows produced on a given date
-
-  Note: This table processes data from 2 days ago, matching the offset of the upstream
-  adm_daily_aggregates_v1 table it validates.
-  This is a temporary measure until the Merino sanitization job is further optimized.
 owners:
-- kwindau@mozilla.com
+- cklein@mozilla.com
 labels:
   incremental: true
-  owner1: kwindau
+  owner1: cklein
 scheduling:
   dag_name: bqetl_search_terms_daily
-  date_partition_offset: -1
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_aggregates_v1/metadata.yaml
@@ -6,9 +6,6 @@ description: |-
 
   The sending to adMarketplace takes place in a separate DAG defined in
   the telemetry-airflow repository directly.
-
-  Note: This table processes data from 2 days ago,ensuring complete upstream data from the Merino sanitization job (~16 hours).
-  This is a temporary measure until the sanitization job is further optimized.
 owners:
   - ctroy@mozilla.com
 workgroup_access:
@@ -23,4 +20,3 @@ bigquery:
 scheduling:
   dag_name: bqetl_search_terms_daily
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
-  date_partition_offset: -1

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_dma_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/adm_daily_dma_aggregates_v1/metadata.yaml
@@ -6,10 +6,6 @@ description: |-
 
   The sending to adMarketplace takes place in a separate DAG defined in
   the telemetry-airflow repository directly.
-
-  Note: This table processes data from 2 days ago, ensuring complete upstream data
-  from the Merino sanitization job (~16 hours).
-  This is a temporary measure until the sanitization job is further optimized.
 owners:
   - llisi@mozilla.com
 workgroup_access:
@@ -24,4 +20,3 @@ bigquery:
 scheduling:
   dag_name: bqetl_search_terms_daily
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
-  date_partition_offset: -1

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/metadata.yaml
@@ -1,10 +1,6 @@
 friendly_name: Search Terms Daily
 description: |-
   Daily count of terminal search terms collected by Merino.
-
-  Note: This table processes data from 2 days ago, allowing time for the
-  upstream Merino sanitization job (~16 hours) to complete.
-  This is a temporary measure until the sanitization job is further optimized.
 owners:
   - ctroy@mozilla.com
   - rburwei@mozilla.com
@@ -23,4 +19,3 @@ bigquery:
 scheduling:
   dag_name: bqetl_search_terms_daily
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
-  date_partition_offset: -1

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/checks.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/checks.sql
@@ -2,7 +2,9 @@
 SELECT
   IF(
     COUNT(*) = 0,
-    ERROR("Merino sanitization job has not completed successfully for today. Will retry."),
+    ERROR(
+      "Merino sanitization job has not completed successfully for today. Wait for sanitization job to complete and re-run parent task."
+    ),
     NULL
   )
 FROM

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/checks.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/checks.sql
@@ -1,0 +1,12 @@
+#fail
+SELECT
+  IF(
+    COUNT(*) = 0,
+    ERROR("Merino sanitization job has not completed successfully for today. Will retry."),
+    NULL
+  )
+FROM
+  `moz-fx-data-shared-prod.search_terms_derived.sanitization_job_metadata_v2`
+WHERE
+  DATE(started_at) = CURRENT_DATE()
+  AND status = 'SUCCESS';

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/metadata.yaml
@@ -14,10 +14,6 @@ description: |-
   This table allows removal of PII and slightly longer retention than
   the underlying ping table.
 
-  Note: This table processes data from 2 days ago,allowing time for the
-  upstream Merino sanitization job (~16 hours) to complete.
-  This is a temporary measure until the sanitization job is further optimized.
-
 bigquery:
   time_partitioning:
     type: day
@@ -28,7 +24,6 @@ bigquery:
 scheduling:
   dag_name: bqetl_search_terms_daily
   arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
-  date_partition_offset: -1
 
 workgroup_access:
   - role: roles/bigquery.dataViewer


### PR DESCRIPTION
## Description
This PR 
- reverts the schedule back to what it was previously. See related PR for more details:
  - https://github.com/mozilla/bigquery-etl/pull/8759
- replaces kwindau as owner
- updates DAG schedule to run 4 hours later in anticipation of another volume increase

Note: We should look into getting  
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* [AD-1342](https://mozilla-hub.atlassian.net/browse/AD-1342)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[AD-1342]: https://mozilla-hub.atlassian.net/browse/AD-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ