### PR TITLE
chore(schema): add field descriptions for braze_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/braze_derived/fxa_win10_users_historical_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/fxa_win10_users_historical_v1/schema.yaml
@@ -2,15 +2,25 @@ fields:
 - name: submission_date
   type: DATE
   mode: NULLABLE
+  description: The date the user record was added to this historical list, corresponding
+    to the pipeline run date.
 - name: external_id
   type: STRING
   mode: NULLABLE
+  description: The Braze external identifier for this user, typically their Basket
+    email_id (UUID). Used to uniquely identify the user across Braze records.
 - name: email
   type: STRING
   mode: NULLABLE
+  description: Primary email address of the Firefox Account user. Used for Braze outreach
+    targeting Windows 10 users who have been inactive for 14–21 days.
 - name: locale
   type: STRING
   mode: NULLABLE
+  description: Browser locale of the user at the time of their most recent fx-accounts
+    ping, e.g. 'en-US' or 'de'. Only users in a supported locale set are included.
 - name: fxa_id_sha256
   type: STRING
   mode: NULLABLE
+  description: SHA-256 hash of the user's Firefox Account (FxA) UID. Used as a privacy-safe
+    join key to link Braze records to FxA identity without exposing raw UIDs.

--- a/sql/moz-fx-data-shared-prod/braze_derived/newsletters_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/newsletters_v1/schema.yaml
@@ -2,25 +2,43 @@ fields:
 - mode: NULLABLE
   name: external_id
   type: STRING
+  description: The Braze external identifier for this user, corresponding to their
+    Basket email_id (UUID). Used to join to users_v1 and other Braze-derived tables.
 - fields:
   - mode: NULLABLE
     name: newsletter_name
     type: STRING
+    description: The slug identifier of the newsletter (e.g. 'mozilla-and-you', 'security-privacy-news').
+      Matches the braze_subscription_name values in subscriptions_map_v1.
   - mode: NULLABLE
     name: subscribed
     type: BOOLEAN
+    description: Whether the user is currently subscribed to this newsletter. True
+      means actively subscribed; false means unsubscribed.
   - mode: NULLABLE
     name: newsletter_lang
     type: STRING
+    description: The language in which the user receives this newsletter (e.g. 'en',
+      'fr'). Stored in lowercase.
   - mode: NULLABLE
     name: newsletter_source
     type: STRING
+    description: The source or channel through which the user subscribed to this newsletter
+      (e.g. a website or campaign slug), as recorded in CTMS.
   - mode: NULLABLE
     name: create_timestamp
     type: TIMESTAMP
+    description: Timestamp when this newsletter subscription record was first created
+      in CTMS.
   - mode: NULLABLE
     name: update_timestamp
     type: TIMESTAMP
+    description: Timestamp when this newsletter subscription record was most recently
+      updated in CTMS.
   mode: REPEATED
   name: newsletters
   type: RECORD
+  description: Array of newsletter subscription records for the user, sourced from
+    the CTMS newsletters table. Each element contains the newsletter name, subscription
+    status, language, source, and creation/update timestamps. Only users with at least
+    one active subscription are included.

--- a/sql/moz-fx-data-shared-prod/braze_derived/products_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/products_v1/schema.yaml
@@ -2,142 +2,233 @@ fields:
 - mode: NULLABLE
   name: external_id
   type: STRING
+  description: The Braze external identifier for this user, corresponding to their
+    Basket email_id (UUID). Used to join to users_v1 and other Braze-derived tables.
 - fields:
   - mode: NULLABLE
     name: provider
     type: STRING
+    description: The subscription provider platform (e.g. 'stripe', 'apple', 'google')
+      that manages this subscription.
   - mode: NULLABLE
     name: payment_provider
     type: STRING
+    description: The payment processor used for this subscription (e.g. 'stripe',
+      'paypal').
   - mode: NULLABLE
     name: product_name
     type: STRING
+    description: Human-readable name of the Mozilla product the user is subscribed
+      to (e.g. 'Mozilla VPN', 'Firefox Relay').
   - mode: NULLABLE
     name: service_name
     type: STRING
+    description: Internal service identifier for the product, derived from the subscription_platform
+      services table.
   - mode: NULLABLE
     name: subscription_plan_id
     type: STRING
+    description: The provider-assigned plan identifier for this subscription (e.g.
+      a Stripe plan ID).
   - mode: NULLABLE
     name: subscription_product_id
     type: STRING
+    description: The provider-assigned product identifier for this subscription (e.g.
+      a Stripe product ID).
   - mode: NULLABLE
     name: subscription_started_at
     type: TIMESTAMP
+    description: Timestamp when the subscription became active.
   - mode: NULLABLE
     name: subscription_ended_at
     type: TIMESTAMP
+    description: Timestamp when the subscription ended or was cancelled. Null if the
+      subscription is still active.
   - mode: NULLABLE
     name: subscription_summary
     type: STRING
+    description: A human-readable summary string describing the subscription plan
+      details (e.g. billing interval and price).
   - mode: NULLABLE
     name: subscription_billing_interval
     type: STRING
+    description: The billing interval type for the subscription plan (e.g. 'month',
+      'year').
   - mode: NULLABLE
     name: subscription_interval_count
     type: INTEGER
+    description: The number of billing interval units per billing cycle (e.g. 1 for
+      monthly, 12 for annual).
   - mode: NULLABLE
     name: subscription_currency
     type: STRING
+    description: ISO 4217 currency code for the subscription price (e.g. 'usd', 'eur').
   - mode: NULLABLE
     name: subscription_amount
     type: NUMERIC
+    description: The subscription price in the smallest unit of the currency (e.g.
+      cents for USD), as a numeric value.
   - mode: NULLABLE
     name: is_bundle
     type: BOOLEAN
+    description: Whether this subscription is part of a bundle offer (e.g. a VPN+Relay
+      bundle). True if bundled; false otherwise.
   - mode: NULLABLE
     name: is_trial
     type: BOOLEAN
+    description: Whether this subscription is in a free trial period. True if currently
+      in trial; false otherwise.
   - mode: NULLABLE
     name: is_active
     type: BOOLEAN
+    description: Whether the subscription is currently active. True means the user
+      has an active entitlement; false means the subscription has lapsed or been cancelled.
   - mode: NULLABLE
     name: subscription_status
     type: STRING
+    description: The provider-reported status of the subscription (e.g. 'active',
+      'cancelled', 'past_due'), as stored in the upstream subscription_platform table.
   - mode: NULLABLE
     name: subscription_country_code
     type: STRING
+    description: ISO 3166-1 alpha-2 country code for the subscriber's billing country
+      (e.g. 'us', 'de'), stored in lowercase.
   - mode: NULLABLE
     name: subscription_country_name
     type: STRING
+    description: Full country name for the subscriber's billing country (e.g. 'United
+      States', 'Germany').
   - mode: NULLABLE
     name: current_period_started_at
     type: TIMESTAMP
+    description: Timestamp when the current billing period began.
   - mode: NULLABLE
     name: current_period_ends_at
     type: TIMESTAMP
+    description: Timestamp when the current billing period ends and the next renewal
+      is due.
   - mode: NULLABLE
     name: is_auto_renew
     type: BOOLEAN
+    description: Whether the subscription is set to renew automatically at the end
+      of the current period. True means auto-renewal is enabled; false means the user
+      has cancelled or disabled it.
   - mode: NULLABLE
     name: auto_renew_disabled_at
     type: TIMESTAMP
+    description: Timestamp when auto-renewal was disabled for this subscription. Null
+      if auto-renewal is still active.
   - mode: NULLABLE
     name: has_refunds
     type: BOOLEAN
+    description: Whether any refunds have been issued for this subscription. True
+      if at least one refund has been processed.
   - mode: NULLABLE
     name: has_fraudulent_charges
     type: BOOLEAN
+    description: Whether any fraudulent charges have been identified for this subscription.
+      True if at least one fraudulent charge has been flagged.
   - mode: NULLABLE
     name: first_touch_impression_at
     type: TIMESTAMP
+    description: Timestamp of the first marketing impression attributed to this subscription.
+      Currently always null (not yet populated in the ETL).
   - mode: NULLABLE
     name: first_touch_entrypoint
     type: STRING
+    description: The FxA entrypoint associated with the user's first marketing touchpoint
+      before subscribing. Currently always null (not yet populated in the ETL).
   - mode: NULLABLE
     name: first_touch_entrypoint_experiment
     type: STRING
+    description: The experiment identifier associated with the first-touch FxA entrypoint.
+      Currently always null (not yet populated in the ETL).
   - mode: NULLABLE
     name: first_touch_entrypoint_variation
     type: STRING
+    description: The experiment variation associated with the first-touch FxA entrypoint.
+      Currently always null (not yet populated in the ETL).
   - mode: NULLABLE
     name: first_touch_utm_campaign
     type: STRING
+    description: UTM campaign parameter from the first marketing touchpoint before
+      subscribing. Currently always null (not yet populated in the ETL).
   - mode: NULLABLE
     name: first_touch_utm_content
     type: STRING
+    description: UTM content parameter from the first marketing touchpoint before
+      subscribing. Currently always null (not yet populated in the ETL).
   - mode: NULLABLE
     name: first_touch_utm_medium
     type: STRING
+    description: UTM medium parameter from the first marketing touchpoint before subscribing.
+      Currently always null (not yet populated in the ETL).
   - mode: NULLABLE
     name: first_touch_utm_source
     type: STRING
+    description: UTM source parameter from the first marketing touchpoint before subscribing.
+      Currently always null (not yet populated in the ETL).
   - mode: NULLABLE
     name: first_touch_utm_term
     type: STRING
+    description: UTM term parameter from the first marketing touchpoint before subscribing.
+      Currently always null (not yet populated in the ETL).
   - mode: NULLABLE
     name: last_touch_impression_at
     type: TIMESTAMP
+    description: Timestamp of the most recent marketing impression attributed to this
+      subscription, from the last-touch attribution record in subscription_platform.
   - mode: NULLABLE
     name: last_touch_entrypoint
     type: STRING
+    description: The FxA entrypoint associated with the user's most recent marketing
+      touchpoint before subscribing.
   - mode: NULLABLE
     name: last_touch_entrypoint_experiment
     type: STRING
+    description: The experiment identifier associated with the last-touch FxA entrypoint.
   - mode: NULLABLE
     name: last_touch_entrypoint_variation
     type: STRING
+    description: The experiment variation associated with the last-touch FxA entrypoint.
   - mode: NULLABLE
     name: last_touch_utm_campaign
     type: STRING
+    description: UTM campaign parameter from the most recent marketing touchpoint
+      before subscribing.
   - mode: NULLABLE
     name: last_touch_utm_content
     type: STRING
+    description: UTM content parameter from the most recent marketing touchpoint before
+      subscribing.
   - mode: NULLABLE
     name: last_touch_utm_medium
     type: STRING
+    description: UTM medium parameter from the most recent marketing touchpoint before
+      subscribing.
   - mode: NULLABLE
     name: last_touch_utm_source
     type: STRING
+    description: UTM source parameter from the most recent marketing touchpoint before
+      subscribing.
   - mode: NULLABLE
     name: last_touch_utm_term
     type: STRING
+    description: UTM term parameter from the most recent marketing touchpoint before
+      subscribing.
   - mode: NULLABLE
     name: subscription_created_at
     type: TIMESTAMP
+    description: Timestamp when the subscription record was first created at the provider.
   - mode: NULLABLE
     name: subscription_updated_at
     type: TIMESTAMP
+    description: Timestamp when the subscription record was most recently updated
+      at the provider.
   mode: REPEATED
   name: products
   type: RECORD
+  description: Array of paid product subscription records for the user, sourced from
+    the subscription_platform logical_subscriptions table. Each element contains provider,
+    plan, pricing, status, attribution, and lifecycle timestamp details. Only users
+    with at least one subscription are included.

--- a/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_map_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_map_v1/schema.yaml
@@ -2,18 +2,30 @@ fields:
 - mode: NULLABLE
   name: braze_subscription_name
   type: STRING
+  description: The subscription or newsletter slug as used in Braze and in the CTMS
+    data (e.g. 'mozilla-and-you', 'relay-waitlist'). Serves as the primary key for
+    this mapping table.
 - mode: NULLABLE
   name: description
   type: STRING
+  description: A human-readable description of the Braze subscription group (e.g.
+    'Mozilla Community Newsletter', 'Firefox Relay Waitlist').
 - mode: NULLABLE
   name: mozilla_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Mozilla production
+    Braze workspace.
 - mode: NULLABLE
   name: firefox_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Firefox Braze workspace.
 - mode: NULLABLE
   name: mozilla_dev_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Mozilla development/staging
+    Braze workspace.
 - mode: NULLABLE
   name: basket_slug
   type: STRING
+  description: The corresponding newsletter or waitlist slug as used in Mozilla's
+    Basket email subscription service. Typically matches braze_subscription_name.

--- a/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_map_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_map_v2/schema.yaml
@@ -2,18 +2,30 @@ fields:
 - mode: NULLABLE
   name: braze_subscription_name
   type: STRING
+  description: The subscription or newsletter slug as used in Braze and in the CTMS
+    data (e.g. 'mozilla-and-you', 'relay-waitlist'). Serves as the primary key for
+    this mapping table.
 - mode: NULLABLE
   name: description
   type: STRING
+  description: A human-readable description of the Braze subscription group (e.g.
+    'Mozilla Community Newsletter', 'Firefox Relay Waitlist').
 - mode: NULLABLE
   name: mozilla_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Mozilla production
+    Braze workspace.
 - mode: NULLABLE
   name: firefox_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Firefox Braze workspace.
 - mode: NULLABLE
   name: mozilla_dev_subscription_id
   type: STRING
+  description: The UUID identifying this subscription group in the Mozilla development/staging
+    Braze workspace.
 - mode: NULLABLE
   name: basket_slug
   type: STRING
+  description: The corresponding newsletter or waitlist slug as used in Mozilla's
+    Basket email subscription service. Typically matches braze_subscription_name.

--- a/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/subscriptions_v1/schema.yaml
@@ -2,25 +2,43 @@ fields:
 - mode: NULLABLE
   name: external_id
   type: STRING
+  description: The Braze external identifier for this user, corresponding to their
+    Basket email_id (UUID). Used to join to users_v1 and other Braze-derived tables.
 - fields:
   - mode: NULLABLE
     name: subscription_name
     type: STRING
+    description: The Braze subscription group slug for this subscription (e.g. 'mozilla-and-you',
+      'relay-waitlist'). Matches braze_subscription_name in subscriptions_map_v1.
   - mode: NULLABLE
     name: firefox_subscription_id
     type: STRING
+    description: UUID of the corresponding Braze subscription group in the Firefox
+      workspace, from subscriptions_map_v1.
   - mode: NULLABLE
     name: mozilla_subscription_id
     type: STRING
+    description: UUID of the corresponding Braze subscription group in the Mozilla
+      production workspace, from subscriptions_map_v1.
   - mode: NULLABLE
     name: mozilla_dev_subscription_id
     type: STRING
+    description: UUID of the corresponding Braze subscription group in the Mozilla
+      development/staging workspace, from subscriptions_map_v1.
   - mode: NULLABLE
     name: subscription_state
     type: STRING
+    description: The current state of the user's subscription. Values are 'subscribed'
+      (actively subscribed) or 'unsubscribed' (previously subscribed, now opted out).
   - mode: NULLABLE
     name: update_timestamp
     type: TIMESTAMP
+    description: Timestamp of the most recent update to this subscription record,
+      taken as the max update_timestamp across newsletter and waitlist sources.
   mode: REPEATED
   name: subscriptions
   type: RECORD
+  description: Array of Braze subscription group membership records for the user,
+    derived from their newsletter and waitlist subscriptions in user_profiles_v1 mapped
+    via subscriptions_map_v1. Each element captures the subscription name, provider-specific
+    IDs, current state, and last update time.

--- a/sql/moz-fx-data-shared-prod/braze_derived/user_profiles_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/user_profiles_v1/schema.yaml
@@ -1,308 +1,381 @@
 fields:
-
 - name: external_id
   type: STRING
   mode: NULLABLE
-
+  description: The Braze external identifier for this user, corresponding to their
+    Basket email_id (UUID). Unique per user and used as the primary join key across
+    all Braze-derived tables.
 - name: email
   type: STRING
   mode: NULLABLE
-
+  description: The user's primary email address as stored in CTMS, in lowercase. Used
+    for Braze messaging.
 - name: mailing_country
   type: STRING
   mode: NULLABLE
-
+  description: ISO 3166-1 alpha-2 country code (lowercase) for the user's mailing
+    country as recorded in CTMS (e.g. 'us', 'de'). Null for approximately 36% of users
+    where country is not on record.
 - name: email_subscribe
   type: STRING
   mode: NULLABLE
-
+  description: The user's email subscription status for Braze. Values are 'opted_in'
+    (double opt-in confirmed) or 'subscribed' (single opt-in). Unsubscribed users
+    are excluded from this table.
 - name: basket_token
   type: STRING
   mode: NULLABLE
-
+  description: UUID token identifying the user in Mozilla's Basket email subscription
+    service. Used as an alternative identifier for newsletter management.
 - name: email_lang
   type: STRING
   mode: NULLABLE
-
+  description: The preferred language for email communications as recorded in CTMS
+    (e.g. 'en', 'fr', 'de'). Stored in lowercase.
 - name: create_timestamp
   type: TIMESTAMP
   mode: NULLABLE
-
+  description: Timestamp when this user's record was first created in CTMS.
 - name: update_timestamp
   type: TIMESTAMP
   mode: NULLABLE
-
+  description: Timestamp when this user's record was most recently updated in CTMS.
 - name: fxa_id_sha256
   type: STRING
   mode: NULLABLE
-
+  description: SHA-256 hash of the user's Firefox Account (FxA) UID. Null for approximately
+    7.5% of users who do not have a linked FxA account.
 - name: has_fxa
   type: BOOLEAN
   mode: NULLABLE
-
+  description: Whether the user has a linked, non-deleted Firefox Account. True for
+    approximately 92.5% of users; false for users with no associated FxA record.
 - name: fxa_primary_email
   type: STRING
   mode: NULLABLE
-
+  description: The primary email address associated with the user's Firefox Account
+    (may differ from the CTMS email). Null if the user has no linked FxA.
 - name: fxa_lang
   type: STRING
   mode: NULLABLE
-
+  description: The browser Accept-Language header string recorded at the time of FxA
+    account creation (e.g. 'en-us,en;q=0.5'). Null for approximately 47% of users.
 - name: fxa_first_service
   type: STRING
   mode: NULLABLE
-
+  description: The first Mozilla service the user signed into with their Firefox Account
+    (e.g. 'sync', 'fenix', 'pocket-web'). Null for approximately 49% of users.
 - name: fxa_created_at
   type: TIMESTAMP
   mode: NULLABLE
-
+  description: Timestamp when the user's Firefox Account was created. Null for approximately
+    7.6% of users who do not have a linked FxA account.
 - name: newsletters
   type: RECORD
   mode: REPEATED
   fields:
-
   - name: newsletter_name
     type: STRING
     mode: NULLABLE
-
+    description: The slug identifier of the newsletter (e.g. 'mozilla-and-you', 'security-privacy-news').
   - name: subscribed
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether the user is currently subscribed to this newsletter. True
+      means actively subscribed; false means unsubscribed.
   - name: newsletter_lang
     type: STRING
     mode: NULLABLE
-
+    description: The language in which the user receives this newsletter (e.g. 'en',
+      'fr'), stored in lowercase.
   - name: newsletter_source
     type: STRING
     mode: NULLABLE
-
+    description: The source or channel through which the user subscribed to this newsletter,
+      as recorded in CTMS.
   - name: create_timestamp
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when this newsletter subscription record was first created
+      in CTMS.
   - name: update_timestamp
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when this newsletter subscription record was most recently
+      updated in CTMS.
+  description: Array of newsletter subscription records for the user, joined from
+    newsletters_v1. Each element contains newsletter name, subscription status, language,
+    source, and timestamps. Null if the user has no newsletter subscriptions.
 - name: waitlists
   type: RECORD
   mode: REPEATED
   fields:
-
   - name: waitlist_name
     type: STRING
     mode: NULLABLE
-
+    description: The name of the Mozilla product waitlist the user joined (e.g. 'vpn',
+      'relay', 'monitor').
   - name: waitlist_geo
     type: STRING
     mode: NULLABLE
-
+    description: The geographic region the user selected when joining the waitlist
+      (e.g. a country or region code), stored in lowercase.
   - name: waitlist_platform
     type: STRING
     mode: NULLABLE
-
+    description: The platform or device type the user indicated when joining the waitlist
+      (e.g. 'ios', 'android', 'mac'), stored in lowercase.
   - name: waitlist_source
     type: STRING
     mode: NULLABLE
-
+    description: The source or channel through which the user joined the waitlist,
+      stored in lowercase.
   - name: create_timestamp
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when this waitlist record was first created in CTMS.
   - name: subscribed
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether the user is currently on this waitlist. True means actively
+      signed up; false means the user has unsubscribed from the waitlist.
   - name: unsub_reason
     type: STRING
     mode: NULLABLE
-
+    description: The reason provided by the user when unsubscribing from the waitlist,
+      if any. Null if the user is still subscribed or did not provide a reason.
   - name: update_timestamp
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when this waitlist record was most recently updated in
+      CTMS.
+  description: Array of product waitlist records for the user, joined from waitlists_v1.
+    Each element captures the waitlist name, geographic/platform preferences, source,
+    subscription status, and timestamps. Null if the user is not on any waitlists.
 - name: products
   type: RECORD
   mode: REPEATED
   fields:
-
   - name: provider
     type: STRING
     mode: NULLABLE
-
+    description: The subscription provider platform (e.g. 'stripe', 'apple', 'google')
+      that manages this subscription.
   - name: payment_provider
     type: STRING
     mode: NULLABLE
-
+    description: The payment processor used for this subscription (e.g. 'stripe',
+      'paypal').
   - name: product_name
     type: STRING
     mode: NULLABLE
-
+    description: Human-readable name of the Mozilla product the user is subscribed
+      to (e.g. 'Mozilla VPN', 'Firefox Relay').
   - name: service_name
     type: STRING
     mode: NULLABLE
-
+    description: Internal service identifier for the product, derived from the subscription_platform
+      services table.
   - name: subscription_plan_id
     type: STRING
     mode: NULLABLE
-
+    description: The provider-assigned plan identifier for this subscription (e.g.
+      a Stripe plan ID).
   - name: subscription_product_id
     type: STRING
     mode: NULLABLE
-
+    description: The provider-assigned product identifier for this subscription (e.g.
+      a Stripe product ID).
   - name: subscription_started_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when the subscription became active.
   - name: subscription_ended_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when the subscription ended or was cancelled. Null if the
+      subscription is still active.
   - name: subscription_summary
     type: STRING
     mode: NULLABLE
-
+    description: A human-readable summary string describing the subscription plan
+      details (e.g. billing interval and price).
   - name: subscription_billing_interval
     type: STRING
     mode: NULLABLE
-
+    description: The billing interval type for the subscription plan (e.g. 'month',
+      'year').
   - name: subscription_interval_count
     type: INTEGER
     mode: NULLABLE
-
+    description: The number of billing interval units per billing cycle (e.g. 1 for
+      monthly, 12 for annual).
   - name: subscription_currency
     type: STRING
     mode: NULLABLE
-
+    description: ISO 4217 currency code for the subscription price (e.g. 'usd', 'eur').
   - name: subscription_amount
     type: NUMERIC
     mode: NULLABLE
-
+    description: The subscription price in the smallest unit of the currency (e.g.
+      cents for USD), as a numeric value.
   - name: is_bundle
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether this subscription is part of a bundle offer. True if bundled;
+      false otherwise.
   - name: is_trial
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether this subscription is in a free trial period. True if currently
+      in trial; false otherwise.
   - name: is_active
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether the subscription is currently active. True means the user
+      has an active entitlement; false means the subscription has lapsed or been cancelled.
   - name: subscription_status
     type: STRING
     mode: NULLABLE
-
+    description: The provider-reported status of the subscription (e.g. 'active',
+      'cancelled', 'past_due').
   - name: subscription_country_code
     type: STRING
     mode: NULLABLE
-
+    description: ISO 3166-1 alpha-2 country code for the subscriber's billing country
+      (e.g. 'us', 'de'), stored in lowercase.
   - name: subscription_country_name
     type: STRING
     mode: NULLABLE
-
+    description: Full country name for the subscriber's billing country (e.g. 'United
+      States', 'Germany').
   - name: current_period_started_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when the current billing period began.
   - name: current_period_ends_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when the current billing period ends and the next renewal
+      is due.
   - name: is_auto_renew
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether the subscription is set to renew automatically at period
+      end. True means auto-renewal is enabled; false means it has been cancelled or
+      disabled.
   - name: auto_renew_disabled_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when auto-renewal was disabled for this subscription. Null
+      if auto-renewal is still active.
   - name: has_refunds
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether any refunds have been issued for this subscription. True
+      if at least one refund has been processed.
   - name: has_fraudulent_charges
     type: BOOLEAN
     mode: NULLABLE
-
+    description: Whether any fraudulent charges have been identified for this subscription.
+      True if at least one fraudulent charge has been flagged.
   - name: first_touch_impression_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp of the first marketing impression attributed to this subscription.
+      Currently always null (not yet populated in the ETL).
   - name: first_touch_entrypoint
     type: STRING
     mode: NULLABLE
-
+    description: The FxA entrypoint associated with the user's first marketing touchpoint.
+      Currently always null (not yet populated in the ETL).
   - name: first_touch_entrypoint_experiment
     type: STRING
     mode: NULLABLE
-
+    description: The experiment identifier associated with the first-touch FxA entrypoint.
+      Currently always null (not yet populated in the ETL).
   - name: first_touch_entrypoint_variation
     type: STRING
     mode: NULLABLE
-
+    description: The experiment variation associated with the first-touch FxA entrypoint.
+      Currently always null (not yet populated in the ETL).
   - name: first_touch_utm_campaign
     type: STRING
     mode: NULLABLE
-
+    description: UTM campaign parameter from the first marketing touchpoint. Currently
+      always null (not yet populated in the ETL).
   - name: first_touch_utm_content
     type: STRING
     mode: NULLABLE
-
+    description: UTM content parameter from the first marketing touchpoint. Currently
+      always null (not yet populated in the ETL).
   - name: first_touch_utm_medium
     type: STRING
     mode: NULLABLE
-
+    description: UTM medium parameter from the first marketing touchpoint. Currently
+      always null (not yet populated in the ETL).
   - name: first_touch_utm_source
     type: STRING
     mode: NULLABLE
-
+    description: UTM source parameter from the first marketing touchpoint. Currently
+      always null (not yet populated in the ETL).
   - name: first_touch_utm_term
     type: STRING
     mode: NULLABLE
-
+    description: UTM term parameter from the first marketing touchpoint. Currently
+      always null (not yet populated in the ETL).
   - name: last_touch_impression_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp of the most recent marketing impression attributed to this
+      subscription.
   - name: last_touch_entrypoint
     type: STRING
     mode: NULLABLE
-
+    description: The FxA entrypoint associated with the user's most recent marketing
+      touchpoint before subscribing.
   - name: last_touch_entrypoint_experiment
     type: STRING
     mode: NULLABLE
-
+    description: The experiment identifier associated with the last-touch FxA entrypoint.
   - name: last_touch_entrypoint_variation
     type: STRING
     mode: NULLABLE
-
+    description: The experiment variation associated with the last-touch FxA entrypoint.
   - name: last_touch_utm_campaign
     type: STRING
     mode: NULLABLE
-
+    description: UTM campaign parameter from the most recent marketing touchpoint
+      before subscribing.
   - name: last_touch_utm_content
     type: STRING
     mode: NULLABLE
-
+    description: UTM content parameter from the most recent marketing touchpoint before
+      subscribing.
   - name: last_touch_utm_medium
     type: STRING
     mode: NULLABLE
-
+    description: UTM medium parameter from the most recent marketing touchpoint before
+      subscribing.
   - name: last_touch_utm_source
     type: STRING
     mode: NULLABLE
-
+    description: UTM source parameter from the most recent marketing touchpoint before
+      subscribing.
   - name: last_touch_utm_term
     type: STRING
     mode: NULLABLE
-
+    description: UTM term parameter from the most recent marketing touchpoint before
+      subscribing.
   - name: subscription_created_at
     type: TIMESTAMP
     mode: NULLABLE
-
+    description: Timestamp when the subscription record was first created at the provider.
   - name: subscription_updated_at
     type: TIMESTAMP
     mode: NULLABLE
+    description: Timestamp when the subscription record was most recently updated
+      at the provider.
+  description: Array of paid product subscription records for the user, joined from
+    products_v1. Each element contains provider, plan, pricing, status, attribution,
+    and lifecycle timestamp details. Null if the user has no paid subscriptions.

--- a/sql/moz-fx-data-shared-prod/braze_derived/users_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/users_v1/schema.yaml
@@ -2,42 +2,69 @@ fields:
 - mode: NULLABLE
   name: external_id
   type: STRING
+  description: The Braze external identifier for this user, corresponding to their
+    Basket email_id (UUID). Unique per user and used as the primary join key across
+    all Braze-derived tables.
 - mode: NULLABLE
   name: email
   type: STRING
+  description: The user's primary email address as stored in CTMS, in lowercase. Users
+    on the marketing suppression list or who have opted out of all email are excluded.
 - mode: NULLABLE
   name: mailing_country
   type: STRING
+  description: ISO 3166-1 alpha-2 country code (lowercase) for the user's mailing
+    country as recorded in CTMS (e.g. 'us', 'de'). Null for approximately 36% of users.
 - mode: NULLABLE
   name: email_subscribe
   type: STRING
+  description: The user's email subscription status for Braze. Values are 'opted_in'
+    (double opt-in confirmed) or 'subscribed' (single opt-in, not yet double opt-in).
 - mode: NULLABLE
   name: basket_token
   type: STRING
+  description: UUID token identifying the user in Mozilla's Basket email subscription
+    service. Used as an alternative identifier for newsletter management.
 - mode: NULLABLE
   name: email_lang
   type: STRING
+  description: The preferred language for email communications as recorded in CTMS
+    (e.g. 'en', 'fr', 'de'). Stored in lowercase.
 - mode: NULLABLE
   name: create_timestamp
   type: TIMESTAMP
+  description: Timestamp when this user's record was first created in CTMS.
 - mode: NULLABLE
   name: update_timestamp
   type: TIMESTAMP
+  description: Timestamp when this user's record was most recently updated in CTMS.
 - mode: NULLABLE
   name: fxa_id_sha256
   type: STRING
+  description: SHA-256 hash of the user's Firefox Account (FxA) UID. Null for approximately
+    7.5% of users who have no linked FxA account.
 - mode: NULLABLE
   name: has_fxa
   type: BOOLEAN
+  description: Whether the user has a linked, non-deleted Firefox Account. True for
+    approximately 92.5% of users; false for users with no associated FxA.
 - mode: NULLABLE
   name: fxa_primary_email
   type: STRING
+  description: The primary email address of the user's Firefox Account (may differ
+    from the CTMS email). Null if the user has no linked FxA.
 - mode: NULLABLE
   name: fxa_lang
   type: STRING
+  description: The browser Accept-Language header string from the time of FxA account
+    creation (e.g. 'en-us,en;q=0.5'). Null for approximately 47% of users.
 - mode: NULLABLE
   name: fxa_first_service
   type: STRING
+  description: The first Mozilla service the user signed into with their Firefox Account
+    (e.g. 'sync', 'fenix', 'pocket-web'). Null for approximately 49% of users.
 - mode: NULLABLE
   name: fxa_created_at
   type: TIMESTAMP
+  description: Timestamp when the user's Firefox Account was created. Null for approximately
+    7.6% of users who do not have a linked FxA.

--- a/sql/moz-fx-data-shared-prod/braze_derived/waitlists_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_derived/waitlists_v1/schema.yaml
@@ -2,31 +2,52 @@ fields:
 - mode: NULLABLE
   name: external_id
   type: STRING
+  description: The Braze external identifier for this user, corresponding to their
+    Basket email_id (UUID). Used to join to users_v1 and other Braze-derived tables.
 - fields:
   - mode: NULLABLE
     name: waitlist_name
     type: STRING
+    description: The name of the Mozilla product waitlist (e.g. 'vpn', 'relay', 'monitor')
+      as recorded in the CTMS waitlists table.
   - mode: NULLABLE
     name: waitlist_geo
     type: STRING
+    description: The geographic region the user indicated when joining the waitlist
+      (extracted from the CTMS waitlist fields JSON), stored in lowercase.
   - mode: NULLABLE
     name: waitlist_platform
     type: STRING
+    description: The platform or device type the user selected when joining the waitlist
+      (extracted from the CTMS waitlist fields JSON), stored in lowercase.
   - mode: NULLABLE
     name: waitlist_source
     type: STRING
+    description: The source or channel through which the user joined the waitlist,
+      stored in lowercase.
   - mode: NULLABLE
     name: create_timestamp
     type: TIMESTAMP
+    description: Timestamp when this waitlist record was first created in CTMS.
   - mode: NULLABLE
     name: subscribed
     type: BOOLEAN
+    description: Whether the user is currently on this waitlist. True means actively
+      signed up; false means the user has unsubscribed.
   - mode: NULLABLE
     name: unsub_reason
     type: STRING
+    description: The reason provided when unsubscribing from the waitlist. Null if
+      the user is still subscribed or no reason was given.
   - mode: NULLABLE
     name: update_timestamp
     type: TIMESTAMP
+    description: Timestamp when this waitlist record was most recently updated in
+      CTMS.
   mode: REPEATED
   name: waitlists
   type: RECORD
+  description: Array of product waitlist records for the user, sourced from the CTMS
+    waitlists table. Each element captures the waitlist name, geo/platform preferences,
+    source channel, subscription status, unsubscribe reason, and timestamps. Only
+    users with at least one active waitlist signup are included.


### PR DESCRIPTION
## Schema Update: `moz-fx-data-shared-prod.braze_derived`

> Generated by the metadata agent pipeline on 2026-05-27.

### Summary

| | |
|---|---|
| Tables updated | 9 |
| Fields described | 180 |
| Probe-matched | 0 / 180 |
| Global.yaml candidates | 0 |
| Contradictions flagged | 0 |

### How Descriptions Were Generated

1. **Data profiling** — null rates, distinct values, and value distributions sampled from live BigQuery data
2. **Probe context** — No telemetry probe lineage found for any braze_derived table via DataHub. fxa_win10_users_historical_v1 resolved to the firefox_desktop fx-accounts Glean ping but field names did not directly match probe names; ETL SQL was used as primary context for all tables. Descriptions are based on ETL query logic and column profiling stats.
3. **Reconciliation** — ovserved data reconciled with probe definitions

### Fields Updated by Table

| Table | Fields Described | Probe Matches |
|---|---|---|
| `fxa_win10_users_historical_v1` | 5 | 1/5 |
| `newsletters_v1` | 8 | 0/8 |
| `products_v1` | 47 | 0/47 |
| `subscriptions_map_v1` | 6 | 0/6 |
| `subscriptions_map_v2` | 6 | 0/6 |
| `subscriptions_v1` | 8 | 0/8 |
| `user_profiles_v1` | 76 | 0/76 |
| `users_v1` | 14 | 0/14 |
| `waitlists_v1` | 10 | 0/10 |

### Global.yaml Candidates

Fields routed to `global.yaml` — consistent meaning across datasets:

_None_

### Contradictions Found

_None_

### Skipped

- 0 ARRAY/REPEATED fields (undocumented tier — out of scope)
- 0 empty or undeployed tables
- 0 fields already described (unchanged)

### Checklist

- [ ] Descriptions reviewed for accuracy
- [ ] Global.yaml candidates verified as truly cross-dataset
- [ ] Contradictions investigated before merging
