### PR TITLE
fix(sumo_metrics): Complete Backfill for Bugzilla data

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/bugzilla_tickets_base_v1/backfill.yaml
@@ -6,7 +6,7 @@
     resolved definition to also treat a set resolution as resolved.
   watchers:
   - kpham@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

This PR completes the backfill for this PR: https://github.com/mozilla/bigquery-etl/pull/9501 to update the `running_backlog` logic

## Validation Query

Query [LINK](https://github.com/mozilla/bigquery-etl/pull/9515#issuecomment-4624858656) - passes validation. The query substitutes with the new backfilled data and shows `running_backlog` as positive numbers correctly.


## Related Tickets & Documents
* DENG-11184

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
