### PR TITLE
fix(nimbus): add dataset_metadata.yaml for nimbus_feature_monitoring

### DIFF
--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/dataset_metadata.yaml
@@ -1,6 +1,8 @@
 friendly_name: Nimbus Feature Monitoring
 description: |-
-  Derived tables for monitoring the rollout of Nimbus features.
+  Aggregate tables for monitoring the rollout of Nimbus features.
+  Populated by the sql_generators/nimbus_feature_monitoring generator
+  via the bqetl_nimbus_feature_monitoring DAG (daily).
 dataset_base_acl: derived
 user_facing: true
 labels: {}

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/dataset_metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: Nimbus Feature Monitoring
 description: |-
   Derived tables for monitoring the rollout of Nimbus features.
 dataset_base_acl: derived
-user_facing: false
+user_facing: true
 labels: {}
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/dataset_metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Nimbus Feature Monitoring
+description: |-
+  Derived tables for monitoring the rollout of Nimbus features.
+dataset_base_acl: derived
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential/data-viewers


### PR DESCRIPTION
## Summary

- Adds the missing `dataset_metadata.yaml` for the `nimbus_feature_monitoring` BigQuery dataset
- Without this file bigquery-etl never creates the dataset, causing **every** task in `bqetl_nimbus_feature_monitoring` to fail with:
  ```
  Not found: Dataset moz-fx-data-shared-prod:nimbus_feature_monitoring was not found in location US
  ```
- The dataset was moved from `firefox_desktop_derived` to `nimbus_feature_monitoring` in #9388, but no `dataset_metadata.yaml` was included in that PR
