### PR TITLE
chore(DENG-10777): backfill 17 april for urlbar_events_daily_v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v2/backfill.yaml
@@ -1,3 +1,15 @@
+2026-04-24:
+  start_date: 2026-04-17
+  end_date: 2026-04-17
+  reason: |
+    Need to fill in 17 April for https://mozilla-hub.atlassian.net/browse/DENG-10777.
+  watchers:
+    - kbammarito@mozilla.com
+    - nflorez@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
 2026-04-17:
   start_date: 2025-01-01
   end_date: 2026-04-17
@@ -7,8 +19,8 @@
     The `shredder_mitigation` is set to False from this backfill on
     in alignment with the business requirement; "Doing YoY computations we need to be measuring the same historically".
   watchers:
-  - kbammarito@mozilla.com
-  - nflorez@mozilla.com
+    - kbammarito@mozilla.com
+    - nflorez@mozilla.com
   status: Complete
   shredder_mitigation: false
   override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v2/backfill.yaml
@@ -4,8 +4,8 @@
   reason: |
     Need to fill in 17 April for https://mozilla-hub.atlassian.net/browse/DENG-10777.
   watchers:
-    - kbammarito@mozilla.com
-    - nflorez@mozilla.com
+  - kbammarito@mozilla.com
+  - nflorez@mozilla.com
   status: Initiate
   shredder_mitigation: false
   override_retention_limit: false
@@ -19,8 +19,8 @@
     The `shredder_mitigation` is set to False from this backfill on
     in alignment with the business requirement; "Doing YoY computations we need to be measuring the same historically".
   watchers:
-    - kbammarito@mozilla.com
-    - nflorez@mozilla.com
+  - kbammarito@mozilla.com
+  - nflorez@mozilla.com
   status: Complete
   shredder_mitigation: false
   override_retention_limit: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR backfills 17 April for `urlbar_events_daily_v2`.

## Related Tickets & Documents
* DENG-10777

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
