### PR TITLE
feat: add backfill entry 2026-04-27 to amo_stats_dau_* queries due to upstream query change

### DIFF
--- a/sql/moz-fx-data-shared-prod/addons_derived/amo_stats_dau_combined_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/amo_stats_dau_combined_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2026-04-27:
+  start_date: 2024-03-14
+  end_date: 2026-04-27
+  reason: Backfill due to upstream query change.
+  watchers:
+  - kik@mozilla.com
+  - lgreco@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false
+
 2026-04-23:
   start_date: 2024-03-10
   end_date: 2026-04-22

--- a/sql/moz-fx-data-shared-prod/addons_derived/amo_stats_dau_legacy_source_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/amo_stats_dau_legacy_source_v1/backfill.yaml
@@ -1,0 +1,12 @@
+2026-04-27:
+  start_date: 2025-12-01
+  end_date: 2026-04-27
+  reason: Backfill due to upstream query change.
+  watchers:
+  - kik@mozilla.com
+  - lgreco@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/addons_derived/amo_stats_dau_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/amo_stats_dau_v1/backfill.yaml
@@ -1,0 +1,12 @@
+2026-04-27:
+  start_date: 2025-12-01
+  end_date: 2026-04-27
+  reason: Backfill due to upstream query change.
+  watchers:
+  - kik@mozilla.com
+  - lgreco@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false


### PR DESCRIPTION
# feat: add backfill entry 2026-04-27 to amo_stats_dau_* queries due to upstream query change

depends on: https://github.com/mozilla/bigquery-etl/pull/9265, should only be merged once this backfill is done.

This includes creating a backfill entry for the following:

- `addons_derived.amo_stats_dau_combined_v1` - Backfill as far back as possible
- `addons_derived.amo_stats_dau_legacy_source_v1` - Backfill only need to cover app version 148 and above
- `addons_derived.amo_stats_dau_v1` - Backfill only need to cover app version 148 and above