### PR TITLE
Fix BigConfig deployment to different workspaces

### DIFF
--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -84,13 +84,9 @@ def _resolve_workspace(metadata: Metadata, default_workspace: int) -> int:
     return workspace_id
 
 
-def _client_for_workspace(api_auth: APIKeyAuth, workspace_id: int, _cache: dict = {}):
-    """Return a cached datawatch client for the given Bigeye workspace."""
-    if workspace_id not in _cache:
-        _cache[workspace_id] = datawatch_client_factory(
-            api_auth, workspace_id=workspace_id
-        )
-    return _cache[workspace_id]
+def _client_for_workspace(api_auth: APIKeyAuth, workspace_id: int):
+    """Build a datawatch client for the given Bigeye workspace."""
+    return datawatch_client_factory(api_auth, workspace_id=workspace_id)
 
 
 @click.group(help="""
@@ -138,7 +134,7 @@ def deploy(
     name: str,
     sql_dir: Optional[str],
     project_id: Optional[str],
-    workspace: str,
+    workspace: int,
     base_url: str,
     dry_run: bool,
 ) -> None:
@@ -313,37 +309,23 @@ def deploy_custom_rules(
     warehouse_id = ConfigLoader.get("monitoring", "bigeye_warehouse_id")
     url = "/api/v1/custom-rules"
 
-    # Per-workspace caches; populated lazily on first encounter of a metadata
-    # file declaring that workspace.
-    workspace_state: dict = {}
-
-    def _state_for(workspace_id: int):
-        if workspace_id not in workspace_state:
-            client = _client_for_workspace(api_auth, workspace_id)
-            existing = client.get_rules_for_source(warehouse_id=warehouse_id)
-            workspace_state[workspace_id] = {
-                "client": client,
-                "collections": client.get_collections(),
-                "existing_rules_sql": [
-                    rule.custom_rule.sql for rule in existing.custom_rules
-                ],
-                "existing_schedules": {
-                    schedule.name: schedule.id
-                    for schedule in client.get_named_schedule().named_schedules
-                },
-            }
-        return workspace_state[workspace_id]
-
     for custom_rule_file in list(set(custom_rules_files)):
         project, dataset, table = extract_from_query_path(custom_rule_file)
         try:
             metadata = Metadata.from_file(custom_rule_file.parent / METADATA_FILE)
             if metadata.monitoring and metadata.monitoring.enabled:
-                state = _state_for(_resolve_workspace(metadata, workspace))
-                client = state["client"]
-                collections = state["collections"]
-                existing_rules_sql = state["existing_rules_sql"]
-                existing_schedules = state["existing_schedules"]
+                client = _client_for_workspace(
+                    api_auth, _resolve_workspace(metadata, workspace)
+                )
+                collections = client.get_collections()
+                existing_rules = client.get_rules_for_source(warehouse_id=warehouse_id)
+                existing_rules_sql = [
+                    rule.custom_rule.sql for rule in existing_rules.custom_rules
+                ]
+                existing_schedules = {
+                    schedule.name: schedule.id
+                    for schedule in client.get_named_schedule().named_schedules
+                }
                 # Convert all the Airflow params to jinja usable dict.
                 for select_statement in _sql_rules_from_file(
                     custom_rule_file, project, dataset, table
@@ -809,22 +791,6 @@ def delete(
     api_auth = APIKeyAuth(base_url=base_url, api_key=api_key)
     warehouse_id = ConfigLoader.get("monitoring", "bigeye_warehouse_id")
 
-    workspace_state: dict = {}
-
-    def _state_for(workspace_id: int):
-        if workspace_id not in workspace_state:
-            client = _client_for_workspace(api_auth, workspace_id)
-            workspace_state[workspace_id] = {
-                "client": client,
-                "existing_rules": {
-                    rule.custom_rule.sql: rule.id
-                    for rule in client.get_rules_for_source(
-                        warehouse_id=warehouse_id
-                    ).custom_rules
-                },
-            }
-        return workspace_state[workspace_id]
-
     for metadata_file in list(set(metadata_files)):
         project, dataset, table = extract_from_query_path(metadata_file)
         try:
@@ -832,9 +798,15 @@ def delete(
         except FileNotFoundError:
             print("No metadata file for: {}.{}.{}".format(project, dataset, table))
             continue
-        state = _state_for(_resolve_workspace(metadata, workspace))
-        client = state["client"]
-        existing_rules = state["existing_rules"]
+        client = _client_for_workspace(
+            api_auth, _resolve_workspace(metadata, workspace)
+        )
+        existing_rules = {
+            rule.custom_rule.sql: rule.id
+            for rule in client.get_rules_for_source(
+                warehouse_id=warehouse_id
+            ).custom_rules
+        }
 
         if metrics:
             deployed_metrics = client.get_metric_info_batch_post(
@@ -900,26 +872,6 @@ def run(name, project_id, sql_dir, workspace, base_url, marker):
     api_auth = APIKeyAuth(base_url=base_url, api_key=api_key)
     warehouse_id = ConfigLoader.get("monitoring", "bigeye_warehouse_id")
 
-    workspace_state: dict = {}
-
-    def _state_for(workspace_id: int):
-        if workspace_id not in workspace_state:
-            client = _client_for_workspace(api_auth, workspace_id)
-            workspace_state[workspace_id] = {
-                "client": client,
-                "existing_rules": {
-                    rule.custom_rule.sql: {
-                        "id": rule.id,
-                        "name": rule.custom_rule.name,
-                    }
-                    for rule in client.get_rules_for_source(
-                        warehouse_id=warehouse_id
-                    ).custom_rules
-                    if rule.custom_rule.name.endswith(marker or "")
-                },
-            }
-        return workspace_state[workspace_id]
-
     metadata_files = paths_matching_name_pattern(
         name, sql_dir, project_id=project_id, files=["metadata.yaml"]
     )
@@ -932,9 +884,17 @@ def run(name, project_id, sql_dir, workspace, base_url, marker):
             metadata = Metadata.from_file(metadata_file)
             if metadata.monitoring and metadata.monitoring.enabled:
                 table_workspace = _resolve_workspace(metadata, workspace)
-                state = _state_for(table_workspace)
-                client = state["client"]
-                existing_rules = state["existing_rules"]
+                client = _client_for_workspace(api_auth, table_workspace)
+                existing_rules = {
+                    rule.custom_rule.sql: {
+                        "id": rule.id,
+                        "name": rule.custom_rule.name,
+                    }
+                    for rule in client.get_rules_for_source(
+                        warehouse_id=warehouse_id
+                    ).custom_rules
+                    if rule.custom_rule.name.endswith(marker or "")
+                }
                 metrics = client.get_metric_info_batch_post(
                     table_name=table,
                     schema_name=f"{project}.{dataset}",
@@ -966,7 +926,10 @@ def run(name, project_id, sql_dir, workspace, base_url, marker):
                             f"Error running check {metric_info.metric_configuration.id}: {metric_info.active_issue.display_name}"
                         )
                         click.echo(
-                            f"Check {base_url}/w/{table_workspace}/catalog/data-sources/metric/{metric_info.metric_configuration.id}/chart for more information."
+                            f"Check {base_url}/w/{table_workspace}/catalog/"
+                            f"data-sources/metric/"
+                            f"{metric_info.metric_configuration.id}/chart "
+                            "for more information."
                         )
 
                 if (metadata_file.parent / CUSTOM_RULES_FILE).exists():

--- a/bigquery_etl/cli/monitoring.py
+++ b/bigquery_etl/cli/monitoring.py
@@ -63,6 +63,36 @@ METRIC_STATUS_FAILURES = [
 ]
 
 
+def _resolve_workspace(metadata: Metadata, default_workspace: int) -> int:
+    """Return the Bigeye workspace ID for a table.
+
+    Uses `metadata.monitoring.workspace` if set, otherwise falls back to the
+    --workspace CLI flag default. Validates against
+    `monitoring.bigeye_workspace_ids` in bqetl_project.yaml when configured.
+    """
+    workspace_id = (
+        metadata.monitoring.workspace
+        if metadata.monitoring and metadata.monitoring.workspace is not None
+        else default_workspace
+    )
+    allowed = ConfigLoader.get("monitoring", "bigeye_workspace_ids", fallback=None)
+    if allowed and workspace_id not in allowed:
+        raise click.ClickException(
+            f"workspace {workspace_id} is not in monitoring.bigeye_workspace_ids "
+            f"({allowed}) configured in bqetl_project.yaml"
+        )
+    return workspace_id
+
+
+def _client_for_workspace(api_auth: APIKeyAuth, workspace_id: int, _cache: dict = {}):
+    """Return a cached datawatch client for the given Bigeye workspace."""
+    if workspace_id not in _cache:
+        _cache[workspace_id] = datawatch_client_factory(
+            api_auth, workspace_id=workspace_id
+        )
+    return _cache[workspace_id]
+
+
 @click.group(help="""
     Commands for managing monitoring of datasets.
     """)
@@ -129,6 +159,10 @@ def deploy(
         print(f"No metadata files matching {name}")
         return
 
+    api_auth = APIKeyAuth(base_url=base_url, api_key=api_key)
+    # bigconfig files grouped by the workspace they target — needed because
+    # `mc.execute_bigconfig` validates against a single workspace's catalog.
+    bigconfigs_by_workspace: dict = {}
     for metadata_file in list(set(metadata_files)):
         project, dataset, table = extract_from_query_path(metadata_file)
         try:
@@ -140,9 +174,10 @@ def deploy(
                     sql_dir=sql_dir,
                     project_id=project_id,
                 )
-                api_auth = APIKeyAuth(base_url=base_url, api_key=api_key)
-                client = datawatch_client_factory(api_auth, workspace_id=workspace)
-                mc = MetricSuiteController(client=client)
+                table_workspace = _resolve_workspace(metadata, workspace)
+                bigconfigs_by_workspace.setdefault(table_workspace, []).append(
+                    metadata_file.parent / BIGCONFIG_FILE
+                )
 
                 ctx.invoke(
                     validate,
@@ -162,6 +197,7 @@ def deploy(
                             name=metadata_file.parent,
                             sql_dir=sql_dir,
                             project_id=project_id,
+                            workspace=table_workspace,
                         )
 
                 if (metadata_file.parent / CUSTOM_RULES_FILE).exists():
@@ -180,28 +216,29 @@ def deploy(
         except FileNotFoundError:
             print("No metadata file for: {}.{}.{}".format(project, dataset, table))
 
-    try:
-        # Deploy BigConfig files at once.
-        # Deploying BigConfig files separately can lead to previously deployed metrics being removed.
-        mc.execute_bigconfig(
-            input_path=[
-                metadata_file.parent / BIGCONFIG_FILE
-                for metadata_file in list(set(metadata_files))
-            ]
-            + [f"{sql_dir}/{BIGCONFIG_FILE}"],
-            output_path=Path(sql_dir).parent if sql_dir else None,
-            apply=not dry_run,
-            recursive=False,
-            strict_mode=True,
-            auto_approve=True,
-        )
-    except Exception as e:
-        if dry_run:
-            bigconfig_result = Path(f"{project_id}_PLAN.yml")
-        else:
-            bigconfig_result = Path(f"{project_id}_APPLY.yml")
-        click.echo(bigconfig_result.read_text())
-        raise e
+    # Deploy bigconfig files once per workspace. Batching within a workspace
+    # preserves the original "deploy together so previously-deployed metrics
+    # aren't removed" guarantee; splitting across workspaces is required since
+    # each MetricSuiteController binds to a single workspace's catalog.
+    for ws_id, bigconfig_paths in bigconfigs_by_workspace.items():
+        client = _client_for_workspace(api_auth, ws_id)
+        mc = MetricSuiteController(client=client)
+        try:
+            mc.execute_bigconfig(
+                input_path=bigconfig_paths + [f"{sql_dir}/{BIGCONFIG_FILE}"],
+                output_path=Path(sql_dir).parent if sql_dir else None,
+                apply=not dry_run,
+                recursive=False,
+                strict_mode=True,
+                auto_approve=True,
+            )
+        except Exception as e:
+            if dry_run:
+                bigconfig_result = Path(f"{project_id}_PLAN.yml")
+            else:
+                bigconfig_result = Path(f"{project_id}_APPLY.yml")
+            click.echo(bigconfig_result.read_text())
+            raise e
 
 
 def _sql_rules_from_file(custom_rules_file, project, dataset, table) -> list:
@@ -273,22 +310,40 @@ def deploy_custom_rules(
     )
 
     api_auth = APIKeyAuth(base_url=base_url, api_key=api_key)
-    client = datawatch_client_factory(api_auth, workspace_id=workspace)
-    collections = client.get_collections()
     warehouse_id = ConfigLoader.get("monitoring", "bigeye_warehouse_id")
-    existing_rules = client.get_rules_for_source(warehouse_id=warehouse_id)
-    existing_rules_sql = [rule.custom_rule.sql for rule in existing_rules.custom_rules]
-    existing_schedules = {
-        schedule.name: schedule.id
-        for schedule in client.get_named_schedule().named_schedules
-    }
     url = "/api/v1/custom-rules"
+
+    # Per-workspace caches; populated lazily on first encounter of a metadata
+    # file declaring that workspace.
+    workspace_state: dict = {}
+
+    def _state_for(workspace_id: int):
+        if workspace_id not in workspace_state:
+            client = _client_for_workspace(api_auth, workspace_id)
+            existing = client.get_rules_for_source(warehouse_id=warehouse_id)
+            workspace_state[workspace_id] = {
+                "client": client,
+                "collections": client.get_collections(),
+                "existing_rules_sql": [
+                    rule.custom_rule.sql for rule in existing.custom_rules
+                ],
+                "existing_schedules": {
+                    schedule.name: schedule.id
+                    for schedule in client.get_named_schedule().named_schedules
+                },
+            }
+        return workspace_state[workspace_id]
 
     for custom_rule_file in list(set(custom_rules_files)):
         project, dataset, table = extract_from_query_path(custom_rule_file)
         try:
             metadata = Metadata.from_file(custom_rule_file.parent / METADATA_FILE)
             if metadata.monitoring and metadata.monitoring.enabled:
+                state = _state_for(_resolve_workspace(metadata, workspace))
+                client = state["client"]
+                collections = state["collections"]
+                existing_rules_sql = state["existing_rules_sql"]
+                existing_schedules = state["existing_schedules"]
                 # Convert all the Airflow params to jinja usable dict.
                 for select_statement in _sql_rules_from_file(
                     custom_rule_file, project, dataset, table
@@ -631,6 +686,7 @@ def set_partition_column(
         name, sql_dir, project_id=project_id, files=["metadata.yaml"]
     )
 
+    api_auth = APIKeyAuth(base_url=base_url, api_key=api_key)
     for metadata_file in list(set(metadata_files)):
         project, dataset, table = extract_from_query_path(metadata_file)
         try:
@@ -639,8 +695,9 @@ def set_partition_column(
                 if not metadata.monitoring.partition_column_set:
                     click.echo(f"No partition column set for {metadata_file.parent}")
                     continue
-                api_auth = APIKeyAuth(base_url=base_url, api_key=api_key)
-                client = datawatch_client_factory(api_auth, workspace_id=workspace)
+                client = _client_for_workspace(
+                    api_auth, _resolve_workspace(metadata, workspace)
+                )
 
                 warehouse_id = ConfigLoader.get("monitoring", "bigeye_warehouse_id")
                 table_id = client.get_table_ids(
@@ -750,15 +807,35 @@ def delete(
         name, sql_dir, project_id=project_id, files=["metadata.yaml"]
     )
     api_auth = APIKeyAuth(base_url=base_url, api_key=api_key)
-    client = datawatch_client_factory(api_auth, workspace_id=workspace)
     warehouse_id = ConfigLoader.get("monitoring", "bigeye_warehouse_id")
-    existing_rules = {
-        rule.custom_rule.sql: rule.id
-        for rule in client.get_rules_for_source(warehouse_id=warehouse_id).custom_rules
-    }
+
+    workspace_state: dict = {}
+
+    def _state_for(workspace_id: int):
+        if workspace_id not in workspace_state:
+            client = _client_for_workspace(api_auth, workspace_id)
+            workspace_state[workspace_id] = {
+                "client": client,
+                "existing_rules": {
+                    rule.custom_rule.sql: rule.id
+                    for rule in client.get_rules_for_source(
+                        warehouse_id=warehouse_id
+                    ).custom_rules
+                },
+            }
+        return workspace_state[workspace_id]
 
     for metadata_file in list(set(metadata_files)):
         project, dataset, table = extract_from_query_path(metadata_file)
+        try:
+            metadata = Metadata.from_file(metadata_file)
+        except FileNotFoundError:
+            print("No metadata file for: {}.{}.{}".format(project, dataset, table))
+            continue
+        state = _state_for(_resolve_workspace(metadata, workspace))
+        client = state["client"]
+        existing_rules = state["existing_rules"]
+
         if metrics:
             deployed_metrics = client.get_metric_info_batch_post(
                 table_name=table,
@@ -821,13 +898,27 @@ def run(name, project_id, sql_dir, workspace, base_url, marker):
         sys.exit(1)
 
     api_auth = APIKeyAuth(base_url=base_url, api_key=api_key)
-    client = datawatch_client_factory(api_auth, workspace_id=workspace)
     warehouse_id = ConfigLoader.get("monitoring", "bigeye_warehouse_id")
-    existing_rules = {
-        rule.custom_rule.sql: {"id": rule.id, "name": rule.custom_rule.name}
-        for rule in client.get_rules_for_source(warehouse_id=warehouse_id).custom_rules
-        if rule.custom_rule.name.endswith(marker or "")
-    }
+
+    workspace_state: dict = {}
+
+    def _state_for(workspace_id: int):
+        if workspace_id not in workspace_state:
+            client = _client_for_workspace(api_auth, workspace_id)
+            workspace_state[workspace_id] = {
+                "client": client,
+                "existing_rules": {
+                    rule.custom_rule.sql: {
+                        "id": rule.id,
+                        "name": rule.custom_rule.name,
+                    }
+                    for rule in client.get_rules_for_source(
+                        warehouse_id=warehouse_id
+                    ).custom_rules
+                    if rule.custom_rule.name.endswith(marker or "")
+                },
+            }
+        return workspace_state[workspace_id]
 
     metadata_files = paths_matching_name_pattern(
         name, sql_dir, project_id=project_id, files=["metadata.yaml"]
@@ -840,6 +931,10 @@ def run(name, project_id, sql_dir, workspace, base_url, marker):
         try:
             metadata = Metadata.from_file(metadata_file)
             if metadata.monitoring and metadata.monitoring.enabled:
+                table_workspace = _resolve_workspace(metadata, workspace)
+                state = _state_for(table_workspace)
+                client = state["client"]
+                existing_rules = state["existing_rules"]
                 metrics = client.get_metric_info_batch_post(
                     table_name=table,
                     schema_name=f"{project}.{dataset}",
@@ -871,7 +966,7 @@ def run(name, project_id, sql_dir, workspace, base_url, marker):
                             f"Error running check {metric_info.metric_configuration.id}: {metric_info.active_issue.display_name}"
                         )
                         click.echo(
-                            f"Check {base_url}/w/{workspace}/catalog/data-sources/metric/{metric_info.metric_configuration.id}/chart for more information."
+                            f"Check {base_url}/w/{table_workspace}/catalog/data-sources/metric/{metric_info.metric_configuration.id}/chart for more information."
                         )
 
                 if (metadata_file.parent / CUSTOM_RULES_FILE).exists():
@@ -904,7 +999,7 @@ def run(name, project_id, sql_dir, workspace, base_url, marker):
 
                                 click.echo(
                                     f"Error running custom rule {existing_rules[sql]} for {project}.{dataset}.{table}. "
-                                    + f"Check {base_url}/w/{workspace}/catalog/data-sources/{warehouse_id}/rules/{existing_rules[sql]['id']}/runs "
+                                    + f"Check {base_url}/w/{table_workspace}/catalog/data-sources/{warehouse_id}/rules/{existing_rules[sql]['id']}/runs "
                                     + "for more information."
                                 )
 

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -186,6 +186,10 @@ class MonitoringMetadata:
     volume: Optional[MonitoringMetricMetadata] = attr.ib(
         MonitoringMetricMetadata(blocking=True)
     )
+    # Bigeye workspace ID this table is registered in. When unset, monitoring
+    # commands fall back to the --workspace CLI flag default. Must be one of
+    # `monitoring.bigeye_workspace_ids` in bqetl_project.yaml.
+    workspace: Optional[int] = attr.ib(None)
 
 
 @attr.s(auto_attribs=True)

--- a/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/metadata.yaml
@@ -45,6 +45,7 @@ workgroup_access:
       - workgroup:mozilla-confidential/data-viewers
 monitoring:
   enabled: true
+  workspace: 508
   collection: Ads Client
   freshness:
     blocking: false


### PR DESCRIPTION
## Description
See https://mozilla.slack.com/archives/C4D5ZA91B/p1777486372818799

Related to https://github.com/mozilla/bigquery-etl/pull/9270

https://github.com/mozilla/bigquery-etl/pull/9270 added a BigConfig file for and `ads_derived` table. Subsequently, the BigConfig deploys started failing: https://workflow.telemetry.mozilla.org/dags/bqetl_artifact_deployment/grid?dag_run_id=manual__2026-04-29T15%3A28%3A23.174956%2B00%3A00&task_id=publish_bigeye_monitors&tab=logs

By default the deployment tries to deploy the Bigeye metrics to the default workspace (ID: 463). However, the metrics in the linked PR are defined on a restricted table (`ads_derived`) that is in a different, restricted workspace (Ads ID: 503), which the deploy mechanism currently doesn't pick up. 

This PR introduced a field in the metadata to override the default Bigeye workspace and to deploy metrics to that workspace. The dryrun tests did succeed.

cc @Almaju 


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
