### PR TITLE
feat(DENG-): update attribution_clients.query.sql template to include the new play_store_attribution ping

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/mobile_kpi_support_metrics.py
+++ b/sql_generators/mobile_kpi_support_metrics/mobile_kpi_support_metrics.py
@@ -44,9 +44,10 @@ BIGEYE_NOTIFICATION_SLACK_CHANNEL = "#de-bigeye-triage"
 class AttributionPings(Enum):
     """An enumerator containing a list of pings that could be the source of attribution information."""
 
-    metrics: str = "metrics"
-    first_session: str = "first_session"
-    baseline: str = "baseline"
+    metrics = "metrics"
+    first_session = "first_session"
+    baseline = "baseline"
+    play_store_attribution = "play_store_attribution"
 
 
 @dataclass
@@ -106,7 +107,10 @@ class AttributionFields:
     )
     play_store = AttributionFieldGroup(
         name="play_store",
-        source_pings=[AttributionPings.first_session],
+        source_pings=[
+            AttributionPings.first_session,
+            AttributionPings.play_store_attribution,
+        ],
         fields=[
             {
                 "name": "play_store_attribution_campaign",
@@ -295,7 +299,7 @@ def generate_mobile_kpi_support_metrics(target_project: str, output_dir: click.P
     The parent folders will be created if not existing and existing files will be overwritten.
     """
     env = Environment(loader=FileSystemLoader(str(GENERATOR_ROOT / "templates")))
-    output_dir = Path(output_dir) / target_project
+    project_output_dir = Path(str(output_dir)) / target_project
 
     default_template_args = {
         "header": HEADER,
@@ -357,7 +361,7 @@ def generate_mobile_kpi_support_metrics(target_project: str, output_dir: click.P
             )
 
             write_sql(
-                output_dir=output_dir,
+                output_dir=project_output_dir,
                 full_table_id=full_table_id,
                 basename=f"{target_filename}.{target_extension}",
                 sql=rendered_sql,
@@ -386,7 +390,7 @@ def generate_mobile_kpi_support_metrics(target_project: str, output_dir: click.P
                 )
 
                 write_sql(
-                    output_dir=output_dir,
+                    output_dir=project_output_dir,
                     full_table_id=full_table_id,
                     basename=query_support_config,
                     sql=(
@@ -443,7 +447,7 @@ def generate_mobile_kpi_support_metrics(target_project: str, output_dir: click.P
         )
 
         write_sql(
-            output_dir=output_dir,
+            output_dir=project_output_dir,
             full_table_id=f"{target_project}.{target_dataset}.{union_target_name}",
             basename=f"{target_filename}.{target_extension}",
             sql=(reformat(union_sql_rendered)),

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.metadata.yaml
@@ -7,6 +7,8 @@ description: |-
 
   Notes:
   - 2025-05-14: `normalized_channel` field added (backfilled up until 2023-04-08, prior to this the value will always be `null`)
+  {%- if app_name == 'fenix' %}
+  - 2026-04-07: first-session ping no longer contains play store attribution, this now comes from play-store-attribution ping.{%- endif %}
 
 owners:
   - mozilla/kpi_table_reviewers

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.query.sql
@@ -191,6 +191,9 @@ SELECT
     `moz-fx-data-shared-prod.{{ dataset }}.play_store_attribution`
   WHERE
     DATE(submission_timestamp) = @submission_date
+    -- We stopped receiving play_store_attribution via the first-session ping on 2026-04-07 including this filter
+    -- to only start using the new ping starting one day prior to this to ensure consistency.
+    AND DATE(submission_timestamp) >= "2026-04-06"
     AND client_info.client_id IS NOT NULL
 ),
 play_store_attribution_ping AS (

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.query.sql
@@ -170,6 +170,68 @@ first_session_ping AS (
     normalized_channel
 )
 {% endif %}
+{% if 'play_store_attribution' in product_attribution_group_pings %}
+, play_store_attribution_ping_base AS (
+SELECT
+    client_info.client_id,
+    sample_id,
+    normalized_channel,
+    submission_timestamp,
+    ping_info.seq AS ping_seq,
+    {% for attribution_group in product_attribution_groups if attribution_group.name == 'play_store' %}
+    {% for field in attribution_group.fields if not field.name.endswith("_timestamp") %}
+      {% if field.name == 'play_store_attribution_install_referrer_response' %}
+      NULLIF(metrics.text2.{{ field.name }}, "") AS {{ field.name }},
+      {% else %}
+      NULLIF(metrics.string.{{ field.name }}, "") AS {{ field.name }},
+      {% endif %}
+    {% endfor %}
+    {% endfor %}
+  FROM
+    `moz-fx-data-shared-prod.{{ dataset }}.play_store_attribution`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND client_info.client_id IS NOT NULL
+),
+play_store_attribution_ping AS (
+  SELECT
+    client_id,
+    sample_id,
+    normalized_channel,
+    {% if 'play_store' in product_attribution_group_names %}
+    ARRAY_AGG(
+      IF(
+        {% for attribution_group in product_attribution_groups if attribution_group.name == 'play_store' %}
+        {% for field in attribution_group.fields if not field.name.endswith("_timestamp") %}
+          {% if not loop.first %}OR {% endif %}{{ field.name }} IS NOT NULL{% if loop.last %},{% endif %}
+        {% endfor %}
+        {% endfor %}
+        STRUCT(
+          {% for attribution_group in product_attribution_groups if attribution_group.name == 'play_store' %}
+          {% for field in attribution_group.fields %}
+            {% if field.name.endswith("_timestamp") %}
+              submission_timestamp AS {{ field.name }}
+            {% else %}
+              {{ field.name }}
+            {% endif %}
+            {% if not loop.last %},{% endif %}
+          {% endfor %}
+          {% endfor %}
+        ),
+        NULL
+      ) IGNORE NULLS
+      ORDER BY
+        ping_seq ASC, submission_timestamp ASC
+      LIMIT
+        1
+    )[SAFE_OFFSET(0)] AS play_store_info,
+    {% endif %}
+  FROM
+    play_store_attribution_ping_base
+  GROUP BY
+    ALL
+)
+{% endif %}
 {% if 'metrics' in product_attribution_group_pings %}
 , metrics_ping_base AS (
   SELECT
@@ -286,7 +348,7 @@ SELECT
   COALESCE(first_session_ping.adjust_info, metrics_ping.adjust_info) AS adjust_info,
   {% endif %}
   {% if 'play_store' in product_attribution_group_names %}
-  first_session_ping.play_store_info,
+  COALESCE(play_store_attribution_ping.play_store_info, first_session_ping.play_store_info) AS play_store_info,
   {% endif %}
   {% if 'meta' in product_attribution_group_names %}
   first_session_ping.meta_info,
@@ -299,6 +361,9 @@ SELECT
   {% endif %}
 FROM
   new_profiles
+{% if 'play_store_attribution' in product_attribution_group_pings %}LEFT JOIN
+  play_store_attribution_ping USING(client_id, sample_id, normalized_channel)
+{% endif %}
 {% if 'first_session' in product_attribution_group_pings %}LEFT JOIN
   first_session_ping USING(client_id, sample_id, normalized_channel)
 {% endif %}

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/metadata.yaml
@@ -7,6 +7,7 @@ description: |-
 
   Notes:
   - 2025-05-14: `normalized_channel` field added (backfilled up until 2023-04-08, prior to this the value will always be `null`)
+  - 2026-04-07: first-session ping no longer contains play store attribution, this now comes from play-store-attribution ping.
 
 owners:
   - mozilla/kpi_table_reviewers

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/query.sql
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/query.sql
@@ -119,6 +119,66 @@ first_session_ping AS (
     sample_id,
     normalized_channel
 ),
+play_store_attribution_ping_base AS (
+  SELECT
+    client_info.client_id,
+    sample_id,
+    normalized_channel,
+    submission_timestamp,
+    ping_info.seq AS ping_seq,
+    NULLIF(metrics.string.play_store_attribution_campaign, "") AS play_store_attribution_campaign,
+    NULLIF(metrics.string.play_store_attribution_medium, "") AS play_store_attribution_medium,
+    NULLIF(metrics.string.play_store_attribution_source, "") AS play_store_attribution_source,
+    NULLIF(metrics.string.play_store_attribution_content, "") AS play_store_attribution_content,
+    NULLIF(metrics.string.play_store_attribution_term, "") AS play_store_attribution_term,
+    NULLIF(
+      metrics.text2.play_store_attribution_install_referrer_response,
+      ""
+    ) AS play_store_attribution_install_referrer_response,
+  FROM
+    `moz-fx-data-shared-prod.fenix.play_store_attribution`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    -- We stopped receiving play_store_attribution via the first-session ping on 2026-04-07 including this filter
+    -- to only start using the new ping starting one day prior to this to ensure consistency.
+    AND DATE(submission_timestamp) >= "2026-04-06"
+    AND client_info.client_id IS NOT NULL
+),
+play_store_attribution_ping AS (
+  SELECT
+    client_id,
+    sample_id,
+    normalized_channel,
+    ARRAY_AGG(
+      IF(
+        play_store_attribution_campaign IS NOT NULL
+        OR play_store_attribution_medium IS NOT NULL
+        OR play_store_attribution_source IS NOT NULL
+        OR play_store_attribution_content IS NOT NULL
+        OR play_store_attribution_term IS NOT NULL
+        OR play_store_attribution_install_referrer_response IS NOT NULL,
+        STRUCT(
+          play_store_attribution_campaign,
+          play_store_attribution_medium,
+          play_store_attribution_source,
+          submission_timestamp AS play_store_attribution_timestamp,
+          play_store_attribution_content,
+          play_store_attribution_term,
+          play_store_attribution_install_referrer_response
+        ),
+        NULL
+      ) IGNORE NULLS
+      ORDER BY
+        ping_seq ASC,
+        submission_timestamp ASC
+      LIMIT
+        1
+    )[SAFE_OFFSET(0)] AS play_store_info,
+  FROM
+    play_store_attribution_ping_base
+  GROUP BY
+    ALL
+),
 metrics_ping_base AS (
   SELECT
     client_info.client_id AS client_id,
@@ -196,7 +256,10 @@ SELECT
   normalized_channel,
   COALESCE(new_profiles.install_source, metrics_ping.install_source) AS install_source,
   COALESCE(first_session_ping.adjust_info, metrics_ping.adjust_info) AS adjust_info,
-  first_session_ping.play_store_info,
+  COALESCE(
+    play_store_attribution_ping.play_store_info,
+    first_session_ping.play_store_info
+  ) AS play_store_info,
   first_session_ping.meta_info,
   COALESCE(
     first_session_ping.distribution_id,
@@ -205,6 +268,9 @@ SELECT
   ) AS distribution_id,
 FROM
   new_profiles
+LEFT JOIN
+  play_store_attribution_ping
+  USING (client_id, sample_id, normalized_channel)
 LEFT JOIN
   first_session_ping
   USING (client_id, sample_id, normalized_channel)


### PR DESCRIPTION
# feat: update attribution_clients.query.sql template to include the new play_store_attribution ping

## Description

play_store_attribution attribution is no longer send using first-session ping, instead now this information is shared using the new play-store-attribution ping. This change updated the attribution_clients query template to account for this. Once updated and deployed we should be able to re-run the pipeline for affected dates to ensure play store attribution information is correctly propagated.