### PR TITLE
feat(etl): Update subscription deletion ETL scripts

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus/delete_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus/delete_events/view.sql
@@ -5,3 +5,8 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.subscription_platform_backend_cirrus_derived.delete_events_v1`
+UNION ALL
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.subscription_platform_backend_cirrus_derived.delete_events_v2`

--- a/sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus_derived/delete_events_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus_derived/delete_events_v2/metadata.yaml
@@ -1,0 +1,18 @@
+---
+friendly_name: Subscription Platform Backend Cirrus Delete Events
+description: Deletion events for subscription platform backend cirrus, derived
+  from payments-api GKE logs containing pre-derived nimbus_user_id
+owners:
+  - dalvarez@mozilla.com
+labels:
+  incremental: true
+  schedule: daily
+  table_type: client_level
+scheduling:
+  dag_name: bqetl_fxa_events
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_timestamp
+    require_partition_filter: false
+  require_column_description: true

--- a/sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus_derived/delete_events_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus_derived/delete_events_v2/query.sql
@@ -1,0 +1,16 @@
+SELECT
+  MIN(`timestamp`) AS submission_timestamp,
+  jsonPayload.fields.nimbus_user_id AS nimbus_user_id,
+FROM
+  `moz-fx-fxa-prod.gke_fxa_prod_log.stderr`
+WHERE
+  (
+    DATE(_PARTITIONTIME)
+    BETWEEN DATE_SUB(@submission_date, INTERVAL 1 DAY)
+    AND DATE_ADD(@submission_date, INTERVAL 1 DAY)
+  )
+  AND DATE(`timestamp`) = @submission_date
+  AND jsonPayload.type = 'glean.user.delete'
+  AND jsonPayload.fields.nimbus_user_id IS NOT NULL
+GROUP BY
+  jsonPayload.fields.nimbus_user_id

--- a/sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus_derived/delete_events_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus_derived/delete_events_v2/schema.yaml
@@ -1,0 +1,9 @@
+fields:
+- name: submission_timestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: Earliest timestamp of the account deletion log entry for this nimbus_user_id on the given date
+- name: nimbus_user_id
+  type: STRING
+  mode: NULLABLE
+  description: Pre-derived Nimbus user identifier logged by payments-api at account deletion time


### PR DESCRIPTION
Because:

* Current glean deletion ETL query duplicates the nimbus_user_id derivation logic that lives in the fxa repository

This commit:

* Updates the script to match the paired [PR](https://github.com/mozilla/fxa/pull/20381), while still supporting the existing approach

Closes #PAY-3438
