### PR TITLE
chore(DENG-11184): Initial backfill for Bugzilla data

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2026-06-02:
+  start_date: 2025-03-29
+  end_date: 2026-06-02
+  reason: Initial back fill for Bugzilla data (DENG-11184).
+  watchers:
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

This PR performs an initial back fill for the Bugzilla data - related PR: https://github.com/mozilla/bigquery-etl/pull/9482

## Related Tickets & Documents
* DENG-11184

