### PR TITLE
feat: add braze_external.changed_products_v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v1/metadata.yaml
@@ -16,9 +16,3 @@ bigquery:
   field: updated_at
   require_partition_filter: false
   expiration_days: 7
-scheduling:
-  dag_name: bqetl_braze
-  date_partition_parameter: null
-  arguments:
-  - --append_table
-  - --noreplace

--- a/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/metadata.yaml
@@ -1,0 +1,24 @@
+friendly_name: Braze Changed Products Sync
+description: |-
+  Changes in product data from the previous day. In order to consume the least amount
+  of data points, we only want to sync rows changed since the last sync. This table holds
+  all of the changed product data that syncs to braze.
+
+  See https://mozilla-hub.atlassian.net/browse/DENG-3182
+owners:
+- cbeck@mozilla.com
+labels:
+  incremental: true
+  owner: cbeck
+bigquery:
+  time_partitioning:
+  type: day
+  field: updated_at
+  require_partition_filter: false
+  expiration_days: 7
+scheduling:
+  dag_name: bqetl_braze
+  date_partition_parameter: null
+  arguments:
+  - --append_table
+  - --noreplace

--- a/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/metadata.yaml
@@ -14,10 +14,10 @@ labels:
   owner: cbeck
 bigquery:
   time_partitioning:
-  type: day
-  field: updated_at
-  require_partition_filter: false
-  expiration_days: 7
+    type: day
+    field: updated_at
+    require_partition_filter: false
+    expiration_days: 7
 scheduling:
   dag_name: bqetl_braze
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/metadata.yaml
@@ -5,6 +5,8 @@ description: |-
   all of the changed product data that syncs to braze.
 
   See https://mozilla-hub.atlassian.net/browse/DENG-3182
+
+  The v2 table is a new schema format to sync on alias columns instead of external_id.
 owners:
 - cbeck@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/query.sql
@@ -6,7 +6,7 @@ WITH max_update AS (
       TIMESTAMP(JSON_VALUE(payload.products_v1[0].subscription_updated_at, '$."$time"'))
     ) AS latest_subscription_updated_at
   FROM
-    `moz-fx-data-shared-prod.braze_external.changed_products_sync_v1`
+    `moz-fx-data-shared-prod.braze_external.changed_products_sync_v2`
 ),
 -- Counts the number of subscriptions per product
 products_with_counts AS (

--- a/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/query.sql
@@ -22,7 +22,7 @@ products_with_counts AS (
 SELECT
   CURRENT_TIMESTAMP() AS UPDATED_AT,
   products.external_id AS ALIAS_NAME,
-  'fxa_id' AS ALIAS_LABEL,
+  'fxa_id' AS ALIAS_LABEL, -- Braze requires this to know it's syncing on fxa_id
   TO_JSON(
     STRUCT(
       ARRAY_AGG(
@@ -165,7 +165,7 @@ SELECT
         )
         ORDER BY
           products.subscription_updated_at DESC
-      ) AS products_v1
+      ) AS products_v1 -- name of array in Braze - does not correspond w/ table name
     )
   ) AS PAYLOAD
 FROM

--- a/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/query.sql
@@ -1,0 +1,174 @@
+-- Retrieves the maximum subscription updated timestamp from the last run to only
+-- select recently changed records
+WITH max_update AS (
+  SELECT
+    MAX(
+      TIMESTAMP(JSON_VALUE(payload.products_v1[0].subscription_updated_at, '$."$time"'))
+    ) AS latest_subscription_updated_at
+  FROM
+    `moz-fx-data-shared-prod.braze_external.changed_products_sync_v1`
+),
+-- Counts the number of subscriptions per product
+products_with_counts AS (
+  SELECT
+    products.*,
+    COUNT(*) OVER (PARTITION BY products.external_id, products.product_name) AS subscription_count
+  FROM
+    `moz-fx-data-shared-prod.braze_derived.products_v2` AS products
+  WHERE
+    products.subscription_updated_at > (SELECT latest_subscription_updated_at FROM max_update)
+)
+-- Construct the JSON payload in Braze required format
+SELECT
+  CURRENT_TIMESTAMP() AS UPDATED_AT,
+  products.external_id AS ALIAS_NAME,
+  'fxa_id' AS ALIAS_LABEL,
+  TO_JSON(
+    STRUCT(
+      ARRAY_AGG(
+        STRUCT(
+          products.provider AS provider,
+          products.payment_provider AS payment_provider,
+          products.product_name AS product_name,
+          products.service_name AS service_name,
+          products.subscription_plan_id AS subscription_plan_id,
+          products.subscription_product_id AS subscription_product_id,
+          (
+            CASE
+              WHEN products.subscription_started_at IS NOT NULL -- null timestamp values cause errors in Braze
+                THEN STRUCT(
+                    FORMAT_TIMESTAMP(
+                      '%Y-%m-%d %H:%M:%E6S UTC', -- format is Braze requirement for nested timestamps
+                      products.subscription_started_at,
+                      'UTC'
+                    ) AS `$time`
+                  )
+            END
+          ) AS subscription_started_at,
+          (
+            CASE
+              WHEN products.subscription_ended_at IS NOT NULL
+                THEN STRUCT(
+                    FORMAT_TIMESTAMP(
+                      '%Y-%m-%d %H:%M:%E6S UTC',
+                      products.subscription_ended_at,
+                      'UTC'
+                    ) AS `$time`
+                  )
+            END
+          ) AS subscription_ended_at,
+          products.subscription_summary AS subscription_summary,
+          products.subscription_billing_interval AS subscription_billing_interval,
+          products.subscription_interval_count AS subscription_interval_count,
+          products.subscription_currency AS subscription_currency,
+          products.subscription_amount AS subscription_amount,
+          products.is_bundle AS is_bundle,
+          products.is_trial AS is_trial,
+          products.is_active AS is_active,
+          products.subscription_status AS subscription_status,
+          products.subscription_count AS subscription_count,
+          products.subscription_country_code AS subscription_country_code,
+          products.subscription_country_name AS subscription_country_name,
+          (
+            CASE
+              WHEN products.current_period_started_at IS NOT NULL
+                THEN STRUCT(
+                    FORMAT_TIMESTAMP(
+                      '%Y-%m-%d %H:%M:%E6S UTC',
+                      products.current_period_started_at,
+                      'UTC'
+                    ) AS `$time`
+                  )
+            END
+          ) AS current_period_started_at,
+          (
+            CASE
+              WHEN products.current_period_ends_at IS NOT NULL
+                THEN STRUCT(
+                    FORMAT_TIMESTAMP(
+                      '%Y-%m-%d %H:%M:%E6S UTC',
+                      products.current_period_ends_at,
+                      'UTC'
+                    ) AS `$time`
+                  )
+            END
+          ) AS current_period_ends_at,
+          products.is_auto_renew AS is_auto_renew,
+          (
+            CASE
+              WHEN products.auto_renew_disabled_at IS NOT NULL
+                THEN STRUCT(
+                    FORMAT_TIMESTAMP(
+                      '%Y-%m-%d %H:%M:%E6S UTC',
+                      products.auto_renew_disabled_at,
+                      'UTC'
+                    ) AS `$time`
+                  )
+            END
+          ) AS auto_renew_disabled_at,
+          products.has_refunds AS has_refunds,
+          products.has_fraudulent_charges AS has_fraudulent_charges,
+          (
+            CASE
+              WHEN products.first_touch_impression_at IS NOT NULL
+                THEN STRUCT(
+                    FORMAT_TIMESTAMP(
+                      '%Y-%m-%d %H:%M:%E6S UTC',
+                      products.first_touch_impression_at,
+                      'UTC'
+                    ) AS `$time`
+                  )
+            END
+          ) AS first_touch_impression_at,
+          products.first_touch_entrypoint AS first_touch_entrypoint,
+          products.first_touch_entrypoint_experiment AS first_touch_entrypoint_experiment,
+          products.first_touch_entrypoint_variation AS first_touch_entrypoint_variation,
+          products.first_touch_utm_campaign AS first_touch_utm_campaign,
+          products.first_touch_utm_content AS first_touch_utm_content,
+          products.first_touch_utm_medium AS first_touch_utm_medium,
+          products.first_touch_utm_source AS first_touch_utm_source,
+          products.first_touch_utm_term AS first_touch_utm_term,
+          (
+            CASE
+              WHEN products.last_touch_impression_at IS NOT NULL
+                THEN STRUCT(
+                    FORMAT_TIMESTAMP(
+                      '%Y-%m-%d %H:%M:%E6S UTC',
+                      products.last_touch_impression_at,
+                      'UTC'
+                    ) AS `$time`
+                  )
+            END
+          ) AS last_touch_impression_at,
+          products.last_touch_entrypoint AS last_touch_entrypoint,
+          products.last_touch_entrypoint_experiment AS last_touch_entrypoint_experiment,
+          products.last_touch_entrypoint_variation AS last_touch_entrypoint_variation,
+          products.last_touch_utm_campaign AS last_touch_utm_campaign,
+          products.last_touch_utm_content AS last_touch_utm_content,
+          products.last_touch_utm_medium AS last_touch_utm_medium,
+          products.last_touch_utm_source AS last_touch_utm_source,
+          products.last_touch_utm_term AS last_touch_utm_term,
+          STRUCT(
+            FORMAT_TIMESTAMP(
+              '%Y-%m-%d %H:%M:%E6S UTC',
+              products.subscription_created_at,
+              'UTC'
+            ) AS `$time`
+          ) AS subscription_created_at,
+          STRUCT(
+            FORMAT_TIMESTAMP(
+              '%Y-%m-%d %H:%M:%E6S UTC',
+              products.subscription_updated_at,
+              'UTC'
+            ) AS `$time`
+          ) AS subscription_updated_at
+        )
+        ORDER BY
+          products.subscription_updated_at DESC
+      ) AS products_v1
+    )
+  ) AS PAYLOAD
+FROM
+  products_with_counts AS products
+GROUP BY
+  products.external_id;

--- a/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_external/changed_products_sync_v2/schema.yaml
@@ -1,0 +1,17 @@
+fields:
+- mode: NULLABLE
+  name: UPDATED_AT
+  type: TIMESTAMP
+  description: The day and time this table was last updated.
+- mode: NULLABLE
+  name: ALIAS_NAME
+  type: STRING
+  description: The value that syncs to this alias record (fxa_id).
+- mode: NULLABLE
+  name: ALIAS_LABEL
+  type: STRING
+  description: The name of the label (fxa_id) in Braze.
+- mode: NULLABLE
+  name: PAYLOAD
+  type: JSON
+  description: A combination of all fields from products_v2, packaged as a payload to sync to Braze.


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR creates a v2 table for `braze_external.changed_products`. It holds the same data as the v1 table but with a different structure to sync to Braze since `external_id` is no longer provided

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
