### PR TITLE
Bug 2034599 - Create initial per-metric storage use dataset for per-metric cost projection 

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/glean_per_metric_logical_bytes_stored/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/glean_per_metric_logical_bytes_stored/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: Glean Per-Metric Logical Bytes Stored
+description: |-
+  Daily logical (uncompressed) bytes of telemetry collected per Glean metric per
+  app, derived from monitoring_derived.glean_per_metric_logical_bytes_stored_v1.
+  Volume-only input for telemetry cost projection; cost is applied downstream.
+owners:
+- tlong@mozilla.com

--- a/sql/moz-fx-data-shared-prod/monitoring/glean_per_metric_logical_bytes_stored/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/glean_per_metric_logical_bytes_stored/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.monitoring.glean_per_metric_logical_bytes_stored`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.monitoring_derived.glean_per_metric_logical_bytes_stored_v1`

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/metadata.yaml
@@ -1,0 +1,32 @@
+friendly_name: Glean Per-Metric Logical Bytes Stored
+description: |-
+  Daily logical (uncompressed) bytes of telemetry collected per Glean metric,
+  per app (Firefox for Desktop / Android / iOS).
+
+  Combines two sources, both already aggregated:
+    - event metrics from monitoring_derived.event_counts_glean_v2 (uses
+      event_extras_length, the aggregated event-extra byte size, which only
+      exists in v2)
+    - non-event metric columns from monitoring_derived.column_size_v1
+
+  This table intentionally contains volume only (logical bytes). Cost modelling
+  (compression ratio, retention, storage rate) and projection scenarios are
+  applied downstream (e.g. in Grafana) as constants, since cost is linear in
+  bytes. It is the reproducible per-metric input for the telemetry cost
+  projection framework.
+owners:
+- tlong@mozilla.com
+labels:
+  incremental: true
+  owner1: tlong
+scheduling:
+  dag_name: bqetl_monitoring
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: false
+    expiration_days: null
+  clustering:
+    fields:
+    - normalized_app_name

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/metadata.yaml
@@ -30,3 +30,4 @@ bigquery:
   clustering:
     fields:
     - normalized_app_name
+    - metric_identifier

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/query.sql
@@ -1,14 +1,21 @@
-WITH column_metrics AS (
+WITH metrics_ping_metrics AS (
   -- Non-event metric columns from column_size_v1, normalizing dataset_id into an app
   -- (combining channels) and normalizing column_name into a metric_identifier.
   -- Datasets outside the three target apps map to NULL and are excluded below, so this
   -- branch stays symmetric with the event branch (which already filters to the three apps).
-  -- The metric_identifier normalization mirrors the Glean column hierarchy:
-  --   ping_info.*   / client_info.*  -> keep the full path only at depth 2
-  --   metadata.*.*                   -> keep the full path only at depth 3
-  --   metrics.<type>.<name>          -> keep just <name> (depth 3)
+  -- column_name is the BigQuery field_path (from column_size_v1). The
+  -- metric_identifier normalization mirrors the Glean column hierarchy by depth:
+  --   ping_info.*   / client_info.*  -> keep the full path (depth 2)
+  --   metadata.*.*                   -> keep the full path (depth 3)
+  --   metrics.<type>.<id>            -> keep <id>, the leaf column name (depth 3)
   --   anything else                  -> keep as-is
   -- Paths that don't match their expected depth are set to NULL and excluded below.
+  -- NOTE: for the metrics.* case, <id> is Glean's underscore-flattened metric id
+  -- (e.g. "addons_has_enabled_addons") -- it already includes BOTH category and name;
+  -- it is NOT just the name. The "." is flattened to "_" because this is a BigQuery
+  -- column name (where "." denotes struct traversal). The event branch below keeps the
+  -- "category.name" dot form instead. See the metric_identifier description in
+  -- schema.yaml for the full rationale; do not split this field to recover hierarchy.
   SELECT
     submission_date,
     CASE
@@ -43,9 +50,11 @@ WITH column_metrics AS (
     submission_date = @submission_date
     AND table_id = "metrics_v1"
 ),
-sample AS (
-  -- Event metrics from event_counts_glean_v2, concatenating category and name into a
-  -- single identifier. The logical bytes collected for each event is:
+combine_metrics_and_events AS (
+  -- Event metrics from event_counts_glean_v2, concatenating category and name into the
+  -- dot-joined "category.name" identifier (event_category/event_name are column values
+  -- here, so the "." is preserved -- unlike the underscore-flattened metric columns
+  -- above; see schema.yaml). The logical bytes collected for each event is:
   --   ((8 bytes of timestamp + category length + name length) * total events) + aggregated extras length
   -- event_extras_length is already aggregated upstream in v2, so it is added once and is
   -- NOT multiplied by total_events.
@@ -54,7 +63,9 @@ sample AS (
     normalized_app_name,
     CONCAT(event_category, ".", event_name) AS metric_identifier,
     SUM(
-      ((8 + LENGTH(event_category) + LENGTH(event_name)) * total_events) + event_extras_length
+      (
+        (8 + BYTE_LENGTH(event_category) + BYTE_LENGTH(event_name)) * total_events
+      ) + event_extras_length
     ) AS logical_bytes
   FROM
     `moz-fx-data-shared-prod.monitoring_derived.event_counts_glean_v2`
@@ -72,7 +83,7 @@ sample AS (
     metric_identifier,
     SUM(byte_size) AS logical_bytes
   FROM
-    column_metrics
+    metrics_ping_metrics
   WHERE
     metric_identifier IS NOT NULL
     AND normalized_app_name IS NOT NULL
@@ -87,7 +98,7 @@ SELECT
   metric_identifier,
   SUM(logical_bytes) AS daily_logical_bytes
 FROM
-  sample
+  combine_metrics_and_events
 GROUP BY
   submission_date,
   normalized_app_name,

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/query.sql
@@ -1,0 +1,94 @@
+WITH column_metrics AS (
+  -- Non-event metric columns from column_size_v1, normalizing dataset_id into an app
+  -- (combining channels) and normalizing column_name into a metric_identifier.
+  -- Datasets outside the three target apps map to NULL and are excluded below, so this
+  -- branch stays symmetric with the event branch (which already filters to the three apps).
+  -- The metric_identifier normalization mirrors the Glean column hierarchy:
+  --   ping_info.*   / client_info.*  -> keep the full path only at depth 2
+  --   metadata.*.*                   -> keep the full path only at depth 3
+  --   metrics.<type>.<name>          -> keep just <name> (depth 3)
+  --   anything else                  -> keep as-is
+  -- Paths that don't match their expected depth are set to NULL and excluded below.
+  SELECT
+    submission_date,
+    CASE
+      WHEN dataset_id IN ("org_mozilla_ios_firefox_stable", "org_mozilla_ios_firefoxbeta_stable")
+        THEN "Firefox for iOS"
+      WHEN dataset_id IN (
+          "org_mozilla_fenix_stable",
+          "org_mozilla_firefox_beta_stable",
+          "org_mozilla_firefox_stable"
+        )
+        THEN "Firefox for Android"
+      WHEN dataset_id IN ("firefox_desktop_stable")
+        THEN "Firefox for Desktop"
+      ELSE NULL
+    END AS normalized_app_name,
+    CASE
+      SPLIT(column_name, ".")[OFFSET(0)]
+      WHEN "ping_info"
+        THEN IF(ARRAY_LENGTH(SPLIT(column_name, ".")) = 2, column_name, NULL)
+      WHEN "client_info"
+        THEN IF(ARRAY_LENGTH(SPLIT(column_name, ".")) = 2, column_name, NULL)
+      WHEN "metadata"
+        THEN IF(ARRAY_LENGTH(SPLIT(column_name, ".")) = 3, column_name, NULL)
+      WHEN "metrics"
+        THEN IF(ARRAY_LENGTH(SPLIT(column_name, ".")) = 3, SPLIT(column_name, ".")[OFFSET(2)], NULL)
+      ELSE column_name
+    END AS metric_identifier,
+    byte_size
+  FROM
+    `moz-fx-data-shared-prod.monitoring_derived.column_size_v1`
+  WHERE
+    submission_date = @submission_date
+    AND table_id = "metrics_v1"
+),
+sample AS (
+  -- Event metrics from event_counts_glean_v2, concatenating category and name into a
+  -- single identifier. The logical bytes collected for each event is:
+  --   ((8 bytes of timestamp + category length + name length) * total events) + aggregated extras length
+  -- event_extras_length is already aggregated upstream in v2, so it is added once and is
+  -- NOT multiplied by total_events.
+  SELECT
+    submission_date,
+    normalized_app_name,
+    CONCAT(event_category, ".", event_name) AS metric_identifier,
+    SUM(
+      ((8 + LENGTH(event_category) + LENGTH(event_name)) * total_events) + event_extras_length
+    ) AS logical_bytes
+  FROM
+    `moz-fx-data-shared-prod.monitoring_derived.event_counts_glean_v2`
+  WHERE
+    submission_date = @submission_date
+    AND normalized_app_name IN ("Firefox for Desktop", "Firefox for Android", "Firefox for iOS")
+  GROUP BY
+    submission_date,
+    normalized_app_name,
+    metric_identifier
+  UNION ALL
+  SELECT
+    submission_date,
+    normalized_app_name,
+    metric_identifier,
+    SUM(byte_size) AS logical_bytes
+  FROM
+    column_metrics
+  WHERE
+    metric_identifier IS NOT NULL
+    AND normalized_app_name IS NOT NULL
+  GROUP BY
+    submission_date,
+    normalized_app_name,
+    metric_identifier
+)
+SELECT
+  submission_date,
+  normalized_app_name,
+  metric_identifier,
+  SUM(logical_bytes) AS daily_logical_bytes
+FROM
+  sample
+GROUP BY
+  submission_date,
+  normalized_app_name,
+  metric_identifier

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/schema.yaml
@@ -13,9 +13,18 @@ fields:
   type: STRING
   mode: NULLABLE
   description: >-
-    Per-metric identifier. For event metrics this is "category.name"; for other
-    metric columns it is the normalized Glean column path (see the column_metrics
-    normalization in query.sql).
+    Flat Glean metric identifier. Treat it as opaque: do NOT split it to recover
+    the category/name hierarchy. The two source branches use different,
+    canonical separators by design. Event metrics (event_counts_glean_v2) appear
+    as "category.name" (dot), since event_category/event_name are stored as
+    column values so the "." is preserved. Non-event metrics (column_size_v1)
+    appear underscore-flattened, e.g. "addons_has_enabled_addons" for
+    addons.has_enabled_addons, because the identifier is a BigQuery column name
+    where "." is illegal; recovering the original "." needs a Glean registry
+    lookup (the underscore is not a reliable split point) and is out of scope for
+    this MVP. A given metric normally takes only one separator form, but may be
+    sent on multiple pings and land in multiple datasets; we count every
+    occurrence, since each consumes storage.
 - name: daily_logical_bytes
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/schema.yaml
@@ -1,0 +1,25 @@
+fields:
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+  description: Date the telemetry was submitted / aggregated.
+- name: normalized_app_name
+  type: STRING
+  mode: NULLABLE
+  description: >-
+    Canonical app name (Firefox for Desktop / Firefox for Android /
+    Firefox for iOS). Rows for datasets outside these three apps are excluded.
+- name: metric_identifier
+  type: STRING
+  mode: NULLABLE
+  description: >-
+    Per-metric identifier. For event metrics this is "category.name"; for other
+    metric columns it is the normalized Glean column path (see the column_metrics
+    normalization in query.sql).
+- name: daily_logical_bytes
+  type: INTEGER
+  mode: NULLABLE
+  description: >-
+    Logical (uncompressed) bytes of telemetry collected for this metric on this
+    day, summed across channels. Derived from dry-run byte sizes
+    (column_size_v1) and the event size approximation (event_counts_glean_v2).


### PR DESCRIPTION
This adds a derived dataset with submission_date, application, metric identifier, and estimated stored logical bytes for the purpose of estimating and projecting the overhead cost of collecting a given metric.

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-XXXX
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
