### PR TITLE
chore(AGENTS): Update commit attribution config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution" : {
+    "commit" : "",
+    "pr" : ""
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,3 @@ Generate SQL files with `./bqetl generate`. When running locally, add `--output_
 - Common workflows: `docs/cookbooks/common_workflows.md`
 - Testing guide: `docs/cookbooks/testing.md`
 - Reference docs: `docs/reference/`
-
-## Workflow
-- Do not perform commits yourself, ever


### PR DESCRIPTION
## Description

We initially added "no commit" instructions to avoid marking commits as AI-assisted. More reliable and convenient approach is to use `attribution` config.
