### PR TITLE
UDFs for sources in the customer experience domain

### DIFF
--- a/sql/mozfun/customer_experience/README.md
+++ b/sql/mozfun/customer_experience/README.md
@@ -1,0 +1,7 @@
+# Customer Experience
+
+These functions provide with a centralized and standard transformation logic
+for classifications within the Customer Experience domain.
+
+If an update it required, this logic should be updated in the specific UDF
+to maintain queries clean and consistent across the sources.

--- a/sql/mozfun/customer_experience/classify_appbot_group/README.md
+++ b/sql/mozfun/customer_experience/classify_appbot_group/README.md
@@ -1,0 +1,45 @@
+# classify_appbot_group
+
+Classify a Zendesk ticket by its aggregated tags into an Appbot ticket group.
+
+Returns `STRUCT<ticket_group STRING, is_bot BOOL, is_english BOOL>`:
+
+- `ticket_group` — `'Appbot - English'` when `'bot'` is present alongside any English-locale tag; `'Appbot - Non-English'` when `'bot'` is present without any English-locale tag; `'Other'` when no `'bot'` tag is present.
+- `is_bot` — TRUE when `'bot'` is in the tag set, otherwise FALSE.
+- `is_english` — TRUE when at least one English-locale tag is in the set, otherwise FALSE.
+
+The authoritative English-locale tag list lives in the UDF body — see [`udf.sql`](./udf.sql).
+
+The whole STRUCT is `NULL` when the input array itself is `NULL` (input data missing) — distinct from an empty tag set, where `is_bot` and `is_english` are FALSE and `ticket_group` is `'Other'`.
+
+## Usage
+
+Per-ticket classification — caller aggregates `tag` rows per `ticket_id` and dots into the struct:
+
+```sql
+SELECT
+  ticket_id,
+  mozfun.customer_experience.classify_appbot_group(ARRAY_AGG(tag)).ticket_group
+FROM `moz-fx-data-shared-prod.zendesk_syndicate.ticket_tag`
+GROUP BY ticket_id
+```
+
+Note: `ARRAY_AGG(tag)` may include `NULL` elements; the UDF treats them as non-matching. A `NULL` input array (missing data) returns a `NULL` struct, while an empty array (no tags) returns `is_bot = FALSE`, `is_english = FALSE`, `ticket_group = 'Other'`.
+
+If you want all details and want to avoid invoking the UDF three times per row, alias the struct once in a CTE and dot into it downstream:
+
+```sql
+WITH classified AS (
+  SELECT
+    ticket_id,
+    mozfun.customer_experience.classify_appbot_group(ARRAY_AGG(tag)) AS appbot
+  FROM `moz-fx-data-shared-prod.zendesk_syndicate.ticket_tag`
+  GROUP BY ticket_id
+)
+SELECT
+  ticket_id,
+  appbot.ticket_group,
+  appbot.is_bot,
+  appbot.is_english
+FROM classified
+```

--- a/sql/mozfun/customer_experience/classify_appbot_group/metadata.yaml
+++ b/sql/mozfun/customer_experience/classify_appbot_group/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Classify Appbot Group
+description: >
+  Classify a Zendesk ticket by its aggregated tag set into an Appbot reporting group.
+  Returns a STRUCT<ticket_group STRING, is_bot BOOL, is_english BOOL>.
+  See README for usage and details.

--- a/sql/mozfun/customer_experience/classify_appbot_group/udf.sql
+++ b/sql/mozfun/customer_experience/classify_appbot_group/udf.sql
@@ -1,0 +1,121 @@
+-- UDF to classify a Zendesk ticket by its aggregated tag set into an Appbot reporting group.
+-- Note from the Customer Experience team:
+-- This classification exists because we do not offer language support for email or app reviews.
+-- All non-English tickets auto-close under a fake account named "SUMOJr"; agents never see them.
+-- The 'Appbot - Non-English' bucket lets callers filter that out-of-scope work downstream.
+CREATE OR REPLACE FUNCTION customer_experience.classify_appbot_group(tags ARRAY<STRING>)
+RETURNS STRUCT<ticket_group STRING, is_bot BOOL, is_english BOOL> AS (
+  IF(
+    tags IS NULL,
+    NULL,
+    (
+      SELECT
+        STRUCT(
+          CASE
+            WHEN is_bot
+              AND is_english
+              THEN 'Appbot - English'
+            WHEN is_bot
+              AND NOT is_english
+              THEN 'Appbot - Non-English'
+            ELSE 'Other'
+          END AS ticket_group,
+          is_bot,
+          is_english
+        )
+      FROM
+        (
+          SELECT
+            IFNULL(LOGICAL_OR(tag = 'bot'), FALSE) AS is_bot,
+            IFNULL(
+              LOGICAL_OR(tag IN ('english', 'usa', 'unitedkingdom', 'canada', 'australia')),
+              FALSE
+            ) AS is_english
+          FROM
+            UNNEST(tags) AS tag
+        )
+    )
+  )
+);
+
+-- Tests
+SELECT
+  -- ticket_group field
+  assert.equals(
+    'Appbot - English',
+    customer_experience.classify_appbot_group(['bot', 'english']).ticket_group
+  ),
+  assert.equals(
+    'Appbot - English',
+    customer_experience.classify_appbot_group(['bot', 'usa']).ticket_group
+  ),
+  assert.equals(
+    'Appbot - English',
+    customer_experience.classify_appbot_group(['bot', 'unitedkingdom']).ticket_group
+  ),
+  assert.equals(
+    'Appbot - English',
+    customer_experience.classify_appbot_group(['bot', 'canada']).ticket_group
+  ),
+  assert.equals(
+    'Appbot - English',
+    customer_experience.classify_appbot_group(['bot', 'australia']).ticket_group
+  ),
+  assert.equals(
+    'Appbot - English',
+    customer_experience.classify_appbot_group(['bot', 'english', 'usa', 'canada']).ticket_group
+  ),
+  assert.equals(
+    'Appbot - Non-English',
+    customer_experience.classify_appbot_group(['bot', 'spanish']).ticket_group
+  ),
+  assert.equals(
+    'Appbot - Non-English',
+    customer_experience.classify_appbot_group(['bot']).ticket_group
+  ),
+  assert.equals('Other', customer_experience.classify_appbot_group(['english']).ticket_group),
+  assert.equals(
+    'Other',
+    customer_experience.classify_appbot_group(['english', 'usa']).ticket_group
+  ),
+  assert.equals(
+    'Other',
+    customer_experience.classify_appbot_group(
+      ['english', 'usa', 'unitedkingdom', 'canada', 'australia']
+    ).ticket_group
+  ),
+  assert.equals('Other', customer_experience.classify_appbot_group(['spanish']).ticket_group),
+  assert.equals(
+    'Other',
+    customer_experience.classify_appbot_group(['spanish', 'french']).ticket_group
+  ),
+  assert.equals('Other', customer_experience.classify_appbot_group([]).ticket_group),
+  -- is_bot field
+  assert.true(customer_experience.classify_appbot_group(['bot']).is_bot),
+  assert.true(customer_experience.classify_appbot_group(['bot', 'english']).is_bot),
+  assert.false(customer_experience.classify_appbot_group(['english']).is_bot),
+  assert.false(customer_experience.classify_appbot_group([]).is_bot),
+  -- is_english field
+  assert.true(customer_experience.classify_appbot_group(['bot', 'english']).is_english),
+  assert.true(customer_experience.classify_appbot_group(['unitedkingdom']).is_english),
+  assert.false(customer_experience.classify_appbot_group(['bot']).is_english),
+  assert.false(customer_experience.classify_appbot_group(['spanish']).is_english),
+  assert.false(customer_experience.classify_appbot_group([]).is_english),
+  -- NULL elements inside the array (LOGICAL_OR skips NULL comparisons; IFNULL pins flags to FALSE)
+  assert.equals(
+    'Other',
+    customer_experience.classify_appbot_group([CAST(NULL AS STRING)]).ticket_group
+  ),
+  assert.false(customer_experience.classify_appbot_group([CAST(NULL AS STRING)]).is_bot),
+  assert.false(customer_experience.classify_appbot_group([CAST(NULL AS STRING)]).is_english),
+  assert.equals(
+    'Appbot - Non-English',
+    customer_experience.classify_appbot_group(['bot', CAST(NULL AS STRING)]).ticket_group
+  ),
+  assert.true(customer_experience.classify_appbot_group(['bot', CAST(NULL AS STRING)]).is_bot),
+  assert.false(customer_experience.classify_appbot_group(['bot', CAST(NULL AS STRING)]).is_english),
+  -- NULL input → NULL struct (and NULL fields)
+  assert.null(customer_experience.classify_appbot_group(CAST(NULL AS ARRAY<STRING>))),
+  assert.null(customer_experience.classify_appbot_group(CAST(NULL AS ARRAY<STRING>)).ticket_group),
+  assert.null(customer_experience.classify_appbot_group(CAST(NULL AS ARRAY<STRING>)).is_bot),
+  assert.null(customer_experience.classify_appbot_group(CAST(NULL AS ARRAY<STRING>)).is_english)

--- a/sql/mozfun/customer_experience/is_automated/README.md
+++ b/sql/mozfun/customer_experience/is_automated/README.md
@@ -1,0 +1,36 @@
+# is_automated
+
+Returns TRUE when the aggregated tag set contains any of the automation / autosolve
+/ experiment-macro tags maintained by the Zendesk / Customer Experience teams.
+
+- **TRUE** — at least one automation tag is present.
+- **FALSE** — tags exist but none match (including the empty array).
+- **NULL** — the input array itself is `NULL` (input data missing) — distinct from an empty tag set.
+
+## Tag list
+
+The tags captured cover Self-Service Automation (SSA) flows, Appbot autosolve, loginless autosolve, and the SSA experiment macro / star variants. Tickets matching any of these were resolved or rated through automation rather than agent handling.
+
+The authoritative list lives in the UDF body — see [`udf.sql`](./udf.sql).
+
+## Usage
+
+Per-ticket flag — caller aggregates `tag` rows per `ticket_id`:
+
+```sql
+SELECT
+  ticket_id,
+  mozfun.customer_experience.is_automated(ARRAY_AGG(tag)) AS is_automated
+FROM `moz-fx-data-shared-prod.zendesk_syndicate.ticket_tag`
+GROUP BY ticket_id
+```
+
+If a 1/0 column is needed downstream (matching the original `automation_class` CTE):
+
+```sql
+SELECT
+  ticket_id,
+  IF(mozfun.customer_experience.is_automated(ARRAY_AGG(tag)), 1, 0) AS automation_class
+FROM `moz-fx-data-shared-prod.zendesk_syndicate.ticket_tag`
+GROUP BY ticket_id
+```

--- a/sql/mozfun/customer_experience/is_automated/metadata.yaml
+++ b/sql/mozfun/customer_experience/is_automated/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: Is Automated
+description: >
+  Returns TRUE when a tag set contains any of the automation / autosolve / experiment-macro tags
+  maintained by the Zendesk / Customer Experience teams.
+  FALSE when tags exist but none match (including the empty array). NULL when
+  the input array itself is NULL (input data missing).
+  See README for the full tag list and usage.

--- a/sql/mozfun/customer_experience/is_automated/udf.sql
+++ b/sql/mozfun/customer_experience/is_automated/udf.sql
@@ -1,0 +1,77 @@
+-- UDF that returns TRUE when a Zendesk ticket's aggregated tag set contains any of the
+-- automation / autosolve / experiment-macro tags maintained by the Customer Experience team.
+-- Mirrors the `automation_class` CTE that aggregates `moz-fx-data-shared-prod.zendesk_syndicate.ticket_tag`
+-- per ticket_id with `MAX(CASE WHEN tag IN (...) THEN 1 ELSE 0 END)`.
+-- Returns:
+--   TRUE  when at least one automation tag is present in the input array.
+--   FALSE when tags exist but none are in the automation set (including the empty array).
+--   NULL  when the input array itself is NULL (input data missing) — distinct from an
+--         empty tag set, which evaluates to FALSE.
+-- Note from the Customer Experience team:
+-- The tag list captures Self-Service Automation (SSA) flows, Appbot autosolve, loginless
+-- autosolve, and the SSA experiment macro / star variants. Tickets matching any of these
+-- were resolved or rated through automation rather than agent handling.
+CREATE OR REPLACE FUNCTION customer_experience.is_automated(tags ARRAY<STRING>)
+RETURNS BOOL AS (
+  IF(
+    tags IS NULL,
+    NULL,
+    (
+      SELECT
+        IFNULL(
+          LOGICAL_OR(
+            tag IN (
+              'ssa-sign-in-failure-automation',
+              'ssa-connection-issues-automation',
+              'ssa-sync-data-automation',
+              'appbot-autosolve',
+              'ssa-experiment-2fa-automation',
+              'ssa-experiment-pwrdreset-automation',
+              'ssa-experiment-emailverify-automation',
+              'ssa-experiment-2fa-macro',
+              'ssa-experiment-pwrdreset-macro',
+              'ssa-experiment-emailverify-macro',
+              'ssa-experiment-connectionissues-macro',
+              'ssa-experiment-changeemail-macro',
+              'ssa-experiment-sign-in-failure-macro',
+              'ssa-experiment-sync-data-macro',
+              'ssa-experiment-4-star',
+              'ssa-experiment-5-star',
+              'loginless-autosolve'
+            )
+          ),
+          FALSE
+        )
+      FROM
+        UNNEST(tags) AS tag
+    )
+  )
+);
+
+-- Tests
+SELECT
+  -- TRUE when any single automation tag is present
+  assert.true(customer_experience.is_automated(['ssa-sign-in-failure-automation'])),
+  assert.true(customer_experience.is_automated(['appbot-autosolve'])),
+  assert.true(customer_experience.is_automated(['loginless-autosolve'])),
+  assert.true(customer_experience.is_automated(['ssa-experiment-2fa-macro'])),
+  assert.true(customer_experience.is_automated(['ssa-experiment-4-star'])),
+  assert.true(customer_experience.is_automated(['ssa-experiment-5-star'])),
+  -- TRUE when an automation tag is mixed with unrelated tags
+  assert.true(customer_experience.is_automated(['bot', 'english', 'appbot-autosolve'])),
+  assert.true(
+    customer_experience.is_automated(
+      ['ssa-sync-data-automation', 'ssa-experiment-changeemail-macro']
+    )
+  ),
+  -- FALSE when no automation tag is present
+  assert.false(customer_experience.is_automated(['bot', 'english'])),
+  assert.false(customer_experience.is_automated(['spanish'])),
+  assert.false(customer_experience.is_automated(['automation', 'autosolve'])),
+  -- Empty array → FALSE (no automation tags is a known answer, not missing data)
+  assert.false(customer_experience.is_automated([])),
+  -- NULL elements inside the array (LOGICAL_OR skips NULL comparisons; IFNULL pins to FALSE)
+  assert.false(customer_experience.is_automated([CAST(NULL AS STRING)])),
+  assert.true(customer_experience.is_automated(['appbot-autosolve', CAST(NULL AS STRING)])),
+  -- NULL input → NULL (input data missing)
+  assert.null(customer_experience.is_automated(CAST(NULL AS ARRAY<STRING>)))


### PR DESCRIPTION
Adds UDFs for the transformation logic for sources within the customer experience domain, such as zendesk and SUMO.

These logic might need further update, thus is important to keep it in a single place to maintain queries clean and consistent across the sources.

## Related Tickets & Documents
* [DENG-11109](https://mozilla-hub.atlassian.net/browse/DENG-11109)
* [DENG-11111](https://mozilla-hub.atlassian.net/browse/DENG-11111)
* [DENG-11112](https://mozilla-hub.atlassian.net/browse/DENG-11112)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-11109]: https://mozilla-hub.atlassian.net/browse/DENG-11109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-11111]: https://mozilla-hub.atlassian.net/browse/DENG-11111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-11112]: https://mozilla-hub.atlassian.net/browse/DENG-11112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ