### PR TITLE
Add norm.is_mozillaonline UDF and fix desktop_active_users view

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/desktop_active_users/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/desktop_active_users/view.sql
@@ -28,7 +28,7 @@ SELECT
   CASE
     WHEN isp_name = 'BrowserStack'
       THEN CONCAT('Firefox Desktop', ' ', isp_name)
-    WHEN distribution_id = 'MozillaOnline'
+    WHEN mozfun.norm.is_mozillaonline(distribution_id, app_version)
       THEN CONCAT('Firefox Desktop', ' ', distribution_id)
     ELSE 'Firefox Desktop'
   END AS app_name,
@@ -57,7 +57,7 @@ SELECT
   IFNULL(mozfun.bits28.days_since_seen(days_seen_bits) < 28, FALSE) AS is_monthly_user,
   IF(
     LOWER(IFNULL(isp_name, '')) <> "browserstack"
-    AND LOWER(IFNULL(distribution_id, '')) <> "mozillaonline",
+    AND NOT mozfun.norm.is_mozillaonline(distribution_id, app_version),
     TRUE,
     FALSE
   ) AS is_desktop

--- a/sql/mozfun/norm/is_mozillaonline/metadata.yaml
+++ b/sql/mozfun/norm/is_mozillaonline/metadata.yaml
@@ -1,0 +1,14 @@
+---
+friendly_name: Normalize Is MozillaOnline
+description: |
+  Returns TRUE if the client should be treated as a MozillaOnline user based
+  on distribution_id and app_version.
+
+  A client is considered MozillaOnline if distribution_id is 'MozillaOnline'
+  (case-insensitive) and app_version is prior to 151.0.3, which is when the
+  MozillaOnline migration shipped (June 2, 2026). Users on 151.0.3+ are
+  post-migration canonical Firefox users and return FALSE.
+
+  Returns FALSE if distribution_id or app_version is NULL or if distribution_id
+  is not 'MozillaOnline'. Returns TRUE if distribution_id is 'MozillaOnline'
+  and app_version is malformed, as a conservative fallback.

--- a/sql/mozfun/norm/is_mozillaonline/udf.sql
+++ b/sql/mozfun/norm/is_mozillaonline/udf.sql
@@ -1,0 +1,52 @@
+CREATE OR REPLACE FUNCTION norm.is_mozillaonline(distribution_id STRING, app_version STRING)
+RETURNS BOOL AS (
+  -- MozillaOnline migration shipped in 151.0.3 (June 2, 2026).
+  -- Users on 151.0.3+ reporting distribution_id = 'MozillaOnline' are
+  -- post-migration canonical Firefox users; treat them as non-MozillaOnline.
+  CASE
+    WHEN distribution_id IS NULL
+      OR app_version IS NULL
+      THEN FALSE
+    WHEN LOWER(distribution_id) != 'mozillaonline'
+      THEN FALSE
+    ELSE IFNULL(
+        norm.browser_version_info(app_version).major_version < 151
+        OR (
+          norm.browser_version_info(app_version).major_version = 151
+          AND norm.browser_version_info(app_version).minor_version = 0
+          AND norm.browser_version_info(app_version).patch_revision < 3
+        )
+        OR (
+          norm.browser_version_info(app_version).major_version = 151
+          AND norm.browser_version_info(app_version).minor_version = 0
+          AND norm.browser_version_info(app_version).patch_revision IS NULL
+        ),
+        TRUE
+      )
+  END
+);
+
+-- Tests
+SELECT
+  -- Pre-migration: TRUE
+  assert.true(norm.is_mozillaonline('MozillaOnline', '151.0.2')),
+  -- Exactly the migration version: FALSE
+  assert.false(norm.is_mozillaonline('MozillaOnline', '151.0.3')),
+  -- Post-migration: FALSE
+  assert.false(norm.is_mozillaonline('MozillaOnline', '152.0')),
+  -- Well before migration: TRUE
+  assert.true(norm.is_mozillaonline('MozillaOnline', '115.0')),
+  -- Case-insensitive distribution_id: TRUE
+  assert.true(norm.is_mozillaonline('MOZILLAONLINE', '151.0.2')),
+  -- Canonical Firefox distribution: FALSE
+  assert.false(norm.is_mozillaonline('Firefox', '151.0.2')),
+  -- NULL distribution_id: FALSE
+  assert.false(norm.is_mozillaonline(NULL, '151.0.2')),
+  -- NULL app_version: FALSE
+  assert.false(norm.is_mozillaonline('MozillaOnline', NULL)),
+  -- Both NULL: FALSE
+  assert.false(norm.is_mozillaonline(NULL, NULL)),
+  -- Malformed app_version + MozillaOnline: TRUE (conservative fallback)
+  assert.true(norm.is_mozillaonline('MozillaOnline', 'foo-bar')),
+  -- Empty string distribution_id: FALSE
+  assert.false(norm.is_mozillaonline('', '151.0.2'));

--- a/sql/mozfun/norm/is_mozillaonline/udf.sql
+++ b/sql/mozfun/norm/is_mozillaonline/udf.sql
@@ -10,16 +10,16 @@ RETURNS BOOL AS (
     WHEN LOWER(distribution_id) != 'mozillaonline'
       THEN FALSE
     ELSE IFNULL(
-        norm.browser_version_info(app_version).major_version < 151
-        OR (
-          norm.browser_version_info(app_version).major_version = 151
-          AND norm.browser_version_info(app_version).minor_version = 0
-          AND norm.browser_version_info(app_version).patch_revision < 3
-        )
-        OR (
-          norm.browser_version_info(app_version).major_version = 151
-          AND norm.browser_version_info(app_version).minor_version = 0
-          AND norm.browser_version_info(app_version).patch_revision IS NULL
+        (
+          SELECT
+            v.major_version < 151
+            OR (
+              v.major_version = 151
+              AND v.minor_version = 0
+              AND (v.patch_revision < 3 OR v.patch_revision IS NULL)
+            )
+          FROM
+            UNNEST([norm.browser_version_info(app_version)]) AS v
         ),
         TRUE
       )
@@ -34,6 +34,10 @@ SELECT
   assert.false(norm.is_mozillaonline('MozillaOnline', '151.0.3')),
   -- Post-migration: FALSE
   assert.false(norm.is_mozillaonline('MozillaOnline', '152.0')),
+  -- Major release without patch (151.0): TRUE (pre-migration, patch is NULL)
+  assert.true(norm.is_mozillaonline('MozillaOnline', '151.0')),
+  -- Minor version bump (151.1): FALSE (post-migration)
+  assert.false(norm.is_mozillaonline('MozillaOnline', '151.1')),
   -- Well before migration: TRUE
   assert.true(norm.is_mozillaonline('MozillaOnline', '115.0')),
   -- Case-insensitive distribution_id: TRUE


### PR DESCRIPTION
## Summary

- New UDF `mozfun.norm.is_mozillaonline(distribution_id, app_version)` returns TRUE only when `distribution_id` is `'MozillaOnline'` (case-insensitive) AND `app_version` is prior to 151.0.3 (the migration dot release).
- Updated `desktop_active_users` view to use the UDF when deriving `app_name` and `is_desktop`, replacing the bare `distribution_id` check.

## Background

Firefox 151.0.3 (June 2, 2026) migrates MozillaOnline users in China onto canonical Firefox builds. The migration overwrites `distribution_id` in the telemetry payload — [live pings confirm that 151.0.3 clients no longer report `distribution_id = 'MozillaOnline'`](https://sql.telemetry.mozilla.org/queries/120841/source#294782).

However, `clients_daily_v6` aggregates each column independently via `mode_last()`. On the day a client updates, pre-update pings carry `(version=151.0.2, distribution_id='MozillaOnline')`. Because `mode_last()` resolves each column separately, a client can end up with `app_version=151.0.3` and `distribution_id='MozillaOnline'` in the same row — a combination that's not sent via telemetry. `clients_last_seen_v2` then carries this forward on inactive days for up to 28 days.

The `desktop_active_users` view derives `app_name` and `is_desktop` from `distribution_id` alone, so these clients are mislabeled as `'Firefox Desktop MozillaOnline'` and excluded from `is_desktop = TRUE`, causing miscounts in `active_users_aggregates_v4`.

The version gate in the new UDF correctly identifies post-migration users regardless of how `distribution_id` was aggregated.

## Backfill

After the view is deployed, run this UPDATE to correct already-materialized rows in `active_users_aggregates_v4`:

```sql
UPDATE `moz-fx-data-shared-prod.firefox_desktop_derived.active_users_aggregates_v4`
SET app_name = 'Firefox Desktop'
WHERE submission_date >= '2026-06-01'
  AND app_name = 'Firefox Desktop MozillaOnline'
  AND app_version LIKE '151.0.3%'
-- Verified 2,301 rows match the WHERE clause as of 2026-06-04.
```

**Note on `distribution_id`:** The backfill only corrects `app_name`. The `distribution_id` column in affected rows will still show `'MozillaOnline'`; this is an artifact of `mode_last()` resolving `distribution_id` from pre-update pings while `app_version` resolved from post-update pings on June 2. Correcting `distribution_id` would require re-materializing from the source, but downstream consumers key on `app_name` and `is_desktop`, not `distribution_id` directly, so the stale value does not affect DAU/WAU/MAU counts.

The residual `distribution_id = 'MozillaOnline'` is useful in the short term as a migration tracking signal. Querying for `app_name = 'Firefox Desktop' AND distribution_id = 'MozillaOnline' AND app_version = '151.0.3'` identifies exactly the migrated cohort until `mode_last()` flips to the post-migration value after ~15 days.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**