### PR TITLE
fix(CI): Drop --max-turns from Claude code review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -64,4 +64,3 @@ jobs:
             Refer to docs/reference/recommended_practices.md for SQL conventions and best practices.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
-            --max-turns 10


### PR DESCRIPTION
The 10-turn cap was too tight - runs were failing with error_max_turns before Claude could finish reading the diff, consulting `recommended_practices.md`, and posting comments.
Example failures:
* https://github.com/mozilla/bigquery-etl/pull/9311
* https://github.com/mozilla/bigquery-etl/pull/9310
Removing the cap and will observe.
