### PR TITLE
fix: Enable catchup for the `bqetl_public_data_json` DAG

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -364,6 +364,7 @@ bqetl_experiments_daily:
 # queries should not be explicitly assigned to this DAG (done automatically)
 bqetl_public_data_json:
   schedule_interval: 0 5 * * *
+  catchup: true
   description: |
     Daily exports of query data marked as public to GCS.
 


### PR DESCRIPTION
## Description
I'm going to pause the long-running [bqetl_public_data_json](https://workflow.telemetry.mozilla.org/dags/bqetl_public_data_json/grid) DAG (it's been taking over 5 hours) to avoid interfering with ETL reruns for past days to recover from a data incident ([IIM-153](https://mozilla-hub.atlassian.net/browse/IIM-153)).

This PR enables catchup for that DAG so any intermediate runs will get queued once it's unpaused.

Although I just noticed the DAG description says:
> As long as the most recent DAG run is successful this job can be considered healthy.
> In such case, past DAG failures can be ignored.

So maybe past runs don't actually matter for this DAG?

## Related Tickets & Documents
* [IIM-153](https://mozilla-hub.atlassian.net/browse/IIM-153): Missing Equative Impressions (2026-04-17)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[IIM-153]: https://mozilla-hub.atlassian.net/browse/IIM-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IIM-153]: https://mozilla-hub.atlassian.net/browse/IIM-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ