### PR TITLE
[DENG-4042] Fix service account IAM prefix for backfills

### DIFF
--- a/bigquery_etl/backfill/utils.py
+++ b/bigquery_etl/backfill/utils.py
@@ -356,6 +356,8 @@ def _access_entries_to_bindings(access_entries) -> List[dict]:
         prefix = entity_type_to_member_prefix.get(entry.entity_type)
         if prefix is None:
             continue
+        if prefix == "user:" and entry.entity_id.endswith(".iam.gserviceaccount.com"):
+            prefix = "serviceAccount:"
         member = f"{prefix}{entry.entity_id}" if prefix else entry.entity_id
         iam_role = legacy_role_to_iam.get(entry.role, entry.role)
         role_to_members.setdefault(iam_role, set()).add(member)

--- a/bigquery_etl/backfill/utils.py
+++ b/bigquery_etl/backfill/utils.py
@@ -356,7 +356,9 @@ def _access_entries_to_bindings(access_entries) -> List[dict]:
         prefix = entity_type_to_member_prefix.get(entry.entity_type)
         if prefix is None:
             continue
-        if prefix == "user:" and entry.entity_id.endswith(".iam.gserviceaccount.com"):
+        if entry.entity_type == "userByEmail" and entry.entity_id.endswith(
+            "gserviceaccount.com"
+        ):
             prefix = "serviceAccount:"
         member = f"{prefix}{entry.entity_id}" if prefix else entry.entity_id
         iam_role = legacy_role_to_iam.get(entry.role, entry.role)

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/backfill_test_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/backfill_test_v1/backfill.yaml
@@ -1,0 +1,10 @@
+2026-05-11:
+  start_date: 2026-04-20
+  end_date: 2026-04-25
+  reason: Test ACLs
+  watchers:
+  - bewu@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/backfill_test_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/stub_attribution_service_derived/backfill_test_v1/backfill.yaml
@@ -1,0 +1,10 @@
+2026-05-11:
+  start_date: 2026-04-20
+  end_date: 2026-04-25
+  reason: Test ACLs
+  watchers:
+  - bewu@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -2755,6 +2755,11 @@ class TestCopyPermissionsToStagingTable:
                 entity_type="userByEmail",
                 entity_id="airflow@project.iam.gserviceaccount.com",
             ),
+            MagicMock(
+                role="READER",
+                entity_type="userByEmail",
+                entity_id="123-compute@developer.gserviceaccount.com",
+            ),
         ]
         client = self.build_client(
             prod_table_bindings=[],
@@ -2770,5 +2775,6 @@ class TestCopyPermissionsToStagingTable:
             "roles/bigquery.dataViewer": {
                 "user:abc@mozilla.com",
                 "serviceAccount:airflow@project.iam.gserviceaccount.com",
+                "serviceAccount:123-compute@developer.gserviceaccount.com",
             },
         }

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -2741,3 +2741,34 @@ class TestCopyPermissionsToStagingTable:
             "roles/bigquery.dataEditor": {"user:writer@mozilla.com"},
             "roles/bigquery.dataOwner": {"user:owner@mozilla.com"},
         }
+
+    def test_userbyemail_service_accounts_get_serviceaccount_prefix(self):
+        """Permission copy should use the `serviceAccount:` prefix for service accounts."""
+        dataset_access_entries = [
+            MagicMock(
+                role="READER",
+                entity_type="userByEmail",
+                entity_id="abc@mozilla.com",
+            ),
+            MagicMock(
+                role="READER",
+                entity_type="userByEmail",
+                entity_id="airflow@project.iam.gserviceaccount.com",
+            ),
+        ]
+        client = self.build_client(
+            prod_table_bindings=[],
+            dataset_access_entries=dataset_access_entries,
+            staging_bindings=[],
+        )
+
+        copy_permissions_to_staging_table(client, self.PROD_TABLE, self.STAGING_TABLE)
+
+        applied_policy = client.set_iam_policy.call_args.args[1]
+        applied = {b["role"]: set(b["members"]) for b in applied_policy.bindings}
+        assert applied == {
+            "roles/bigquery.dataViewer": {
+                "user:abc@mozilla.com",
+                "serviceAccount:airflow@project.iam.gserviceaccount.com",
+            },
+        }


### PR DESCRIPTION
## Description

Sevice accounts need to be prefixed with `serviceAccount:` instead of `user:`.  Also adding two additional test backfills for non-standard ACLs

## Related Tickets & Documents
* DENG-4042

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
