### PR TITLE
bug 2041536  fix(sampled_metrics): filter GLAM tombstones and track per-OS sampling

### DIFF
--- a/bigquery_etl/glam/client_side_sampled_metrics.py
+++ b/bigquery_etl/glam/client_side_sampled_metrics.py
@@ -55,9 +55,12 @@ def get(
     else:
         metric_types = []
     if product is not None:
-        app_name = _PRODUCT_TO_APP_NAME.get(product)
-        if app_name is None:
-            return {}
+        if product not in _PRODUCT_TO_APP_NAME:
+            raise ValueError(
+                f"Unknown product {product!r}; "
+                f"add a mapping in _PRODUCT_TO_APP_NAME if it's expected."
+            )
+        app_name = _PRODUCT_TO_APP_NAME[product]
     else:
         app_name = None
     where_clause = _build_where_clause(metric_types, app_name)
@@ -71,7 +74,7 @@ def get(
           FROM `{PROJECT_ID}.{DATASET}.{TABLE_NAME}`
           {where_clause}
           QUALIFY ROW_NUMBER() OVER (
-            PARTITION BY metric_type, metric_name, os
+            PARTITION BY metric_type, metric_name, channel, app_name, os
             ORDER BY start_date DESC
           ) = 1
         )

--- a/bigquery_etl/glam/client_side_sampled_metrics.py
+++ b/bigquery_etl/glam/client_side_sampled_metrics.py
@@ -14,6 +14,11 @@ DATASET = "telemetry_derived"
 TABLE_NAME = "sampled_metrics_v1"
 EXPECTED_SAMPLE_RATE = 0.1  # For now, we only support 10% sampling.
 
+_PRODUCT_TO_APP_NAME = {
+    "firefox_desktop": "firefox_desktop",
+    "org_mozilla_fenix": "fenix",
+}
+
 
 def _run_bq_query(query: str):
     """Run a BigQuery query and return rows."""
@@ -22,28 +27,40 @@ def _run_bq_query(query: str):
     return query_job.result()
 
 
-def _format_metric_types_filter(metric_types: Iterable[str]) -> str:
-    """Return a SQL filter for the provided metric types."""
-    unique_types = {mt for mt in metric_types}
-    if not unique_types:
+def _build_where_clause(metric_types: List[str], app_name: Optional[str]) -> str:
+    """Return a SQL WHERE clause for metric_types + app_name, or '' if neither."""
+    conditions = []
+    if metric_types:
+        quoted = ",".join(f"'{mt}'" for mt in sorted(set(metric_types)))
+        conditions.append(f"metric_type IN ({quoted})")
+    if app_name:
+        conditions.append(f"app_name = '{app_name}'")
+    if not conditions:
         return ""
-    quoted = ",".join(f"'{mt}'" for mt in sorted(unique_types))
-    return f"WHERE metric_type IN ({quoted})"
+    return "WHERE " + " AND ".join(conditions)
 
 
-def get(metric_types: Optional[Iterable[str]] = None) -> dict[str, List[str]]:
+def get(
+    metric_types: Optional[Iterable[str]] = None,
+    product: Optional[str] = None,
+) -> dict[str, List[str]]:
     """Return sampled metrics grouped by metric_type from BigQuery.
 
     Takes the latest submission for each metric.
-    Pass metric_types to restrict the query to specific types.
     """
     if metric_types is not None:
         metric_types = list(metric_types)
         if not metric_types:
             return {}
-        where_clause = _format_metric_types_filter(metric_types)
     else:
-        where_clause = ""
+        metric_types = []
+    if product is not None:
+        app_name = _PRODUCT_TO_APP_NAME.get(product)
+        if app_name is None:
+            return {}
+    else:
+        app_name = None
+    where_clause = _build_where_clause(metric_types, app_name)
     # Rows with experimenter_slug = NULL are tombstones written by the
     # sampled_metrics ETL when a metric is no longer covered by any active
     # experiment/rollout. They aren't real sampled metrics and should be

--- a/bigquery_etl/glam/client_side_sampled_metrics.py
+++ b/bigquery_etl/glam/client_side_sampled_metrics.py
@@ -44,9 +44,13 @@ def get(metric_types: Optional[Iterable[str]] = None) -> dict[str, List[str]]:
         where_clause = _format_metric_types_filter(metric_types)
     else:
         where_clause = ""
+    # Rows with experimenter_slug = NULL are tombstones written by the
+    # sampled_metrics ETL when a metric is no longer covered by any active
+    # experiment/rollout. They aren't real sampled metrics and should be
+    # filtered out before the sample-rate guard runs.
     query = dedent(f"""
         WITH latest_metrics AS (
-          SELECT metric_type, metric_name, sample_rate, start_date
+          SELECT metric_type, metric_name, sample_rate, experimenter_slug, start_date
           FROM `{PROJECT_ID}.{DATASET}.{TABLE_NAME}`
           {where_clause}
           QUALIFY ROW_NUMBER() OVER (
@@ -56,6 +60,7 @@ def get(metric_types: Optional[Iterable[str]] = None) -> dict[str, List[str]]:
         )
         SELECT metric_type, metric_name, sample_rate
         FROM latest_metrics
+        WHERE experimenter_slug IS NOT NULL
         """)
 
     try:

--- a/bigquery_etl/glam/client_side_sampled_metrics.py
+++ b/bigquery_etl/glam/client_side_sampled_metrics.py
@@ -71,7 +71,7 @@ def get(
           FROM `{PROJECT_ID}.{DATASET}.{TABLE_NAME}`
           {where_clause}
           QUALIFY ROW_NUMBER() OVER (
-            PARTITION BY metric_type, metric_name
+            PARTITION BY metric_type, metric_name, os
             ORDER BY start_date DESC
           ) = 1
         )

--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -3,7 +3,7 @@
 import argparse
 import sys
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from jinja2 import Environment, PackageLoader
 
@@ -36,6 +36,7 @@ def render_main(**kwargs):
 
 def get_distribution_metrics(
     schema: Dict,
+    product: Optional[str] = None,
 ) -> tuple[Dict[str, List[str]], Dict[str, List[str]]]:
     """Find all distribution-like metrics in a Glean table.
 
@@ -53,7 +54,7 @@ def get_distribution_metrics(
     excluded_metrics = get_etl_excluded_probes_quickfix("fenix")
 
     # Metrics that are already sampled
-    sampled_metrics = get_sampled_metrics(metric_type_set)
+    sampled_metrics = get_sampled_metrics(metric_type_set, product=product)
     found_sampled_metrics = defaultdict(list)
 
     # Iterate over every element in the schema under the metrics section and
@@ -143,7 +144,9 @@ def main():
     )
 
     schema = get_schema(args.source_table)
-    distributions, client_sampled_distributions = get_distribution_metrics(schema)
+    distributions, client_sampled_distributions = get_distribution_metrics(
+        schema, product=args.product
+    )
     metrics_sql = get_metrics_sql(distributions)
     client_sampled_metrics_sql = {"labeled": [], "unlabeled": []}
     if args.product == "firefox_desktop":

--- a/bigquery_etl/glam/clients_daily_scalar_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_scalar_aggregates.py
@@ -4,7 +4,7 @@
 import argparse
 import sys
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from jinja2 import Environment, PackageLoader
 
@@ -96,7 +96,7 @@ def get_unlabeled_metrics_sql(probes: Dict[str, List[str]]) -> str:
 
 
 def get_scalar_metrics(
-    schema: Dict, scalar_type: str
+    schema: Dict, scalar_type: str, product: Optional[str] = None
 ) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
     """Find all scalar probes in a Glean table.
 
@@ -115,7 +115,7 @@ def get_scalar_metrics(
     excluded_metrics = get_etl_excluded_probes_quickfix("fenix")
 
     # Metrics that are already sampled
-    sampled_metrics = get_sampled_metrics(metric_type_set[scalar_type])
+    sampled_metrics = get_sampled_metrics(metric_type_set[scalar_type], product=product)
     found_sampled_metrics = defaultdict(list)
 
     # Iterate over every element in the schema under the metrics section and
@@ -167,10 +167,14 @@ def main():
 
     schema = get_schema(args.source_table)
     unlabeled_metric_names, unlabeled_sampled_metric_names = get_scalar_metrics(
-        schema, "unlabeled"
+        schema, "unlabeled", product=args.product
     )
-    labeled_metric_names, _ = get_scalar_metrics(schema, "labeled")
-    dual_labeled_metric_names, _ = get_scalar_metrics(schema, "dual_labeled")
+    labeled_metric_names, _ = get_scalar_metrics(
+        schema, "labeled", product=args.product
+    )
+    dual_labeled_metric_names, _ = get_scalar_metrics(
+        schema, "dual_labeled", product=args.product
+    )
     metrics_with_too_many_labels = get_etl_excluded_probes_quickfix("desktop")
     dual_labeled_metric_names["dual_labeled_counter"] = [
         name

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sampled_metrics_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sampled_metrics_v1/query.py
@@ -34,13 +34,13 @@ BQ_SCHEMA = (
     bigquery.SchemaField("is_rollout", "BOOLEAN"),
     bigquery.SchemaField("app_name", "STRING"),
     bigquery.SchemaField("channel", "STRING"),
-    bigquery.SchemaField("os", "STRING"),
     bigquery.SchemaField("min_version", "STRING"),
     bigquery.SchemaField("max_version", "STRING"),
     bigquery.SchemaField("end_date", "DATE"),
     bigquery.SchemaField("metric_type", "STRING"),
     bigquery.SchemaField("metric_name", "STRING"),
     bigquery.SchemaField("sample_rate", "FLOAT"),
+    bigquery.SchemaField("os", "STRING"),
 )
 
 parser = ArgumentParser(description=__doc__)

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sampled_metrics_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sampled_metrics_v1/query.py
@@ -34,6 +34,7 @@ BQ_SCHEMA = (
     bigquery.SchemaField("is_rollout", "BOOLEAN"),
     bigquery.SchemaField("app_name", "STRING"),
     bigquery.SchemaField("channel", "STRING"),
+    bigquery.SchemaField("os", "STRING"),
     bigquery.SchemaField("min_version", "STRING"),
     bigquery.SchemaField("max_version", "STRING"),
     bigquery.SchemaField("end_date", "DATE"),
@@ -92,6 +93,38 @@ def parse_max_version(targeting):
     if match:
         return match.group(1)
     return None
+
+
+_OS_TARGETING_MAP = {
+    "Windows": r"\bos\.isWindows\b",
+    "Mac": r"\bos\.isMac\b",
+    "Linux": r"\bos\.isLinux\b",
+}
+
+
+def parse_os(targeting):
+    """Parse the OS targets from a Nimbus targeting string.
+
+    Raises ValueError on negation or unknown `os.is<X>` predicates —
+    silently mis-parsing the OS dimension would make downstream queries
+    return incorrect results.
+    """
+    if re.search(r"!\s*os\.is\w+", targeting):
+        raise ValueError(
+            f"Unsupported OS targeting (negation of os.is*) in: {targeting!r}"
+        )
+    known = set(_OS_TARGETING_MAP.keys())
+    for match in re.finditer(r"\bos\.is(\w+)\b", targeting):
+        candidate = match.group(1)
+        if candidate not in known:
+            raise ValueError(
+                f"Unsupported OS predicate 'os.is{candidate}' in: {targeting!r}"
+            )
+    return [
+        name
+        for name, pattern in _OS_TARGETING_MAP.items()
+        if re.search(pattern, targeting)
+    ]
 
 
 def get_metric_type(metric_name, app_name):
@@ -155,6 +188,7 @@ def get_sampled_metrics_from_api():
         sample_rate = round(1 - (count / total), 4) if total > 0 else 1.0
 
         channel = parse_channel(targeting)
+        oses = parse_os(targeting) or [None]
         min_version = parse_min_version(targeting)
         max_version = parse_max_version(targeting)
 
@@ -180,21 +214,23 @@ def get_sampled_metrics_from_api():
             metric_name = metric.replace(".", "_")
             metric_type = get_metric_type(metric_name, app_name)
 
-            rows.append(
-                {
-                    "start_date": start_date,
-                    "experimenter_slug": slug,
-                    "is_rollout": is_rollout,
-                    "app_name": app_name,
-                    "channel": channel,
-                    "min_version": min_version,
-                    "max_version": max_version,
-                    "end_date": end_date,
-                    "metric_type": metric_type,
-                    "metric_name": metric_name,
-                    "sample_rate": sample_rate,
-                }
-            )
+            for os_target in oses:
+                rows.append(
+                    {
+                        "start_date": start_date,
+                        "experimenter_slug": slug,
+                        "is_rollout": is_rollout,
+                        "app_name": app_name,
+                        "channel": channel,
+                        "os": os_target,
+                        "min_version": min_version,
+                        "max_version": max_version,
+                        "end_date": end_date,
+                        "metric_type": metric_type,
+                        "metric_name": metric_name,
+                        "sample_rate": sample_rate,
+                    }
+                )
 
     return rows
 
@@ -202,14 +238,14 @@ def get_sampled_metrics_from_api():
 def get_current_state(client, destination_table):
     """Query the latest row per metric from BigQuery.
 
-    Returns a dict keyed by (metric_type, metric_name, channel, app_name)
+    Returns a dict keyed by (metric_type, metric_name, channel, app_name, os)
     with the sample_rate as value.
     """
     query = f"""
-        SELECT metric_type, metric_name, channel, app_name, sample_rate
+        SELECT metric_type, metric_name, channel, app_name, os, sample_rate
         FROM `{destination_table}`
         QUALIFY ROW_NUMBER() OVER (
-            PARTITION BY metric_type, metric_name, channel, app_name
+            PARTITION BY metric_type, metric_name, channel, app_name, os
             ORDER BY start_date DESC
         ) = 1
     """
@@ -220,6 +256,7 @@ def get_current_state(client, destination_table):
             row["metric_name"],
             row["channel"],
             row["app_name"],
+            row["os"],
         )
         state[key] = float(row["sample_rate"])
     return state
@@ -242,6 +279,7 @@ def compute_diff(api_rows, current_state):
             row["metric_name"],
             row["channel"],
             row["app_name"],
+            row["os"],
         )
         # If multiple experiments affect the same metric, keep the most
         # recent one (by start date)
@@ -262,7 +300,7 @@ def compute_diff(api_rows, current_state):
     # Metrics that are no longer sampled (were < 1.0, now absent from API)
     for key, current_rate in current_state.items():
         if key not in api_state and round(current_rate, 4) != 1.0:
-            metric_type, metric_name, channel, app_name = key
+            metric_type, metric_name, channel, app_name, os = key
             rows_to_insert.append(
                 {
                     "start_date": today,
@@ -270,6 +308,7 @@ def compute_diff(api_rows, current_state):
                     "is_rollout": None,
                     "app_name": app_name,
                     "channel": channel,
+                    "os": os,
                     "min_version": None,
                     "max_version": None,
                     "end_date": None,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sampled_metrics_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sampled_metrics_v1/query.py
@@ -95,11 +95,7 @@ def parse_max_version(targeting):
     return None
 
 
-_OS_TARGETING_MAP = {
-    "Windows": r"\bos\.isWindows\b",
-    "Mac": r"\bos\.isMac\b",
-    "Linux": r"\bos\.isLinux\b",
-}
+_SUPPORTED_OS_PREDICATES = {"Windows", "Mac", "Linux"}
 
 
 def parse_os(targeting):
@@ -109,22 +105,20 @@ def parse_os(targeting):
     silently mis-parsing the OS dimension would make downstream queries
     return incorrect results.
     """
-    if re.search(r"!\s*os\.is\w+", targeting):
-        raise ValueError(
-            f"Unsupported OS targeting (negation of os.is*) in: {targeting!r}"
-        )
-    known = set(_OS_TARGETING_MAP.keys())
-    for match in re.finditer(r"\bos\.is(\w+)\b", targeting):
-        candidate = match.group(1)
-        if candidate not in known:
+    found = []
+    for match in re.finditer(r"(!?)\s*\bos\.is(\w+)\b", targeting):
+        if match.group(1):
             raise ValueError(
-                f"Unsupported OS predicate 'os.is{candidate}' in: {targeting!r}"
+                f"Unsupported OS targeting (negation of os.is*) in: {targeting!r}"
             )
-    return [
-        name
-        for name, pattern in _OS_TARGETING_MAP.items()
-        if re.search(pattern, targeting)
-    ]
+        name = match.group(2)
+        if name not in _SUPPORTED_OS_PREDICATES:
+            raise ValueError(
+                f"Unsupported OS predicate 'os.is{name}' in: {targeting!r}"
+            )
+        if name not in found:
+            found.append(name)
+    return found
 
 
 def get_metric_type(metric_name, app_name):

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sampled_metrics_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sampled_metrics_v1/schema.yaml
@@ -19,10 +19,6 @@ fields:
   type: STRING
   mode: NULLABLE
   description: Release channel (e.g., release, beta, nightly)
-- name: os
-  type: STRING
-  mode: NULLABLE
-  description: Operating system the rollout targets (e.g., Windows, Mac, Linux), parsed from the experiment targeting expression.
 - name: min_version
   type: STRING
   mode: NULLABLE
@@ -47,3 +43,7 @@ fields:
   type: FLOAT64
   mode: NULLABLE
   description: Fraction of clients sampled (bucketConfig count / total)
+- name: os
+  type: STRING
+  mode: NULLABLE
+  description: Operating system the rollout targets (e.g., Windows, Mac, Linux), parsed from the experiment targeting expression.

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sampled_metrics_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sampled_metrics_v1/schema.yaml
@@ -19,6 +19,10 @@ fields:
   type: STRING
   mode: NULLABLE
   description: Release channel (e.g., release, beta, nightly)
+- name: os
+  type: STRING
+  mode: NULLABLE
+  description: Operating system the rollout targets (e.g., Windows, Mac, Linux), parsed from the experiment targeting expression.
 - name: min_version
   type: STRING
   mode: NULLABLE

--- a/tests/glam/__init__.py
+++ b/tests/glam/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the bigquery_etl.glam package."""

--- a/tests/glam/test_client_side_sampled_metrics.py
+++ b/tests/glam/test_client_side_sampled_metrics.py
@@ -56,17 +56,17 @@ class TestGet:
         assert "experimenter_slug IS NOT NULL" in rendered_query
 
     @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
-    def test_partitions_by_os_so_stale_tombstones_dont_mask_newer_os(self, mock_run):
-        """A stale os=NULL tombstone must not outrank a newer os=Windows
-        row for the same metric. Adding `os` to PARTITION BY keeps the
-        two in separate partitions, so the tombstone only dominates its
-        own (os=NULL) partition and gets dropped by the slug-IS-NOT-NULL
-        filter — leaving the os=Windows row intact in the output.
-        """
+    def test_partition_matches_upstream_state_key(self, mock_run):
+        """Mirror the producer's (metric_type, metric_name, channel, app_name, os)
+        state key so the latest-per-group invariant holds even if a caller
+        skips `product` and the app/channel filters aren't applied."""
         mock_run.return_value = []
         client_side_sampled_metrics.get(product="firefox_desktop")
         rendered_query = mock_run.call_args.args[0]
-        assert "PARTITION BY metric_type, metric_name, os" in rendered_query
+        assert (
+            "PARTITION BY metric_type, metric_name, channel, app_name, os"
+            in rendered_query
+        )
 
     def test_empty_metric_types_short_circuits(self):
         assert client_side_sampled_metrics.get(metric_types=[]) == {}
@@ -99,10 +99,11 @@ class TestGet:
         assert " AND " in rendered_query
 
     @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
-    def test_unknown_product_returns_empty_without_querying(self, mock_run):
-        """Unmapped products short-circuit so we don't read another app's rows."""
-        result = client_side_sampled_metrics.get(product="org_mozilla_fennec_aurora")
-        assert result == {}
+    def test_unknown_product_raises(self, mock_run):
+        """Typos / new products surface as ValueError instead of silently
+        returning no sampled metrics (which would emit them as unsampled)."""
+        with pytest.raises(ValueError, match="firefox-desktop"):
+            client_side_sampled_metrics.get(product="firefox-desktop")
         mock_run.assert_not_called()
 
     @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
@@ -110,4 +111,4 @@ class TestGet:
         mock_run.return_value = []
         client_side_sampled_metrics.get(metric_types=["counter"])
         rendered_query = mock_run.call_args.args[0]
-        assert "app_name" not in rendered_query
+        assert "app_name =" not in rendered_query

--- a/tests/glam/test_client_side_sampled_metrics.py
+++ b/tests/glam/test_client_side_sampled_metrics.py
@@ -1,0 +1,100 @@
+"""Tests for bigquery_etl.glam.client_side_sampled_metrics."""
+
+from unittest import mock
+
+import pytest
+
+from bigquery_etl.glam import client_side_sampled_metrics
+
+
+class TestGet:
+    @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
+    def test_groups_rows_by_metric_type(self, mock_run):
+        mock_run.return_value = [
+            {
+                "metric_type": "timing_distribution",
+                "metric_name": "paint_build_displaylist_time",
+                "sample_rate": 0.1,
+            },
+            {
+                "metric_type": "timing_distribution",
+                "metric_name": "wr_rasterize_glyphs_time",
+                "sample_rate": 0.1,
+            },
+            {
+                "metric_type": "memory_distribution",
+                "metric_name": "fog_ipc_buffer_sizes",
+                "sample_rate": 0.1,
+            },
+        ]
+        result = client_side_sampled_metrics.get(product="firefox_desktop")
+        assert result == {
+            "timing_distribution": [
+                "paint_build_displaylist_time",
+                "wr_rasterize_glyphs_time",
+            ],
+            "memory_distribution": ["fog_ipc_buffer_sizes"],
+        }
+
+    @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
+    def test_unexpected_sample_rate_raises(self, mock_run):
+        mock_run.return_value = [
+            {
+                "metric_type": "timing_distribution",
+                "metric_name": "paint_build_displaylist_time",
+                "sample_rate": 0.5,
+            },
+        ]
+        with pytest.raises(RuntimeError, match="paint_build_displaylist_time"):
+            client_side_sampled_metrics.get(product="firefox_desktop")
+
+    @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
+    def test_tombstones_are_filtered_at_sql_layer(self, mock_run):
+        mock_run.return_value = []
+        client_side_sampled_metrics.get(product="firefox_desktop")
+        rendered_query = mock_run.call_args.args[0]
+        assert "experimenter_slug IS NOT NULL" in rendered_query
+
+    def test_empty_metric_types_short_circuits(self):
+        assert client_side_sampled_metrics.get(metric_types=[]) == {}
+
+    @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
+    def test_product_filter_in_query(self, mock_run):
+        """firefox_desktop maps to app_name=firefox_desktop in the WHERE."""
+        mock_run.return_value = []
+        client_side_sampled_metrics.get(product="firefox_desktop")
+        rendered_query = mock_run.call_args.args[0]
+        assert "app_name = 'firefox_desktop'" in rendered_query
+
+    @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
+    def test_fenix_product_translates_to_fenix_app_name(self, mock_run):
+        """org_mozilla_fenix maps to Experimenter's appName 'fenix'."""
+        mock_run.return_value = []
+        client_side_sampled_metrics.get(product="org_mozilla_fenix")
+        rendered_query = mock_run.call_args.args[0]
+        assert "app_name = 'fenix'" in rendered_query
+
+    @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
+    def test_metric_types_and_product_combined(self, mock_run):
+        mock_run.return_value = []
+        client_side_sampled_metrics.get(
+            metric_types=["counter"], product="org_mozilla_fenix"
+        )
+        rendered_query = mock_run.call_args.args[0]
+        assert "metric_type IN ('counter')" in rendered_query
+        assert "app_name = 'fenix'" in rendered_query
+        assert " AND " in rendered_query
+
+    @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
+    def test_unknown_product_returns_empty_without_querying(self, mock_run):
+        """Unmapped products short-circuit so we don't read another app's rows."""
+        result = client_side_sampled_metrics.get(product="org_mozilla_fennec_aurora")
+        assert result == {}
+        mock_run.assert_not_called()
+
+    @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
+    def test_no_product_omits_app_filter(self, mock_run):
+        mock_run.return_value = []
+        client_side_sampled_metrics.get(metric_types=["counter"])
+        rendered_query = mock_run.call_args.args[0]
+        assert "app_name" not in rendered_query

--- a/tests/glam/test_client_side_sampled_metrics.py
+++ b/tests/glam/test_client_side_sampled_metrics.py
@@ -55,6 +55,19 @@ class TestGet:
         rendered_query = mock_run.call_args.args[0]
         assert "experimenter_slug IS NOT NULL" in rendered_query
 
+    @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
+    def test_partitions_by_os_so_stale_tombstones_dont_mask_newer_os(self, mock_run):
+        """A stale os=NULL tombstone must not outrank a newer os=Windows
+        row for the same metric. Adding `os` to PARTITION BY keeps the
+        two in separate partitions, so the tombstone only dominates its
+        own (os=NULL) partition and gets dropped by the slug-IS-NOT-NULL
+        filter — leaving the os=Windows row intact in the output.
+        """
+        mock_run.return_value = []
+        client_side_sampled_metrics.get(product="firefox_desktop")
+        rendered_query = mock_run.call_args.args[0]
+        assert "PARTITION BY metric_type, metric_name, os" in rendered_query
+
     def test_empty_metric_types_short_circuits(self):
         assert client_side_sampled_metrics.get(metric_types=[]) == {}
 

--- a/tests/sampled_metrics/test_query.py
+++ b/tests/sampled_metrics/test_query.py
@@ -28,6 +28,7 @@ spec.loader.exec_module(query_mod)
 parse_channel = query_mod.parse_channel
 parse_min_version = query_mod.parse_min_version
 parse_max_version = query_mod.parse_max_version
+parse_os = query_mod.parse_os
 is_active = query_mod.is_active
 get_sampled_metrics_from_api = query_mod.get_sampled_metrics_from_api
 get_current_state = query_mod.get_current_state
@@ -59,7 +60,7 @@ def _make_experiment(
     app_name="firefox_desktop",
     start_date="2025-04-30",
     end_date=None,
-    targeting="(browserSettings.update.channel == \"release\") && (version|versionCompare('138.!') >= 0)",
+    targeting="(browserSettings.update.channel == \"release\") && (os.isWindows) && (version|versionCompare('138.!') >= 0)",
     bucket_count=1000,
     bucket_total=10000,
     metrics_enabled=None,
@@ -182,6 +183,71 @@ class TestParseMaxVersion:
         assert parse_max_version("") is None
 
 
+# -- Tests: parse_os ----------------------------------------------------------
+
+
+class TestParseOs:
+    def test_windows(self):
+        assert parse_os(
+            '(browserSettings.update.channel == "release") && (os.isWindows)'
+        ) == ["Windows"]
+
+    def test_windows_in_compound_expression(self):
+        targeting = "((experiment.slug in activeRollouts) || ((os.isWindows) && (version|versionCompare('105.!') >= 0)))"
+        assert parse_os(targeting) == ["Windows"]
+
+    def test_mac(self):
+        assert parse_os("(os.isMac)") == ["Mac"]
+
+    def test_linux(self):
+        assert parse_os("(os.isLinux)") == ["Linux"]
+
+    def test_no_os(self):
+        assert parse_os('(browserSettings.update.channel == "release")') == []
+
+    def test_empty_string(self):
+        assert parse_os("") == []
+
+    def test_multi_os_returns_all_detected(self):
+        """A rollout that targets multiple OSes returns each of them."""
+        assert set(parse_os("(os.isWindows || os.isMac)")) == {"Windows", "Mac"}
+
+    def test_all_three_oses(self):
+        assert set(parse_os("(os.isWindows || os.isMac || os.isLinux)")) == {
+            "Windows",
+            "Mac",
+            "Linux",
+        }
+
+    def test_negation_raises(self):
+        with pytest.raises(ValueError, match="negation"):
+            parse_os("(!os.isWindows)")
+
+    def test_negation_with_space_raises(self):
+        with pytest.raises(ValueError, match="negation"):
+            parse_os("(! os.isWindows)")
+
+    def test_unknown_predicate_raises(self):
+        with pytest.raises(ValueError, match="os.isAndroid"):
+            parse_os("(os.isAndroid)")
+
+    def test_unknown_mixed_with_known_raises(self):
+        with pytest.raises(ValueError, match="os.isIOS"):
+            parse_os("(os.isWindows || os.isIOS)")
+
+    def test_os_windows_version_property_does_not_raise(self):
+        """os.windowsVersion is a property comparison, not an OS selector."""
+        assert parse_os("(os.windowsVersion >= 6.1)") == []
+
+    def test_real_rollout_shape_with_property_and_predicate(self):
+        """Real rollouts mix os.isWindows with os.windowsVersion — must parse cleanly."""
+        targeting = (
+            "((currentDate|date - profileAgeCreated|date) / 86400000 >= 28 "
+            "&& os.isWindows && os.windowsVersion >= 6.1)"
+        )
+        assert parse_os(targeting) == ["Windows"]
+
+
 # -- Tests: is_active ---------------------------------------------------------
 
 
@@ -232,6 +298,7 @@ class TestGetSampledMetricsFromApi:
         assert all(r["experimenter_slug"] == "test-sampling-rollout" for r in rows)
         assert all(r["sample_rate"] == 0.9 for r in rows)
         assert all(r["channel"] == "release" for r in rows)
+        assert all(r["os"] == "Windows" for r in rows)
         assert all(r["min_version"] == "138.!" for r in rows)
         assert all(r["max_version"] is None for r in rows)
         assert all(r["app_name"] == "firefox_desktop" for r in rows)
@@ -338,6 +405,44 @@ class TestGetSampledMetricsFromApi:
         assert rows[0]["metric_type"] == "memory_distribution"
 
     @mock.patch.object(query_mod, "fetch")
+    def test_multi_os_fans_out_one_row_per_os(self, mock_fetch):
+        """Multi-OS targeting emits one row per (metric, os)."""
+        targeting = (
+            '(browserSettings.update.channel == "release") '
+            "&& (os.isWindows || os.isMac) "
+            "&& (version|versionCompare('138.!') >= 0)"
+        )
+        mock_fetch.return_value = [
+            _make_experiment(
+                end_date=FUTURE_DATE,
+                targeting=targeting,
+                metrics_enabled={"paint.build_displaylist_time": False},
+            ),
+        ]
+        rows = get_sampled_metrics_from_api()
+        assert len(rows) == 2
+        oses = {r["os"] for r in rows}
+        assert oses == {"Windows", "Mac"}
+        # The non-OS fields are identical across the fanned-out rows.
+        assert all(r["metric_name"] == "paint_build_displaylist_time" for r in rows)
+        assert all(r["metric_type"] == "timing_distribution" for r in rows)
+
+    @mock.patch.object(query_mod, "fetch")
+    def test_no_os_targeting_emits_null_os(self, mock_fetch):
+        """Targeting with no os.is* predicate falls back to a single os=NULL row."""
+        targeting = '(browserSettings.update.channel == "release")'
+        mock_fetch.return_value = [
+            _make_experiment(
+                end_date=FUTURE_DATE,
+                targeting=targeting,
+                metrics_enabled={"paint.build_displaylist_time": False},
+            ),
+        ]
+        rows = get_sampled_metrics_from_api()
+        assert len(rows) == 1
+        assert rows[0]["os"] is None
+
+    @mock.patch.object(query_mod, "fetch")
     def test_unknown_metric_raises(self, mock_fetch):
         mock_fetch.return_value = [
             _make_experiment(
@@ -391,84 +496,66 @@ class TestGetMetricType:
 # -- Tests: compute_diff ------------------------------------------------------
 
 
+def _api_row(metric_name, sample_rate, **overrides):
+    """Default api_row dict used in compute_diff tests."""
+    row = {
+        "start_date": "2025-04-30",
+        "experimenter_slug": "rollout-1",
+        "is_rollout": True,
+        "app_name": "firefox_desktop",
+        "channel": "release",
+        "os": "Windows",
+        "min_version": "138.!",
+        "max_version": None,
+        "end_date": None,
+        "metric_type": "counter",
+        "metric_name": metric_name,
+        "sample_rate": sample_rate,
+    }
+    row.update(overrides)
+    return row
+
+
 class TestComputeDiff:
     def test_new_metric_inserted(self):
-        api_rows = [
-            {
-                "start_date": "2025-04-30",
-                "experimenter_slug": "rollout-1",
-                "is_rollout": True,
-                "app_name": "firefox_desktop",
-                "channel": "release",
-                "min_version": "138.!",
-                "max_version": None,
-                "end_date": None,
-                "metric_type": "counter",
-                "metric_name": "new_metric",
-                "sample_rate": 0.1,
-            }
-        ]
-        current_state = {}
-
-        result = compute_diff(api_rows, current_state)
+        result = compute_diff([_api_row("new_metric", 0.1)], {})
         assert len(result) == 1
         assert result[0]["metric_name"] == "new_metric"
         assert result[0]["sample_rate"] == 0.1
 
     def test_unchanged_metric_not_inserted(self):
-        api_rows = [
-            {
-                "start_date": "2025-04-30",
-                "experimenter_slug": "rollout-1",
-                "is_rollout": True,
-                "app_name": "firefox_desktop",
-                "channel": "release",
-                "min_version": "138.!",
-                "max_version": None,
-                "end_date": None,
-                "metric_type": "counter",
-                "metric_name": "stable_metric",
-                "sample_rate": 0.1,
-            }
-        ]
         current_state = {
-            ("counter", "stable_metric", "release", "firefox_desktop"): 0.1,
+            ("counter", "stable_metric", "release", "firefox_desktop", "Windows"): 0.1,
         }
-
-        result = compute_diff(api_rows, current_state)
+        result = compute_diff([_api_row("stable_metric", 0.1)], current_state)
         assert result == []
 
     def test_changed_rate_inserted(self):
-        api_rows = [
-            {
-                "start_date": "2025-04-30",
-                "experimenter_slug": "rollout-1",
-                "is_rollout": True,
-                "app_name": "firefox_desktop",
-                "channel": "release",
-                "min_version": "138.!",
-                "max_version": None,
-                "end_date": None,
-                "metric_type": "counter",
-                "metric_name": "changed_metric",
-                "sample_rate": 0.5,
-            }
-        ]
         current_state = {
-            ("counter", "changed_metric", "release", "firefox_desktop"): 0.1,
+            ("counter", "changed_metric", "release", "firefox_desktop", "Windows"): 0.1,
         }
-
-        result = compute_diff(api_rows, current_state)
+        result = compute_diff([_api_row("changed_metric", 0.5)], current_state)
         assert len(result) == 1
         assert result[0]["sample_rate"] == 0.5
 
-    def test_removed_metric_gets_100_percent(self):
-        api_rows = []
+    def test_same_metric_different_os_is_distinct(self):
+        """A new OS for the same (metric_type, metric_name, channel, app_name)
+        is a different key — the Windows row must not be treated as a state
+        change of the Mac row."""
         current_state = {
-            ("counter", "removed_metric", "release", "firefox_desktop"): 0.1,
+            ("counter", "m", "release", "firefox_desktop", "Mac"): 0.1,
         }
+        result = compute_diff([_api_row("m", 0.1)], current_state)
+        # Mac row is a tombstone (no longer in api_state), Windows row is new.
+        assert len(result) == 2
+        oses = {r["os"] for r in result}
+        assert oses == {"Windows", "Mac"}
 
-        result = compute_diff(api_rows, current_state)
+    def test_removed_metric_gets_100_percent(self):
+        current_state = {
+            ("counter", "removed_metric", "release", "firefox_desktop", "Windows"): 0.1,
+        }
+        result = compute_diff([], current_state)
         assert len(result) == 1
         assert result[0]["metric_name"] == "removed_metric"
         assert result[0]["sample_rate"] == 1.0
@@ -479,96 +566,55 @@ class TestComputeDiff:
         assert result[0]["end_date"] is None
         assert result[0]["channel"] == "release"
         assert result[0]["app_name"] == "firefox_desktop"
+        assert result[0]["os"] == "Windows"
 
     def test_already_at_100_not_reinserted(self):
-        api_rows = []
         current_state = {
-            ("counter", "already_full", "release", "firefox_desktop"): 1.0,
+            ("counter", "already_full", "release", "firefox_desktop", "Windows"): 1.0,
         }
-
-        result = compute_diff(api_rows, current_state)
+        result = compute_diff([], current_state)
         assert result == []
 
     def test_multiple_experiments_picks_most_recent(self):
         api_rows = [
-            {
-                "start_date": "2025-03-01",
-                "experimenter_slug": "older-experiment",
-                "is_rollout": True,
-                "app_name": "firefox_desktop",
-                "channel": "release",
-                "min_version": "136.!",
-                "max_version": None,
-                "end_date": None,
-                "metric_type": "counter",
-                "metric_name": "shared_metric",
-                "sample_rate": 0.5,
-            },
-            {
-                "start_date": "2025-06-01",
-                "experimenter_slug": "newer-experiment",
-                "is_rollout": False,
-                "app_name": "firefox_desktop",
-                "channel": "release",
-                "min_version": "140.!",
-                "max_version": None,
-                "end_date": None,
-                "metric_type": "counter",
-                "metric_name": "shared_metric",
-                "sample_rate": 0.2,
-            },
+            _api_row(
+                "shared_metric",
+                0.5,
+                start_date="2025-03-01",
+                experimenter_slug="older-experiment",
+                min_version="136.!",
+            ),
+            _api_row(
+                "shared_metric",
+                0.2,
+                start_date="2025-06-01",
+                experimenter_slug="newer-experiment",
+                is_rollout=False,
+                min_version="140.!",
+            ),
         ]
-        current_state = {}
-
-        result = compute_diff(api_rows, current_state)
+        result = compute_diff(api_rows, {})
         assert len(result) == 1
         assert result[0]["experimenter_slug"] == "newer-experiment"
         assert result[0]["sample_rate"] == 0.2
 
     def test_mixed_new_changed_removed(self):
         api_rows = [
-            {
-                "start_date": "2025-04-30",
-                "experimenter_slug": "rollout-1",
-                "is_rollout": True,
-                "app_name": "firefox_desktop",
-                "channel": "release",
-                "min_version": "138.!",
-                "max_version": None,
-                "end_date": None,
-                "metric_type": "counter",
-                "metric_name": "new_metric",
-                "sample_rate": 0.1,
-            },
-            {
-                "start_date": "2025-04-30",
-                "experimenter_slug": "rollout-1",
-                "is_rollout": True,
-                "app_name": "firefox_desktop",
-                "channel": "release",
-                "min_version": "138.!",
-                "max_version": None,
-                "end_date": None,
-                "metric_type": "counter",
-                "metric_name": "stable_metric",
-                "sample_rate": 0.1,
-            },
+            _api_row("new_metric", 0.1),
+            _api_row("stable_metric", 0.1),
         ]
         current_state = {
-            ("counter", "stable_metric", "release", "firefox_desktop"): 0.1,
-            ("counter", "removed_metric", "release", "firefox_desktop"): 0.1,
+            ("counter", "stable_metric", "release", "firefox_desktop", "Windows"): 0.1,
+            ("counter", "removed_metric", "release", "firefox_desktop", "Windows"): 0.1,
         }
-
         result = compute_diff(api_rows, current_state)
-        slugs = {r["metric_name"] for r in result}
-        assert slugs == {"new_metric", "removed_metric"}
-
+        names = {r["metric_name"] for r in result}
+        assert names == {"new_metric", "removed_metric"}
         removed = [r for r in result if r["metric_name"] == "removed_metric"][0]
         assert removed["sample_rate"] == 1.0
 
     def test_empty_api_and_empty_state(self):
-        result = compute_diff([], {})
-        assert result == []
+        assert compute_diff([], {}) == []
 
 
 # -- Tests: get_current_state (mocked BQ) -------------------------------------
@@ -583,6 +629,7 @@ class TestGetCurrentState:
                 "metric_name": "my_metric",
                 "channel": "release",
                 "app_name": "firefox_desktop",
+                "os": "Windows",
                 "sample_rate": 0.1,
             },
             {
@@ -590,6 +637,7 @@ class TestGetCurrentState:
                 "metric_name": "page_load",
                 "channel": "beta",
                 "app_name": "firefox_desktop",
+                "os": "Mac",
                 "sample_rate": 0.5,
             },
         ]
@@ -598,10 +646,21 @@ class TestGetCurrentState:
         state = get_current_state(mock_client, "project.dataset.table")
 
         assert state == {
-            ("counter", "my_metric", "release", "firefox_desktop"): 0.1,
-            ("timing_distribution", "page_load", "beta", "firefox_desktop"): 0.5,
+            ("counter", "my_metric", "release", "firefox_desktop", "Windows"): 0.1,
+            (
+                "timing_distribution",
+                "page_load",
+                "beta",
+                "firefox_desktop",
+                "Mac",
+            ): 0.5,
         }
         mock_client.query.assert_called_once()
+        rendered_query = mock_client.query.call_args.args[0]
+        assert (
+            "PARTITION BY metric_type, metric_name, channel, app_name, os"
+            in rendered_query
+        )
 
     def test_empty_table(self):
         mock_client = mock.Mock()


### PR DESCRIPTION
## Description

* Skip experimenter_slug IS NULL tombstones in the GLAM-ETL query so end-of-rollout markers don't trip the sample-rate guard. 

* Add an `os` column to `sampled_metrics_v1`, parse os.is predicates out of the Nimbus targeting string, and fan out one row per (metric, os) so multi-OS rollouts and per-OS state transitions are tracked independently. 

* I'll manually run a migration script that will backfill all `os` entries with `Windows`, which is accurate up until now.

## Related Tickets & Documents
https://bugzilla.mozilla.org/show_bug.cgi?id=2041536

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
