### PR TITLE
Dataset data_governance_metadata for metadata completeness

### DIFF
--- a/sql/moz-fx-data-shared-prod/data_governance_metadata/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata/dataset_metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: Data Governance Metadata
+description: |-
+  Metadata tables supporting Mozilla data governance. Access is restricted to
+  the dataplatform/data-governance-developers workgroup.
+dataset_base_acl: derived_restricted
+user_facing: false
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataEditor
+  members:
+  - workgroup:dataplatform/data-governance-developers

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata/dataset_metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: Data Governance Metadata
 description: |-
   Metadata tables supporting Mozilla data governance. Access is restricted to
   the dataplatform/data-governance-developers workgroup.
-dataset_base_acl: derived_restricted
+dataset_base_acl: restricted
 user_facing: false
 labels: {}
 workgroup_access:

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/dataset_metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: Data Governance Metadata
 description: |-
   Metadata tables supporting Mozilla data governance. Access is restricted to
   the dataplatform/data-governance-developers workgroup.
-dataset_base_acl: restricted
+dataset_base_acl: derived_restricted
 user_facing: false
 labels: {}
 workgroup_access:


### PR DESCRIPTION
## Description

Creates the `data_governance_metadata_derived` dataset in `moz-fx-data-shared-prod` to hold metadata tables supporting Mozilla data governance.

The dataset is being created with restricted access and the initial tables created will be used for the metadata completeness project


## Related Tickets & Documents
* DENG-11192: Ticket associated with metadata completeness

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
