### PR TITLE
Set query file priority for deploys

### DIFF
--- a/bigquery_etl/cli/deploy.py
+++ b/bigquery_etl/cli/deploy.py
@@ -391,7 +391,7 @@ def _discover_artifacts(
     artifact_types: List[str],
 ) -> Dict[str, Tuple[Path, str]]:
     """Find artifacts."""
-    artifacts = {}
+    artifacts: Dict[str, Tuple[Path, str]] = {}
     patterns = {
         "table": [QUERY_FILE, QUERY_SCRIPT, "script.sql"],
         "view": [VIEW_FILE],

--- a/bigquery_etl/cli/deploy.py
+++ b/bigquery_etl/cli/deploy.py
@@ -397,6 +397,10 @@ def _discover_artifacts(
         "view": [VIEW_FILE],
     }
 
+    # Prefer query files when a directory contains multiple definition files (e.g. stage deploys
+    # for query.sql manually refreshed materialized views will have a query.sql and script.sql)
+    table_priority = {QUERY_FILE: 0, QUERY_SCRIPT: 1, "script.sql": 2}
+
     file_patterns = [
         pattern
         for artifact_type in artifact_types
@@ -427,6 +431,19 @@ def _discover_artifacts(
             if artifact_type is None:
                 log.debug(f"Skipping {file_path}: not a table or view artifact")
                 continue
+
+            # don't add if higher priority file is already associated with the path
+            existing = artifacts.get(artifact_id)
+            if (
+                existing is not None
+                and existing[1] == "table"
+                and artifact_type == "table"
+            ):
+                if table_priority.get(file_path.name, 10) >= table_priority.get(
+                    existing[0].name, 10
+                ):
+                    continue
+
             artifacts[artifact_id] = (file_path, artifact_type)
 
     return artifacts

--- a/tests/cli/test_cli_deploy.py
+++ b/tests/cli/test_cli_deploy.py
@@ -40,6 +40,26 @@ class TestArtifactDiscovery:
         assert "test-project.test_dataset.test_view" in artifacts
         assert artifacts["test-project.test_dataset.test_view"][1] == "view"
 
+    def test_discover_prefers_query_sql_over_script_sql(self, tmp_path):
+        """query.sql should take priority over query.py and script.sql."""
+        table_dir = tmp_path / "sql/test-project/test_dataset/test_table_v1"
+        table_dir.mkdir(parents=True)
+        (table_dir / "query.sql").write_text("SELECT 1")
+        (table_dir / "query.py").write_text("")
+        (table_dir / "script.sql").write_text("CALL BQ.REFRESH_MATERIALIZED_VIEW('')")
+
+        artifacts = _discover_artifacts(
+            paths=(str(table_dir),),
+            sql_dir=str(tmp_path / "sql"),
+            project_ids=["test-project"],
+            artifact_types=["table"],
+        )
+
+        assert len(artifacts) == 1
+        artifact_id = "test-project.test_dataset.test_table_v1"
+        assert artifacts[artifact_id][0].name == "query.sql"
+        assert artifacts[artifact_id][1] == "table"
+
     def test_discover_mixed_artifacts(self, tmp_path):
         table_dir = tmp_path / "sql/test-project/test_dataset/test_table_v1"
         table_dir.mkdir(parents=True)


### PR DESCRIPTION
## Description

Might fix the occasional `firefox_desktop_derived.event_monitoring_live_v1` dry run errors like https://github.com/mozilla/bigquery-etl/actions/runs/24996932491/job/73200438623.  I think the cause is from manually refreshed materialized views having both a query.sql and script.sql created for stage deploys.  The script.sql is the one that gets deployed but it fails because there's no schema.yaml and one can't be created from a script.sql:

```
⊘ moz-fx-data-integration-tests.firefox_desktop_derived_moz_fx_data_shared_prod_8805483571ff9979ee776970b809431664ce3879_24996932491.event_monitoring_live_v1 (skipped: Schema missing for sql/moz-fx-data-integration-tests/firefox_desktop_derived_moz_fx_data_shared_prod_8805483571ff9979ee776970b809431664ce3879_24996932491/event_monitoring_live_v1/script.sql.)
```
in https://github.com/mozilla/bigquery-etl/actions/runs/24996932491/job/73197780670

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
