### PR TITLE
chore(DENG-10738): complete backfill for fenix_derived.metrics_clients_last_seen_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - kbammarito@mozilla.com
   - msun@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR completes the backfill for `fenix_derived.metrics_clients_last_seen_v1`.

## Related Tickets & Documents
* DENG-10738
* https://github.com/mozilla/bigquery-etl/pull/9377

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
