### PR TITLE
Keep hidden files in stage deploy artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -588,7 +588,6 @@ jobs:
         with:
           name: staged-generated-sql
           path: /tmp/workspace/staged-generated-sql
-          include-hidden-files: true
 
   dry-run-sql:
     name: Dry Run SQL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -588,6 +588,7 @@ jobs:
         with:
           name: staged-generated-sql
           path: /tmp/workspace/staged-generated-sql
+          include-hidden-files: true
 
   dry-run-sql:
     name: Dry Run SQL

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ generated_docs/
 generated-sql/
 
 # ignore target deployment manifests
-**/.bqetl_target_info.yaml
+**/bqetl_target_info.yaml
 
 # ignore local dev target deployments
 sql/*-sandbox/

--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -186,7 +186,7 @@ class DryRun:
 
         # Stage deploys rewrite every artifact's path, so a prod-side skip
         # entry no longer matches the file's stage path. Reverse the mapping
-        # via each stage dir's .bqetl_target_info.yaml manifest (written by
+        # via each stage dir's bqetl_target_info.yaml manifest (written by
         # prepare_target_directory) — layout-independent, so any future
         # bqetl_targets.yaml rename scheme still works.
         #

--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -47,7 +47,7 @@ MATERIALIZED_VIEW = "materialized_view.sql"
 
 ROOT = Path(__file__).parent.parent.parent
 
-MANIFEST_FILENAME = ".bqetl_target_info.yaml"
+MANIFEST_FILENAME = "bqetl_target_info.yaml"
 DEFAULT_TARGETS_FILENAME = "bqetl_targets.yaml"
 
 

--- a/tests/test_dryrun.py
+++ b/tests/test_dryrun.py
@@ -359,7 +359,7 @@ class TestDryRun:
         # to the source-side skip pattern.
         stage_dir = sql_dir / test_project / "any_dataset" / "any_table_dir"
         stage_dir.mkdir(parents=True)
-        (stage_dir / ".bqetl_target_info.yaml").write_text(
+        (stage_dir / "bqetl_target_info.yaml").write_text(
             yaml.dump(
                 {
                     "source_project": "src-proj",


### PR DESCRIPTION
## Description

Add `include-hidden-files: true` to the `staged-generated-sql` upload artifact step. The `.bqetl_target_info.yaml` manifest files (dotfiles) were silently excluded by upload-artifact v4+, which defaults to omitting hidden files. Without them, the dryrun job can't map stage paths back to the skip list, causing skip-listed queries to fail dryrun in CI. See https://github.com/mozilla/bigquery-etl/actions/runs/26177369598/job/77011766034?pr=9402

Tested in https://github.com/mozilla/bigquery-etl/actions/runs/26179373260/job/77018731680?pr=9408

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
