### PR TITLE
fix(glam): stop dropping sampled metrics outside release+Windows

### DIFF
--- a/bigquery_etl/glam/client_side_sampled_metrics.py
+++ b/bigquery_etl/glam/client_side_sampled_metrics.py
@@ -34,14 +34,23 @@ def _run_bq_query(query: str):
     return query_job.result()
 
 
-def _build_where_clause(metric_types: List[str], app_name: Optional[str]) -> str:
-    """Return a SQL WHERE clause for metric_types + app_name, or '' if neither."""
+def _build_where_clause(
+    metric_types: List[str],
+    app_name: Optional[str],
+    channel: Optional[str] = None,
+    os: Optional[str] = None,
+) -> str:
+    """Return a SQL WHERE clause for the given filters, or '' if none apply."""
     conditions = []
     if metric_types:
         quoted = ",".join(f"'{mt}'" for mt in sorted(set(metric_types)))
         conditions.append(f"metric_type IN ({quoted})")
     if app_name:
         conditions.append(f"app_name = '{app_name}'")
+    if channel:
+        conditions.append(f"channel = '{channel}'")
+    if os:
+        conditions.append(f"os = '{os}'")
     if not conditions:
         return ""
     return "WHERE " + " AND ".join(conditions)
@@ -50,10 +59,13 @@ def _build_where_clause(metric_types: List[str], app_name: Optional[str]) -> str
 def get(
     metric_types: Optional[Iterable[str]] = None,
     product: Optional[str] = None,
+    channel: Optional[str] = None,
+    os: Optional[str] = None,
 ) -> dict[str, List[str]]:
     """Return sampled metrics grouped by metric_type from BigQuery.
 
-    Takes the latest submission for each metric.
+    Takes the latest submission for each metric. ``channel``/``os`` scope the
+    lookup to the population a metric is sampled on.
     """
     if metric_types is not None:
         metric_types = list(metric_types)
@@ -70,7 +82,7 @@ def get(
         app_name = _PRODUCT_TO_APP_NAME[product]
     else:
         app_name = None
-    where_clause = _build_where_clause(metric_types, app_name)
+    where_clause = _build_where_clause(metric_types, app_name, channel, os)
     # Rows with experimenter_slug = NULL are tombstones written by the
     # sampled_metrics ETL when a metric is no longer covered by any active
     # experiment/rollout. They aren't real sampled metrics and should be

--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -26,6 +26,11 @@ ATTRIBUTES = ",".join(
     ]
 )
 
+# Population the sampling rollout targets; drives the lookup and query routing.
+CLIENT_SAMPLED_CHANNEL = "release"
+CLIENT_SAMPLED_OS = "Windows"
+CLIENT_SAMPLED_MAX_SAMPLE_ID = 99  # sample_id buckets are 0-99
+
 
 def render_main(**kwargs):
     """Create a SQL query for the clients_daily_histogram_aggregates dataset."""
@@ -53,8 +58,13 @@ def get_distribution_metrics(
     metrics: Dict[str, List[str]] = {metric_type: [] for metric_type in metric_type_set}
     excluded_metrics = get_etl_excluded_probes_quickfix("fenix")
 
-    # Metrics that are already sampled
-    sampled_metrics = get_sampled_metrics(metric_type_set, product=product)
+    # Metrics sampled on the rollout's target population.
+    sampled_metrics = get_sampled_metrics(
+        metric_type_set,
+        product=product,
+        channel=CLIENT_SAMPLED_CHANNEL,
+        os=CLIENT_SAMPLED_OS,
+    )
     found_sampled_metrics = defaultdict(list)
 
     # Iterate over every element in the schema under the metrics section and
@@ -166,9 +176,9 @@ def main():
             ping_type=ping_type_from_table(args.source_table),
             client_sampled_histograms=client_sampled_metrics_sql["unlabeled"],
             client_sampled_labeled_histograms=client_sampled_metrics_sql["labeled"],
-            client_sampled_channel="release",
-            client_sampled_os="Windows",
-            client_sampled_max_sample_id=100,
+            client_sampled_channel=CLIENT_SAMPLED_CHANNEL,
+            client_sampled_os=CLIENT_SAMPLED_OS,
+            client_sampled_max_sample_id=CLIENT_SAMPLED_MAX_SAMPLE_ID,
         )
     )
 

--- a/bigquery_etl/glam/clients_daily_scalar_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_scalar_aggregates.py
@@ -26,6 +26,11 @@ ATTRIBUTES = ",".join(
     ]
 )
 
+# Population the sampling rollout targets; drives the lookup and query routing.
+CLIENT_SAMPLED_CHANNEL = "release"
+CLIENT_SAMPLED_OS = "Windows"
+CLIENT_SAMPLED_MAX_SAMPLE_ID = 99  # sample_id buckets are 0-99
+
 
 def render_main(**kwargs):
     """Create a SQL query for the clients_daily_scalar_aggregates dataset."""
@@ -114,8 +119,13 @@ def get_scalar_metrics(
     }
     excluded_metrics = get_etl_excluded_probes_quickfix("fenix")
 
-    # Metrics that are already sampled
-    sampled_metrics = get_sampled_metrics(metric_type_set[scalar_type], product=product)
+    # Metrics sampled on the rollout's target population.
+    sampled_metrics = get_sampled_metrics(
+        metric_type_set[scalar_type],
+        product=product,
+        channel=CLIENT_SAMPLED_CHANNEL,
+        os=CLIENT_SAMPLED_OS,
+    )
     found_sampled_metrics = defaultdict(list)
 
     # Iterate over every element in the schema under the metrics section and
@@ -205,9 +215,9 @@ def main():
             ping_type=ping_type_from_table(args.source_table),
             client_sampled_unlabeled_metrics=client_sampled_metrics_sql["unlabeled"],
             client_sampled_labeled_metrics=client_sampled_metrics_sql["labeled"],
-            client_sampled_channel="release",
-            client_sampled_os="Windows",
-            client_sampled_max_sample_id=100,
+            client_sampled_channel=CLIENT_SAMPLED_CHANNEL,
+            client_sampled_os=CLIENT_SAMPLED_OS,
+            client_sampled_max_sample_id=CLIENT_SAMPLED_MAX_SAMPLE_ID,
         )
     )
 

--- a/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_histogram_aggregates_v1.sql
@@ -43,6 +43,25 @@ histograms AS (
         sample_id < 10)
 ),
 {% if client_sampled_histograms %}
+-- Sampled metrics are full-rate everywhere except the rollout's target
+-- population; collect them here like normal metrics.
+full_rate_sampled_histograms AS (
+  SELECT
+    {{ attributes }},
+    ARRAY<
+      STRUCT<
+        key STRING,
+        metric STRING,
+        metric_type STRING,
+        value ARRAY<STRUCT<key STRING, value INT64>>
+      >
+    >[{{ client_sampled_histograms }}] AS metadata
+  FROM
+    extracted
+  WHERE
+    channel IN ("nightly", "beta")
+    OR (channel = "release" AND os != "Windows")
+),
 sampled_histograms AS (
   SELECT
     {{ attributes }},
@@ -59,12 +78,14 @@ sampled_histograms AS (
   WHERE
     channel = "{{ client_sampled_channel}}"
     AND os = "{{ client_sampled_os}}"
-    AND sample_id < {{ client_sampled_max_sample_id }}
+    AND sample_id <= {{ client_sampled_max_sample_id }}
 ),
 {% endif %}
 unioned_histograms AS (
   SELECT * FROM histograms
   {% if client_sampled_histograms %}
+  UNION ALL
+  SELECT * FROM full_rate_sampled_histograms
   UNION ALL
   SELECT * FROM sampled_histograms
   {% endif %}
@@ -108,6 +129,28 @@ labeled_histograms AS (
     )
 ),
 {% if client_sampled_labeled_histograms %}
+-- Full-rate everywhere except the rollout's target population.
+full_rate_sampled_labeled_histograms AS (
+  SELECT
+    {{ attributes }},
+    ARRAY<
+      STRUCT<
+        metric STRING,
+        metric_type STRING,
+        keyed_values ARRAY<
+          STRUCT<
+            key STRING,
+            value ARRAY<STRUCT<key STRING, value INT64>>
+          >
+        >
+      >
+    >[{{ client_sampled_labeled_histograms }}] AS metadata
+  FROM
+    extracted
+  WHERE
+    channel IN ("nightly", "beta")
+    OR (channel = "release" AND os != "Windows")
+),
 sampled_labeled_histograms AS (
   SELECT
     {{ attributes }},
@@ -128,12 +171,14 @@ sampled_labeled_histograms AS (
   WHERE
     channel = "{{ client_sampled_channel}}"
     AND os = "{{ client_sampled_os}}"
-    AND sample_id < {{ client_sampled_max_sample_id }}
+    AND sample_id <= {{ client_sampled_max_sample_id }}
 ),
 {% endif %}
 unioned_labeled_histograms AS (
   SELECT * FROM labeled_histograms
   {% if client_sampled_labeled_histograms %}
+  UNION ALL
+  SELECT * FROM full_rate_sampled_labeled_histograms
   UNION ALL
   SELECT * FROM sampled_labeled_histograms
   {% endif %}

--- a/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
+++ b/bigquery_etl/glam/templates/clients_daily_scalar_aggregates_v1.sql
@@ -43,6 +43,22 @@ unlabeled_metrics AS (
     {{ attributes }}
 ),
 {% if client_sampled_unlabeled_metrics %}
+  -- Sampled metrics are full-rate everywhere except the rollout's target
+  -- population; collect them here like normal metrics.
+  full_rate_sampled_unlabeled_metrics AS (
+    SELECT
+      {{ attributes }},
+      ARRAY<STRUCT<metric STRING, metric_type STRING, key STRING, agg_type STRING, value FLOAT64>>[
+        {{ client_sampled_unlabeled_metrics }}
+      ] AS scalar_aggregates
+    FROM
+      extracted
+    WHERE
+      channel IN ("nightly", "beta")
+      OR (channel = "release" AND os != "Windows")
+    GROUP BY
+      {{ attributes }}
+  ),
   sampled_unlabeled_metrics AS (
     SELECT
       {{ attributes }},
@@ -54,7 +70,7 @@ unlabeled_metrics AS (
     WHERE
       channel = "{{ client_sampled_channel}}"
       AND os = "{{ client_sampled_os}}"
-      AND sample_id = {{ client_sampled_max_sample_id }}
+      AND sample_id <= {{ client_sampled_max_sample_id }}
     GROUP BY
       {{ attributes }}
   ),
@@ -65,6 +81,11 @@ unioned_unlabeled_metrics AS (
   FROM
     unlabeled_metrics
     {% if client_sampled_unlabeled_metrics %}
+      UNION ALL
+      SELECT
+        *
+      FROM
+        full_rate_sampled_unlabeled_metrics
       UNION ALL
       SELECT
         *
@@ -88,6 +109,19 @@ grouped_labeled_metrics AS (
     OR (channel = "release" AND os = "Windows" AND sample_id < 10)
 ),
 {% if client_sampled_labeled_metrics %}
+  -- Full-rate everywhere except the rollout's target population.
+  full_rate_grouped_sampled_labeled_metrics AS (
+    SELECT
+      {{ attributes }},
+      ARRAY<STRUCT<name STRING, type STRING, value ARRAY<STRUCT<key STRING, value INT64>>>>[
+        {{ client_sampled_labeled_metrics }}
+      ] AS metrics
+    FROM
+      extracted
+    WHERE
+      channel IN ("nightly", "beta")
+      OR (channel = "release" AND os != "Windows")
+  ),
   grouped_sampled_labeled_metrics AS (
     SELECT
       {{ attributes }},
@@ -99,7 +133,7 @@ grouped_labeled_metrics AS (
     WHERE
       channel = "{{ client_sampled_channel}}"
       AND os = "{{ client_sampled_os}}"
-      AND sample_id = {{ client_sampled_max_sample_id }}
+      AND sample_id <= {{ client_sampled_max_sample_id }}
   ),
 {% endif %}
 unioned_grouped_labeled_metrics AS (
@@ -108,6 +142,11 @@ unioned_grouped_labeled_metrics AS (
   FROM
     grouped_labeled_metrics
     {% if client_sampled_labeled_metrics %}
+      UNION ALL
+      SELECT
+        *
+      FROM
+        full_rate_grouped_sampled_labeled_metrics
       UNION ALL
       SELECT
         *

--- a/tests/glam/test_client_side_sampled_metrics.py
+++ b/tests/glam/test_client_side_sampled_metrics.py
@@ -122,3 +122,23 @@ class TestGet:
         client_side_sampled_metrics.get(metric_types=["counter"])
         rendered_query = mock_run.call_args.args[0]
         assert "app_name =" not in rendered_query
+
+    @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
+    def test_channel_and_os_filters_in_query(self, mock_run):
+        """Scoping to a population restricts the lookup to metrics sampled
+        there, so a metric not sampled on (channel, os) isn't returned."""
+        mock_run.return_value = []
+        client_side_sampled_metrics.get(
+            product="firefox_desktop", channel="release", os="Windows"
+        )
+        rendered_query = mock_run.call_args.args[0]
+        assert "channel = 'release'" in rendered_query
+        assert "os = 'Windows'" in rendered_query
+
+    @mock.patch.object(client_side_sampled_metrics, "_run_bq_query")
+    def test_channel_and_os_omitted_by_default(self, mock_run):
+        mock_run.return_value = []
+        client_side_sampled_metrics.get(product="firefox_desktop")
+        rendered_query = mock_run.call_args.args[0]
+        assert "channel =" not in rendered_query
+        assert "os =" not in rendered_query


### PR DESCRIPTION
## Description

Fixes https://github.com/mozilla/glam/issues/3522

They're full-rate on other channels/OSes; collect them there via a full-rate CTE while keeping the sampled path for release+Windows.

Metrics affected:
```
wr_time_to_render_start
wr_rasterize_glyphs_time
ssl_handshake_result
ssl_handshake_result_first_try
fog_ipc_buffer_sizes
wr_texture_cache_update_time
cert_validation_success_by_ca_2
javascript_gc_minor_time
ssl_handshake_result_ech_grease
paint_build_displaylist_time
```

## Related Tickets & Documents
* DENG-11214


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
