### PR TITLE
Add subscription_platform_backend_cirrus_derived/delete_events_v2 to skip list

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -90,6 +90,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/activity_stream/impression_stats_by_experiment/view.sql
   - sql/moz-fx-data-shared-prod/activity_stream/impression_stats_flat/view.sql
   - sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus_derived/delete_events_v1/query.sql
+  - sql/moz-fx-data-shared-prod/subscription_platform_backend_cirrus_derived/delete_events_v2/query.sql
   - sql/moz-fx-data-shared-prod/sumo_metrics_derived/translation_daily_eng_base_v1/query.sql
   - sql/moz-fx-data-shared-prod/sumo_metrics_derived/translation_daily_locale_base_v1/query.sql
   - sql/moz-fx-data-shared-prod/sumo_metrics_derived/translation_daily_locale_base_v1/query.sql


### PR DESCRIPTION
## Description

This should fix: https://workflow.telemetry.mozilla.org/dags/bqetl_dryrun/grid?search=bqetl_dryrun&dag_run_id=manual__2026-04-17T05%3A06%3A44.820848%2B00%3A00&task_id=dryrun
`subscription_platform_backend_cirrus_derived/delete_events_v1/query.sql` is already getting skipped, so I think this was just forgotten to get added to the list. It's accessing `moz-fx-fxa-prod:gke_fxa_prod_log.stderr` which the dryrun account doesn't have access to

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
