### PR TITLE
backfill(fxci): populate worker cost history (RELOPS-2373)

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci_derived/worker_costs_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/worker_costs_v1/backfill.yaml
@@ -1,3 +1,19 @@
+2026-05-19:
+  start_date: 2026-03-20
+  end_date: 2026-05-17
+  reason: >-
+    RELOPS-2373 - Backfill worker_costs_v1 with the cloud_provider field added
+    for Azure and GCP worker costs in
+    https://github.com/mozilla/bigquery-etl/pull/9315. This source-cost window
+    covers the 30-day lookback needed before recomputing task_run_costs_v1 with
+    the cross-cloud attribution query from
+    https://github.com/mozilla/bigquery-etl/pull/9369 for Looker dashboard 2049.
+  watchers:
+  - jmoss@mozilla.com
+  - ahalberstadt@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+
 2024-10-15:
   start_date: 2024-09-01
   end_date: 2024-10-12


### PR DESCRIPTION
## Description

Initiates a managed backfill for `fxci_derived.worker_costs_v1` from `2026-03-20` through `2026-05-17`.

This is the first production-data step for [RELOPS-2373](https://mozilla-hub.atlassian.net/browse/RELOPS-2373). The goal is to populate historical worker cost rows with the Azure/GCP `cloud_provider` source-cost data needed before recomputing per-task costs for Looker dashboard 2049.

This PR intentionally does **not** backfill `task_run_costs_v1` yet. That backfill reads `worker_costs_v1` from production, so it should wait until this worker-cost backfill finishes, is validated in staging, and is completed/swapped into production.

## Context

Relevant prior work:

- #9315 added Azure worker costs and `cloud_provider` support to `worker_costs_v1`.
- #9368 added `worker_usage_v1` and the stable `fxci.worker_usage` view.
- #9371 initiated the `worker_usage_v1` history backfill.
- #9375 completed the `worker_usage_v1` history backfill.
- #9369 updated `task_run_costs_v1` to emit cross-cloud task attribution fields.

As of the 2026-05-19 Redash checks, `task_runs_v1` has live task data, and `worker_usage_v1` has Azure/GCP usage data. The remaining gap for dashboard 2049 is materialized cost attribution history: source worker costs first, then final task-run costs.

## Rollout

1. Merge this PR to initiate the `worker_costs_v1` managed backfill.
2. Validate the staged `worker_costs_v1` output has non-null `cloud_provider` values for Azure and GCP across the backfill window.
3. Open the follow-up completion PR for this backfill by changing this entry from `Initiate` to `Complete`.
4. After `worker_costs_v1` is complete in production, open the `task_run_costs_v1` backfill PR for the dashboard `Submission Date` window.
5. Validate `fxci.task_run_costs` and Looker dashboard 2049 can split/filter costs by `cloud_provider`.

## Validation

- `./bqetl backfill validate moz-fx-data-shared-prod.fxci_derived.worker_costs_v1`
- `git diff --check`

## Related

- [RELOPS-2373](https://mozilla-hub.atlassian.net/browse/RELOPS-2373)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

[RELOPS-2373]: https://mozilla-hub.atlassian.net/browse/RELOPS-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RELOPS-2373]: https://mozilla-hub.atlassian.net/browse/RELOPS-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ