### PR TITLE
chore(CI): Allow claude-review to use the native inline-comment MCP tool

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -140,6 +140,7 @@ jobs:
           claude_args: |
             --max-budget-usd 6.00
             --allowedTools mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review
+            --allowedTools mcp__github_inline_comment__create_inline_comment
             --allowedTools mcp__github__submit_pending_pull_request_review,mcp__github__delete_pending_pull_request_review
             --allowedTools mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments,mcp__github__add_reply_to_pull_request_comment
             --allowedTools mcp__github__get_pull_request,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_file_contents


### PR DESCRIPTION
The review workflow drives inline comments through the github MCP server's pending-review flow, but the model sometimes reaches for claude-code-action's own `github_inline_comment` server instead. This can be seen in #9493 - that tool wasn't in allowed_tools, so the attempt was denied and the whole review collapsed to a single top-level `gh pr comment`, losing all inline anchoring.
