### PR TITLE
feat: Have Airflow tasks for data quality checks retry once

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -624,7 +624,8 @@ class Task:
         task.is_dq_check = True
         task.is_dq_check_fail = is_check_fail
         task.depends_on_past = False
-        task.retries = 0
+        task.retries = 1
+        task.retry_delay = "5m"
         task.depends_on_fivetran = []
         task.referenced_tables = None
         task.depends_on = []

--- a/tests/data/dags/test_dag_external_check_dependency
+++ b/tests/data/dags/test_dag_external_check_dependency
@@ -58,7 +58,8 @@ with DAG(
         email=["telemetry-alerts@mozilla.com", "test@example.org"],
         depends_on_past=False,
         parameters=["submission_date:DATE:{{ds}}"],
-        retries=0,
+        retry_delay=datetime.timedelta(seconds=300),
+        retries=1,
     )
 
     with TaskGroup(

--- a/tests/data/dags/test_dag_with_check_dependencies
+++ b/tests/data/dags/test_dag_with_check_dependencies
@@ -70,7 +70,8 @@ with DAG(
         email=["telemetry-alerts@mozilla.com", "test@example.org"],
         depends_on_past=False,
         parameters=["submission_date:DATE:{{ds}}"],
-        retries=0,
+        retry_delay=datetime.timedelta(seconds=300),
+        retries=1,
     )
 
     test__query__v1 = bigquery_etl_query(

--- a/tests/data/dags/test_dag_with_check_table_dependencies
+++ b/tests/data/dags/test_dag_with_check_table_dependencies
@@ -58,7 +58,8 @@ with DAG(
         email=["telemetry-alerts@mozilla.com", "test@example.org"],
         depends_on_past=False,
         parameters=["submission_date:DATE:{{ds}}"],
-        retries=0,
+        retry_delay=datetime.timedelta(seconds=300),
+        retries=1,
     )
 
     test__table1__v1 = bigquery_etl_query(


### PR DESCRIPTION
## Description
Not retrying at all means if a check fails due to a transient BigQuery error then it fails and blocks any downstream tasks from running until someone recursively clears the failed check task.

For example, this happened last night, where the `checks__fail_fenix_derived__firefox_android_clients__v1` task in the [bqetl_analytics_tables](https://workflow.telemetry.mozilla.org/dags/bqetl_analytics_tables/grid) DAG failed due to some transient BigQuery error, blocking ~60 downstream tasks from running until I recursively cleared the tasks to rerun.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/4359

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
