### PR TITLE
feat(DENG-11153): Create Metric for # of Solved Posts

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_forum_metrics_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_forum_metrics_daily_v1/query.sql
@@ -74,6 +74,8 @@ questions AS (
     q.locale,
     ttfr.first_reply_date,
     ttfr.ttfr_mins,
+    COALESCE(q.is_solved, FALSE) AS is_solved,
+    DATE(q.solved_date) AS solved_date,
     COALESCE(hv.total_helpful_votes, 0) AS total_helpful_votes,
     COALESCE(hv.total_unhelpful_votes, 0) AS total_unhelpful_votes
   FROM
@@ -92,10 +94,12 @@ questions AS (
 SELECT
   created_date,
   first_reply_date,
+  solved_date,
   product,
   locale,
   COUNT(*) AS questions_created,
   COUNTIF(first_reply_date IS NOT NULL) AS questions_replied,
+  COUNTIF(is_solved) AS questions_solved,
   AVG(ttfr_mins / 60.0) AS avg_ttfr_hrs,
   SUM(ttfr_mins / 60.0) AS total_ttfr_hrs,
   SUM(total_helpful_votes) AS total_helpful_votes,
@@ -108,10 +112,12 @@ WHERE
 GROUP BY
   created_date,
   first_reply_date,
+  solved_date,
   product,
   locale
 ORDER BY
   created_date,
   first_reply_date,
+  solved_date,
   product,
   locale

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_forum_metrics_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_forum_metrics_daily_v1/schema.yaml
@@ -40,16 +40,16 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: |
-    Number of non-spam, non-locked Firefox questions created on `created_date`
-    for this product and locale (counted within each first_reply_date bucket).
+    Number of non-spam, non-locked Firefox questions in this
+    (created_date, first_reply_date, solved_date, product, locale) bucket.
 - name: questions_replied
   type: INTEGER
   mode: NULLABLE
   description: |
-    Number of questions in this (created_date, first_reply_date, product,
-    locale) bucket that received a qualifying first reply. A qualifying reply
-    excludes OP self-replies, spam answers, and answers from deactivated
-    users. To get replies-per-day, aggregate by first_reply_date.
+    Number of questions in this (created_date, first_reply_date, solved_date,
+    product, locale) bucket that received a qualifying first reply. A
+    qualifying reply excludes OP self-replies, spam answers, and answers from
+    deactivated users. To get replies-per-day, aggregate by first_reply_date.
     Reply Rate:
       SUM(questions_replied) / SUM(questions_created)
 - name: questions_solved
@@ -59,7 +59,15 @@ fields:
     Number of questions in this (created_date, first_reply_date, solved_date,
     product, locale) bucket that have been marked as solved, as of ETL run
     time. To get solves-per-day, aggregate by solved_date.
-    Solved Rate:
+
+    Note: this column is NOT stable across ETL runs — `is_solved` reflects
+    current solved state, so `questions_solved` for a given `created_date`
+    will increase over time as historical questions are solved. When
+    aggregated by `created_date`, the formula below yields a *cumulative*
+    solved rate (share of questions created on that date that are solved
+    as of the latest ETL run), not a same-day solved rate. For a
+    solve-date-aligned view, aggregate by `solved_date` instead.
+    Solved Rate (cumulative, by created_date):
       SUM(questions_solved) / SUM(questions_created)
 - name: avg_ttfr_hrs
   type: FLOAT

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_forum_metrics_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_forum_metrics_daily_v1/schema.yaml
@@ -13,6 +13,13 @@ fields:
     OP self-replies, spam answers, and answers from deactivated users). NULL
     for questions that have not received a qualifying reply. Use this column
     to aggregate questions_replied by reply date.
+- name: solved_date
+  type: DATE
+  mode: NULLABLE
+  description: |
+    The UTC date the question was marked as solved. NULL for questions that
+    are not solved. Use this column to aggregate questions_solved by solve
+    date.
 - name: product
   type: STRING
   mode: NULLABLE
@@ -45,6 +52,15 @@ fields:
     users. To get replies-per-day, aggregate by first_reply_date.
     Reply Rate:
       SUM(questions_replied) / SUM(questions_created)
+- name: questions_solved
+  type: INTEGER
+  mode: NULLABLE
+  description: |
+    Number of questions in this (created_date, first_reply_date, solved_date,
+    product, locale) bucket that have been marked as solved, as of ETL run
+    time. To get solves-per-day, aggregate by solved_date.
+    Solved Rate:
+      SUM(questions_solved) / SUM(questions_created)
 - name: avg_ttfr_hrs
   type: FLOAT
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_forum_kpis/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_forum_kpis/view.sql
@@ -4,10 +4,12 @@ AS
 SELECT
   created_date,
   first_reply_date,
+  solved_date,
   product,
   locale,
   questions_created,
   questions_replied,
+  questions_solved,
   avg_ttfr_hrs,
   total_ttfr_hrs,
   total_helpful_votes,


### PR DESCRIPTION
## Description

Adds `questions_solved` and `solved_date` to the daily SUMO forum metrics table so dashboards can track solved questions and compute solved rate.

`query.sql`: pulls `is_solved` / `solved_date` from `kitsune_questions_plus`, adds `solved_date` to the grain, and emits `COUNTIF(is_solved) AS questions_solved`.
`schema.yaml`: documents the two new fields and the solved-rate formula `SUM(questions_solved) / SUM(questions_created)`.
`view.sql`: surfaces both new columns through the `sumo_forum_kpis` view.

Following the table's existing convention, the rate is computed downstream from daily counts so rollups stay properly weighted (same pattern as reply rate and helpfulness).

## Validation

Compared the modified query against the original at git HEAD. Columns validated: `questions_created`, `questions_replied`, `total_helpful_votes`, `total_unhelpful_votes`.

| Check | Result |
|---|---|
| Row counts | new: 103,599 / orig: 72,253 — expected mismatch (finer grain from added `solved_date`) |
| Schema | `bqetl query validate` OK; `schema.yaml` correctly adds `solved_date` and `questions_solved` |
| Statistical profile | All four columns' SUMs match exactly; 0 nulls in both queries |

**SUM totals (all match):**
- questions_created: 572,990
- questions_replied: 417,730
- total_helpful_votes: 667,718
- total_unhelpful_votes: 708,060

The change is a clean re-partition: adding `solved_date` to the GROUP BY splits existing buckets into finer ones without double-counting or losing rows. Per-bucket avg/max are lower in the new query (e.g., `total_helpful_votes` max 6,879 → 5,356) purely because each bucket now holds a smaller slice of the same totals — this is the expected and correct behavior.

<details>
<summary>Validation SQL</summary>

```sql
-- =======================================================================
-- DENG-11153 Validation SQL
-- Query: sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_forum_metrics_daily_v1/query.sql
-- Compared against: original query at HEAD (git)
-- Date: 2026-05-21
-- Columns validated: questions_created, questions_replied, total_helpful_votes, total_unhelpful_votes
-- =======================================================================

-- -----------------------------------------------------------------------
-- CHECK 1: Row Counts (new vs original)
-- -----------------------------------------------------------------------
WITH new_query AS (
  <contents of working-tree query.sql>
),
orig_query AS (
  <contents of HEAD query.sql>
)
SELECT 'new_query' AS source, COUNT(*) AS row_count FROM new_query
UNION ALL
SELECT 'orig_query' AS source, COUNT(*) AS row_count FROM orig_query;

-- Result:
--   orig_query: 72,253 rows
--   new_query:  103,599 rows
-- Note: row count increase is expected because solved_date was added to the
-- GROUP BY, producing a finer-grained breakdown.

-- -----------------------------------------------------------------------
-- CHECK 2: Schema validation (bqetl query validate)
-- -----------------------------------------------------------------------
-- ./bqetl query validate sumo_metrics_derived.kitsune_forum_metrics_daily_v1
-- Result: OK (4.18s) - schema.yaml matches query output columns including
-- newly added solved_date (DATE) and questions_solved (INTEGER).

-- -----------------------------------------------------------------------
-- CHECK 3: Statistical Profile for the 4 target columns
-- -----------------------------------------------------------------------
WITH new_query AS (
  <contents of working-tree query.sql>
),
orig_query AS (
  <contents of HEAD query.sql>
)
SELECT 'new_query' AS source,
  COUNT(*) AS total_rows,
  SUM(questions_created)     AS sum_qc, MIN(questions_created) AS min_qc,
  MAX(questions_created)     AS max_qc, AVG(questions_created) AS avg_qc,
  COUNTIF(questions_created IS NULL) AS null_qc,
  SUM(questions_replied)     AS sum_qr, MIN(questions_replied) AS min_qr,
  MAX(questions_replied)     AS max_qr, AVG(questions_replied) AS avg_qr,
  COUNTIF(questions_replied IS NULL) AS null_qr,
  SUM(total_helpful_votes)   AS sum_hv, MIN(total_helpful_votes) AS min_hv,
  MAX(total_helpful_votes)   AS max_hv, AVG(total_helpful_votes) AS avg_hv,
  COUNTIF(total_helpful_votes IS NULL) AS null_hv,
  SUM(total_unhelpful_votes) AS sum_uv, MIN(total_unhelpful_votes) AS min_uv,
  MAX(total_unhelpful_votes) AS max_uv, AVG(total_unhelpful_votes) AS avg_uv,
  COUNTIF(total_unhelpful_votes IS NULL) AS null_uv
FROM new_query
UNION ALL
SELECT 'orig_query',
  COUNT(*),
  SUM(questions_created),   MIN(questions_created),   MAX(questions_created),   AVG(questions_created),   COUNTIF(questions_created IS NULL),
  SUM(questions_replied),   MIN(questions_replied),   MAX(questions_replied),   AVG(questions_replied),   COUNTIF(questions_replied IS NULL),
  SUM(total_helpful_votes), MIN(total_helpful_votes), MAX(total_helpful_votes), AVG(total_helpful_votes), COUNTIF(total_helpful_votes IS NULL),
  SUM(total_unhelpful_votes), MIN(total_unhelpful_votes), MAX(total_unhelpful_votes), AVG(total_unhelpful_votes), COUNTIF(total_unhelpful_votes IS NULL)
FROM orig_query;

-- Results:
-- Column                  | orig SUM | new SUM  | match? | orig avg  | new avg   | orig max | new max
-- questions_created       | 572,990  | 572,990  | YES    | 7.930     | 5.531     | 864      | 864
-- questions_replied       | 417,730  | 417,730  | YES    | 5.781     | 4.032     | 489      | 437
-- total_helpful_votes     | 667,718  | 667,718  | YES    | 9.241     | 6.445     | 6,879    | 5,356
-- total_unhelpful_votes   | 708,060  | 708,060  | YES    | 9.800     | 6.835     | 2,266    | 1,831
-- Nulls: 0 across all columns in both queries.
-- All SUMs match exactly — adding solved_date redistributes the same totals
-- across more buckets. Per-bucket avg/max are lower in new_query because of
-- the finer grain, which is the expected behavior.
```

</details>

## Related Tickets & Documents
* DENG-11153
