### PR TITLE
feat(nimbus): complete backfill for firefox_desktop nimbus feature monitoring tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_aboutwelcome_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_aboutwelcome_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_address_autofill_feature_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_address_autofill_feature_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_backgroundtaskmessage_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_backgroundtaskmessage_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_featurecallout_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_featurecallout_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_bmb_button_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_bmb_button_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_16_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_16_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_1_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_1_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_20_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_20_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_21_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_21_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_22_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_22_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_7_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_fxms_message_7_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_infobar_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_infobar_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabadsizingexperiment_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabadsizingexperiment_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabinferredpersonalization_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabinferredpersonalization_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabmerinoohttp_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabmerinoohttp_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabprivateping_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabprivateping_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabpromocard_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabpromocard_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabsectionsexperiment_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabsectionsexperiment_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabsponsoredcontent_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabsponsoredcontent_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabtrainhop_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabtrainhop_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabtrainhopaddon_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_newtabtrainhopaddon_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_pocketnewtab_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_pocketnewtab_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_preonboarding_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_preonboarding_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_urlbar_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/nimbus_feature_monitoring/firefox_desktop_urlbar_v1/backfill.yaml
@@ -3,8 +3,8 @@
   end_date: 2026-05-19
   reason: New table, initial backfill.
   watchers:
-  - yashika.khurana@mozilla.com
-  status: Initiate
+  - ykhurana@mozilla.com
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Summary

- Marks all 24 `firefox_desktop` nimbus feature monitoring backfills as `Complete`
- Corrects watcher email from `yashika.khurana@mozilla.com` → `ykhurana@mozilla.com`

## Validation

Spot-checked `firefox_desktop_newtabsponsoredcontent_v1` staging table:
- Date range: 2025-11-14 → 2026-05-19 ✅
- Row count: 447,885,100 ✅
- Distinct dates: 187 (full coverage) ✅
- Distinct metrics: 20 ✅

All 24 tables received Slack confirmation from airflow-bot that backfill processing is done.