### PR TITLE
backfill(fxci): rerun task run cost history (RELOPS-2373)

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci_derived/task_run_costs_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/task_run_costs_v1/backfill.yaml
@@ -1,14 +1,16 @@
-2026-05-19:
+2026-05-20:
   start_date: 2026-04-19
   end_date: 2026-05-17
   reason: >-
     RELOPS-2373 - Recompute task_run_costs_v1 with the cross-cloud attribution
     query from https://github.com/mozilla/bigquery-etl/pull/9369 so Looker
-    dashboard 2049 can show Azure and GCP task costs for the 30-day Submission
-    Date window. This depends on the worker_costs_v1 history backfill from
-    https://github.com/mozilla/bigquery-etl/pull/9389 being completed into
-    production first, because task_run_costs_v1 reads worker_costs_v1 through a
-    30-day lookback window.
+    dashboard 2049 can show Azure and GCP task costs for the 30-day
+    Submission Date window. This reruns the task-cost backfill after the
+    worker_costs_v1 history backfill from
+    https://github.com/mozilla/bigquery-etl/pull/9392 was completed into
+    production. The earlier 2026-05-19 task_run_costs_v1 staging output was
+    generated before worker_costs_v1 production history was swapped, so it
+    should not be completed.
   watchers:
   - jmoss@mozilla.com
   - ahalberstadt@mozilla.com


### PR DESCRIPTION
## Description

Re-initiates the managed backfill for `fxci_derived.task_run_costs_v1` from `2026-04-19` through `2026-05-17` using a fresh `2026-05-20` backfill entry.

This supersedes the earlier `2026-05-19` task-run-cost staging output from #9390. That staging table was generated before #9392 completed `worker_costs_v1` into production, so it should not be completed.

Now that #9392 has swapped the Azure/GCP `worker_costs_v1` history into production, this rerun should recompute task-level costs with non-null `cloud_provider` values across the full dashboard window.

## Current production state

Validated after #9392:

- `fxci.worker_costs` from `2026-03-20` through `2026-05-17`: all `6,910,463` rows have non-null `cloud_provider`; providers are `azure` and `gcp`.
- `fxci.task_run_costs` from `2026-04-19` through `2026-05-17`: `0` rows currently have non-null `cloud_provider`, so this rerun is still needed for Looker dashboard 2049.

## Validation

- `TZ=UTC ./bqetl backfill validate moz-fx-data-shared-prod.fxci_derived.task_run_costs_v1`
- `git diff --check`

Note: local validation used `TZ=UTC` because the entry date is `2026-05-20`; DataOps/GitHub are already operating on UTC May 20 while my local shell was still EDT May 19.

## Follow-up

After DataOps reports the new `task_run_costs_v1` staging table is done, validate that the new staging output has non-null `cloud_provider` rows for both Azure and GCP across the full backfill window. If it validates, open the final completion PR for this backfill.

## Related

- [RELOPS-2373](https://mozilla-hub.atlassian.net/browse/RELOPS-2373)
- Supersedes the task-run-cost staging output from #9390
- Depends on completed worker-cost swap from #9392

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[RELOPS-2373]: https://mozilla-hub.atlassian.net/browse/RELOPS-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ