### PR TITLE
feat(CI): auto-minimize previous Claude review comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -44,6 +44,44 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Minimize previous Claude review comments
+        if: steps.fork-check.outputs.is_fork != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          ids=$(gh api graphql \
+            -f query='
+              query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    comments(last: 100) {
+                      nodes { id author { login } bodyText isMinimized }
+                    }
+                  }
+                }
+              }' \
+            -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" \
+            | jq -r '.data.repository.pullRequest.comments.nodes[]
+                    | select(.author.login == "github-actions"
+                             and (.isMinimized | not)
+                             and (.bodyText | test("Claude Code is working|Claude finished")))
+                    | .id')
+          for id in $ids; do
+            echo "Minimizing $id"
+            gh api graphql \
+              -f query='
+                mutation($id: ID!) {
+                  minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+                    clientMutationId
+                  }
+                }' \
+              -f id="$id"
+          done
+
       - name: Run Claude Code Review
         if: steps.fork-check.outputs.is_fork != 'true'
         # Mozilla org allowlist permits either "anthropics/claude-code-action@v1" (mutable tag)


### PR DESCRIPTION
The Claude review workflow can run more than once on a PR - re-triggered via a `@claude` comment, or fired again when a draft PR is marked ready for review. Each run posts a fresh tracking comment.

This mirrors the existing `post-diff.js` minimization pattern: before running the Claude action, query the PR's last 100 comments and mark prior Claude tracking comments as OUTDATED.