### PR TITLE
backfill(fxci): populate worker usage history

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/backfill.yaml
@@ -1,0 +1,14 @@
+2026-05-15:
+  start_date: 2026-02-14
+  end_date: 2026-05-14
+  reason: >-
+    RELOPS-2369 - Initial backfill of worker_usage_v1 for 90 days after adding
+    the table in https://github.com/mozilla/bigquery-etl/pull/9368. This gives
+    https://github.com/mozilla/bigquery-etl/pull/9369 enough GCP and Azure
+    worker usage history for task cost attribution without waiting for scheduled
+    daily runs to accumulate data.
+  watchers:
+  - jmoss@mozilla.com
+  - ahalberstadt@mozilla.com
+  status: Initiate
+  shredder_mitigation: false


### PR DESCRIPTION
## Description

Adds a managed backfill entry for `fxci_derived.worker_usage_v1` covering 90 days, from `2026-02-14` through `2026-05-14`.

This gives #9369 the worker usage history it needs for task cost attribution without waiting for scheduled daily runs to accumulate enough partitions naturally.

This PR is stacked on #9368 because #9368 introduces `worker_usage_v1`. After #9368 lands, this PR should be rebased/retargeted if needed and the diff should collapse to just `backfill.yaml`.

## Reviewer Notes

This is the `Initiate` step for the managed backfill. After the staged backfill finishes and the data validates, a follow-up PR should change this entry to `status: Complete` so the staged data is swapped into production.

Watchers should join `#dataops-alerts` for backfill status notifications.

## Validation

- `./bqetl backfill validate moz-fx-data-shared-prod.fxci_derived.worker_usage_v1`

## Related

- Depends on #9368
- Unblocks #9369
- [RELOPS-2369](https://mozilla-hub.atlassian.net/browse/RELOPS-2369)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[RELOPS-2369]: https://mozilla-hub.atlassian.net/browse/RELOPS-2369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ