### PR TITLE
[DENG=10934] Remove thunderbird_crashreporter from glean_usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,6 +354,11 @@ jobs:
             GENERATED_SQL_CHANGED=true
           fi
 
+          if [[ $(git diff --no-index --name-only bqetl_project.yaml ~/remote-bigquery-etl-main/bqetl_project.yaml) ]]; then
+            echo "bqetl_project.yaml changed; re-generate SQL"
+            GENERATED_SQL_CHANGED=true
+          fi
+
           mkdir -p /tmp/workspace/generated-sql
           cp bqetl_project.yaml /tmp/workspace/generated-sql/
 

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -421,6 +421,7 @@ generate:
     - regrets_reporter
     - tiktokreporter_android
     - tiktokreporter_ios
+    - thunderbird_crashreporter  # https://mozilla-hub.atlassian.net/browse/DENG-10934
     events_stream:
       skip_apps:
       - bergamot
@@ -483,7 +484,6 @@ generate:
       - mozillavpn_backend_cirrus
       - pine
       - thunderbird_android
-      - thunderbird_crashreporter
       - thunderbird_desktop
     clients_last_seen_joined:
       skip_apps:
@@ -498,7 +498,6 @@ generate:
       - mozillavpn_backend_cirrus
       - pine
       - thunderbird_android
-      - thunderbird_crashreporter
       - thunderbird_desktop
     bigconfig:
       skip_apps:


### PR DESCRIPTION
## Description

This app only sends crash pings so all the glean_usage tables are empty.  I want to remove these and delete the tables so I can test it as a new app and see if it can have all the tables deploy in one attempt with https://github.com/mozilla/bigquery-etl/pull/9256.

Also updates the CI to run sql_generation if `bqetl_project.yaml` changes because that file controls a lot of sql generation.

## Related Tickets & Documents
* DENG-10934

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
