### PR TITLE
chore(deps): Increase Dependabot's open PR limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Description
The default is 5, but it's fairly common for some Dependabot PRs to get hung up on incompatibilities.

Dependabot has been blocked from creating new PRs for at least two weeks due to this limit and the number of currently open PRs.

This isn't necessarily the best approach, but it's one option.  Another option could be automatically merging Dependabot PRs with passing CI checks (DENG-8512).

## Related Tickets & Documents
* https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-
* DENG-8512: Investigate if we can automatically approve dependabot PRs

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
