### PR TITLE
feat: Add `legacy` labels to ETLs/views that only select from legacy telemetry

### DIFF
--- a/docs/reference/recommended_practices.md
+++ b/docs/reference/recommended_practices.md
@@ -132,6 +132,7 @@ labels:
   incremental_export: false # non-incremental JSON export writes all data to a single location
 ```
 
+- Queries that only select from legacy telemetry data should be assigned a `legacy: true` label.
 - only labels where value types are eithers integers or strings are published, all other values types are being skipped
 
 ### Dynamic Schemas
@@ -166,6 +167,12 @@ Without this flag, `--skip-existing` will skip schema updates for queries that a
 - Should not refer to views in the `mozdata` project which are duplicates of views in another project
   (commonly `moz-fx-data-shared-prod`). Refer to the original view instead.
 - Views are interpreted as [Jinja](https://jinja.palletsprojects.com/en/3.1.x/) templates, so it is possible to use Jinja statements and expressions
+
+## View Metadata
+
+- For each view, a `metadata.yaml` file may be created in the same directory.
+- This file contains a description, owners, and labels (see the query metadata example above).
+- Views that only select from legacy telemetry data should be assigned a `legacy: true` label.
 
 ## UDFs
 

--- a/sql/moz-fx-data-shared-prod/addons/firefox_desktop_addons_by_client/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addons/firefox_desktop_addons_by_client/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_addons_by_client_legacy_source_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_addons_by_client_legacy_source_v1/metadata.yaml
@@ -13,6 +13,7 @@ labels:
   incremental: true
   schedule: daily
   table_table: client_level
+  legacy: true
 scheduling:
   dag_name: bqetl_amo_stats
 bigquery:

--- a/sql/moz-fx-data-shared-prod/amo_prod/desktop_addons_by_client_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/amo_prod/desktop_addons_by_client_v1/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   incremental: true
   schedule: daily
   table_table: client_level
+  legacy: true
 scheduling:
   dag_name: bqetl_amo_stats
 bigquery:

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/locale_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/locale_aggregates/metadata.yaml
@@ -3,3 +3,5 @@ description: |-
   Firefox Desktop DAU, WAU, MAU and client counts by locale and core dimensions of analysis.
 owners:
 - lvargas@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/resurrection_week_2_retention/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/resurrection_week_2_retention/metadata.yaml
@@ -14,3 +14,4 @@ owners:
 labels:
   owner1: rbaffourawuah@mozilla.com
   owner2: mhirose@mozilla.com
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/locale_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/locale_aggregates_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_analytics_aggregations
   date_partition_offset: -1

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/resurrection_week_2_retention_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/resurrection_week_2_retention_v1/metadata.yaml
@@ -19,6 +19,7 @@ labels:
   shredder_mitigation: false
   owner1: rbaffourawuah@mozilla.com
   owner2: mhirose@mozilla.com
+  legacy: true
 scheduling:
   dag_name: bqetl_desktop_retention_model
 bigquery:

--- a/sql/moz-fx-data-shared-prod/google_ads/conversion_event_categorization/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads/conversion_event_categorization/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Conversion Event Categorization
 description: Classifies conversion events
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/conversion_event_categorization_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/conversion_event_categorization_v2/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: kik@mozilla.com
+  legacy: true
 scheduling:
   dag_name: bqetl_desktop_conv_evnt_categorization
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v1/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v2/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/telemetry_missing_columns_v3/metadata.yaml
@@ -8,6 +8,7 @@ owners:
 labels:
   schedule: daily
   incremental: false
+  legacy: true
 scheduling:
   dag_name: bqetl_monitoring
 bigquery:

--- a/sql/moz-fx-data-shared-prod/search/desktop_search_aggregates_by_userstate/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search/desktop_search_aggregates_by_userstate/metadata.yaml
@@ -9,3 +9,5 @@ description: 'This query creates a table based on clients_last_seen containing
 owners:
 - cmorales@mozilla.com
 - akommasani@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/desktop_search_aggregates_by_userstate_v1/metadata.yaml
@@ -15,6 +15,7 @@ labels:
   owner2: akommasani
   shredder_mitigation: true
   table_type: aggregate
+  legacy: true
 scheduling:
   dag_name: bqetl_search_dashboard
   depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/telemetry/accessibility_clients/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/accessibility_clients/metadata.yaml
@@ -4,3 +4,5 @@ description: >
   partitioned by day.
 owners:
   - yzenevich@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/addon_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/addon_aggregates/metadata.yaml
@@ -4,3 +4,5 @@ description: |-
   and partitioned by day.
 owners:
 - kik@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/addon_aggregates_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/addon_aggregates_v2/metadata.yaml
@@ -4,3 +4,5 @@ description: |-
   and partitioned by day.
 owners:
 - kik@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/addon_names/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/addon_names/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Addon Names
 description: Addon IDs, names and number of occurences.
 owners:
   - kik@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/addons/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/addons/metadata.yaml
@@ -3,3 +3,5 @@ description: |-
   Addon usage by client, partitioned by day
 owners:
 - kik@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/addons_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/addons_v2/metadata.yaml
@@ -3,3 +3,5 @@ description: |-
   Addon usage by client, partitioned by day
 owners:
 - kik@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_first_seen/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_first_seen/metadata.yaml
@@ -19,3 +19,4 @@ owners:
   - rzhao@mozilla.com
 labels:
   application: firefox
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_first_seen_28_days_later/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_first_seen_28_days_later/metadata.yaml
@@ -4,3 +4,5 @@ description: Client cohorts 28 days after their first seen date with relevant re
 owners:
 - mhirose@mozilla.com
 - shong@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen/metadata.yaml
@@ -26,3 +26,4 @@ owners:
   - ascholtz@mozilla.com
 labels:
   application: firefox
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen_v1/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/clients_last_seen_v2/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/core/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/core/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/core_clients_daily/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/core_clients_daily/metadata.yaml
@@ -3,3 +3,5 @@ description: |
   A daily aggregate of baseline and metrics pings from each client sending core pings, partitioned by day
 owners:
 - ascholtz@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/core_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/core_clients_daily_v1/metadata.yaml
@@ -3,3 +3,5 @@ description: |
   A daily aggregate of baseline and metrics pings from each client sending core pings, partitioned by day
 owners:
 - ascholtz@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/core_clients_last_seen/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/core_clients_last_seen/metadata.yaml
@@ -5,3 +5,5 @@ description: 'Captures history of activity of each client sending core pings in 
   '
 owners:
 - ascholtz@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/core_clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/core_clients_last_seen_v1/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/crashes_daily/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/crashes_daily/metadata.yaml
@@ -8,3 +8,5 @@ description: |-
   query dimensions.
 owners:
 - ascholtz@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/desktop_acquisition_funnel/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/desktop_acquisition_funnel/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/desktop_active_users/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/desktop_active_users/metadata.yaml
@@ -3,3 +3,5 @@ description: |-
   Data used for reporting DAU, WAU, and MAU KPIs.
   Based on legacy telemetry data.
   Rows are at a client ID, submission date grain.
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/desktop_cohort_daily_retention/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/desktop_cohort_daily_retention/metadata.yaml
@@ -20,3 +20,5 @@ description: 'Desktop Cohort Daily Retention consists of one row per first_seen_
   importantly clients_first_seen_v2'
 owners:
 - mhirose@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/desktop_engagement/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/desktop_engagement/metadata.yaml
@@ -3,3 +3,5 @@ description: |-
   Contains aggregated DAU, WAU, and MAU by different attributes for engagement ratio calculation.
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/desktop_engagement_clients/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/desktop_engagement_clients/metadata.yaml
@@ -3,3 +3,5 @@ description: |-
   Desktop engagement data at the client level, including attribution information
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/desktop_new_profiles_clients/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/desktop_new_profiles_clients/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/desktop_retention_1_week/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/desktop_retention_1_week/metadata.yaml
@@ -10,3 +10,4 @@ owners:
   - ascholtz@mozilla.com
 labels:
   application: firefox
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fennec_ios_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fennec_ios_events_v1/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/focus_event/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/focus_event/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_antivirus/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_antivirus/metadata.yaml
@@ -3,3 +3,5 @@ description: Aggregate table based on 1% user sample showing antivirus software 
   by OS
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_country/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_country/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Firefox Health Indicator - Bookmarks By Country
 description: Please provide a description for the query
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_os/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_os/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Firefox Health Indicators - Bookmarks By OS by DAU
 description: Bookmarks per DAU by PS, for release channel only, app version >= 84
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_os_version/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_bookmarks_by_os_version/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Firefox Health Indicator - Bookmarks By Windows OS Version
 description: Bookmarks per DAU by OS and channel, app version >= 84
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_new_profiles_by_os/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_new_profiles_by_os/metadata.yaml
@@ -3,3 +3,5 @@ description: Aggregate table used in Firefox Health dashboard, contains number o
   new profiles by OS
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_page_reloads/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_page_reloads/metadata.yaml
@@ -3,3 +3,5 @@ description: Aggregate table used in Firefox Health Indicator dashboard, calcula
   number of users doing page reloads per country per day
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_ratios_smooth/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_ratios_smooth/metadata.yaml
@@ -3,3 +3,5 @@ description: Calculates % of clients with Firefox set as default based on a 1% s
   for Windows OS 10, release channel only; used in Firefox Health Indicator dashboard
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_country/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_country/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Fx Health Ind Vid Plybck By Os
 description: Aggregate table of video playback minutes per user per OS
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_os/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_os/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Fx Health Ind Vid Plybck By Os
 description: Aggregate table of video playback minutes per user per OS
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_os_version/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_vid_plybck_by_os_version/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Fx Health Ind Vid Plybck By Os
 description: Aggregate table of video playback minutes per user per OS
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_win_uninstll/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/fx_health_ind_win_uninstll/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Fx Health Ind Win Uninstll
 description: Aggregate view of Windows uninstalls by day
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/health/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/health/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/lockwise_mobile_events/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/lockwise_mobile_events/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/lockwise_mobile_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/lockwise_mobile_events_v1/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/main_1pct/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_1pct/metadata.yaml
@@ -28,3 +28,4 @@ owners:
   - ascholtz@mozilla.com
 labels:
   application: firefox
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/main_nightly/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_nightly/metadata.yaml
@@ -24,3 +24,4 @@ owners:
   - jklukas@mozilla.com
 labels:
   application: firefox
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/main_remainder_1pct/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_remainder_1pct/metadata.yaml
@@ -28,3 +28,4 @@ owners:
   - ascholtz@mozilla.com
 labels:
   application: firefox
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/main_use_counter_1pct/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/main_use_counter_1pct/metadata.yaml
@@ -28,3 +28,4 @@ owners:
   - ascholtz@mozilla.com
 labels:
   application: firefox
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/mobile_event/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/mobile_event/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/network_usage/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/network_usage/metadata.yaml
@@ -1,3 +1,5 @@
 friendly_name: Network Usage
 description: |-
   Compares private vs non private network usage
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/rocket_android_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/rocket_android_events_v1/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/ssl_ratios/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/ssl_ratios/metadata.yaml
@@ -4,3 +4,5 @@ description: 'Percentages of page loads Firefox users have performed that were
   conducted over SSL broken down by country.'
 owners:
 - chutten@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/ssl_ratios_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/ssl_ratios_v1/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/sync/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/sync/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_anonymous_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_anonymous_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_core_parquet/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_core_parquet/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_core_parquet_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_core_parquet_v3/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_downgrade_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_downgrade_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_focus_event_parquet/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_focus_event_parquet/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_focus_event_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_focus_event_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_heartbeat_parquet_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_heartbeat_parquet_v1/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_mobile_event_parquet/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_mobile_event_parquet/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/telemetry_mobile_event_parquet_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/telemetry_mobile_event_parquet_v2/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_account_signed_in_status/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_account_signed_in_status/metadata.yaml
@@ -3,3 +3,5 @@ description: 'Aggregate table calculating # unique clients with uninstalls by ac
   enabled status and date'
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_addon/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_addon/metadata.yaml
@@ -3,3 +3,5 @@ description: 'Aggregate table calculating # unique clients with uninstalls by ad
   on and date'
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_attr_src/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_attr_src/metadata.yaml
@@ -3,3 +3,5 @@ description: 'Aggregate table calculating # unique clients with uninstalls by at
   source and date'
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_browser_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_browser_aggregates/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Uninstalls By Browser Aggregates
 description: Aggregate table calculating uninstalls by browser and date
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_channel_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_channel_aggregates/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Uninstalls By Channel Aggregates
 description: Aggregate table calculating uninstalls by channel and submission date
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_country_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_country_aggregates/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Uninstalls By Country Aggregates
 description: Calculates uninstalls by country and submission date
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_cpu_cores/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_cpu_cores/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Uninstalls By Cpu Cores
 description: Records number of unique clients uninstalling by day and CPU core count
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_day/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_day/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Uninstalls By Day
 description: Records number of unique clients uninstalling by day
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_default/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_default/metadata.yaml
@@ -1,3 +1,5 @@
 friendly_name: Uninstalls By Default
 description: |-
   Number of clients uninstalling by date, broken by those having Fx as default browser vs not
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_default_search_engine/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_default_search_engine/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Uninstalls By Default Search Engine
 description: Uninstall trends by default search engine over time
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_distribution_id/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_distribution_id/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Uninstalls By Distribution Id
 description: Number of clients uninstalling by date and distribution ID
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_dlsource/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_dlsource/metadata.yaml
@@ -3,3 +3,5 @@ description: Number of unique clients uninstalling by submission date and downlo
   source
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_isp/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_isp/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Uninstalls By ISP Name
 description: Number of clients uninstalling by submission date and ISP
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_os_install_yr/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_os_install_yr/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Uninstalls By Os Install Yr
 description: Uninstalls by submission date & Windows installation year
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_os_ver_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_by_os_ver_aggregates/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Uninstalls By OS Version
 description: Aggregate table with uninstalls by normalized OS version and date
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_account_signed_in_status/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_account_signed_in_status/metadata.yaml
@@ -3,3 +3,5 @@ description: Uninstalls by account enabled status by if the uninstall was on dat
   of installation or not
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_addon/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_addon/metadata.yaml
@@ -3,3 +3,5 @@ description: Uninstalls by addon split by if the uninstall was on date of instal
   or not
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_attr_src/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_attr_src/metadata.yaml
@@ -3,3 +3,5 @@ description: Uninstalls by attribution source split by if the uninstall was on d
   of installation or not
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_browser/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_browser/metadata.yaml
@@ -3,3 +3,5 @@ description: Uninstalls by browser split by if the uninstall was on date of inst
   or not
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_country/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_country/metadata.yaml
@@ -3,3 +3,5 @@ description: Uninstalls by country split by if the uninstall was on date of inst
   or not
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_cpu_core_count/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_cpu_core_count/metadata.yaml
@@ -3,3 +3,5 @@ description: Uninstalls by CPU cores split by if the uninstall was on date of in
   or not
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_dflt_srch/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_dflt_srch/metadata.yaml
@@ -3,3 +3,5 @@ description: Uninstalls by default search engine split by if the uninstall was o
   date of installation or not
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_dlsource/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_dlsource/metadata.yaml
@@ -3,3 +3,5 @@ description: Uninstalls by attribution_dlsource split by if the uninstall was on
   of installation or not
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_os_install_yr/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_os_install_yr/metadata.yaml
@@ -3,3 +3,5 @@ description: Uninstalls by OS install year split by if the uninstall was on date
   installation or not
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_os_ver/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_on_day_of_install_by_os_ver/metadata.yaml
@@ -3,3 +3,5 @@ description: Uninstalls by OS version split by if the uninstall was on date of i
   or not
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_per_other_installs/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_per_other_installs/metadata.yaml
@@ -2,3 +2,5 @@ friendly_name: Uninstalls Per Other Installs
 description: Calculates uninstallations per number of other installs
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry/uninstalls_relative_to_profile_creation/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/uninstalls_relative_to_profile_creation/metadata.yaml
@@ -3,3 +3,5 @@ description: Number of clients uninstalling each date relative to their profile 
   date
 owners:
 - kwindau@mozilla.com
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/accessibility_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/accessibility_clients_v1/metadata.yaml
@@ -8,6 +8,7 @@ owners:
 labels:
   application: firefox
   schedule: daily
+  legacy: true
 scheduling:
   dag_name: bqetl_desktop_platform
   start_date: "2018-11-01"

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/addon_aggregates_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/addon_aggregates_v2/metadata.yaml
@@ -11,6 +11,7 @@ labels:
   table_type: client_level
   dag: bqetl_addons
   owner1: kik
+  legacy: true
 scheduling:
   dag_name: bqetl_addons
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/addon_names_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/addon_names_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   incremental: true
   table_type: aggregate
   shredder_mitigation: false
+  legacy: true
 scheduling:
   dag_name: bqetl_addons
   # This is an unpartitioned table that we recreate each day based on the

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/addons_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/addons_v2/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   dag: bqetl_addons
   owner1: kik
   table_type: client_level
+  legacy: true
 scheduling:
   dag_name: bqetl_addons
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/metadata.yaml
@@ -18,6 +18,7 @@ labels:
   dag: bqetl_main_summary
   owner1: ascholtz
   table_type: client_level
+  legacy: true
 scheduling:
   dag_name: bqetl_main_summary
   start_date: '2019-11-05'

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   incremental: true
   dag: bqetl_analytics_tables
   owner1: loines
+  legacy: true
 scheduling:
   dag_name: bqetl_analytics_tables
   date_partition_offset: -27

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_28_days_later_v3/metadata.yaml
@@ -7,6 +7,7 @@ owners:
 labels:
   incremental: true
   owner1: example
+  legacy: true
 scheduling:
   dag_name: bqetl_analytics_tables
   date_partition_offset: -27

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/metadata.yaml
@@ -13,6 +13,7 @@ labels:
   schedule: daily
   dag: bqetl_main_summary
   owner1: jklukas
+  legacy: true
 scheduling:
   dag_name: bqetl_main_summary
   start_date: '2020-05-05'

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v2/metadata.yaml
@@ -27,6 +27,7 @@ labels:
   schedule: daily
   depends_on_past: true
   owner1: lvargas
+  legacy: true
 scheduling:
   dag_name: bqetl_analytics_tables
   task_name: clients_first_seen_v2

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v3/metadata.yaml
@@ -33,6 +33,7 @@ labels:
   depends_on_past: true
   owner1: mhirose
   dag: bqetl_analytics_tables
+  legacy: true
 scheduling:
   dag_name: bqetl_analytics_tables
   task_name: clients_first_seen_v3

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v1/metadata.yaml
@@ -16,6 +16,7 @@ labels:
   dag: bqetl_main_summary
   owner1: ascholtz
   table_type: client_level
+  legacy: true
 scheduling:
   dag_name: bqetl_main_summary
   priority: 85

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
@@ -22,6 +22,7 @@ labels:
   dag: bqetl_main_summary
   owner1: kwindau
   table_type: client_level
+  legacy: true
 scheduling:
   dag_name: bqetl_main_summary
   priority: 85

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_daily_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   dag: bqetl_core
   owner1: ascholtz
   table_type: client_level
+  legacy: true
 scheduling:
   dag_name: bqetl_core
   priority: 75

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_first_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_first_seen_v1/metadata.yaml
@@ -5,6 +5,7 @@ owners:
 - data-platform-infra-wg@mozilla.com
 labels:
   owner1: data-platform-infra-wg
+  legacy: true
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_last_seen_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   dag: bqetl_core
   owner1: ascholtz
   table_type: client_level
+  legacy: true
 scheduling:
   dag_name: bqetl_core
   priority: 70

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_live/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/crash_frames_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/crash_frames_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   schedule: daily
   dag: bqetl_crash
   owner1: dthorn
+  legacy: true
 # scheduling:
 #  dag_name: bqetl_crash
 #  start_date: '2023-12-10'

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/crashes_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/crashes_daily_v1/metadata.yaml
@@ -10,6 +10,7 @@ owners:
 - ascholtz@mozilla.com
 labels:
   incremental: true
+  legacy: true
 scheduling:
   dag_name: bqetl_main_summary
   task_name: crashes_daily_v1

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/deanonymized_events/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/deanonymized_events/metadata.yaml
@@ -6,3 +6,4 @@ owners:
   - frank@mozilla.com
 labels:
   application: firefox
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_cohort_daily_retention_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_cohort_daily_retention_v1/metadata.yaml
@@ -18,6 +18,7 @@ labels:
   table_type: aggregate
   dag: bqetl_analytics_aggregations
   owner1: mhirose
+  legacy: true
 scheduling:
   dag_name: bqetl_analytics_aggregations
   date_partition_parameter: submission_date

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_engagement_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_engagement_clients_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   owner1: kwindau
   table_type: client_level
   dag: bqetl_desktop_engagement_model
+  legacy: true
 scheduling:
   dag_name: bqetl_desktop_engagement_model
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_engagement_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/desktop_engagement_v1/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   shredder_mitigation: true
   table_type: aggregate
   dag: bqetl_desktop_engagement_model
+  legacy: true
 scheduling:
   dag_name: bqetl_desktop_engagement_model
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/devtools_accessiblility_panel_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/devtools_accessiblility_panel_usage_v1/metadata.yaml
@@ -8,6 +8,7 @@ owners:
 labels:
   application: devtools
   schedule: daily
+  legacy: true
 scheduling:
   dag_name: bqetl_devtools
   start_date: "2018-08-01"

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/error_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/error_aggregates/metadata.yaml
@@ -1,0 +1,2 @@
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/error_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/error_aggregates_v1/metadata.yaml
@@ -7,6 +7,7 @@ owners:
   - wkahngreene@mozilla.com
 labels:
   incremental: true
+  legacy: true
 scheduling:
   dag_name: bqetl_error_aggregates
   # This dag runs more frequently than upstream tables, so it can't depend on

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_events_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   owner1: data-platform-infra-wg
   table_type: client_level
+  legacy: true
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_history_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_history_v1/metadata.yaml
@@ -12,6 +12,7 @@ labels:
   schedule: daily
   owner1: wlachance
   owner2: akomar
+  legacy: true
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/event_types_v1/metadata.yaml
@@ -9,4 +9,5 @@ labels:
   schedule: daily
   owner1: wlachance
   owner2: akomar
+  legacy: true
 bigquery: null

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/events_live/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/events_live/metadata.yaml
@@ -3,3 +3,5 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:remote-settings/telescope
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v2/metadata.yaml
@@ -11,6 +11,7 @@ labels:
   incremental: true
   shredder_mitigation: true
   table_type: aggregate
+  legacy: true
 scheduling:
   dag_name: bqetl_main_summary
   task_name: firefox_desktop_exact_mau28_by_dimensions_v2

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_antivirus_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_country_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_bookmarks_by_os_version_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   table_type: aggregate
   shredder_mitigation: true
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_new_profiles_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_new_profiles_by_os_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_page_reloads_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_page_reloads_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_ratios_smooth_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_ratios_smooth_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: kik
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_country_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   incremental: true
   owner1: kik@mozilla.com
   table_type: aggregate
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_vid_plybck_by_os_version_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   incremental: true
   owner1: kik@mozilla.com
   table_type: aggregate
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/fx_health_ind_win_uninstll_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   incremental: true
   owner1: kik@mozilla.com
   table_type: aggregate
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/latest_versions/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/latest_versions/metadata.yaml
@@ -1,1 +1,3 @@
 friendly_name: Latest Versions
+labels:
+  legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_1pct_v1/metadata.yaml
@@ -22,6 +22,7 @@ description: |-
   down to a 0.01% sample. Like sample_id, it ranges from 0 to 99.
 labels:
   incremental: true
+  legacy: true
 owners:
 - jklukas@mozilla.com
 scheduling:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_events_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   owner1: data-platform-infra-wg
   table_type: client_level
+  legacy: true
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_nightly_v1/metadata.yaml
@@ -23,6 +23,7 @@ description: |-
   down to a 0.01% sample. Like sample_id, it ranges from 0 to 99.
 labels:
   incremental: true
+  legacy: true
 owners:
 - jklukas@mozilla.com
 scheduling:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_remainder_1pct_v1/metadata.yaml
@@ -22,6 +22,7 @@ description: |-
   down to a 0.01% sample. Like sample_id, it ranges from 0 to 99.
 labels:
   incremental: true
+  legacy: true
 owners:
 - ascholtz@mozilla.com
 scheduling:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/main_use_counter_1pct_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/main_use_counter_1pct_v1/metadata.yaml
@@ -22,6 +22,7 @@ description: |-
   down to a 0.01% sample. Like sample_id, it ranges from 0 to 99.
 labels:
   incremental: true
+  legacy: true
 owners:
 - ascholtz@mozilla.com
 scheduling:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/network_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/network_usage_v1/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   table_type: aggregate
   shredder_mitigation: true
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_hardware_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/public_data_report_hardware_aggregates_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
 labels:
   incremental: true
   owner1: bewu
+  legacy: true
 bigquery:
   time_partitioning:
     type: day

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_compressed_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_compressed_v2/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   incremental: true
   schedule: daily
   table_type: aggregate
+  legacy: true
 scheduling:
   dag_name: bqetl_gud
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/smoot_usage_desktop_v2/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   table_type: aggregate
   dag: bqetl_gud
   owner1: jklukas
+  legacy: true
 scheduling:
   dag_name: bqetl_gud
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ssl_ratios_v1/metadata.yaml
@@ -12,6 +12,7 @@ labels:
   review_bugs:
     - 1414839
   incremental_export: false
+  legacy: true
 scheduling:
   dag_name: bqetl_ssl_ratios
 monitoring:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_account_signed_in_status_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_account_signed_in_status_v1/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   table_type: aggregate
   shredder_mitigation: true
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_addon_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_addon_v1/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   table_type: aggregate
   shredder_mitigation: true
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_attr_src_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_attr_src_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_browser_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_browser_aggregates_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_channel_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_channel_aggregates_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   table_type: aggregate
   shredder_mitigation: true
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_country_aggregates_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   table_type: aggregate
   shredder_mitigation: true
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_cpu_cores_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_cpu_cores_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   shedder_mitigation: true
   table_type: aggregate
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_day_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_day_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   incremental: true
   owner1: kik
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_default_search_engine_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_default_search_engine_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_default_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_default_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   incremental: true
   owner1: kik
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_distribution_id_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_distribution_id_v1/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   table_type: aggregate
   shredder_mitigation: true
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dlsource_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_dlsource_v1/metadata.yaml
@@ -10,6 +10,7 @@ labels:
   table_type: aggregate
   shredder_mitigation: true
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_isp_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_isp_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   incremental: true
   owner1: kik
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_install_yr_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_install_yr_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   table_type: aggregate
   shredder_mitigation: true
   dag: bqetl_fx_health_ind_dashboard
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_ver_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_by_os_ver_aggregates_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_account_signed_in_status_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_account_signed_in_status_v1/metadata.yaml
@@ -9,6 +9,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_addon_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_addon_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_attr_src_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_attr_src_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_browser_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_browser_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_country_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_country_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_cpu_core_count_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_cpu_core_count_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dflt_srch_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dflt_srch_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dlsource_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_dlsource_v1/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 labels:
   incremental: true
   owner1: kik
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_install_yr_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_install_yr_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_ver_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_on_day_of_install_by_os_ver_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_per_other_installs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_per_other_installs_v1/metadata.yaml
@@ -7,6 +7,7 @@ labels:
   incremental: true
   owner1: kik
   table_type: aggregate
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_relative_to_profile_creation_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/uninstalls_relative_to_profile_creation_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   owner1: kik
   table_type: aggregate
   shredder_mitigation: true
+  legacy: true
 scheduling:
   dag_name: bqetl_fx_health_ind_dashboard
 bigquery:

--- a/sql/moz-fx-glam-prod/glam_etl/latest_versions/metadata.yaml
+++ b/sql/moz-fx-glam-prod/glam_etl/latest_versions/metadata.yaml
@@ -3,3 +3,5 @@ description: |-
   Most recent major release versions per channel.
 owners:
 - efilho@mozilla.com
+labels:
+  legacy: true

--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -368,6 +368,12 @@ def write_view_if_not_exists(
         document_namespace=schema.document_namespace,
         document_type=schema.document_type,
     )
+    labels = {}
+    if schema.bq_dataset_family == "telemetry":
+        # Views over `telemetry_stable` only select from Firefox Desktop
+        # legacy telemetry.
+        labels["legacy"] = True
+
     metadata_file = target_dir / "metadata.yaml"
     should_write_metadata = False
     # append metadata if existing metadata doesn't have name and description
@@ -379,7 +385,11 @@ def write_view_if_not_exists(
                 and "description" not in existing_metadata
             ):
                 should_write_metadata = True
+                if labels:
+                    existing_metadata.setdefault("labels", {}).update(labels)
                 metadata_content = metadata_content + yaml.dump(existing_metadata)
+    elif labels:
+        metadata_content = metadata_content + yaml.dump({"labels": labels})
 
     if not metadata_file.exists() or should_write_metadata:
         with metadata_file.open("w") as f:

--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -369,9 +369,8 @@ def write_view_if_not_exists(
         document_type=schema.document_type,
     )
     labels = {}
+    # Add a `legacy` label to stable views that select from legacy telemetry ping tables.
     if schema.bq_dataset_family == "telemetry":
-        # Views over `telemetry_stable` only select from Firefox Desktop
-        # legacy telemetry.
         labels["legacy"] = True
 
     metadata_file = target_dir / "metadata.yaml"
@@ -380,16 +379,22 @@ def write_view_if_not_exists(
     if metadata_file.exists():
         with metadata_file.open() as f:
             existing_metadata = yaml.load(f, Loader=yaml.FullLoader)
+            if labels:
+                if existing_labels := existing_metadata.get("labels"):
+                    existing_labels.update(labels)
+                else:
+                    existing_metadata["labels"] = labels
             if (
                 "friendly_name" not in existing_metadata
                 and "description" not in existing_metadata
             ):
                 should_write_metadata = True
-                if labels:
-                    existing_metadata.setdefault("labels", {}).update(labels)
-                metadata_content = metadata_content + yaml.dump(existing_metadata)
+                metadata_content += yaml.dump(existing_metadata)
+            elif labels:
+                should_write_metadata = True
+                metadata_content = yaml.dump(existing_metadata)
     elif labels:
-        metadata_content = metadata_content + yaml.dump({"labels": labels})
+        metadata_content += yaml.dump({"labels": labels})
 
     if not metadata_file.exists() or should_write_metadata:
         with metadata_file.open("w") as f:


### PR DESCRIPTION
## Description
To make it easier for both humans and AI agents to identify legacy telemetry views/tables, and help us deprioritize the usage of such views/tables going forward as we're working on sunsetting the legacy telemetry.

## Related Tickets & Documents
* DENG-10445: Metadata Completeness

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
