### PR TITLE
feat(nimbus): add application column to all_features view

### DIFF
--- a/sql_generators/nimbus_feature_monitoring/__init__.py
+++ b/sql_generators/nimbus_feature_monitoring/__init__.py
@@ -255,7 +255,7 @@ def generate_queries(project, path, write_dir):
             (write_path / "metadata.yaml").write_text(metadata_template.render(**args))
             (write_path / "schema.yaml").write_text(schema)
 
-            all_feature_tables.append((feature.name, sql_table_name))
+            all_feature_tables.append((feature.name, dataset, sql_table_name))
 
     # Write a single consolidated view over all apps' feature tables.
     view_args = {

--- a/sql_generators/nimbus_feature_monitoring/templates/nimbus_feature_monitoring_v1/view.sql
+++ b/sql_generators/nimbus_feature_monitoring/templates/nimbus_feature_monitoring_v1/view.sql
@@ -2,11 +2,11 @@ CREATE OR REPLACE VIEW
   `{{ view }}`
 AS
 (
-  {% for feature, app_dataset, sql_table_name in feature_tables %}
+  {% for feature, application, sql_table_name in feature_tables %}
     SELECT
       *,
       '{{ feature }}' AS feature,
-      '{{ app_dataset }}' AS application,
+      '{{ application }}' AS application,
     FROM
       `{{ sql_table_name }}`
     {{ "UNION ALL" if not loop.last }}

--- a/sql_generators/nimbus_feature_monitoring/templates/nimbus_feature_monitoring_v1/view.sql
+++ b/sql_generators/nimbus_feature_monitoring/templates/nimbus_feature_monitoring_v1/view.sql
@@ -2,10 +2,11 @@ CREATE OR REPLACE VIEW
   `{{ view }}`
 AS
 (
-  {% for feature, sql_table_name in feature_tables %}
+  {% for feature, app_dataset, sql_table_name in feature_tables %}
     SELECT
       *,
       '{{ feature }}' AS feature,
+      '{{ app_dataset }}' AS application,
     FROM
       `{{ sql_table_name }}`
     {{ "UNION ALL" if not loop.last }}

--- a/tests/sql_generators/nimbus_feature_monitoring/test_generate_queries.py
+++ b/tests/sql_generators/nimbus_feature_monitoring/test_generate_queries.py
@@ -139,6 +139,9 @@ class TestGenerateQueries:
         for i in range(3):
             assert f"feature_{i}" in sql
         assert "fenix_feature" in sql
+        # Each app should appear as the application literal in the view
+        assert "firefox_desktop" in sql
+        assert "fenix" in sql
 
     def test_generates_query_for_string_metric(self, tmp_path):
         app = make_app_config(

--- a/tests/sql_generators/nimbus_feature_monitoring/test_generate_queries.py
+++ b/tests/sql_generators/nimbus_feature_monitoring/test_generate_queries.py
@@ -139,9 +139,9 @@ class TestGenerateQueries:
         for i in range(3):
             assert f"feature_{i}" in sql
         assert "fenix_feature" in sql
-        # Each app should appear as the application literal in the view
-        assert "firefox_desktop" in sql
-        assert "fenix" in sql
+        # Verify the application column literal is emitted for each app
+        assert "'firefox_desktop' AS application" in sql
+        assert "'fenix' AS application" in sql
 
     def test_generates_query_for_string_metric(self, tmp_path):
         app = make_app_config(


### PR DESCRIPTION
## Summary
- Adds `'${app_dataset}' AS application` to each SELECT in the consolidated `all_features` view
- Enables Grafana dashboard to filter by application (e.g. `firefox_desktop`, `fenix`) as more apps are onboarded
- Updates `__init__.py` to pass `(feature_name, dataset, sql_table_name)` tuples to the view template
- Adds test assertions to verify app literals appear in the generated view SQL