### PR TITLE
Cleanup init for ads_clients_operations_and_errors_hourly_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/query.sql
@@ -22,7 +22,11 @@ WITH ios_base AS (
     metrics.labeled_string.ads_client_deserialization_error AS deserialization_error,
     metrics.labeled_string.ads_client_http_cache_outcome AS http_cache_outcome,
   FROM
-    `moz-fx-data-shared-prod.org_mozilla_ios_firefox_live.metrics_v1`
+    {% if is_init() %}
+      `moz-fx-data-shared-prod.org_mozilla_ios_firefox_stable.metrics_v1`
+    {% else %}
+      `moz-fx-data-shared-prod.org_mozilla_ios_firefox_live.metrics_v1`
+    {% endif %}
   WHERE
     {% if is_init() %}
       DATE(submission_timestamp) >= DATE("2026-02-01")
@@ -53,7 +57,11 @@ android_release_base AS (
     metrics.labeled_string.ads_client_deserialization_error AS deserialization_error,
     metrics.labeled_string.ads_client_http_cache_outcome AS http_cache_outcome,
   FROM
-    `moz-fx-data-shared-prod.org_mozilla_firefox_live.metrics_v1`
+    {% if is_init() %}
+      `moz-fx-data-shared-prod.org_mozilla_firefox_stable.metrics_v1`
+    {% else %}
+      `moz-fx-data-shared-prod.org_mozilla_firefox_live.metrics_v1`
+    {% endif %}
   WHERE
     {% if is_init() %}
       DATE(submission_timestamp) >= DATE("2026-02-01")
@@ -84,7 +92,11 @@ android_nightly_base AS (
     metrics.labeled_string.ads_client_deserialization_error AS deserialization_error,
     metrics.labeled_string.ads_client_http_cache_outcome AS http_cache_outcome,
   FROM
-    `moz-fx-data-shared-prod.org_mozilla_fenix_live.metrics_v1`
+    {% if is_init() %}
+      `moz-fx-data-shared-prod.org_mozilla_fenix_stable.metrics_v1`
+    {% else %}
+      `moz-fx-data-shared-prod.org_mozilla_fenix_live.metrics_v1`
+    {% endif %}
   WHERE
     {% if is_init() %}
       DATE(submission_timestamp) >= DATE("2026-02-01")

--- a/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/query.sql
@@ -28,14 +28,14 @@ WITH ios_base AS (
       DATE(submission_timestamp) >= DATE("2026-02-01")
     {% else %}
       DATE(submission_timestamp) = @submission_date
-      AND (
-        ARRAY_LENGTH(metrics.labeled_counter.ads_client_client_operation_total) > 0
-        OR ARRAY_LENGTH(metrics.labeled_string.ads_client_client_error) > 0
-        OR ARRAY_LENGTH(metrics.labeled_string.ads_client_build_cache_error) > 0
-        OR ARRAY_LENGTH(metrics.labeled_string.ads_client_deserialization_error) > 0
-        OR ARRAY_LENGTH(metrics.labeled_string.ads_client_http_cache_outcome) > 0
-      )
     {% endif %}
+    AND (
+      ARRAY_LENGTH(metrics.labeled_counter.ads_client_client_operation_total) > 0
+      OR ARRAY_LENGTH(metrics.labeled_string.ads_client_client_error) > 0
+      OR ARRAY_LENGTH(metrics.labeled_string.ads_client_build_cache_error) > 0
+      OR ARRAY_LENGTH(metrics.labeled_string.ads_client_deserialization_error) > 0
+      OR ARRAY_LENGTH(metrics.labeled_string.ads_client_http_cache_outcome) > 0
+    )
 ),
 android_release_base AS (
   SELECT
@@ -55,7 +55,11 @@ android_release_base AS (
   FROM
     `moz-fx-data-shared-prod.org_mozilla_firefox_live.metrics_v1`
   WHERE
-    DATE(submission_timestamp) = @submission_date
+    {% if is_init() %}
+      DATE(submission_timestamp) >= DATE("2026-02-01")
+    {% else %}
+      DATE(submission_timestamp) = @submission_date
+    {% endif %}
     AND (
       ARRAY_LENGTH(metrics.labeled_counter.ads_client_client_operation_total) > 0
       OR ARRAY_LENGTH(metrics.labeled_string.ads_client_client_error) > 0
@@ -82,7 +86,11 @@ android_nightly_base AS (
   FROM
     `moz-fx-data-shared-prod.org_mozilla_fenix_live.metrics_v1`
   WHERE
-    DATE(submission_timestamp) = @submission_date
+    {% if is_init() %}
+      DATE(submission_timestamp) >= DATE("2026-02-01")
+    {% else %}
+      DATE(submission_timestamp) = @submission_date
+    {% endif %}
     AND (
       ARRAY_LENGTH(metrics.labeled_counter.ads_client_client_operation_total) > 0
       OR ARRAY_LENGTH(metrics.labeled_string.ads_client_client_error) > 0
@@ -108,7 +116,7 @@ base AS (
     android_nightly_base
 )
 SELECT
-  @submission_date AS submission_date,
+  DATE(submission_timestamp) AS submission_date,
   TIMESTAMP_TRUNC(submission_timestamp, HOUR) AS submission_hour,
   surface,
   normalized_os,


### PR DESCRIPTION
## Description

This change does not affect the hourly run, and I already ran the init locally, so this is just recording the correct init SQL

## Related Tickets & Documents


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
