### PR TITLE
chore(CI): tune Claude review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,11 +21,13 @@ jobs:
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.draft == false &&
-        github.event.pull_request.head.repo.fork != true
+        github.event.pull_request.head.repo.fork != true &&
+        github.event.pull_request.user.type != 'Bot'
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
-        contains(github.event.comment.body, '@claude')
+        contains(github.event.comment.body, '@claude') &&
+        github.event.comment.user.type != 'Bot'
       )
     runs-on: ubuntu-latest
     permissions:
@@ -48,7 +50,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Minimize previous Claude review comments
+      - name: Minimize previous Claude reviews
         if: steps.fork-check.outputs.is_fork != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -57,32 +59,37 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           set -euo pipefail
+          # Filter on the `<!-- claude-review -->` marker that the prompt asks Claude to embed
+          # in the review body, so we don't accidentally minimize reviews from other bots.
           ids=$(gh api graphql \
             -f query='
               query($owner: String!, $repo: String!, $pr: Int!) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $pr) {
-                    comments(last: 100) {
-                      nodes { id author { login } bodyText isMinimized }
+                    reviews(last: 100) {
+                      nodes {
+                        id
+                        isMinimized
+                        author { login }
+                        body
+                        comments(first: 100) { nodes { id isMinimized } }
+                      }
                     }
                   }
                 }
               }' \
             -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" \
-            | jq -r '.data.repository.pullRequest.comments.nodes[]
+            | jq -r '.data.repository.pullRequest.reviews.nodes[]
                     | select(.author.login == "github-actions"
-                             and (.isMinimized | not)
-                             and (.bodyText | test("Claude Code is working|Claude finished")))
-                    | .id')
+                             and (.body | test("<!-- claude-review -->")))
+                    | (
+                        (select(.isMinimized | not) | .id),
+                        (.comments.nodes[] | select(.isMinimized | not) | .id)
+                      )')
           for id in $ids; do
             echo "Minimizing $id"
             gh api graphql \
-              -f query='
-                mutation($id: ID!) {
-                  minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
-                    clientMutationId
-                  }
-                }' \
+              -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { clientMutationId } }' \
               -f id="$id"
           done
 
@@ -98,19 +105,52 @@ jobs:
           # (which would require `id-token: write`). Comments will be authored by github-actions[bot].
           github_token: ${{ github.token }}
           trigger_phrase: "@claude"
-          track_progress: true
           include_fix_links: false
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
             Review this pull request for code quality, best practices, and potential issues.
             Refer to docs/reference/recommended_practices.md for SQL conventions and best practices.
+            Also consult .github/reviewer_checklist.md and address items applicable to this PR.
 
-            Post a single formal GitHub review:
-            - Inline comments on specific lines for actionable findings.
-            - The review body summarizes cross-cutting observations and overall assessment.
-            Do not post separate top-level PR comments.
+            Post a single GitHub review using these tools in order:
+            1. `mcp__github__create_pending_pull_request_review` to start a pending review.
+            2. `mcp__github__add_comment_to_pending_review` for each inline finding tied to specific lines.
+               Prefix each comment body with a Conventional Comments label. Don't use the `(blocking)` decorator — humans decide what's blocking.
+            3. `mcp__github__submit_pending_pull_request_review` to finalize. Required parameters:
+               - `event`: must be `"COMMENT"`. Never `APPROVE` or `REQUEST_CHANGES` — those statuses are reserved for human reviewers.
+               - `body`: cross-cutting observations and overall assessment. Always include the literal string `<!-- claude-review -->`
+                 in this body. It's a hidden HTML comment used to auto-collapse this review on rerun.
+
+            If any of those tools fail, fall back to posting a single consolidated top-level comment via `gh pr comment` so the run isn't silent.
           claude_args: |
+            --max-budget-usd 6.00
             --allowedTools mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review
             --allowedTools mcp__github__submit_pending_pull_request_review,mcp__github__delete_pending_pull_request_review
             --allowedTools mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments,mcp__github__add_reply_to_pull_request_comment
+            --allowedTools mcp__github__get_pull_request,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files
             --allowedTools mcp__github__get_workflow_run,mcp__github__list_workflow_runs,mcp__github__list_workflow_jobs
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,Grep,Glob"
+
+      - name: Log Claude permission denials
+        if: ${{ always() && steps.fork-check.outputs.is_fork != 'true' }}
+        env:
+          LOG: ${{ runner.temp }}/claude-execution-output.json
+        run: |
+          set -euo pipefail
+          if [[ ! -f "$LOG" ]]; then
+            echo "No execution log at $LOG; skipping denial check."
+            exit 0
+          fi
+          DENIALS=$(jq '[.[] | select(.type == "result") | .permission_denials // []] | add' "$LOG")
+          COUNT=$(jq 'length' <<< "$DENIALS")
+          if [[ "$COUNT" -eq 0 ]]; then
+            echo "No permission denials detected."
+            exit 0
+          fi
+          TOOLS=$(jq -r 'map(.tool_name) | unique | join(",")' <<< "$DENIALS")
+          echo "::warning::Claude had $COUNT permission denial(s) — review may be incomplete. Denied tools: $TOOLS"
+          echo "::group::Permission denial details"
+          jq -r '.[] | "- \(.tool_name): \(.tool_input | tojson)"' <<< "$DENIALS"
+          echo "::endgroup::"


### PR DESCRIPTION
Couple of improvements to review the bot config after observing last week's runs, tested in private repo:
- don't review bot-created PRs (including Dependabot); they currently start and fail, alternatively could be allowlisted per bot
- drop progress-tracking comment - it clutters the timeline, status of the run can be observed on the checks section; this requires to now pass `REPO`/`PR NUMBER` in prompt (apparently for historical reasons with `track_progress: true` action injected them automatically)
- cap cost; we initially tried 10-turn cap that was too low (https://github.com/mozilla/bigquery-etl/pull/9313), cost is what we care for and the value set gives us headroom to observe
- minimize prior Claude reviews via `<!-- claude-review -->` marker; existing mechanism minimized only the tracking comment that we're getting rid of here
- update permissions and log denials; this is based on failures in some runs
- update the prompt:
  - pending-review tool sequence should ensure comments are batched under a review (previous failed attempt: https://github.com/mozilla/bigquery-etl/pull/9332)
  - add instructions to follow conventional comments convention and point at reviewer checklist