### PR TITLE
DENG-10977: backfill newtab_content_items_daily_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/backfill.yaml
@@ -4,6 +4,7 @@
   reason: Need to backfill table because we had to fix a field. See https://mozilla-hub.atlassian.net/browse/DENG-10977.
   watchers:
   - kbammarito@mozilla.com
+  - rrando@mozilla.com
   status: Initiate
   shredder_mitigation: false
   override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/backfill.yaml
@@ -1,3 +1,15 @@
+2026-04-20:
+  start_date: 2026-02-01
+  end_date: 2026-04-20
+  reason: Need to backfill table because we had to fix a field. See https://mozilla-hub.atlassian.net/browse/DENG-10977.
+  watchers:
+  - kbammarito@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false
+
 2025-09-22:
   start_date: 2023-08-10
   end_date: 2025-08-07


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR backfills `newtab_content_items_daily_v1` due to a [UDF update](https://mozilla-hub.atlassian.net/browse/DENG-10976).

## Related Tickets & Documents
* DENG-10977

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
