### PR TITLE
add recent_new_profile_churn files so we can effect a rolling window …

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry/new_profile_churn_clients/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry/new_profile_churn_clients/metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: New Profile Churn Clients
+description: |-
+  Union view combining new_profile_churn_clients_v1 (complete cohorts with 30-day lag)
+  and recent_new_profile_churn_clients_v1 (recent cohorts with partial data still filling in).
+  Provides a complete view of all cohorts: the recent table supplies the most current 30 days,
+  and the complete table supplies all older cohorts with fully populated day columns.
+
+  Jira: https://mozilla-hub.atlassian.net/browse/DENG-10676
+owners:
+- bbaird@mozilla.com
+- mhirose@mozilla.com
+labels:
+  owner1: bbaird
+  owner2: mhirose

--- a/sql/moz-fx-data-shared-prod/glean_telemetry/new_profile_churn_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry/new_profile_churn_clients/view.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.glean_telemetry.new_profile_churn_clients`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.glean_telemetry_derived.recent_new_profile_churn_clients_v1`
+UNION ALL
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.glean_telemetry_derived.new_profile_churn_clients_v1`
+WHERE
+  cohort_date < (
+    SELECT
+      MIN(cohort_date)
+    FROM
+      `moz-fx-data-shared-prod.glean_telemetry_derived.recent_new_profile_churn_clients_v1`
+  )

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/metadata.yaml
@@ -18,10 +18,11 @@ labels:
   owner2: mhirose
 scheduling:
   dag_name: bqetl_cohort_daily_churn
+  date_partition_offset: -30
 bigquery:
   time_partitioning:
     type: day
-    field: 'submission_date'
+    field: 'cohort_date'
     require_partition_filter: true
     expiration_days: null
   clustering:

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/metadata.yaml
@@ -26,5 +26,5 @@ bigquery:
     require_partition_filter: true
     expiration_days: null
   clustering:
-    fields: [cohort_date]
+    fields: [cohort_date, sample_id]
 require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/query.sql
@@ -22,7 +22,7 @@ WITH activity_range AS (
 max_available_date AS (
   SELECT
     MAX(submission_date) AS max_date,
-    DATE_DIFF(CURRENT_DATE(), MAX(submission_date), DAY) AS days_since_last_data
+    DATE_DIFF(@submission_date, MAX(submission_date), DAY) AS days_since_last_data
   FROM
     activity_range
 ),

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/query.sql
@@ -613,7 +613,7 @@ SELECT
   -- Client is in the cohort but never active across the entire 30-day window
   -- NULL if day 30 data not yet available
   CASE
-    WHEN days_data_available < 31
+    WHEN days_data_available < 28
       THEN NULL
     WHEN day_0 = FALSE
       AND day_1 = FALSE

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/query.sql
@@ -674,9 +674,12 @@ SELECT
   day_25,
   day_26,
   day_27,
-  day_28,
-  day_29,
-  day_30
+  -- bits28 tracks 28 days (bits 0-27); clients inactive for 28+ days fall out of
+  -- baseline_clients_last_seen entirely, producing NULL instead of FALSE. Coerce to
+  -- FALSE when days_data_available confirms the date is in the past.
+  IF(days_data_available >= 28 AND day_28 IS NULL, FALSE, day_28) AS day_28,
+  IF(days_data_available >= 29 AND day_29 IS NULL, FALSE, day_29) AS day_29,
+  IF(days_data_available >= 30 AND day_30 IS NULL, FALSE, day_30) AS day_30
 FROM
   client_level
 LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/query.sql
@@ -643,9 +643,6 @@ SELECT
       AND day_25 = FALSE
       AND day_26 = FALSE
       AND day_27 = FALSE
-      AND IFNULL(day_28, FALSE) = FALSE
-      AND IFNULL(day_29, FALSE) = FALSE
-      AND IFNULL(day_30, FALSE) = FALSE
       THEN TRUE
     ELSE FALSE
   END AS immediately_churned,

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/query.sql
@@ -145,7 +145,7 @@ client_level AS (
     client_id,
     sample_id,
     first_seen_date,
-    DATE_DIFF(max_date, first_seen_date, DAY) AS days_data_available,
+    DATE_DIFF(max_date, first_seen_date, DAY) + 1 AS days_data_available,
     days_since_last_data,
     MAX(
       CASE
@@ -526,7 +526,7 @@ SELECT
   -- No activity on days 2-6; at risk of churning by day 7
   -- NULL if day 6 data not yet available
   CASE
-    WHEN days_data_available < 6
+    WHEN days_data_available < 7
       THEN NULL
     WHEN day_2 = FALSE
       AND day_3 = FALSE
@@ -569,7 +569,7 @@ SELECT
       AND day_25 = FALSE
       AND day_26 = FALSE
       AND day_27 = FALSE
-      AND day_28 = FALSE
+      AND IFNULL(day_28, FALSE) = FALSE
       THEN TRUE
     ELSE FALSE
   END AS churned_after_1_day,
@@ -605,15 +605,15 @@ SELECT
       AND day_25 = FALSE
       AND day_26 = FALSE
       AND day_27 = FALSE
-      AND day_28 = FALSE
-      AND day_29 = FALSE
+      AND IFNULL(day_28, FALSE) = FALSE
+      AND IFNULL(day_29, FALSE) = FALSE
       THEN TRUE
     ELSE FALSE
   END AS churned_after_2_days,
   -- Client is in the cohort but never active across the entire 30-day window
   -- NULL if day 30 data not yet available
   CASE
-    WHEN days_data_available < 28
+    WHEN days_data_available < 31
       THEN NULL
     WHEN day_0 = FALSE
       AND day_1 = FALSE
@@ -643,6 +643,9 @@ SELECT
       AND day_25 = FALSE
       AND day_26 = FALSE
       AND day_27 = FALSE
+      AND IFNULL(day_28, FALSE) = FALSE
+      AND IFNULL(day_29, FALSE) = FALSE
+      AND IFNULL(day_30, FALSE) = FALSE
       THEN TRUE
     ELSE FALSE
   END AS immediately_churned,
@@ -677,9 +680,9 @@ SELECT
   -- bits28 tracks 28 days (bits 0-27); clients inactive for 28+ days fall out of
   -- baseline_clients_last_seen entirely, producing NULL instead of FALSE. Coerce to
   -- FALSE when days_data_available confirms the date is in the past.
-  IF(days_data_available >= 28 AND day_28 IS NULL, FALSE, day_28) AS day_28,
-  IF(days_data_available >= 29 AND day_29 IS NULL, FALSE, day_29) AS day_29,
-  IF(days_data_available >= 30 AND day_30 IS NULL, FALSE, day_30) AS day_30
+  IF(days_data_available >= 29 AND day_28 IS NULL, FALSE, day_28) AS day_28,
+  IF(days_data_available >= 30 AND day_29 IS NULL, FALSE, day_29) AS day_29,
+  IF(days_data_available >= 31 AND day_30 IS NULL, FALSE, day_30) AS day_30
 FROM
   client_level
 LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/metadata.yaml
@@ -1,0 +1,29 @@
+friendly_name: Recent New Profile Churn Clients - Desktop Glean
+description: |-
+  Recent client-level churn metrics for new Firefox Desktop profiles, covering cohorts
+  not yet present in new_profile_churn_clients_v1 (i.e. cohorts within the last 30 days
+  whose data is still filling in). Structure is identical to new_profile_churn_clients_v1;
+  day columns are partially populated with NULLs for days not yet available. The entire
+  table is overwritten on each daily run. Intended to be unioned with
+  new_profile_churn_clients_v1 for a complete view of all cohorts.
+
+  Jira: https://mozilla-hub.atlassian.net/browse/DENG-10676
+owners:
+- bbaird@mozilla.com
+- mhirose@mozilla.com
+labels:
+  incremental: false
+  owner1: bbaird
+  owner2: mhirose
+scheduling:
+  dag_name: bqetl_cohort_daily_churn
+  date_partition_parameter: null
+bigquery:
+  time_partitioning:
+    type: day
+    field: 'cohort_date'
+    require_partition_filter: false
+    expiration_days: null
+  clustering:
+    fields: [cohort_date]
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/metadata.yaml
@@ -25,5 +25,5 @@ bigquery:
     require_partition_filter: false
     expiration_days: null
   clustering:
-    fields: [cohort_date]
+    fields: [cohort_date, sample_id]
 require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
@@ -1,4 +1,12 @@
-WITH activity_range AS (
+WITH cohort_cutoff AS (
+  -- Start from the day after the most recent complete cohort; fall back to 30 days ago
+  -- to cover gaps if the complete table ETL has fallen behind.
+  SELECT
+    COALESCE(MAX(cohort_date) + 1, DATE_SUB(@submission_date, INTERVAL 30 DAY)) AS min_cohort_date
+  FROM
+    `moz-fx-data-shared-prod.glean_telemetry_derived.new_profile_churn_clients_v1`
+),
+activity_range AS (
   SELECT
     last_seen.client_id,
     last_seen.sample_id,
@@ -12,17 +20,22 @@ WITH activity_range AS (
     `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_clients_first_seen_v1` AS first_seen
     ON last_seen.client_id = first_seen.client_id
     AND last_seen.sample_id = first_seen.sample_id
+  CROSS JOIN
+    cohort_cutoff
   WHERE
-    first_seen.first_seen_date = @submission_date
+    first_seen.first_seen_date >= cohort_cutoff.min_cohort_date
+    AND first_seen.first_seen_date <= @submission_date
+    AND last_seen.submission_date >= DATE_SUB(@submission_date, INTERVAL 30 DAY)
+    AND last_seen.submission_date <= @submission_date
     AND last_seen.submission_date
-    BETWEEN @submission_date
-    AND DATE_ADD(@submission_date, INTERVAL 30 DAY)
+    BETWEEN first_seen.first_seen_date
+    AND DATE_ADD(first_seen.first_seen_date, INTERVAL 30 DAY)
 ),
   -- Latest date with data available; drives NULL logic for future day columns
 max_available_date AS (
   SELECT
     MAX(submission_date) AS max_date,
-    DATE_DIFF(CURRENT_DATE(), MAX(submission_date), DAY) AS days_since_last_data
+    DATE_DIFF(@submission_date, MAX(submission_date), DAY) AS days_since_last_data
   FROM
     activity_range
 ),
@@ -136,9 +149,8 @@ client_attributes AS (
   WHERE
       -- Pull attributes from each client's cohort date (first seen day) row
     last_seen.submission_date = last_seen.first_seen_date
-    AND last_seen.submission_date
-    BETWEEN DATE_SUB(@submission_date, INTERVAL 30 DAY)
-    AND @submission_date
+    AND last_seen.submission_date >= DATE_SUB(@submission_date, INTERVAL 30 DAY)
+    AND last_seen.submission_date <= @submission_date
 ),
 client_level AS (
   SELECT
@@ -469,7 +481,7 @@ client_level AS (
     days_since_last_data
 )
 SELECT
-  @submission_date AS submission_date,
+  first_seen_date AS submission_date,
   client_id,
   sample_id,
   first_seen_date AS cohort_date,

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
@@ -157,7 +157,7 @@ client_level AS (
     client_id,
     sample_id,
     first_seen_date,
-    DATE_DIFF(max_date, first_seen_date, DAY) AS days_data_available,
+    DATE_DIFF(max_date, first_seen_date, DAY) + 1 AS days_data_available,
     days_since_last_data,
     MAX(
       CASE
@@ -538,7 +538,7 @@ SELECT
   -- No activity on days 2-6; at risk of churning by day 7
   -- NULL if day 6 data not yet available
   CASE
-    WHEN days_data_available < 6
+    WHEN days_data_available < 7
       THEN NULL
     WHEN day_2 = FALSE
       AND day_3 = FALSE
@@ -581,7 +581,7 @@ SELECT
       AND day_25 = FALSE
       AND day_26 = FALSE
       AND day_27 = FALSE
-      AND day_28 = FALSE
+      AND IFNULL(day_28, FALSE) = FALSE
       THEN TRUE
     ELSE FALSE
   END AS churned_after_1_day,
@@ -617,15 +617,15 @@ SELECT
       AND day_25 = FALSE
       AND day_26 = FALSE
       AND day_27 = FALSE
-      AND day_28 = FALSE
-      AND day_29 = FALSE
+      AND IFNULL(day_28, FALSE) = FALSE
+      AND IFNULL(day_29, FALSE) = FALSE
       THEN TRUE
     ELSE FALSE
   END AS churned_after_2_days,
   -- Client is in the cohort but never active across the entire 30-day window
   -- NULL if day 30 data not yet available
   CASE
-    WHEN days_data_available < 28
+    WHEN days_data_available < 31
       THEN NULL
     WHEN day_0 = FALSE
       AND day_1 = FALSE
@@ -655,6 +655,9 @@ SELECT
       AND day_25 = FALSE
       AND day_26 = FALSE
       AND day_27 = FALSE
+      AND IFNULL(day_28, FALSE) = FALSE
+      AND IFNULL(day_29, FALSE) = FALSE
+      AND IFNULL(day_30, FALSE) = FALSE
       THEN TRUE
     ELSE FALSE
   END AS immediately_churned,
@@ -689,9 +692,9 @@ SELECT
   -- bits28 tracks 28 days (bits 0-27); clients inactive for 28+ days fall out of
   -- baseline_clients_last_seen entirely, producing NULL instead of FALSE. Coerce to
   -- FALSE when days_data_available confirms the date is in the past.
-  IF(days_data_available >= 28 AND day_28 IS NULL, FALSE, day_28) AS day_28,
-  IF(days_data_available >= 29 AND day_29 IS NULL, FALSE, day_29) AS day_29,
-  IF(days_data_available >= 30 AND day_30 IS NULL, FALSE, day_30) AS day_30
+  IF(days_data_available >= 29 AND day_28 IS NULL, FALSE, day_28) AS day_28,
+  IF(days_data_available >= 30 AND day_29 IS NULL, FALSE, day_29) AS day_29,
+  IF(days_data_available >= 31 AND day_30 IS NULL, FALSE, day_30) AS day_30
 FROM
   client_level
 LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
@@ -655,9 +655,6 @@ SELECT
       AND day_25 = FALSE
       AND day_26 = FALSE
       AND day_27 = FALSE
-      AND IFNULL(day_28, FALSE) = FALSE
-      AND IFNULL(day_29, FALSE) = FALSE
-      AND IFNULL(day_30, FALSE) = FALSE
       THEN TRUE
     ELSE FALSE
   END AS immediately_churned,

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
@@ -686,9 +686,12 @@ SELECT
   day_25,
   day_26,
   day_27,
-  day_28,
-  day_29,
-  day_30
+  -- bits28 tracks 28 days (bits 0-27); clients inactive for 28+ days fall out of
+  -- baseline_clients_last_seen entirely, producing NULL instead of FALSE. Coerce to
+  -- FALSE when days_data_available confirms the date is in the past.
+  IF(days_data_available >= 28 AND day_28 IS NULL, FALSE, day_28) AS day_28,
+  IF(days_data_available >= 29 AND day_29 IS NULL, FALSE, day_29) AS day_29,
+  IF(days_data_available >= 30 AND day_30 IS NULL, FALSE, day_30) AS day_30
 FROM
   client_level
 LEFT JOIN

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
@@ -625,7 +625,7 @@ SELECT
   -- Client is in the cohort but never active across the entire 30-day window
   -- NULL if day 30 data not yet available
   CASE
-    WHEN days_data_available < 31
+    WHEN days_data_available < 28
       THEN NULL
     WHEN day_0 = FALSE
       AND day_1 = FALSE

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/schema.yaml
@@ -1,0 +1,312 @@
+fields:
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+  description: The date when the telemetry ping is received on the server side.
+- name: client_id
+  type: STRING
+  mode: NULLABLE
+  description: A unique identifier (UUID) for the client.
+- name: sample_id
+  type: INTEGER
+  mode: NULLABLE
+  description: A number, 0-99, that samples by client_id and allows filtering data for analysis.
+- name: cohort_date
+  type: DATE
+  mode: NULLABLE
+  description: Cohort Date - First Seen Date
+- name: days_data_available
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of days since first_seen_date
+- name: days_since_last_data
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of days since the last data pull
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Name of the country in which the activity took place, as determined
+    by the IP geolocation.
+- name: city
+  type: STRING
+  mode: NULLABLE
+  description: City
+- name: locale
+  type: STRING
+  mode: NULLABLE
+  description: Set of language- and/or country-based preferences for a user interface.
+- name: app_name
+  type: STRING
+  mode: NULLABLE
+  description: The name of the browser.
+- name: app_version
+  type: STRING
+  mode: NULLABLE
+  description: User visible version string (e.g. "1.0.3") for the browser.
+- name: app_version_major
+  type: NUMERIC
+  mode: NULLABLE
+  description: The major version of the user visible app version string for the browser,
+    e.g. "142.1.3", has major version 142.
+- name: app_version_minor
+  type: NUMERIC
+  mode: NULLABLE
+  description: The minor version of the user visible app version string for the browser,
+    e.g. "142.1.3" has minor version 1.
+- name: app_version_patch_revision
+  type: NUMERIC
+  mode: NULLABLE
+  description: Application Version Patch Revision number
+- name: app_version_is_major_release
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Is app_version a major release or not
+- name: channel
+  type: STRING
+  mode: NULLABLE
+  description: The normalized channel the application is being distributed on.
+- name: distribution_id
+  type: STRING
+  mode: NULLABLE
+  description: The distribution id associated with the install of Firefox.
+- name: distribution_id_source
+  type: STRING
+  mode: NULLABLE
+  description: Distribution Id - Legacy or Glean
+- name: os
+  type: STRING
+  mode: NULLABLE
+  description: The normalized name of the operating system running at the client.
+- name: os_grouped
+  type: STRING
+  mode: NULLABLE
+  description: OS grouping
+- name: os_version
+  type: STRING
+  mode: NULLABLE
+  description: The normalized version of the operating system running at the client. E.g. "100.9.11".
+- name: os_version_build
+  type: STRING
+  mode: NULLABLE
+  description: OS Version Build
+- name: os_version_major
+  type: INTEGER
+  mode: NULLABLE
+  description: Major or first part of the operating system version running at the
+    client. E.g. for version "100.9.11", the major is 100.
+- name: os_version_minor
+  type: INTEGER
+  mode: NULLABLE
+  description: Minor part of the operating system version running at the client. E.g.
+    for version "100.9.11", the minor is 9.
+- name: activity_segment
+  type: STRING
+  mode: NULLABLE
+  description: Classification of users based on their browsing activity. E.g., infrequent,
+    casual, regular.
+- name: first_seen_year
+  type: INTEGER
+  mode: NULLABLE
+  description: Year of first seen date
+- name: attribution_campaign
+  type: STRING
+  mode: NULLABLE
+  description: The attribution campaign (e.g. 'mozilla-org').
+- name: attribution_content
+  type: STRING
+  mode: NULLABLE
+  description: The attribution content (e.g. 'firefoxview').
+- name: attribution_medium
+  type: STRING
+  mode: NULLABLE
+  description: The attribution medium (e.g. 'organic' for a search engine).
+- name: attribution_source
+  type: STRING
+  mode: NULLABLE
+  description: The attribution source (e.g. 'google-play').
+- name: attribution_term
+  type: STRING
+  mode: NULLABLE
+  description: The attribution term (e.g. 'browser with developer tools for android').
+- name: distribution_name
+  type: STRING
+  mode: NULLABLE
+  description: The distribution name (e.g. 'MozillaOnline').
+- name: first_seen_attribution_campaign
+  type: STRING
+  mode: NULLABLE
+  description: The attribution campaign at first seen (e.g. 'mozilla-org').
+- name: first_seen_attribution_content
+  type: STRING
+  mode: NULLABLE
+  description: The attribution content at first seen (e.g. 'firefoxview').
+- name: first_seen_attribution_medium
+  type: STRING
+  mode: NULLABLE
+  description: The attribution medium at first seen (e.g. 'organic' for a search engine).
+- name: first_seen_attribution_source
+  type: STRING
+  mode: NULLABLE
+  description: The attribution source at first seen (e.g. 'google-play').
+- name: first_seen_attribution_term
+  type: STRING
+  mode: NULLABLE
+  description: The attribution term at first seen (e.g. 'browser with developer tools for android').
+- name: first_seen_distribution_name
+  type: STRING
+  mode: NULLABLE
+  description: The distribution name at first seen (e.g. 'MozillaOnline').
+- name: is_desktop
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Indicates if the client is included in the desktop KPI.
+- name: policies_is_enterprise
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Attempt to determine if the user is an enterprise user based on various
+    signals.
+- name: churn_risk_after_5_days
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Is the user a high risk of already churning, based on their inactivity levels in the five days after they are first seen?
+- name: churn_risk_after_7_days
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Is the user a high risk of already churning, based on their inactivity levels in the seven days after they are first seen?
+- name: churned_after_1_day
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Shows if the client was active on their first seen date, but then immediately churned with no DAU activity for the following 28 days.
+- name: churned_after_2_days
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Shows if client was active in the first 48 hours after first seen, then then immediately churned no DAU activity for the following 28 days.
+- name: immediately_churned
+  type: BOOLEAN
+  mode: NULLABLE
+  description: User was not active in any of the the 28 days from the day they are first seen (i.e., qualified as "churned" immediately).
+- name: day_0
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Whether the client qualified as DAU on their first seen date (Day 0).
+- name: day_1
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 1 since first seen
+- name: day_2
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 2 since first seen
+- name: day_3
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 3 since first seen
+- name: day_4
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 4 since first seen
+- name: day_5
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 5 since first seen
+- name: day_6
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 6 since first seen
+- name: day_7
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 7 since first seen
+- name: day_8
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 8 since first seen
+- name: day_9
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 9 since first seen
+- name: day_10
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 10 since first seen
+- name: day_11
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 11 since first seen
+- name: day_12
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 12 since first seen
+- name: day_13
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 13 since first seen
+- name: day_14
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 14 since first seen
+- name: day_15
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 15 since first seen
+- name: day_16
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 16 since first seen
+- name: day_17
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 17 since first seen
+- name: day_18
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 18 since first seen
+- name: day_19
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 19 since first seen
+- name: day_20
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 20 since first seen
+- name: day_21
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 21 since first seen
+- name: day_22
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 22 since first seen
+- name: day_23
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 23 since first seen
+- name: day_24
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 24 since first seen
+- name: day_25
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 25 since first seen
+- name: day_26
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 26 since first seen
+- name: day_27
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 27 since first seen
+- name: day_28
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 28 since first seen
+- name: day_29
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 29 since first seen
+- name: day_30
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Active on day 30 since first seen


### PR DESCRIPTION
…of data, add view files to effect the rolling window

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR creates a `recent` table for new_profile_churn_clients. It also adds a 30 day lag to the original new_profile_churn_clients as well as a UNION view of the recent and the original tables so we can get a rolling window of data

## Related Tickets & Documents
* DENG-10676
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
