### PR TITLE
fix(ads): Remove Suggest Impression v2 table build job from airflow dag

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/aggregated_search_terms_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/aggregated_search_terms_daily_v1/metadata.yaml
@@ -13,6 +13,3 @@ bigquery:
     type: day
     field: submission_date
     require_partition_filter: true
-scheduling:
-  dag_name: bqetl_search_terms_daily
-  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2/metadata.yaml
@@ -12,9 +12,6 @@ owners:
   - ctroy@mozilla.com
 labels:
   incremental: true
-scheduling:
-  dag_name: bqetl_search_terms_daily
-  arguments: ['--schema_update_option=ALLOW_FIELD_ADDITION']
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description

This PR should remove the scheduling of `search_terms_derived__suggest_impression_sanitized__v2` from the `bqetl_search_terms_daily` dag.

Ref: https://workflow.telemetry.mozilla.org/dags/bqetl_search_terms_daily/grid?base_date=2026-01-18T03%3A00%3A00Z&task_id=search_terms_derived__suggest_impression_sanitized__v2

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
