### PR TITLE
fix(CI): batch Claude reviewer's inline comments under one review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,6 +11,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
     if: |
@@ -62,8 +66,13 @@ jobs:
             Review this pull request for code quality, best practices, and potential issues.
             Refer to docs/reference/recommended_practices.md for SQL conventions and best practices.
 
-            Use `mcp__github_inline_comment__create_inline_comment` for findings tied to
-            specific lines (bugs, suggested edits, style nits). Reserve the review summary
-            comment for cross-cutting observations and overall assessment.
+            Post a single formal GitHub review:
+            - Inline comments on specific lines for actionable findings.
+            - The review body summarizes cross-cutting observations and overall assessment.
+            Do not post separate top-level PR comments.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+            --allowedTools mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review
+            --allowedTools mcp__github__submit_pending_pull_request_review,mcp__github__delete_pending_pull_request_review
+            --allowedTools mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments,mcp__github__add_reply_to_pull_request_comment
+            --allowedTools mcp__github__get_workflow_run,mcp__github__list_workflow_runs,mcp__github__list_workflow_jobs
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"


### PR DESCRIPTION
Example review where lack of batching shows up: https://github.com/mozilla/bigquery-etl/pull/9119#issuecomment-4397381400