### PR TITLE
Add labels to shredder and copy_dedupe jobs for billing data

### DIFF
--- a/bigquery_etl/copy_deduplicate.py
+++ b/bigquery_etl/copy_deduplicate.py
@@ -189,7 +189,12 @@ def _get_query_job_configs(
     if write_to_v2:
         stable_table = v2_table
 
-    kwargs = dict(use_legacy_sql=False, dry_run=dry_run, priority=priority)
+    kwargs = dict(
+        use_legacy_sql=False,
+        dry_run=dry_run,
+        priority=priority,
+        labels={"type": "copy_deduplicate"},
+    )
     start_time = datetime(*submission_date.timetuple()[:6])
     end_time = start_time + timedelta(days=1)
     if slices > 1:

--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -341,6 +341,9 @@ def delete_from_partition(
         dry_run=dry_run,
         priority=priority,
         reservation=reservation_override,
+        labels={
+            "type": "shredder",
+        },
     )
     # The event_id backfill logic in this function is just temporary for https://mozilla-hub.atlassian.net/browse/DENG-9800.
     event_id_backfill = target.table_id == "events_stream_v1" and target.dataset_id in (


### PR DESCRIPTION
## Description

There are currently some shredder jobs that run in shared-prod which makes it hard to see the cost of actual query costs per project from the billing export data using the "slots attribution" SKU because of the different pricing models.  The label should go into the billing data according to https://docs.cloud.google.com/bigquery/docs/labels-intro.  I also added copy_dedupe because it's another large group of etl so the label might be useful in the future

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
