### PR TITLE
Create placeholder field in empty target deploy schemas

### DIFF
--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -581,6 +581,18 @@ def default_partition_for(dataset: str) -> Optional[str]:
     return None
 
 
+_PLACEHOLDER_STUB_SCHEMA = {
+    "fields": [
+        {
+            "name": "_bqetl_stub_placeholder",
+            "type": "STRING",
+            "mode": "NULLABLE",
+            "description": "Placeholder for a stub table when schema can't be fetched",
+        }
+    ]
+}
+
+
 def _fetch_stub_schema(
     project: str,
     dataset: str,
@@ -593,31 +605,41 @@ def _fetch_stub_schema(
 
     Tries `client.get_table` first (fast, works on partition-required tables),
     falls back to `Schema.for_table`'s dry-run for cases where the source
-    table doesn't exist yet. Logs both errors when both fail.
+    table doesn't exist yet. If both fail, an error is logged and a placeholder
+    schema is created so downstream `SELECT *` views can still be created in stage.
     """
     get_table_err: Optional[Exception] = None
     try:
         bq_table = bigquery.Client(project=project).get_table(
             f"{project}.{dataset}.{name}"
         )
-        Schema.from_bigquery_schema(bq_table.schema).to_yaml_file(out_path)
-        return
+        if bq_table.schema:
+            Schema.from_bigquery_schema(bq_table.schema).to_yaml_file(out_path)
+            return
     except Exception as e:
         get_table_err = e
 
+    for_table_err: Optional[Exception] = None
     try:
-        Schema.for_table(
+        schema = Schema.for_table(
             project=project,
             dataset=dataset,
             table=name,
             id_token=id_token,
             partitioned_by=resolve_partition_for(sql_dir, project, dataset, name),
-        ).to_yaml_file(out_path)
-    except Exception as for_table_err:
-        print(
-            f"Warning: Could not fetch schema for {project}.{dataset}.{name}: "
-            f"get_table: {get_table_err}; dry-run: {for_table_err}"
         )
+        if schema.schema.get("fields"):
+            schema.to_yaml_file(out_path)
+            return
+    except Exception as e:
+        for_table_err = e
+
+    print(
+        f"Warning: Could not fetch schema for {project}.{dataset}.{name}: "
+        f"get_table: {get_table_err}; dry-run: {for_table_err}. "
+        f"Writing placeholder schema for stage deploy."
+    )
+    Schema(_PLACEHOLDER_STUB_SCHEMA).to_yaml_file(out_path)
 
 
 def _create_target_stub(

--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -581,16 +581,18 @@ def default_partition_for(dataset: str) -> Optional[str]:
     return None
 
 
-_PLACEHOLDER_STUB_SCHEMA = {
-    "fields": [
-        {
-            "name": "_bqetl_stub_placeholder",
-            "type": "STRING",
-            "mode": "NULLABLE",
-            "description": "Placeholder for a stub table when schema can't be fetched",
-        }
-    ]
-}
+def _placeholder_stub_schema() -> Dict[str, List]:
+    """Build a single-field placeholder schema for stub tables."""
+    return {
+        "fields": [
+            {
+                "name": "_bqetl_stub_placeholder",
+                "type": "STRING",
+                "mode": "NULLABLE",
+                "description": "Placeholder for a stub table when schema can't be fetched",
+            }
+        ]
+    }
 
 
 def _fetch_stub_schema(
@@ -605,8 +607,9 @@ def _fetch_stub_schema(
 
     Tries `client.get_table` first (fast, works on partition-required tables),
     falls back to `Schema.for_table`'s dry-run for cases where the source
-    table doesn't exist yet. If both fail, an error is logged and a placeholder
-    schema is created so downstream `SELECT *` views can still be created in stage.
+    table doesn't exist yet. If both fail to produce a non-empty schema, a
+    single-field placeholder is written so downstream `SELECT *` stage views can
+    still be created. Downstream artifacts that reference specific columns will still fail.
     """
     get_table_err: Optional[Exception] = None
     try:
@@ -619,27 +622,25 @@ def _fetch_stub_schema(
     except Exception as e:
         get_table_err = e
 
-    for_table_err: Optional[Exception] = None
-    try:
-        schema = Schema.for_table(
-            project=project,
-            dataset=dataset,
-            table=name,
-            id_token=id_token,
-            partitioned_by=resolve_partition_for(sql_dir, project, dataset, name),
-        )
-        if schema.schema.get("fields"):
-            schema.to_yaml_file(out_path)
-            return
-    except Exception as e:
-        for_table_err = e
+    # Schema.for_table catches its own exceptions and returns {"fields": []} on failure
+    schema = Schema.for_table(
+        project=project,
+        dataset=dataset,
+        table=name,
+        id_token=id_token,
+        partitioned_by=resolve_partition_for(sql_dir, project, dataset, name),
+    )
+    if schema.schema.get("fields"):
+        schema.to_yaml_file(out_path)
+        return
 
     print(
-        f"Warning: Could not fetch schema for {project}.{dataset}.{name}: "
-        f"get_table: {get_table_err}; dry-run: {for_table_err}. "
-        f"Writing placeholder schema for stage deploy."
+        f"Warning: Could not fetch schema for {project}.{dataset}.{name} "
+        f"(get_table: {get_table_err}; dry-run returned no fields, see stdout "
+        "above for the underlying dry-run error). Writing single-field "
+        "placeholder schema for stage deploy."
     )
-    Schema(_PLACEHOLDER_STUB_SCHEMA).to_yaml_file(out_path)
+    Schema(_placeholder_stub_schema()).to_yaml_file(out_path)
 
 
 def _create_target_stub(

--- a/sql/moz-fx-data-shared-prod/telemetry/buildhub2/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/buildhub2/view.sql
@@ -4,7 +4,6 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.buildhub2`
 AS
--- test
 SELECT
   *
 FROM

--- a/sql/moz-fx-data-shared-prod/telemetry/buildhub2/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/buildhub2/view.sql
@@ -4,6 +4,7 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.telemetry.buildhub2`
 AS
+-- test
 SELECT
   *
 FROM

--- a/tests/util/test_target.py
+++ b/tests/util/test_target.py
@@ -744,6 +744,34 @@ class TestCollectTargetDependencies:
         mock_fetch_schema.assert_not_called()
 
 
+class TestFetchStubSchema:
+    """
+    When both get_table and dry run fail to get a schema, the stub table should fall back
+    to a placeholder so downstream `SELECT *` views can still be created in stage.
+    """
+
+    @patch("bigquery_etl.util.target.Schema.for_table")
+    @patch("bigquery_etl.util.target.bigquery.Client")
+    def test_placeholder_written_when_schema_inaccesible(
+        self, mock_client, mock_for_table, tmp_path
+    ):
+        """Placeholder schema should be created when get_table and dry run fail."""
+        from bigquery_etl.util.target import _fetch_stub_schema
+
+        mock_client.return_value.get_table.side_effect = PermissionError("403")
+        mock_for_table.return_value.schema = {"fields": []}
+
+        out_path = tmp_path / "schema.yaml"
+        _fetch_stub_schema(
+            "src-proj", "src_ds", "src_tbl", out_path, id_token="t", sql_dir="sql"
+        )
+
+        assert out_path.exists()
+        written = yaml.safe_load(out_path.read_text())
+        assert written["fields"], "placeholder schema must have at least one field"
+        assert written["fields"][0]["name"] == "_bqetl_stub_placeholder"
+
+
 class TestStripMaterializedView:
     def test_strips_create_clause(self, tmp_path):
         from bigquery_etl.cli.deploy import _strip_materialized_view

--- a/tests/util/test_target.py
+++ b/tests/util/test_target.py
@@ -752,10 +752,10 @@ class TestFetchStubSchema:
 
     @patch("bigquery_etl.util.target.Schema.for_table")
     @patch("bigquery_etl.util.target.bigquery.Client")
-    def test_placeholder_written_when_schema_inaccesible(
+    def test_placeholder_written_when_schema_inaccessible(
         self, mock_client, mock_for_table, tmp_path
     ):
-        """Placeholder schema should be created when get_table and dry run fail."""
+        """Placeholder schema should be created when get_table raises and dry run is empty."""
         from bigquery_etl.util.target import _fetch_stub_schema
 
         mock_client.return_value.get_table.side_effect = PermissionError("403")
@@ -769,6 +769,25 @@ class TestFetchStubSchema:
         assert out_path.exists()
         written = yaml.safe_load(out_path.read_text())
         assert written["fields"], "placeholder schema must have at least one field"
+        assert written["fields"][0]["name"] == "_bqetl_stub_placeholder"
+
+    @patch("bigquery_etl.util.target.Schema.for_table")
+    @patch("bigquery_etl.util.target.bigquery.Client")
+    def test_placeholder_written_when_get_table_returns_empty_schema(
+        self, mock_client, mock_for_table, tmp_path
+    ):
+        """get_table on a table that has no columns should fall through to the dry run path."""
+        from bigquery_etl.util.target import _fetch_stub_schema
+
+        mock_client.return_value.get_table.return_value.schema = []
+        mock_for_table.return_value.schema = {"fields": []}
+
+        out_path = tmp_path / "schema.yaml"
+        _fetch_stub_schema(
+            "src-proj", "src_ds", "src_tbl", out_path, id_token="t", sql_dir="sql"
+        )
+
+        written = yaml.safe_load(out_path.read_text())
         assert written["fields"][0]["name"] == "_bqetl_stub_placeholder"
 
 


### PR DESCRIPTION
## Description

For target deploys, empty schemas (`fields: []`) are being created when the dry run to get schemas fails.  The empty schema causes issues since the downstream tables and views can't query it. Example failed run: https://github.com/mozilla/bigquery-etl/actions/runs/26305494345/job/77442626593?pr=9429. This is blocking #9429 

Creating a schema with one field allows at least `SELECT *` views to work. I think this hasn't come up before because there are very few cases where it would fail and they haven't been edited so they didn't get stage deployed. `buildhub2` is one example that I used as a test failure: https://github.com/mozilla/bigquery-etl/actions/runs/26310264998/job/77457419956

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
