### PR TITLE
Fix circular import in sql generators

### DIFF
--- a/sql_generators/baseline_clients_city_seen_v1/__init__.py
+++ b/sql_generators/baseline_clients_city_seen_v1/__init__.py
@@ -11,7 +11,7 @@ from bigquery_etl.cli.utils import use_cloud_function_option
 from bigquery_etl.config import ConfigLoader
 from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.util.common import render, write_sql
-from sql_generators.glean_usage import get_app_info
+from sql_generators.glean_usage.common import get_app_info
 
 THIS_PATH = Path(__file__).parent
 TABLE_NAME = THIS_PATH.name


### PR DESCRIPTION
## Description

This is causing some convoluted import chain issue where it's not possible to import `sql_generators.glean_usage.common` from outside sql generators (for testing). e.g. `from sql_generators.glean_usage.common import PROBEINFO_URL` and `from sql_generators.glean_usage import common` give this error

```
Traceback (most recent call last):
  File "/.../scratch.py", line 1, in <module>
    from sql_generators.glean_usage.common import PROBEINFO_URL
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../bigquery-etl/sql_generators/glean_usage/__init__.py", line 9, in <module>
    from bigquery_etl.cli.utils import (
  File "/.../bigquery-etl/bigquery_etl/cli/__init__.py", line 13, in <module>
    from ..cli.backfill import backfill
  File "/.../bigquery-etl/bigquery_etl/cli/backfill.py", line 52, in <module>
    from ..cli.query import backfill as query_backfill
  File "/.../bigquery-etl/bigquery_etl/cli/query.py", line 87, in <module>
    from .generate import generate_all
  File "/.../bigquery-etl/bigquery_etl/cli/generate.py", line 62, in <module>
    generate = generate_group(
               ^^^^^^^^^^^^^^^
  File "/.../bigquery-etl/bigquery_etl/cli/generate.py", line 42, in generate_group
    spec.loader.exec_module(module)
  File "/.../bigquery-etl/sql_generators/baseline_clients_city_seen_v1/__init__.py", line 14, in <module>
    from sql_generators.glean_usage import get_app_info
ImportError: cannot import name 'get_app_info' from partially initialized module 'sql_generators.glean_usage' (most likely due to a circular import) (/.../bigquery-etl/sql_generators/glean_usage/__init__.py)
```

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
