### PR TITLE
feat(ads): add Bigeye monitoring for ads_client_operations_and_errors_hourly_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/bigconfig.yml
@@ -1,0 +1,66 @@
+type: BIGCONFIG_FILE
+tag_deployments:
+  - collection:
+      name: Ads Client
+      notification_channels:
+        - slack: '#ads-client-notifications'
+    deployments:
+      - column_selectors:
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.*
+        metrics:
+          - metric_type:
+              type: PREDEFINED
+              predefined_metric: FRESHNESS
+            metric_name: FRESHNESS
+            metric_schedule:
+              named_schedule:
+                name: Default Schedule - 13:00 UTC
+      - column_selectors:
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.op_request_ads
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.op_record_click
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.op_record_impression
+        metrics:
+          - metric_type:
+              type: PREDEFINED
+              predefined_metric: SUM
+            threshold:
+              type: AUTO
+              sensitivity: MEDIUM
+              lower_bound_only: true
+            metric_schedule:
+              named_schedule:
+                name: Default Schedule - 13:00 UTC
+      - column_selectors:
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.client_error_request_ads
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.client_error_record_click
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.client_error_record_impression
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.build_cache_error_builder_error
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.build_cache_error_database_error
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.build_cache_error_empty_db_path
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.build_cache_error_invalid_max_size
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.build_cache_error_invalid_ttl
+        metrics:
+          - metric_type:
+              type: PREDEFINED
+              predefined_metric: SUM
+            threshold:
+              type: AUTO
+              sensitivity: MEDIUM
+              upper_bound_only: true
+            metric_schedule:
+              named_schedule:
+                name: Default Schedule - 13:00 UTC
+      - column_selectors:
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.deserialization_error_invalid_ad_item
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.deserialization_error_invalid_array
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.deserialization_error_invalid_structure
+        metrics:
+          - metric_type:
+              type: PREDEFINED
+              predefined_metric: SUM
+            threshold:
+              type: CONSTANT
+              upper_bound: 0
+            metric_schedule:
+              named_schedule:
+                name: Default Schedule - 13:00 UTC

--- a/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/metadata.yaml
@@ -43,3 +43,9 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:mozilla-confidential/data-viewers
+monitoring:
+  enabled: true
+  collection: Ads Client
+  freshness:
+    blocking: false
+  volume: null


### PR DESCRIPTION
## Summary

Adds Bigeye monitoring for `moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1`, the hourly aggregates of ads SDK operation counts and error counts. Creates a new **Ads Client** Bigeye collection routed to `#ads-client-notifications`.

All monitoring is implemented as native `bigconfig.yml` predefined metrics — no custom SQL rules needed. Coverage:

| Metric | Columns | Threshold |
|---|---|---|
| `FRESHNESS` | table-level | (Bigeye default, non-blocking) |
| `SUM` autothreshold ↓ (volume drops) | `op_request_ads`, `op_record_click`, `op_record_impression` | `AUTO`, sensitivity `MEDIUM`, `lower_bound_only: true` |
| `SUM` autothreshold ↑ (error spikes) | `client_error_request_ads`, `client_error_record_click`, `client_error_record_impression`, `build_cache_error_builder_error`, `build_cache_error_database_error`, `build_cache_error_empty_db_path`, `build_cache_error_invalid_max_size`, `build_cache_error_invalid_ttl` | `AUTO`, sensitivity `MEDIUM`, `upper_bound_only: true` |
| `SUM` zero-tolerance | `deserialization_error_invalid_ad_item`, `deserialization_error_invalid_array`, `deserialization_error_invalid_structure` | `CONSTANT`, `upper_bound: 0` |

Bigeye checks fire hourly: bqetl auto-generates a `bigquery_bigeye_check` task in the `bqetl_ads_hourly` DAG (which runs hourly) when a table has `bigconfig.yml` + `monitoring.enabled: true`.

### Notes

- **Autothreshold warmup:** Bigeye autothresholds need ~1–2 days of partition data to learn baselines. Expect false positives or silence in the first 24–48h. Don't tune sensitivity until the autothresholds have a baseline window.
- **Hourly granularity:** intra-day cycles (e.g., 3am vs noon) make hourly autothresholds jitterier than daily. If `MEDIUM` sensitivity is too noisy after a week, bump individual metrics to `WIDE`.
- **Note on the `Default Schedule - 13:00 UTC` in `metric_schedule`:** redundant with the Airflow trigger but matches the convention used by all 35 other bigconfigs in the repo.

## Test plan

- [x] `./bqetl monitoring validate` passes
- [x] `bigeye_sdk` `BigConfig.load` round-trips the YAML cleanly
- [ ] After merge, confirm `bqetl_artifact_deployment.publish_bigeye_monitors` deploys the metrics to Bigeye
- [ ] After merge, confirm the auto-generated `bigeye__ads_derived__ads_client_operations_and_errors_hourly__v1` task appears in `bqetl_ads_hourly` DAG
- [ ] After ~48h of data, review autothreshold sensitivity and tune per metric if needed