### PR TITLE
Fork PR approval gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1522,6 +1522,7 @@ jobs:
       - test-bqetl
       - integration
       - generate-sql
+      - private-generate-sql 
       - docs
       - deploy-changes-to-stage
       - dry-run-sql

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1512,7 +1512,7 @@ jobs:
   # the fork-PR Checks UI without needing edits here.
   report-checks:
     name: Report PR checks
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    if: always() && github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     needs:
       - decide-runs
       - build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1474,6 +1474,11 @@ jobs:
   # Only runs when build.yml is triggered via `workflow_run` (i.e. after the
   # fork-gate approval). For same-repo PRs the native pull_request checks
   # already appear in the PR UI, so this job is unnecessary there.
+  #
+  # !!! COUPLING: the `needs:` list below must include every job whose status
+  # should appear in the fork-PR Checks UI. If you ADD a job to this workflow
+  # that should be visible to fork-PR reviewers, ADD it to `needs:` here too.
+  # Forgetting means the new job runs but its status never reaches the PR.
   report-checks:
     name: Report PR checks
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
@@ -1527,3 +1532,32 @@ jobs:
               -f conclusion="$conclusion" \
               -f details_url="$DETAILS_URL" >/dev/null
           done
+
+  # Surface gate rejection / failure as a single check on the PR. Without this,
+  # a rejected approval (or errored gate) shows nothing in the PR UI.
+  report-gate-failure:
+    name: Report fork-gate result
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - name: Post failure check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          GATE_URL: ${{ github.event.workflow_run.html_url }}
+          GATE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+          summary="The fork-PR approval gate concluded with \`$GATE_CONCLUSION\`. "
+          summary+="CI did not run. A maintainer must approve the gate workflow "
+          summary+="for this push, or re-run if it errored."
+          gh api -X POST "/repos/${{ github.repository }}/check-runs" \
+            -f name='Fork PR Gate' \
+            -f head_sha="$HEAD_SHA" \
+            -f status=completed \
+            -f conclusion=failure \
+            -f details_url="$GATE_URL" \
+            -f "output[title]=Gate $GATE_CONCLUSION" \
+            -f "output[summary]=$summary" >/dev/null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,9 @@ on:
     types:
       - opened
       - synchronize
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
+  workflow_run:
+    workflows: ["Fork PR Gate"]
+    types: [completed]
   merge_group:
   workflow_dispatch:
     inputs:
@@ -44,12 +43,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: &is-allowed-event |
-      case(
-        github.event_name == 'pull_request_target', github.event.pull_request.head.repo.fork == true,
-        github.event_name == 'pull_request', github.event.pull_request.head.repo.fork != true,
-        true
-      )
+    if: &is-allowed-event >-
+      ${{
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true)
+        || github.event_name == 'push'
+        || github.event_name == 'merge_group'
+        || github.event_name == 'workflow_dispatch'
+      }}
     outputs:
       validate-routines: ${{ steps.set-flags.outputs.validate-routines }}
       deploy: ${{ steps.set-flags.outputs.deploy }}
@@ -62,8 +63,11 @@ jobs:
           persist-credentials: false
           filter: blob:none
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
       - id: changed-files-routines
+        # Skip path-based gating for fork PRs reaching us via workflow_run;
+        # PR event payload isn't available, so we run everything conservatively.
+        if: github.event_name != 'workflow_run'
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: |
@@ -76,6 +80,7 @@ jobs:
             bqetl_project.yaml
           base_sha: ${{ github.event.pull_request.base.sha || github.event.before }}
       - id: changed-files-sql
+        if: github.event_name != 'workflow_run'
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: |
@@ -89,6 +94,7 @@ jobs:
             bqetl_project.yaml
           base_sha: ${{ github.event.pull_request.base.sha || github.event.before }}
       - id: changed-files-bqetl
+        if: github.event_name != 'workflow_run'
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: |
@@ -107,7 +113,17 @@ jobs:
           VALIDATE_ROUTINES: ${{ steps.changed-files-routines.outputs.any_changed }}
           VALIDATE_SQL: ${{ steps.changed-files-sql.outputs.any_changed }}
           VALIDATE_BQETL: ${{ steps.changed-files-bqetl.outputs.any_changed }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
+          # For workflow_run (fork PRs post-gate), the changed-files steps were
+          # skipped — default everything to true so all validation jobs run.
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            echo "validate-routines=true" >> $GITHUB_OUTPUT
+            echo "validate-sql=true" >> $GITHUB_OUTPUT
+            echo "validate-bqetl=true" >> $GITHUB_OUTPUT
+            echo "deploy=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           echo "validate-routines=$VALIDATE_ROUTINES" >> $GITHUB_OUTPUT
           echo "validate-sql=$VALIDATE_SQL" >> $GITHUB_OUTPUT
           echo "validate-bqetl=$VALIDATE_BQETL" >> $GITHUB_OUTPUT
@@ -123,7 +139,7 @@ jobs:
     permissions:
       contents: read
     environment: &build-env
-      name: ${{ github.event.pull_request.head.repo.fork == true && github.event.pull_request.author_association != 'MEMBER' && 'external-fork' || 'dev' }}
+      name: dev
       deployment: false
     if: *is-allowed-event
     steps:
@@ -132,7 +148,7 @@ jobs:
         with:
           persist-credentials: false
           filter: blob:none
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
       - &setup-python
         name: Set up Python
         id: setup_python
@@ -156,7 +172,7 @@ jobs:
           pip-sync --pip-args=--no-deps
       - name: Save cached virtualenv
         # Don't let forked PRs update the shared cache.
-        if: steps.restore-venv.outputs.cache-hit != 'true' && github.event.pull_request.head.repo.fork != true
+        if: steps.restore-venv.outputs.cache-hit != 'true' && github.event.pull_request.head.repo.fork != true && github.event_name != 'workflow_run'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
@@ -219,7 +235,7 @@ jobs:
       id-token: write
       contents: read
     environment: &job-env
-      name: ${{ github.event.pull_request.head.repo.fork == true && 'external-fork' || 'dev' }}
+      name: dev
       deployment: false
     steps:
       - *checkout
@@ -291,7 +307,7 @@ jobs:
         with:
           persist-credentials: true
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
       - *setup-python
       - *restore-venv
       - *auth-gcp-dryrun
@@ -1453,3 +1469,61 @@ jobs:
           git add private-bigquery-etl
           git commit --allow-empty -m "Automatic commit from bigquery-etl commit ${{ github.sha }} [skip ci]"
           git push origin main
+
+  # Surface upstream job results as Checks-API check runs on the PR's head SHA.
+  # Only runs when build.yml is triggered via `workflow_run` (i.e. after the
+  # fork-gate approval). For same-repo PRs the native pull_request checks
+  # already appear in the PR UI, so this job is unnecessary there.
+  report-checks:
+    name: Report PR checks
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    needs:
+      - decide-runs
+      - build
+      - verify-requirements
+      - verify-format-yaml
+      - verify-format-sql
+      - test-bqetl
+      - integration
+      - generate-sql
+      - docs
+      - deploy-changes-to-stage
+      - dry-run-sql
+      - test-sql
+      - test-routines
+      - validate-views
+      - validate-metadata
+      - validate-backfills
+      - main-generate-sql-and-dags
+      - generate-dags
+      - validate-dags
+      - generate-diff
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - name: Post check runs for each upstream job
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key)\t\(.value.result)"' | \
+          while IFS=$'\t' read -r name result; do
+            case "$result" in
+              success)   conclusion=success ;;
+              failure)   conclusion=failure ;;
+              cancelled) conclusion=cancelled ;;
+              skipped)   conclusion=skipped ;;
+              *)         conclusion=neutral ;;
+            esac
+            echo "Reporting check: $name -> $conclusion"
+            gh api -X POST "/repos/${{ github.repository }}/check-runs" \
+              -f name="$name" \
+              -f head_sha="$HEAD_SHA" \
+              -f status=completed \
+              -f conclusion="$conclusion" \
+              -f details_url="$DETAILS_URL" >/dev/null
+          done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1522,7 +1522,7 @@ jobs:
       - test-bqetl
       - integration
       - generate-sql
-      - private-generate-sql 
+      - private-generate-sql
       - docs
       - deploy-changes-to-stage
       - dry-run-sql

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read  # for resolve-pr-base on workflow_run events
     if: &is-allowed-event >-
       ${{
         (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
@@ -64,10 +65,36 @@ jobs:
           filter: blob:none
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
+      # For workflow_run (fork PRs post-gate), the PR event payload isn't
+      # available. Resolve the PR's base SHA via the API so changed-files can
+      # still compute a real diff instead of conservatively running everything.
+      # workflow_run.pull_requests[0] is reliable for same-repo PRs but often
+      # empty for fork PRs, so we fall back to looking up by head SHA.
+      - id: resolve-pr-base
+        if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_FROM_EVENT: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+          pr_number="$PR_FROM_EVENT"
+          if [ -z "$pr_number" ] || [ "$pr_number" = "null" ]; then
+            pr_number=$(gh api \
+              "/repos/${{ github.repository }}/commits/$HEAD_SHA/pulls" \
+              --jq '.[0].number')
+          fi
+          if [ -z "$pr_number" ] || [ "$pr_number" = "null" ]; then
+            echo "Could not resolve PR for head $HEAD_SHA; falling back to full validation."
+            echo "base_sha=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base_sha=$(gh api "/repos/${{ github.repository }}/pulls/$pr_number" --jq '.base.sha')
+          echo "Resolved PR #$pr_number, base $base_sha"
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
       - id: changed-files-routines
-        # Skip path-based gating for fork PRs reaching us via workflow_run;
-        # PR event payload isn't available, so we run everything conservatively.
-        if: github.event_name != 'workflow_run'
+        # Skip if we couldn't resolve a base SHA for workflow_run (run everything).
+        if: github.event_name != 'workflow_run' || steps.resolve-pr-base.outputs.base_sha != ''
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: |
@@ -78,9 +105,9 @@ jobs:
             sql/moz-fx-data-shared-prod/udf/**
             sql/moz-fx-data-shared-prod/udf_js/**
             bqetl_project.yaml
-          base_sha: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base_sha: ${{ steps.resolve-pr-base.outputs.base_sha || github.event.pull_request.base.sha || github.event.before }}
       - id: changed-files-sql
-        if: github.event_name != 'workflow_run'
+        if: github.event_name != 'workflow_run' || steps.resolve-pr-base.outputs.base_sha != ''
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: |
@@ -92,9 +119,9 @@ jobs:
             bigquery_etl/query_scheduling/**
             tests/sql/**
             bqetl_project.yaml
-          base_sha: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base_sha: ${{ steps.resolve-pr-base.outputs.base_sha || github.event.pull_request.base.sha || github.event.before }}
       - id: changed-files-bqetl
-        if: github.event_name != 'workflow_run'
+        if: github.event_name != 'workflow_run' || steps.resolve-pr-base.outputs.base_sha != ''
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: |
@@ -106,7 +133,7 @@ jobs:
             requirements.txt
             requirements.in
             .github/workflows/**
-          base_sha: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base_sha: ${{ steps.resolve-pr-base.outputs.base_sha || github.event.pull_request.base.sha || github.event.before }}
       - name: Decide which jobs to run
         id: set-flags
         env:
@@ -114,10 +141,12 @@ jobs:
           VALIDATE_SQL: ${{ steps.changed-files-sql.outputs.any_changed }}
           VALIDATE_BQETL: ${{ steps.changed-files-bqetl.outputs.any_changed }}
           EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_RESOLVED: ${{ steps.resolve-pr-base.outputs.base_sha }}
         run: |
-          # For workflow_run (fork PRs post-gate), the changed-files steps were
-          # skipped — default everything to true so all validation jobs run.
-          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+          # For workflow_run when PR base SHA couldn't be resolved, fall back to
+          # running everything (conservative). Otherwise the changed-files
+          # outputs are valid for both event paths.
+          if [[ "$EVENT_NAME" == "workflow_run" && -z "$PR_BASE_RESOLVED" ]]; then
             echo "validate-routines=true" >> $GITHUB_OUTPUT
             echo "validate-sql=true" >> $GITHUB_OUTPUT
             echo "validate-bqetl=true" >> $GITHUB_OUTPUT
@@ -127,7 +156,9 @@ jobs:
           echo "validate-routines=$VALIDATE_ROUTINES" >> $GITHUB_OUTPUT
           echo "validate-sql=$VALIDATE_SQL" >> $GITHUB_OUTPUT
           echo "validate-bqetl=$VALIDATE_BQETL" >> $GITHUB_OUTPUT
-          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            echo "deploy=false" >> $GITHUB_OUTPUT
+          elif [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
             echo "deploy=true" >> $GITHUB_OUTPUT
           else
             echo "deploy=false" >> $GITHUB_OUTPUT
@@ -1475,10 +1506,10 @@ jobs:
   # fork-gate approval). For same-repo PRs the native pull_request checks
   # already appear in the PR UI, so this job is unnecessary there.
   #
-  # !!! COUPLING: the `needs:` list below must include every job whose status
-  # should appear in the fork-PR Checks UI. If you ADD a job to this workflow
-  # that should be visible to fork-PR reviewers, ADD it to `needs:` here too.
-  # Forgetting means the new job runs but its status never reaches the PR.
+  # `needs:` enforces ordering (run after all upstream jobs complete). The
+  # actual list of jobs to report is derived dynamically from the Actions Jobs
+  # API at runtime, so new jobs added to this workflow automatically appear in
+  # the fork-PR Checks UI without needing edits here.
   report-checks:
     name: Report PR checks
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
@@ -1506,32 +1537,41 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+      actions: read  # for listing jobs in this workflow run
     steps:
       - name: Post check runs for each upstream job
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEEDS_JSON: ${{ toJSON(needs) }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key)\t\(.value.result)"' | \
-          while IFS=$'\t' read -r name result; do
-            case "$result" in
-              success)   conclusion=success ;;
-              failure)   conclusion=failure ;;
-              cancelled) conclusion=cancelled ;;
-              skipped)   conclusion=skipped ;;
-              *)         conclusion=neutral ;;
-            esac
-            echo "Reporting check: $name -> $conclusion"
-            gh api -X POST "/repos/${{ github.repository }}/check-runs" \
-              -f name="$name" \
-              -f head_sha="$HEAD_SHA" \
-              -f status=completed \
-              -f conclusion="$conclusion" \
-              -f details_url="$DETAILS_URL" >/dev/null
-          done
+          # Iterate the Actions Jobs API for this run; each check-run's
+          # details_url points at the specific job's log so failing checks
+          # deep-link directly to the failure (rather than the run overview).
+          # Skip the reporter jobs themselves to avoid self-reporting.
+          gh api --paginate \
+            "/repos/${{ github.repository }}/actions/runs/$RUN_ID/jobs" \
+            --jq '.jobs[]
+                  | select(.name != "Report PR checks"
+                        and .name != "Report fork-gate result")
+                  | "\(.name)\t\(.conclusion // "neutral")\t\(.html_url)"' \
+          | while IFS=$'\t' read -r name conclusion html_url; do
+              case "$conclusion" in
+                success)   c=success ;;
+                failure)   c=failure ;;
+                cancelled) c=cancelled ;;
+                skipped)   c=skipped ;;
+                *)         c=neutral ;;
+              esac
+              echo "Reporting: $name -> $c ($html_url)"
+              gh api -X POST "/repos/${{ github.repository }}/check-runs" \
+                -f name="$name" \
+                -f head_sha="$HEAD_SHA" \
+                -f status=completed \
+                -f conclusion="$c" \
+                -f details_url="$html_url" >/dev/null
+            done
 
   # Surface gate rejection / failure as a single check on the PR. Without this,
   # a rejected approval (or errored gate) shows nothing in the PR UI.

--- a/.github/workflows/fork-gate.yml
+++ b/.github/workflows/fork-gate.yml
@@ -13,9 +13,7 @@ permissions: {}
 
 jobs:
   approve:
-    if: |
-      github.event.pull_request.head.repo.fork == true &&
-      github.event.pull_request.author_association != 'MEMBER'
+    if: github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest
     environment: external-fork
     steps:

--- a/.github/workflows/fork-gate.yml
+++ b/.github/workflows/fork-gate.yml
@@ -1,0 +1,27 @@
+name: Fork PR Gate
+
+# Single approval gate for fork PRs. Once a maintainer approves the
+# `external-fork` environment here, build.yml fires via `workflow_run` and
+# runs all downstream jobs in trusted context without further per-job approval.
+# Non-fork PRs and MEMBER-authored PRs skip this workflow entirely.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  approve:
+    if: |
+      github.event.pull_request.head.repo.fork == true &&
+      github.event.pull_request.author_association != 'MEMBER'
+    runs-on: ubuntu-latest
+    environment: external-fork
+    steps:
+      - run: |
+          echo "::warning::Approving runs build.yml with this fork's code in trusted context."
+          echo "::warning::Re-review every push: a new commit re-fires this gate; approval is per-SHA, not per-PR."
+          echo "::warning::Inspect dependency changes (requirements.txt, setup.py, package-lock, Makefile) — these execute with secrets after approval."
+          echo "Approved fork PR #${{ github.event.pull_request.number }}"
+          echo "head_sha=${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/fork-gate.yml
+++ b/.github/workflows/fork-gate.yml
@@ -3,11 +3,17 @@ name: Fork PR Gate
 # Single approval gate for fork PRs. Once a maintainer approves the
 # `external-fork` environment here, build.yml fires via `workflow_run` and
 # runs all downstream jobs in trusted context without further per-job approval.
-# Non-fork PRs and MEMBER-authored PRs skip this workflow entirely.
+# Non-fork PRs skip this workflow entirely.
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+
+# Cancel any pending approval for an older SHA when the fork pushes again —
+# avoids a backlog of stale approval prompts the maintainer has to dismiss.
+concurrency:
+  group: fork-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions: {}
 


### PR DESCRIPTION
## Description

This PR replaces per-job `environment: external-fork` approval prompts with a single gate workflow (`fork-gate.yml`). One maintainer approval per fork PR push now authorizes the whole build run, instead of ~6 separate clicks. `build.yml` is triggered for fork PRs via `workflow_run` after the gate completes successfully. It checks out `workflow_run.head_sha` so it runs against exactly the SHA the maintainer approved. There is a new `report-checks` job that posts a check run per upstream job to the PR's head SHA, so the PR UI continues to show per-job pass/fail (which `workflow_run` doesn't surface natively).

Testing this without merging is a little difficult. I propose we merge this and then open a fork PR to test that everything is working as intended. If not, we can revert this change.



<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
