### PR TITLE
Rename private deploy key secret

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -707,7 +707,7 @@ jobs:
         name: Setup SSH key for private repo
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_KEY_PRIVATE_BQETL }}" > ~/.ssh/id_rsa
+          echo "${{ secrets.DEPLOY_KEY_BQETL_PRIVATE }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan github.com >> ~/.ssh/known_hosts
       - name: Pull down private SQL content
@@ -1419,7 +1419,7 @@ jobs:
       - name: Setup SSH keys for multiple repos
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_KEY_PRIVATE_BQETL }}" > ~/.ssh/id_rsa
+          echo "${{ secrets.DEPLOY_KEY_BQETL_PRIVATE }}" > ~/.ssh/id_rsa
           echo "${{ secrets.DEPLOY_KEY_TELEMETRY_AIRFLOW_DAGS }}" > ~/.ssh/id_rsa_telemetry
           chmod 600 ~/.ssh/id_rsa ~/.ssh/id_rsa_telemetry
           ssh-keyscan github.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
## Description

This renames the private-bigquery-etl deploy key secret

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
