### PR TITLE
Clean up bqetl_ads_hourly DAG

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/metadata.yaml
@@ -27,6 +27,7 @@ scheduling:
       (execution_date - macros.timedelta(hours=1)).strftime('%Y-%m-%d')
       }}
   query_file_path: sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/query.sql
+  referenced_tables: []
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/ads_derived/test_ads_bqetl_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/test_ads_bqetl_v1/metadata.yaml
@@ -33,3 +33,4 @@ bigquery:
     fields:
     - advertiser
     - country
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/ads_derived/test_ads_bqetl_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/test_ads_bqetl_v1/metadata.yaml
@@ -5,9 +5,9 @@ owners:
 - cbeck@mozilla.com
 labels:
   incremental: true
-  schedule: hourly
+  # schedule: hourly
 scheduling:
-  dag_name: bqetl_ads_hourly
+  # dag_name: bqetl_ads_hourly
   date_partition_parameter: null
   # We reprocess the same day every hour up until 1:00 the following day, to give
   # the live data time to come in


### PR DESCRIPTION
## Description

Adds a line to config to remove any dependencies for `ads_client_operations_and_errors_hourly_v1`.

Also unschedules a test table.

## Related Tickets & Documents



**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
