### PR TITLE
backfill(fxci): complete worker cost history (RELOPS-2373)

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci_derived/worker_costs_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/worker_costs_v1/backfill.yaml
@@ -11,7 +11,7 @@
   watchers:
   - jmoss@mozilla.com
   - ahalberstadt@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
 
 2024-10-15:


### PR DESCRIPTION
## Description

Completes the managed backfill for `fxci_derived.worker_costs_v1` that was initiated by #9389 for `2026-03-20` through `2026-05-17`.

The staged worker-cost table now has non-null `cloud_provider` values for both Azure and GCP across the backfill window. Completing this step swaps the staged worker-cost history into production so the downstream task-cost attribution backfill can be rerun against complete source-cost data for Looker dashboard 2049.

## Validation

Staging table checked: `moz-fx-data-shared-prod.backfills_staging_derived.fxci_derived__worker_costs_v1_2026_05_19`.

Summary from Redash:

- Date window: `2026-03-20` through `2026-05-17`
- Rows: `6,910,463`
- Non-null `cloud_provider` rows: `6,910,463`
- Providers: `azure`, `gcp`

Local validation:

- `./bqetl backfill validate moz-fx-data-shared-prod.fxci_derived.worker_costs_v1`
- `git diff --check`

## Follow-up

Do not complete the existing `task_run_costs_v1` staging output from #9390 as-is. It was initiated before this worker-cost completion, so it should be rerun after this PR completes into production.

## Related

- [RELOPS-2373](https://mozilla-hub.atlassian.net/browse/RELOPS-2373)
- Initiates/completes #9389
- Precedes the corrected `task_run_costs_v1` backfill rerun

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[RELOPS-2373]: https://mozilla-hub.atlassian.net/browse/RELOPS-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ