### PR TITLE
Add support for ./bqetl target migrate-branch

### DIFF
--- a/bigquery_etl/cli/target.py
+++ b/bigquery_etl/cli/target.py
@@ -19,6 +19,7 @@ from ..util.common import block_coding_agents
 from ..util.target import (
     IAM_ROLE_MAP,
     MANIFEST_FILENAME,
+    _get_git_context,
     _reapply_shared_access,
     render_artifact_prefix_pattern,
     render_dataset_pattern,
@@ -358,30 +359,30 @@ def share(
 
 
 @target.command(
-    "rename-branch",
-    help="""Rename a branch's target deployment in BigQuery.
+    "migrate-branch",
+    help="""Migrate a previous branch's target deployment to the current branch.
 
     Useful after renaming a local git branch: rewrites the sanitized branch
     string in dataset and/or artifact names so existing artifacts match the
-    new branch without redeploying from scratch.
+    current (new) branch without redeploying from scratch. Must be run
+    while checked out on the destination branch.
 
     Tables are copied to their new location and the originals deleted.
-    Views, materialized views, and routines are skipped during the rename;
+    Views, materialized views, and routines are skipped during the migration;
     the deploy step prompted at the end of the command recreates them at
     the new location from local SQL templates and cleans up the originals.
 
     Example:
 
-      ./bqetl --target dev target rename-branch old-feature new-feature
+      ./bqetl --target dev target migrate-branch old-feature
     """,
 )
 @click.argument("old_branch")
-@click.argument("new_branch")
 @click.option(
     "--dry-run/--no-dry-run",
     "--dry_run/--no_dry_run",
     default=False,
-    help="Show the rename plan without executing.",
+    help="Show the migration plan without executing.",
 )
 @click.option(
     "--yes",
@@ -393,8 +394,8 @@ def share(
 @sql_dir_option
 @block_coding_agents
 @click.pass_context
-def rename_branch(ctx, old_branch, new_branch, dry_run, yes, sql_dir):
-    """Rename a target deployment from old_branch to new_branch."""
+def migrate_branch(ctx, old_branch, dry_run, yes, sql_dir):
+    """Migrate a target deployment from old_branch to the current git branch."""
     target_config = ctx.obj["target"]
     project_id = target_config.project_id
 
@@ -411,11 +412,13 @@ def rename_branch(ctx, old_branch, new_branch, dry_run, yes, sql_dir):
             f"Target '{target_config.name}' has no git.branch in its templates."
         )
 
+    new_branch = _get_git_context().get("branch", "")
     old_sanitized = sanitize_bq_id(old_branch)
     new_sanitized = sanitize_bq_id(new_branch)
     if old_sanitized == new_sanitized:
         raise click.UsageError(
-            "old_branch and new_branch sanitize to the same name; nothing to rename."
+            f"old_branch '{old_branch}' matches the current branch '{new_branch}'; "
+            "nothing to migrate."
         )
 
     client = bigquery.Client(project=project_id)
@@ -433,10 +436,10 @@ def rename_branch(ctx, old_branch, new_branch, dry_run, yes, sql_dir):
         branch_in_artifact,
     )
     if not plan:
-        click.echo("Nothing to rename.")
+        click.echo("Nothing to migrate.")
         return
 
-    click.echo(f"\nRename plan for {project_id}:\n")
+    click.echo(f"\nMigration plan for {project_id}:\n")
     for old_ds, new_ds, renames in plan:
         header = f"  {old_ds} -> {new_ds}" if old_ds != new_ds else f"  {old_ds}:"
         click.echo(header)
@@ -444,7 +447,7 @@ def rename_branch(ctx, old_branch, new_branch, dry_run, yes, sql_dir):
             click.echo(f"    {old_t} -> {new_t} ({ttype})")
     click.echo()
 
-    if not _confirm(len(plan), "dataset(s)", dry_run, yes, verb="rename"):
+    if not _confirm(len(plan), "dataset(s)", dry_run, yes, verb="migrate"):
         return
 
     for old_ds, new_ds, renames in plan:
@@ -466,9 +469,9 @@ def _prompt_and_deploy(ctx, client, project_id, plan, sql_dir, yes):
     if not (
         yes
         or click.confirm(
-            "\nRenamed tables reflect BigQuery state at rename time, not local "
-            "SQL templates. Views, materialized views, and routines were skipped "
-            "and don't yet exist at the new location.\n"
+            "\nMigrated tables reflect BigQuery state at migration time, not "
+            "local SQL templates. Views, materialized views, and routines were "
+            "skipped and don't yet exist at the new location.\n"
             "Run `./bqetl deploy` now to re-render everything from templates? "
             "(skipped views/MVs/routines at the old location will be deleted "
             "first so deploy can recreate them cleanly)",
@@ -494,15 +497,10 @@ def _rewrite_target_references(sql_dir, project_id, old_sanitized, new_sanitized
     other artifacts in the target dir that point at the renamed names. Skipped
     when old_sanitized is short enough that false positives are likely.
     """
-    if len(old_sanitized) < 4:
-        click.echo(
-            f"  Skipping reference rewrite: '{old_sanitized}' is too short "
-            "to substring-replace safely."
-        )
-        return
-
     project_dir = Path(sql_dir) / project_id
     if not project_dir.exists():
+        return
+    if len(old_sanitized) < 4:
         return
 
     updated = 0

--- a/bigquery_etl/cli/target.py
+++ b/bigquery_etl/cli/target.py
@@ -543,9 +543,7 @@ def _prompt_and_deploy(ctx, client, project_id, plan, sql_dir, yes):
             "\nMigrated tables reflect BigQuery state at migration time, not "
             "local SQL templates. Views, materialized views, and routines were "
             "skipped and don't yet exist at the new location.\n"
-            "Run `./bqetl deploy` now to re-render everything from templates? "
-            "(skipped views/MVs/routines at the old location will be deleted "
-            "first so deploy can recreate them cleanly)",
+            "Run `./bqetl deploy` to re-deploy these artifacts",
             default=False,
         )
     ):

--- a/bigquery_etl/cli/target.py
+++ b/bigquery_etl/cli/target.py
@@ -368,10 +368,17 @@ def share(
     current (new) branch without redeploying from scratch. Must be run
     while checked out on the destination branch.
 
+    If the target template includes git.commit, only the newest commit's
+    datasets are migrated (older commit deployments are left behind) and
+    the commit hash is rewritten to current HEAD so the next deploy lands
+    at the matching location.
+
     Tables are copied to their new location and the originals deleted.
     Views, materialized views, and routines are skipped during the migration;
     the deploy step prompted at the end of the command recreates them at
     the new location from local SQL templates and cleans up the originals.
+    References (FROM clauses, routine calls, manifests) in local SQL/YAML
+    files under the target dir are also rewritten to the new names.
 
     Example:
 
@@ -443,17 +450,15 @@ def migrate_branch(ctx, old_branch, dry_run, yes, sql_dir):
         (old_commit, new_commit) if old_commit and old_commit != new_commit else None
     )
 
-    branch_pair = (old_sanitized, new_sanitized)
+    branch_pairs = [(old_sanitized, new_sanitized)]
+    commit_pairs = [commit_pair] if commit_pair else []
     rename_ds_id = _make_transform(
-        [branch_pair] if branch_in_dataset else [], commit_pair
+        (branch_pairs if branch_in_dataset else []) + commit_pairs
     )
     rename_art_id = _make_transform(
-        [branch_pair] if branch_in_artifact else [], commit_pair
+        (branch_pairs if branch_in_artifact else []) + commit_pairs
     )
-    # File sweep uses a 4-char guard to avoid rewriting short substrings everywhere.
-    rewrite_content = _make_transform(
-        [branch_pair] if len(old_sanitized) >= 4 else [], commit_pair
-    )
+    rewrite_content = _make_transform(branch_pairs + commit_pairs)
 
     plan = _build_rename_plan(client, project_id, matching, rename_ds_id, rename_art_id)
     if not plan:
@@ -478,14 +483,11 @@ def migrate_branch(ctx, old_branch, dry_run, yes, sql_dir):
     _prompt_and_deploy(ctx, client, project_id, plan, sql_dir, yes)
 
 
-def _make_transform(branch_pairs, commit_pair):
+def _make_transform(pairs):
     """Build a str->str substring-replace transform from (old, new) pairs."""
-    replacements = list(branch_pairs)
-    if commit_pair:
-        replacements.append(commit_pair)
 
     def transform(s):
-        for old, new in replacements:
+        for old, new in pairs:
             s = s.replace(old, new)
         return s
 
@@ -549,7 +551,7 @@ def _prompt_and_deploy(ctx, client, project_id, plan, sql_dir, yes):
     ):
         return
 
-    _delete_skipped_artifacts(client, project_id, plan)
+    _cleanup_old_location(client, project_id, plan)
     ctx.invoke(
         deploy_cmd,
         paths=tuple(renamed_paths),
@@ -589,8 +591,8 @@ def _rewrite_target_references(sql_dir, project_id, transform):
         click.echo(f"  Rewrote references in {updated} local file(s)")
 
 
-def _delete_skipped_artifacts(client, project_id, plan):
-    """Delete old views/MVs/routines that rename skipped so deploy can recreate them."""
+def _cleanup_old_location(client, project_id, plan):
+    """Delete old views/MVs/routines (so deploy can recreate them) and the old dataset if renamed."""
     for old_ds, new_ds, renames in plan:
         for old_name, _, ttype in renames:
             ref = f"{project_id}.{old_ds}.{old_name}"

--- a/bigquery_etl/cli/target.py
+++ b/bigquery_etl/cli/target.py
@@ -21,6 +21,7 @@ from ..util.target import (
     MANIFEST_FILENAME,
     _get_git_context,
     _reapply_shared_access,
+    extract_commit_from_dataset_name,
     render_artifact_prefix_pattern,
     render_dataset_pattern,
     sanitize_bq_id,
@@ -412,7 +413,8 @@ def migrate_branch(ctx, old_branch, dry_run, yes, sql_dir):
             f"Target '{target_config.name}' has no git.branch in its templates."
         )
 
-    new_branch = _get_git_context().get("branch", "")
+    git_context = _get_git_context()
+    new_branch = git_context.get("branch", "")
     old_sanitized = sanitize_bq_id(old_branch)
     new_sanitized = sanitize_bq_id(new_branch)
     if old_sanitized == new_sanitized:
@@ -426,15 +428,34 @@ def migrate_branch(ctx, old_branch, dry_run, yes, sql_dir):
     if not matching:
         return
 
-    plan = _build_rename_plan(
-        client,
-        project_id,
-        matching,
-        old_sanitized,
-        new_sanitized,
-        branch_in_dataset,
-        branch_in_artifact,
+    before = len(matching)
+    matching, old_commit = _narrow_to_newest_commit(
+        client, project_id, target_config, matching, old_branch
     )
+    if old_commit and len(matching) < before:
+        click.echo(
+            f"Multiple commits found for branch; migrating only the most recent: "
+            f"{old_commit} ({len(matching)} dataset(s))"
+        )
+
+    new_commit = git_context.get("commit", "")
+    commit_pair = (
+        (old_commit, new_commit) if old_commit and old_commit != new_commit else None
+    )
+
+    branch_pair = (old_sanitized, new_sanitized)
+    rename_ds_id = _make_transform(
+        [branch_pair] if branch_in_dataset else [], commit_pair
+    )
+    rename_art_id = _make_transform(
+        [branch_pair] if branch_in_artifact else [], commit_pair
+    )
+    # File sweep uses a 4-char guard to avoid rewriting short substrings everywhere.
+    rewrite_content = _make_transform(
+        [branch_pair] if len(old_sanitized) >= 4 else [], commit_pair
+    )
+
+    plan = _build_rename_plan(client, project_id, matching, rename_ds_id, rename_art_id)
     if not plan:
         click.echo("Nothing to migrate.")
         return
@@ -453,8 +474,56 @@ def migrate_branch(ctx, old_branch, dry_run, yes, sql_dir):
     for old_ds, new_ds, renames in plan:
         _rename_dataset(client, project_id, old_ds, new_ds, renames, sql_dir)
 
-    _rewrite_target_references(sql_dir, project_id, old_sanitized, new_sanitized)
+    _rewrite_target_references(sql_dir, project_id, rewrite_content)
     _prompt_and_deploy(ctx, client, project_id, plan, sql_dir, yes)
+
+
+def _make_transform(branch_pairs, commit_pair):
+    """Build a str->str substring-replace transform from (old, new) pairs."""
+    replacements = list(branch_pairs)
+    if commit_pair:
+        replacements.append(commit_pair)
+
+    def transform(s):
+        for old, new in replacements:
+            s = s.replace(old, new)
+        return s
+
+    return transform
+
+
+def _dataset_modified(client, project_id, ds):
+    """Return the dataset's BQ modified timestamp, or None if it cannot be read."""
+    try:
+        return client.get_dataset(f"{project_id}.{ds.dataset_id}").modified
+    except Exception:
+        return None
+
+
+def _narrow_to_newest_commit(client, project_id, target_config, matching, old_branch):
+    """Group matching datasets by extracted commit and keep only the newest group.
+
+    Returns (narrowed_matching, old_commit). If the dataset template has no
+    git.commit slot (every extraction returns None), returns matching unchanged
+    with old_commit=None.
+    """
+    groups: dict = {}
+    for ds in matching:
+        commit = extract_commit_from_dataset_name(
+            target_config, ds.dataset_id, old_branch
+        )
+        groups.setdefault(commit, []).append(ds)
+    if list(groups) == [None]:
+        return matching, None
+
+    epoch = datetime.min.replace(tzinfo=timezone.utc)
+    newest = max(
+        (c for c in groups if c is not None),
+        key=lambda c: max(
+            _dataset_modified(client, project_id, ds) or epoch for ds in groups[c]
+        ),
+    )
+    return groups[newest], newest
 
 
 def _prompt_and_deploy(ctx, client, project_id, plan, sql_dir, yes):
@@ -490,17 +559,16 @@ def _prompt_and_deploy(ctx, client, project_id, plan, sql_dir, yes):
     )
 
 
-def _rewrite_target_references(sql_dir, project_id, old_sanitized, new_sanitized):
-    """Substring-replace old_sanitized with new_sanitized in SQL/YAML files under the target project.
+def _rewrite_target_references(sql_dir, project_id, transform):
+    """Apply transform to SQL/YAML files under the target project.
 
     Catches downstream references (FROM clauses, routine calls, manifests) in
-    other artifacts in the target dir that point at the renamed names. Skipped
-    when old_sanitized is short enough that false positives are likely.
+    other artifacts in the target dir that point at renamed names. The caller
+    supplies a str->str transform; this function only walks files and writes
+    back when the content changed.
     """
     project_dir = Path(sql_dir) / project_id
     if not project_dir.exists():
-        return
-    if len(old_sanitized) < 4:
         return
 
     updated = 0
@@ -511,9 +579,10 @@ def _rewrite_target_references(sql_dir, project_id, old_sanitized, new_sanitized
             content = path.read_text()
         except (UnicodeDecodeError, OSError):
             continue
-        if old_sanitized not in content:
+        new_content = transform(content)
+        if new_content == content:
             continue
-        path.write_text(content.replace(old_sanitized, new_sanitized))
+        path.write_text(new_content)
         updated += 1
 
     if updated:
@@ -546,34 +615,19 @@ def _delete_skipped_artifacts(client, project_id, plan):
                 click.echo(f"  Could not delete dataset {old_ds}: {e}", err=True)
 
 
-def _build_rename_plan(
-    client,
-    project_id,
-    datasets,
-    old_sanitized,
-    new_sanitized,
-    branch_in_dataset,
-    branch_in_artifact,
-):
+def _build_rename_plan(client, project_id, datasets, rename_ds_id, rename_art_id):
     """Compute [(old_ds, new_ds, [(old_name, new_name, type), ...])] entries.
 
     Type is the BigQuery table type (TABLE, VIEW, MATERIALIZED_VIEW, ...) or
     "ROUTINE" for UDFs and stored procedures.
-    """
-    rename_ds = (
-        (lambda s: s.replace(old_sanitized, new_sanitized))
-        if branch_in_dataset
-        else (lambda s: s)
-    )
-    rename_art = (
-        (lambda s: s.replace(old_sanitized, new_sanitized))
-        if branch_in_artifact
-        else (lambda s: s)
-    )
 
+    rename_ds_id and rename_art_id are str->str transforms applied to the
+    dataset and table/routine names respectively. The caller decides which
+    substitutions apply where (branch, commit, both, or none).
+    """
     plan = []
     for ds in datasets:
-        new_ds_id = rename_ds(ds.dataset_id)
+        new_ds_id = rename_ds_id(ds.dataset_id)
         ds_path = f"{project_id}.{ds.dataset_id}"
         try:
             tables = list(client.list_tables(ds_path))
@@ -584,7 +638,7 @@ def _build_rename_plan(
 
         renames = []
         for old_id, ttype in candidates:
-            new_id = rename_art(old_id)
+            new_id = rename_art_id(old_id)
             if new_ds_id == ds.dataset_id and new_id == old_id:
                 continue
             renames.append((old_id, new_id, ttype))

--- a/bigquery_etl/cli/target.py
+++ b/bigquery_etl/cli/target.py
@@ -11,14 +11,18 @@ import yaml
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 
+from bigquery_etl.cli.deploy import deploy as deploy_cmd
+
 from ..cli.utils import sql_dir_option
 from ..query_scheduling.formatters import format_timedelta
 from ..util.common import block_coding_agents
 from ..util.target import (
     IAM_ROLE_MAP,
     MANIFEST_FILENAME,
+    _reapply_shared_access,
     render_artifact_prefix_pattern,
     render_dataset_pattern,
+    sanitize_bq_id,
 )
 
 log = logging.getLogger(__name__)
@@ -351,6 +355,315 @@ def share(
             return
 
         _share_datasets(client, matching, emails, role)
+
+
+@target.command(
+    "rename-branch",
+    help="""Rename a branch's target deployment in BigQuery.
+
+    Useful after renaming a local git branch: rewrites the sanitized branch
+    string in dataset and/or artifact names so existing artifacts match the
+    new branch without redeploying from scratch.
+
+    Tables are copied to their new location and the originals deleted.
+    Views, materialized views, and routines are skipped during the rename;
+    the deploy step prompted at the end of the command recreates them at
+    the new location from local SQL templates and cleans up the originals.
+
+    Example:
+
+      ./bqetl --target dev target rename-branch old-feature new-feature
+    """,
+)
+@click.argument("old_branch")
+@click.argument("new_branch")
+@click.option(
+    "--dry-run/--no-dry-run",
+    "--dry_run/--no_dry_run",
+    default=False,
+    help="Show the rename plan without executing.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip confirmation prompt.",
+)
+@sql_dir_option
+@block_coding_agents
+@click.pass_context
+def rename_branch(ctx, old_branch, new_branch, dry_run, yes, sql_dir):
+    """Rename a target deployment from old_branch to new_branch."""
+    target_config = ctx.obj["target"]
+    project_id = target_config.project_id
+
+    branch_in_dataset = any(
+        t and "git.branch" in t
+        for t in (target_config.raw_dataset, target_config.raw_dataset_prefix)
+    )
+    branch_in_artifact = bool(
+        target_config.raw_artifact_prefix
+        and "git.branch" in target_config.raw_artifact_prefix
+    )
+    if not (branch_in_dataset or branch_in_artifact):
+        raise click.UsageError(
+            f"Target '{target_config.name}' has no git.branch in its templates."
+        )
+
+    old_sanitized = sanitize_bq_id(old_branch)
+    new_sanitized = sanitize_bq_id(new_branch)
+    if old_sanitized == new_sanitized:
+        raise click.UsageError(
+            "old_branch and new_branch sanitize to the same name; nothing to rename."
+        )
+
+    client = bigquery.Client(project=project_id)
+    matching = _find_matching_datasets(client, target_config, branch=old_branch)
+    if not matching:
+        return
+
+    plan = _build_rename_plan(
+        client,
+        project_id,
+        matching,
+        old_sanitized,
+        new_sanitized,
+        branch_in_dataset,
+        branch_in_artifact,
+    )
+    if not plan:
+        click.echo("Nothing to rename.")
+        return
+
+    click.echo(f"\nRename plan for {project_id}:\n")
+    for old_ds, new_ds, renames in plan:
+        header = f"  {old_ds} -> {new_ds}" if old_ds != new_ds else f"  {old_ds}:"
+        click.echo(header)
+        for old_t, new_t, ttype in renames:
+            click.echo(f"    {old_t} -> {new_t} ({ttype})")
+    click.echo()
+
+    if not _confirm(len(plan), "dataset(s)", dry_run, yes, verb="rename"):
+        return
+
+    for old_ds, new_ds, renames in plan:
+        _rename_dataset(client, project_id, old_ds, new_ds, renames, sql_dir)
+
+    _rewrite_target_references(sql_dir, project_id, old_sanitized, new_sanitized)
+    _prompt_and_deploy(ctx, client, project_id, plan, sql_dir, yes)
+
+
+def _prompt_and_deploy(ctx, client, project_id, plan, sql_dir, yes):
+    """Prompt the user to re-deploy renamed artifacts and invoke deploy if confirmed."""
+    renamed_paths = [
+        str(Path(sql_dir) / project_id / new_ds / new_name)
+        for _, new_ds, renames in plan
+        for _, new_name, _ in renames
+    ]
+    if not renamed_paths:
+        return
+    if not (
+        yes
+        or click.confirm(
+            "\nRenamed tables reflect BigQuery state at rename time, not local "
+            "SQL templates. Views, materialized views, and routines were skipped "
+            "and don't yet exist at the new location.\n"
+            "Run `./bqetl deploy` now to re-render everything from templates? "
+            "(skipped views/MVs/routines at the old location will be deleted "
+            "first so deploy can recreate them cleanly)",
+            default=False,
+        )
+    ):
+        return
+
+    _delete_skipped_artifacts(client, project_id, plan)
+    ctx.invoke(
+        deploy_cmd,
+        paths=tuple(renamed_paths),
+        tables=True,
+        views=True,
+        routines=True,
+    )
+
+
+def _rewrite_target_references(sql_dir, project_id, old_sanitized, new_sanitized):
+    """Substring-replace old_sanitized with new_sanitized in SQL/YAML files under the target project.
+
+    Catches downstream references (FROM clauses, routine calls, manifests) in
+    other artifacts in the target dir that point at the renamed names. Skipped
+    when old_sanitized is short enough that false positives are likely.
+    """
+    if len(old_sanitized) < 4:
+        click.echo(
+            f"  Skipping reference rewrite: '{old_sanitized}' is too short "
+            "to substring-replace safely."
+        )
+        return
+
+    project_dir = Path(sql_dir) / project_id
+    if not project_dir.exists():
+        return
+
+    updated = 0
+    for path in project_dir.rglob("*"):
+        if not path.is_file() or path.suffix not in (".sql", ".yaml"):
+            continue
+        try:
+            content = path.read_text()
+        except (UnicodeDecodeError, OSError):
+            continue
+        if old_sanitized not in content:
+            continue
+        path.write_text(content.replace(old_sanitized, new_sanitized))
+        updated += 1
+
+    if updated:
+        click.echo(f"  Rewrote references in {updated} local file(s)")
+
+
+def _delete_skipped_artifacts(client, project_id, plan):
+    """Delete old views/MVs/routines that rename skipped so deploy can recreate them."""
+    for old_ds, new_ds, renames in plan:
+        for old_name, _, ttype in renames:
+            ref = f"{project_id}.{old_ds}.{old_name}"
+            try:
+                if ttype == "ROUTINE":
+                    client.delete_routine(ref)
+                elif ttype in ("VIEW", "MATERIALIZED_VIEW"):
+                    client.delete_table(ref, not_found_ok=True)
+                else:
+                    continue
+                click.echo(f"  Deleted {ttype.lower()} {old_ds}.{old_name}")
+            except Exception as e:
+                click.echo(
+                    f"  Failed to delete {ttype.lower()} {old_ds}.{old_name}: {e}",
+                    err=True,
+                )
+        if old_ds != new_ds:
+            try:
+                client.delete_dataset(f"{project_id}.{old_ds}", not_found_ok=True)
+                click.echo(f"  Deleted dataset {old_ds}")
+            except Exception as e:
+                click.echo(f"  Could not delete dataset {old_ds}: {e}", err=True)
+
+
+def _build_rename_plan(
+    client,
+    project_id,
+    datasets,
+    old_sanitized,
+    new_sanitized,
+    branch_in_dataset,
+    branch_in_artifact,
+):
+    """Compute [(old_ds, new_ds, [(old_name, new_name, type), ...])] entries.
+
+    Type is the BigQuery table type (TABLE, VIEW, MATERIALIZED_VIEW, ...) or
+    "ROUTINE" for UDFs and stored procedures.
+    """
+    rename_ds = (
+        (lambda s: s.replace(old_sanitized, new_sanitized))
+        if branch_in_dataset
+        else (lambda s: s)
+    )
+    rename_art = (
+        (lambda s: s.replace(old_sanitized, new_sanitized))
+        if branch_in_artifact
+        else (lambda s: s)
+    )
+
+    plan = []
+    for ds in datasets:
+        new_ds_id = rename_ds(ds.dataset_id)
+        ds_path = f"{project_id}.{ds.dataset_id}"
+        try:
+            tables = list(client.list_tables(ds_path))
+        except NotFound:
+            continue
+        candidates = [(t.table_id, t.table_type) for t in tables]
+        candidates += [(r.routine_id, "ROUTINE") for r in client.list_routines(ds_path)]
+
+        renames = []
+        for old_id, ttype in candidates:
+            new_id = rename_art(old_id)
+            if new_ds_id == ds.dataset_id and new_id == old_id:
+                continue
+            renames.append((old_id, new_id, ttype))
+        if new_ds_id != ds.dataset_id or renames:
+            plan.append((ds.dataset_id, new_ds_id, renames))
+    return plan
+
+
+def _rename_dataset(client, project_id, old_ds, new_ds, renames, sql_dir):
+    """Copy tables in parallel, skip views/MVs/routines (handled by deploy), update local files."""
+    if old_ds != new_ds:
+        _ensure_new_dataset(client, project_id, old_ds, new_ds)
+
+    jobs = []
+    for old_name, new_name, ttype in renames:
+        if ttype in ("VIEW", "MATERIALIZED_VIEW", "ROUTINE"):
+            click.echo(
+                f"  Skipped {ttype.lower()} {old_ds}.{old_name} — deploy will recreate",
+                err=True,
+            )
+            continue
+        src = f"{project_id}.{old_ds}.{old_name}"
+        dst = f"{project_id}.{new_ds}.{new_name}"
+        jobs.append((old_name, new_name, src, client.copy_table(src, dst)))
+
+    for old_t, new_t, src, job in jobs:
+        try:
+            job.result()
+            click.echo(f"  Copied {old_ds}.{old_t} -> {new_ds}.{new_t}")
+        except Exception as e:
+            click.echo(f"  Failed to copy {old_ds}.{old_t}: {e}", err=True)
+            continue
+
+        manifest_file = Path(sql_dir) / project_id / old_ds / old_t / MANIFEST_FILENAME
+        _reapply_shared_access(client, f"{project_id}.{new_ds}.{new_t}", manifest_file)
+
+        try:
+            client.delete_table(src, not_found_ok=True)
+        except Exception as e:
+            click.echo(f"  Failed to delete {old_ds}.{old_t}: {e}", err=True)
+
+    _rename_local_files(sql_dir, project_id, old_ds, new_ds, renames)
+
+
+def _ensure_new_dataset(client, project_id, old_ds, new_ds):
+    """Create new_ds (if missing) as a metadata copy of old_ds."""
+    new_ds_ref = f"{project_id}.{new_ds}"
+    try:
+        client.get_dataset(new_ds_ref)
+        return
+    except NotFound:
+        pass
+    old = client.get_dataset(f"{project_id}.{old_ds}")
+    new = bigquery.Dataset(new_ds_ref)
+    new.location = old.location
+    new.labels = dict(old.labels) if old.labels else {}
+    new.description = old.description
+    new.access_entries = list(old.access_entries)
+    client.create_dataset(new)
+    click.echo(f"  Created dataset {new_ds}")
+
+
+def _rename_local_files(sql_dir, project_id, old_ds, new_ds, renames):
+    """Move local target dirs to match the new BigQuery names."""
+    old_dir = Path(sql_dir) / project_id / old_ds
+    if not old_dir.exists():
+        return
+    new_dir = Path(sql_dir) / project_id / new_ds
+    new_dir.mkdir(parents=True, exist_ok=True)
+    for old_t, new_t, _ in renames:
+        src = old_dir / old_t
+        dst = new_dir / new_t
+        if src == dst or not src.exists() or dst.exists():
+            continue
+        shutil.move(str(src), str(dst))
+    if old_dir != new_dir and old_dir.exists() and not any(old_dir.iterdir()):
+        old_dir.rmdir()
 
 
 def _grant_dataset_access(client, dataset_ref, email, role):

--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -100,7 +100,10 @@ class Target:
 
 
 def _template_to_pattern(
-    template_str: str, branch: Optional[str] = None, anchor_end: bool = False
+    template_str: str,
+    branch: Optional[str] = None,
+    anchor_end: bool = False,
+    capture_commit: bool = False,
 ) -> str:
     """Render a Jinja2 template into a regex pattern for matching BQ identifiers.
 
@@ -109,6 +112,10 @@ def _template_to_pattern(
     legacy templates; other variable slots become [a-zA-Z0-9_]+. Anchoring
     the commit slot to a hex SHA prefix prevents over-matching when the
     literal branch is a substring of another branch's sanitized name.
+
+    If capture_commit is True, the first commit slot is wrapped in a
+    (non-greedy) capture group so the commit can be extracted from a name
+    that matches the pattern.
 
     Returns a ^-anchored regex string, optionally $-anchored.
     """
@@ -120,10 +127,11 @@ def _template_to_pattern(
         artifact={"project_id": _WILDCARD, "dataset_id": _WILDCARD},
     )
 
-    pattern = (
-        re.escape(sanitize_bq_id(rendered))
-        .replace(_COMMIT_WILDCARD, "[a-f0-9]{7,}[a-zA-Z0-9_]*")
-        .replace(_WILDCARD, "[a-zA-Z0-9_]+")
+    escaped = re.escape(sanitize_bq_id(rendered))
+    if capture_commit:
+        escaped = escaped.replace(_COMMIT_WILDCARD, "([a-f0-9]{7,}[a-zA-Z0-9_]*?)", 1)
+    pattern = escaped.replace(_COMMIT_WILDCARD, "[a-f0-9]{7,}[a-zA-Z0-9_]*").replace(
+        _WILDCARD, "[a-zA-Z0-9_]+"
     )
 
     return f"^{pattern}$" if anchor_end else f"^{pattern}"
@@ -149,6 +157,27 @@ def render_artifact_prefix_pattern(
     if not target.raw_artifact_prefix:
         return None
     return _template_to_pattern(target.raw_artifact_prefix, branch=branch)
+
+
+def extract_commit_from_dataset_name(
+    target: Target, dataset_id: str, branch: str
+) -> Optional[str]:
+    """Extract the git.commit value from a dataset name using the target's template.
+
+    Returns None if the template has no git.commit slot or the name does not
+    match the expected pattern.
+    """
+    template_str = target.raw_dataset or target.raw_dataset_prefix
+    if not template_str or "git.commit" not in template_str:
+        return None
+    pattern = _template_to_pattern(
+        template_str,
+        branch=branch,
+        anchor_end=bool(target.raw_dataset),
+        capture_commit=True,
+    )
+    m = re.match(pattern, dataset_id)
+    return m.group(1) if m else None
 
 
 def render_artifact_template(

--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -104,19 +104,27 @@ def _template_to_pattern(
 ) -> str:
     """Render a Jinja2 template into a regex pattern for matching BQ identifiers.
 
-    Known values (branch, username) are rendered literally; variable parts
-    (commit, artifact ids) become [a-zA-Z0-9_]+ regex wildcards.
+    Known values (branch, username) are rendered literally; the commit slot
+    must start with 7+ hex chars (short SHA) and may have trailing chars from
+    legacy templates; other variable slots become [a-zA-Z0-9_]+. Anchoring
+    the commit slot to a hex SHA prefix prevents over-matching when the
+    literal branch is a substring of another branch's sanitized name.
 
     Returns a ^-anchored regex string, optionally $-anchored.
     """
     _WILDCARD = "XBQETLWCX"
+    _COMMIT_WILDCARD = "XBQETLCOMMITX"
     rendered = Template(template_str).render(
-        git={"branch": branch or _WILDCARD, "commit": _WILDCARD},
+        git={"branch": branch or _WILDCARD, "commit": _COMMIT_WILDCARD},
         account=_get_account_context(),
         artifact={"project_id": _WILDCARD, "dataset_id": _WILDCARD},
     )
 
-    pattern = re.escape(sanitize_bq_id(rendered)).replace(_WILDCARD, "[a-zA-Z0-9_]+")
+    pattern = (
+        re.escape(sanitize_bq_id(rendered))
+        .replace(_COMMIT_WILDCARD, "[a-f0-9]{7,}[a-zA-Z0-9_]*")
+        .replace(_WILDCARD, "[a-zA-Z0-9_]+")
+    )
 
     return f"^{pattern}$" if anchor_end else f"^{pattern}"
 

--- a/docs/cookbooks/development_workflows.md
+++ b/docs/cookbooks/development_workflows.md
@@ -231,6 +231,18 @@ deploy, migrated tables won't pick those changes up. Accept the deploy
 prompt at the end of the command — or run `./bqetl deploy` manually on
 the migrated paths — to re-render everything from templates.
 
+**Caveat: substring replacement.** Renames and local reference rewrites
+are implemented as plain substring replacement of the sanitized branch
+(and commit) string. A very short or generic branch name (e.g. `dev`,
+`test`, `a`) can incorrectly match unrelated substrings inside identifiers
+or SQL/YAML content, producing bad names or content edits. In practice
+ticket-prefixed branch names (`DENG-1234-*`, `feature-xyz`) are unique
+enough that this doesn't bite, and the rewrite is scoped to the target
+project's dev directory — but if you use generic branch names, preview
+with `--dry-run` and spot-check the migration plan before accepting.
+A more robust implementation would match qualified table IDs via regex
+rather than using raw substring replace.
+
 ### 8. Isolated deploys (e.g. for staging) _(future)_
 
 Use `--isolated` to rewrite **all** references to the target environment, ensuring complete isolation:

--- a/docs/cookbooks/development_workflows.md
+++ b/docs/cookbooks/development_workflows.md
@@ -188,28 +188,36 @@ Empty datasets are removed automatically after table-level cleanup.
 
 Local copied files are cleaned up in both cases.
 
-### 7. Handle branch renames
+### 7. Migrate a previous branch's deployment to the current branch
 
 ```bash
-./bqetl --target dev target rename-branch old-feature-name new-feature-name
+# Check out the destination branch first
+git checkout new-feature-name
+
+./bqetl --target dev target migrate-branch old-feature-name
 
 # Preview first
-./bqetl --target dev target rename-branch old-feature-name new-feature-name --dry-run
+./bqetl --target dev target migrate-branch old-feature-name --dry-run
 ```
 
-Replaces the sanitized old-branch string with the new-branch string in
-dataset and/or artifact names, depending on where `git.branch` appears in
-the target's templates. Tables are copied to their new location and the
-originals deleted. Views, materialized views, and routines are skipped
-during the rename; the deploy step prompted at the end of the command
-recreates them at the new location from local SQL templates and cleans up
-the originals.
+The destination branch is always the currently checked-out git branch —
+the deploy step that recreates views/MVs/routines renders target names
+from the current branch, so this command must be run from the branch
+you're migrating to.
 
-Renamed tables reflect the BigQuery state at time of rename, not the
+Replaces the sanitized old-branch string with the current-branch string
+in dataset and/or artifact names, depending on where `git.branch` appears
+in the target's templates. Tables are copied to their new location and
+the originals deleted. Views, materialized views, and routines are
+skipped during the migration; the deploy step prompted at the end of the
+command recreates them at the new location from local SQL templates and
+cleans up the originals.
+
+Migrated tables reflect the BigQuery state at time of migration, not the
 current local SQL templates. If templates have drifted since the last
-deploy, renamed tables won't pick those changes up. Accept the deploy
+deploy, migrated tables won't pick those changes up. Accept the deploy
 prompt at the end of the command — or run `./bqetl deploy` manually on
-the renamed paths — to re-render everything from templates.
+the migrated paths — to re-render everything from templates.
 
 ### 8. Isolated deploys (e.g. for staging) _(future)_
 

--- a/docs/cookbooks/development_workflows.md
+++ b/docs/cookbooks/development_workflows.md
@@ -188,11 +188,28 @@ Empty datasets are removed automatically after table-level cleanup.
 
 Local copied files are cleaned up in both cases.
 
-### 7. Handle branch renames _(future)_
+### 7. Handle branch renames
 
 ```bash
-./bqetl --target dev rename-branch old-feature-name new-feature-name
+./bqetl --target dev target rename-branch old-feature-name new-feature-name
+
+# Preview first
+./bqetl --target dev target rename-branch old-feature-name new-feature-name --dry-run
 ```
+
+Replaces the sanitized old-branch string with the new-branch string in
+dataset and/or artifact names, depending on where `git.branch` appears in
+the target's templates. Tables are copied to their new location and the
+originals deleted. Views, materialized views, and routines are skipped
+during the rename; the deploy step prompted at the end of the command
+recreates them at the new location from local SQL templates and cleans up
+the originals.
+
+Renamed tables reflect the BigQuery state at time of rename, not the
+current local SQL templates. If templates have drifted since the last
+deploy, renamed tables won't pick those changes up. Accept the deploy
+prompt at the end of the command — or run `./bqetl deploy` manually on
+the renamed paths — to re-render everything from templates.
 
 ### 8. Isolated deploys (e.g. for staging) _(future)_
 

--- a/docs/cookbooks/development_workflows.md
+++ b/docs/cookbooks/development_workflows.md
@@ -213,6 +213,18 @@ skipped during the migration; the deploy step prompted at the end of the
 command recreates them at the new location from local SQL templates and
 cleans up the originals.
 
+References (FROM clauses, routine calls, manifests) in local SQL/YAML
+files under the target dir are also rewritten to the new names, so
+downstream queries generated under the target path keep pointing at the
+migrated artifacts.
+
+If the target template includes `git.commit`, only the most recently
+modified commit's datasets are migrated — older commit deployments are
+left behind (clean those up with `./bqetl target clean` if no longer
+needed). The commit hash in dataset and artifact names is rewritten to
+the current `HEAD`, so the next deploy lands at the matching location
+instead of creating a parallel set of artifacts.
+
 Migrated tables reflect the BigQuery state at time of migration, not the
 current local SQL templates. If templates have drifted since the last
 deploy, migrated tables won't pick those changes up. Accept the deploy

--- a/tests/cli/test_cli_target.py
+++ b/tests/cli/test_cli_target.py
@@ -107,7 +107,7 @@ class TestRewriteTargetReferences:
         yaml_file.write_text("owners:\n  - user_oldname_owner\n")
 
         _rewrite_target_references(
-            str(tmp_path), "proj", _make_transform([("oldname", "newname")], None)
+            str(tmp_path), "proj", _make_transform([("oldname", "newname")])
         )
 
         assert "user_newname_ds.tbl" in sql_file.read_text()
@@ -119,7 +119,7 @@ class TestRewriteTargetReferences:
         txt_file.write_text("oldname should stay")
 
         _rewrite_target_references(
-            str(tmp_path), "proj", _make_transform([("oldname", "newname")], None)
+            str(tmp_path), "proj", _make_transform([("oldname", "newname")])
         )
 
         assert txt_file.read_text() == "oldname should stay"
@@ -128,7 +128,7 @@ class TestRewriteTargetReferences:
         _rewrite_target_references(
             str(tmp_path),
             "nonexistent",
-            _make_transform([("oldname", "newname")], None),
+            _make_transform([("oldname", "newname")]),
         )
 
 
@@ -174,7 +174,9 @@ class TestBuildRenamePlan:
                 }
             }
         )
-        transform = _make_transform([("feat_old", "feat_new")], ("abc1234", "def5678"))
+        transform = _make_transform(
+            [("feat_old", "feat_new"), ("abc1234", "def5678")]
+        )
 
         plan = _build_rename_plan(client, "proj", [ds], transform, transform)
 
@@ -196,7 +198,7 @@ class TestBuildRenamePlan:
                 }
             }
         )
-        identity = _make_transform([], None)
+        identity = _make_transform([])
 
         plan = _build_rename_plan(client, "proj", [ds], identity, identity)
 
@@ -209,8 +211,8 @@ class TestBuildRenamePlan:
         client = _mock_client(
             {f"proj.{old_ds}": {"tables": [("tbl", "TABLE")], "routines": []}}
         )
-        rename_ds = _make_transform([("old", "new")], None)
-        identity = _make_transform([], None)
+        rename_ds = _make_transform([("old", "new")])
+        identity = _make_transform([])
 
         plan = _build_rename_plan(client, "proj", [ds], rename_ds, identity)
 

--- a/tests/cli/test_cli_target.py
+++ b/tests/cli/test_cli_target.py
@@ -174,9 +174,7 @@ class TestBuildRenamePlan:
                 }
             }
         )
-        transform = _make_transform(
-            [("feat_old", "feat_new"), ("abc1234", "def5678")]
-        )
+        transform = _make_transform([("feat_old", "feat_new"), ("abc1234", "def5678")])
 
         plan = _build_rename_plan(client, "proj", [ds], transform, transform)
 

--- a/tests/cli/test_cli_target.py
+++ b/tests/cli/test_cli_target.py
@@ -4,7 +4,11 @@ import click
 import pytest
 import yaml
 
-from bigquery_etl.cli.target import _parse_duration, _persist_share
+from bigquery_etl.cli.target import (
+    _parse_duration,
+    _persist_share,
+    _rewrite_target_references,
+)
 from bigquery_etl.util.target import MANIFEST_FILENAME
 
 
@@ -82,3 +86,44 @@ class TestPersistShare:
     def test_no_manifest_is_noop(self, tmp_path):
         _persist_share(tmp_path, "proj", "ds", "tbl", "a@b.com", "READER")
         assert not (tmp_path / "proj" / "ds" / "tbl" / MANIFEST_FILENAME).exists()
+
+
+class TestRewriteTargetReferences:
+    def _setup(self, tmp_path):
+        project_dir = tmp_path / "proj"
+        (project_dir / "ds" / "tbl").mkdir(parents=True)
+        (project_dir / "ds2" / "tbl2").mkdir(parents=True)
+        return project_dir
+
+    def test_replaces_in_sql_and_yaml(self, tmp_path):
+        project_dir = self._setup(tmp_path)
+        sql_file = project_dir / "ds" / "tbl" / "query.sql"
+        sql_file.write_text("SELECT * FROM proj.user_oldname_ds.tbl")
+        yaml_file = project_dir / "ds" / "tbl" / "metadata.yaml"
+        yaml_file.write_text("owners:\n  - user_oldname_owner\n")
+
+        _rewrite_target_references(str(tmp_path), "proj", "oldname", "newname")
+
+        assert "user_newname_ds.tbl" in sql_file.read_text()
+        assert "user_newname_owner" in yaml_file.read_text()
+
+    def test_skips_non_sql_yaml(self, tmp_path):
+        project_dir = self._setup(tmp_path)
+        txt_file = project_dir / "ds" / "tbl" / "notes.txt"
+        txt_file.write_text("oldname should stay")
+
+        _rewrite_target_references(str(tmp_path), "proj", "oldname", "newname")
+
+        assert txt_file.read_text() == "oldname should stay"
+
+    def test_short_sanitized_is_noop(self, tmp_path):
+        project_dir = self._setup(tmp_path)
+        sql_file = project_dir / "ds" / "tbl" / "query.sql"
+        sql_file.write_text("SELECT abc FROM t")
+
+        _rewrite_target_references(str(tmp_path), "proj", "abc", "xyz")
+
+        assert sql_file.read_text() == "SELECT abc FROM t"
+
+    def test_missing_project_dir_is_noop(self, tmp_path):
+        _rewrite_target_references(str(tmp_path), "nonexistent", "oldname", "newname")

--- a/tests/cli/test_cli_target.py
+++ b/tests/cli/test_cli_target.py
@@ -1,15 +1,19 @@
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
 
 import click
 import pytest
 import yaml
 
 from bigquery_etl.cli.target import (
+    _build_rename_plan,
+    _make_transform,
+    _narrow_to_newest_commit,
     _parse_duration,
     _persist_share,
     _rewrite_target_references,
 )
-from bigquery_etl.util.target import MANIFEST_FILENAME
+from bigquery_etl.util.target import MANIFEST_FILENAME, Target
 
 
 class TestParseDuration:
@@ -102,7 +106,9 @@ class TestRewriteTargetReferences:
         yaml_file = project_dir / "ds" / "tbl" / "metadata.yaml"
         yaml_file.write_text("owners:\n  - user_oldname_owner\n")
 
-        _rewrite_target_references(str(tmp_path), "proj", "oldname", "newname")
+        _rewrite_target_references(
+            str(tmp_path), "proj", _make_transform([("oldname", "newname")], None)
+        )
 
         assert "user_newname_ds.tbl" in sql_file.read_text()
         assert "user_newname_owner" in yaml_file.read_text()
@@ -112,18 +118,151 @@ class TestRewriteTargetReferences:
         txt_file = project_dir / "ds" / "tbl" / "notes.txt"
         txt_file.write_text("oldname should stay")
 
-        _rewrite_target_references(str(tmp_path), "proj", "oldname", "newname")
+        _rewrite_target_references(
+            str(tmp_path), "proj", _make_transform([("oldname", "newname")], None)
+        )
 
         assert txt_file.read_text() == "oldname should stay"
 
-    def test_short_sanitized_is_noop(self, tmp_path):
-        project_dir = self._setup(tmp_path)
-        sql_file = project_dir / "ds" / "tbl" / "query.sql"
-        sql_file.write_text("SELECT abc FROM t")
-
-        _rewrite_target_references(str(tmp_path), "proj", "abc", "xyz")
-
-        assert sql_file.read_text() == "SELECT abc FROM t"
-
     def test_missing_project_dir_is_noop(self, tmp_path):
-        _rewrite_target_references(str(tmp_path), "nonexistent", "oldname", "newname")
+        _rewrite_target_references(
+            str(tmp_path),
+            "nonexistent",
+            _make_transform([("oldname", "newname")], None),
+        )
+
+
+def _mock_client(datasets):
+    """Build a MagicMock bigquery.Client with list_tables/list_routines stubbed."""
+    client = MagicMock()
+    client.list_tables.side_effect = lambda path: [
+        _mock_table(t, ttype) for t, ttype in datasets.get(path, {}).get("tables", [])
+    ]
+    client.list_routines.side_effect = lambda path: [
+        _mock_routine(r) for r in datasets.get(path, {}).get("routines", [])
+    ]
+    return client
+
+
+def _mock_table(table_id, ttype):
+    t = MagicMock()
+    t.table_id = table_id
+    t.table_type = ttype
+    return t
+
+
+def _mock_routine(routine_id):
+    r = MagicMock()
+    r.routine_id = routine_id
+    return r
+
+
+class _FakeDataset:
+    def __init__(self, dataset_id):
+        self.dataset_id = dataset_id
+
+
+class TestBuildRenamePlan:
+    def test_applies_branch_and_commit_transforms(self):
+        old_ds = "dev_feat_old_abc1234_moz_fx"
+        ds = _FakeDataset(old_ds)
+        client = _mock_client(
+            {
+                f"proj.{old_ds}": {
+                    "tables": [("feat_old_abc1234_tbl", "TABLE")],
+                    "routines": [],
+                }
+            }
+        )
+        transform = _make_transform([("feat_old", "feat_new")], ("abc1234", "def5678"))
+
+        plan = _build_rename_plan(client, "proj", [ds], transform, transform)
+
+        assert len(plan) == 1
+        old_ds_name, new_ds_name, renames = plan[0]
+        assert old_ds_name == old_ds
+        assert new_ds_name == "dev_feat_new_def5678_moz_fx"
+        assert renames == [("feat_old_abc1234_tbl", "feat_new_def5678_tbl", "TABLE")]
+
+    def test_identity_transforms_produce_empty_plan(self):
+        """When nothing changes (no branch/commit match), that dataset is skipped."""
+        old_ds = "dev_feat_old_abc1234_moz_fx"
+        ds = _FakeDataset(old_ds)
+        client = _mock_client(
+            {
+                f"proj.{old_ds}": {
+                    "tables": [("feat_old_abc1234_tbl", "TABLE")],
+                    "routines": [],
+                }
+            }
+        )
+        identity = _make_transform([], None)
+
+        plan = _build_rename_plan(client, "proj", [ds], identity, identity)
+
+        assert plan == []
+
+    def test_dataset_only_branch_rename(self):
+        """rename_ds_id renames the dataset; rename_art_id identity leaves tables alone."""
+        old_ds = "dev_old_xx"
+        ds = _FakeDataset(old_ds)
+        client = _mock_client(
+            {f"proj.{old_ds}": {"tables": [("tbl", "TABLE")], "routines": []}}
+        )
+        rename_ds = _make_transform([("old", "new")], None)
+        identity = _make_transform([], None)
+
+        plan = _build_rename_plan(client, "proj", [ds], rename_ds, identity)
+
+        assert plan == [("dev_old_xx", "dev_new_xx", [("tbl", "tbl", "TABLE")])]
+
+
+class TestNarrowToNewestCommit:
+    def test_no_commit_template_returns_unchanged(self):
+        target = Target(
+            name="dev",
+            project_id="proj",
+            raw_dataset_prefix="dev_{{ git.branch }}_",
+        )
+        matching = [_FakeDataset("dev_feat_a"), _FakeDataset("dev_feat_b")]
+
+        narrowed, commit = _narrow_to_newest_commit(
+            MagicMock(), "proj", target, matching, "feat"
+        )
+
+        assert narrowed == matching
+        assert commit is None
+
+    def test_keeps_all_datasets_from_newest_commit_group(self):
+        target = Target(
+            name="dev",
+            project_id="proj",
+            raw_dataset_prefix="dev_{{ git.branch }}_{{ git.commit }}_{{ artifact.project_id }}_",
+        )
+        # 2 datasets for commit aaaa1234 (older), 2 for bbbb5678 (newer).
+        matching = [
+            _FakeDataset("dev_feat_aaaa1234_proj_one"),
+            _FakeDataset("dev_feat_aaaa1234_proj_two"),
+            _FakeDataset("dev_feat_bbbb5678_proj_one"),
+            _FakeDataset("dev_feat_bbbb5678_proj_two"),
+        ]
+        times = {
+            "dev_feat_aaaa1234_proj_one": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            "dev_feat_aaaa1234_proj_two": datetime(2026, 1, 2, tzinfo=timezone.utc),
+            "dev_feat_bbbb5678_proj_one": datetime(2026, 1, 10, tzinfo=timezone.utc),
+            "dev_feat_bbbb5678_proj_two": datetime(2026, 1, 11, tzinfo=timezone.utc),
+        }
+        client = MagicMock()
+        client.get_dataset.side_effect = lambda path: MagicMock(
+            modified=times[path.split(".")[-1]]
+        )
+
+        narrowed, commit = _narrow_to_newest_commit(
+            client, "proj", target, matching, "feat"
+        )
+
+        assert commit == "bbbb5678"
+        assert sorted(ds.dataset_id for ds in narrowed) == [
+            "dev_feat_bbbb5678_proj_one",
+            "dev_feat_bbbb5678_proj_two",
+        ]

--- a/tests/util/test_target.py
+++ b/tests/util/test_target.py
@@ -347,9 +347,9 @@ class TestRenderDatasetPattern:
         pattern = render_dataset_pattern(target, branch="feature/xyz")
         regex = re.compile(pattern)
 
-        assert regex.match("dev_feature_xyz_abc123_moz_fx_data_shared_prod_telemetry")
+        assert regex.match("dev_feature_xyz_abc1234_moz_fx_data_shared_prod_telemetry")
         assert not regex.match(
-            "dev_other_branch_abc123_moz_fx_data_shared_prod_telemetry"
+            "dev_other_branch_abc1234_moz_fx_data_shared_prod_telemetry"
         )
 
     def test_dataset_prefix_without_branch(self):
@@ -362,8 +362,8 @@ class TestRenderDatasetPattern:
         pattern = render_dataset_pattern(target)
         regex = re.compile(pattern)
 
-        assert regex.match("dev_feature_xyz_abc123_telemetry")
-        assert regex.match("dev_main_def456_telemetry")
+        assert regex.match("dev_feature_xyz_abc1234_telemetry")
+        assert regex.match("dev_main_def4567_telemetry")
 
     def test_dataset_anchored_end(self):
         """dataset (not dataset_prefix) produces a $-anchored pattern."""
@@ -375,9 +375,13 @@ class TestRenderDatasetPattern:
         pattern = render_dataset_pattern(target, branch="feature-xyz")
         regex = re.compile(pattern)
 
-        # Commit wildcard matches any alphanumeric+underscore suffix
-        assert regex.match("dev_feature_xyz_abc123")
-        assert regex.match("dev_feature_xyz_abc123_extra_stuff")
+        # Commit starts with a short-SHA-length hex prefix; trailing alphanumeric
+        # segments from legacy template variants are tolerated.
+        assert regex.match("dev_feature_xyz_abc1234")
+        assert regex.match("dev_feature_xyz_abc1234_extra_stuff")
+        assert regex.match("dev_feature_xyz_f379269e_json")
+        # Substring branch must not over-match a longer branch's dataset
+        assert not regex.match("dev_feature_xyz_branch_rename_abc1234")
 
     def test_username_rendered_literally(self):
         """account.username is rendered with real value, not wildcarded."""
@@ -406,8 +410,8 @@ class TestRenderArtifactPrefixPattern:
         pattern = render_artifact_prefix_pattern(target, branch="feature-xyz")
         regex = re.compile(pattern)
 
-        assert regex.match("feature_xyz_abc123_clients_daily_v6")
-        assert not regex.match("other_branch_abc123_clients_daily_v6")
+        assert regex.match("feature_xyz_abc1234_clients_daily_v6")
+        assert not regex.match("other_branch_abc1234_clients_daily_v6")
 
     def test_returns_none_without_artifact_prefix(self):
         target = Target(name="dev", project_id="test-project")

--- a/tests/util/test_target.py
+++ b/tests/util/test_target.py
@@ -9,6 +9,7 @@ import yaml
 from bigquery_etl.util.target import (
     MANIFEST_FILENAME,
     Target,
+    extract_commit_from_dataset_name,
     get_deployed_tables_in_target,
     get_target,
     prepare_target_directory,
@@ -429,6 +430,74 @@ class TestRenderArtifactPrefixPattern:
 
         assert regex.match("moz_fx_data_shared_prod_testuser_clients_daily_v6")
         assert not regex.match("moz_fx_data_shared_prod_otheruser_clients_daily_v6")
+
+
+@pytest.mark.usefixtures("mock_account")
+class TestExtractCommitFromDatasetName:
+    """Tests for extract_commit_from_dataset_name used by target migrate-branch."""
+
+    def test_extracts_from_dataset_prefix(self):
+        target = Target(
+            name="dev",
+            project_id="test-project",
+            raw_dataset_prefix="dev_{{ git.branch }}_{{ git.commit }}_{{ artifact.project_id }}_",
+        )
+        commit = extract_commit_from_dataset_name(
+            target,
+            "dev_feature_xyz_abc1234_moz_fx_data_shared_prod_telemetry",
+            branch="feature-xyz",
+        )
+        assert commit == "abc1234"
+
+    def test_extracts_full_sha(self):
+        target = Target(
+            name="dev",
+            project_id="test-project",
+            raw_dataset="dev_{{ git.branch }}_{{ git.commit }}",
+        )
+        commit = extract_commit_from_dataset_name(
+            target,
+            "dev_feature_xyz_235bf9cf0ac1ef0fa3a127cdc5f0061a588dd819",
+            branch="feature-xyz",
+        )
+        assert commit == "235bf9cf0ac1ef0fa3a127cdc5f0061a588dd819"
+
+    def test_extracts_legacy_trailing_segment(self):
+        target = Target(
+            name="dev",
+            project_id="test-project",
+            raw_dataset="dev_{{ git.branch }}_{{ git.commit }}",
+        )
+        commit = extract_commit_from_dataset_name(
+            target, "dev_feature_xyz_f379269e_json", branch="feature-xyz"
+        )
+        assert commit == "f379269e_json"
+
+    def test_returns_none_without_commit_in_template(self):
+        target = Target(
+            name="dev",
+            project_id="test-project",
+            raw_dataset_prefix="dev_{{ git.branch }}_",
+        )
+        assert (
+            extract_commit_from_dataset_name(
+                target, "dev_feature_xyz_telemetry", branch="feature-xyz"
+            )
+            is None
+        )
+
+    def test_returns_none_when_name_does_not_match(self):
+        target = Target(
+            name="dev",
+            project_id="test-project",
+            raw_dataset="dev_{{ git.branch }}_{{ git.commit }}",
+        )
+        assert (
+            extract_commit_from_dataset_name(
+                target, "completely_unrelated", branch="feature-xyz"
+            )
+            is None
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Adds `./bqetl --target <name> target migrate-branch <old_branch>` for moving an existing target deployment from a previous branch to the currently checked-out branch. This is useful after renaming a local git branch, so existing dev artifacts match the new branch.

- Renames datasets and/or artifacts (depending on where git.branch appears in the target's templates) by replacing the sanitized old-branch string with the new one.
- Tables are copied in place and the originals deleted. Views, materialized views, and routines are skipped during migration and recreated by a deploy step prompted at the end
- Rewrites references (FROM clauses, routine calls, manifests) in local SQL/YAML files under the target project dir, so downstream queries under the target path keep pointing at the migrated artifacts.
- When the target template includes `git.commit`, only the newest commit's datasets are migrated, and the commit hash is rewritten to current HEAD so the next deploy lands at the matching location instead of creating a parallel set of artifacts.


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
