### PR TITLE
Update fixes issue with country events

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/query.sql
@@ -105,7 +105,8 @@ newtab_content_events_unnested AS (
     mozfun.newtab.surface_id_country(
       metrics.string.newtab_content_surface_id,
       NULL,
-      normalized_country_code
+      metrics.string.newtab_content_country
+      -- normalized_country_code is fastly relay country, so that field should never be used
     ) AS country,
     metrics.string.newtab_content_surface_id AS newtab_content_surface_id,
     `timestamp` AS event_timestamp,


### PR DESCRIPTION
## Description

In the process of investigating some other issues, I noticed that the per-item counts for non US engagement were way off in the newtab_content_items_daily and _combined reports.

This was due to a small bug in the country mapping code. The tables are used for our merino_priors_v1 calculations that affect ranking, so it's important that the country attribution is accurate.


You can see how the issue has started if you Query:

select sum(impression_count) as total, country from moz-fx-data-shared-prod.firefox_desktop_derived.newtab_content_items_daily_v1 where corpus_item_id is not NULL and submission_date='2026-01-10' group by country order by total desc

And then compare to 2026-04-10. You'll see that there is a 90%+ change in attribution of German impressions

## Related Tickets & Documents
This relates to work done in the epic https://mozilla-hub.atlassian.net/browse/DENG-10566


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
