### PR TITLE
[DENG-10973] Generate dag with copy_deduplicate task_markers

### DIFF
--- a/bigquery_etl/cli/dag.py
+++ b/bigquery_etl/cli/dag.py
@@ -9,6 +9,10 @@ import yaml
 
 from ..cli.utils import is_valid_dir, is_valid_file, sql_dir_option
 from ..metadata.parse_metadata import METADATA_FILE, Metadata
+from ..query_scheduling.copy_deduplicate_task_markers import (
+    TASK_MARKERS_DAG_NAME,
+    write_task_markers_dag,
+)
 from ..query_scheduling.dag import Dag
 from ..query_scheduling.dag_collection import DagCollection
 from ..query_scheduling.generate_airflow_dags import get_dags
@@ -239,7 +243,13 @@ def create(
 def generate(name, dags_config, sql_dir, output_dir):
     """CLI command for generating Airflow DAGs."""
     dags = get_dags(None, dags_config, sql_dir)
-    if name:
+    if name == TASK_MARKERS_DAG_NAME:
+        # copy_deduplicate task markers need to resolve every task's upstream dependencies
+        for _dag in dags.dags:
+            _dag.with_upstream_dependencies(dags)
+        output_file = write_task_markers_dag(dags, output_dir)
+        click.echo(f"Generated {output_file}")
+    elif name:
         # only generate specific DAG
         dag = dags.dag_by_name(name)
 

--- a/bigquery_etl/query_scheduling/copy_deduplicate_task_markers.py
+++ b/bigquery_etl/query_scheduling/copy_deduplicate_task_markers.py
@@ -1,8 +1,8 @@
 """Generate the copy_deduplicate_task_markers DAG.
 
 Generate an intermediate DAG between copy_deduplicate in the telemetry-airflow repo and
-its dependent DAGs.  This DAG contains `ExternalTaskMarker`s for the downstream tasks/DAGs so
-that setting state on the upstream copy_deduplicate tasks will propagate to downstream tasks.
+its dependent DAGs. This DAG contains `ExternalTaskMarker`s for the downstream tasks/DAGs so
+that clearing tasks in the upstream copy_deduplicate tasks will propagate to downstream tasks.
 This allows the task markers to stay updated without needing to change the code in telemetry-airflow.
 """
 
@@ -61,7 +61,11 @@ def build_markers_context(dag_collection) -> dict:
         for task in dag.tasks:
             deps = (task.upstream_dependencies or []) + (task.depends_on or [])
             for dep in deps:
+                # not copy_deduplicate
                 if dep.dag_name != SOURCE_DAG_NAME:
+                    continue
+                # already looked at task + dag
+                if dag.name in consumers_by_source[dep.task_id]:
                     continue
                 source_schedule = source_schedules.get(dep.task_id)
                 if source_schedule is None:
@@ -77,7 +81,7 @@ def build_markers_context(dag_collection) -> dict:
                         f"{dag.name} ({downstream_schedule!r})."
                     )
                 delta_seconds = _execution_delta_seconds(delta_string)
-                consumers_by_source[dep.task_id].setdefault(dag.name, delta_seconds)
+                consumers_by_source[dep.task_id][dag.name] = delta_seconds
 
     sources: List[tuple] = []
     for source_task_id in sorted(consumers_by_source):
@@ -98,9 +102,6 @@ def build_markers_context(dag_collection) -> dict:
         "schedule_interval": markers_schedule,
         "owner": TELEMETRY_ALERTS_EMAIL,
         "email": [TELEMETRY_ALERTS_EMAIL],
-        "start_date_year": 2019,
-        "start_date_month": 7,
-        "start_date_day": 25,
         "tags": [
             "impact/tier_1",
             "repo/bigquery-etl",

--- a/bigquery_etl/query_scheduling/copy_deduplicate_task_markers.py
+++ b/bigquery_etl/query_scheduling/copy_deduplicate_task_markers.py
@@ -1,0 +1,128 @@
+"""Generate the copy_deduplicate_task_markers DAG.
+
+Generate an intermediate DAG between copy_deduplicate in the telemetry-airflow repo and
+its dependent DAGs.  This DAG contains `ExternalTaskMarker`s for the downstream tasks/DAGs so
+that setting state on the upstream copy_deduplicate tasks will propagate to downstream tasks.
+This allows the task markers to stay updated without needing to change the code in telemetry-airflow.
+"""
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+from black import FileMode, format_file_contents
+from jinja2 import Environment, PackageLoader
+
+from bigquery_etl.query_scheduling.task import EXTERNAL_TASKS
+from bigquery_etl.query_scheduling.utils import (
+    TELEMETRY_ALERTS_EMAIL,
+    schedule_interval_delta,
+)
+
+TASK_MARKERS_DAG_NAME = "copy_deduplicate_task_markers"
+TASK_MARKERS_TEMPLATE = "copy_deduplicate_task_markers.j2"
+SOURCE_DAG_NAME = "copy_deduplicate"
+
+
+def _execution_delta_seconds(delta_string: str) -> int:
+    """Parse a `<int>s` timedelta string into an int number of seconds."""
+    if delta_string is None:
+        return 0
+    if not delta_string.endswith("s"):
+        raise ValueError(
+            f"schedule_interval_delta should end with 's', got {delta_string!r}"
+        )
+    return int(delta_string[:-1])
+
+
+def build_markers_context(dag_collection) -> dict:
+    """Build the Jinja context used to render the task-markers DAG.
+
+    Walks every task in `dag_collection`, finds upstream deps pointing at
+    `copy_deduplicate`, and groups consumers by source task id.
+    """
+    # {task_id: schedule_interval} for each copy_deduplicate task
+    source_schedules = {
+        task_ref.task_id: task_ref.schedule_interval
+        for task_ref in EXTERNAL_TASKS
+        if task_ref.dag_name == SOURCE_DAG_NAME
+    }
+    if not source_schedules:
+        raise ValueError(
+            f"No {SOURCE_DAG_NAME} tasks found in EXTERNAL_TASKS; "
+            f"cannot generate {TASK_MARKERS_DAG_NAME} DAG."
+        )
+
+    # {source_task_id: {downstream_dag_name: execution_delta_seconds}}
+    consumers_by_source: Dict[str, Dict[str, int]] = defaultdict(dict)
+
+    for dag in dag_collection.dags:
+        downstream_schedule = dag.schedule_interval
+        for task in dag.tasks:
+            deps = (task.upstream_dependencies or []) + (task.depends_on or [])
+            for dep in deps:
+                if dep.dag_name != SOURCE_DAG_NAME:
+                    continue
+                source_schedule = source_schedules.get(dep.task_id)
+                if source_schedule is None:
+                    raise ValueError(
+                        f"unknown {SOURCE_DAG_NAME} task_id {dep.task_id!r} in DAG"
+                    )
+                delta_string = schedule_interval_delta(
+                    source_schedule, downstream_schedule
+                )
+                if delta_string is None:
+                    raise ValueError(
+                        f"Cannot compute execution_delta between {SOURCE_DAG_NAME} ({source_schedule!r}) and "
+                        f"{dag.name} ({downstream_schedule!r})."
+                    )
+                delta_seconds = _execution_delta_seconds(delta_string)
+                consumers_by_source[dep.task_id].setdefault(dag.name, delta_seconds)
+
+    sources: List[tuple] = []
+    for source_task_id in sorted(consumers_by_source):
+        consumers = [
+            {"dag_name": dag_name, "execution_delta_seconds": delta_seconds}
+            for dag_name, delta_seconds in sorted(
+                consumers_by_source[source_task_id].items()
+            )
+        ]
+        sources.append((source_task_id, consumers))
+
+    # Use copy_deduplicate's own schedule so execution_dates line up 1:1
+    markers_schedule = next(iter(source_schedules.values()))
+
+    return {
+        "name": TASK_MARKERS_DAG_NAME,
+        "source_dag_id": SOURCE_DAG_NAME,
+        "schedule_interval": markers_schedule,
+        "owner": TELEMETRY_ALERTS_EMAIL,
+        "email": [TELEMETRY_ALERTS_EMAIL],
+        "start_date_year": 2019,
+        "start_date_month": 7,
+        "start_date_day": 25,
+        "tags": [
+            "impact/tier_1",
+            "repo/bigquery-etl",
+        ],
+        "sources": sources,
+    }
+
+
+def render_task_markers_dag(dag_collection) -> str:
+    """Render the task-markers DAG."""
+    env = Environment(
+        loader=PackageLoader("bigquery_etl", "query_scheduling/templates"),
+        extensions=["jinja2.ext.do"],
+    )
+    template = env.get_template(TASK_MARKERS_TEMPLATE)
+    context = build_markers_context(dag_collection)
+    rendered = template.render(context)
+    return format_file_contents(rendered, fast=False, mode=FileMode())
+
+
+def write_task_markers_dag(dag_collection, output_dir) -> Path:
+    """Render and write the task-markers DAG into output_dir."""
+    output_file = Path(output_dir) / f"{TASK_MARKERS_DAG_NAME}.py"
+    output_file.write_text(render_task_markers_dag(dag_collection))
+    return output_file

--- a/bigquery_etl/query_scheduling/dag_collection.py
+++ b/bigquery_etl/query_scheduling/dag_collection.py
@@ -11,6 +11,9 @@ import yaml
 from black import FileMode, format_file_contents
 
 from bigquery_etl.dependency import extract_table_references_without_views
+from bigquery_etl.query_scheduling.copy_deduplicate_task_markers import (
+    write_task_markers_dag,
+)
 from bigquery_etl.query_scheduling.dag import Dag, InvalidDag, PublicDataJsonDag
 from bigquery_etl.query_scheduling.utils import negate_timedelta_string
 from bigquery_etl.schema.stable_table_schema import get_stable_table_schemas
@@ -239,6 +242,9 @@ class DagCollection:
         for dag in self.dags:
             dag.with_upstream_dependencies(self)
             dag.with_downstream_dependencies(self)
+
+        # Create copy_deduplicate_task_markers DAG to support task state propagation
+        write_task_markers_dag(self, output_dir)
 
         # Finally, parallelize DAG-to-Airflow conversion
         to_airflow_dag = partial(self.dag_to_airflow, output_dir)

--- a/bigquery_etl/query_scheduling/templates/copy_deduplicate_task_markers.j2
+++ b/bigquery_etl/query_scheduling/templates/copy_deduplicate_task_markers.j2
@@ -2,20 +2,18 @@
 
 from airflow import DAG
 from airflow.operators.empty import EmptyOperator
-from airflow.sensors.external_task import ExternalTaskMarker, ExternalTaskSensor
+from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.utils.task_group import TaskGroup
 import datetime
-
-from utils.constants import ALLOWED_STATES, FAILED_STATES
 
 docs = """
 ### {{ name }}
 
-Generated DAG that propagates `copy_deduplicate` state changes to every
+Generated DAG that propagates `copy_deduplicate` task clears to every
 downstream bqetl DAG via `ExternalTaskMarker`s.
 
 The `copy_deduplicate` DAG has a single marker per source task pointing at
-this DAG. When a source task is cleared in `copy_deduplicate`, the clear
+the `{source_task_id}_marker` tasks in this DAG. When a source task is cleared, the clear
 propagates through the markers here, propagating to every downstream
 `wait_for_{source_task_id}` sensor in the corresponding bqetl DAGs.
 
@@ -31,12 +29,12 @@ copy_deduplicate should be cleared with "Recursive" selected.
 
 default_args = {
     "owner": "{{ owner }}",
-    "start_date": datetime.datetime({{ start_date_year }}, {{ start_date_month }}, {{ start_date_day }}),
+    "start_date": datetime.datetime(2026, 4, 23),
     "email": {{ email }},
     "email_on_failure": True,
     "email_on_retry": False,
-    "retries": 2,
-    "retry_delay": datetime.timedelta(minutes=5),
+    "retries": 1,
+    "retry_delay": datetime.timedelta(minutes=30),
 }
 
 tags = {{ tags }}
@@ -47,38 +45,27 @@ with DAG(
     schedule_interval="{{ schedule_interval }}",
     doc_md=docs,
     tags=tags,
-    catchup=False,
+    catchup=True,
 ) as dag:
     {% if not sources %}
     EmptyOperator(task_id="noop")
     {% endif %}
     {% for source_task_id, consumers in sources %}
-    wait_for_{{ source_task_id }} = ExternalTaskSensor(
-        task_id="wait_for_{{ source_task_id }}",
-        external_dag_id="{{ source_dag_id }}",
-        external_task_id="{{ source_task_id }}",
-        execution_delta=datetime.timedelta(seconds=0),
-        check_existence=True,
-        mode="reschedule",
-        poke_interval=datetime.timedelta(minutes=5),
-        allowed_states=ALLOWED_STATES,
-        failed_states=FAILED_STATES,
-        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    {{ source_task_id }}_marker = EmptyOperator(
+        task_id="{{ source_task_id }}_marker",
     )
 
     with TaskGroup("{{ source_task_id }}_task_markers") as {{ source_task_id }}_task_markers:
         {% for consumer in consumers %}
         ExternalTaskMarker(
-            task_id="{{ consumer.dag_name }}__wait_for_{{ source_task_id }}",
+            task_id="{{ consumer.dag_name }}__{{ source_task_id }}",
             external_dag_id="{{ consumer.dag_name }}",
             external_task_id="wait_for_{{ source_task_id }}",
             {% if consumer.execution_delta_seconds != 0 -%}
             execution_date="{% raw %}{{{% endraw %} (logical_date + datetime.timedelta(seconds={{ consumer.execution_delta_seconds }})).isoformat() {% raw %}}}{% endraw %}",
-            {%- else -%}
-            execution_date="{% raw %}{{{% endraw %} logical_date.isoformat() {% raw %}}}{% endraw %}",
             {%- endif %}
         )
         {% endfor %}
 
-    wait_for_{{ source_task_id }} >> {{ source_task_id }}_task_markers
+    {{ source_task_id }}_marker >> {{ source_task_id }}_task_markers
     {% endfor %}

--- a/bigquery_etl/query_scheduling/templates/copy_deduplicate_task_markers.j2
+++ b/bigquery_etl/query_scheduling/templates/copy_deduplicate_task_markers.j2
@@ -1,0 +1,84 @@
+# Generated via https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/query_scheduling/copy_deduplicate_task_markers.py
+
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.sensors.external_task import ExternalTaskMarker, ExternalTaskSensor
+from airflow.utils.task_group import TaskGroup
+import datetime
+
+from utils.constants import ALLOWED_STATES, FAILED_STATES
+
+docs = """
+### {{ name }}
+
+Generated DAG that propagates `copy_deduplicate` state changes to every
+downstream bqetl DAG via `ExternalTaskMarker`s.
+
+The `copy_deduplicate` DAG has a single marker per source task pointing at
+this DAG. When a source task is cleared in `copy_deduplicate`, the clear
+propagates through the markers here, propagating to every downstream
+`wait_for_{source_task_id}` sensor in the corresponding bqetl DAGs.
+
+This DAG is generated in bigquery-etl so that new bqetl DAGs appear automatically
+without requiring a change to `copy_deduplicate.py`.
+
+### Triage notes
+
+This DAG contains only task markers, so its state should match copy_deduplicate. Tasks here
+typically should not be directly cleared or marked as success/fail. Instead, the tasks in
+copy_deduplicate should be cleared with "Recursive" selected.
+"""
+
+default_args = {
+    "owner": "{{ owner }}",
+    "start_date": datetime.datetime({{ start_date_year }}, {{ start_date_month }}, {{ start_date_day }}),
+    "email": {{ email }},
+    "email_on_failure": True,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": datetime.timedelta(minutes=5),
+}
+
+tags = {{ tags }}
+
+with DAG(
+    "{{ name }}",
+    default_args=default_args,
+    schedule_interval="{{ schedule_interval }}",
+    doc_md=docs,
+    tags=tags,
+    catchup=False,
+) as dag:
+    {% if not sources %}
+    EmptyOperator(task_id="noop")
+    {% endif %}
+    {% for source_task_id, consumers in sources %}
+    wait_for_{{ source_task_id }} = ExternalTaskSensor(
+        task_id="wait_for_{{ source_task_id }}",
+        external_dag_id="{{ source_dag_id }}",
+        external_task_id="{{ source_task_id }}",
+        execution_delta=datetime.timedelta(seconds=0),
+        check_existence=True,
+        mode="reschedule",
+        poke_interval=datetime.timedelta(minutes=5),
+        allowed_states=ALLOWED_STATES,
+        failed_states=FAILED_STATES,
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+    )
+
+    with TaskGroup("{{ source_task_id }}_task_markers") as {{ source_task_id }}_task_markers:
+        {% for consumer in consumers %}
+        ExternalTaskMarker(
+            task_id="{{ consumer.dag_name }}__wait_for_{{ source_task_id }}",
+            external_dag_id="{{ consumer.dag_name }}",
+            external_task_id="wait_for_{{ source_task_id }}",
+            {% if consumer.execution_delta_seconds != 0 -%}
+            execution_date="{% raw %}{{{% endraw %} (logical_date + datetime.timedelta(seconds={{ consumer.execution_delta_seconds }})).isoformat() {% raw %}}}{% endraw %}",
+            {%- else -%}
+            execution_date="{% raw %}{{{% endraw %} logical_date.isoformat() {% raw %}}}{% endraw %}",
+            {%- endif %}
+        )
+        {% endfor %}
+
+    wait_for_{{ source_task_id }} >> {{ source_task_id }}_task_markers
+    {% endfor %}

--- a/tests/query_scheduling/test_copy_deduplicate_task_markers.py
+++ b/tests/query_scheduling/test_copy_deduplicate_task_markers.py
@@ -1,0 +1,182 @@
+"""Tests for the copy_deduplicate_task_markers generator."""
+
+import ast
+from dataclasses import dataclass, field
+from typing import List
+
+from bigquery_etl.query_scheduling.copy_deduplicate_task_markers import (
+    TASK_MARKERS_DAG_NAME,
+    build_markers_context,
+    render_task_markers_dag,
+    write_task_markers_dag,
+)
+from bigquery_etl.query_scheduling.dag_collection import DagCollection
+from bigquery_etl.query_scheduling.task import TaskRef
+
+
+@dataclass
+class MockTask:
+    """Minimal stand-in for Task that exposes upstream_dependencies/depends_on."""
+
+    upstream_dependencies: List[TaskRef] = field(default_factory=list)
+    depends_on: List[TaskRef] = field(default_factory=list)
+
+
+@dataclass
+class MockDag:
+    """Minimal stand-in for a Dag with name, tasks (List[MockTask]), and schedule_interval."""
+
+    name: str
+    schedule_interval: str
+    tasks: List[MockTask] = field(default_factory=list)
+
+
+def build_collection():
+    """Build a DagCollection with two bqetl DAGs consuming copy_deduplicate."""
+    # bqetl_a runs at 02:00, waits on copy_deduplicate_all and copy_deduplicate_main_ping
+    bqetl_a = MockDag(
+        name="bqetl_a",
+        schedule_interval="0 2 * * *",
+        tasks=[
+            MockTask(
+                upstream_dependencies=[
+                    TaskRef(
+                        dag_name="copy_deduplicate",
+                        task_id="copy_deduplicate_all",
+                    ),
+                    TaskRef(
+                        dag_name="copy_deduplicate",
+                        task_id="copy_deduplicate_main_ping",
+                    ),
+                ]
+            )
+        ],
+    )
+    # bqetl_b runs at 04:15, waits on copy_deduplicate_all only
+    bqetl_b = MockDag(
+        name="bqetl_b",
+        schedule_interval="15 4 * * *",
+        tasks=[
+            MockTask(
+                upstream_dependencies=[
+                    TaskRef(
+                        dag_name="copy_deduplicate",
+                        task_id="copy_deduplicate_all",
+                    )
+                ]
+            )
+        ],
+    )
+    # bqetl_c has no copy_deduplicate dependency
+    bqetl_c = MockDag(
+        name="bqetl_c",
+        schedule_interval="0 3 * * *",
+        tasks=[
+            MockTask(
+                upstream_dependencies=[
+                    TaskRef(dag_name="some_other", task_id="some_task")
+                ]
+            )
+        ],
+    )
+    collection = DagCollection([])
+    collection.dags = [bqetl_a, bqetl_b, bqetl_c]
+    return collection
+
+
+class TestCopyDeduplicateTaskMarkers:
+    def test_render_task_markers_dag_produces_valid_python(self):
+        """render_task_markers_dag should return a valid dag with correct task markers."""
+        source = render_task_markers_dag(build_collection())
+
+        ast.parse(source)
+
+        # same execution_delta as ExternalTaskSensor
+        assert "datetime.timedelta(seconds=3600)" in source
+        assert "datetime.timedelta(seconds=11700)" in source
+
+        # Sensors are emitted per source task
+        assert 'task_id="wait_for_copy_deduplicate_all"' in source
+        assert 'task_id="wait_for_copy_deduplicate_main_ping"' in source
+
+        # Markers are emitted per (source, consumer) pair.
+        assert 'task_id="bqetl_a__wait_for_copy_deduplicate_all"' in source
+        assert 'task_id="bqetl_b__wait_for_copy_deduplicate_all"' in source
+        assert 'task_id="bqetl_a__wait_for_copy_deduplicate_main_ping"' in source
+
+        # bqetl_c does depend on copy_deduplicate so it shouldn't appear
+        assert "bqetl_c" not in source
+
+    def test_write_task_markers_dag(self, tmp_path):
+        """"""
+        output_file = write_task_markers_dag(build_collection(), tmp_path)
+
+        assert output_file.exists()
+        assert output_file.name == f"{TASK_MARKERS_DAG_NAME}.py"
+
+        contents = output_file.read_text()
+        ast.parse(contents)
+        assert "copy_deduplicate_task_markers" in contents
+        assert "with DAG(" in contents
+
+    def test_build_markers_context_groups_consumers_by_source(self):
+        """Task markers context should get all downstream dags with correct execution_delta's."""
+        ctx = build_markers_context(build_collection())
+
+        assert ctx["name"] == TASK_MARKERS_DAG_NAME
+        assert ctx["source_dag_id"] == "copy_deduplicate"
+        assert ctx["schedule_interval"] == "0 1 * * *"
+
+        sources = dict(ctx["sources"])
+
+        # copy_deduplicate_all has two consumers (bqetl_a at 02:00, bqetl_b at 04:15).
+        all_consumers = {c["dag_name"]: c for c in sources["copy_deduplicate_all"]}
+        assert set(all_consumers) == {"bqetl_a", "bqetl_b"}
+        # bqetl_a: 02:00 - 01:00 = 3600 seconds.
+        assert all_consumers["bqetl_a"]["execution_delta_seconds"] == 3600
+        # bqetl_b: 04:15 - 01:00 = 3*3600 + 15*60 = 11700 seconds.
+        assert all_consumers["bqetl_b"]["execution_delta_seconds"] == 11700
+
+        main_consumers = {
+            c["dag_name"]: c for c in sources["copy_deduplicate_main_ping"]
+        }
+        assert set(main_consumers) == {"bqetl_a"}
+        assert main_consumers["bqetl_a"]["execution_delta_seconds"] == 3600
+
+    def test_build_markers_context_daily_alias(self):
+        """The 'daily' alias should be handled by schedule_interval_delta."""
+        collection = DagCollection([])
+        collection.dags = [
+            MockDag(
+                name="bqetl_daily_alias",
+                schedule_interval="daily",
+                tasks=[
+                    MockTask(
+                        upstream_dependencies=[
+                            TaskRef(
+                                dag_name="copy_deduplicate",
+                                task_id="copy_deduplicate_all",
+                            )
+                        ]
+                    )
+                ],
+            )
+        ]
+        ctx = build_markers_context(collection)
+        sources = dict(ctx["sources"])
+        consumer = sources["copy_deduplicate_all"][0]
+        assert consumer["dag_name"] == "bqetl_daily_alias"
+        # 'daily' = '0 0 * * *', source copy_deduplicate = '0 1 * * *',
+        # so the consumer runs 1h before the source: delta = -3600 seconds.
+        assert consumer["execution_delta_seconds"] == -3600
+
+    def test_build_markers_context_no_consumers(self):
+        """Noop DAG should be built if copy_deduplicate has no downstream tasks."""
+        empty_collection = DagCollection([])
+        empty_collection.dags = []
+
+        ctx = build_markers_context(empty_collection)
+        assert ctx["sources"] == []
+
+        source = render_task_markers_dag(empty_collection)
+        ast.parse(source)

--- a/tests/query_scheduling/test_copy_deduplicate_task_markers.py
+++ b/tests/query_scheduling/test_copy_deduplicate_task_markers.py
@@ -95,14 +95,17 @@ class TestCopyDeduplicateTaskMarkers:
         assert "datetime.timedelta(seconds=3600)" in source
         assert "datetime.timedelta(seconds=11700)" in source
 
-        # Sensors are emitted per source task
-        assert 'task_id="wait_for_copy_deduplicate_all"' in source
-        assert 'task_id="wait_for_copy_deduplicate_main_ping"' in source
+        # EmptyOperators are emitted per source task.
+        assert 'task_id="copy_deduplicate_all_marker"' in source
+        assert 'task_id="copy_deduplicate_main_ping_marker"' in source
 
         # Markers are emitted per (source, consumer) pair.
-        assert 'task_id="bqetl_a__wait_for_copy_deduplicate_all"' in source
-        assert 'task_id="bqetl_b__wait_for_copy_deduplicate_all"' in source
-        assert 'task_id="bqetl_a__wait_for_copy_deduplicate_main_ping"' in source
+        assert 'task_id="bqetl_a__copy_deduplicate_all"' in source
+        assert 'task_id="bqetl_b__copy_deduplicate_all"' in source
+        assert 'task_id="bqetl_a__copy_deduplicate_main_ping"' in source
+        # Each ExternalTaskMarker still targets the wait_for_* sensor in the downstream DAG.
+        assert 'external_task_id="wait_for_copy_deduplicate_all"' in source
+        assert 'external_task_id="wait_for_copy_deduplicate_main_ping"' in source
 
         # bqetl_c does depend on copy_deduplicate so it shouldn't appear
         assert "bqetl_c" not in source


### PR DESCRIPTION
## Description

This generates a new dag that only has task markers for tasks directly downstream of copy_deduplicate.  copy_deduplicate will have a task marker on the tasks in this new dag.  This allows state changes in copy_deduplicate to automatically propagate down without needing to manually keep copy_deduplicate up to date.

Draft for the copy_deduplicate dag changes: https://github.com/mozilla/telemetry-airflow/pull/2380/changes

I did a small validation of this setup with https://github.com/mozilla/telemetry-airflow/commit/9903e4e076572a0c8151598826b6faa355d339ae

## Related Tickets & Documents
* DENG-10973

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
