### PR TITLE
fix: stop _strip_materialized_view regex from matching 'as' inside identifiers

### DIFF
--- a/bigquery_etl/cli/deploy.py
+++ b/bigquery_etl/cli/deploy.py
@@ -566,8 +566,13 @@ def _strip_materialized_view(target_file: Path) -> Path:
     materialized views can't be recreated without source data access.
     """
     sql_content = target_file.read_text()
+    # \bAS\b — match the keyword, not the substring "as" inside identifiers.
+    # Under --isolated the staged FQN is rewritten to embed the source dataset
+    # name (e.g. `..._firefox_crashreporter_derived__...`), and with
+    # IGNORECASE + non-greedy .*? a bare `AS` would match the "as" in "crash"
+    # and chop the identifier.
     sql_content = re.sub(
-        r"CREATE\s+MATERIALIZED\s+VIEW.*?AS",
+        r"CREATE\s+MATERIALIZED\s+VIEW.*?\bAS\b",
         "",
         sql_content,
         flags=re.DOTALL | re.IGNORECASE,

--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -266,13 +266,13 @@ class DryRun:
             raise ValueError(f"Invalid file path: {self.sqlfile}")
         if self.strip_dml:
             sql = re.sub(
-                "CREATE OR REPLACE VIEW.*?AS",
+                r"CREATE OR REPLACE VIEW.*?\bAS\b",
                 "",
                 sql,
                 flags=re.DOTALL,
             )
             sql = re.sub(
-                "CREATE MATERIALIZED VIEW.*?AS",
+                r"CREATE MATERIALIZED VIEW.*?\bAS\b",
                 "",
                 sql,
                 flags=re.DOTALL,

--- a/tests/util/test_target.py
+++ b/tests/util/test_target.py
@@ -762,6 +762,32 @@ class TestStripMaterializedView:
         assert "CREATE MATERIALIZED VIEW" not in new_path.read_text()
         assert "SELECT a, b FROM" in new_path.read_text()
 
+    def test_strips_when_identifier_contains_as_substring(self, tmp_path):
+        # Regression: under --isolated the staged FQN embeds the source
+        # dataset name, which can contain the substring "as" (e.g.
+        # `firefox_crashreporter_derived`, `..._tasks_derived`). The strip
+        # regex must match `AS` as a keyword, not as a substring inside the
+        # backticked identifier.
+        from bigquery_etl.cli.deploy import _strip_materialized_view
+
+        mv_dir = tmp_path / "p" / "ds" / "tbl"
+        mv_dir.mkdir(parents=True)
+        mv_file = mv_dir / "materialized_view.sql"
+        mv_file.write_text(
+            "CREATE MATERIALIZED VIEW "
+            "`moz-fx-data-integration-tests`.`test_schema`."
+            "`moz_fx_data_shared_prod__firefox_crashreporter_derived"
+            "__event_monitoring_live_v1`\n"
+            "OPTIONS(refresh_interval_minutes=10) AS\n"
+            "SELECT a, b FROM `p.other.tbl`"
+        )
+        new_path = _strip_materialized_view(mv_file)
+        body = new_path.read_text()
+        assert "CREATE MATERIALIZED VIEW" not in body
+        # Identifier must NOT have been chopped at the "as" in "crash".
+        assert "hreporter_derived" not in body
+        assert body.lstrip().startswith("SELECT a, b FROM")
+
 
 class TestRewriteTestsForTarget:
     def test_renames_files_in_target_subtree(self, tmp_path):


### PR DESCRIPTION
Should fix dry run failure in https://github.com/mozilla/bigquery-etl/pull/9421.

The strip regex in deploy.py used `.*?AS` with re.IGNORECASE, which matched the first 'as' substring, including the one inside source dataset names like `firefox_crashreporter_derived` or `..._tasks_derived`.
This chopped the identifier mid-name and produced unparseable SQL.

This PR makes the regex use `\bAS\b` so only the keyword matches, aligns the sibling patterns in dryrun.py, and adds a regression test.