### PR TITLE
feat(DENG-11157): Initiate Backfill

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/backfill.yaml
@@ -1,3 +1,15 @@
+2026-05-25:
+  start_date: 2024-04-10
+  end_date: 2026-05-22
+  reason: Initiate backfill to update product field using the new UDF in (DENG-11157).
+  watchers:
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false
+
 2026-04-10:
   start_date: 2024-04-10
   end_date: 2026-04-10


### PR DESCRIPTION
## Description

This PR back fills table `ga4_engagement_sessions_daily_v1` so that it can use the new UDF logic for the `product` field from [DENG-11157](https://mozilla-hub.atlassian.net/browse/DENG-11157)

## Related Tickets & Documents
* DENG-11157

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-11157]: https://mozilla-hub.atlassian.net/browse/DENG-11157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ