### PR TITLE
chore(DENG-10722): complete backfill for urlbar_events_v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_v2/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
     - kbammarito@mozilla.com
     - nflorez@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR completes the backfill for `urlbar_events_v2` from `2026-02-22` onward.

## Related Tickets & Documents
* DENG-10722
* https://github.com/mozilla/bigquery-etl/pull/9426

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
