### PR TITLE
fix(DENG-11078): preserve --parameter flags for python-query tables in bqetl check run

### DIFF
--- a/bigquery_etl/cli/check.py
+++ b/bigquery_etl/cli/check.py
@@ -205,9 +205,10 @@ def run(ctx, dataset, project_id, sql_dir, marker, dry_run):
     for checks_file, project_id, dataset_id, table in paths_matching_checks_pattern(
         dataset, sql_dir, project_id=project_id
     ):
-        query_args = (
-            [] if (Path(checks_file).parent / "query.py").exists() else ctx.args
-        )
+        if (Path(checks_file).parent / "query.py").exists():
+            query_args = [a for a in ctx.args if a.startswith("--parameter=")]
+        else:
+            query_args = ctx.args
         _run_check(
             checks_file,
             project_id,

--- a/bigquery_etl/cli/check.py
+++ b/bigquery_etl/cli/check.py
@@ -206,6 +206,7 @@ def run(ctx, dataset, project_id, sql_dir, marker, dry_run):
         dataset, sql_dir, project_id=project_id
     ):
         if (Path(checks_file).parent / "query.py").exists():
+            # python-query tables: drop script-only flags; keep --parameter=... bindings for checks.sql
             query_args = [a for a in ctx.args if a.startswith("--parameter=")]
         else:
             query_args = ctx.args


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR fixes `bqetl check run` dropping `--parameter=*` flags for Python-query tables, which caused Airflow `bigquery_dq_check` tasks to fail with `Query parameter 'date' not found` whenever a `checks.sql` macro emits `@date` (or any other parameterized reference).

**Testing:** I ran `./bqetl check run moz-fx-data-shared-prod.statcounter_derived.browser_market_share_worldwide_v1 --marker=warn --parameter=date:DATE:2026-05-20 ; echo "exit=$?"` before the fix to verify that it first failed with the same error and then succeeded afterward.

## Related Tickets & Documents
* DENG-11078
* https://github.com/mozilla/bigquery-etl/pull/9384

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
