### PR TITLE
chore(CI): Set `environment` for the `docs` job for consistency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -407,6 +407,9 @@ jobs:
       github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: write
+    environment: &deploy-env
+      name: dev
+      deployment: true
     steps:
       - *checkout
       - *setup-python
@@ -1097,9 +1100,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-sql, validate-dags]
     if: *is-main-deploy
-    environment: &deploy-env
-      name: dev
-      deployment: true
+    environment: *deploy-env
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:


### PR DESCRIPTION
## Description
When I was doing https://github.com/mozilla/bigquery-etl/pull/9316 I noticed this job was also missing an `environment` setting.

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/9316

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
