### PR TITLE
fix: add jinja to filter out fenix-specific field for clients_last_seen_joined_v1

### DIFF
--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -37,7 +37,9 @@ SELECT
       sample_id,
       is_default_browser,
       device_manufacturer,
-      isp_name -- removes the `isp_name` that comes from `metrics` and leaves in the `baseline.isp
+      {% if app_name == "fenix" %}
+      isp_name -- removes the `isp_name` that comes from `metrics` and leaves in the `baseline.isp`
+      {% endif %}
     ),
   baseline.is_default_browser,
   baseline.device_manufacturer

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.query.sql
@@ -36,9 +36,9 @@ SELECT
       client_id,
       sample_id,
       is_default_browser,
-      device_manufacturer,
+      device_manufacturer
       {% if app_name == "fenix" %}
-      isp_name -- removes the `isp_name` that comes from `metrics` and leaves in the `baseline.isp`
+      , isp_name -- removes the `isp_name` that comes from `metrics` and leaves in the `baseline.isp`
       {% endif %}
     ),
   baseline.is_default_browser,


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR is a follow-up to https://github.com/mozilla/bigquery-etl/pull/9319. Filters out `isp_name` just for `fenix`.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
