### PR TITLE
[chore] start backfill for new_profile_churn_clients_v1 table

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2026-04-29:
+  start_date: 2024-03-23
+  end_date: 2026-04-27
+  reason: 'backfill of new table, https://mozilla-hub.atlassian.net/browse/DENG-10676'
+  watchers:
+  - mhirose@mozilla.com
+  - bbaird_@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR starts the backfill for the new table `glean_telemetry_derived.new_profile_churn_clients_v1`
## Related Tickets & Documents
* DENG-10676
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
