### PR TITLE
fix(etl): address failing deletion script

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus_derived/delete_events_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus_derived/delete_events_v2/query.sql
@@ -1,6 +1,6 @@
 SELECT
   MIN(`timestamp`) AS submission_timestamp,
-  jsonPayload.fields.nimbus_user_id AS nimbus_user_id,
+  JSON_VALUE(TO_JSON(jsonPayload.fields), '$.nimbus_user_id') AS nimbus_user_id,
 FROM
   `moz-fx-fxa-prod.gke_fxa_prod_log.stderr`
 WHERE
@@ -11,6 +11,6 @@ WHERE
   )
   AND DATE(`timestamp`) = @submission_date
   AND jsonPayload.type = 'glean.user.delete'
-  AND jsonPayload.fields.nimbus_user_id IS NOT NULL
+  AND JSON_VALUE(TO_JSON(jsonPayload.fields), '$.nimbus_user_id') IS NOT NULL
 GROUP BY
-  jsonPayload.fields.nimbus_user_id
+  nimbus_user_id


### PR DESCRIPTION
## Description

The Airflow pod surfaced a BigQuery error, `Field name nimbus_user_id does not exist in STRUCT<errno FLOAT64, path STRING, method STRING, ...> at [14:26]`, rejecting the prior query at compile time. The actual log entries matching the new syntax have not been deployed to production, so no typing inference could be made to support the new syntax. This converts the delete_events_v2 query to use raw JSON values rather than the expected structs, with the goal of supporting the upcoming change.

We should be able to revert this change once the accompanying change in the fxa repository has been deployed to production.
