### PR TITLE
fix: Add clustering field to pr_embeddings_v1 load function to fix airflow failure

### DIFF
--- a/sql/moz-fx-data-shared-prod/github_derived/pr_embeddings_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/github_derived/pr_embeddings_v1/query.py
@@ -141,6 +141,7 @@ def load_to_bq(client, records, destination):
             type_=bigquery.TimePartitioningType.DAY,
             field="merged_date",
         ),
+        clustering_fields=["repo_name"],
     )
     job = client.load_table_from_json(records, destination, job_config=job_config)
     job.result()


### PR DESCRIPTION
## Description

The load_to_bq function was missing clustering_fields=["repo_name"] in the LoadJobConfig, causing Airflow to fail. 

## Related Tickets & Documents
* DENG-11156


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
