### PR TITLE
DENG-10977: Complete backfill for newtab_content_items_daily_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - kbammarito@mozilla.com
   - rrando@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR completes the backfill for `newtab_content_items_daily_v1` due to a [UDF update](https://mozilla-hub.atlassian.net/browse/DENG-10976).

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/9227
* DENG-10977

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
