### PR TITLE
feat(DENG-11185): Kitsune weekly contributor metrics

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_answers_base_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_answers_base_v1/bigconfig.yml
@@ -1,0 +1,24 @@
+type: BIGCONFIG_FILE
+tag_deployments:
+- collection:
+    name: Operational Checks
+    notification_channels:
+    - slack: '#de-bigeye-triage'
+  deployments:
+  - column_selectors:
+    - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.sumo_metrics_derived.kitsune_contributor_answers_base_v1.*
+    metrics:
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: FRESHNESS
+      metric_name: freshness
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 13:00 UTC
+    - metric_type:
+        type: PREDEFINED
+        predefined_metric: VOLUME
+      metric_name: volume
+      metric_schedule:
+        named_schedule:
+          name: Default Schedule - 13:00 UTC

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_answers_base_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_answers_base_v1/metadata.yaml
@@ -1,0 +1,43 @@
+friendly_name: Kitsune Contributor Answers Base
+description: |
+  Answer-level fact table for the SUMO (Kitsune) support forum, with one row per
+  qualifying answer used to measure contributor activity.
+
+  Grain: Answer
+
+  Each row is a single answer that satisfies all of the following (matching the
+  `main` CTE of the kitsune_weekly_contributors dashboard query):
+  - Not spam (kitsune_answers_raw.is_spam IS NOT TRUE)
+  - Posted by an active user (kitsune_auth_user.is_active = TRUE)
+  - On a Firefox product (firefox, mobile, ios, firefox-enterprise)
+  - Not an OP self-answer (answer creator <> question creator)
+
+  Product mapping:
+    firefox            -> Firefox desktop
+    mobile             -> Firefox for Android
+    ios                -> Firefox for iOS
+    firefox-enterprise -> Firefox for Enterprise
+  Non-Firefox products are excluded.
+
+  This table is the reusable base for kitsune_contributor_metrics_weekly_v1 and
+  for any other answer-level contributor reporting.
+
+  Note: total_helpful_votes / total_unhelpful_votes are cumulative vote totals
+  as of ETL run time, and last_login reflects current state. These columns are
+  not stable across runs. The contributor metrics built on top of this table do
+  not depend on those columns.
+
+  Replaces the `main` CTE in:
+  - kitsune_weekly_contributors.sql (dashboard queries)
+owners:
+  - plee@mozilla.com
+  - mozilla/customer_insights
+labels:
+  incremental: false
+  application: sumo
+  type: base_metrics
+  schedule: daily
+scheduling:
+  dag_name: bqetl_sumo_metrics
+  date_partition_parameter: null
+  depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_answers_base_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_answers_base_v1/query.sql
@@ -1,0 +1,102 @@
+-- Answer-level contributor fact for the SUMO Kitsune support forum.
+-- One row per qualifying answer: non-spam, posted by an active user, on a
+-- Firefox product, excluding OP self-answers. Mirrors the `main` CTE of the
+-- kitsune_weekly_contributors dashboard query and is the reusable base on top
+-- of which kitsune_contributor_metrics_weekly_v1 is built.
+WITH questions AS (
+  SELECT
+    q.question_id,
+    DATE(q.created_date) AS question_date,
+    -- Canonicalize Firefox product names; non-Firefox products are excluded.
+    CASE
+      q.product
+      WHEN 'firefox'
+        THEN 'Firefox desktop'
+      WHEN 'mobile'
+        THEN 'Firefox for Android'
+      WHEN 'ios'
+        THEN 'Firefox for iOS'
+      WHEN 'firefox-enterprise'
+        THEN 'Firefox for Enterprise'
+    END AS product,
+    q.locale,
+    q.creator_username AS question_creator_username,
+    q.num_replies,
+    q.num_replies_from_others
+  FROM
+    `moz-fx-data-shared-prod.sumo_syndicate.kitsune_questions_plus` q
+  WHERE
+    q.product IN ('firefox', 'mobile', 'ios', 'firefox-enterprise')
+),
+-- Last reply timestamp per question across ALL answers (unfiltered), matching
+-- the dashboard's MAX(created_date) OVER (PARTITION BY question_id).
+last_reply_per_question AS (
+  SELECT
+    question_id,
+    MAX(created_date) AS last_reply_on_question
+  FROM
+    `moz-fx-data-shared-prod.sumo_syndicate.kitsune_answers_raw`
+  GROUP BY
+    question_id
+),
+-- First/last answer dates per user across ALL their answers (unfiltered:
+-- includes spam, inactive, non-Firefox and OP self-answers).
+user_answer_span AS (
+  SELECT
+    creator_username,
+    MIN(DATE(created_date)) AS user_first_answer_date,
+    MAX(DATE(created_date)) AS user_last_answer_date
+  FROM
+    `moz-fx-data-shared-prod.sumo_syndicate.kitsune_answers_raw`
+  GROUP BY
+    creator_username
+)
+SELECT
+  a.answer_id,
+  DATE(a.created_date) AS answer_date,
+  a.creator_username,
+  CONCAT('https://support.mozilla.org/user/', a.creator_username) AS creator_profile,
+  u.email,
+  a.question_id,
+  q.question_date,
+  CONCAT(
+    'https://support.mozilla.org/',
+    q.locale,
+    '/questions/',
+    CAST(a.question_id AS STRING),
+    '#answer-',
+    CAST(a.answer_id AS STRING)
+  ) AS answer_url,
+  q.product,
+  q.locale,
+  q.num_replies_from_others,
+  lr.last_reply_on_question,
+  IF(q.num_replies > q.num_replies_from_others, 1, 0) AS op_reply_back,
+  a.num_helpful_votes AS total_helpful_votes,
+  a.num_unhelpful_votes AS total_unhelpful_votes,
+  a.num_helpful_votes + a.num_unhelpful_votes AS total_helpfulness,
+  s.user_first_answer_date,
+  s.user_last_answer_date,
+  DATE(u.date_joined) AS date_joined,
+  DATE(u.last_login) AS last_login,
+  CURRENT_TIMESTAMP() AS generated_time
+FROM
+  `moz-fx-data-shared-prod.sumo_syndicate.kitsune_answers_raw` a
+JOIN
+  questions q
+  ON a.question_id = q.question_id
+LEFT JOIN
+  `moz-fx-data-shared-prod.sumo_syndicate.kitsune_auth_user` u
+  ON a.creator_username = u.username
+LEFT JOIN
+  last_reply_per_question lr
+  ON a.question_id = lr.question_id
+LEFT JOIN
+  user_answer_span s
+  ON a.creator_username = s.creator_username
+WHERE
+  a.is_spam IS NOT TRUE
+  AND u.is_active IS TRUE
+  -- Exclude OP self-answers (keep when creators differ or OP is unknown),
+  -- matching is_answer_by_op = 0 in the dashboard query.
+  AND COALESCE(a.creator_username = q.question_creator_username, FALSE) IS NOT TRUE

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_answers_base_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_answers_base_v1/schema.yaml
@@ -1,0 +1,99 @@
+fields:
+- name: answer_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Unique identifier of the answer in Kitsune.
+- name: answer_date
+  type: DATE
+  mode: NULLABLE
+  description: UTC date the answer was created.
+- name: creator_username
+  type: STRING
+  mode: NULLABLE
+  description: Username of the contributor who posted the answer.
+- name: creator_profile
+  type: STRING
+  mode: NULLABLE
+  description: URL of the contributor's SUMO profile.
+- name: email
+  type: STRING
+  mode: NULLABLE
+  description: Email address of the contributor (from kitsune_auth_user).
+- name: question_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Identifier of the question this answer belongs to.
+- name: question_date
+  type: DATE
+  mode: NULLABLE
+  description: UTC date the question was created.
+- name: answer_url
+  type: STRING
+  mode: NULLABLE
+  description: Deep link to the answer on support.mozilla.org.
+- name: product
+  type: STRING
+  mode: NULLABLE
+  description: |
+    Canonicalized Firefox product name:
+    - 'Firefox desktop'
+    - 'Firefox for Android'
+    - 'Firefox for iOS'
+    - 'Firefox for Enterprise'
+    Non-Firefox products are excluded from this table.
+- name: locale
+  type: STRING
+  mode: NULLABLE
+  description: BCP-47 locale code of the question (e.g. 'en-US', 'pt-BR').
+- name: num_replies_from_others
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of replies on the question from users other than the OP.
+- name: last_reply_on_question
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: |
+    Timestamp of the most recent reply on the question, across all answers
+    (unfiltered, includes spam and OP self-answers).
+- name: op_reply_back
+  type: INTEGER
+  mode: NULLABLE
+  description: 1 if the OP replied back on the question (num_replies > num_replies_from_others), else 0.
+- name: total_helpful_votes
+  type: INTEGER
+  mode: NULLABLE
+  description: |
+    Helpful votes on this answer as of ETL run time. Not stable across runs.
+- name: total_unhelpful_votes
+  type: INTEGER
+  mode: NULLABLE
+  description: |
+    Unhelpful votes on this answer as of ETL run time. Not stable across runs.
+- name: total_helpfulness
+  type: INTEGER
+  mode: NULLABLE
+  description: Sum of helpful and unhelpful votes on this answer, as of ETL run time.
+- name: user_first_answer_date
+  type: DATE
+  mode: NULLABLE
+  description: |
+    Date of the contributor's first answer across ALL their answers
+    (unfiltered: includes spam, inactive, non-Firefox and OP self-answers).
+- name: user_last_answer_date
+  type: DATE
+  mode: NULLABLE
+  description: |
+    Date of the contributor's most recent answer across ALL their answers
+    (unfiltered). Reflects state as of ETL run time.
+- name: date_joined
+  type: DATE
+  mode: NULLABLE
+  description: Date the contributor's SUMO account was created.
+- name: last_login
+  type: DATE
+  mode: NULLABLE
+  description: Date the contributor last logged in, as of ETL run time. Not stable across runs.
+- name: generated_time
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: Timestamp when this record was loaded into BigQuery.

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_metrics_weekly_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_metrics_weekly_v1/metadata.yaml
@@ -1,0 +1,38 @@
+friendly_name: Kitsune Contributor Metrics Weekly
+description: |
+  Weekly SUMO (Kitsune) support-forum contributor metrics, built on the
+  answer-level fact kitsune_contributor_answers_base_v1.
+
+  Grain: ISO week (one row per week)
+
+  Weeks are anchored to ISOWEEK and span the full history of qualifying answers
+  through the current week. The table is rebuilt in full each run (incremental:
+  false): contributor metrics are immutable historical facts derivable from the
+  full answer history, and the cross-week window functions (4-week moving
+  averages, 4-week lags, retention period comparisons) reference other weeks'
+  rows, so a full refresh is both correct and simplest.
+
+  Metrics (each with a 4-week moving average and a 4-weeks-prior lag of that MA):
+  - weekly_contributor_count: distinct contributors who answered that week
+  - new_contributors: contributors whose first qualifying answer was that week
+  - top_contributor_percentage: share of the week's answers from Top Contributors
+    (top 10 by answer count over the trailing 4 weeks)
+  - retention_rate: share of the prior 4-week period's contributors still active
+    in the current 4-week period (also split into Top / Regular by prior tier)
+
+  Replaces the weekly aggregation CTEs in:
+  - kitsune_weekly_contributors.sql (dashboard queries)
+
+  Exposed to the dashboard layer via the sumo_contributor_kpis view.
+owners:
+  - plee@mozilla.com
+  - mozilla/customer_insights
+labels:
+  incremental: false
+  application: sumo
+  type: derived_metrics
+  schedule: daily
+scheduling:
+  dag_name: bqetl_sumo_metrics
+  date_partition_parameter: null
+  depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_metrics_weekly_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_metrics_weekly_v1/query.sql
@@ -1,0 +1,270 @@
+-- Weekly SUMO (Kitsune) contributor metrics, built on the answer-level fact
+-- kitsune_contributor_answers_base_v1. Ported from the kitsune_weekly_contributors
+-- dashboard query. Full-refresh daily: the `iso_week` series is anchored to the
+-- full history of answers (not a trailing year), so each run reproduces the entire
+-- weekly time series. Metrics are keyed on ISO week.
+WITH main AS (
+  SELECT
+    answer_id,
+    answer_date,
+    creator_username
+  FROM
+    `moz-fx-data-shared-prod.sumo_metrics_derived.kitsune_contributor_answers_base_v1`
+),
+-- First answer per user based on the filtered base data.
+filtered_first_answer_per_user AS (
+  SELECT
+    creator_username,
+    MIN(answer_date) AS first_answer_date
+  FROM
+    main
+  GROUP BY
+    creator_username
+),
+-- Full history of ISO weeks, from the first answer week through the current week.
+weeks AS (
+  SELECT
+    iso_week
+  FROM
+    UNNEST(
+      GENERATE_DATE_ARRAY(
+        (SELECT DATE_TRUNC(MIN(answer_date), ISOWEEK) FROM main),
+        DATE_TRUNC(CURRENT_DATE(), ISOWEEK),
+        INTERVAL 1 WEEK
+      )
+    ) AS iso_week
+),
+-- New contributors per week (based on filtered first answer date).
+new_contributors AS (
+  SELECT
+    *,
+    LAG(new_contributors_4w_ma, 4) OVER (ORDER BY iso_week) AS lagged_new_contributors_4w_ma
+  FROM
+    (
+      SELECT
+        w.iso_week,
+        COUNT(DISTINCT f.creator_username) AS new_contributors,
+        AVG(COUNT(DISTINCT f.creator_username)) OVER (
+          ORDER BY
+            w.iso_week
+          ROWS BETWEEN
+            3 PRECEDING
+            AND CURRENT ROW
+        ) AS new_contributors_4w_ma
+      FROM
+        weeks w
+      LEFT JOIN
+        filtered_first_answer_per_user f
+        ON DATE_TRUNC(f.first_answer_date, ISOWEEK) = w.iso_week
+      GROUP BY
+        w.iso_week
+    )
+),
+-- Top contributors: top 10 by answer count over the trailing 4 weeks of each week.
+contributor_tiers AS (
+  SELECT
+    *,
+    DENSE_RANK() OVER (PARTITION BY iso_week ORDER BY answers DESC) AS ranking,
+    CASE
+      WHEN DENSE_RANK() OVER (PARTITION BY iso_week ORDER BY answers DESC) <= 10
+        THEN 'Top Contributor'
+      ELSE 'Regular Contributor'
+    END AS contributor_tier
+  FROM
+    (
+      SELECT
+        a.iso_week,
+        m.creator_username,
+        COUNT(m.answer_id) AS answers
+      FROM
+        (SELECT DISTINCT DATE_TRUNC(answer_date, ISOWEEK) AS iso_week FROM main) a
+      JOIN
+        main m
+        ON DATE(m.answer_date) >= DATE_SUB(a.iso_week, INTERVAL 4 WEEK)
+        AND DATE(m.answer_date) < DATE_ADD(a.iso_week, INTERVAL 1 WEEK)
+      GROUP BY
+        1,
+        2
+    )
+),
+main_with_tiers AS (
+  SELECT
+    main.*,
+    contributor_tier
+  FROM
+    main
+  LEFT JOIN
+    contributor_tiers
+    ON main.creator_username = contributor_tiers.creator_username
+    AND DATE_TRUNC(main.answer_date, ISOWEEK) = contributor_tiers.iso_week
+),
+-- Share of weekly answers coming from Top Contributors.
+top_contributor_perc AS (
+  SELECT
+    *,
+    LAG(top_contributor_percentage_4w_ma, 4) OVER (
+      ORDER BY
+        iso_week
+    ) AS lagged_top_contributor_percentage_4w_ma
+  FROM
+    (
+      SELECT
+        w.iso_week,
+        SUM(CASE WHEN m.contributor_tier = 'Top Contributor' THEN 1 ELSE 0 END) / NULLIF(
+          COUNT(m.answer_id),
+          0
+        ) AS top_contributor_percentage,
+        AVG(
+          SUM(CASE WHEN m.contributor_tier = 'Top Contributor' THEN 1 ELSE 0 END) / NULLIF(
+            COUNT(m.answer_id),
+            0
+          )
+        ) OVER (
+          ORDER BY
+            w.iso_week
+          ROWS BETWEEN
+            3 PRECEDING
+            AND CURRENT ROW
+        ) AS top_contributor_percentage_4w_ma
+      FROM
+        weeks w
+      LEFT JOIN
+        main_with_tiers m
+        ON DATE_TRUNC(m.answer_date, ISOWEEK) = w.iso_week
+      GROUP BY
+        w.iso_week
+    )
+),
+-- Pre-dedupe to (answer_date, creator_username, tier) for the retention range joins.
+contributor_dates AS (
+  SELECT DISTINCT
+    answer_date,
+    creator_username,
+    contributor_tier
+  FROM
+    main_with_tiers
+),
+-- Contributor retention: % of the prior 4-week period's contributors still active
+-- in the current 4-week period, broken out by their prior-period tier.
+contributor_retention AS (
+  SELECT
+    *,
+    LAG(retention_rate_4w_ma, 4) OVER (ORDER BY iso_week) AS lagged_retention_rate_4w_ma
+  FROM
+    (
+      SELECT
+        iso_week,
+        SAFE_DIVIDE(retained_count, prev_count) AS retention_rate,
+        AVG(SAFE_DIVIDE(retained_count, prev_count)) OVER (
+          ORDER BY
+            iso_week
+          ROWS BETWEEN
+            3 PRECEDING
+            AND CURRENT ROW
+        ) AS retention_rate_4w_ma,
+        SAFE_DIVIDE(retained_count_top, prev_count_top) AS retention_rate_top,
+        SAFE_DIVIDE(retained_count_regular, prev_count_regular) AS retention_rate_regular
+      FROM
+        (
+          SELECT
+            w.iso_week,
+            COUNT(DISTINCT prev.creator_username) AS prev_count,
+            COUNT(
+              DISTINCT
+              CASE
+                WHEN curr.creator_username IS NOT NULL
+                  THEN prev.creator_username
+              END
+            ) AS retained_count,
+            COUNT(
+              DISTINCT
+              CASE
+                WHEN prev.contributor_tier = 'Top Contributor'
+                  THEN prev.creator_username
+              END
+            ) AS prev_count_top,
+            COUNT(
+              DISTINCT
+              CASE
+                WHEN prev.contributor_tier = 'Top Contributor'
+                  AND curr.creator_username IS NOT NULL
+                  THEN prev.creator_username
+              END
+            ) AS retained_count_top,
+            COUNT(
+              DISTINCT
+              CASE
+                WHEN prev.contributor_tier = 'Regular Contributor'
+                  THEN prev.creator_username
+              END
+            ) AS prev_count_regular,
+            COUNT(
+              DISTINCT
+              CASE
+                WHEN prev.contributor_tier = 'Regular Contributor'
+                  AND curr.creator_username IS NOT NULL
+                  THEN prev.creator_username
+              END
+            ) AS retained_count_regular
+          FROM
+            weeks w
+          LEFT JOIN
+            contributor_dates prev
+            ON prev.answer_date >= DATE_SUB(w.iso_week, INTERVAL 8 WEEK)
+            AND prev.answer_date < DATE_SUB(w.iso_week, INTERVAL 4 WEEK)
+          LEFT JOIN
+            contributor_dates curr
+            ON curr.creator_username = prev.creator_username
+            AND curr.answer_date >= DATE_SUB(w.iso_week, INTERVAL 4 WEEK)
+            AND curr.answer_date < DATE_ADD(w.iso_week, INTERVAL 1 WEEK)
+          GROUP BY
+            w.iso_week
+        )
+    )
+),
+-- Unique contributors who posted an answer in each specific week.
+weekly_contributors AS (
+  SELECT
+    *,
+    LAG(weekly_contributor_count_4w_ma, 4) OVER (
+      ORDER BY
+        iso_week
+    ) AS lagged_weekly_contributor_count_4w_ma
+  FROM
+    (
+      SELECT
+        w.iso_week,
+        COUNT(DISTINCT a.creator_username) AS weekly_contributor_count,
+        AVG(COUNT(DISTINCT a.creator_username)) OVER (
+          ORDER BY
+            w.iso_week
+          ROWS BETWEEN
+            3 PRECEDING
+            AND CURRENT ROW
+        ) AS weekly_contributor_count_4w_ma
+      FROM
+        weeks w
+      LEFT JOIN
+        main a
+        ON DATE_TRUNC(a.answer_date, ISOWEEK) = w.iso_week
+      GROUP BY
+        w.iso_week
+    )
+)
+SELECT
+  weekly_contributors.*,
+  new_contributors.* EXCEPT (iso_week),
+  top_contributor_perc.* EXCEPT (iso_week),
+  contributor_retention.* EXCEPT (iso_week),
+  CURRENT_TIMESTAMP() AS generated_time
+FROM
+  weekly_contributors
+LEFT JOIN
+  new_contributors
+  ON weekly_contributors.iso_week = new_contributors.iso_week
+LEFT JOIN
+  top_contributor_perc
+  ON weekly_contributors.iso_week = top_contributor_perc.iso_week
+LEFT JOIN
+  contributor_retention
+  ON weekly_contributors.iso_week = contributor_retention.iso_week

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_metrics_weekly_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kitsune_contributor_metrics_weekly_v1/schema.yaml
@@ -1,0 +1,74 @@
+fields:
+- name: iso_week
+  type: DATE
+  mode: NULLABLE
+  description: ISO week start (Monday, ISOWEEK-truncated) the metrics are reported for.
+- name: weekly_contributor_count
+  type: INTEGER
+  mode: NULLABLE
+  description: Distinct contributors who posted a qualifying answer during this ISO week.
+- name: weekly_contributor_count_4w_ma
+  type: FLOAT
+  mode: NULLABLE
+  description: 4-week trailing moving average of weekly_contributor_count.
+- name: lagged_weekly_contributor_count_4w_ma
+  type: FLOAT
+  mode: NULLABLE
+  description: weekly_contributor_count_4w_ma from 4 weeks earlier (for week-over-period comparison).
+- name: new_contributors
+  type: INTEGER
+  mode: NULLABLE
+  description: Contributors whose first qualifying answer (ever) fell in this ISO week.
+- name: new_contributors_4w_ma
+  type: FLOAT
+  mode: NULLABLE
+  description: 4-week trailing moving average of new_contributors.
+- name: lagged_new_contributors_4w_ma
+  type: FLOAT
+  mode: NULLABLE
+  description: new_contributors_4w_ma from 4 weeks earlier.
+- name: top_contributor_percentage
+  type: FLOAT
+  mode: NULLABLE
+  description: |
+    Share of this week's answers posted by Top Contributors. Top Contributors are
+    the top 10 contributors (DENSE_RANK) by answer count over the trailing 4 weeks.
+- name: top_contributor_percentage_4w_ma
+  type: FLOAT
+  mode: NULLABLE
+  description: 4-week trailing moving average of top_contributor_percentage.
+- name: lagged_top_contributor_percentage_4w_ma
+  type: FLOAT
+  mode: NULLABLE
+  description: top_contributor_percentage_4w_ma from 4 weeks earlier.
+- name: retention_rate
+  type: FLOAT
+  mode: NULLABLE
+  description: |
+    Overall contributor retention: share of contributors active in the prior
+    4-week period (weeks -8 to -4) who were also active in the current 4-week
+    period (weeks -4 to +1).
+- name: retention_rate_4w_ma
+  type: FLOAT
+  mode: NULLABLE
+  description: 4-week trailing moving average of retention_rate.
+- name: retention_rate_top
+  type: FLOAT
+  mode: NULLABLE
+  description: |
+    Retention rate restricted to contributors who were Top Contributors in the
+    prior 4-week period.
+- name: retention_rate_regular
+  type: FLOAT
+  mode: NULLABLE
+  description: |
+    Retention rate restricted to contributors who were Regular Contributors in
+    the prior 4-week period.
+- name: lagged_retention_rate_4w_ma
+  type: FLOAT
+  mode: NULLABLE
+  description: retention_rate_4w_ma from 4 weeks earlier.
+- name: generated_time
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: Timestamp when this record was loaded into BigQuery.

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_contributor_kpis/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_contributor_kpis/metadata.yaml
@@ -1,0 +1,16 @@
+friendly_name: SUMO Contributor KPIs
+description: |
+  View exposing weekly SUMO (Kitsune) support-forum contributor KPIs, sourced
+  from kitsune_contributor_metrics_weekly_v1.
+
+  Grain: ISO week
+
+  KPIs exposed (each with a 4-week moving average and a 4-weeks-prior lag):
+    weekly_contributor_count    = distinct contributors who answered that week
+    new_contributors            = contributors whose first answer was that week
+    top_contributor_percentage  = share of the week's answers from Top Contributors
+    retention_rate              = prior-period contributors still active this period
+                                  (also split into Top / Regular by prior tier)
+owners:
+  - plee@mozilla.com
+  - mozilla/customer_insights

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_contributor_kpis/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_contributor_kpis/view.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.sumo_metrics_derived.sumo_contributor_kpis`
+AS
+SELECT
+  iso_week,
+  weekly_contributor_count,
+  weekly_contributor_count_4w_ma,
+  lagged_weekly_contributor_count_4w_ma,
+  new_contributors,
+  new_contributors_4w_ma,
+  lagged_new_contributors_4w_ma,
+  top_contributor_percentage,
+  top_contributor_percentage_4w_ma,
+  lagged_top_contributor_percentage_4w_ma,
+  retention_rate,
+  retention_rate_4w_ma,
+  retention_rate_top,
+  retention_rate_regular,
+  lagged_retention_rate_4w_ma
+FROM
+  `moz-fx-data-shared-prod.sumo_metrics_derived.kitsune_contributor_metrics_weekly_v1`


### PR DESCRIPTION
## Description

Breaks the `kitsune_weekly_contributors.sql` dashboard query into a maintainable, scheduled base-table → metrics-table → view stack in `sumo_metrics_derived`, following the existing `*_base_v1` / `*_daily_v1` / `*_kpis` pattern in that dataset.

## What's added

`kitsune_contributor_answers_base_v1` — answer-level fact table (one row per qualifying answer: non-spam, active user, Firefox product, non-OP-self-answer). Materializes the dashboard query's `main` CTE. Sourced from `sumo_syndicate.*`.

`kitsune_contributor_metrics_weekly_v1` — weekly contributor metrics (weekly/new contributors, top-contributor %, retention rate by tier, each with 4-week moving averages and lags), built on the base table.

`sumo_contributor_kpis` — thin view exposing curated weekly KPI columns for the dashboard layer.
Both tables are incremental: false (full daily rebuild) on the existing bqetl_sumo_metrics DAG.

## Key design decisions

**Weekly grain for the metrics table** — the measures are non-additive distinct counts over weekly/trailing-4-week windows, so they can't be reconstructed from daily aggregates via a view.

**Full-history weeks** — the weeks series is anchored to `MIN(answer_date)` instead of the dashboard's trailing `CURRENT_DATE - 1 YEAR`, so each full refresh reproduces the entire time series.

**Dropped** `CURRENT_DATE()`-relative flags (`is_newbie`, `days_since_last_answer`, etc.) — "as of now" snapshots that don't belong in a historical fact and aren't used downstream.


## Related Tickets & Documents
* DENG-11185


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
