### PR TITLE
feat(CI): Add Claude automated code review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,64 @@
+# Automated code review using Claude
+# Triggers:
+#   - Once automatically when a PR is opened or marked ready for review
+#   - On demand by commenting "@claude" on a PR (non-fork PRs only)
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: |
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.fork != true
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '@claude')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check PR is not from a fork
+        if: github.event_name == 'issue_comment'
+        id: fork-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          IS_FORK=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} --jq '.head.repo.fork')
+          echo "is_fork=$IS_FORK" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        if: steps.fork-check.outputs.is_fork != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run Claude Code Review
+        if: steps.fork-check.outputs.is_fork != 'true'
+        # Mozilla org allowlist permits either "anthropics/claude-code-action@v1" (mutable tag)
+        # or a specific older SHA (73367208d0bc0c529b8b3fb223cbd4a8f63586e4, between v1.0.66 and v1.0.67).
+        # Using @v1 to stay current.
+        uses: anthropics/claude-code-action@v1 # zizmor: ignore[unpinned-uses]
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "@claude"
+          track_progress: true
+          use_sticky_comment: true
+          include_fix_links: false
+          prompt: |
+            Review this pull request for code quality, best practices, and potential issues.
+            Refer to docs/reference/recommended_practices.md for SQL conventions and best practices.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+            --max-turns 10

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -52,6 +52,9 @@ jobs:
         uses: anthropics/claude-code-action@v1 # zizmor: ignore[unpinned-uses]
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Pass GITHUB_TOKEN explicitly so the action doesn't try to mint an OIDC token
+          # (which would require `id-token: write`). Comments will be authored by github-actions[bot].
+          github_token: ${{ github.token }}
           trigger_phrase: "@claude"
           track_progress: true
           use_sticky_comment: true


### PR DESCRIPTION
Another attempt at https://github.com/mozilla/bigquery-etl/pull/8938 that was reverted in https://github.com/mozilla/bigquery-etl/pull/9307 due to permissions issue. This uses allowlisted `v1` tag.

## Description

This adds an action to run automated code reviews on PRs using Claude.
Triggers:
* Once automatically when a PR is opened or marked ready for review
* On demand by commenting "@claude" on a PR
