### PR TITLE
chore(schema): add shared field descriptions to global.yaml

### DIFF
--- a/bigquery_etl/schema/global.yaml
+++ b/bigquery_etl/schema/global.yaml
@@ -364,3 +364,138 @@ fields:
 - name: event_type
   description: The high-level type or category of the recorded event, describing what kind of interaction or lifecycle change occurred (e.g., 'login',
     'New', 'Cancelled', 'contact').
+- name: exposure_count
+  description: Number of experiment exposure events recorded in the aggregation window, reflecting how many times enrolled clients encountered the
+    experimental feature or surface being tested.
+- name: first_event_timestamp
+  description: The timestamp of the first qualifying event observed for the client, used to anchor event-based cohort or first-seen analysis.
+- name: first_seen_city
+  description: The city where the client was first observed, as determined by IP geolocation on the date of first contact with Mozilla's telemetry
+    pipeline.
+- name: first_seen_city_date
+  description: The date on which the client's first-seen city was recorded, corresponding to the earliest geolocation observation for the client.
+- name: first_seen_country
+  description: The ISO 3166-1 alpha-2 country code of the country where the client was first observed, as determined by IP geolocation on the date
+    of first contact with Mozilla's telemetry pipeline.
+- name: first_seen_subdivision1
+  description: The first-level administrative subdivision (e.g., state or province code) where the client was first observed, as determined by IP geolocation
+    on the date of first contact with Mozilla's telemetry pipeline.
+- name: first_seen_subdivision2
+  description: The second-level administrative subdivision where the client was first observed, as determined by IP geolocation. Not applicable for
+    most countries and is typically null.
+- name: last_seen_city
+  description: The city where the client was most recently observed, as determined by IP geolocation on the date of last contact with Mozilla's telemetry
+    pipeline.
+- name: last_seen_city_date
+  description: The date on which the client's last-seen city was recorded, corresponding to the most recent geolocation observation for the client.
+- name: last_seen_country
+  description: The ISO 3166-1 alpha-2 country code of the country where the client was most recently observed, as determined by IP geolocation on the
+    date of last contact with Mozilla's telemetry pipeline.
+- name: last_seen_subdivision1
+  description: The first-level administrative subdivision (e.g., state or province code) where the client was most recently observed, as determined
+    by IP geolocation on the date of last contact with Mozilla's telemetry pipeline.
+- name: last_seen_subdivision2
+  description: The second-level administrative subdivision where the client was most recently observed, as determined by IP geolocation. Not applicable
+    for most countries and is typically null.
+- name: ad_clicks_count
+  description: Number of ad click events recorded for enrolled experiment clients in the aggregation window, counting clicks on advertisements shown
+    on search engine result pages.
+- name: clicks
+  description: The total number of times a user clicked on an ad or link within the reporting period.
+- name: disqualification_count
+  description: Number of experiment disqualification events recorded in the aggregation window, reflecting how many times a client was removed from
+    an experiment due to targeting criteria no longer being met.
+- name: enroll_count
+  description: Number of experiment enrollment events recorded in the aggregation window, reflecting how many times clients were successfully enrolled
+    into an experiment branch.
+- name: enroll_failed_count
+  description: Number of failed experiment enrollment attempts recorded in the aggregation window, where the client attempted but did not successfully
+    join an experiment.
+- name: first_seen_year
+  description: The calendar year in which the client profile was first observed by Mozilla's telemetry pipeline, extracted from first_seen_date and
+    used for cohort-level analysis.
+- name: graduate_count
+  description: Number of experiment graduation events recorded in the aggregation window, reflecting how many times clients transitioned out of an
+    experiment upon its conclusion.
+- name: new_profiles_metric_date
+  description: Count of new client profiles first seen on the metric date, used as the cohort base for retention calculations.
+- name: provider
+  description: The name of the external service or platform that provides the resource, product, or service described by the row (e.g., an ad server,
+    subscription platform, or AI service).
+- name: repeat_profiles
+  description: Count of new profiles created on the metric date that were recorded as daily active users at least twice in the following 28-day window,
+    indicating early retention.
+- name: retained_week_4_new_profiles
+  description: Count of new profiles created on the metric date that were recorded as daily active users at least once between days 22 and 28 after
+    the metric date, indicating four-week retention.
+- name: search_with_ads_count
+  description: Number of search engine result pages that contained advertisements, as recorded for enrolled experiment clients in the aggregation window.
+- name: title
+  description: A human-readable name or heading associated with the record, such as an ad creative title, content item heading, or pull request title.
+- name: unenroll_count
+  description: Number of experiment unenrollment events recorded in the aggregation window, reflecting how many times clients exited an experiment
+    before its conclusion.
+- name: unenroll_failed_count
+  description: Number of failed experiment unenrollment attempts recorded in the aggregation window, where a client attempted but did not successfully
+    exit an experiment.
+- name: update_failed_count
+  description: Number of failed experiment recipe update attempts recorded in the aggregation window, where the client could not successfully apply
+    an updated experiment configuration.
+- name: ad_clicks
+  description: The total number of advertisement clicks recorded for the client or dimension grouping in the reporting period, aggregated across all
+    applicable search access points or surfaces.
+- name: attributed
+  description: True if the client or install has a known attribution source (i.e., both attribution source and medium are present); false if the install
+    was organic or attribution data is unavailable.
+- name: daily_users
+  description: Count of clients that sent at least one ping on the submission date, used as the daily active user count for the given dimension grouping.
+- name: metric_date
+  description: The reference date used as the anchor for a retention or feature-usage measurement, typically representing the cohort date from which
+    downstream activity is measured.
+- name: monthly_users
+  description: Count of clients that sent at least one ping in the 28-day window ending on the submission date, used as the monthly active user count
+    for the given dimension grouping.
+- name: uri_count
+  description: The total number of URIs (web pages) visited by the client in the reporting period, derived from browser engagement scalars or equivalent
+    telemetry.
+- name: validation_failed_count
+  description: Number of experiment validation failure events recorded in the aggregation window, where a client's experiment configuration failed
+    a validation check.
+- name: weekly_users
+  description: Count of clients that sent at least one ping in the 7-day window ending on the submission date, used as the weekly active user count
+    for the given dimension grouping.
+- name: ad_click
+  description: The total number of advertisement clicks recorded for the client in the reporting period, aggregated across all applicable search engines
+    and access points.
+- name: search_with_ads
+  description: The total number of search engine result pages that contained advertisements, seen by the client or dimension grouping in the reporting
+    period.
+- name: count
+  description: The number of records, events, or entities matching the row's dimension combination.
+- name: email
+  description: The primary email address associated with the user or contact. This field contains personally identifiable information (PII) and should
+    be handled accordingly.
+- name: event_date
+  description: The calendar date on which the event occurred or was recorded.
+- name: ping_sent_metric_date
+  description: Count of client profiles that sent a telemetry ping on the metric date, used to measure activity at the cohort anchor point.
+- name: ping_sent_week_4
+  description: Count of client profiles that sent a telemetry ping between days 22 and 28 after the metric date, used to measure four-week retention.
+- name: product_id
+  description: An identifier for a product record, which may represent a Mozilla ad product, a subscription product, or a reference to a product in
+    an external system such as Stripe or an ad server.
+- name: active
+  description: Indicates whether the entity (e.g., account, user, or plan) is currently active. For accounts, this typically means the account is not
+    disabled and has a verified email address.
+- name: browser
+  description: The web browser used by the client or visitor (e.g., 'Firefox', 'Chrome', 'Safari'), as parsed from the user agent string.
+- name: content
+  description: The UTM content parameter associated with a traffic source or campaign, used to identify the specific link or creative variant within
+    a campaign.
+- name: currency
+  description: The three-letter ISO 4217 currency code (e.g., 'usd', 'eur') representing the currency used for the transaction or pricing.
+- name: sessions
+  description: The number of distinct browsing sessions recorded for the client or dimension grouping in the reporting period.
+- name: activations
+  description: Count of new client profiles that met the activation criterion, typically defined as returning to use the application within a specified
+    window after first install.

--- a/bigquery_etl/schema/global.yaml
+++ b/bigquery_etl/schema/global.yaml
@@ -231,3 +231,136 @@ fields:
   aliases:
   - updated_timestamp
   - updated_date
+- name: normalized_app_id
+  description: The normalized application identifier for the Mozilla product (e.g., 'org_mozilla_firefox', 'org_mozilla_fenix'). Distinguishes product
+    variants and release channels within the same product family.
+- name: experiment
+  description: The unique slug identifier of the Nimbus experiment for which data is aggregated or recorded (e.g., 'smart-shortcuts-v4p1'). Null when
+    the row is not scoped to a specific experiment.
+- name: total_events
+  description: The total count of events recorded for the given dimension combination in the aggregation period. Excludes page-view events where distinguished.
+- name: window_end
+  description: The exclusive end timestamp of the aggregation window for the row's time-bucketed metrics.
+- name: window_start
+  description: The inclusive start timestamp of the aggregation window for the row's time-bucketed metrics.
+- name: event_extra_key
+  description: The name of an extra key attached to a telemetry event, used to further classify or parameterize the event beyond its category and name.
+- name: days_sent_metrics_ping_bits
+  description: A 28-bit integer bitmask recording the days within the past 28-day window on which the client sent a metrics ping, with the least-significant
+    bit representing the most recent day.
+- name: n_metrics_ping
+  description: The number of metrics pings received from this client on the submission date or within the aggregation window.
+- name: date
+  description: The calendar date associated with the record, such as the date of an event, cost entry, metric observation, or partition boundary.
+- name: id
+  description: A unique identifier for the record within its source system. The type and format depend on the source (e.g., integer, UUID, or hex string).
+- name: type
+  description: A string classifying the kind or category of the record within its domain (e.g., event type, transaction type, or content type). Permitted
+    values vary by table.
+- name: is_active
+  description: Boolean flag indicating whether the entity (e.g., subscription, client, advertiser, or DAG) was active at the time of the record. True
+    means active; false means inactive or churned.
+- name: days_seen_bytes
+  description: A 365-bit (46-byte) binary representation of the days this client was seen over the past year, where the rightmost bit corresponds to
+    the most recent day.
+- name: status
+  description: The current lifecycle or operational state of the record (e.g., active, closed, canceled, succeeded). Permitted values are domain-specific.
+- name: baseline_profile_group_id
+  description: A UUID identifying the profile group as reported in the Glean baseline ping. Identifies which group of profiles this client belongs
+    to across baseline-ping-derived tables.
+- name: search_count
+  description: The total number of searches performed by the client or cohort for the given dimension combination on the submission date or aggregation
+    window.
+- name: name
+  description: A human-readable display name for the entity in the record (e.g., a product, add-on, participant, country, or data source). Interpretation
+    depends on the table context.
+- name: days_active_bytes
+  description: A binary representation of the days this client was considered active over a trailing window, encoded as a byte sequence with the most
+    recent day in the least-significant bit position.
+- name: region
+  description: The geographic region (e.g., a country subdivision or market area) associated with the client or event. Encoding and granularity vary
+    by source (e.g., ISO subdivision code, free-text region name).
+- name: source
+  description: A string identifying the origin or upstream system that produced or attributed the record (e.g., a traffic source, data pipeline, or
+    referral partner).
+- name: app_id
+  description: The application identifier for the Mozilla product that sent the event or ping (e.g., 'org.mozilla.firefox', 'firefox.desktop'). Uses
+    dot notation as defined in the Glean app registry.
+- name: platform
+  description: The operating system or device platform on which the event or activity occurred (e.g., 'Windows', 'Android', 'iOS', 'web'). Encoding
+    and granularity vary by source.
+- name: usage_profile_id
+  description: A UUID that uniquely identifies a Firefox usage-reporting profile. Used as the primary identifier in usage-reporting pipeline tables.
+- name: value
+  description: A generic payload field whose interpretation depends on the record's context. May hold a numeric measurement, a user-defined event string,
+    or an extra-field value.
+- name: url
+  description: A Uniform Resource Locator (URL) associated with the record, such as a clicked link, a content item, a source repository, or an ad placement.
+- name: created
+  description: The timestamp at which the entity (e.g., a customer record, subscription, or plan) was first created in the source system.
+- name: state
+  description: The current or computed state of the entity in its lifecycle model (e.g., a Markov state, DAG run state, or email address state). Permitted
+    values are domain-specific.
+- name: partition_date
+  description: The date used to partition this table's storage, typically matching submission_date and included to enable efficient partition-pruning
+    queries.
+- name: product
+  description: The Mozilla product or ad product associated with the record (e.g., 'Firefox', 'tile', 'spoc'). Interpretation and normalization depend
+    on the source system.
+- name: campaign_id
+  description: The unique identifier for an advertising or marketing campaign, as assigned by the originating ad platform or internal system.
+- name: impressions
+  description: The count of times an ad, content item, or search result was displayed to a user for the given dimension combination in the aggregation
+    period.
+- name: campaign_name
+  description: The human-readable name of the advertising or marketing campaign associated with the record.
+- name: description
+  description: A human-readable text field providing additional context or explanation for the record, such as the name of a subscription group, details
+    of a detected anomaly, or a product description.
+- name: end_date
+  description: The date or timestamp marking the end of the period or entity described by the record (e.g., experiment end date, subscription end date,
+    or time-window boundary).
+- name: device_type
+  description: The category of device on which the activity occurred (e.g., 'Desktop', 'Mobile', 'Tablet'). Encoding and permitted values vary by source.
+- name: category
+  description: A high-level classification grouping the record into a named category relevant to its domain (e.g., Glean event category, content category,
+    or release category).
+- name: language
+  description: The language setting of the user's device or account, typically expressed as an IETF BCP 47 language tag (e.g., 'en-US', 'de-DE').
+- name: metric
+  description: The name of the specific metric or measurement being recorded or aggregated for the row (e.g., a Glean metric name, a KPI name, or a
+    scalar identifier).
+- name: start_date
+  description: The date or timestamp marking the beginning of the period or entity described by the record (e.g., experiment start date, subscription
+    start date, or time-window boundary).
+- name: user_id
+  description: A unique identifier for a user within the source system. The format and scoping (e.g., UUID, integer, or hex string) depend on the system
+    of origin.
+- name: active_metric_date
+  description: A count or boolean flag indicating whether the client or profile was active on the metric date. When used as a count, represents the
+    number of active profiles on that date.
+- name: country_name
+  description: The full standardized name of the country associated with the record, as determined by IP geolocation or subscription data (e.g., 'United
+    States', 'Germany').
+- name: first_submission_timestamp
+  description: The timestamp of the first telemetry submission received from this client for the relevant event or entity, as recorded on the server
+    side.
+- name: new_profiles
+  description: The count of client profiles first seen on the date or within the dimension grouping represented by the row.
+- name: retained_week_4
+  description: A count or boolean indicating whether the client returned during the fourth week (approximately days 21–28) after the profile's first-seen
+    date, used as a 28-day retention metric.
+- name: timestamp
+  description: The date and time at which the event, change, or data point occurred, as recorded by the originating system. Precision and timezone
+    encoding vary by source.
+- name: update_count
+  description: The count of update events recorded for the entity within the aggregation window.
+- name: criteria
+  description: A string or label identifying the filtering condition or eligibility rule applied to select events or clients for the given row (e.g.,
+    a named event-selection criteria like 'any_event' or 'chatbot_usage').
+- name: device
+  description: The device type or form factor associated with the activity (e.g., 'desktop', 'mobile', 'tablet'). May also carry a raw OS or hardware
+    string from certain ad-platform sources.
+- name: event_type
+  description: The high-level type or category of the recorded event, describing what kind of interaction or lifecycle change occurred (e.g., 'login',
+    'New', 'Cancelled', 'contact').

--- a/bigquery_etl/schema/global.yaml
+++ b/bigquery_etl/schema/global.yaml
@@ -614,3 +614,47 @@ fields:
   description: The version string of the installed browser add-on or extension.
 - name: app
   description: The name or identifier of the Mozilla application associated with the record (e.g., 'Firefox Desktop', 'Firefox iOS', 'Firefox Android').
+- name: crash_count
+  description: The number of crashes recorded for the client or entity within the observation window. A value of zero indicates no crashes occurred
+    during that period.
+- name: crash_process_type
+  description: The type of process in which the crash occurred (e.g., 'main', 'content', 'gpu', 'extension'). Identifies which browser process component
+    was responsible for the crash.
+- name: customer_id
+  description: The unique identifier for the billing customer account assigned by the payment provider (e.g., a Stripe customer ID prefixed with 'cus_').
+    Used to associate subscriptions and charges with a single billing customer.
+- name: ended_at
+  description: The timestamp at which the subscription or entity definitively ended. Null for records that are still active.
+- name: first_reported_country
+  description: The first country code reported by the client, as observed in the earliest ping received from that client. Represents the country at
+    the time of initial activity.
+- name: installs
+  description: The count of successful installations within the observation period or cohort. Excludes reinstalls, upgrades, or ineligible install
+    events unless the specific table indicates otherwise.
+- name: is_daily_user
+  description: Boolean flag indicating whether the client qualifies as a daily active user on the given submission date, meaning a qualifying activity
+    ping was received on that day.
+- name: is_monthly_user
+  description: Boolean flag indicating whether the client qualifies as a monthly active user on the given submission date, meaning a qualifying ping
+    was received within the preceding 28 days inclusive.
+- name: is_weekly_user
+  description: Boolean flag indicating whether the client qualifies as a weekly active user on the given submission date, meaning a qualifying ping
+    was received within the preceding 7 days inclusive.
+- name: medium
+  description: The marketing or traffic medium describing the category of channel through which a user arrived (e.g., 'organic', 'cpc', 'referral',
+    'email'). Corresponds to the UTM medium parameter when set.
+- name: model
+  description: The identifier of the AI or machine learning model used to process a request (e.g., 'claude-sonnet-4-20250514', 'gpt-4o-mini-2024-07-18').
+    Null when the model is not applicable or not recorded for the provider.
+- name: project
+  description: The name or identifier of the cloud or organizational project associated with the resource or cost record (e.g., a GCP project ID or
+    Azure subscription name).
+- name: release_channel
+  description: The Firefox release channel on the client at the time the event or ping was recorded (e.g., 'release', 'beta', 'nightly', 'esr'). Reflects
+    the raw channel value, distinct from the normalized channel.
+- name: run_id
+  description: A unique identifier for a specific run or attempt of a task or job. In task execution contexts this is typically a zero-based integer
+    index; in pipeline contexts it may be a UUID or string token scoped to a single execution.
+- name: time
+  description: A Unix timestamp (seconds since epoch) representing when an event occurred on the client or system side. Use submission_timestamp for
+    ping receipt time; this field captures the event occurrence time.

--- a/bigquery_etl/schema/global.yaml
+++ b/bigquery_etl/schema/global.yaml
@@ -499,3 +499,118 @@ fields:
 - name: activations
   description: Count of new client profiles that met the activation criterion, typically defined as returning to use the application within a specified
     window after first install.
+- name: campaign
+  description: Identifier for the marketing campaign associated with an install or visit, typically sourced from the utm_campaign URL parameter or
+    an equivalent attribution signal.
+- name: client_count
+  description: The number of distinct clients contributing to the row or aggregation.
+- name: default_search_engine
+  description: The identifier or name of the default search engine configured by the client (e.g., 'google-b-d', 'baidu', 'DuckDuckGo').
+- name: duration
+  description: A time interval measured in seconds representing the elapsed time of a task, session, or participation window.
+- name: is_dau
+  description: Boolean flag indicating whether the client qualifies as a daily active user on the given submission date.
+- name: is_mau
+  description: Boolean flag indicating whether the client qualifies as a monthly active user, i.e., was active at least once in the 28 days ending
+    on the submission date.
+- name: is_wau
+  description: Boolean flag indicating whether the client qualifies as a weekly active user, i.e., was active at least once in the 7 days ending on
+    the submission date.
+- name: os_name
+  description: The human-readable name of the operating system on which the client was running (e.g., 'Windows', 'Mac', 'Android').
+- name: paid_vs_organic
+  description: Classification of a client's attribution as 'Paid' (attributed to a paid marketing channel) or 'Organic' (not attributed to paid spend).
+- name: priority
+  description: A label indicating the importance or urgency level assigned to a record (e.g., job, issue, or task).
+- name: slug
+  description: A URL-safe string identifier used as a path segment to uniquely reference a resource (e.g., an article, experiment, or content item).
+- name: active_hours
+  description: The total number of hours the client spent actively using the browser, expressed in fractional hours.
+- name: app_version_is_major_release
+  description: Boolean flag indicating whether the installed app version is a major release (i.e., the patch/revision component of the version string
+    is zero).
+- name: app_version_patch_revision
+  description: The patch or revision number component of the app version string (e.g., for version '142.1.3', the patch revision is 3); null for major
+    releases where no patch revision exists.
+- name: early_engagements
+  description: Count of early-engagement events recorded for a new profile within the first few days after installation, used to measure initial activation
+    quality.
+- name: num_days_active_day_2_7
+  description: The number of days the client was active between day 2 and day 7 (inclusive) after the first-seen date.
+- name: num_days_seen_day_2_7
+  description: The number of days the client submitted a ping between day 2 and day 7 (inclusive) after the first-seen date.
+- name: os_grouped
+  description: Operating system grouped into high-level categories such as 'Windows', 'Mac', 'Linux', 'Android', 'iOS', or 'Other'.
+- name: paid_vs_organic_gclid
+  description: Classification of an install as 'Paid' when the install referrer response contains a Google Click ID (gclid), or 'Organic' otherwise.
+- name: position
+  description: The ordinal position of a content or ad element within a page or grid layout; indexing convention (0-based or 1-based) may vary by context.
+- name: sap
+  description: Search Access Point — the entry point through which a user initiated a search (e.g., the address bar, a search box, or a new-tab tile).
+- name: subdivision1
+  description: The first-level administrative subdivision (e.g., state, province, or region) derived from IP geolocation, typically represented as
+    an ISO 3166-2 subdivision code.
+- name: activity_date
+  description: The calendar date on which a user action or conversion event took place, which may differ from the submission date when events are reported
+    with a delay.
+- name: clients
+  description: Count of distinct clients contributing to the aggregation.
+- name: crash_signature
+  description: A string identifying the type or location of a browser crash, used to group and classify crash events.
+- name: geo_country
+  description: ISO 3166-1 alpha-2 country code derived from the client's IP address geolocation.
+- name: organic_search_count
+  description: The total number of organic (non-ad-click) searches performed by the client or cohort.
+- name: surface
+  description: The high-level platform or form factor on which the client is running (e.g., 'desktop', 'mobile', 'tablet').
+- name: total_downloads
+  description: The total number of times a resource (such as an app or add-on) was downloaded in the reporting period.
+- name: updated
+  description: Timestamp indicating when the record was last modified in the source system.
+- name: appVersion
+  description: The version string of the application as recorded by the client at the time of the event or context snapshot.
+- name: as_of_date
+  description: The logical date associated with the data snapshot; rows reflect the state of the system as of this date.
+- name: creation_date
+  description: The date or timestamp when the record (e.g., question, ping, or table) was originally created.
+- name: events
+  description: A compact encoded or serialized representation of user interaction events recorded during a session or day.
+- name: expires
+  description: The expiry specification for a metric or probe, expressed as 'never', a calendar date, or a browser version number after which collection
+    stops.
+- name: fxa_uid
+  description: The Firefox Accounts user ID (SHA-256 hex string) that uniquely identifies a Mozilla account holder.
+- name: index
+  description: A compact string encoding of a numeric index, using Unicode code points to represent an event type or entry position in a compressed
+    event sequence.
+- name: is_activated
+  description: Boolean flag indicating whether a client or entity has met the defined activation criterion (e.g., returning to use the product within
+    a specified window after first install).
+- name: new_profile_metric_date
+  description: Boolean flag indicating whether the client's profile was newly created on the metric date being evaluated.
+- name: plan_id
+  description: The Stripe price or plan identifier (e.g., 'price_1JmRSRJNcmPzuWtRN9MG5cBy') representing the billing plan associated with a subscription.
+- name: price
+  description: The monetary price associated with a product, ad placement, or billing item.
+- name: product_name
+  description: The human-readable name of the Mozilla product or service the user is subscribed to or interacting with (e.g., 'Mozilla VPN', 'Firefox
+    Relay').
+- name: repeat_profile
+  description: Boolean flag indicating whether a new profile from the metric date was counted as a daily active user on at least two separate days
+    within their first 28 days.
+- name: retained_week_4_new_profile
+  description: Boolean flag indicating whether a new profile from the metric date was retained through week 4 (i.e., submitted at least one qualifying
+    ping in the fourth week after first seen).
+- name: subscription_id
+  description: The Stripe subscription identifier (e.g., 'sub_1LZXOfJNcmPzuWtRX6qIHqHA') that uniquely identifies a subscriber's subscription record.
+- name: _fivetran_synced
+  description: Timestamp recording when Fivetran last synced this record from the source system.
+- name: activated
+  description: Boolean flag indicating whether the client met the new-profile activation criterion, typically defined as returning to use the product
+    within the first week after installation.
+- name: addon_id
+  description: The unique string identifier for a browser add-on or extension (e.g., 'uBlock0@raymondhill.net').
+- name: addon_version
+  description: The version string of the installed browser add-on or extension.
+- name: app
+  description: The name or identifier of the Mozilla application associated with the record (e.g., 'Firefox Desktop', 'Firefox iOS', 'Firefox Android').


### PR DESCRIPTION
## Base Schema: `global`

Adds 215 shared field descriptions to `bigquery_etl/schema/global.yaml`. Candidate columns appear in ten or more datasets

### Checklist

- [ ] Field descriptions reviewed for accuracy
- [ ] Merge this PR before enricher chunk PRs that reference it
