### PR TITLE
fix(bug-2040539): add parameter @submission_date to metadata.yaml and fix partition filter required error

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/metadata.yaml
@@ -18,6 +18,8 @@ labels:
 scheduling:
   dag_name: bqetl_cohort_daily_churn
   date_partition_parameter: null
+  parameters:
+  - submission_date:DATE:{{ds}}
 bigquery:
   time_partitioning:
     type: day
@@ -25,5 +27,6 @@ bigquery:
     require_partition_filter: false
     expiration_days: null
   clustering:
-    fields: [sample_id]
+    fields:
+    - sample_id
 require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/recent_new_profile_churn_clients_v1/query.sql
@@ -5,6 +5,8 @@ WITH cohort_cutoff AS (
     COALESCE(MAX(cohort_date) + 1, DATE_SUB(@submission_date, INTERVAL 30 DAY)) AS min_cohort_date
   FROM
     `moz-fx-data-shared-prod.glean_telemetry_derived.new_profile_churn_clients_v1`
+  WHERE
+    cohort_date < @submission_date
 ),
 activity_range AS (
   SELECT


### PR DESCRIPTION
# fix(bug-2040539): add parameter @submission_date to metadata.yaml and fix partition filter required error

This should address the following error we get when running the job:

```
Query parameter 'submission_date' not found at [5:45]
```

During dry-run also found that partition filter is required on `glean_telemetry_derived.new_profile_churn_clients_v1`, this does not appear to align with the metadata configuration.