### PR TITLE
DENG-11155 - Create Newtab Widget aggregation table

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_widgets_daily_aggregates/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_widgets_daily_aggregates/metadata.yaml
@@ -1,0 +1,8 @@
+friendly_name: Newtab Widgets Daily Aggregates
+description: |-
+  Daily aggregation of newtab widget actions (impressions, usage actions, clicks,
+  enable/disable, etc.) for Firefox Desktop. One row per
+  (submission_date, app_version, os, channel, country, locale, widget_name) over
+  the underlying `firefox_desktop_derived.newtab_widgets_daily_aggregates_v1` table.
+owners:
+- ledi@mozilla.com

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_widgets_daily_aggregates/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/newtab_widgets_daily_aggregates/view.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.newtab_widgets_daily_aggregates`
+AS
+SELECT
+  'Firefox Desktop' AS app_name,
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.newtab_widgets_daily_aggregates_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/checks.sql
@@ -5,7 +5,6 @@
 {{ min_row_count(1, "submission_date = @submission_date") }}
 --
 --
--- Grain integrity: enforce the documented "one row per (submission_date, widget_name)"
 -- grain so downstream aggregations stay correct if the GROUP BY ever changes.
 
 #fail

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/checks.sql
@@ -1,0 +1,19 @@
+-- Pipeline-health canary: fail if no rows were written for the partition,
+-- which signals upstream newtab_v1 breakage or that widget telemetry stopped emitting.
+
+#fail
+{{ min_row_count(1, "submission_date = @submission_date") }}
+--
+--
+-- Grain integrity: enforce the documented "one row per (submission_date, widget_name)"
+-- grain so downstream aggregations stay correct if the GROUP BY ever changes.
+
+#fail
+{{ is_unique(["submission_date", "app_version", "os", "channel", "country", "locale", "widget_name"], "submission_date = @submission_date") }}
+--
+--
+-- Defensive guard: query.sql filters out null widget_name, so this should never fire;
+-- warn if it does so a regression in the WHERE clause is surfaced without blocking downstream.
+
+#warn
+{{ not_null(["widget_name"], "submission_date = @submission_date") }}

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/metadata.yaml
@@ -1,0 +1,30 @@
+friendly_name: Newtab Widgets Daily Aggregates
+description: |-
+  Daily aggregation of newtab widget impression and user-event metrics, rolled
+  up from `firefox_desktop_derived.widgets_client_daily_v1` to the widget level.
+  One row per (widget_name, app_version, os, channel, country, locale) per submission_date.
+  visit-level dimensions are aggregated in the same manner as the newtab_items_daily table.
+owners:
+  - ledi@mozilla.com
+labels:
+  application: newtab
+  incremental: true
+  schedule: daily
+  dag: bqetl_newtab
+  owner1: ledi
+  table_type: aggregate
+scheduling:
+  dag_name: bqetl_newtab
+  date_partition_parameter: submission_date
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  range_partitioning: null
+  clustering:
+    fields:
+      - widget_name
+      - country
+      - channel

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
@@ -127,11 +127,7 @@ widget_metrics AS (
     SUM(widget_user_event_visits) AS widget_user_event_visits,
     SUM(widget_enabled_visits) AS widget_enabled_visits,
     SUM(widget_disabled_visits) AS widget_disabled_visits,
-    SUM(impression_count) AS impression_count,
-    SUM(user_event_count) AS user_event_count,
     SUM(change_size_or_learn_more_count) AS change_size_or_learn_more_count,
-    SUM(enabled_count) AS enabled_count,
-    SUM(disabled_count) AS disabled_count,
   FROM
     `moz-fx-data-shared-prod.firefox_desktop_derived.widgets_client_daily_v1`
   WHERE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
@@ -88,7 +88,7 @@ action_counts_summary AS (
       )
     ) AS widget_utility_action_count,
     SUM(IF(user_action = 'opt_in_accepted', action_count, 0)) AS widget_optin_accept_count,
-    ARRAY_AGG(STRUCT(user_action, action_count)) AS widget_user_action_counts
+    ARRAY_AGG(STRUCT(user_action, action_count) ORDER BY user_action) AS widget_user_action_counts
   FROM
     action_counts_per_widget
   GROUP BY

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
@@ -138,9 +138,12 @@ widget_metrics AS (
     submission_date = @submission_date
   GROUP BY
     submission_date,
-    client_id,
     widget_name,
-    widget_size
+    app_version,
+    os,
+    channel,
+    country,
+    locale
 )
 SELECT
   widget_metrics.*,

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
@@ -78,7 +78,6 @@ action_counts_summary AS (
           'timer_set',
           'timer_toggle_break',
           'timer_toggle_focus',
-          'timer_toggle_play',
           'view_key_dates',
           'view_schedule',
           'view_upcoming'

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
@@ -127,7 +127,7 @@ widget_metrics AS (
     SUM(widget_user_event_visits) AS widget_user_event_visits,
     SUM(widget_enabled_visits) AS widget_enabled_visits,
     SUM(widget_disabled_visits) AS widget_disabled_visits,
-    SUM(change_size_or_learn_more_count) AS change_size_or_learn_more_count,
+    SUM(change_size_or_learn_more_count) AS change_size_or_learn_more_count
   FROM
     `moz-fx-data-shared-prod.firefox_desktop_derived.widgets_client_daily_v1`
   WHERE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
@@ -1,0 +1,156 @@
+WITH action_counts_per_widget AS (
+    -- unnest each visit's user_action_counts and sum per user_action to client-day grain
+  SELECT
+    submission_date,
+    widget_name,
+    app_version,
+    os,
+    channel,
+    country,
+    locale,
+    uac.user_action,
+    SUM(uac.count) AS action_count,
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_derived.widgets_client_daily_v1`,
+    UNNEST(user_action_counts) AS uac
+  WHERE
+    submission_date = @submission_date
+  GROUP BY
+    submission_date,
+    widget_name,
+    app_version,
+    os,
+    channel,
+    country,
+    locale,
+    uac.user_action
+),
+action_counts_summary AS (
+  SELECT
+    submission_date,
+    widget_name,
+    app_version,
+    os,
+    channel,
+    country,
+    locale,
+    SUM(
+      IF(user_action IN ('learn_more', 'provider_link_click'), action_count, 0)
+    ) AS widget_link_click_count,
+    SUM(
+      IF(
+        user_action IN (
+          'change_hour_format',
+          'change_location',
+          'change_size',
+          'change_temperature_units',
+          'change_weather_display',
+          'collapse',
+          'detect_location',
+          'expand'
+        ),
+        action_count,
+        0
+      )
+    ) AS widget_setting_change_count,
+    SUM(
+      IF(
+        user_action IN (
+          'add_clock',
+          'add_nickname',
+          'edit_clock',
+          'follow_teams',
+          'list_copy',
+          'list_create',
+          'list_delete',
+          'list_edit',
+          'open_match_search',
+          'remove_clock',
+          'save_teams',
+          'task_complete',
+          'task_create',
+          'task_delete',
+          'task_edit',
+          'timer_end',
+          'timer_pause',
+          'timer_play',
+          'timer_reset',
+          'timer_set',
+          'timer_toggle_break',
+          'timer_toggle_focus',
+          'timer_toggle_play',
+          'view_key_dates',
+          'view_schedule',
+          'view_upcoming'
+        ),
+        action_count,
+        0
+      )
+    ) AS widget_utility_action_count,
+    SUM(IF(user_action = 'opt_in_accepted', action_count, 0)) AS widget_optin_accept_count,
+    ARRAY_AGG(STRUCT(user_action, action_count)) AS widget_user_action_counts
+  FROM
+    action_counts_per_widget
+  GROUP BY
+    submission_date,
+    widget_name,
+    app_version,
+    os,
+    channel,
+    country,
+    locale
+),
+widget_metrics AS (
+  SELECT
+    submission_date,
+    widget_name,
+    app_version,
+    os,
+    channel,
+    country,
+    locale,
+    COUNT(DISTINCT IF(is_widget_enabled, client_id, NULL)) AS widget_enabled_clients,
+    COUNT(
+      DISTINCT IF(is_widget_enabled AND all_visits > 0, client_id, NULL)
+    ) AS widget_visited_clients,
+    COUNT(
+      DISTINCT IF(user_event_count + enabled_count > 0, client_id, NULL)
+    ) AS widget_engaged_clients,
+    COUNT(DISTINCT IF(default_ui_visits > 0, client_id, NULL)) AS default_ui_clients,
+    SUM(enabled_count) AS widget_enabled_count,
+    SUM(disabled_count) AS widget_disabled_count,
+    SUM(impression_count) AS widget_impression_count,
+    SUM(user_event_count) AS widget_user_event_count,
+    SUM(all_visits) AS all_visits,
+    SUM(default_ui_visits) AS default_ui_visits,
+    SUM(widget_impression_visits) AS widget_impression_visits,
+    SUM(widget_user_event_visits) AS widget_user_event_visits,
+    SUM(widget_enabled_visits) AS widget_enabled_visits,
+    SUM(widget_disabled_visits) AS widget_disabled_visits,
+    SUM(impression_count) AS impression_count,
+    SUM(user_event_count) AS user_event_count,
+    SUM(change_size_or_learn_more_count) AS change_size_or_learn_more_count,
+    SUM(enabled_count) AS enabled_count,
+    SUM(disabled_count) AS disabled_count,
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_derived.widgets_client_daily_v1`
+  WHERE
+    submission_date = @submission_date
+  GROUP BY
+    submission_date,
+    client_id,
+    widget_name,
+    widget_size
+)
+SELECT
+  widget_metrics.*,
+  action_counts_summary.widget_link_click_count,
+  action_counts_summary.widget_setting_change_count,
+  action_counts_summary.widget_utility_action_count,
+  action_counts_summary.widget_optin_accept_count,
+  action_counts_summary.widget_user_action_counts
+FROM
+  widget_metrics
+LEFT JOIN
+  action_counts_summary
+  USING (submission_date, widget_name, app_version, os, channel, country, locale)

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
@@ -112,7 +112,7 @@ widget_metrics AS (
     COUNT(DISTINCT IF(is_widget_enabled, client_id, NULL)) AS widget_enabled_clients,
     COUNT(
       DISTINCT IF(is_widget_enabled AND all_visits > 0, client_id, NULL)
-    ) AS widget_visited_clients,
+    ) AS widget_enabled_clients_with_visit,
     COUNT(
       DISTINCT IF(user_event_count + enabled_count > 0, client_id, NULL)
     ) AS widget_engaged_clients,

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/query.sql
@@ -1,5 +1,5 @@
 WITH action_counts_per_widget AS (
-    -- unnest each visit's user_action_counts and sum per user_action to client-day grain
+    -- unnest each visit's user_action_counts and sum per user_action to widget-day grain
   SELECT
     submission_date,
     widget_name,

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/schema.yaml
@@ -3,10 +3,14 @@ fields:
   type: DATE
   mode: NULLABLE
   description: Date the widget telemetry was recorded, derived from submission_timestamp.
+- name: widget_name
+  type: STRING
+  mode: NULLABLE
+  description: Name of the widget that emitted the event.
 - name: app_version
   type: INTEGER
   mode: NULLABLE
-  description: User visible version string (e.g. "1.0.3") for the browser.
+  description: Most-common Firefox Desktop major version observed for the client this day.
 - name: os
   type: STRING
   mode: NULLABLE
@@ -15,19 +19,14 @@ fields:
   type: STRING
   mode: NULLABLE
   description: The normalized channel the application is being distributed on.
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Country code in which the activity took place, as determined.
 - name: locale
   type: STRING
   mode: NULLABLE
   description: Set of language- and/or country-based preferences for a user interface.
-- name: country
-  type: STRING
-  mode: NULLABLE
-  description: Name of the country in which the activity took place, as determined
-    by the IP geolocation.
-- name: widget_name
-  type: STRING
-  mode: NULLABLE
-  description: Name of the widget that emitted the event.
 - name: widget_enabled_clients
   type: INTEGER
   mode: NULLABLE
@@ -90,28 +89,12 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Number of New Tab visits where the widget was disabled.
-- name: impression_count
-  type: INTEGER
-  mode: NULLABLE
-  description: Number of widget impression events recorded during the day.
-- name: user_event_count
-  type: INTEGER
-  mode: NULLABLE
-  description: Number of widget user interaction events recorded during the day.
 - name: change_size_or_learn_more_count
   type: INTEGER
   mode: NULLABLE
   description: >
     Number of user interactions that either changed the widget size or clicked
     the learn more link.
-- name: enabled_count
-  type: INTEGER
-  mode: NULLABLE
-  description: Number of widget enable events recorded during the day.
-- name: disabled_count
-  type: INTEGER
-  mode: NULLABLE
-  description: Number of widget disable events recorded during the day.
 - name: widget_link_click_count
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/schema.yaml
@@ -42,7 +42,7 @@ fields:
   mode: NULLABLE
   description: >
     Number of distinct clients who actively engaged with the widget during the day,
-    via a user interaction or enable/disable action.
+    via a user interaction or enable action.
 - name: default_ui_clients
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/schema.yaml
@@ -1,0 +1,145 @@
+fields:
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+  description: Date the widget telemetry was recorded, derived from submission_timestamp.
+- name: app_version
+  type: INTEGER
+  mode: NULLABLE
+  description: User visible version string (e.g. "1.0.3") for the browser.
+- name: os
+  type: STRING
+  mode: NULLABLE
+  description: Set to "Other" if this message contained an unrecognized OS name.
+- name: channel
+  type: STRING
+  mode: NULLABLE
+  description: The normalized channel the application is being distributed on.
+- name: locale
+  type: STRING
+  mode: NULLABLE
+  description: Set of language- and/or country-based preferences for a user interface.
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Name of the country in which the activity took place, as determined
+    by the IP geolocation.
+- name: widget_name
+  type: STRING
+  mode: NULLABLE
+  description: Name of the widget that emitted the event.
+- name: widget_enabled_clients
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of distinct clients who had the widget enabled during the day.
+- name: widget_visited_clients
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    Number of distinct clients who had the widget enabled and visited the New Tab
+    page during the day.
+- name: widget_engaged_clients
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    Number of distinct clients who actively engaged with the widget during the day,
+    via a user interaction or enable/disable action.
+- name: default_ui_clients
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    Number of distinct clients who saw the default New Tab UI (no widget impression)
+    during the day.
+- name: widget_enabled_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of times users enabled the widget during the day.
+- name: widget_disabled_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of times users disabled the widget during the day.
+- name: widget_impression_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of times the widget was viewed on the New Tab page.
+- name: widget_user_event_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Total number of user interaction events recorded for the widget.
+- name: all_visits
+  type: INTEGER
+  mode: NULLABLE
+  description: Total number of New Tab visits recorded during the day.
+- name: default_ui_visits
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of New Tab visits that displayed the default UI (no widget impression).
+- name: widget_impression_visits
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of New Tab visits where the widget was viewed.
+- name: widget_user_event_visits
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of New Tab visits with at least one user interaction with the widget.
+- name: widget_enabled_visits
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of New Tab visits where the widget was enabled.
+- name: widget_disabled_visits
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of New Tab visits where the widget was disabled.
+- name: impression_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of widget impression events recorded during the day.
+- name: user_event_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of widget user interaction events recorded during the day.
+- name: change_size_or_learn_more_count
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    Number of user interactions that either changed the widget size or clicked
+    the learn more link.
+- name: enabled_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of widget enable events recorded during the day.
+- name: disabled_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of widget disable events recorded during the day.
+- name: widget_link_click_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of clicks on provider links or learn more links within the widget.
+- name: widget_setting_change_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of times users changed a widget setting, such as location or temperature unit.
+- name: widget_utility_action_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of utility interactions on the widget, such as timer or list and task actions.
+- name: widget_optin_accept_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of times users accepted an opt-in prompt within the widget.
+- name: widget_user_action_counts
+  type: RECORD
+  mode: REPEATED
+  description: >-
+    Per-widget breakdown of widgets_user_event interactions, with one entry per
+    distinct user_action value. Ordered by action.
+  fields:
+  - name: user_action
+    type: STRING
+    mode: NULLABLE
+    description: The user_action extra value from a widgets_user_event event.
+  - name: action_count
+    type: INTEGER
+    mode: NULLABLE
+    description: Number of widgets_user_event events with this action on the day.

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_widgets_daily_aggregates_v1/schema.yaml
@@ -31,7 +31,7 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Number of distinct clients who had the widget enabled during the day.
-- name: widget_visited_clients
+- name: widget_enabled_clients_with_visit
   type: INTEGER
   mode: NULLABLE
   description: >


### PR DESCRIPTION
## Description

This PR creates the `firefox_desktop_derived.newtab_widgets_daily_v1`, a daily aggregation of Firefox New Tab widget telemetry from `firefox_desktop_stable.newtab_v1` with segments and metrics. 
It also creates a corresponding view of the table.

Includes update to:
- `query.sql`
- `metadata.yaml`
- `schema.yaml`
- `checks.sql`

## Related Tickets & Documents
* DENG-11155

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)** 

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
