### PR TITLE
feat(DENG-11157) Complete Back fill for historical data Zendesk table

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/zendesk_tickets_base_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/zendesk_tickets_base_v1/backfill.yaml
@@ -4,7 +4,7 @@
   reason: Backfill historical data to update product field using the new UDF in (DENG-11157).
   watchers:
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

This PR completes the historical data back fill for the `zendesk_tickets_base_v1`CX Sumo Table. This is needed from the `product` field having new logic applied to it via a UDF.

## Related Tickets & Documents
* DENG-11157
* PR: https://github.com/mozilla/bigquery-etl/pull/9424


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
