### PR TITLE
feat(fxci): add worker usage data

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci/worker_costs/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci/worker_costs/metadata.yaml
@@ -1,4 +1,4 @@
 friendly_name: Firefox-CI Worker Costs
-description: Derived Firefox-CI worker cost data from the GCP billing export.
+description: Derived Firefox-CI worker cost data from the GCP and Azure billing exports.
 owners:
 - ahalberstadt@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fxci/worker_usage/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci/worker_usage/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Firefox-CI Worker Usage
+description: Derived Firefox-CI worker usage data used to attribute worker costs to task runs.
+owners:
+- ahalberstadt@mozilla.com
+- jmoss@mozilla.com

--- a/sql/moz-fx-data-shared-prod/fxci/worker_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/fxci/worker_usage/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.fxci.worker_usage`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.fxci_derived.worker_usage_v1`

--- a/sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/metadata.yaml
@@ -1,0 +1,28 @@
+friendly_name: Firefox-CI Worker Usage
+description: |-
+  Derived Firefox-CI worker usage data used to attribute worker costs to task
+  runs across GCP and Azure.
+owners:
+- ahalberstadt@mozilla.com
+- jmoss@mozilla.com
+labels:
+  incremental: true
+  owner1: ahalberstadt
+  owner2: jmoss
+  dag: bqetl_fxci
+scheduling:
+  dag_name: bqetl_fxci
+  task_name: fxci_worker_usage__v1
+bigquery:
+  time_partitioning:
+    type: day
+    field: usage_start_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+    - cloud_provider
+    - project
+    - zone
+    - instance_id

--- a/sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/query.sql
@@ -1,0 +1,73 @@
+WITH azure_billing AS (
+  SELECT
+    daily_load.subscriptionName,
+    daily_load.`date`,
+    daily_load.ResourceId,
+    daily_load.resourceLocation,
+    daily_load.quantity,
+    daily_load.chargeType,
+    daily_load.meterCategory,
+    daily_load.unitOfMeasure
+  FROM
+    `moz-fx-data-shared-prod.azure_billing_syndicate.fxci_daily_actual_load` AS daily_load
+  INNER JOIN
+    `moz-fx-data-shared-prod.azure_billing_syndicate.fxci_daily_actual_lookup` AS daily_lookup
+    USING (sourceDataId)
+  WHERE
+    daily_load.`date` = @submission_date
+  UNION ALL
+  SELECT
+    daily_load.subscriptionName,
+    daily_load.`date`,
+    daily_load.ResourceId,
+    daily_load.resourceLocation,
+    daily_load.quantity,
+    daily_load.chargeType,
+    daily_load.meterCategory,
+    daily_load.unitOfMeasure
+  FROM
+    `moz-fx-data-shared-prod.azure_billing_syndicate.taskcluster_daily_actual_load` AS daily_load
+  INNER JOIN
+    `moz-fx-data-shared-prod.azure_billing_syndicate.taskcluster_daily_actual_lookup` AS daily_lookup
+    USING (sourceDataId)
+  WHERE
+    daily_load.`date` = @submission_date
+)
+SELECT
+  "gcp" AS cloud_provider,
+  project,
+  zone,
+  instance_id,
+  submission_date AS usage_start_date,
+  SUM(uptime) AS uptime,
+  "gcp_monitoring_instance_uptime" AS attribution_method
+FROM
+  `moz-fx-data-shared-prod.fxci_derived.worker_metrics_v1`
+WHERE
+  submission_date = @submission_date
+GROUP BY
+  project,
+  zone,
+  instance_id,
+  usage_start_date
+UNION ALL
+SELECT
+  "azure" AS cloud_provider,
+  subscriptionName AS project,
+  resourceLocation AS zone,
+  REGEXP_EXTRACT(ResourceId, r"(?i)/virtualmachines/([^/]+)$") AS instance_id,
+  DATE(`date`) AS usage_start_date,
+  SUM(quantity * 3600) AS uptime,
+  "azure_billing_vm_quantity" AS attribution_method
+FROM
+  azure_billing
+WHERE
+  REGEXP_CONTAINS(ResourceId, r"(?i)/virtualmachines/vm-")
+  AND chargeType = "Usage"
+  AND meterCategory = "Virtual Machines"
+  AND unitOfMeasure = "1 Hour"
+GROUP BY
+  project,
+  zone,
+  instance_id,
+  usage_start_date

--- a/sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/schema.yaml
@@ -1,0 +1,22 @@
+fields:
+- name: cloud_provider
+  type: STRING
+  mode: NULLABLE
+- name: project
+  type: STRING
+  mode: NULLABLE
+- name: zone
+  type: STRING
+  mode: NULLABLE
+- name: instance_id
+  type: STRING
+  mode: NULLABLE
+- name: usage_start_date
+  type: DATE
+  mode: NULLABLE
+- name: uptime
+  type: FLOAT
+  mode: NULLABLE
+- name: attribution_method
+  type: STRING
+  mode: NULLABLE


### PR DESCRIPTION
## Description

Adds a cross-cloud `fxci_derived.worker_usage_v1` table and stable `fxci.worker_usage` view for Firefox-CI worker usage data.

The new table provides the denominator needed to attribute worker cost to task runs across GCP and Azure:

- GCP usage comes from the existing `fxci_derived.worker_metrics_v1` uptime export.
- Azure usage comes from the Azure billing export VM quantity where `meterCategory = "Virtual Machines"` and `unitOfMeasure = "1 Hour"`, converted to seconds.

This PR does not change task cost attribution yet. `task_run_costs_v1` remains unchanged so `worker_usage_v1` can be deployed and backfilled before downstream task-cost logic depends on it.

## Reviewer Notes

This follows the existing FXCI cost table pattern:

- versioned derived table under `fxci_derived`
- stable public view under `fxci`
- daily incremental scheduling in `bqetl_fxci`
- partitioning by the date field with `require_partition_filter: true`
- source partition filters on all partitioned inputs

The follow-up task attribution PR should not land until this table has been deployed and populated by the managed backfill in #9371. That backfill covers 90 days, from `2026-02-14` through `2026-05-14`.

## Validation

- `./bqetl format --check sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/query.sql sql/moz-fx-data-shared-prod/fxci/worker_usage/view.sql`
- `./bqetl query validate --no-dryrun fxci_derived.worker_usage_v1`
- `bq query --project_id=mozdata --use_legacy_sql=false --dry_run --parameter=submission_date:DATE:2026-05-13 < sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/query.sql`
- Checked against `docs/reference/recommended_practices.md`: versioned query dir, metadata/schema files, incremental label, partition filter, stable view, escaped keyword column, and no `mozdata` duplicate view references.

## Related

- Backfill: #9371
- Follow-up: #9369
- [RELOPS-2330](https://mozilla-hub.atlassian.net/browse/RELOPS-2330)
- [mozilla/bigquery-etl#9315](https://github.com/mozilla/bigquery-etl/pull/9315)
- [mozilla/global-platform-admin#6256](https://github.com/mozilla/global-platform-admin/pull/6256)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[RELOPS-2330]: https://mozilla-hub.atlassian.net/browse/RELOPS-2330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ