### PR TITLE
Update model name

### DIFF
--- a/sql/moz-fx-data-shared-prod/customer_experience_derived/kitsune_retrieval_index_v1/README.md
+++ b/sql/moz-fx-data-shared-prod/customer_experience_derived/kitsune_retrieval_index_v1/README.md
@@ -243,7 +243,7 @@ WHERE creation_date BETWEEN '2026-04-01' AND '2026-04-30'
 | What changed | Field to update in `query.sql` |
 |---|---|
 | Prompt text or `output_schema` in `AI.GENERATE` | `prompt_version` — increment to `v2`, `v3`, … |
-| Generative model (currently `gemini-2.5-pro-001`) | `metadata.model_version` literal |
+| Generative model (currently `gemini-2.5-pro`) | `metadata.model_version` literal |
 | Embedding model (currently `gemini-embedding-001`) | `metadata.embedding_version` literal + re-embed full history |
 
 `prompt_version` is stored per row in `metadata.prompt_version`, so rows written under different prompts can be identified and re-processed during backfills. Add a row to this table for every change.

--- a/sql/moz-fx-data-shared-prod/customer_experience_derived/kitsune_retrieval_index_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/customer_experience_derived/kitsune_retrieval_index_v1/query.sql
@@ -76,7 +76,7 @@ kitsune_llm AS (
         'Content: ',
         content
       ),
-      endpoint => 'gemini-2.5-pro-001',
+      endpoint => 'gemini-2.5-pro',
       output_schema => 'question_summary_llm STRING, question_category_llm STRING, question_language_llm STRING, question_entities_llm ARRAY<STRING>, question_topics_llm ARRAY<STRING>, question_sentiment_score FLOAT64'
     ) AS llm_result
   FROM
@@ -131,7 +131,7 @@ SELECT
   STRUCT(
     ['title', 'content'] AS input_fields,
     LENGTH(CONCAT(kitsune_joined.title, ' ', kitsune_joined.content)) AS input_char_count,
-    'gemini-2.5-pro-001' AS model_version,
+    'gemini-2.5-pro' AS model_version,
     'gemini-embedding-001' AS embedding_version,
     'v1' AS prompt_version,
     TIMESTAMP(@submission_date) AS analysis_timestamp,

--- a/sql/moz-fx-data-shared-prod/customer_experience_derived/kitsune_retrieval_index_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/customer_experience_derived/kitsune_retrieval_index_v1/schema.yaml
@@ -127,7 +127,7 @@ fields:
   - name: model_version
     type: STRING
     mode: NULLABLE
-    description: Version identifier of the generative AI model used for analysis (e.g., gemini-2.5-pro-001).
+    description: Version identifier of the generative AI model used for analysis (e.g., gemini-2.5-pro).
   - name: embedding_version
     type: STRING
     mode: NULLABLE


### PR DESCRIPTION
## Description
Fixes [Bug 2038787](https://bugzilla.mozilla.org/show_bug.cgi?id=2038787)

According to [Gemini's release notes](https://ai.google.dev/gemini-api/docs/changelog): `The preview models gemini-2.5-pro-preview-05-06 and gemini-2.5-pro-preview-03-25 are now redirecting to the latest stable version gemini-2.5-pro.` and this applies to other suffixes. The current stable version is `gemini-2.5-pro` which is also expected to be deprecated in June 17, 2026.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
