### PR TITLE
feat(DENG-9505): add addons derived/firefox desktop stats installs combined v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/addons/firefox_desktop_stats_installs/view.sql
+++ b/sql/moz-fx-data-shared-prod/addons/firefox_desktop_stats_installs/view.sql
@@ -1,75 +1,7 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.addons.firefox_desktop_stats_installs`
 AS
--- View to combine firefox_desktop install stats from both legacy and glean based data sources.
--- Glean source containing clients using app version 148 and above.
 SELECT
-  submission_date,
-  hashed_addon_id,
-  total_downloads,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(downloads_per_campaign)
-  ) AS downloads_per_campaign,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(downloads_per_content)
-  ) AS downloads_per_content,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(downloads_per_source)
-  ) AS downloads_per_source,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(downloads_per_medium)
-  ) AS downloads_per_medium,
+  *
 FROM
-  `moz-fx-data-shared-prod.addons_derived.firefox_desktop_stats_installs_v1`
-UNION ALL
--- Legacy source containing clients using app version major below 148.
-SELECT
-  submission_date,
-  hashed_addon_id,
-  total_downloads,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(downloads_per_campaign)
-  ) AS downloads_per_campaign,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(downloads_per_content)
-  ) AS downloads_per_content,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(downloads_per_source)
-  ) AS downloads_per_source,
-  ARRAY(
-    SELECT AS STRUCT
-      IFNULL(`key`, 'Unknown') AS `key`,
-      `value`
-    FROM
-      UNNEST(downloads_per_medium)
-  ) AS downloads_per_medium,
-FROM
-  `moz-fx-data-shared-prod.addons_derived.amo_stats_installs_legacy_source_v1`
+  `moz-fx-data-shared-prod.addons_derived.firefox_desktop_stats_installs_combined_v1`

--- a/sql/moz-fx-data-shared-prod/addons/firefox_desktop_stats_installs/view.sql
+++ b/sql/moz-fx-data-shared-prod/addons/firefox_desktop_stats_installs/view.sql
@@ -2,6 +2,36 @@ CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.addons.firefox_desktop_stats_installs`
 AS
 SELECT
-  *
+  submission_date,
+  hashed_addon_id,
+  total_downloads,
+  ARRAY(
+    SELECT AS STRUCT
+      IFNULL(`key`, 'Unknown') AS `key`,
+      `value`
+    FROM
+      UNNEST(downloads_per_campaign)
+  ) AS downloads_per_campaign,
+  ARRAY(
+    SELECT AS STRUCT
+      IFNULL(`key`, 'Unknown') AS `key`,
+      `value`
+    FROM
+      UNNEST(downloads_per_content)
+  ) AS downloads_per_content,
+  ARRAY(
+    SELECT AS STRUCT
+      IFNULL(`key`, 'Unknown') AS `key`,
+      `value`
+    FROM
+      UNNEST(downloads_per_source)
+  ) AS downloads_per_source,
+  ARRAY(
+    SELECT AS STRUCT
+      IFNULL(`key`, 'Unknown') AS `key`,
+      `value`
+    FROM
+      UNNEST(downloads_per_medium)
+  ) AS downloads_per_medium,
 FROM
   `moz-fx-data-shared-prod.addons_derived.firefox_desktop_stats_installs_combined_v1`

--- a/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/metadata.yaml
@@ -1,0 +1,31 @@
+---
+friendly_name: AMO Stats Installs Combined (legacy + Glean)
+description: |-
+  Daily install statistics to power addons.mozilla.org stats pages.
+  See bug 1654330. Note that this table uses a hashed_addon_id
+  defined as `TO_HEX(SHA256(addon_id))` because the underlying event
+  pings have limitations on length of properties attached to events
+  and addon_id values are sometimes too long. The AMO stats application
+  looks up records in this table based on the hashed_addon_id.
+
+  The hashed_addon_id is only valid for install_stats:
+  https://searchfox.org/firefox-main/rev/ba7a7a320649794a9948b32156f5b438fef5ce7a/toolkit/mozapps/extensions/metrics.yaml#347-349
+
+  This table is built using Legacy (app version up to major version 147) and Glean data (major app version 148 and above).
+owners:
+  - kik@mozilla.com
+  - lgreco@mozilla.com
+labels:
+  application: amo
+  incremental: true
+  schedule: daily
+  table_type: aggregate
+  shredder_mitigation: false
+scheduling:
+  dag_name: bqetl_amo_stats
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null

--- a/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/query.sql
@@ -1,0 +1,156 @@
+-- Combine firefox_desktop install stats from both legacy and glean based data sources.
+-- Glean source containing clients using app version 148 and above.
+WITH unioned_install_stats AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    client_id,
+    extras.string.hashed_addon_id,
+    extras.string.utm_content,
+    extras.string.utm_campaign,
+    extras.string.utm_source,
+    extras.string.utm_medium,
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.events_stream`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND app_version_major >= 148
+    AND event_category = "addons_manager"
+    AND event_name = "install_stats"
+  UNION ALL BY NAME
+  -- Legacy source containing clients using app version major below 148.
+  SELECT
+    submission_date,
+    client_id,
+    event_string_value AS hashed_addon_id,
+    mozfun.map.get_key(event_map_values, 'utm_content') AS utm_content,
+    mozfun.map.get_key(event_map_values, 'utm_campaign') AS utm_campaign,
+    mozfun.map.get_key(event_map_values, 'utm_source') AS utm_source,
+    mozfun.map.get_key(event_map_values, 'utm_medium') AS utm_medium,
+  FROM
+    `moz-fx-data-shared-prod.telemetry.events`
+  WHERE
+    event_category = 'addonsManager'
+    AND mozfun.norm.truncate_version(app_version, "major") < 148
+    AND event_method = 'install_stats'
+    AND submission_date = @submission_date
+),
+per_source AS (
+  SELECT
+    hashed_addon_id,
+    submission_date,
+    ARRAY_AGG(STRUCT(`key`, `value`) ORDER BY `value` DESC) AS downloads_per_source
+  FROM
+    (
+      SELECT
+        hashed_addon_id,
+        submission_date,
+        utm_source AS `key`,
+        COUNT(DISTINCT client_id) AS `value`
+      FROM
+        unioned_install_stats
+      GROUP BY
+        submission_date,
+        hashed_addon_id,
+        `key`
+    )
+  GROUP BY
+    submission_date,
+    hashed_addon_id
+),
+per_content AS (
+  SELECT
+    hashed_addon_id,
+    submission_date,
+    ARRAY_AGG(STRUCT(`key`, `value`) ORDER BY `value` DESC) AS downloads_per_content
+  FROM
+    (
+      SELECT
+        hashed_addon_id,
+        submission_date,
+        utm_content AS `key`,
+        COUNT(DISTINCT client_id) AS `value`
+      FROM
+        unioned_install_stats
+      GROUP BY
+        submission_date,
+        hashed_addon_id,
+        `key`
+    )
+  GROUP BY
+    submission_date,
+    hashed_addon_id
+),
+per_medium AS (
+  SELECT
+    hashed_addon_id,
+    submission_date,
+    ARRAY_AGG(STRUCT(`key`, `value`) ORDER BY `value` DESC) AS downloads_per_medium
+  FROM
+    (
+      SELECT
+        hashed_addon_id,
+        submission_date,
+        utm_medium AS `key`,
+        COUNT(DISTINCT client_id) AS `value`
+      FROM
+        unioned_install_stats
+      GROUP BY
+        submission_date,
+        hashed_addon_id,
+        `key`
+    )
+  GROUP BY
+    submission_date,
+    hashed_addon_id
+),
+per_campaign AS (
+  SELECT
+    hashed_addon_id,
+    submission_date,
+    ARRAY_AGG(STRUCT(`key`, `value`) ORDER BY `value` DESC) AS downloads_per_campaign
+  FROM
+    (
+      SELECT
+        hashed_addon_id,
+        submission_date,
+        utm_campaign AS `key`,
+        COUNT(DISTINCT client_id) AS `value`
+      FROM
+        unioned_install_stats
+      GROUP BY
+        submission_date,
+        hashed_addon_id,
+        `key`
+    )
+  GROUP BY
+    submission_date,
+    hashed_addon_id
+),
+--
+total_downloads AS (
+  SELECT
+    hashed_addon_id,
+    submission_date,
+    COUNT(DISTINCT client_id) AS total_downloads
+  FROM
+    unioned_install_stats
+  GROUP BY
+    hashed_addon_id,
+    submission_date
+)
+SELECT
+  *
+FROM
+  total_downloads
+LEFT JOIN
+  per_source
+  USING (submission_date, hashed_addon_id)
+LEFT JOIN
+  per_content
+  USING (submission_date, hashed_addon_id)
+LEFT JOIN
+  per_medium
+  USING (submission_date, hashed_addon_id)
+LEFT JOIN
+  per_campaign
+  USING (submission_date, hashed_addon_id)

--- a/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/query.sql
@@ -1,6 +1,6 @@
 -- Combine firefox_desktop install stats from both legacy and glean based data sources.
--- Glean source containing clients using app version 148 and above.
 WITH unioned_install_stats AS (
+  -- Glean source containing clients using app version 148 and above.
   SELECT
     DATE(submission_timestamp) AS submission_date,
     client_id,

--- a/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/schema.yaml
@@ -1,0 +1,64 @@
+fields:
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+  description: The date when the telemetry ping is received on the server side.
+- name: hashed_addon_id
+  type: STRING
+  mode: NULLABLE
+  description: Hashed Addon id (`TO_HEX(SHA256(addon_id))`).
+- name: total_downloads
+  type: INTEGER
+  mode: NULLABLE
+- name: downloads_per_source
+  type: RECORD
+  mode: REPEATED
+  description: Source info.
+  fields:
+  - name: key
+    type: STRING
+    mode: NULLABLE
+    description: Source name.
+  - name: value
+    type: INTEGER
+    mode: NULLABLE
+    description: Number of downloads attributed to the source.
+- name: downloads_per_content
+  type: RECORD
+  mode: REPEATED
+  description: Content info.
+  fields:
+  - name: key
+    type: STRING
+    mode: NULLABLE
+    description: Content name.
+  - name: value
+    type: INTEGER
+    mode: NULLABLE
+    description: Number of downloads attributed to the content.
+- name: downloads_per_medium
+  type: RECORD
+  mode: REPEATED
+  description: Medium info.
+  fields:
+  - name: key
+    type: STRING
+    mode: NULLABLE
+    description: Medium name.
+  - name: value
+    type: INTEGER
+    mode: NULLABLE
+    description: Number of downloads attributed to the medium.
+- name: downloads_per_campaign
+  type: RECORD
+  mode: REPEATED
+  description: Campaign info.
+  fields:
+  - name: key
+    type: STRING
+    mode: NULLABLE
+    description: Campaign name.
+  - name: value
+    type: INTEGER
+    mode: NULLABLE
+    description: Number of downloads attributed to the campaign.

--- a/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/schema.yaml
@@ -10,6 +10,7 @@ fields:
 - name: total_downloads
   type: INTEGER
   mode: NULLABLE
+  description: Number of distinct clients that triggered an install_stats event.
 - name: downloads_per_source
   type: RECORD
   mode: REPEATED


### PR DESCRIPTION
# feat(DENG-9505): add addons derived/firefox desktop stats installs combined v1

## Description

Adds `addons_derived.firefox_desktop_stats_installs_combined_v1` query which combined legacy and Glean telemetry amo install events and aggregates them to produce a single source of truth for addons install stats.

Glean is used for major app version 148 and above, legacy for records coming from app version major below 148 (the same as amo dau stats).