### PR TITLE
chore(DENG-10777): complete backfill for 17 april for urlbar_events_daily_v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v2/backfill.yaml
@@ -6,7 +6,7 @@
   watchers:
   - kbammarito@mozilla.com
   - nflorez@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR completes the backfill for 17 April for `urlbar_events_daily_v2`.

## Related Tickets & Documents
* DENG-10777
* https://github.com/mozilla/bigquery-etl/pull/9253

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
