### PR TITLE
Optimize Merino New Tab Interactions Query

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_to_gcs_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_to_gcs_v3/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   owner1: cbeck
 scheduling:
   dag_name: bqetl_merino_newtab_extract_to_gcs
+  priority: 2
   arguments:
   - --source-project=moz-fx-data-shared-prod
   - --source-dataset=telemetry_derived

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/metadata.yaml
@@ -13,5 +13,6 @@ bigquery:
 scheduling:
   dag_name: bqetl_merino_newtab_extract_to_gcs
   date_partition_parameter: null
+  priority: 2
   # This dag runs more frequently than upstream propensity table calculation
   referenced_tables: []

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
@@ -1,19 +1,4 @@
-WITH legacy_pings AS (
-  SELECT
-    submission_timestamp,
-    document_id,
-    events,
-    mozfun.newtab.surface_id_country(
-      metrics.string.newtab_content_surface_id,
-      metrics.string.newtab_locale,
-      normalized_country_code
-    ) AS normalized_country_code
-  FROM
-    `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
-  WHERE
-    submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
-),
-private_pings AS (
+WITH private_pings AS (
   SELECT
     submission_timestamp,
     document_id,
@@ -28,22 +13,11 @@ private_pings AS (
   WHERE
     submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
 ),
-combined_pings AS (
-  SELECT
-    *
-  FROM
-    legacy_pings
-  UNION ALL
-  SELECT
-    *
-  FROM
-    private_pings
-),
 deduplicated_pings AS (
   SELECT
     *
   FROM
-    combined_pings
+    private_pings
   QUALIFY
     ROW_NUMBER() OVER (
       PARTITION BY
@@ -95,21 +69,6 @@ raw_grouped_totals AS (
     format,
     section_position
 ),
-/* Find default propensity for long tail items. We only calculate up to 100 */
-default_propensity AS (
-  SELECT
-    COALESCE(
-      (
-        SELECT
-          AVG(wt.weight)
-        FROM
-          `moz-fx-data-shared-prod.telemetry_derived.newtab_merino_propensity_v1` wt
-        WHERE
-          position > 80
-      ),
-      1.0
-    ) AS default_weight
-),
 /* Separate and adjust section events */
 section_events AS (
   SELECT
@@ -118,17 +77,22 @@ section_events AS (
     rw.raw_impression_count,
     -- apply propensity scaling to impressions only
     rw.raw_impression_count / COALESCE(
-      wt.weight,
-      (SELECT default_weight FROM default_propensity LIMIT 1)
+      wt_exact.weight,
+      wt_any.weight,
+      1.0
     ) AS adjusted_impression_count,
     rw.report_count,
     rw.click_count
   FROM
     raw_grouped_totals rw
   LEFT JOIN
-    `moz-fx-data-shared-prod.telemetry_derived.newtab_merino_propensity_v1` wt
-    ON SAFE_CAST(wt.position AS INT64) = rw.position
-    AND wt.tile_format = rw.format
+    `moz-fx-data-shared-prod.telemetry_derived.newtab_merino_propensity_v1` wt_exact
+    ON SAFE_CAST(wt_exact.position AS INT64) = rw.position
+    AND wt_exact.tile_format = rw.format
+  LEFT JOIN
+    `moz-fx-data-shared-prod.telemetry_derived.newtab_merino_propensity_v1` wt_any
+    ON SAFE_CAST(wt_any.position AS INT64) = rw.position
+    AND wt_any.tile_format = 'any'
   WHERE
     rw.section_position IS NOT NULL
 ),

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_to_gcs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_to_gcs_v1/metadata.yaml
@@ -11,6 +11,7 @@ labels:
   owner1: cbeck
 scheduling:
   dag_name: bqetl_merino_newtab_priors_to_gcs
+  priority: 2
   arguments:
   - --source-project=moz-fx-data-shared-prod
   - --source-dataset=telemetry_derived

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_to_gcs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_to_gcs_v1/metadata.yaml
@@ -11,7 +11,6 @@ labels:
   owner1: cbeck
 scheduling:
   dag_name: bqetl_merino_newtab_priors_to_gcs
-  priority: 2
   arguments:
   - --source-project=moz-fx-data-shared-prod
   - --source-dataset=telemetry_derived


### PR DESCRIPTION
## Description
There are three fixes in here:

With the rollout of additional sections and propensity based query calculations, the cost of the merino extract query has gone up over time. 96% of events worldwide are in the newtab_content ping. 

Therefore we can drop the newtab ping and rely on the newtab_content ping exclusively

Background is in this doc https://docs.google.com/document/d/1ByJJ3IdKRhiOT4wjjdYTbs8P4MNHfWq6T9bTVIBW1zo/edit?tab=t.0

This image shows per country adoption. US over 95%, with FR, IT and IN in the 86% percent range, but it should be improving.
<img width="107" height="405" alt="image" src="https://github.com/user-attachments/assets/7d1824b9-ca83-4b15-8e40-0210fbe6d93e" />

A manual run shows 70% reduction in slot time.


2.
Our propensity https://github.com/mozilla/bigquery-etl/pull/9154 upgrade includes an 'any' field that shows the propensity weight at a position independent of tile format. Adding 'any' fallback allows better propensity calculations when we have new formats such as the new Daily Briefing format.

3. This job sometimes gets delayed at midnight EST or UTC. I was told a while ago that we could boost the priority and set it to 2. Someone should review this.

## Related Tickets & Documents


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
