### PR TITLE
feat: update amo_stats_dau to use the new combined table and update metadata for amo queries

### DIFF
--- a/sql/moz-fx-data-shared-prod/addons/amo_stats_dau/view.sql
+++ b/sql/moz-fx-data-shared-prod/addons/amo_stats_dau/view.sql
@@ -1,8 +1,6 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.addons.amo_stats_dau`
 AS
--- View to combine stats dau from both legacy and glean based data sources.
--- Glean source containing clients using app version 148 and above.
 SELECT
   submission_date,
   addon_id,
@@ -50,54 +48,4 @@ SELECT
       UNNEST(dau_by_locale)
   ) AS dau_by_locale,
 FROM
-  `moz-fx-data-shared-prod.addons_derived.amo_stats_dau_v1`
-UNION ALL
--- Legacy source containing clients using app version major below 148.
-SELECT
-  submission_date,
-  addon_id,
-  dau,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(dau_by_addon_version)
-  ) AS dau_by_addon_version,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(dau_by_app_os)
-  ) AS dau_by_app_os,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(dau_by_app_version)
-  ) AS dau_by_app_version,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(dau_by_fenix_build)
-  ) AS dau_by_fenix_build,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(dau_by_country)
-  ) AS dau_by_country,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(dau_by_locale)
-  ) AS dau_by_locale,
-FROM
-  `moz-fx-data-shared-prod.addons_derived.amo_stats_dau_legacy_source_v1`
+  `moz-fx-data-shared-prod.addons_derived.amo_stats_dau_combined_v1`

--- a/sql/moz-fx-data-shared-prod/addons/amo_stats_installs/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addons/amo_stats_installs/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: AMO Stats Installs
+
+description: |-
+  Daily install statistics to power addons.mozilla.org stats pages.
+
+owners:
+- kik@mozilla.com
+- lgreco@mozilla.com
+
+labels:
+  application: amo

--- a/sql/moz-fx-data-shared-prod/addons_derived/amo_stats_dau_combined_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/amo_stats_dau_combined_v1/metadata.yaml
@@ -5,8 +5,7 @@ description: |-
   See bug 1572873.
 
   Each row in this table represents a particular addon on a particular day
-  and provides all the information needed to populate the various
-  "Daily Users" plots for the AMO stats dashboard.
+  and provides all the information needed to populate the various "Daily Users" plots for the AMO stats dashboard.
 
   NOTE: Includes BOTH clients that reported major app_version older than 148 using legacy source
         and clients that reported major app version 148 and above using the new addons ping.

--- a/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_v1/metadata.yaml
@@ -1,5 +1,5 @@
 ---
-friendly_name: AMO Stats DAU
+friendly_name: AMO Stats Installs
 description: >
   Daily install statistics to power addons.mozilla.org stats pages.
   See bug 1654330. Note that this table uses a hashed_addon_id


### PR DESCRIPTION
# feat: update amo_stats_dau to use the new combined table and update metadata for amo queries

## Description

This PR fixes some documentation errors and updated `addons.amo_stats_dau` to use the new amo_stats_dau_combined_v1 table.
