### PR TITLE
[DENG-10727] Replace legacy_sql usage in shredder

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -643,9 +643,11 @@ def list_partitions(
                         SELECT
                           partition_id
                         FROM
-                          [{sql_table_id(table)}$__PARTITIONS_SUMMARY__]
+                          `{table.project}.{table.dataset_id}.INFORMATION_SCHEMA.PARTITIONS`
+                        WHERE
+                          table_name = '{table.table_id}'
+                          AND partition_id IS NOT NULL
                         """).strip(),
-                    bigquery.QueryJobConfig(use_legacy_sql=True),
                 ).result()
             ]
             if table.num_bytes > max_single_dml_bytes and partition_expr is not None


### PR DESCRIPTION
## Description

[bigquery legacy sql is being phased out](https://docs.cloud.google.com/bigquery/docs/legacy-sql-feature-availability) and AFAIK this is the only usage we have. Replacing `__PARTITIONS_SUMMARY__` with `INFORMATION_SCHEMA.PARTITIONS` (which is pre-GA but has been for many years)

## Related Tickets & Documents
* DENG-10727

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
