### PR TITLE
feat(DENG-11157): Complete Backfill for GA4 Table

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_engagement_sessions_daily_v1/backfill.yaml
@@ -4,7 +4,7 @@
   reason: Initiate backfill to update product field using the new UDF in (DENG-11157).
   watchers:
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

This PR completes the back fill for GA4 CX Sumo Table.

## Validation Results

Schemas: Identical.

`events` : identical — exact match across the full 2024-04-10 → 2026-05-22 overlap (19,093,767 events on both sides; per-day and per-content-type match).

`sessions` : backfilled is -7,088 (-0.046%) lower than prod

kb: -6,962, forum_question: -126
Prod ≥ backfilled on every day; largest single-day delta is -89 (2025-05-23)
Likely explanation: backfill normalizes product slugs via `mozfun.customer_experience.normalize_product()` before `COUNT(DISTINCT session)`, so sessions that appeared under multiple raw slugs (e.g. firefox and Firefox) collapse to one. Prod has 42 distinct product values; backfilled has 13.
Row count delta (-30%) is expected — same normalization rolls niche/legacy slugs (pocket, hubs, focus, garbage paths, etc.) into Other.

Verdict: Backfill looks correct. The small session reduction is a deliberate side effect of canonicalizing product names.

## Related Tickets & Documents
* DENG-11157
* PR: https://github.com/mozilla/bigquery-etl/pull/9424

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
