### PR TITLE
fix(glam): add all fenix app names to sampled_metrics map

### DIFF
--- a/bigquery_etl/glam/client_side_sampled_metrics.py
+++ b/bigquery_etl/glam/client_side_sampled_metrics.py
@@ -16,7 +16,14 @@ EXPECTED_SAMPLE_RATE = 0.1  # For now, we only support 10% sampling.
 
 _PRODUCT_TO_APP_NAME = {
     "firefox_desktop": "firefox_desktop",
+    # Experimenter doesn't distinguish Fenix variants; all map to appName=fenix.
+    # Variants follow the Play Store app-id history
+    # (see https://github.com/mozilla/telemetry-airflow/blob/2caa0865f017afa0743c94df02666c9af3d66862/dags/glam_fenix.py#L47-L56).
     "org_mozilla_fenix": "fenix",
+    "org_mozilla_fenix_nightly": "fenix",
+    "org_mozilla_firefox": "fenix",
+    "org_mozilla_firefox_beta": "fenix",
+    "org_mozilla_fennec_aurora": "fenix",
 }
 
 

--- a/tests/glam/test_client_side_sampled_metrics.py
+++ b/tests/glam/test_client_side_sampled_metrics.py
@@ -79,11 +79,21 @@ class TestGet:
         rendered_query = mock_run.call_args.args[0]
         assert "app_name = 'firefox_desktop'" in rendered_query
 
+    @pytest.mark.parametrize(
+        "product",
+        [
+            "org_mozilla_fenix",
+            "org_mozilla_fenix_nightly",
+            "org_mozilla_firefox",
+            "org_mozilla_firefox_beta",
+            "org_mozilla_fennec_aurora",
+        ],
+    )
     @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
-    def test_fenix_product_translates_to_fenix_app_name(self, mock_run):
-        """org_mozilla_fenix maps to Experimenter's appName 'fenix'."""
+    def test_fenix_variants_translate_to_fenix_app_name(self, mock_run, product):
+        """All Fenix variants share Experimenter's appName 'fenix'."""
         mock_run.return_value = []
-        client_side_sampled_metrics.get(product="org_mozilla_fenix")
+        client_side_sampled_metrics.get(product=product)
         rendered_query = mock_run.call_args.args[0]
         assert "app_name = 'fenix'" in rendered_query
 


### PR DESCRIPTION
## Description

Fenix's `app_name`s are excessively weird and I forgot about it.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
