### PR TITLE
[fix] take out quote marks around chore and remove redundant cohort_d…

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/new_profile_churn_clients_v1/metadata.yaml
@@ -22,9 +22,9 @@ scheduling:
 bigquery:
   time_partitioning:
     type: day
-    field: 'cohort_date'
+    field: cohort_date
     require_partition_filter: true
     expiration_days: null
   clustering:
-    fields: [cohort_date, sample_id]
+    fields: [sample_id]
 require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/metadata.yaml
@@ -21,9 +21,9 @@ scheduling:
 bigquery:
   time_partitioning:
     type: day
-    field: 'cohort_date'
+    field: cohort_date
     require_partition_filter: false
     expiration_days: null
   clustering:
-    fields: [cohort_date, sample_id]
+    fields: [sample_id]
 require_column_descriptions: true


### PR DESCRIPTION
…ate clustering field

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR fixes the metadata by taking out extraneous quote marks around cohort_date and takes out redundant cohort_date in clustering
## Related Tickets & Documents
* DENG-10676
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
