### PR TITLE
Backfills for datasets affected by core clients duplicates

### DIFF
--- a/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v3/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v3/backfill.yaml
@@ -1,0 +1,9 @@
+2026-05-25:
+  start_date: 2026-04-15
+  end_date: 2026-05-25
+  reason: Fix inflated Focus Android metrics caused by duplicate client_ids in core_clients_last_seen_v1.
+  watchers:
+  - ascholtz@mozilla.com
+  status: Initiate
+  shredder_mitigation: true
+  override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v3/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v3/backfill.yaml
@@ -4,6 +4,7 @@
   reason: Fix inflated Focus Android metrics caused by duplicate client_ids in core_clients_last_seen_v1.
   watchers:
   - ascholtz@mozilla.com
+  - lvargas@mozilla.com
   status: Initiate
   shredder_mitigation: true
   override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/core_clients_daily_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2026-05-25:
+  start_date: 2026-04-15
+  end_date: 2026-05-25
+  reason: Fix duplicate client_ids caused by cross-partition duplicates in core_clients_first_seen_v1.
+  watchers:
+  - ascholtz@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/unified_metrics_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2026-05-25:
+  start_date: 2026-04-15
+  end_date: 2026-05-25
+  reason: Fix inflated Focus Android metrics caused by duplicate client_ids in core_clients_last_seen_v1.
+  watchers:
+  - ascholtz@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false


### PR DESCRIPTION
## Description

See https://bugzilla.mozilla.org/show_bug.cgi?id=2042189 for more details.

`telemetry_derived__core_clients_last_seen__v1` and `core_clients_first_seen_v1` were affected by rows doubling daily and client_id duplicates. The duplication was introduced around 2026-04-15 due to some backfilling. This has been fixed but there are 3 downstream ETLs which may be affected and need backfilling. `core_clients_last_seen__v1` is only used for computing Focus Android metrics, so the impact should be relatively low.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
