### PR TITLE
feat(relay_derived): add relay_mask_firefox_retention table

### DIFF
--- a/sql/moz-fx-data-shared-prod/relay/relay_mask_firefox_retention/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/relay/relay_mask_firefox_retention/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: Relay Mask Firefox Retention
+description: |-
+  Firefox Desktop 4th-week retention segmented by Relay mask usage.
+  Shows correlation only.
+owners:
+- lcrouch@mozilla.com

--- a/sql/moz-fx-data-shared-prod/relay/relay_mask_firefox_retention/view.sql
+++ b/sql/moz-fx-data-shared-prod/relay/relay_mask_firefox_retention/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.relay.relay_mask_firefox_retention`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod`.relay_derived.relay_mask_firefox_retention_v1

--- a/sql/moz-fx-data-shared-prod/relay_derived/relay_mask_firefox_retention_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/relay_derived/relay_mask_firefox_retention_v1/metadata.yaml
@@ -1,0 +1,21 @@
+friendly_name: Relay Mask Firefox Retention
+description: |-
+  Firefox Desktop 4th-week retention segmented by Relay mask usage.
+  Joins Relay events (mask counts by fxa_id) through the fx_accounts
+  bridge table to desktop retention data. Shows correlation only.
+owners:
+- lcrouch@mozilla.com
+labels:
+  application: relay
+  incremental: true
+  owner1: lcrouch
+  schedule: daily
+scheduling:
+  dag_name: bqetl_desktop_retention_model
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: 90
+  range_partitioning: null

--- a/sql/moz-fx-data-shared-prod/relay_derived/relay_mask_firefox_retention_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/relay_derived/relay_mask_firefox_retention_v1/query.sql
@@ -1,0 +1,91 @@
+WITH bridge AS (
+  SELECT
+    metrics.string.client_association_uid AS fxa_uid,
+    client_info.client_id AS client_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        metrics.string.client_association_uid
+      ORDER BY
+        submission_timestamp DESC
+    ) AS rn
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.fx_accounts`
+  WHERE
+    DATE(submission_timestamp) >= DATE_SUB(@submission_date, INTERVAL 30 DAY)
+    AND metrics.string.client_association_uid IS NOT NULL
+    AND client_info.client_id IS NOT NULL
+),
+relay_masks AS (
+  SELECT
+    extras.string.fxa_id AS fxa_uid,
+    MAX(
+      COALESCE(extras.quantity.n_random_masks, 0) + COALESCE(extras.quantity.n_domain_masks, 0)
+    ) AS total_masks,
+    MAX(extras.string.premium_status) AS premium_status
+  FROM
+    `moz-fx-data-shared-prod.relay_backend.events_stream`
+  WHERE
+    DATE(submission_timestamp) >= DATE_SUB(@submission_date, INTERVAL 90 DAY)
+    AND extras.string.fxa_id IS NOT NULL
+  GROUP BY
+    1
+),
+retention AS (
+  SELECT
+    client_id,
+    metric_date,
+    active_metric_date,
+    retained_week_4,
+    is_desktop,
+    country,
+    normalized_channel
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.desktop_retention_clients`
+  WHERE
+    is_desktop = TRUE
+    AND submission_date = @submission_date
+    AND metric_date = DATE_SUB(@submission_date, INTERVAL 27 DAY)
+)
+SELECT
+  @submission_date AS submission_date,
+  r.metric_date,
+  r.country,
+  r.normalized_channel,
+  rm.premium_status AS relay_premium_status,
+  rm.total_masks,
+  CASE
+    WHEN rm.fxa_uid IS NULL
+      THEN 'No Relay account'
+    WHEN rm.total_masks = 0
+      THEN '0 masks'
+    WHEN rm.total_masks
+      BETWEEN 1
+      AND 5
+      THEN '1-5 masks'
+    WHEN rm.total_masks
+      BETWEEN 6
+      AND 10
+      THEN '6-10 masks'
+    WHEN rm.total_masks
+      BETWEEN 11
+      AND 25
+      THEN '11-25 masks'
+    WHEN rm.total_masks
+      BETWEEN 26
+      AND 50
+      THEN '26-50 masks'
+    ELSE '51+ masks'
+  END AS mask_count_tier,
+  rm.fxa_uid IS NOT NULL AS has_relay_account,
+  r.active_metric_date,
+  r.retained_week_4,
+  r.client_id
+FROM
+  retention r
+LEFT JOIN
+  bridge b
+  ON r.client_id = b.client_id
+  AND b.rn = 1
+LEFT JOIN
+  relay_masks rm
+  ON b.fxa_uid = rm.fxa_uid

--- a/sql/moz-fx-data-shared-prod/relay_derived/relay_mask_firefox_retention_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/relay_derived/relay_mask_firefox_retention_v1/query.sql
@@ -2,12 +2,7 @@ WITH bridge AS (
   SELECT
     metrics.string.client_association_uid AS fxa_uid,
     client_info.client_id AS client_id,
-    ROW_NUMBER() OVER (
-      PARTITION BY
-        metrics.string.client_association_uid
-      ORDER BY
-        submission_timestamp DESC
-    ) AS rn
+    ROW_NUMBER() OVER (PARTITION BY client_info.client_id ORDER BY submission_timestamp DESC) AS rn
   FROM
     `moz-fx-data-shared-prod.firefox_desktop.fx_accounts`
   WHERE
@@ -17,18 +12,31 @@ WITH bridge AS (
 ),
 relay_masks AS (
   SELECT
-    extras.string.fxa_id AS fxa_uid,
-    MAX(
-      COALESCE(extras.quantity.n_random_masks, 0) + COALESCE(extras.quantity.n_domain_masks, 0)
-    ) AS total_masks,
-    MAX(extras.string.premium_status) AS premium_status
+    fxa_uid,
+    total_masks,
+    premium_status
   FROM
-    `moz-fx-data-shared-prod.relay_backend.events_stream`
+    (
+      SELECT
+        extras.string.fxa_id AS fxa_uid,
+        MAX(
+          COALESCE(extras.quantity.n_random_masks, 0) + COALESCE(extras.quantity.n_domain_masks, 0)
+        ) OVER (PARTITION BY extras.string.fxa_id) AS total_masks,
+        extras.string.premium_status AS premium_status,
+        ROW_NUMBER() OVER (
+          PARTITION BY
+            extras.string.fxa_id
+          ORDER BY
+            submission_timestamp DESC
+        ) AS rn
+      FROM
+        `moz-fx-data-shared-prod.relay_backend.events_stream`
+      WHERE
+        DATE(submission_timestamp) >= DATE_SUB(@submission_date, INTERVAL 90 DAY)
+        AND extras.string.fxa_id IS NOT NULL
+    )
   WHERE
-    DATE(submission_timestamp) >= DATE_SUB(@submission_date, INTERVAL 90 DAY)
-    AND extras.string.fxa_id IS NOT NULL
-  GROUP BY
-    1
+    rn = 1
 ),
 retention AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/relay_derived/relay_mask_firefox_retention_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/relay_derived/relay_mask_firefox_retention_v1/schema.yaml
@@ -1,0 +1,45 @@
+fields:
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+  description: Partition date for this row
+- name: metric_date
+  type: DATE
+  mode: NULLABLE
+  description: The retention metric date from desktop_retention_clients
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Client country code
+- name: normalized_channel
+  type: STRING
+  mode: NULLABLE
+  description: Firefox release channel (release, beta, nightly, esr)
+- name: relay_premium_status
+  type: STRING
+  mode: NULLABLE
+  description: Relay premium subscription status
+- name: total_masks
+  type: INT64
+  mode: NULLABLE
+  description: Total number of Relay masks (random + domain)
+- name: mask_count_tier
+  type: STRING
+  mode: NULLABLE
+  description: "Bucketed mask count: No Relay account, 0 masks, 1-5, 6-10, 11-25, 26-50, 51+"
+- name: has_relay_account
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Whether the client is linked to a Relay account via FxA
+- name: active_metric_date
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Whether the client was active on the metric date
+- name: retained_week_4
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Whether the client was retained at week 4
+- name: client_id
+  type: STRING
+  mode: NULLABLE
+  description: Firefox Desktop Glean client_id


### PR DESCRIPTION
## Description
Joins Relay mask counts through the fx_accounts bridge to desktop retention data. Runs daily on the desktop retention DAG. Looker reads the public view so any user can see the dashboard.

Corresponding looker dashboard PR: https://github.com/mozilla/looker-spoke-default/pull/1349

## Related Tickets & Documents
* [MPP-4588](https://mozilla-hub.atlassian.net/browse/MPP-4588)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[MPP-4588]: https://mozilla-hub.atlassian.net/browse/MPP-4588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ