### PR TITLE
fix(sumo_metrics): make running_backlog count all open bugs

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/backfill.yaml
@@ -1,3 +1,16 @@
+2026-06-03:
+  start_date: 2025-03-29
+  end_date: 2026-06-02
+  reason: >-
+    Add bugs_open (point-in-time open-bug backlog) column and update the
+    resolved definition to also treat a set resolution as resolved.
+  watchers:
+  - kpham@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false
 2026-06-02:
   start_date: 2025-03-29
   end_date: 2026-06-02

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/backfill.yaml
@@ -1,6 +1,6 @@
-2026-06-03:
+2026-06-04:
   start_date: 2025-03-29
-  end_date: 2026-06-02
+  end_date: 2026-06-03
   reason: >-
     Add bugs_open (point-in-time open-bug backlog) column and update the
     resolved definition to also treat a set resolution as resolved.
@@ -11,6 +11,7 @@
   override_retention_limit: false
   override_depends_on_past_end_date: false
   ignore_date_partition_offset: false
+
 2026-06-02:
   start_date: 2025-03-29
   end_date: 2026-06-02

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/query.sql
@@ -2,7 +2,12 @@ WITH bug_history AS (
   SELECT
     id,
     DATE(creation_ts) AS creation_date,
-    MIN(IF(status = 'RESOLVED', snapshot_date, NULL)) AS first_resolved_date,
+    MIN(
+      COALESCE(
+        IF(status = 'RESOLVED', snapshot_date, NULL),
+        IF(resolution IS NOT NULL, snapshot_date, NULL)
+      )
+    ) AS first_resolved_date,
     MAX(IF(status = 'REOPENED', snapshot_date, NULL)) AS last_reopened_resolved_date,
   FROM
     `moz-fx-data-shared-prod.bugzilla_metrics.bugs`
@@ -44,14 +49,29 @@ resolved AS (
     resolution_date = @submission_date
   GROUP BY
     `date`
+),
+-- Point-in-time count of bugs open as of @submission_date: created on or before
+-- that day and not yet resolved as of that day, regardless of creation date.
+open_bugs AS (
+  SELECT
+    COUNT(*) AS bugs_open,
+  FROM
+    bugs
+  WHERE
+    creation_date <= @submission_date
+    AND (resolution_date IS NULL OR resolution_date > @submission_date)
 )
 SELECT
   @submission_date AS `date`,
   COALESCE(created.bugs_created, 0) AS bugs_created,
   COALESCE(resolved.bugs_resolved, 0) AS bugs_resolved,
+  open_bugs.bugs_open,
   CURRENT_TIMESTAMP() AS etl_timestamp,
 FROM
+  open_bugs
+LEFT JOIN
   created
-FULL OUTER JOIN
+  ON created.date = @submission_date
+LEFT JOIN
   resolved
-  USING (`date`)
+  ON resolved.date = @submission_date

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/query.sql
@@ -3,10 +3,7 @@ WITH bug_history AS (
     id,
     DATE(creation_ts) AS creation_date,
     MIN(
-      COALESCE(
-        IF(status = 'RESOLVED', snapshot_date, NULL),
-        IF(resolution IS NOT NULL, snapshot_date, NULL)
-      )
+      IF(status = 'RESOLVED' OR resolution IS NOT NULL, snapshot_date, NULL)
     ) AS first_resolved_date,
     MAX(IF(status = 'REOPENED', snapshot_date, NULL)) AS last_reopened_resolved_date,
   FROM

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/schema.yaml
@@ -12,8 +12,16 @@ fields:
   mode: NULLABLE
   description: |
     Number of Knowledge Base Content bugs resolved on this date.
-    Resolution date is the most recent of the first RESOLVED snapshot and any
+    A bug is considered resolved on the first snapshot where status = 'RESOLVED'
+    or resolution is set; resolution date is the most recent of that and any
     later REOPENED→RESOLVED snapshot.
+- name: bugs_open
+  type: INTEGER
+  mode: NULLABLE
+  description: |
+    Number of Knowledge Base Content bugs open as of this date: created on or
+    before this date and not yet resolved as of this date, regardless of when
+    they were created.
 - name: etl_timestamp
   type: TIMESTAMP
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_bugzilla_kpis/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_bugzilla_kpis/view.sql
@@ -7,23 +7,27 @@ WITH weeks AS (
   FROM
     UNNEST(
       GENERATE_DATE_ARRAY(
-        DATE_TRUNC(DATE_SUB(CURRENT_DATE, INTERVAL 1 YEAR), WEEK(SUNDAY)),
-        DATE_TRUNC(CURRENT_DATE, WEEK(SUNDAY)),
+        (
+          SELECT
+            DATE_TRUNC(MIN(`date`), ISOWEEK)
+          FROM
+            `moz-fx-data-shared-prod.sumo_metrics_derived.bugzilla_tickets_base_v1`
+        ),
+        DATE_TRUNC(CURRENT_DATE, ISOWEEK),
         INTERVAL 1 WEEK
       )
     ) AS week
 ),
 weekly AS (
   SELECT
-    DATE_TRUNC(`date`, WEEK(SUNDAY)) AS week,
+    DATE_TRUNC(`date`, ISOWEEK) AS week,
     SUM(bugs_created) AS bugs_created,
     SUM(bugs_resolved) AS bugs_resolved,
+    -- Open-bug backlog is a stock metric: take the count as of the latest day
+    -- in the week rather than summing across days.
+    ARRAY_AGG(bugs_open ORDER BY `date` DESC LIMIT 1)[OFFSET(0)] AS running_backlog,
   FROM
     `moz-fx-data-shared-prod.sumo_metrics_derived.bugzilla_tickets_base_v1`
-  WHERE
-    `date`
-    BETWEEN DATE_SUB(CURRENT_DATE, INTERVAL 1 YEAR)
-    AND CURRENT_DATE
   GROUP BY
     WEEK
 ),
@@ -33,10 +37,7 @@ joined AS (
     COALESCE(weekly.bugs_created, 0) AS bugs_created,
     COALESCE(weekly.bugs_resolved, 0) AS bugs_resolved,
     COALESCE(weekly.bugs_created, 0) - COALESCE(weekly.bugs_resolved, 0) AS bug_inventory,
-    SUM(COALESCE(weekly.bugs_created, 0) - COALESCE(weekly.bugs_resolved, 0)) OVER (
-      ORDER BY
-        weeks.week
-    ) AS running_backlog,
+    weekly.running_backlog,
   FROM
     weeks
   LEFT JOIN


### PR DESCRIPTION
## Description

Redefines the SUMO Bugzilla KPI `running_backlog` to be a **point-in-time count of open bugs** (created on or before a day and not yet resolved as of that day), **regardless of when the bug was created** — replacing the previous cumulative `SUM(created - resolved)` that was restricted to the trailing year and reset to 0 at the window edge.

### `bugzilla_tickets_base_v1`
- Add a `bugs_open` column: count of bugs open as of `@submission_date`, computed from full bug history.
- Update the "resolved" definition to treat a set `resolution` as resolved, not just `status = 'RESOLVED'` (kept consistent with the view). A historical subset of bugs were not being counted as resolved since `status != 'RESOLVED'` but `resolution` was not null.
- Always emit one row per `submission_date` (previously a date with no creations and no resolutions produced no row).

### `sumo_bugzilla_kpis` view
- `running_backlog` now surfaces `bugs_open` as the end-of-week snapshot (latest day in the ISO week), removing the duplicated bug-level resolution logic.
- View now spans all available history instead of the trailing year (week spine starts at the earliest base-table date).
- Weeks truncate to `ISOWEEK` (Monday-aligned) instead of `WEEK(SUNDAY)` to stay consistent with other SUMO views.

### Backfill
- Added an `Initiate` backfill entry to repopulate the base table with the new `bugs_open` column and updated resolved definition (2025-03-29 → 2026-06-02).

## Related Tickets & Documents
* DENG-11184

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**

> [!NOTE]
> Both queries pass `bqetl query validate` (dry run) locally.
> Deploy ordering: the view references the base table's new `bugs_open` column, so `bugzilla_tickets_base_v1` must be deployed before the `sumo_bugzilla_kpis` view.
