### PR TITLE
Attempt to cache gcloud creds in backfill

### DIFF
--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -888,6 +888,11 @@ def backfill(
         )
 
     if not depends_on_past and parallelism > 1:
+        # Attempt to populate the gcloud credential store before running the parallel queries below
+        subprocess.check_call(
+            ["bq", "query", "--use_legacy_sql=false", "--dry_run", "SELECT 1"]
+        )
+
         # run backfill for dates in parallel if depends_on_past is false
         failed_backfills = []
         with futures.ThreadPoolExecutor(max_workers=parallelism) as executor:

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -889,9 +889,15 @@ def backfill(
 
     if not depends_on_past and parallelism > 1:
         # Attempt to populate the gcloud credential store before running the parallel queries below
-        subprocess.check_call(
-            ["bq", "query", "--use_legacy_sql=false", "--dry_run", "SELECT 1"]
-        )
+        auth_init_args = ["bq", "query", "--use_legacy_sql=false", "--dry_run"]
+        auth_init_project = billing_project or project_id
+        if auth_init_project is not None:
+            auth_init_args.append(f"--project_id={auth_init_project}")
+        auth_init_args.append("SELECT 1")
+        try:
+            subprocess.check_call(auth_init_args, stdout=subprocess.DEVNULL)
+        except subprocess.CalledProcessError as e:
+            click.echo(f"Credential init failed, continuing anyway: {e}", err=True)
 
         # run backfill for dates in parallel if depends_on_past is false
         failed_backfills = []


### PR DESCRIPTION
## Description

This is an attempt to fix a rare issue where backfills fail early in the dry run stage with an error like 
```
ERROR: (bq) You do not currently have an active account selected.
Please run:
  $ gcloud auth login
to obtain new credentials.
If you have already logged in with a different account, run:
  $ gcloud config set account ACCOUNT
to select an already authenticated account to use.
Backfill run: 2026-03-10 Destination_table: moz-fx-data-shared-prod.backfills_staging_derived.firefox_desktop_derived__urlbar_events_v2_2026_05_19$20260310 Scheduling Parameters: ['--parameter=submission_date:DATE:2026-03-10']
Encountered exception Command '['bq', 'query', '--use_legacy_sql=false', '--replace', '--max_rows=100', '--project_id=moz-fx-data-shared-prod', '--format=none', '--parameter=submission_date:DATE:2026-03-03', '--dry_run', '--project_id=moz-fx-data-backfill-slots', '--destination_table=moz-fx-data-shared-prod:backfills_staging_derived.firefox_desktop_derived__urlbar_events_v2_2026_05_19$20260303'...
```
([example task](https://workflow.telemetry.mozilla.org/dags/bqetl_backfill_initiate/grid?dag_run_id=scheduled__2026-05-19T18%3A00%3A00%2B00%3A00&task_id=initiate_backfill.process_backfill&tab=mapped_tasks&map_index=0))

This always fails early on. I'm not sure that this is the issue but I'm guessing it's due to  multiple threads (16) all running `bq query` at the same time, causing some write concurrency issue when writing the auth to `gcloud/credentials.db`.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
