### PR TITLE
cancel existing backfill and initiate a new one

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_v2/backfill.yaml
@@ -1,3 +1,15 @@
+2026-05-22:
+  start_date: 2026-02-22
+  end_date: 2026-05-22
+  reason: Backfill new fields added in DENG-10722, PR 9246
+  watchers:
+    - kbammarito@mozilla.com
+    - nflorez@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false
 2026-05-19:
   start_date: 2026-02-22
   end_date: 2026-05-19
@@ -5,7 +17,7 @@
   watchers:
     - kbammarito@mozilla.com
     - nflorez@mozilla.com
-  status: Initiate
+  status: Cancelled
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR cancels the existing backfill and initiates a new one from the same date.
## Related Tickets & Documents
* DENG-10722
* https://github.com/mozilla/bigquery-etl/pull/9370

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
