### PR TITLE
[DENG-11122] Import repositories.yaml applications into BigQuery

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/probe_scraper_applications/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/probe_scraper_applications/metadata.yaml
@@ -1,0 +1,6 @@
+friendly_name: Probe Scraper Applications
+description: |-
+  Application metadata imported from probe-scraper's repositories.yaml:
+  https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml
+owners:
+  - ascholtz@mozilla.com

--- a/sql/moz-fx-data-shared-prod/monitoring/probe_scraper_applications/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/probe_scraper_applications/metadata.yaml
@@ -1,6 +1,8 @@
 friendly_name: Probe Scraper Applications
 description: |-
-  Application metadata imported from probe-scraper's repositories.yaml:
-  https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml
+  Application metadata imported from probe-scraper app listings:
+  https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings
+
+  One row per `applications:` entry. Refreshed daily (WRITE_TRUNCATE).
 owners:
   - ascholtz@mozilla.com

--- a/sql/moz-fx-data-shared-prod/monitoring/probe_scraper_applications/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/probe_scraper_applications/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.monitoring.probe_scraper_applications`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.monitoring_derived.probe_scraper_applications_v1`

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/metadata.yaml
@@ -1,0 +1,12 @@
+friendly_name: Probe Scraper Applications
+description: |-
+  Application metadata imported from probe-scraper's repositories.yaml:
+  https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml
+
+  One row per `applications:` entry. Refreshed daily (WRITE_TRUNCATE).
+owners:
+  - ascholtz@mozilla.com
+labels:
+  incremental: false
+scheduling:
+  dag_name: bqetl_monitoring

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/metadata.yaml
@@ -1,7 +1,7 @@
 friendly_name: Probe Scraper Applications
 description: |-
-  Application metadata imported from probe-scraper's repositories.yaml:
-  https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml
+  Application metadata imported from probe-scraper app listings:
+  https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings
 
   One row per `applications:` entry. Refreshed daily (WRITE_TRUNCATE).
 owners:

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/query.py
@@ -1,4 +1,12 @@
-"""Import applications from probe-scraper's repositories.yaml into BigQuery."""
+"""Import Glean app listings from the probe-info service into BigQuery.
+
+Source: https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings
+
+The endpoint returns one entry per Glean app + channel (e.g. fenix release,
+fenix beta, ...). Each entry is a flat record; the only nested shape is
+``moz_pipeline_metadata``, which is a map keyed by ping name in the source
+and is flattened here into a repeated record with ``ping_name`` set.
+"""
 
 import io
 import json
@@ -10,14 +18,14 @@ import requests
 import yaml
 from google.cloud import bigquery
 
-URL = "https://raw.githubusercontent.com/mozilla/probe-scraper/main/repositories.yaml"
+URL = "https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings"
 SCHEMA_FILE = Path(__file__).parent / "schema.yaml"
 
 
 def _flatten_pipeline_metadata(metadata: dict | None) -> list[dict]:
     """Convert the moz_pipeline_metadata map (keyed by ping name) into a list.
 
-    BigQuery doesn't have a native map type, so the YAML form
+    BigQuery doesn't have a native map type, so the source form
     ``{ping_name: {...}}`` becomes a repeated record with ``ping_name`` as a
     field on each row.
     """
@@ -26,25 +34,30 @@ def _flatten_pipeline_metadata(metadata: dict | None) -> list[dict]:
     return [{"ping_name": ping_name, **fields} for ping_name, fields in metadata.items()]
 
 
-def _row_for_app(app: dict[str, Any]) -> dict[str, Any]:
+def _row_for_listing(listing: dict[str, Any]) -> dict[str, Any]:
     return {
-        "app_name": app["app_name"],
-        "canonical_app_name": app.get("canonical_app_name"),
-        "app_description": app.get("app_description"),
-        "url": app.get("url"),
-        "branch": app.get("branch"),
-        "deprecated": app.get("deprecated") or False,
-        "skip_documentation": app.get("skip_documentation") or False,
-        "prototype": app.get("prototype") or False,
-        "notification_emails": app.get("notification_emails") or [],
-        "metrics_files": app.get("metrics_files") or [],
-        "ping_files": app.get("ping_files") or [],
-        "tag_files": app.get("tag_files") or [],
-        "dependencies": app.get("dependencies") or [],
-        "channels": app.get("channels") or [],
-        "moz_pipeline_metadata_defaults": app.get("moz_pipeline_metadata_defaults"),
+        "app_name": listing["app_name"],
+        "canonical_app_name": listing.get("canonical_app_name"),
+        "app_description": listing.get("app_description"),
+        "app_id": listing.get("app_id"),
+        "v1_name": listing.get("v1_name"),
+        "app_channel": listing.get("app_channel"),
+        "description": listing.get("description"),
+        "bq_dataset_family": listing.get("bq_dataset_family"),
+        "document_namespace": listing.get("document_namespace"),
+        "url": listing.get("url"),
+        "branch": listing.get("branch"),
+        "deprecated": listing.get("deprecated") or False,
+        "skip_documentation": listing.get("skip_documentation") or False,
+        "prototype": listing.get("prototype") or False,
+        "notification_emails": listing.get("notification_emails") or [],
+        "metrics_files": listing.get("metrics_files") or [],
+        "ping_files": listing.get("ping_files") or [],
+        "tag_files": listing.get("tag_files") or [],
+        "dependencies": listing.get("dependencies") or [],
+        "moz_pipeline_metadata_defaults": listing.get("moz_pipeline_metadata_defaults"),
         "moz_pipeline_metadata": _flatten_pipeline_metadata(
-            app.get("moz_pipeline_metadata")
+            listing.get("moz_pipeline_metadata")
         ),
     }
 
@@ -58,9 +71,9 @@ def main():
 
     response = requests.get(URL, timeout=60)
     response.raise_for_status()
-    data = yaml.safe_load(response.text)
+    listings = response.json()
 
-    rows = [_row_for_app(app) for app in data.get("applications", [])]
+    rows = [_row_for_listing(listing) for listing in listings]
 
     client = bigquery.Client(args.project)
     schema_dict = yaml.safe_load(SCHEMA_FILE.read_text())["fields"]
@@ -76,7 +89,7 @@ def main():
     )
     job.result()
     print(
-        f"Loaded {len(rows)} applications into "
+        f"Loaded {len(rows)} app listings into "
         f"{args.project}.{args.destination_dataset}.{args.destination_table}"
     )
 

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/query.py
@@ -78,7 +78,7 @@ def main():
     client = bigquery.Client(args.project)
     schema_dict = yaml.safe_load(SCHEMA_FILE.read_text())["fields"]
     job_config = bigquery.LoadJobConfig(
-        schema=client.schema_from_json(io.StringIO(json.dumps(schema_dict))),
+        schema=[bigquery.SchemaField.from_api_repr(f) for f in schema_dict],
         write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
     )
 

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/query.py
@@ -42,7 +42,7 @@ def _row_for_listing(listing: dict[str, Any]) -> dict[str, Any]:
         "app_id": listing.get("app_id"),
         "v1_name": listing.get("v1_name"),
         "app_channel": listing.get("app_channel"),
-        "description": listing.get("description"),
+        "channel_description": listing.get("description"),
         "bq_dataset_family": listing.get("bq_dataset_family"),
         "document_namespace": listing.get("document_namespace"),
         "url": listing.get("url"),

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/query.py
@@ -1,0 +1,85 @@
+"""Import applications from probe-scraper's repositories.yaml into BigQuery."""
+
+import io
+import json
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Any
+
+import requests
+import yaml
+from google.cloud import bigquery
+
+URL = "https://raw.githubusercontent.com/mozilla/probe-scraper/main/repositories.yaml"
+SCHEMA_FILE = Path(__file__).parent / "schema.yaml"
+
+
+def _flatten_pipeline_metadata(metadata: dict | None) -> list[dict]:
+    """Convert the moz_pipeline_metadata map (keyed by ping name) into a list.
+
+    BigQuery doesn't have a native map type, so the YAML form
+    ``{ping_name: {...}}`` becomes a repeated record with ``ping_name`` as a
+    field on each row.
+    """
+    if not metadata:
+        return []
+    return [{"ping_name": ping_name, **fields} for ping_name, fields in metadata.items()]
+
+
+def _row_for_app(app: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "app_name": app["app_name"],
+        "canonical_app_name": app.get("canonical_app_name"),
+        "app_description": app.get("app_description"),
+        "url": app.get("url"),
+        "branch": app.get("branch"),
+        "deprecated": app.get("deprecated") or False,
+        "skip_documentation": app.get("skip_documentation") or False,
+        "prototype": app.get("prototype") or False,
+        "notification_emails": app.get("notification_emails") or [],
+        "metrics_files": app.get("metrics_files") or [],
+        "ping_files": app.get("ping_files") or [],
+        "tag_files": app.get("tag_files") or [],
+        "dependencies": app.get("dependencies") or [],
+        "channels": app.get("channels") or [],
+        "moz_pipeline_metadata_defaults": app.get("moz_pipeline_metadata_defaults"),
+        "moz_pipeline_metadata": _flatten_pipeline_metadata(
+            app.get("moz_pipeline_metadata")
+        ),
+    }
+
+
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--project", default="moz-fx-data-shared-prod")
+    parser.add_argument("--destination_dataset", default="monitoring_derived")
+    parser.add_argument("--destination_table", default="probe_scraper_applications_v1")
+    args = parser.parse_args()
+
+    response = requests.get(URL, timeout=60)
+    response.raise_for_status()
+    data = yaml.safe_load(response.text)
+
+    rows = [_row_for_app(app) for app in data.get("applications", [])]
+
+    client = bigquery.Client(args.project)
+    schema_dict = yaml.safe_load(SCHEMA_FILE.read_text())["fields"]
+    job_config = bigquery.LoadJobConfig(
+        schema=client.schema_from_json(io.StringIO(json.dumps(schema_dict))),
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+    )
+
+    job = client.load_table_from_json(
+        rows,
+        f"{args.destination_dataset}.{args.destination_table}",
+        job_config=job_config,
+    )
+    job.result()
+    print(
+        f"Loaded {len(rows)} applications into "
+        f"{args.project}.{args.destination_dataset}.{args.destination_table}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/schema.yaml
@@ -32,7 +32,7 @@ fields:
   type: STRING
   mode: NULLABLE
   description: Release channel name (e.g. `release`, `beta`, `nightly`).
-- name: description
+- name: channel_description
   type: STRING
   mode: NULLABLE
   description: Channel-specific description (distinct from `app_description`).

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/schema.yaml
@@ -1,0 +1,207 @@
+fields:
+- name: app_name
+  type: STRING
+  mode: REQUIRED
+  description: |-
+    Application name as referenced in probe-scraper. Stable identifier used
+    across telemetry tooling (e.g. `firefox_desktop`, `fenix`, `firefox_ios`).
+- name: canonical_app_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Human-readable application name (e.g. `Firefox for Desktop`). Intended
+    for display in dashboards and documentation.
+- name: app_description
+  type: STRING
+  mode: NULLABLE
+  description: Free-text description of the application from repositories.yaml.
+- name: url
+  type: STRING
+  mode: NULLABLE
+  description: URL of the source repository that probe-scraper scrapes for this app.
+- name: branch
+  type: STRING
+  mode: NULLABLE
+  description: Git branch in `url` that probe-scraper reads from (typically `main`).
+- name: deprecated
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    True when the application is marked as deprecated in repositories.yaml.
+    Deprecated apps are no longer actively scraped or maintained.
+- name: skip_documentation
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    True when probe-scraper is configured to omit this app from generated
+    documentation.
+- name: prototype
+  type: BOOLEAN
+  mode: NULLABLE
+  description: |-
+    True when the application is marked as a prototype / experimental app
+    not intended for production reporting.
+- name: notification_emails
+  type: STRING
+  mode: REPEATED
+  description: |-
+    Email addresses notified by probe-scraper for issues with this app
+    (e.g. schema breaks, expiring metrics).
+- name: metrics_files
+  type: STRING
+  mode: REPEATED
+  description: |-
+    Paths (relative to the repository root) of Glean `metrics.yaml` files
+    that define metrics for this application.
+- name: ping_files
+  type: STRING
+  mode: REPEATED
+  description: |-
+    Paths (relative to the repository root) of Glean `pings.yaml` files
+    that define pings for this application.
+- name: tag_files
+  type: STRING
+  mode: REPEATED
+  description: |-
+    Paths (relative to the repository root) of Glean `tags.yaml` files
+    that define metric tags for this application.
+- name: dependencies
+  type: STRING
+  mode: REPEATED
+  description: |-
+    Names of probe-scraper libraries (or Android dependency coordinates)
+    whose metrics and pings are merged into this application's schema.
+- name: channels
+  type: RECORD
+  mode: REPEATED
+  description: |-
+    Release channels this application ships through. One row per channel
+    (e.g. release / beta / nightly).
+  fields:
+  - name: v1_name
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Legacy v1 channel identifier used in BigQuery dataset names
+      (e.g. `firefox-android-release`).
+  - name: app_id
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Glean application ID for this channel (e.g. `org.mozilla.firefox`).
+      Maps to the `client_info.app_id` field in pings.
+  - name: app_channel
+    type: STRING
+    mode: NULLABLE
+    description: Release channel name (e.g. `release`, `beta`, `nightly`).
+  - name: description
+    type: STRING
+    mode: NULLABLE
+    description: Human-readable description of the channel.
+  - name: additional_dependencies
+    type: STRING
+    mode: REPEATED
+    description: |-
+      Channel-specific dependencies appended to the app's `dependencies`
+      list (e.g. a channel-specific Gecko engine variant).
+  - name: deprecated
+    type: BOOLEAN
+    mode: NULLABLE
+    description: |-
+      True when this specific channel is deprecated (independent of the
+      app-level `deprecated` flag).
+- name: moz_pipeline_metadata_defaults
+  type: RECORD
+  mode: NULLABLE
+  description: |-
+    Pipeline-level defaults applied to every ping for this app unless
+    overridden by an entry in `moz_pipeline_metadata`.
+  fields:
+  - name: expiration_policy
+    type: RECORD
+    mode: NULLABLE
+    description: Default expiration policy applied to pings for this app.
+    fields:
+    - name: delete_after_days
+      type: INTEGER
+      mode: NULLABLE
+      description: |-
+        Number of days after submission that ping data is retained before
+        deletion by the shredder pipeline.
+  - name: geoip_skip_entries
+    type: INTEGER
+    mode: NULLABLE
+    description: |-
+      Number of leading entries to drop when GeoIP-resolving the client
+      IP (used to skip CDN / proxy hops).
+  - name: submission_timestamp_granularity
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Default truncation applied to `submission_timestamp` before storage
+      (e.g. `seconds`, `minutes`, `hours`, `days`).
+  - name: override_attributes
+    type: RECORD
+    mode: REPEATED
+    description: |-
+      Default attribute overrides applied during pipeline ingestion
+      (e.g. nullifying geo fields).
+    fields:
+    - name: name
+      type: STRING
+      mode: NULLABLE
+      description: Attribute name being overridden (e.g. `geo_city`).
+    - name: value
+      type: STRING
+      mode: NULLABLE
+      description: |-
+        Replacement value. NULL means the attribute is cleared (the
+        common case for redaction).
+- name: moz_pipeline_metadata
+  type: RECORD
+  mode: REPEATED
+  description: |-
+    Per-ping pipeline metadata overrides. The source YAML keys this as a
+    map by ping name; we flatten it into a repeated record with
+    `ping_name` set to the original key.
+  fields:
+  - name: ping_name
+    type: STRING
+    mode: NULLABLE
+    description: Name of the ping this override applies to (e.g. `baseline`, `metrics`).
+  - name: expiration_policy
+    type: RECORD
+    mode: NULLABLE
+    description: |-
+      Per-ping expiration policy, overriding
+      `moz_pipeline_metadata_defaults.expiration_policy`.
+    fields:
+    - name: delete_after_days
+      type: INTEGER
+      mode: NULLABLE
+      description: |-
+        Number of days after submission that this ping's data is retained
+        before deletion by the shredder pipeline.
+  - name: submission_timestamp_granularity
+    type: STRING
+    mode: NULLABLE
+    description: |-
+      Per-ping submission_timestamp truncation, overriding the app-level
+      default (e.g. `seconds`, `minutes`).
+  - name: override_attributes
+    type: RECORD
+    mode: REPEATED
+    description: |-
+      Per-ping attribute overrides applied during ingestion
+      (e.g. nullifying `geo_city` for impression pings).
+    fields:
+    - name: name
+      type: STRING
+      mode: NULLABLE
+      description: Attribute name being overridden (e.g. `geo_city`).
+    - name: value
+      type: STRING
+      mode: NULLABLE
+      description: |-
+        Replacement value. NULL means the attribute is cleared (the
+        common case for redaction).

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/probe_scraper_applications_v1/schema.yaml
@@ -5,6 +5,7 @@ fields:
   description: |-
     Application name as referenced in probe-scraper. Stable identifier used
     across telemetry tooling (e.g. `firefox_desktop`, `fenix`, `firefox_ios`).
+    Not unique on its own — multi-channel apps repeat across rows.
 - name: canonical_app_name
   type: STRING
   mode: NULLABLE
@@ -14,7 +15,40 @@ fields:
 - name: app_description
   type: STRING
   mode: NULLABLE
-  description: Free-text description of the application from repositories.yaml.
+  description: Free-text description of the application.
+- name: app_id
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Glean application ID for this channel (e.g. `org.mozilla.firefox`).
+    Maps to the `client_info.app_id` field in pings. Unique per row.
+- name: v1_name
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Legacy v1 channel identifier used in BigQuery dataset names
+    (e.g. `firefox-android-release`). Unique per row.
+- name: app_channel
+  type: STRING
+  mode: NULLABLE
+  description: Release channel name (e.g. `release`, `beta`, `nightly`).
+- name: description
+  type: STRING
+  mode: NULLABLE
+  description: Channel-specific description (distinct from `app_description`).
+- name: bq_dataset_family
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    BigQuery dataset family this channel ingests into. Pings from this
+    channel land in datasets prefixed with this value
+    (e.g. `firefox_desktop`, `firefox_desktop_stable`).
+- name: document_namespace
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Edge/ingestion namespace used by the Glean pipeline (e.g.
+    `firefox-desktop`). Differs from `bq_dataset_family` in casing/format.
 - name: url
   type: STRING
   mode: NULLABLE
@@ -27,14 +61,14 @@ fields:
   type: BOOLEAN
   mode: NULLABLE
   description: |-
-    True when the application is marked as deprecated in repositories.yaml.
-    Deprecated apps are no longer actively scraped or maintained.
+    True when this app/channel is marked as deprecated and is no longer
+    actively scraped or maintained.
 - name: skip_documentation
   type: BOOLEAN
   mode: NULLABLE
   description: |-
-    True when probe-scraper is configured to omit this app from generated
-    documentation.
+    True when probe-scraper is configured to omit this app/channel from
+    generated documentation.
 - name: prototype
   type: BOOLEAN
   mode: NULLABLE
@@ -70,57 +104,19 @@ fields:
   mode: REPEATED
   description: |-
     Names of probe-scraper libraries (or Android dependency coordinates)
-    whose metrics and pings are merged into this application's schema.
-- name: channels
-  type: RECORD
-  mode: REPEATED
-  description: |-
-    Release channels this application ships through. One row per channel
-    (e.g. release / beta / nightly).
-  fields:
-  - name: v1_name
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Legacy v1 channel identifier used in BigQuery dataset names
-      (e.g. `firefox-android-release`).
-  - name: app_id
-    type: STRING
-    mode: NULLABLE
-    description: |-
-      Glean application ID for this channel (e.g. `org.mozilla.firefox`).
-      Maps to the `client_info.app_id` field in pings.
-  - name: app_channel
-    type: STRING
-    mode: NULLABLE
-    description: Release channel name (e.g. `release`, `beta`, `nightly`).
-  - name: description
-    type: STRING
-    mode: NULLABLE
-    description: Human-readable description of the channel.
-  - name: additional_dependencies
-    type: STRING
-    mode: REPEATED
-    description: |-
-      Channel-specific dependencies appended to the app's `dependencies`
-      list (e.g. a channel-specific Gecko engine variant).
-  - name: deprecated
-    type: BOOLEAN
-    mode: NULLABLE
-    description: |-
-      True when this specific channel is deprecated (independent of the
-      app-level `deprecated` flag).
+    whose metrics and pings are merged into this channel's schema.
+    Includes any channel-specific additional dependencies.
 - name: moz_pipeline_metadata_defaults
   type: RECORD
   mode: NULLABLE
   description: |-
-    Pipeline-level defaults applied to every ping for this app unless
+    Pipeline-level defaults applied to every ping for this channel unless
     overridden by an entry in `moz_pipeline_metadata`.
   fields:
   - name: expiration_policy
     type: RECORD
     mode: NULLABLE
-    description: Default expiration policy applied to pings for this app.
+    description: Default expiration policy applied to pings for this channel.
     fields:
     - name: delete_after_days
       type: INTEGER
@@ -161,9 +157,9 @@ fields:
   type: RECORD
   mode: REPEATED
   description: |-
-    Per-ping pipeline metadata overrides. The source YAML keys this as a
-    map by ping name; we flatten it into a repeated record with
-    `ping_name` set to the original key.
+    Per-ping pipeline metadata overrides. The source keys this as a map
+    by ping name; we flatten it into a repeated record with `ping_name`
+    set to the original key.
   fields:
   - name: ping_name
     type: STRING
@@ -186,7 +182,7 @@ fields:
     type: STRING
     mode: NULLABLE
     description: |-
-      Per-ping submission_timestamp truncation, overriding the app-level
+      Per-ping submission_timestamp truncation, overriding the channel-level
       default (e.g. `seconds`, `minutes`).
   - name: override_attributes
     type: RECORD


### PR DESCRIPTION
## Description

This imports the applications from https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml into BigQuery. 

This will be used for https://mozilla-hub.atlassian.net/browse/DENG-11122 to determine which Looker namespaces are associated with deprecated Glean applications.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
