### PR TITLE
Make geo country data available on org_mozilla_broken_site_report.user_reports

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports/view.sql
@@ -11,7 +11,8 @@ SELECT
   client_info.app_display_version AS app_version,
   normalized_channel AS app_channel,
   normalized_os AS os,
-  metrics AS details
+  metrics AS details,
+  geo.country AS country
 FROM
   (
     SELECT
@@ -21,7 +22,8 @@ FROM
       metrics,
       normalized_channel,
       normalized_os,
-      submission_timestamp
+      submission_timestamp,
+      metadata.geo AS geo
     FROM
       `moz-fx-data-shared-prod.firefox_desktop.broken_site_report`
     WHERE
@@ -34,7 +36,8 @@ FROM
       metrics,
       normalized_channel,
       normalized_os,
-      submission_timestamp
+      submission_timestamp,
+      metadata.geo AS geo
     FROM
       `moz-fx-data-shared-prod.fenix.broken_site_report`
     WHERE

--- a/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_broken_site_report/user_reports_live/view.sql
@@ -66,7 +66,8 @@ SELECT
   client_info.app_display_version AS app_version,
   normalized_channel AS app_channel,
   normalized_os AS os,
-  metrics AS details
+  metrics AS details,
+  metadata.geo.country AS country
 FROM
   live_reports
 WHERE


### PR DESCRIPTION
## Description

This PR adds geolocation country data to `org_mozilla_broken_site_report.user_reports`.

We frequently use this to find reports likely originating in specific regions, but it currently requires looking at the source tables rather than the consolidated views.

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/FFXP-3902

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
