### PR TITLE
fix(glam): Remove inflated sample_count for scalars

### DIFF
--- a/bigquery_etl/glam/templates/extract_probe_counts_v1.sql
+++ b/bigquery_etl/glam/templates/extract_probe_counts_v1.sql
@@ -42,28 +42,22 @@ WITH final_probe_extract AS (
 -- to populate total_sample for agg_type other than 'count'
 glam_sample_counts AS (
   SELECT
-    fsc1.os,
-    fsc1.app_version,
-    fsc1.app_build_id,
-    fsc1.metric,
-    fsc1.key,
-    fsc1.ping_type,
-    fsc1.agg_type,
-    fsc2.total_sample
+    os,
+    app_version,
+    app_build_id,
+    metric,
+    key,
+    ping_type,
+    agg_type,
+    CASE
+      WHEN agg_type IN ('max', 'min', 'sum', 'avg')
+        THEN MAX(IF(agg_type = 'count', total_sample, NULL)) OVER (
+          PARTITION BY os, app_version, app_build_id, metric, key, ping_type
+        )
+      ELSE total_sample
+    END AS total_sample
   FROM
-    `{{ dataset }}.{{ prefix }}__view_sample_counts_v1` fsc1
-  INNER JOIN
-    `{{ dataset }}.{{ prefix }}__view_sample_counts_v1` fsc2
-    ON fsc1.os = fsc2.os
-    AND fsc1.app_build_id = fsc2.app_build_id
-    AND fsc1.app_version = fsc2.app_version
-    AND fsc1.metric = fsc2.metric
-    AND fsc1.key = fsc2.key
-    AND fsc1.ping_type = fsc2.ping_type
-    AND (
-      (fsc1.agg_type IN ('max', 'min', 'sum', 'avg') AND fsc2.agg_type = 'count')
-      OR (fsc1.agg_type NOT IN ('max', 'min', 'sum', 'avg') AND fsc2.agg_type = fsc1.agg_type)
-    )
+    `{{ dataset }}.{{ prefix }}__view_sample_counts_v1`
 ),
 -- get all the rcords from view_probe_counts and the matching from view_sample_counts
 ranked_data AS (

--- a/bigquery_etl/glam/templates/extract_probe_counts_v1.sql
+++ b/bigquery_etl/glam/templates/extract_probe_counts_v1.sql
@@ -49,12 +49,7 @@ glam_sample_counts AS (
     fsc1.key,
     fsc1.ping_type,
     fsc1.agg_type,
-    CASE
-      WHEN fsc1.agg_type IN ('max', 'min', 'sum', 'avg')
-        AND fsc2.agg_type = 'count'
-        THEN fsc2.total_sample
-      ELSE fsc1.total_sample
-    END AS total_sample
+    fsc2.total_sample
   FROM
     `{{ dataset }}.{{ prefix }}__view_sample_counts_v1` fsc1
   INNER JOIN
@@ -65,6 +60,10 @@ glam_sample_counts AS (
     AND fsc1.metric = fsc2.metric
     AND fsc1.key = fsc2.key
     AND fsc1.ping_type = fsc2.ping_type
+    AND (
+      (fsc1.agg_type IN ('max', 'min', 'sum', 'avg') AND fsc2.agg_type = 'count')
+      OR (fsc1.agg_type NOT IN ('max', 'min', 'sum', 'avg') AND fsc2.agg_type = fsc1.agg_type)
+    )
 ),
 -- get all the rcords from view_probe_counts and the matching from view_sample_counts
 ranked_data AS (


### PR DESCRIPTION
## Description
fixes https://github.com/mozilla/glam/issues/3519

adds an `agg_type` predicate to the self-join so each `fsc1` row matches exactly one `fsc2`, which avoids creating inflated  `total_sample` rows  that would get picked by the next step (`ranked_data`) 

## Related Tickets & Documents
* https://github.com/mozilla/glam/issues/3519

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
