### PR TITLE
chore: Add backstage-gke wg to syndicate datasets

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozcloud_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozcloud_derived/dataset_metadata.yaml
@@ -7,3 +7,4 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential/data-viewers
+  - workgroup:platform/backstage-gke

--- a/sql/moz-fx-data-shared-prod/mozcloud_tenants_syndicate/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozcloud_tenants_syndicate/dataset_metadata.yaml
@@ -12,3 +12,4 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential/data-viewers
+  - workgroup:platform/backstage-gke

--- a/sql/moz-fx-data-shared-prod/mozcloud_workgroups_syndicate/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozcloud_workgroups_syndicate/dataset_metadata.yaml
@@ -12,3 +12,4 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential/data-viewers
+  - workgroup:platform/backstage-gke


### PR DESCRIPTION
## Description
According to a comment on MZCLD-3137 Authorizing the public views is not sufficient and the underlying syndicated datasets also need authorization

## Related Tickets & Documents
* MZCLD-3137

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
