### PR TITLE
DENG-11155 - Newtab Widget aggregation table Update

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_v1/README.md
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_v1/README.md
@@ -1,6 +1,6 @@
 # Newtab Widgets Daily
 
-Daily aggregation of Firefox New Tab widget telemetry at one row per widget per day,
+Daily aggregation of Firefox New Tab widget telemetry at one row per widget per day per app version per channel per os per country per locale,
 covering impressions, user interactions, enable/disable actions, and engagement metrics
 derived from the unified widget telemetry shape in `newtab_v1`.
 
@@ -10,11 +10,11 @@ derived from the unified widget telemetry shape in `newtab_v1`.
 
 | | |
 |---|---|
-| **Grain** | One row per `(submission_date, widget_name)` |
+| **Grain** | One row per `(submission_date, app_version, os, channel, country, locale, widget_name)` |
 | **Source** | `moz-fx-data-shared-prod.firefox_desktop_stable.newtab_v1` |
 | **DAG** | `bqetl_newtab` · daily · incremental |
 | **Partitioning** | `submission_date` *(partition filter required)* |
-| **Clustering** | `widget_name` |
+| **Clustering** | `widget_name`, `channel`, `country` |
 | **Retention** | No expiration (aggregate table) |
 | **Owner** | gkatre@mozilla.com |
 | **Version** | v1 (initial version) |
@@ -28,7 +28,7 @@ derived from the unified widget telemetry shape in `newtab_v1`.
 ```mermaid
 flowchart TD
   A[Firefox Desktop Newtab Ping<br/>`firefox_desktop_stable.newtab_v1`] -->|filter @submission_date<br/>UNNEST events · widget events only<br/>GROUP BY widget_name| B[**This query**]
-  B --> C[Partitioned table<br/>time: `submission_date`<br/>cluster: `widget_name`]
+  B --> C[Partitioned table<br/>time: `submission_date`<br/>cluster: `widget_name`, `channel`, `country`]
 ```
 
 ---
@@ -37,7 +37,7 @@ flowchart TD
 
 1. **Input** — `newtab_v1` has one row per Glean ping; each ping contains a repeated `events` array.
 2. **Unnest** — Events are unnested and filtered to widget event types: `widgets_impression`, `widgets_user_event`, and `widgets_enabled`. Rows where `widget_name` is null are excluded.
-3. **Aggregation** — Metrics are computed per `(submission_date, widget_name)` using `COUNTIF` for event-level counts and `COUNT(DISTINCT client_id)` for engaged clients.
+3. **Aggregation** — Metrics are computed per `(submission_date, app_version, os, channel, country, locale, widget_name)` using `COUNTIF` for event-level counts and `COUNT(DISTINCT client_id)` for engaged clients.
 4. **User action breakdown** — A separate CTE computes per-widget `user_action` counts and aggregates them into a repeated `STRUCT<action, count>` array (`widget_user_action_counts`), ordered by `action`, joined back to the main aggregation.
 5. **Data inclusion** — All widget events from the stable table are included; no bot or synthetic client exclusions are applied at this layer.
 
@@ -51,13 +51,15 @@ flowchart TD
 |---|---|
 | Date | `submission_date` |
 | Widget | `widget_name` |
+| App | `app_version`, `channel` |
+| Client | `os`, `locale`, `country` |
 
 ### Metrics
 
 | Category | Fields |
 |---|---|
 | Reach | `widget_impression_count`, `widget_engaged_clients` |
-| Enablement | `widget_{enabled\|disabled}_count` |
+| Enablement | `widget_{enabled\|disabled}_count`, `widget_enabled_clients` |
 | Interaction | `widget_user_event_count`, `widget_link_click_count` |
 | Feature usage | `widget_{setting_change\|utility_action\|optin_accept}_count` |
 | Detail | `widget_user_action_counts` *(repeated `STRUCT<action, count>`)* |
@@ -102,7 +104,7 @@ SELECT
   SAFE_DIVIDE(SUM(widget_user_event_count), SUM(widget_impression_count)) AS interaction_rate,
   SAFE_DIVIDE(SUM(widget_utility_action_count), SUM(widget_user_event_count)) AS utility_rate
 FROM `moz-fx-data-shared-prod.firefox_desktop_derived.newtab_widgets_daily_v1`
-WHERE submission_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+WHERE submission_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY) AND country = 'US'
 GROUP BY 1, 2
 ORDER BY 1 DESC, impressions DESC;
 ```

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_v1/checks.sql
@@ -9,7 +9,7 @@
 -- grain so downstream aggregations stay correct if the GROUP BY ever changes.
 
 #fail
-{{ is_unique(["submission_date", "widget_name"], "submission_date = @submission_date") }}
+{{ is_unique(["submission_date", "app_version", "os", "channel", "country", "locale", "widget_name"], "submission_date = @submission_date") }}
 --
 --
 -- Defensive guard: query.sql filters out null widget_name, so this should never fire;

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_v1/metadata.yaml
@@ -1,9 +1,7 @@
 friendly_name: Newtab Widgets Daily
 description: |-
-  Daily aggregation of Firefox New Tab widget telemetry.
-  One row per widget per day, capturing impressions, user interactions,
-  enable/disable actions, and engagement metrics derived from the unified
-  widget telemetry shape in newtab_v1.
+  A daily aggregation of newtab actions on widgets (example: impressions, usage actions, clicks, etc...)
+  for Firefox desktop, partitioned by day.
 owners:
   - gkatre@mozilla.com
 labels:
@@ -26,3 +24,5 @@ bigquery:
   clustering:
     fields:
       - widget_name
+      - channel
+      - country

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_v1/query.sql
@@ -1,6 +1,13 @@
 WITH widget_events AS (
   SELECT
     DATE(submission_timestamp) AS submission_date,
+    SAFE_CAST(
+      mozfun.norm.browser_version_info(client_info.app_display_version).major_version AS INT64
+    ) AS app_version,
+    normalized_os AS os,
+    normalized_channel AS channel,
+    client_info.locale AS locale,
+    normalized_country_code AS country,
     client_info.client_id AS client_id,
     event.name AS event_name,
     mozfun.map.get_key(event.extra, 'widget_name') AS widget_name,
@@ -18,6 +25,11 @@ WITH widget_events AS (
 aggregated AS (
   SELECT
     submission_date,
+    app_version,
+    os,
+    channel,
+    locale,
+    country,
     widget_name,
     COUNT(
       DISTINCT IF(event_name IN ('widgets_user_event', 'widgets_enabled'), client_id, NULL)
@@ -33,19 +45,30 @@ aggregated AS (
     COUNTIF(
       event_name = 'widgets_user_event'
       AND user_action IN (
+        'change_hour_format',
         'change_location',
+        'change_size',
         'change_temperature_units',
         'change_weather_display',
-        'detect_location'
+        'collapse',
+        'detect_location',
+        'expand'
       )
     ) AS widget_setting_change_count,
     COUNTIF(
       event_name = 'widgets_user_event'
       AND user_action IN (
+        'add_clock',
+        'add_nickname',
+        'edit_clock',
+        'follow_teams',
         'list_copy',
         'list_create',
         'list_delete',
         'list_edit',
+        'open_match_search',
+        'remove_clock',
+        'save_teams',
         'task_complete',
         'task_create',
         'task_delete',
@@ -53,9 +76,14 @@ aggregated AS (
         'timer_end',
         'timer_pause',
         'timer_play',
+        'timer_reset',
         'timer_set',
+        'timer_toggle_break',
         'timer_toggle_focus',
-        'timer_toggle_play'
+        'timer_toggle_play',
+        'view_key_dates',
+        'view_schedule',
+        'view_upcoming'
       )
     ) AS widget_utility_action_count,
     COUNTIF(
@@ -66,11 +94,21 @@ aggregated AS (
     widget_events
   GROUP BY
     submission_date,
+    app_version,
+    os,
+    channel,
+    locale,
+    country,
     widget_name
 ),
 user_action_array AS (
   SELECT
     submission_date,
+    app_version,
+    os,
+    channel,
+    locale,
+    country,
     widget_name,
     ARRAY_AGG(
       STRUCT(user_action AS action, action_count AS count)
@@ -81,6 +119,11 @@ user_action_array AS (
     (
       SELECT
         submission_date,
+        app_version,
+        os,
+        channel,
+        locale,
+        country,
         widget_name,
         user_action,
         COUNT(*) AS action_count,
@@ -91,16 +134,46 @@ user_action_array AS (
         AND user_action IS NOT NULL
       GROUP BY
         submission_date,
+        app_version,
+        os,
+        channel,
+        locale,
+        country,
         widget_name,
         user_action
     )
   GROUP BY
     submission_date,
+    app_version,
+    os,
+    channel,
+    locale,
+    country,
     widget_name
+),
+enabled_users_aggregate AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    SAFE_CAST(
+      mozfun.norm.browser_version_info(client_info.app_display_version).major_version AS INT64
+    ) AS app_version,
+    normalized_os AS os,
+    normalized_channel AS channel,
+    client_info.locale AS locale,
+    normalized_country_code AS country,
+    widget AS widget_name,
+    COUNT(DISTINCT client_info.client_id) AS widget_enabled_clients
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_stable.newtab_v1`,
+    UNNEST(metrics.string_list.newtab_widgets_enabled_list) AS widget
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+    AND NULLIF(widget, '') IS NOT NULL
 )
 SELECT
-  agg.submission_date,
-  agg.widget_name,
+  submission_date,
+  widget_name,
+  eua.widget_enabled_clients,
   agg.widget_engaged_clients,
   agg.widget_enabled_count,
   agg.widget_disabled_count,
@@ -115,4 +188,7 @@ FROM
   aggregated AS agg
 LEFT JOIN
   user_action_array AS uaa
-  USING (submission_date, widget_name)
+  USING (submission_date, widget_name, app_version, os, channel, locale, country)
+LEFT JOIN
+  enabled_users_aggregate AS eua
+  USING (submission_date, widget_name, app_version, os, channel, locale, country)

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_v1/schema.yaml
@@ -3,6 +3,27 @@ fields:
   type: DATE
   mode: NULLABLE
   description: Date the widget telemetry was recorded, derived from submission_timestamp.
+- name: app_version
+  type: INTEGER
+  mode: NULLABLE
+  description: User visible version string (e.g. "1.0.3") for the browser.
+- name: os
+  type: STRING
+  mode: NULLABLE
+  description: Set to "Other" if this message contained an unrecognized OS name.
+- name: channel
+  type: STRING
+  mode: NULLABLE
+  description: The normalized channel the application is being distributed on.
+- name: locale
+  type: STRING
+  mode: NULLABLE
+  description: Set of language- and/or country-based preferences for a user interface.
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Name of the country in which the activity took place, as determined
+    by the IP geolocation.
 - name: widget_name
   type: STRING
   mode: NULLABLE


### PR DESCRIPTION
## Description

This PR updates the `firefox_desktop_derived.newtab_widgets_daily_v1`, a daily aggregation of Firefox New Tab widget telemetry from `firefox_desktop_stable.newtab_v1` with new segments and metrics. 
New segments being added are `(app_version, os, channel, locale, country)`.
A new metric `widget_enabled_clients` is added to track the number of clients with widget enabled.
Existing metrics (`widget_setting_change_count, widget_utility_action_count)` are updated to include more user actions.

Includes update to:
- `query.sql`
- `metadata.yaml`
- `schema.yaml`
- `checks.sql`
- `README.md`

## Related Tickets & Documents
* DENG-11155

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)** 

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
