### PR TITLE
backfill(fxci): complete worker usage history

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/backfill.yaml
@@ -10,5 +10,5 @@
   watchers:
   - jmoss@mozilla.com
   - ahalberstadt@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false


### PR DESCRIPTION
## Description

Completes the managed backfill for `fxci_derived.worker_usage_v1` by changing the 2026-05-15 backfill entry from `Initiate` to `Complete`. This swaps the staged worker usage history into production.

## Context

The initial backfill was added in #9371 after #9368 introduced `worker_usage_v1`. Completing this backfill unblocks #9369, which uses the GCP and Azure worker usage history for task cost attribution.

Staging location from the backfill completion notification: `moz-fx-data-shared-prod.backfills_staging_derived.fxci_derived__worker_usage_v1_2026_05_15`.

## Validation

- `./bqetl backfill validate moz-fx-data-shared-prod.fxci_derived.worker_usage_v1`
- `yamllint -c .yamllint.yaml sql/moz-fx-data-shared-prod/fxci_derived/worker_usage_v1/backfill.yaml`
- Redash validation of staging coverage for `2026-02-14` through `2026-05-14`:
  - `azure`: 90 days, 1,538,582 rows, 1,450,027 instances, 1,999,117.52 uptime hours
  - `gcp`: 90 days, 7,809,163 rows, 4,275,662 instances, 5,792,792.30 uptime hours
- Redash staging quality check found 0 missing `instance_id`, 0 missing `uptime`, and 0 non-positive `uptime` rows for both providers.

## Related

- Completes #9371
- Unblocks #9369
- [RELOPS-2369](https://mozilla-hub.atlassian.net/browse/RELOPS-2369)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

[RELOPS-2369]: https://mozilla-hub.atlassian.net/browse/RELOPS-2369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ