### PR TITLE
[DENG-8911] Filter out pings without stable tables in event_monitoring

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -453,7 +453,6 @@ generate:
       skip_pings:
       - topsites-impression  # access denied
       - serp-categorization  # access denied
-      - background-update  # table doesn't exist
       events_tables:  # overwrite event tables
         pine:  # Probe info returns pings that don't have tables, only use events_v1
         - events_v1

--- a/sql_generators/glean_usage/common.py
+++ b/sql_generators/glean_usage/common.py
@@ -125,6 +125,21 @@ def ping_has_metrics(dataset_family: str, unversioned_table: str) -> bool:
     return (dataset_family, unversioned_table) not in _get_pings_without_metrics()
 
 
+@cache
+def _get_glean_stable_tables():
+    """Return (dataset_family, unversioned_table) for all Glean stable tables."""
+    return {
+        (schema.bq_dataset_family, schema.bq_table_unversioned)
+        for schema in get_stable_table_schemas()
+        if "glean" in schema.schema_id
+    }
+
+
+def ping_has_stable_table(dataset_family: str, ping_name: str) -> bool:
+    """Return true if the given Glean ping has a stable table in the dataset."""
+    return (dataset_family, ping_name.replace("-", "_")) in _get_glean_stable_tables()
+
+
 def table_names_from_baseline(baseline_table, include_project_id=True):
     """Return a dict with full table IDs for derived tables and views.
 
@@ -234,6 +249,10 @@ def get_tables_with_events(
         pings.add("events")
 
     pings = pings.difference(min_pings)
+
+    # Only include pings that have a corresponding stable table deployed
+    # A metric can have a non-existent ping in "send_in_pings"
+    pings = {ping for ping in pings if ping_has_stable_table(bq_dataset_name, ping)}
 
     return pings
 


### PR DESCRIPTION
## Description

Fixes an edgy edge case where a metric can have a non-existent ping in `send_in_pings`, causing invalid sql to be output, e.g. https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/metrics/nimbus_events_enrollment sends in background-update for firefox_desktop.  This change should be a no-op because `firefox_desktop_background_update` is still in the app skip list.

## Related Tickets & Documents
* DENG-8911

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
