### PR TITLE
fix: Complete Backfill older than 28 days

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/backfill.yaml
@@ -4,7 +4,7 @@
   reason: Backfill existing data to support dashboard development for ads client operations and errors monitoring.
   watchers:
   - ahanot@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

This PR completes a Backfill older than 28 days - right it is causing this CI error in a number of my PRs:

Example: 

https://github.com/mozilla/bigquery-etl/actions/runs/25163699117/job/73766455482  

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
