### PR TITLE
fix(CI): direct Claude reviewer to use inline comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -57,10 +57,13 @@ jobs:
           github_token: ${{ github.token }}
           trigger_phrase: "@claude"
           track_progress: true
-          use_sticky_comment: true
           include_fix_links: false
           prompt: |
             Review this pull request for code quality, best practices, and potential issues.
             Refer to docs/reference/recommended_practices.md for SQL conventions and best practices.
+
+            Use `mcp__github_inline_comment__create_inline_comment` for findings tied to
+            specific lines (bugs, suggested edits, style nits). Reserve the review summary
+            comment for cross-cutting observations and overall assessment.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"


### PR DESCRIPTION
Add explicit instruction to call the inline-comment MCP tool for line-specific findings - without this, Claude posts everything in the sticky summary even though the tool is allowlisted.

Drop `use_sticky_comment: true`: it only works under claude[bot] auth (per the action's FAQ), but this workflow uses the default GITHUB_TOKEN, so the lookup never matches and each run posts a fresh summary anyway.