### PR TITLE
feat(DENG-11157): Complete Backfill for Zendesk Table

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/zendesk_tickets_base_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/zendesk_tickets_base_v1/backfill.yaml
@@ -4,7 +4,7 @@
   reason: Initial backfill to update product field using the new UDF in (DENG-11157).
   watchers:
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

This PR completes the back fill for the `zendesk_tickets_base_v1`CX Sumo Table. This is needed from the `product` field having new logic applied to it via a UDF.

## Related Tickets & Documents
* DENG-11157
* PR: https://github.com/mozilla/bigquery-etl/pull/9424

## Validation Results

**Comparison:** backfill staging vs. production for `sumo_metrics_derived.zendesk_tickets_base_v1`.

- **Row counts (full):** backfill 5,667 vs. prod 12,682 — gap is **scope** (prod covers 2019-04-04..2026-05-25; backfill 2024-04-10..2026-05-26).
- **Row counts (overlapping range 2024-04-10..2026-05-25):** backfill 5,660 vs. prod 6,838 — reduction is the expected effect of the new `normalize_product` UDF.
- **`zendesk_tickets_created` totals (overlap):** identical at **257,437** tickets on both sides. **Zero diverging days.**
- **Distinct products:** prod 21 → backfill 8 (UDF consolidation as intended).
- **Grain check:** no duplicate `(date, product)` keys in backfill.

**Conclusion:** Backfill is safe to swap in — ticket totals are preserved exactly while product variants are consolidated per DENG-11157.

**Open question:** Prod has ~5 years of older data (2019-04-04 to 2024-04-09) outside the backfill window. Should those older partitions also be backfilled, or remain on the legacy logic?

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**