### PR TITLE
fix(remote-settings): extra_age should be a decimal not an int

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/remote_settings_uptake_live/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/remote_settings_uptake_live/view.sql
@@ -19,7 +19,7 @@ SELECT
   mozfun.map.get_key(e.extra, 'source') AS extra_source,
   mozfun.map.get_key(e.extra, 'errorName') AS extra_errorname,
   mozfun.map.get_key(e.extra, 'timestamp') AS extra_timestamp,
-  SAFE_CAST(mozfun.map.get_key(e.extra, 'age') AS INT64) AS extra_age,
+  SAFE_CAST(mozfun.map.get_key(e.extra, 'age') AS DECIMAL) AS extra_age,
   SAFE_CAST(mozfun.map.get_key(e.extra, 'duration') AS INT64) AS extra_duration,
 FROM
   `moz-fx-data-shared-prod.firefox_desktop_live.events_v1`


### PR DESCRIPTION
## Description

We weren't seeing a lot of data when using this column. Realized it's a decimal, not an int, which was causing safe_cast to drop it to null values for most of the data.
