### PR TITLE
feat(DENG-11184): add bugzilla_tickets_base_v1 and sumo_bugzilla_kpis

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/metadata.yaml
@@ -1,0 +1,27 @@
+friendly_name: Bugzilla Tickets Base (Daily)
+description: |
+  Daily metrics for SUMO Bugzilla tickets in the 'Knowledge Base Content' component.
+
+  Grain: Daily
+
+  Tracks:
+  - Bugs created on the date
+  - Bugs resolved on the date (first RESOLVED transition, accounting for later REOPEN→RESOLVED cycles)
+
+  Source: moz-fx-data-shared-prod.bugzilla_metrics.bugs (daily snapshots)
+owners:
+  - phlee@mozilla.com
+  - mozilla/customer_experience
+labels:
+  incremental: true
+  application: sumo
+  type: base_metrics
+  schedule: daily
+bigquery:
+  time_partitioning:
+    type: day
+    field: date
+    require_partition_filter: false
+scheduling:
+  dag_name: bqetl_sumo_metrics
+  depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/query.sql
@@ -1,0 +1,57 @@
+WITH bug_history AS (
+  SELECT
+    id,
+    DATE(creation_ts) AS creation_date,
+    MIN(IF(status = 'RESOLVED', snapshot_date, NULL)) AS first_resolved_date,
+    MAX(IF(status = 'REOPENED', snapshot_date, NULL)) AS last_reopened_resolved_date,
+  FROM
+    `moz-fx-data-shared-prod.bugzilla_metrics.bugs`
+  WHERE
+    component = 'Knowledge Base Content'
+  GROUP BY
+    id,
+    creation_date
+),
+bugs AS (
+  SELECT
+    id,
+    creation_date,
+    GREATEST(
+      first_resolved_date,
+      COALESCE(last_reopened_resolved_date, DATE '1900-01-01')
+    ) AS resolution_date,
+  FROM
+    bug_history
+),
+created AS (
+  SELECT
+    creation_date AS `date`,
+    COUNT(*) AS bugs_created,
+  FROM
+    bugs
+  WHERE
+    creation_date = @submission_date
+  GROUP BY
+    `date`
+),
+resolved AS (
+  SELECT
+    resolution_date AS `date`,
+    COUNT(*) AS bugs_resolved,
+  FROM
+    bugs
+  WHERE
+    resolution_date = @submission_date
+  GROUP BY
+    `date`
+)
+SELECT
+  @submission_date AS `date`,
+  COALESCE(created.bugs_created, 0) AS bugs_created,
+  COALESCE(resolved.bugs_resolved, 0) AS bugs_resolved,
+  CURRENT_TIMESTAMP() AS etl_timestamp,
+FROM
+  created
+FULL OUTER JOIN
+  resolved
+  USING (`date`)

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/schema.yaml
@@ -1,0 +1,20 @@
+fields:
+- name: date
+  type: DATE
+  mode: NULLABLE
+  description: Date of the metrics (UTC)
+- name: bugs_created
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of Knowledge Base Content bugs created on this date
+- name: bugs_resolved
+  type: INTEGER
+  mode: NULLABLE
+  description: |
+    Number of Knowledge Base Content bugs resolved on this date.
+    Resolution date is the most recent of the first RESOLVED snapshot and any
+    later REOPENED→RESOLVED snapshot.
+- name: etl_timestamp
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: Timestamp when this record was loaded into BigQuery

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_bugzilla_kpis/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_bugzilla_kpis/metadata.yaml
@@ -1,0 +1,20 @@
+friendly_name: SUMO Bugzilla KPIs
+description: |
+  View aggregating weekly KPIs for SUMO Bugzilla tickets (Knowledge Base Content
+  component) over the trailing 1 year, with 6-week moving averages and 6-week
+  lagged moving averages.
+
+  Grain: Weekly (week starts Sunday)
+
+  Metrics:
+  - bugs_created, bugs_resolved
+  - bug_inventory: created - resolved for the week
+  - running_backlog: cumulative inventory over the window
+  - *_6w_ma: 6-week trailing moving averages
+  - lagged_*_6w_ma: the same MA shifted back 6 weeks (for QoQ-style comparison)
+
+  Source: sumo_metrics_derived.bugzilla_tickets_base_v1
+
+owners:
+  - phlee@mozilla.com
+  - mozilla/customer_experience

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_bugzilla_kpis/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_bugzilla_kpis/view.sql
@@ -1,0 +1,79 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.sumo_metrics_derived.sumo_bugzilla_kpis`
+AS
+WITH weeks AS (
+  SELECT
+    WEEK
+  FROM
+    UNNEST(
+      GENERATE_DATE_ARRAY(
+        DATE_TRUNC(DATE_SUB(CURRENT_DATE, INTERVAL 1 YEAR), WEEK(SUNDAY)),
+        DATE_TRUNC(CURRENT_DATE, WEEK(SUNDAY)),
+        INTERVAL 1 WEEK
+      )
+    ) AS week
+),
+weekly AS (
+  SELECT
+    DATE_TRUNC(`date`, WEEK(SUNDAY)) AS week,
+    SUM(bugs_created) AS bugs_created,
+    SUM(bugs_resolved) AS bugs_resolved,
+  FROM
+    `moz-fx-data-shared-prod.sumo_metrics_derived.bugzilla_tickets_base_v1`
+  WHERE
+    `date`
+    BETWEEN DATE_SUB(CURRENT_DATE, INTERVAL 1 YEAR)
+    AND CURRENT_DATE
+  GROUP BY
+    WEEK
+),
+joined AS (
+  SELECT
+    weeks.week,
+    COALESCE(weekly.bugs_created, 0) AS bugs_created,
+    COALESCE(weekly.bugs_resolved, 0) AS bugs_resolved,
+    COALESCE(weekly.bugs_created, 0) - COALESCE(weekly.bugs_resolved, 0) AS bug_inventory,
+    SUM(COALESCE(weekly.bugs_created, 0) - COALESCE(weekly.bugs_resolved, 0)) OVER (
+      ORDER BY
+        weeks.week
+    ) AS running_backlog,
+  FROM
+    weeks
+  LEFT JOIN
+    weekly
+    USING (WEEK)
+),
+moving_avgs AS (
+  SELECT
+    *,
+    AVG(bugs_created) OVER (
+      ORDER BY
+        WEEK
+      ROWS BETWEEN
+        5 PRECEDING
+        AND CURRENT ROW
+    ) AS bugs_created_6w_ma,
+    AVG(bugs_resolved) OVER (
+      ORDER BY
+        WEEK
+      ROWS BETWEEN
+        5 PRECEDING
+        AND CURRENT ROW
+    ) AS bugs_resolved_6w_ma,
+    AVG(bug_inventory) OVER (
+      ORDER BY
+        WEEK
+      ROWS BETWEEN
+        5 PRECEDING
+        AND CURRENT ROW
+    ) AS bug_inventory_6w_ma,
+  FROM
+    joined
+)
+SELECT
+  *,
+  LAG(bugs_created_6w_ma, 6) OVER (ORDER BY WEEK) AS lagged_bugs_created_6w_ma,
+  LAG(bugs_resolved_6w_ma, 6) OVER (ORDER BY WEEK) AS lagged_bugs_resolved_6w_ma,
+  LAG(bug_inventory_6w_ma, 6) OVER (ORDER BY WEEK) AS lagged_bug_inventory_6w_ma,
+FROM
+  moving_avgs


### PR DESCRIPTION
## Description

Adds a daily base table and a weekly KPI view tracking SUMO Bugzilla activity for the `Knowledge Base Content` component, mirroring the pattern of `zendesk_tickets_base_v1` / `sumo_zendesk_kpis`.

- `sumo_metrics_derived.bugzilla_tickets_base_v1` — daily incremental table with `bugs_created` and `bugs_resolved` counts, sourced from `bugzilla_metrics.bugs`. Resolution date uses the first `RESOLVED` snapshot, overridden by any later `REOPENED → RESOLVED` cycle.

- `sumo_metrics_derived.sumo_bugzilla_kpis` — view aggregating the base table to weekly buckets (`WEEK(SUNDAY)`) over the trailing year, with `bug_inventory`, `running_backlog`, 6-week moving averages, and 6-week lagged MAs. Replaces the ad-hoc dashboard query previously maintained outside bqetl.

**NOTE**: Validated against the original dashboard query in [DENG-11184](https://mozilla-hub.atlassian.net/browse/DENG-11184): per-week deltas are fully explained by (a) the new query including full boundary weeks, and (b) the new query correctly counting resolutions of bugs created prior to the 1-year window (the original under-counted these).

## Related Tickets & Documents
* DENG-11184

## TODO
- [x] Back fill `bugzilla_tickets_base_v1` with `start_date` set to 14 months i.e. `2025-03-29` back so 6-week lag columns are not calculated as `null`

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-11184]: https://mozilla-hub.atlassian.net/browse/DENG-11184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ