### PR TITLE
Syndicate mozsoc ML stats tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozsoc_ml_prod_ml_stats/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozsoc_ml_prod_ml_stats/dataset_metadata.yaml
@@ -1,0 +1,17 @@
+friendly_name: Content ML Team - ML Stats
+description: RSS subtopics drop statistics from New Tab ML jobs
+dataset_base_acl: syndicate
+user_facing: true
+labels: {}
+syndication:
+  prod:
+    syndicated_project: "moz-fx-mozsoc-ml-prod"
+    syndicated_dataset: "prod_ml_stats"
+  syndicated_tables:
+    - rss_subtopics_drop_table
+    - rss_subtopics_drop_table_manifest
+  administer_views: false
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential/data-viewers


### PR DESCRIPTION
  ## Description

  Adds syndicated access to two existing tables in `moz-fx-mozsoc-ml-prod.prod_ml_stats`:

  - `rss_subtopics_drop_table`
  - `rss_subtopics_drop_table_manifest`

  This follows the existing mozsoc ML syndication pattern used by `mozsoc_ml_prod_rss_news` and `mozsoc_ml_prod_articles_zyte_cache`.

  ## Related Tickets & Documents

  N/A - requested from Slack thread.



**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
