### PR TITLE
fix(glam): preserve metric label in view_sample_counts_v1

### DIFF
--- a/bigquery_etl/glam/templates/view_sample_counts_v1.sql
+++ b/bigquery_etl/glam/templates/view_sample_counts_v1.sql
@@ -51,7 +51,7 @@ scalars_histogram_data AS (
       sample_mult,
     {% endif %}
     metric,
-    v1.key,
+    histogram_data.key,
     agg_type,
     v1.value
   FROM
@@ -96,7 +96,7 @@ with_combos AS (
 SELECT
   {{ attributes }},
   metric,
-  '' AS key,
+  key,
   agg_type,
   {% if channel == 'release' %}
     CAST(SUM(value) * MAX(sample_mult) AS BIGNUMERIC) AS total_sample


### PR DESCRIPTION
## Description
fixes https://github.com/mozilla/glam/issues/3521

`view_sample_counts_v1` was dropping the metric label when unnesting histogram buckets, so the downstream `extract_probe_counts_v1` join (`sc.key = cp.metric_key`) failed for labeled distributions (timing/memory/custom), producing `sample_count = 0` in GLAM.

## Related Tickets & Documents
* https://github.com/mozilla/glam/issues/3521

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
