### PR TITLE
backfill(fxci): complete task run cost history

### DIFF
--- a/sql/moz-fx-data-shared-prod/fxci_derived/task_run_costs_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fxci_derived/task_run_costs_v1/backfill.yaml
@@ -14,5 +14,5 @@
   watchers:
   - jmoss@mozilla.com
   - ahalberstadt@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false


### PR DESCRIPTION
## Description

Completes the managed backfill for `fxci_derived.task_run_costs_v1` by changing the 2026-05-20 backfill entry from `Initiate` to `Complete`. This swaps the staged task-level cost attribution data into production for `2026-04-19` through `2026-05-17`.

## Context

The initial rerun backfill was added in #9401 after #9369 landed the cross-cloud task cost attribution query and #9392 completed `worker_costs_v1` into production. This completion step should make Looker dashboard 2049 able to show Azure and GCP task costs for the 30-day Submission Date window.

Staging location from the backfill completion notification: `moz-fx-data-shared-prod.backfills_staging_derived.fxci_derived__task_run_costs_v1_2026_05_20`.

## Validation

- `TZ=UTC ./bqetl backfill validate moz-fx-data-shared-prod.fxci_derived.task_run_costs_v1`
- `yamllint -c .yamllint.yaml sql/moz-fx-data-shared-prod/fxci_derived/task_run_costs_v1/backfill.yaml`
- Redash validation of staging coverage for `2026-04-19` through `2026-05-17`:
  - `azure`: 29 days, 940,634 rows, 913,656 tasks, total run cost 39,825.49
  - `gcp`: 29 days, 3,503,866 rows, 3,368,840 tasks, total run cost 56,831.25
- Redash staging quality check found 0 missing `cloud_provider`, 0 missing `worker_instance_id`, 0 missing `run_cost`, 0 negative `run_cost`, 0 missing `attribution_worker_cost`, and 0 invalid `attribution_worker_uptime` rows for both providers.
- Zero-duration task runs are present and map to zero cost: 291 Azure rows and 950 GCP rows; no negative durations.
- Current production check for the same window still has only `cloud_provider = NULL`, confirming the completion swap is still needed.

## Related

- Completes #9401
- [RELOPS-2373](https://mozilla-hub.atlassian.net/browse/RELOPS-2373)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

[RELOPS-2373]: https://mozilla-hub.atlassian.net/browse/RELOPS-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ