### PR TITLE
fix(CI): Set environment for `deploy-to-private-gar` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1195,6 +1195,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: *deploy-env
     steps:
       - *checkout
       - *download-generated-sql


### PR DESCRIPTION
## Description
So it can access the `ARTIFACT_ENCRYPTION_KEY` secret.

After https://github.com/mozilla/bigquery-etl/pull/9314 the `deploy-to-private-gar` job is failing with the error "_ARTIFACT_ENCRYPTION_KEY is not set_".

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/9314

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
