### PR TITLE
Prevent creation of undeletable backfill staging tables

### DIFF
--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -607,6 +607,16 @@ def initiate(
         / ("query.py" if is_python_script else "query.sql")
     )
 
+    client = bigquery.Client(project=project_id)
+
+    if copy_table_permissions:
+        try:
+            client.get_table(qualified_table_name)
+        except NotFound:
+            raise RuntimeError(
+                f"Cannot use --copy-table-permissions since {qualified_table_name} does not exist."
+            )
+
     # create schema before deploying staging table if it does not exist
     schema_path = query_path.parent / SCHEMA_FILE
 
@@ -618,6 +628,23 @@ def initiate(
             sql_dir=sql_dir,
         ).to_yaml_file(schema_path)
         click.echo(f"Schema file created for {qualified_table_name}: {schema_path}")
+
+    def _copy_permissions_with_cleanup():
+        try:
+            copy_permissions_to_staging_table(
+                client,
+                qualified_table_name,
+                backfill_staging_qualified_table_name,
+            )
+        # try to avoid creating an undeletable staging table
+        except Exception as e:
+            client.delete_table(
+                backfill_staging_qualified_table_name, not_found_ok=True
+            )
+            raise RuntimeError(
+                "Failed to copy permissions to staging table, "
+                f"deleted {backfill_staging_qualified_table_name}."
+            ) from e
 
     try:
         deploy_table(
@@ -635,11 +662,7 @@ def initiate(
     else:
         # python script table permissions are applied after the backfill
         if copy_table_permissions and not is_python_script:
-            copy_permissions_to_staging_table(
-                bigquery.Client(project=project_id),
-                qualified_table_name,
-                backfill_staging_qualified_table_name,
-            )
+            _copy_permissions_with_cleanup()
 
     billing_project = DEFAULT_BILLING_PROJECT
 
@@ -650,7 +673,6 @@ def initiate(
         raise ValueError(
             f"Invalid billing project: {billing_project}.  Please use one of the projects assigned to backfills."
         )
-        sys.exit(1)
 
     if not is_python_script or entry_to_initiate.query_script_dry_run_arg:
         click.echo(
@@ -683,11 +705,7 @@ def initiate(
     )
 
     if copy_table_permissions and is_python_script:
-        copy_permissions_to_staging_table(
-            bigquery.Client(project=project_id),
-            qualified_table_name,
-            backfill_staging_qualified_table_name,
-        )
+        _copy_permissions_with_cleanup()
 
     click.echo(
         f"Processed backfill for {qualified_table_name} with entry date {entry_to_initiate.entry_date}"

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -615,7 +615,7 @@ def initiate(
         except NotFound:
             raise RuntimeError(
                 f"Cannot use --copy-table-permissions since {qualified_table_name} does not exist."
-            )
+            ) from None
 
     # create schema before deploying staging table if it does not exist
     schema_path = query_path.parent / SCHEMA_FILE
@@ -630,20 +630,29 @@ def initiate(
         click.echo(f"Schema file created for {qualified_table_name}: {schema_path}")
 
     def _copy_permissions_with_cleanup():
+        """Copy permissions from prod table and delete the staging table if it fails."""
         try:
             copy_permissions_to_staging_table(
                 client,
                 qualified_table_name,
                 backfill_staging_qualified_table_name,
             )
-        # try to avoid creating an undeletable staging table
         except Exception as e:
-            client.delete_table(
-                backfill_staging_qualified_table_name, not_found_ok=True
-            )
+            try:
+                client.delete_table(
+                    backfill_staging_qualified_table_name, not_found_ok=True
+                )
+                cleanup_msg = f"deleted {backfill_staging_qualified_table_name}"
+            except Exception as delete_exc:
+                click.echo(
+                    f"Failed to delete {backfill_staging_qualified_table_name}: {delete_exc}"
+                )
+                cleanup_msg = (
+                    f"failed to delete {backfill_staging_qualified_table_name}, "
+                    "manual cleanup required"
+                )
             raise RuntimeError(
-                "Failed to copy permissions to staging table, "
-                f"deleted {backfill_staging_qualified_table_name}."
+                f"Failed to copy permissions to staging table, {cleanup_msg}."
             ) from e
 
     try:

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -1943,12 +1943,19 @@ class TestBackfill:
         mock_copy_perms,
         runner,
     ):
+        prod_table = "moz-fx-data-shared-prod.test.test_query_v1"
         staging_table = "moz-fx-data-shared-prod.backfills_staging_derived.test__test_query_v1_2021_05_03"
-        mock_client().get_table.side_effect = [
-            NotFound("staging table not found"),  # _should_initiate check
-            None,  # prod table check
-        ]
-        mock_copy_perms.side_effect = Exception("IAM policy denied")
+
+        def get_table(name, *args, **kwargs):
+            if name == staging_table:
+                raise NotFound("staging table not found")
+            if name == prod_table:
+                return MagicMock()
+            raise AssertionError(f"unexpected get_table call: {name}")
+
+        mock_client().get_table.side_effect = get_table
+        permissions_error = Exception("IAM policy denied")
+        mock_copy_perms.side_effect = permissions_error
 
         backfill_file = Path(QUERY_DIR) / BACKFILL_FILE
         backfill_file.write_text("""
@@ -1972,6 +1979,7 @@ class TestBackfill:
 
         assert result.exit_code == 1
         assert "Failed to copy permissions" in str(result.exception)
+        assert result.exception.__cause__ is permissions_error
         mock_client().delete_table.assert_called_with(staging_table, not_found_ok=True)
 
     @patch("google.cloud.bigquery.Client")

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -1900,6 +1900,80 @@ class TestBackfill:
         assert result.exit_code == 1
         assert "Backfill initiate failed to deploy" in str(result.exception)
 
+    @patch("bigquery_etl.cli.backfill.deploy_table")
+    @patch("google.cloud.bigquery.Client")
+    def test_initiate_with_copy_permissions_fails_if_prod_table_missing(
+        self, mock_client, mock_deploy_table, runner
+    ):
+        mock_client().get_table.side_effect = NotFound("prod table not found")
+
+        backfill_file = Path(QUERY_DIR) / BACKFILL_FILE
+        backfill_file.write_text("""
+        2021-05-03:
+          start_date: 2021-01-03
+          end_date: 2021-01-08
+          reason: test_reason
+          watchers:
+          - test@example.org
+          status: Initiate
+        """)
+
+        result = runner.invoke(
+            initiate,
+            [
+                "moz-fx-data-shared-prod.test.test_query_v1",
+                "--copy-table-permissions",
+                "--parallelism=0",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Cannot use --copy-table-permissions" in str(result.exception)
+        mock_deploy_table.assert_not_called()
+
+    @patch("bigquery_etl.cli.backfill.copy_permissions_to_staging_table")
+    @patch("bigquery_etl.cli.backfill.deploy_table")
+    @patch("bigquery_etl.cli.backfill.Schema.from_query_file")
+    @patch("google.cloud.bigquery.Client")
+    def test_initiate_cleans_up_staging_on_permissions_failure(
+        self,
+        mock_client,
+        mock_from_query_file,
+        mock_deploy_table,
+        mock_copy_perms,
+        runner,
+    ):
+        staging_table = "moz-fx-data-shared-prod.backfills_staging_derived.test__test_query_v1_2021_05_03"
+        mock_client().get_table.side_effect = [
+            NotFound("staging table not found"),  # _should_initiate check
+            None,  # prod table check
+        ]
+        mock_copy_perms.side_effect = Exception("IAM policy denied")
+
+        backfill_file = Path(QUERY_DIR) / BACKFILL_FILE
+        backfill_file.write_text("""
+        2021-05-03:
+          start_date: 2021-01-03
+          end_date: 2021-01-08
+          reason: test_reason
+          watchers:
+          - test@example.org
+          status: Initiate
+        """)
+
+        result = runner.invoke(
+            initiate,
+            [
+                "moz-fx-data-shared-prod.test.test_query_v1",
+                "--copy-table-permissions",
+                "--parallelism=0",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Failed to copy permissions" in str(result.exception)
+        mock_client().delete_table.assert_called_with(staging_table, not_found_ok=True)
+
     @patch("google.cloud.bigquery.Client")
     def test_initiate_partitioned_backfill_with_invalid_billing_project_from_entry_should_fail(
         self, mock_client, runner


### PR DESCRIPTION
## Description

fixes a regression from https://github.com/mozilla/bigquery-etl/pull/9303 where if permission copying fails (e.g. prod table hasn't been deployed yet), we end up with a staging table that we can't delete ourselves.

## Related Tickets & Documents
* DENG-4042

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
