### PR TITLE
Fixes for stage deploy: skip on empty diff, fix render skip-list for stage paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -569,16 +569,22 @@ jobs:
           SKIP_STAGE_DEPLOYS: ${{ github.event.inputs.skip-stage-deploys }}
           GOOGLE_GHA_ID_TOKEN: ${{ steps.auth-dryrun.outputs.id_token }}
         run: |
-          if [ "$SKIP_STAGE_DEPLOYS" != "true" ]; then
-            PATHS="$(git diff --no-index --name-only --diff-filter=d generated-sql/sql sql)" || true
-            echo $PATHS
-            git diff --no-index --diff-filter=d generated-sql/sql sql | head -1000 || true
-            PATH=".venv/bin:$PATH" script/bqetl \
-              --target stage \
-              --run-id "${GITHUB_RUN_ID}" \
-              deploy --tables --views --isolated \
-              $PATHS
+          if [ "$SKIP_STAGE_DEPLOYS" = "true" ]; then
+            echo "SKIP_STAGE_DEPLOYS=true, skipping stage deploy"
+            exit 0
           fi
+          PATHS="$(git diff --no-index --name-only --diff-filter=d generated-sql/sql sql)" || true
+          if [ -z "$PATHS" ]; then
+            echo "No changed SQL paths, skipping stage deploy"
+            exit 0
+          fi
+          echo "$PATHS"
+          git diff --no-index --diff-filter=d generated-sql/sql sql | head -1000 || true
+          PATH=".venv/bin:$PATH" script/bqetl \
+            --target stage \
+            --run-id "${GITHUB_RUN_ID}" \
+            deploy --tables --views --isolated \
+            $PATHS
       - name: Copy generated SQL to temporary stage directory
         run: |
           mkdir -p /tmp/workspace/staged-generated-sql

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -578,7 +578,7 @@ jobs:
             echo "No changed SQL paths, skipping stage deploy"
             exit 0
           fi
-          echo "$PATHS"
+          echo $PATHS
           git diff --no-index --diff-filter=d generated-sql/sql sql | head -1000 || true
           PATH=".venv/bin:$PATH" script/bqetl \
             --target stage \

--- a/bigquery_etl/util/common.py
+++ b/bigquery_etl/util/common.py
@@ -1,5 +1,6 @@
 """Generic utility functions."""
 
+import fnmatch
 import glob
 import logging
 import os
@@ -16,12 +17,14 @@ from uuid import uuid4
 
 import click
 import sqlglot
+import yaml
 from google.cloud import bigquery
 from jinja2 import Environment, FileSystemLoader
 
 from bigquery_etl.config import BQETL_PROJECT_CONFIG, ConfigLoader
 from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.metrics import MetricHub
+from bigquery_etl.util.target import MANIFEST_FILENAME
 
 # Search for all camelCase situations in reverse with arbitrary lookaheads.
 REV_WORD_BOUND_PAT = re.compile(
@@ -123,20 +126,23 @@ def render(
         )
     }
     test_project = ConfigLoader.get("default", "test_project")
-    sql_dir = ConfigLoader.get("default", "sql_dir", fallback="sql")
+    if test_project and test_project in str(path):
 
-    if test_project in str(path):
-        # check if staged file needs to be skipped
-        skip.update(
-            [
-                p
-                for f in [Path(s) for s in skip]
-                for p in glob.glob(
-                    f"{sql_dir}/{test_project}/{f.parent.parent.name}*/{f.parent.name}/{f.name}",
-                    recursive=True,
+        manifest_path = template_folder_path / MANIFEST_FILENAME
+        if manifest_path.is_file():
+            try:
+                manifest = yaml.safe_load(manifest_path.read_text()) or {}
+            except Exception:
+                manifest = {}
+            src_proj = manifest.get("source_project")
+            src_ds = manifest.get("source_dataset")
+            src_table = manifest.get("source_table")
+            if src_proj and src_ds and src_table:
+                source_equivalent = (
+                    f"sql/{src_proj}/{src_ds}/{src_table}/{sql_filename}"
                 )
-            ]
-        )
+                if any(fnmatch.fnmatchcase(source_equivalent, s) for s in skip):
+                    skip.add(str(path))
 
     if any(s in str(path) for s in skip):
         rendered = path.read_text()

--- a/bigquery_etl/util/common.py
+++ b/bigquery_etl/util/common.py
@@ -24,7 +24,6 @@ from jinja2 import Environment, FileSystemLoader
 from bigquery_etl.config import BQETL_PROJECT_CONFIG, ConfigLoader
 from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.metrics import MetricHub
-from bigquery_etl.util.target import MANIFEST_FILENAME
 
 # Search for all camelCase situations in reverse with arbitrary lookaheads.
 REV_WORD_BOUND_PAT = re.compile(
@@ -127,6 +126,7 @@ def render(
     }
     test_project = ConfigLoader.get("default", "test_project")
     if test_project and test_project in str(path):
+        from bigquery_etl.util.target import MANIFEST_FILENAME
 
         manifest_path = template_folder_path / MANIFEST_FILENAME
         if manifest_path.is_file():

--- a/bigquery_etl/util/common.py
+++ b/bigquery_etl/util/common.py
@@ -116,23 +116,28 @@ def render(
     """Render a given template query using Jinja."""
     template_folder_path = Path(template_folder)
     path = template_folder_path / sql_filename
+    skip_patterns = ConfigLoader.get("render", "skip", fallback=[])
     skip = {
         file
-        for skip in ConfigLoader.get("render", "skip", fallback=[])
+        for pat in skip_patterns
         for file in glob.glob(
-            skip,
+            pat,
             recursive=True,
         )
     }
     test_project = ConfigLoader.get("default", "test_project")
-    if test_project and test_project in str(path):
+    if test_project and f"/{test_project}/" in str(path):
         from bigquery_etl.util.target import MANIFEST_FILENAME
 
         manifest_path = template_folder_path / MANIFEST_FILENAME
         if manifest_path.is_file():
             try:
                 manifest = yaml.safe_load(manifest_path.read_text()) or {}
-            except Exception:
+            except (yaml.YAMLError, OSError) as e:
+                click.echo(
+                    f"Warning: could not read manifest {manifest_path}: {e}",
+                    err=True,
+                )
                 manifest = {}
             src_proj = manifest.get("source_project")
             src_ds = manifest.get("source_dataset")
@@ -141,7 +146,9 @@ def render(
                 source_equivalent = (
                     f"sql/{src_proj}/{src_ds}/{src_table}/{sql_filename}"
                 )
-                if any(fnmatch.fnmatchcase(source_equivalent, s) for s in skip):
+                if any(
+                    fnmatch.fnmatchcase(source_equivalent, pat) for pat in skip_patterns
+                ):
                     skip.add(str(path))
 
     if any(s in str(path) for s in skip):


### PR DESCRIPTION
## Description

This PR fixes 2 things I noticed:
* Skip stage deploy when no SQL files changed. 
* Fix Jinja2 render skip-list for stage paths. The old glob-based expansion assumed a specific stage directory layout that no longer matches the `artifact_prefix` naming scheme. Replace with manifest-based lookup (same approach as the dryrun skip-list fix in #9398) 


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
