### PR TITLE
Follow up for a managed backfill due to sql-generators not supported.

### DIFF
--- a/sql_generators/active_users_aggregates_v3/__init__.py
+++ b/sql_generators/active_users_aggregates_v3/__init__.py
@@ -112,6 +112,8 @@ def generate(target_project, output_dir, use_cloud_function):
     desktop_view_schema_template = "desktop_view_schema.yaml"
     mobile_table_schema_template = "mobile_table_schema.yaml"
     mobile_view_schema_template = "mobile_view_schema.yaml"
+    # backfill template
+    focus_android_backfill_template = "focus_android_backfill.yaml"
     # checks templates
     desktop_checks_template = env.get_template("desktop_checks.sql")
     fenix_checks_template = env.get_template("fenix_checks.sql")
@@ -374,6 +376,20 @@ def generate(target_project, output_dir, use_cloud_function):
             ),
             skip_existing=False,
         )
+
+        # Write backfill YAML.
+        if browser.name == "focus_android":
+            write_sql(
+                output_dir=output_dir,
+                full_table_id=f"{target_project}.{browser.name}_derived.{TABLE_NAME}",
+                basename="backfill.yaml",
+                sql=render(
+                    focus_android_backfill_template,
+                    template_folder=THIS_PATH / "templates",
+                    format=False,
+                ),
+                skip_existing=False,
+            )
 
     # Write Mobile unioned view SQL.
     write_sql(

--- a/sql_generators/active_users_aggregates_v3/templates/focus_android_backfill.yaml
+++ b/sql_generators/active_users_aggregates_v3/templates/focus_android_backfill.yaml
@@ -1,0 +1,10 @@
+2026-05-25:
+  start_date: 2026-04-15
+  end_date: 2026-05-25
+  reason: Fix inflated Focus Android metrics caused by duplicate client_ids in core_clients_last_seen_v1.
+  watchers:
+  - ascholtz@mozilla.com
+  - lvargas@mozilla.com
+  status: Initiate
+  shredder_mitigation: true
+  override_retention_limit: false


### PR DESCRIPTION
## Description

Managed backfills don't support sql generators so they result in a failure due to the file not found in main.
This generates the file to keep track of backfills and needs to be triggered from the generated sql.

[PR-9439](https://github.com/mozilla/bigquery-etl/pull/9439)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
