### PR TITLE
feat(CI): Store DAGs in new `generated-dags` and `private-generated-dags` branches (DENG-10984)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1140,7 +1140,7 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions generate-dags job"
           git config --global user.email "dataops+generated-dags@mozilla.com"
-          git clone --single-branch --branch generated-dags \
+          git clone --single-branch --branch generated-dags --depth=1 \
             git@github.com:mozilla/bigquery-etl.git \
             generated-dags
           cd generated-dags/
@@ -1218,7 +1218,7 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions private-generate-dags job"
           git config --global user.email "dataops+private-generated-dags@mozilla.com"
-          git clone --single-branch --branch private-generated-dags \
+          git clone --single-branch --branch private-generated-dags --depth=1 \
             git@github.com:mozilla/private-bigquery-etl \
             private-generated-dags
           cd private-generated-dags/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1374,7 +1374,8 @@ jobs:
           cd telemetry-airflow-dags
           git submodule update --init --depth 1 private-bigquery-etl
           cd private-bigquery-etl
-          git reset --hard origin/private-generated-dags
+          git fetch --depth=1 origin private-generated-dags
+          git reset --hard FETCH_HEAD
           cd ..
           git add private-bigquery-etl
           git commit --allow-empty -m "Automatic commit from bigquery-etl commit ${{ github.sha }} [skip ci]"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -865,7 +865,7 @@ jobs:
   generate-dags:
     name: Generate DAGs
     runs-on: ubuntu-latest
-    needs: [generate-sql, private-generate-sql, decide-runs]
+    needs: [private-generate-sql, decide-runs]
     if: |
       (needs.decide-runs.outputs.validate-sql == 'true' || needs.decide-runs.outputs.validate-routines == 'true' || needs.decide-runs.outputs.deploy == 'true')
     permissions:
@@ -877,10 +877,6 @@ jobs:
       - *setup-python
       - *restore-venv
       - *download-schema-cache
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          name: generated-sql
-          path: /tmp/workspace/generated-sql
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: private-generated-sql
@@ -907,19 +903,19 @@ jobs:
 
           cat ~/private-bigquery-etl/dags.yaml | grep -v '^---$' >> dags.yaml
 
-          mkdir -p /tmp/workspace/generated-sql/dags
-          PATH=".venv/bin:$PATH" script/bqetl dag generate --output-dir=/tmp/workspace/generated-sql/dags
+          mkdir -p /tmp/workspace/generated-dags/dags
+          PATH=".venv/bin:$PATH" script/bqetl dag generate --output-dir=/tmp/workspace/generated-dags/dags
 
-          mkdir -p /tmp/workspace/private-generated-sql/dags
-          mv /tmp/workspace/generated-sql/dags/private_bqetl_*.py /tmp/workspace/private-generated-sql/dags/
+          mkdir -p /tmp/workspace/private-generated-dags/dags
+          mv /tmp/workspace/generated-dags/dags/private_bqetl_*.py /tmp/workspace/private-generated-dags/dags/
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: generated-sql-with-dags
-          path: /tmp/workspace/generated-sql
+          name: generated-dags
+          path: /tmp/workspace/generated-dags
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: private-generated-sql-with-dags
-          path: /tmp/workspace/private-generated-sql
+          name: private-generated-dags
+          path: /tmp/workspace/private-generated-dags
 
   validate-dags:
     name: Validate DAGs
@@ -934,12 +930,12 @@ jobs:
           git clone https://github.com/mozilla/telemetry-airflow.git ~/telemetry-airflow
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: generated-sql-with-dags
-          path: /tmp/workspace/generated-sql
+          name: generated-dags
+          path: /tmp/workspace/generated-dags
       - name: Replace telemetry-airflow DAGs with BigQuery ETL DAGs
         run: |
           rm ~/telemetry-airflow/dags/* -f || true
-          cp -a /tmp/workspace/generated-sql/dags/. ~/telemetry-airflow/dags/
+          cp -a /tmp/workspace/generated-dags/dags/. ~/telemetry-airflow/dags/
       - name: Cache telemetry-airflow dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -971,7 +967,7 @@ jobs:
     name: Generate and Post SQL Diff
     runs-on: ubuntu-latest
     environment: *build-env
-    needs: [generate-dags, main-generate-sql-and-dags, decide-runs]
+    needs: [generate-sql, generate-dags, main-generate-sql-and-dags, decide-runs]
     if: |
       (github.ref != 'refs/heads/main') &&
       (needs.decide-runs.outputs.validate-sql == 'true' || needs.decide-runs.outputs.validate-routines == 'true')
@@ -984,8 +980,12 @@ jobs:
         run: mkdir -p /tmp/workspace
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: generated-sql-with-dags
+          name: generated-sql
           path: /tmp/workspace/generated-sql
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: generated-dags
+          path: /tmp/workspace/generated-dags
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: main-generated-sql
@@ -993,11 +993,11 @@ jobs:
       - name: Generate diff
         run: |
           diff -qr --no-dereference \
-            /tmp/workspace/main-generated-sql/dags/ /tmp/workspace/generated-sql/dags/ \
+            /tmp/workspace/main-generated-sql/dags/ /tmp/workspace/generated-dags/dags/ \
             | grep '^Only in' \
             > /tmp/workspace/sql.diff || true
           diff -bur --no-dereference --new-file \
-            /tmp/workspace/main-generated-sql/dags/ /tmp/workspace/generated-sql/dags/ \
+            /tmp/workspace/main-generated-sql/dags/ /tmp/workspace/generated-dags/dags/ \
             >> /tmp/workspace/sql.diff || true
           diff -qr --no-dereference \
             /tmp/workspace/main-generated-sql/sql/ /tmp/workspace/generated-sql/sql/ \
@@ -1051,10 +1051,10 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.find-pr.outputs.pr_title }}
         run: node .github/workflows/post-diff.js
 
-  push-generated-sql:
-    name: Push Generated SQL
+  push-generated-sql-and-dags:
+    name: Push Generated SQL and DAGs
     runs-on: ubuntu-latest
-    needs: [validate-dags]
+    needs: [generate-sql, validate-dags]
     if: *is-main-deploy
     environment: &deploy-env
       name: dev
@@ -1062,8 +1062,12 @@ jobs:
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: generated-sql-with-dags
+          name: generated-sql
           path: /tmp/workspace/generated-sql
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: generated-dags
+          path: /tmp/workspace/generated-dags
       - name: Setup SSH key for generated-sql
         run: |
           mkdir -p ~/.ssh
@@ -1080,8 +1084,7 @@ jobs:
           cd generated-sql/
           rm -rf sql/
           cp -r /tmp/workspace/generated-sql/sql sql
-          rm -rf dags/
-          cp -r /tmp/workspace/generated-sql/dags dags
+          rm -rf dags/ || true
           git add .
           if git diff --cached --quiet; then
             echo "No changes to push"
@@ -1092,9 +1095,27 @@ jobs:
             git push
             git push origin "c-$GITHUB_SHA"
           fi
+      - name: Push to generated-dags branch
+        run: |
+          git config --global user.name "GitHub Actions generate-dags job"
+          git config --global user.email "dataops+generated-dags@mozilla.com"
+          git clone --single-branch --branch generated-dags \
+            git@github.com:mozilla/bigquery-etl.git \
+            generated-dags
+          cd generated-dags/
+          rm -rf dags/ || true
+          cp -r /tmp/workspace/generated-dags/dags dags
+          git add .
+          if git diff --cached --quiet; then
+            echo "No changes to push"
+          else
+            git commit -m "Auto-push due to change on main branch [ci skip]" \
+              -m "Created from $GITHUB_SHA"
+            git push
+          fi
 
-  push-private-generated-sql:
-    name: Push Private Generated SQL
+  push-private-generated-sql-and-dags:
+    name: Push Private Generated SQL and DAGs
     runs-on: ubuntu-latest
     needs: [private-generate-sql, generate-dags]
     if: *is-main-deploy
@@ -1102,8 +1123,12 @@ jobs:
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: private-generated-sql-with-dags
+          name: private-generated-sql
           path: /tmp/workspace/private-generated-sql
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: private-generated-dags
+          path: /tmp/workspace/private-generated-dags
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: PRIVATE_BIGQUERY_ETL_SHA
@@ -1119,8 +1144,28 @@ jobs:
           cd private-generated-sql/
           rm -rf sql/
           cp -r /tmp/workspace/private-generated-sql/sql sql
-          rm -rf dags/
-          cp -r /tmp/workspace/private-generated-sql/dags dags
+          rm -rf dags/ || true
+          git add .
+
+          private_bqetl_sha=$(cat /tmp/workspace/PRIVATE_BIGQUERY_ETL_SHA)
+
+          if git diff --cached --quiet; then
+            echo "No changes to push"
+          else
+            git commit -m "Auto-push due to change on main branch [ci skip]" \
+              -m "Created from $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA and $private_bqetl_sha"
+            git push
+          fi
+      - name: Push to private-generated-dags branch
+        run: |
+          git config --global user.name "GitHub Actions private-generate-dags job"
+          git config --global user.email "dataops+private-generated-dags@mozilla.com"
+          git clone --single-branch --branch private-generated-dags \
+            git@github.com:mozilla/private-bigquery-etl \
+            private-generated-dags
+          cd private-generated-dags/
+          rm -rf dags/ || true
+          cp -r /tmp/workspace/private-generated-dags/dags dags
           git add .
 
           private_bqetl_sha=$(cat /tmp/workspace/PRIVATE_BIGQUERY_ETL_SHA)
@@ -1266,7 +1311,7 @@ jobs:
   sync-bigquery-etl-submodule:
     name: 🔃 Synchronize bigquery-etl submodule
     runs-on: ubuntu-latest
-    needs: [push-generated-sql]
+    needs: [push-generated-sql-and-dags]
     if: *is-main-deploy
     environment: *deploy-env
     steps:
@@ -1287,7 +1332,7 @@ jobs:
           cd telemetry-airflow-dags
           # Manually clone bigquery-etl submodule to avoid initializing private repos
           rm -rf bigquery-etl
-          git clone --branch generated-sql --depth 1 https://github.com/mozilla/bigquery-etl.git bigquery-etl
+          git clone --branch generated-dags --depth 1 https://github.com/mozilla/bigquery-etl.git bigquery-etl
           git add bigquery-etl
           git commit --allow-empty -m "Automatic commit from bigquery-etl commit ${{ github.sha }} [skip ci]"
           git push origin main
@@ -1295,7 +1340,7 @@ jobs:
   sync-private-bigquery-etl-submodule:
     name: 🔃 Synchronize private-bigquery-etl submodule
     runs-on: ubuntu-latest
-    needs: [push-private-generated-sql, sync-bigquery-etl-submodule]
+    needs: [push-private-generated-sql-and-dags, sync-bigquery-etl-submodule]
     if: *is-main-deploy
     environment: *deploy-env
     steps:
@@ -1329,7 +1374,7 @@ jobs:
           cd telemetry-airflow-dags
           git submodule update --init --depth 1 private-bigquery-etl
           cd private-bigquery-etl
-          git pull origin private-generated-sql
+          git reset --hard origin/private-generated-dags
           cd ..
           git add private-bigquery-etl
           git commit --allow-empty -m "Automatic commit from bigquery-etl commit ${{ github.sha }} [skip ci]"


### PR DESCRIPTION
## Description
So Airflow's Git sync process doesn't need to download hundreds of megabytes of unnecessary SQL files (DENG-10984).

## Related Tickets & Documents
* DENG-10984: Airflow pods' `git-sync-init` containers can be slow

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
