### PR TITLE
feat(DENG-10964): filter kitsune_questions_base_v1 to 2026-01-02 onwards

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_questions_base_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_questions_base_v1/query.sql
@@ -30,6 +30,8 @@ SELECT
   CURRENT_TIMESTAMP() AS generated_time
 FROM
   deduped
+WHERE
+  date_utc >= '2026-01-01'
 GROUP BY
   `creation_date`,
   product


### PR DESCRIPTION
## Description

Adds a `WHERE date_utc >= '2026-01-02'` filter to `kitsune_questions_base_v1` to restrict output to 2026 data, aligning the table with current reporting scope.

## Related Tickets & Documents
* [DENG-10964](https://mozilla-hub.atlassian.net/browse/DENG-10964)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

## Validation Results

**Query:** `sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_questions_base_v1/query.sql`
**Compared against:** `moz-fx-data-shared-prod.sumo_metrics_derived.kitsune_questions_base_v1` (production table)
**Date run:** 2026-04-24

| Check | Result | Details |
|-------|--------|---------|
| Row counts | ❌ Mismatch | new query: **665 rows**, prod: **26,337 rows** |
| Schema | ✅ Match | `creation_date DATE`, `product STRING`, `forum_questions_posted INT64`, `generated_time TIMESTAMP` — matches `schema.yaml` exactly |
| Statistical profile | ❌ Significant differences | See table below |

#### Statistical Profile Detail

| Metric | New Query | Production |
|--------|-----------|------------|
| Total rows | 665 | 26,337 |
| `creation_date` min | 2026-01-02 | 2009-12-24 |
| `creation_date` max | 2026-04-24 | 2026-04-24 |
| Distinct dates | 113 | 5,838 |
| Distinct products | 8 | 21 |
| NULL products | 0 | 863 |
| `forum_questions_posted` min/max/avg | 1 / 179 / 27.8 | 1 / 1,532 / 29.1 |

⚠️ The query's `WHERE date_utc >= '2026-01-02'` filter limits output to ~113 days (2026 only), but the production table contains **16+ years of data** (back to 2009-12-24). Since this table is non-incremental (`incremental: false`), deploying this query would **replace all 26,337 production rows with only 665**, permanently erasing all pre-2026 historical data. The one-day shift from `2026-01-01` → `2026-01-02` is minor, but the date filter itself appears to be the root concern — please confirm whether this cutoff is intentional or if the filter should be removed to preserve the full history.

**Query diff:**
```diff
-  date_utc >= '2026-01-01'
+  date_utc >= '2026-01-02'
```

<details>
<summary>📎 Validation SQL (DENG-10964_validation_2026-04-24.sql.txt)</summary>

```sql
-- DENG-10964 Validation SQL
-- Query: sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_questions_base_v1/query.sql
-- Compared against: moz-fx-data-shared-prod.sumo_metrics_derived.kitsune_questions_base_v1
-- Date run: 2026-04-24

-- CHECK 1: Row Counts
SELECT 'new_query' AS source, COUNT(*) AS row_count FROM (
  WITH questions AS (
    SELECT
      DATE(TIMESTAMP(q.created_utc), "UTC") AS date_utc,
      COALESCE(m.product_mapping, q.product) AS product,
      q.question_id
    FROM `moz-fx-data-shared-prod.sumo_syndicate.kitsune_questions` q
    LEFT JOIN `moz-fx-data-shared-prod.static.cx_product_mappings_v1` m
      ON m.product = q.product AND m.source = 'Kitsune'
  ),
  deduped AS (
    SELECT date_utc, question_id, product
    FROM questions
    GROUP BY date_utc, question_id, product
  )
  SELECT
    date_utc AS creation_date,
    product,
    COUNT(*) AS forum_questions_posted,
    CURRENT_TIMESTAMP() AS generated_time
  FROM deduped
  WHERE date_utc >= '2026-01-02'
  GROUP BY creation_date, product
)
UNION ALL
SELECT 'comparison' AS source, COUNT(*) AS row_count
FROM `moz-fx-data-shared-prod.sumo_metrics_derived.kitsune_questions_base_v1`;

-- CHECK 2: Schema (INFORMATION_SCHEMA)
SELECT column_name, data_type, is_nullable
FROM `moz-fx-data-shared-prod.sumo_metrics_derived.INFORMATION_SCHEMA.COLUMNS`
WHERE table_name = 'kitsune_questions_base_v1'
ORDER BY ordinal_position;

-- CHECK 3: Statistical Profile
WITH new_query AS (
  WITH questions AS (
    SELECT
      DATE(TIMESTAMP(q.created_utc), "UTC") AS date_utc,
      COALESCE(m.product_mapping, q.product) AS product,
      q.question_id
    FROM `moz-fx-data-shared-prod.sumo_syndicate.kitsune_questions` q
    LEFT JOIN `moz-fx-data-shared-prod.static.cx_product_mappings_v1` m
      ON m.product = q.product AND m.source = 'Kitsune'
  ),
  deduped AS (
    SELECT date_utc, question_id, product
    FROM questions
    GROUP BY date_utc, question_id, product
  )
  SELECT
    date_utc AS creation_date,
    product,
    COUNT(*) AS forum_questions_posted,
    CURRENT_TIMESTAMP() AS generated_time
  FROM deduped
  WHERE date_utc >= '2026-01-02'
  GROUP BY creation_date, product
)
SELECT
  'new_query' AS source,
  COUNT(*) AS total_rows,
  COUNTIF(creation_date IS NULL) AS creation_date_nulls,
  MIN(CAST(creation_date AS STRING)) AS creation_date_min,
  MAX(CAST(creation_date AS STRING)) AS creation_date_max,
  COUNT(DISTINCT CAST(creation_date AS STRING)) AS creation_date_distinct,
  COUNTIF(product IS NULL) AS product_nulls,
  COUNT(DISTINCT product) AS product_distinct,
  COUNTIF(forum_questions_posted IS NULL) AS fqp_nulls,
  MIN(forum_questions_posted) AS fqp_min,
  MAX(forum_questions_posted) AS fqp_max,
  AVG(forum_questions_posted) AS fqp_avg
FROM new_query
UNION ALL
SELECT
  'comparison' AS source,
  COUNT(*) AS total_rows,
  COUNTIF(creation_date IS NULL) AS creation_date_nulls,
  MIN(CAST(creation_date AS STRING)) AS creation_date_min,
  MAX(CAST(creation_date AS STRING)) AS creation_date_max,
  COUNT(DISTINCT CAST(creation_date AS STRING)) AS creation_date_distinct,
  COUNTIF(product IS NULL) AS product_nulls,
  COUNT(DISTINCT product) AS product_distinct,
  COUNTIF(forum_questions_posted IS NULL) AS fqp_nulls,
  MIN(forum_questions_posted) AS fqp_min,
  MAX(forum_questions_posted) AS fqp_max,
  AVG(forum_questions_posted) AS fqp_avg
FROM `moz-fx-data-shared-prod.sumo_metrics_derived.kitsune_questions_base_v1`;
```

</details>

[DENG-10964]: https://mozilla-hub.atlassian.net/browse/DENG-10964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ