### PR TITLE
chore(DENG-10738): initiate backfill for fenix_derived.metrics_clients_last_seen_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2026-05-15:
+  start_date: 2026-03-30
+  end_date: 2026-05-15
+  reason: DENG-10738
+  watchers:
+  - kbammarito@mozilla.com
+  - msun@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR initiates a backfill for `fenix_derived.metrics_clients_last_seen_v1` after additions in https://github.com/mozilla/bigquery-etl/pull/9278. The [metadata labels](https://github.com/mozilla/bigquery-etl/blob/main/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml#L12) _do not_ include `shredder_mitigation`.

## Related Tickets & Documents
* DENG-10738

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
