### PR TITLE
feat(nimbus): move feature monitoring tables to nimbus_feature_monitoring dataset

### DIFF
--- a/sql_generators/nimbus_feature_monitoring/__init__.py
+++ b/sql_generators/nimbus_feature_monitoring/__init__.py
@@ -206,9 +206,7 @@ def generate_queries(project, path, write_dir):
                                         event_name=metric.pop(
                                             "event_name", metric_name
                                         ),
-                                        source_type=source_tables[
-                                            source_name
-                                        ].type,
+                                        source_type=source_tables[source_name].type,
                                         **metric,
                                     )
                                 )

--- a/sql_generators/nimbus_feature_monitoring/__init__.py
+++ b/sql_generators/nimbus_feature_monitoring/__init__.py
@@ -161,6 +161,9 @@ def generate_queries(project, path, write_dir):
     metadata_template = env.get_template("metadata.yaml")
     view_template = env.get_template("view.sql")
     schema = (template_dir / "schema.yaml").read_text()
+    # Accumulate all feature tables across all apps so the single consolidated
+    # view is written once after the loop (not overwritten on each iteration).
+    all_feature_tables = []
     for app_config in ConfigCollection.from_github_repo().featmon_configs:
         dataset = app_config.spec.dataset
         source_tables = {}
@@ -228,7 +231,6 @@ def generate_queries(project, path, write_dir):
                 )
             )
 
-        feature_tables = []
         for feature in features:
             args = {
                 "source_tables": [
@@ -240,7 +242,9 @@ def generate_queries(project, path, write_dir):
             }
 
             feature_name_sql = feature.name.replace("-", "_").lower()
-            table = f"{feature_name_sql}_v1"
+            # Prefix with the app dataset to avoid collisions when multiple apps
+            # define a feature with the same Nimbus slug.
+            table = f"{dataset}_{feature_name_sql}_v1"
             sql_table_name = f"{feature.project}.{feature.dataset}.{table}"
 
             write_sql(
@@ -253,19 +257,19 @@ def generate_queries(project, path, write_dir):
             (write_path / "metadata.yaml").write_text(metadata_template.render(**args))
             (write_path / "schema.yaml").write_text(schema)
 
-            feature_tables.append((feature.name, sql_table_name))
+            all_feature_tables.append((feature.name, sql_table_name))
 
-        # generate view over feature tables
-        view_args = {
-            "feature_tables": feature_tables,
-            "view": f"{project}.nimbus_feature_monitoring.nimbus_feature_monitoring",
-        }
-        write_sql(
-            write_dir / project,
-            view_args["view"],
-            "view.sql",
-            reformat(view_template.render(**view_args)),
-        )
+    # Write a single consolidated view over all apps' feature tables.
+    view_args = {
+        "feature_tables": all_feature_tables,
+        "view": f"{project}.nimbus_feature_monitoring.all_features",
+    }
+    write_sql(
+        write_dir / project,
+        view_args["view"],
+        "view.sql",
+        reformat(view_template.render(**view_args)),
+    )
 
 
 @click.command("generate")

--- a/sql_generators/nimbus_feature_monitoring/__init__.py
+++ b/sql_generators/nimbus_feature_monitoring/__init__.py
@@ -222,7 +222,7 @@ def generate_queries(project, path, write_dir):
                 Feature(
                     name=feat.nimbus_slug(),
                     project=project,
-                    dataset=f"{dataset}_derived",
+                    dataset="nimbus_feature_monitoring",
                     ratios=feat.ratios,
                     metrics_by_source=metrics_by_source,
                 )
@@ -240,7 +240,7 @@ def generate_queries(project, path, write_dir):
             }
 
             feature_name_sql = feature.name.replace("-", "_").lower()
-            table = f"nimbus_feature_monitoring_{feature_name_sql}_v1"
+            table = f"{feature_name_sql}_v1"
             sql_table_name = f"{feature.project}.{feature.dataset}.{table}"
 
             write_sql(
@@ -258,7 +258,7 @@ def generate_queries(project, path, write_dir):
         # generate view over feature tables
         view_args = {
             "feature_tables": feature_tables,
-            "view": f"{project}.{dataset}.nimbus_feature_monitoring",
+            "view": f"{project}.nimbus_feature_monitoring.nimbus_feature_monitoring",
         }
         write_sql(
             write_dir / project,

--- a/tests/sql_generators/nimbus_feature_monitoring/test_generate_queries.py
+++ b/tests/sql_generators/nimbus_feature_monitoring/test_generate_queries.py
@@ -48,6 +48,17 @@ class TestGenerateQueries:
                 "moz-fx-data-shared-prod", BASE_DIR / "templates", tmp_path
             )
 
+    def _query_path(self, tmp_path, slug):
+        """Return the expected query.sql path for a feature with the given slug."""
+        feature_name_sql = slug.replace("-", "_").lower()
+        return (
+            tmp_path
+            / "moz-fx-data-shared-prod"
+            / "nimbus_feature_monitoring"
+            / f"{feature_name_sql}_v1"
+            / "query.sql"
+        )
+
     def test_generates_query_for_metrics_source(self, tmp_path):
         app = make_app_config(
             dataset="firefox_desktop",
@@ -63,13 +74,7 @@ class TestGenerateQueries:
             },
         )
         self._run_generate([app], tmp_path)
-        query = (
-            tmp_path
-            / "moz-fx-data-shared-prod"
-            / "firefox_desktop_derived"
-            / "nimbus_feature_monitoring_my_feature_v1"
-            / "query.sql"
-        )
+        query = self._query_path(tmp_path, "my-feature")
         assert query.exists()
         sql = query.read_text()
         assert "my-feature" in sql
@@ -93,13 +98,7 @@ class TestGenerateQueries:
             },
         )
         self._run_generate([app], tmp_path)
-        query = (
-            tmp_path
-            / "moz-fx-data-shared-prod"
-            / "firefox_desktop_derived"
-            / "nimbus_feature_monitoring_my_feature_v1"
-            / "query.sql"
-        )
+        query = self._query_path(tmp_path, "my_feature")
         assert query.exists()
         sql = query.read_text()
         assert "events_stream" in sql
@@ -119,7 +118,7 @@ class TestGenerateQueries:
         view = (
             tmp_path
             / "moz-fx-data-shared-prod"
-            / "firefox_desktop"
+            / "nimbus_feature_monitoring"
             / "nimbus_feature_monitoring"
             / "view.sql"
         )
@@ -146,13 +145,7 @@ class TestGenerateQueries:
             },
         )
         self._run_generate([app], tmp_path)
-        query = (
-            tmp_path
-            / "moz-fx-data-shared-prod"
-            / "firefox_desktop_derived"
-            / "nimbus_feature_monitoring_my_feature_v1"
-            / "query.sql"
-        )
+        query = self._query_path(tmp_path, "my_feature")
         assert query.exists()
         sql = query.read_text()
         # string ping_aggregator must be COUNT, not SUM (SUM of a string is invalid SQL)
@@ -177,13 +170,7 @@ class TestGenerateQueries:
             },
         )
         self._run_generate([app], tmp_path)
-        query = (
-            tmp_path
-            / "moz-fx-data-shared-prod"
-            / "firefox_desktop_derived"
-            / "nimbus_feature_monitoring_my_feature_v1"
-            / "query.sql"
-        )
+        query = self._query_path(tmp_path, "my_feature")
         sql = query.read_text()
         assert "normalized_channel" in sql
 
@@ -206,13 +193,7 @@ class TestGenerateQueries:
             },
         )
         self._run_generate([app], tmp_path)
-        query = (
-            tmp_path
-            / "moz-fx-data-shared-prod"
-            / "firefox_desktop_derived"
-            / "nimbus_feature_monitoring_my_feature_v1"
-            / "query.sql"
-        )
+        query = self._query_path(tmp_path, "my_feature")
         sql = query.read_text()
         assert "SAFE_DIVIDE" in sql
         assert "numerator_avg" in sql

--- a/tests/sql_generators/nimbus_feature_monitoring/test_generate_queries.py
+++ b/tests/sql_generators/nimbus_feature_monitoring/test_generate_queries.py
@@ -48,14 +48,14 @@ class TestGenerateQueries:
                 "moz-fx-data-shared-prod", BASE_DIR / "templates", tmp_path
             )
 
-    def _query_path(self, tmp_path, slug):
+    def _query_path(self, tmp_path, app_dataset, slug):
         """Return the expected query.sql path for a feature with the given slug."""
         feature_name_sql = slug.replace("-", "_").lower()
         return (
             tmp_path
             / "moz-fx-data-shared-prod"
             / "nimbus_feature_monitoring"
-            / f"{feature_name_sql}_v1"
+            / f"{app_dataset}_{feature_name_sql}_v1"
             / "query.sql"
         )
 
@@ -74,7 +74,7 @@ class TestGenerateQueries:
             },
         )
         self._run_generate([app], tmp_path)
-        query = self._query_path(tmp_path, "my-feature")
+        query = self._query_path(tmp_path, "firefox_desktop", "my-feature")
         assert query.exists()
         sql = query.read_text()
         assert "my-feature" in sql
@@ -98,13 +98,14 @@ class TestGenerateQueries:
             },
         )
         self._run_generate([app], tmp_path)
-        query = self._query_path(tmp_path, "my_feature")
+        query = self._query_path(tmp_path, "firefox_desktop", "my_feature")
         assert query.exists()
         sql = query.read_text()
         assert "events_stream" in sql
         assert "my_category_my_event" in sql
 
-    def test_generates_view_over_all_features(self, tmp_path):
+    def test_generates_single_view_over_all_apps(self, tmp_path):
+        """View is written once after all apps, not overwritten per-app iteration."""
         features = {f"feature_{i}": make_feature_spec(f"feature_{i}") for i in range(3)}
         data_sources = {
             "metrics": make_source_table_spec("metrics", "metrics", "metrics"),
@@ -112,20 +113,30 @@ class TestGenerateQueries:
         for feat in features.values():
             feat.metrics_by_source = {"metrics": {"boolean": {"flag": None}}}
 
-        app = make_app_config("firefox_desktop", data_sources, features)
-        self._run_generate([app], tmp_path)
+        app1 = make_app_config("firefox_desktop", data_sources, features)
+        app2 = make_app_config(
+            "fenix",
+            data_sources,
+            {"fenix_feature": make_feature_spec(
+                "fenix_feature",
+                metrics_by_source={"metrics": {"boolean": {"flag": None}}},
+            )},
+        )
+        self._run_generate([app1, app2], tmp_path)
 
         view = (
             tmp_path
             / "moz-fx-data-shared-prod"
             / "nimbus_feature_monitoring"
-            / "nimbus_feature_monitoring"
+            / "all_features"
             / "view.sql"
         )
         assert view.exists()
         sql = view.read_text()
+        # Both apps' features must appear in the single consolidated view
         for i in range(3):
             assert f"feature_{i}" in sql
+        assert "fenix_feature" in sql
 
     def test_generates_query_for_string_metric(self, tmp_path):
         app = make_app_config(
@@ -145,7 +156,7 @@ class TestGenerateQueries:
             },
         )
         self._run_generate([app], tmp_path)
-        query = self._query_path(tmp_path, "my_feature")
+        query = self._query_path(tmp_path, "firefox_desktop", "my_feature")
         assert query.exists()
         sql = query.read_text()
         # string ping_aggregator must be COUNT, not SUM (SUM of a string is invalid SQL)
@@ -170,7 +181,7 @@ class TestGenerateQueries:
             },
         )
         self._run_generate([app], tmp_path)
-        query = self._query_path(tmp_path, "my_feature")
+        query = self._query_path(tmp_path, "firefox_desktop", "my_feature")
         sql = query.read_text()
         assert "normalized_channel" in sql
 
@@ -193,7 +204,7 @@ class TestGenerateQueries:
             },
         )
         self._run_generate([app], tmp_path)
-        query = self._query_path(tmp_path, "my_feature")
+        query = self._query_path(tmp_path, "firefox_desktop", "my_feature")
         sql = query.read_text()
         assert "SAFE_DIVIDE" in sql
         assert "numerator_avg" in sql

--- a/tests/sql_generators/nimbus_feature_monitoring/test_generate_queries.py
+++ b/tests/sql_generators/nimbus_feature_monitoring/test_generate_queries.py
@@ -117,10 +117,12 @@ class TestGenerateQueries:
         app2 = make_app_config(
             "fenix",
             data_sources,
-            {"fenix_feature": make_feature_spec(
-                "fenix_feature",
-                metrics_by_source={"metrics": {"boolean": {"flag": None}}},
-            )},
+            {
+                "fenix_feature": make_feature_spec(
+                    "fenix_feature",
+                    metrics_by_source={"metrics": {"boolean": {"flag": None}}},
+                )
+            },
         )
         self._run_generate([app1, app2], tmp_path)
 


### PR DESCRIPTION
## Summary

Per @mikewilli's suggestion in #9367, consolidates all feature monitoring tables under a single shared dataset instead of per-app `_derived` datasets, and shortens table names by dropping the redundant `nimbus_feature_monitoring_` prefix.

**Before:**
- `moz-fx-data-shared-prod.firefox_desktop_derived.nimbus_feature_monitoring_urlbar_v1`

**After:**
- `moz-fx-data-shared-prod.nimbus_feature_monitoring.urlbar_v1`

Same change applies to all feature monitoring tables across all apps.