### PR TITLE
[SVCSE-4447] Stop generating stable views for coverage

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -560,6 +560,7 @@ generate:
     - org_mozilla_tiktokreporter
     - regrets_reporter_ucs
     - org_mozilla_ios_tiktok_reporter_tiktok_reportershare
+    - coverage
     skip_tables:
       telemetry:
       - modules


### PR DESCRIPTION
## Description
The `coverage` ping is being deprecated. This is to stop stable view generations

## Related Tickets & Documents
* SVCSE-4447

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
