### PR TITLE
chore(schema): add field descriptions for braze_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/braze_derived/fxa_win10_users_historical_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/fxa_win10_users_historical_v1/schema.yaml
@@ -2,15 +2,27 @@ fields:
 - name: submission_date
   type: DATE
   mode: NULLABLE
+  description: The date the user was identified as an inactive Windows 10 Firefox
+    user and added to this list, derived from the fx_accounts ping submission timestamp.
 - name: external_id
   type: STRING
   mode: NULLABLE
+  description: The Braze external user identifier (UUID) linking this record to the
+    user's profile in braze_derived.users_v1, or a generated UUID if the user had
+    no prior Braze record.
 - name: email
   type: STRING
   mode: NULLABLE
+  description: The user's primary email address, sourced from their Braze profile
+    or Firefox Accounts record, used to target this re-engagement campaign.
 - name: locale
   type: STRING
   mode: NULLABLE
+  description: The application locale of the user at the time of their most recent
+    fx_accounts ping (e.g. 'en-US', 'de'). Only users with one of the supported locales
+    (de, en-US, en-GB, es-ES, fr, it, pl, pt-BR) are included.
 - name: fxa_id_sha256
   type: STRING
   mode: NULLABLE
+  description: SHA-256 hash of the user's Firefox Accounts (FxA) user ID, used to
+    link this record to FxA account data without exposing the raw identifier.

--- a/sql/moz-fx-data-shared-prod/braze_derived/newsletters_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/newsletters_v1/schema.yaml
@@ -2,25 +2,41 @@ fields:
 - mode: NULLABLE
   name: external_id
   type: STRING
+  description: The Braze external user identifier (UUID) matching the user's record
+    in braze_derived.users_v1, sourced from the CTMS email_id.
 - fields:
   - mode: NULLABLE
     name: newsletter_name
     type: STRING
+    description: The internal slug identifying the newsletter (e.g. 'mozilla-and-you',
+      'security-privacy-news'), matching names in braze_derived.subscriptions_map_v1.
   - mode: NULLABLE
     name: subscribed
     type: BOOLEAN
+    description: Whether the user is currently subscribed to this newsletter. True
+      indicates an active subscription; false indicates the user has unsubscribed.
   - mode: NULLABLE
     name: newsletter_lang
     type: STRING
+    description: The language code associated with the user's newsletter subscription
+      (e.g. 'en', 'fr'), stored in lowercase.
   - mode: NULLABLE
     name: newsletter_source
     type: STRING
+    description: The acquisition source that attributed this newsletter subscription
+      (e.g. a web form slug or campaign identifier), sourced from CTMS.
   - mode: NULLABLE
     name: create_timestamp
     type: TIMESTAMP
+    description: Timestamp when this newsletter subscription record was first created
+      in CTMS.
   - mode: NULLABLE
     name: update_timestamp
     type: TIMESTAMP
+    description: Timestamp when this newsletter subscription record was most recently
+      updated in CTMS.
   mode: REPEATED
   name: newsletters
   type: RECORD
+  description: Array of newsletter subscription records for this user, each describing
+    a single newsletter the user has ever been subscribed to.

--- a/sql/moz-fx-data-shared-prod/braze_derived/products_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/products_v1/schema.yaml
@@ -2,142 +2,242 @@ fields:
 - mode: NULLABLE
   name: external_id
   type: STRING
+  description: The Braze external user identifier (UUID) matching the user's record
+    in braze_derived.users_v1, linked via the CTMS FxA email_id.
 - fields:
   - mode: NULLABLE
     name: provider
     type: STRING
+    description: The subscription provider platform (e.g. 'stripe', 'apple', 'google')
+      through which this subscription was created.
   - mode: NULLABLE
     name: payment_provider
     type: STRING
+    description: The payment provider used to process subscription charges (e.g. 'stripe',
+      'paypal'), which may differ from the subscription provider.
   - mode: NULLABLE
     name: product_name
     type: STRING
+    description: The human-readable name of the Mozilla subscription product (e.g.
+      'Mozilla VPN', 'Firefox Relay').
   - mode: NULLABLE
     name: service_name
     type: STRING
+    description: The internal service name associated with this subscription, sourced
+      from the logical_subscriptions services array.
   - mode: NULLABLE
     name: subscription_plan_id
     type: STRING
+    description: The provider-assigned plan identifier for this subscription (mapped
+      from provider_plan_id in logical_subscriptions).
   - mode: NULLABLE
     name: subscription_product_id
     type: STRING
+    description: The provider-assigned product identifier for this subscription (mapped
+      from provider_product_id in logical_subscriptions).
   - mode: NULLABLE
     name: subscription_started_at
     type: TIMESTAMP
+    description: Timestamp when the subscription became active, sourced from started_at
+      in logical_subscriptions.
   - mode: NULLABLE
     name: subscription_ended_at
     type: TIMESTAMP
+    description: Timestamp when the subscription ended or was cancelled; null if the
+      subscription is still active.
   - mode: NULLABLE
     name: subscription_summary
     type: STRING
+    description: A human-readable summary string describing the subscription plan
+      (mapped from plan_summary in logical_subscriptions).
   - mode: NULLABLE
     name: subscription_billing_interval
     type: STRING
+    description: The billing interval type for the subscription plan (e.g. 'month',
+      'year'), sourced from plan_interval_type.
   - mode: NULLABLE
     name: subscription_interval_count
     type: INTEGER
+    description: The number of billing interval units per billing cycle (e.g. 1 for
+      monthly, 12 for annual), sourced from plan_interval_count.
   - mode: NULLABLE
     name: subscription_currency
     type: STRING
+    description: The ISO 4217 currency code used for this subscription's billing (e.g.
+      'usd', 'eur'), sourced from plan_currency.
   - mode: NULLABLE
     name: subscription_amount
     type: NUMERIC
+    description: The subscription billing amount in the subscription_currency, sourced
+      from plan_amount in logical_subscriptions.
   - mode: NULLABLE
     name: is_bundle
     type: BOOLEAN
+    description: Whether this subscription is part of a product bundle. True indicates
+      the user is subscribed to a multi-product bundle offer.
   - mode: NULLABLE
     name: is_trial
     type: BOOLEAN
+    description: Whether this subscription is currently in a free trial period. True
+      indicates the user has not yet been charged for this subscription.
   - mode: NULLABLE
     name: is_active
     type: BOOLEAN
+    description: Whether this subscription is currently active. True indicates the
+      subscription has not expired or been cancelled.
   - mode: NULLABLE
     name: subscription_status
     type: STRING
+    description: The provider-reported status of the subscription (mapped from provider_status),
+      such as 'active', 'canceled', or 'past_due'.
   - mode: NULLABLE
     name: subscription_country_code
     type: STRING
+    description: Lowercase ISO 3166-1 alpha-2 country code associated with the subscription,
+      sourced from country_code in logical_subscriptions.
   - mode: NULLABLE
     name: subscription_country_name
     type: STRING
+    description: The full country name associated with the subscription, sourced from
+      country_name in logical_subscriptions.
   - mode: NULLABLE
     name: current_period_started_at
     type: TIMESTAMP
+    description: Timestamp when the current billing period began for this subscription.
   - mode: NULLABLE
     name: current_period_ends_at
     type: TIMESTAMP
+    description: Timestamp when the current billing period ends; after this date the
+      subscription will renew or expire.
   - mode: NULLABLE
     name: is_auto_renew
     type: BOOLEAN
+    description: Whether the subscription is set to automatically renew at the end
+      of the current billing period. True means renewal is enabled.
   - mode: NULLABLE
     name: auto_renew_disabled_at
     type: TIMESTAMP
+    description: Timestamp when auto-renewal was disabled for this subscription; null
+      if auto-renewal is still active.
   - mode: NULLABLE
     name: has_refunds
     type: BOOLEAN
+    description: Whether any refunds have been issued for this subscription. True
+      indicates at least one refund transaction exists.
   - mode: NULLABLE
     name: has_fraudulent_charges
     type: BOOLEAN
+    description: Whether any fraudulent charges have been detected for this subscription.
+      True indicates at least one charge was flagged as fraudulent.
   - mode: NULLABLE
     name: first_touch_impression_at
     type: TIMESTAMP
+    description: Timestamp of the user's first attribution touch impression for this
+      subscription. Currently always null as first-touch attribution is not yet populated.
   - mode: NULLABLE
     name: first_touch_entrypoint
     type: STRING
+    description: The FxA entrypoint slug recorded at the user's first attribution
+      touch for this subscription. Currently always null as first-touch attribution
+      is not yet populated.
   - mode: NULLABLE
     name: first_touch_entrypoint_experiment
     type: STRING
+    description: The experiment slug at the user's first attribution touch for this
+      subscription. Currently always null as first-touch attribution is not yet populated.
   - mode: NULLABLE
     name: first_touch_entrypoint_variation
     type: STRING
+    description: The experiment variation at the user's first attribution touch for
+      this subscription. Currently always null as first-touch attribution is not yet
+      populated.
   - mode: NULLABLE
     name: first_touch_utm_campaign
     type: STRING
+    description: The UTM campaign parameter at the user's first attribution touch
+      for this subscription. Currently always null as first-touch attribution is not
+      yet populated.
   - mode: NULLABLE
     name: first_touch_utm_content
     type: STRING
+    description: The UTM content parameter at the user's first attribution touch for
+      this subscription. Currently always null as first-touch attribution is not yet
+      populated.
   - mode: NULLABLE
     name: first_touch_utm_medium
     type: STRING
+    description: The UTM medium parameter at the user's first attribution touch for
+      this subscription. Currently always null as first-touch attribution is not yet
+      populated.
   - mode: NULLABLE
     name: first_touch_utm_source
     type: STRING
+    description: The UTM source parameter at the user's first attribution touch for
+      this subscription. Currently always null as first-touch attribution is not yet
+      populated.
   - mode: NULLABLE
     name: first_touch_utm_term
     type: STRING
+    description: The UTM term parameter at the user's first attribution touch for
+      this subscription. Currently always null as first-touch attribution is not yet
+      populated.
   - mode: NULLABLE
     name: last_touch_impression_at
     type: TIMESTAMP
+    description: Timestamp of the user's most recent attribution touch impression
+      before subscribing, sourced from last_touch_attribution.impression_at.
   - mode: NULLABLE
     name: last_touch_entrypoint
     type: STRING
+    description: The FxA entrypoint slug recorded at the user's last attribution touch
+      before subscribing.
   - mode: NULLABLE
     name: last_touch_entrypoint_experiment
     type: STRING
+    description: The experiment slug at the user's last attribution touch before subscribing.
   - mode: NULLABLE
     name: last_touch_entrypoint_variation
     type: STRING
+    description: The experiment variation at the user's last attribution touch before
+      subscribing.
   - mode: NULLABLE
     name: last_touch_utm_campaign
     type: STRING
+    description: The UTM campaign parameter at the user's last attribution touch before
+      subscribing.
   - mode: NULLABLE
     name: last_touch_utm_content
     type: STRING
+    description: The UTM content parameter at the user's last attribution touch before
+      subscribing.
   - mode: NULLABLE
     name: last_touch_utm_medium
     type: STRING
+    description: The UTM medium parameter at the user's last attribution touch before
+      subscribing.
   - mode: NULLABLE
     name: last_touch_utm_source
     type: STRING
+    description: The UTM source parameter at the user's last attribution touch before
+      subscribing.
   - mode: NULLABLE
     name: last_touch_utm_term
     type: STRING
+    description: The UTM term parameter at the user's last attribution touch before
+      subscribing.
   - mode: NULLABLE
     name: subscription_created_at
     type: TIMESTAMP
+    description: Timestamp when the subscription was first created at the provider,
+      sourced from provider_subscription_created_at.
   - mode: NULLABLE
     name: subscription_updated_at
     type: TIMESTAMP
+    description: Timestamp when the subscription record was most recently updated
+      at the provider, sourced from provider_subscription_updated_at.
   mode: REPEATED
   name: products
   type: RECORD
+  description: Array of Mozilla subscription product records for this user, sourced
+    from subscription_platform.logical_subscriptions, one entry per active or historical
+    subscription.

--- a/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_map_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_map_v1/schema.yaml
@@ -2,18 +2,30 @@ fields:
 - mode: NULLABLE
   name: braze_subscription_name
   type: STRING
+  description: The Braze subscription group name slug (e.g. 'mozilla-and-you', 'relay-waitlist')
+    used as the canonical identifier for a newsletter or waitlist in the Braze platform.
 - mode: NULLABLE
   name: description
   type: STRING
+  description: A human-readable label for the Braze subscription group (e.g. 'Mozilla
+    Community Newsletter', 'Firefox Relay Waitlist').
 - mode: NULLABLE
   name: mozilla_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Mozilla production
+    Braze environment.
 - mode: NULLABLE
   name: firefox_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Firefox production
+    Braze environment.
 - mode: NULLABLE
   name: mozilla_dev_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Mozilla development/staging
+    Braze environment.
 - mode: NULLABLE
   name: basket_slug
   type: STRING
+  description: The slug identifier used in Mozilla's Basket email subscription service
+    for this subscription group, typically matching braze_subscription_name.

--- a/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_map_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_map_v2/schema.yaml
@@ -2,18 +2,30 @@ fields:
 - mode: NULLABLE
   name: braze_subscription_name
   type: STRING
+  description: The Braze subscription group name slug (e.g. 'mozilla-and-you', 'relay-waitlist')
+    used as the canonical identifier for a newsletter or waitlist in the Braze platform.
 - mode: NULLABLE
   name: description
   type: STRING
+  description: A human-readable label for the Braze subscription group (e.g. 'Mozilla
+    Community Newsletter', 'Firefox Relay Waitlist').
 - mode: NULLABLE
   name: mozilla_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Mozilla production
+    Braze environment.
 - mode: NULLABLE
   name: firefox_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Firefox production
+    Braze environment.
 - mode: NULLABLE
   name: mozilla_dev_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Mozilla development/staging
+    Braze environment.
 - mode: NULLABLE
   name: basket_slug
   type: STRING
+  description: The slug identifier used in Mozilla's Basket email subscription service
+    for this subscription group, typically matching braze_subscription_name.

--- a/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/schema.yaml
@@ -2,25 +2,43 @@ fields:
 - mode: NULLABLE
   name: external_id
   type: STRING
+  description: The Braze external user identifier (UUID) matching the user's record
+    in braze_derived.users_v1.
 - fields:
   - mode: NULLABLE
     name: subscription_name
     type: STRING
+    description: The Braze subscription group name slug for this subscription entry
+      (e.g. 'mozilla-and-you', 'guardian-vpn-waitlist'), matching braze_subscription_name
+      in subscriptions_map_v1.
   - mode: NULLABLE
     name: firefox_subscription_id
     type: STRING
+    description: The UUID identifying this subscription group in the Firefox production
+      Braze environment, sourced from subscriptions_map_v1.
   - mode: NULLABLE
     name: mozilla_subscription_id
     type: STRING
+    description: The UUID identifying this subscription group in the Mozilla production
+      Braze environment, sourced from subscriptions_map_v1.
   - mode: NULLABLE
     name: mozilla_dev_subscription_id
     type: STRING
+    description: The UUID identifying this subscription group in the Mozilla development/staging
+      Braze environment, sourced from subscriptions_map_v1.
   - mode: NULLABLE
     name: subscription_state
     type: STRING
+    description: The current state of this subscription for the user. Values are 'subscribed'
+      (user is actively subscribed) or 'unsubscribed' (user has unsubscribed).
   - mode: NULLABLE
     name: update_timestamp
     type: TIMESTAMP
+    description: Timestamp when this subscription state was most recently updated,
+      sourced from the newsletter or waitlist update_timestamp in user_profiles_v1.
   mode: REPEATED
   name: subscriptions
   type: RECORD
+  description: Array of Braze newsletter and waitlist subscription records for this
+    user, derived from user_profiles_v1 newsletters and waitlists and mapped to Braze
+    subscription IDs via subscriptions_map_v1.

--- a/sql/moz-fx-data-shared-prod/braze_derived/user_profiles_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/user_profiles_v1/schema.yaml
@@ -1,308 +1,377 @@
 fields:
-
 - name: external_id
   type: STRING
   mode: NULLABLE
-
+  description: The Braze external user identifier (UUID), sourced from the CTMS email_id,
+    uniquely identifying each user in the Braze platform.
 - name: email
   type: STRING
   mode: NULLABLE
-
+  description: The user's primary email address in lowercase, sourced from CTMS, used
+    as the primary contact address in Braze.
 - name: mailing_country
   type: STRING
   mode: NULLABLE
-
+  description: Lowercase two-letter country code representing the user's mailing country,
+    sourced from CTMS. Null for approximately 36% of users where country information
+    is unavailable.
 - name: email_subscribe
   type: STRING
   mode: NULLABLE
-
+  description: The user's overall email subscription status in Braze. Values are 'opted_in'
+    (double opt-in confirmed) or 'subscribed' (single opt-in, not yet double-confirmed).
 - name: basket_token
   type: STRING
   mode: NULLABLE
-
+  description: A UUID token identifying the user in Mozilla's Basket email subscription
+    management service, used to link CTMS and Braze records.
 - name: email_lang
   type: STRING
   mode: NULLABLE
-
+  description: The preferred language code for email communications (e.g. 'en', 'fr',
+    'de'), sourced from CTMS and stored in lowercase. Top values are en (~62%), es
+    (~9%), fr (~6%), de (~6%).
 - name: create_timestamp
   type: TIMESTAMP
   mode: NULLABLE
-
+  description: Timestamp when the user's CTMS email record was first created.
 - name: update_timestamp
   type: TIMESTAMP
   mode: NULLABLE
-
+  description: Timestamp when the user's CTMS email record was most recently updated.
 - name: fxa_id_sha256
   type: STRING
   mode: NULLABLE
-
+  description: SHA-256 hex hash of the user's Firefox Accounts user ID, used to join
+    with FxA-derived tables without exposing the raw FxA UID. Null for ~7.5% of users
+    with no linked FxA account.
 - name: has_fxa
   type: BOOLEAN
   mode: NULLABLE
-
+  description: Whether the user has an active linked Firefox Account. True for ~92.5%
+    of users; false when no FxA record exists or the FxA account has been deleted.
 - name: fxa_primary_email
   type: STRING
   mode: NULLABLE
-
+  description: The primary email address registered in Firefox Accounts for this user,
+    in lowercase. May differ from the CTMS email field.
 - name: fxa_lang
   type: STRING
   mode: NULLABLE
-
+  description: The browser Accept-Language header value recorded at FxA account creation
+    (e.g. 'en-us,en;q=0.5', 'fr,fr-fr;q=0.8,en-us;q=0.5,en;q=0.3'). Null for ~47%
+    of users.
 - name: fxa_first_service
   type: STRING
   mode: NULLABLE
-
+  description: The first Mozilla service through which the user created their Firefox
+    Account (e.g. 'sync', 'fenix', 'pocket-web', 'firefox-ios'). Null for ~49% of
+    users.
 - name: fxa_created_at
   type: TIMESTAMP
   mode: NULLABLE
-
+  description: Timestamp when the user's Firefox Account was created, cast from the
+    CTMS FxA created_date. Null for ~7.6% of users with no linked FxA account.
 - name: newsletters
   type: RECORD
   mode: REPEATED
   fields:
-
   - name: newsletter_name
     type: STRING
     mode: NULLABLE
-
+    description: The internal slug identifying the newsletter (e.g. 'mozilla-and-you',
+      'security-privacy-news'), matching names in braze_derived.subscriptions_map_v1.
   - name: subscribed
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether the user is currently subscribed to this newsletter. True
+      indicates an active subscription; false indicates the user has unsubscribed.
   - name: newsletter_lang
     type: STRING
     mode: NULLABLE
-
+    description: The language code associated with the user's newsletter subscription
+      (e.g. 'en', 'fr'), stored in lowercase.
   - name: newsletter_source
     type: STRING
     mode: NULLABLE
-
+    description: The acquisition source that attributed this newsletter subscription
+      (e.g. a web form slug or campaign identifier), sourced from CTMS.
   - name: create_timestamp
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when this newsletter subscription record was first created
+      in CTMS.
   - name: update_timestamp
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when this newsletter subscription record was most recently
+      updated in CTMS.
+  description: Array of newsletter subscription records for this user, joined from
+    braze_derived.newsletters_v1.
 - name: waitlists
   type: RECORD
   mode: REPEATED
   fields:
-
   - name: waitlist_name
     type: STRING
     mode: NULLABLE
-
+    description: The internal name of the product waitlist (e.g. 'relay', 'vpn', 'monitor'),
+      sourced from the CTMS waitlists table.
   - name: waitlist_geo
     type: STRING
     mode: NULLABLE
-
+    description: Lowercase geographic region or country code specified by the user
+      when joining this waitlist, extracted from the CTMS waitlist fields JSON.
   - name: waitlist_platform
     type: STRING
     mode: NULLABLE
-
+    description: Lowercase platform preference specified by the user when joining
+      this waitlist (e.g. 'ios', 'android'), extracted from the CTMS waitlist fields
+      JSON.
   - name: waitlist_source
     type: STRING
     mode: NULLABLE
-
+    description: Lowercase acquisition source that attributed this waitlist sign-up
+      (e.g. a web form slug), sourced from the CTMS waitlists source field.
   - name: create_timestamp
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when the user's waitlist record was first created in CTMS.
   - name: subscribed
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether the user is currently on this waitlist. True indicates an
+      active waitlist sign-up; false indicates the user has unsubscribed from the
+      waitlist.
   - name: unsub_reason
     type: STRING
     mode: NULLABLE
-
+    description: The reason provided when the user unsubscribed from this waitlist,
+      sourced from CTMS. Null when the user is still subscribed or no reason was given.
   - name: update_timestamp
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when this waitlist record was most recently updated in
+      CTMS.
+  description: Array of product waitlist records for this user, joined from braze_derived.waitlists_v1.
 - name: products
   type: RECORD
   mode: REPEATED
   fields:
-
   - name: provider
     type: STRING
     mode: NULLABLE
-
+    description: The subscription provider platform (e.g. 'stripe', 'apple', 'google')
+      through which this subscription was created.
   - name: payment_provider
     type: STRING
     mode: NULLABLE
-
+    description: The payment provider used to process subscription charges (e.g. 'stripe',
+      'paypal'), which may differ from the subscription provider.
   - name: product_name
     type: STRING
     mode: NULLABLE
-
+    description: The human-readable name of the Mozilla subscription product (e.g.
+      'Mozilla VPN', 'Firefox Relay').
   - name: service_name
     type: STRING
     mode: NULLABLE
-
+    description: The internal service name associated with this subscription, sourced
+      from the logical_subscriptions services array.
   - name: subscription_plan_id
     type: STRING
     mode: NULLABLE
-
+    description: The provider-assigned plan identifier for this subscription.
   - name: subscription_product_id
     type: STRING
     mode: NULLABLE
-
+    description: The provider-assigned product identifier for this subscription.
   - name: subscription_started_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when the subscription became active.
   - name: subscription_ended_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when the subscription ended or was cancelled; null if the
+      subscription is still active.
   - name: subscription_summary
     type: STRING
     mode: NULLABLE
-
+    description: A human-readable summary string describing the subscription plan.
   - name: subscription_billing_interval
     type: STRING
     mode: NULLABLE
-
+    description: The billing interval type for the subscription plan (e.g. 'month',
+      'year').
   - name: subscription_interval_count
     type: INTEGER
     mode: NULLABLE
-
+    description: The number of billing interval units per billing cycle (e.g. 1 for
+      monthly, 12 for annual).
   - name: subscription_currency
     type: STRING
     mode: NULLABLE
-
+    description: The ISO 4217 currency code used for this subscription's billing (e.g.
+      'usd', 'eur').
   - name: subscription_amount
     type: NUMERIC
     mode: NULLABLE
-
+    description: The subscription billing amount in the subscription_currency.
   - name: is_bundle
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether this subscription is part of a product bundle. True indicates
+      the user is subscribed to a multi-product bundle offer.
   - name: is_trial
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether this subscription is currently in a free trial period. True
+      indicates the user has not yet been charged.
   - name: is_active
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether this subscription is currently active. True indicates the
+      subscription has not expired or been cancelled.
   - name: subscription_status
     type: STRING
     mode: NULLABLE
-
+    description: The provider-reported status of the subscription (e.g. 'active',
+      'canceled', 'past_due').
   - name: subscription_country_code
     type: STRING
     mode: NULLABLE
-
+    description: Lowercase ISO 3166-1 alpha-2 country code associated with the subscription.
   - name: subscription_country_name
     type: STRING
     mode: NULLABLE
-
+    description: The full country name associated with the subscription.
   - name: current_period_started_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when the current billing period began for this subscription.
   - name: current_period_ends_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when the current billing period ends; after this date the
+      subscription will renew or expire.
   - name: is_auto_renew
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether the subscription is set to automatically renew at the end
+      of the current billing period.
   - name: auto_renew_disabled_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when auto-renewal was disabled for this subscription; null
+      if auto-renewal is still active.
   - name: has_refunds
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether any refunds have been issued for this subscription. True
+      indicates at least one refund transaction exists.
   - name: has_fraudulent_charges
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether any fraudulent charges have been detected for this subscription.
+      True indicates at least one charge was flagged as fraudulent.
   - name: first_touch_impression_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp of the user's first attribution touch impression. Currently
+      always null as first-touch attribution is not yet populated.
   - name: first_touch_entrypoint
     type: STRING
     mode: NULLABLE
-
+    description: The FxA entrypoint at the user's first attribution touch. Currently
+      always null as first-touch attribution is not yet populated.
   - name: first_touch_entrypoint_experiment
     type: STRING
     mode: NULLABLE
-
+    description: The experiment at the user's first attribution touch. Currently always
+      null as first-touch attribution is not yet populated.
   - name: first_touch_entrypoint_variation
     type: STRING
     mode: NULLABLE
-
+    description: The experiment variation at the user's first attribution touch. Currently
+      always null as first-touch attribution is not yet populated.
   - name: first_touch_utm_campaign
     type: STRING
     mode: NULLABLE
-
+    description: The UTM campaign at the user's first attribution touch. Currently
+      always null as first-touch attribution is not yet populated.
   - name: first_touch_utm_content
     type: STRING
     mode: NULLABLE
-
+    description: The UTM content at the user's first attribution touch. Currently
+      always null as first-touch attribution is not yet populated.
   - name: first_touch_utm_medium
     type: STRING
     mode: NULLABLE
-
+    description: The UTM medium at the user's first attribution touch. Currently always
+      null as first-touch attribution is not yet populated.
   - name: first_touch_utm_source
     type: STRING
     mode: NULLABLE
-
+    description: The UTM source at the user's first attribution touch. Currently always
+      null as first-touch attribution is not yet populated.
   - name: first_touch_utm_term
     type: STRING
     mode: NULLABLE
-
+    description: The UTM term at the user's first attribution touch. Currently always
+      null as first-touch attribution is not yet populated.
   - name: last_touch_impression_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp of the user's most recent attribution touch impression
+      before subscribing.
   - name: last_touch_entrypoint
     type: STRING
     mode: NULLABLE
-
+    description: The FxA entrypoint slug at the user's last attribution touch before
+      subscribing.
   - name: last_touch_entrypoint_experiment
     type: STRING
     mode: NULLABLE
-
+    description: The experiment slug at the user's last attribution touch before subscribing.
   - name: last_touch_entrypoint_variation
     type: STRING
     mode: NULLABLE
-
+    description: The experiment variation at the user's last attribution touch before
+      subscribing.
   - name: last_touch_utm_campaign
     type: STRING
     mode: NULLABLE
-
+    description: The UTM campaign parameter at the user's last attribution touch before
+      subscribing.
   - name: last_touch_utm_content
     type: STRING
     mode: NULLABLE
-
+    description: The UTM content parameter at the user's last attribution touch before
+      subscribing.
   - name: last_touch_utm_medium
     type: STRING
     mode: NULLABLE
-
+    description: The UTM medium parameter at the user's last attribution touch before
+      subscribing.
   - name: last_touch_utm_source
     type: STRING
     mode: NULLABLE
-
+    description: The UTM source parameter at the user's last attribution touch before
+      subscribing.
   - name: last_touch_utm_term
     type: STRING
     mode: NULLABLE
-
+    description: The UTM term parameter at the user's last attribution touch before
+      subscribing.
   - name: subscription_created_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when the subscription was first created at the provider.
   - name: subscription_updated_at
     type: TIMESTAMP
     mode: NULLABLE
+    description: Timestamp when the subscription record was most recently updated
+      at the provider.
+  description: Array of Mozilla subscription product records for this user, joined
+    from braze_derived.products_v1.

--- a/sql/moz-fx-data-shared-prod/braze_derived/users_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/users_v1/schema.yaml
@@ -2,42 +2,72 @@ fields:
 - mode: NULLABLE
   name: external_id
   type: STRING
+  description: The Braze external user identifier (UUID), sourced from the CTMS email_id,
+    uniquely identifying each user in the Braze platform.
 - mode: NULLABLE
   name: email
   type: STRING
+  description: The user's primary email address in lowercase, sourced from CTMS, used
+    as the primary contact address in Braze.
 - mode: NULLABLE
   name: mailing_country
   type: STRING
+  description: Lowercase two-letter country code representing the user's mailing country,
+    sourced from CTMS. Null for approximately 36% of users where country information
+    is unavailable.
 - mode: NULLABLE
   name: email_subscribe
   type: STRING
+  description: The user's overall email subscription status in Braze. Values are 'opted_in'
+    (double opt-in confirmed, ~99%) or 'subscribed' (single opt-in, ~1%).
 - mode: NULLABLE
   name: basket_token
   type: STRING
+  description: A UUID token identifying the user in Mozilla's Basket email subscription
+    management service, used to link CTMS and Braze records.
 - mode: NULLABLE
   name: email_lang
   type: STRING
+  description: The preferred language code for email communications (e.g. 'en', 'fr',
+    'de'), sourced from CTMS and stored in lowercase. Top values are en (~62%), es
+    (~9%), fr (~6%), de (~6%).
 - mode: NULLABLE
   name: create_timestamp
   type: TIMESTAMP
+  description: Timestamp when the user's CTMS email record was first created.
 - mode: NULLABLE
   name: update_timestamp
   type: TIMESTAMP
+  description: Timestamp when the user's CTMS email record was most recently updated.
 - mode: NULLABLE
   name: fxa_id_sha256
   type: STRING
+  description: SHA-256 hex hash of the user's Firefox Accounts user ID, used to join
+    with FxA-derived tables without exposing the raw FxA UID. Null for ~7.5% of users
+    with no linked FxA account.
 - mode: NULLABLE
   name: has_fxa
   type: BOOLEAN
+  description: Whether the user has an active linked Firefox Account. True for ~92.5%
+    of users; false when no FxA record exists or the FxA account has been deleted.
 - mode: NULLABLE
   name: fxa_primary_email
   type: STRING
+  description: The primary email address registered in Firefox Accounts for this user,
+    in lowercase. May differ from the CTMS email field.
 - mode: NULLABLE
   name: fxa_lang
   type: STRING
+  description: The browser Accept-Language header value recorded at FxA account creation
+    (e.g. 'en-us,en;q=0.5'). Null for ~47% of users.
 - mode: NULLABLE
   name: fxa_first_service
   type: STRING
+  description: The first Mozilla service through which the user created their Firefox
+    Account (e.g. 'sync', 'fenix', 'pocket-web', 'firefox-ios'). Null for ~49% of
+    users.
 - mode: NULLABLE
   name: fxa_created_at
   type: TIMESTAMP
+  description: Timestamp when the user's Firefox Account was created, cast from the
+    CTMS FxA created_date. Null for ~7.6% of users with no linked FxA account.

--- a/sql/moz-fx-data-shared-prod/braze_derived/waitlists_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/waitlists_v1/schema.yaml
@@ -2,31 +2,51 @@ fields:
 - mode: NULLABLE
   name: external_id
   type: STRING
+  description: The Braze external user identifier (UUID) matching the user's record
+    in braze_derived.users_v1, sourced from the CTMS email_id.
 - fields:
   - mode: NULLABLE
     name: waitlist_name
     type: STRING
+    description: The internal name of the product waitlist (e.g. 'relay', 'vpn', 'monitor'),
+      sourced from the CTMS waitlists name field.
   - mode: NULLABLE
     name: waitlist_geo
     type: STRING
+    description: Lowercase geographic region or country code specified by the user
+      when joining this waitlist, extracted from the CTMS waitlist fields JSON.
   - mode: NULLABLE
     name: waitlist_platform
     type: STRING
+    description: Lowercase platform preference specified by the user when joining
+      this waitlist (e.g. 'ios', 'android'), extracted from the CTMS waitlist fields
+      JSON.
   - mode: NULLABLE
     name: waitlist_source
     type: STRING
+    description: Lowercase acquisition source that attributed this waitlist sign-up,
+      sourced from the CTMS waitlists source field.
   - mode: NULLABLE
     name: create_timestamp
     type: TIMESTAMP
+    description: Timestamp when the user's waitlist record was first created in CTMS.
   - mode: NULLABLE
     name: subscribed
     type: BOOLEAN
+    description: Whether the user is currently on this waitlist. True indicates an
+      active sign-up; false indicates the user has been removed or unsubscribed.
   - mode: NULLABLE
     name: unsub_reason
     type: STRING
+    description: The reason provided when the user unsubscribed from this waitlist,
+      sourced from CTMS. Null when the user is still subscribed or no reason was given.
   - mode: NULLABLE
     name: update_timestamp
     type: TIMESTAMP
+    description: Timestamp when this waitlist record was most recently updated in
+      CTMS.
   mode: REPEATED
   name: waitlists
   type: RECORD
+  description: Array of product waitlist records for this user, each describing a
+    single waitlist the user has signed up for, sourced from ctms_braze.ctms_waitlists.


### PR DESCRIPTION
## Schema Update: `moz-fx-data-shared-prod.braze_derived`

> Generated by the metadata agent pipeline on 2026-05-27.

### Summary

| | |
|---|---|
| Tables updated | 9 |
| Fields described | 180 |
| Probe-matched | 0 / 180 |
| Global.yaml candidates | 0 |
| Contradictions flagged | 0 |

### How Descriptions Were Generated

1. **Data profiling** — null rates, distinct values, and value distributions sampled from live BigQuery data
2. **Probe context** — Probe context was unavailable for most tables (no DataHub lineage). fxa_win10_users_historical_v1 resolved to the firefox_desktop.fx-accounts Glean ping, providing a probe definition for the locale field. All other descriptions were synthesized from ETL query analysis and column profiling statistics.
3. **Reconciliation** — Claude reconciled observed data with probe definitions

### Fields Updated by Table

| Table | Fields Described | Probe Matches |
|---|---|---|
| `fxa_win10_users_historical_v1` | 5 | 1/5 |
| `newsletters_v1` | 8 | 0/8 |
| `products_v1` | 47 | 0/47 |
| `subscriptions_map_v1` | 6 | 0/6 |
| `subscriptions_map_v2` | 6 | 0/6 |
| `subscriptions_v1` | 8 | 0/8 |
| `user_profiles_v1` | 76 | 0/76 |
| `users_v1` | 14 | 0/14 |
| `waitlists_v1` | 10 | 0/10 |

### Global.yaml Candidates

Fields routed to `global.yaml` — consistent meaning across datasets:

_None_

### Contradictions Found

_None_

### Skipped

- 0 ARRAY/REPEATED fields (undocumented tier — out of scope)
- 0 empty or undeployed tables
- 0 fields already described (unchanged)

### Checklist

- [x] Descriptions reviewed for accuracy
- [ ] Global.yaml candidates verified as truly cross-dataset
- [ ] Contradictions investigated before merging
